### PR TITLE
tryPut and putAsync with ttl parameter (2.0 branch patch attached)

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/MapClientProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/MapClientProxy.java
@@ -277,6 +277,12 @@ public class MapClientProxy<K, V> implements IMap<K, V>, EntryHolder {
         return proxyHelper.doAsync(ClusterOperation.CONCURRENT_MAP_PUT, key, value);
     }
 
+    public Future<V> putAsync(K key, V value, long ttl, TimeUnit timeunit) {
+        check(key);
+        check(value);
+        return proxyHelper.doAsync(ClusterOperation.CONCURRENT_MAP_PUT, key, value, ttl, timeunit);
+    }
+
     public Future<V> removeAsync(K key) {
         check(key);
         return proxyHelper.doAsync(ClusterOperation.CONCURRENT_MAP_REMOVE, key, null);
@@ -310,6 +316,13 @@ public class MapClientProxy<K, V> implements IMap<K, V>, EntryHolder {
         check(key);
         check(value);
         return (Boolean) proxyHelper.doOp(ClusterOperation.CONCURRENT_MAP_TRY_PUT, key, value, timeout, timeunit);
+    }
+
+    public boolean tryPut(K key, V value, long ttl, TimeUnit ttlTimeunit, long timeout, TimeUnit timeunit) {
+        check(key);
+        check(value);
+        //FIXME: sending ttl as timeout and timeout as ttl for backward compatibility
+        return (Boolean) proxyHelper.doOpTtlTimeout(ClusterOperation.CONCURRENT_MAP_TRY_PUT, key, value, timeout, timeunit, ttl, ttlTimeunit);
     }
 
     public void putAll(final Map<? extends K, ? extends V> map) {

--- a/hazelcast-client/src/test/java/com/hazelcast/client/HazelcastClientMapTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/HazelcastClientMapTest.java
@@ -293,6 +293,18 @@ public class HazelcastClientMapTest extends HazelcastClientTestBase {
     }
 
     @Test
+    public void tryPutWithTTL() throws InterruptedException {
+        HazelcastClient hClient = getHazelcastClient();
+        IMap<String, String> map = hClient.getMap("tryPut");
+        assertEquals(0, map.size());
+        Boolean result = map.tryPut("1", "CBDEF", 100, TimeUnit.MILLISECONDS, 1, TimeUnit.SECONDS);
+        assertTrue(result);
+        assertEquals(1, map.size());
+        Thread.sleep(300);
+        assertEquals(0, map.size());
+    }
+
+    @Test
     public void putAndGetEmployeeObjects() {
         HazelcastClient hClient = getHazelcastClient();
         int counter = 1000;

--- a/hazelcast/src/main/java/com/hazelcast/core/IMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/IMap.java
@@ -121,6 +121,38 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, Instance {
     Future<V> putAsync(K key, V value);
 
     /**
+     * Asynchronously puts the given key and value with a given ttl (time to live) value.
+     * Entry will expire and get evicted after the ttl. If ttl is 0, then
+     * the entry lives forever.
+     * <code>
+     * Future future = map.putAsync(key, value);
+     * // do some other stuff, when ready get the result
+     * Object oldValue = future.get();
+     * </code>
+     * Future.get() will block until the actual map.get() completes.
+     * If the application requires timely response,
+     * then Future.get(timeout, timeunit) can be used.
+     * <code>
+     * try{
+     * Future future = map.putAsync(key, newValue);
+     * Object oldValue = future.get(40, TimeUnit.MILLISECOND);
+     * }catch (TimeoutException t) {
+     * // time wasn't enough
+     * }
+     * </code>
+     * ExecutionException is never thrown.
+     *
+     * @param key   the key of the map entry
+     * @param value the new value of the map entry
+     * @param ttl      maximum time for this entry to stay in the map
+     *                 0 means infinite.
+     * @param timeunit time unit for the ttl
+     * @return Future from which the old value of the key can be retrieved.
+     * @see java.util.concurrent.Future
+     */
+    Future<V> putAsync(K key, V value, long ttl, TimeUnit timeunit);
+
+    /**
      * Asynchronously removes the given key.
      *
      * @param key The key of the map entry to remove.
@@ -159,6 +191,26 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, Instance {
      *         otherwise.
      */
     boolean tryPut(K key, V value, long timeout, TimeUnit timeunit);
+
+    /**
+     * Tries to put the given key, value into this map within specified
+     * timeout value with a given ttl (time to live) value.
+     * Entry will expire and get evicted after the ttl. If ttl is 0, then
+     * the entry lives forever. If this method returns false, it means that
+     * the caller thread couldn't acquire the lock for the key within
+     * timeout duration, thus put operation is not successful.
+     *
+     * @param key      key of the entry
+     * @param value    value of the entry
+     * @param ttl      maximum time for this entry to stay in the map
+     *                 0 means infinite.
+     * @param ttlTimeunit time unit for the ttl
+     * @param timeout  maximum time to wait
+     * @param timeunit time unit for the timeout
+     * @return <tt>true</tt> if the put is successful, <tt>false</tt>
+     *         otherwise.
+     */
+    boolean tryPut(K key, V value, long ttl, TimeUnit ttlTimeunit, long timeout, TimeUnit timeunit);
 
     /**
      * Puts an entry into this map with a given ttl (time to live) value.

--- a/hazelcast/src/main/java/com/hazelcast/impl/MProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/impl/MProxyImpl.java
@@ -152,6 +152,21 @@ public class MProxyImpl extends FactoryAwareNamedProxy implements MProxy, DataSe
         return call;
     }
 
+    public Future putAsync(Object key, Object value, final long ttl, final TimeUnit timeunit) {
+        beforeCall();
+        final MProxyImpl mProxy = MProxyImpl.this;
+        final Data dataKey = toData(key);
+        final Data dataValue = toData(value);
+        AsyncCall call = new AsyncCall() {
+            @Override
+            protected void call() {
+                setResult(mProxy.put(dataKey, dataValue, ttl, timeunit));
+            }
+        };
+        factory.node.executorManager.executeAsync(call);
+        return call;
+    }
+
     public Future removeAsync(Object key) {
         beforeCall();
         final MProxyImpl mProxy = MProxyImpl.this;
@@ -241,6 +256,10 @@ public class MProxyImpl extends FactoryAwareNamedProxy implements MProxy, DataSe
 
     public boolean tryPut(Object key, Object value, long time, TimeUnit timeunit) {
         return dynamicProxy.tryPut(key, value, time, timeunit);
+    }
+
+    public boolean tryPut(Object key, Object value, long ttl, TimeUnit ttlTimeunit, long time, TimeUnit timeunit) {
+        return dynamicProxy.tryPut(key, value, ttl, ttlTimeunit, time, timeunit);
     }
 
     public void set(Object key, Object value, long time, TimeUnit timeunit) {
@@ -585,6 +604,10 @@ public class MProxyImpl extends FactoryAwareNamedProxy implements MProxy, DataSe
             throw new UnsupportedOperationException();
         }
 
+        public Future putAsync(Object key, Object value, long ttl, TimeUnit timeunit) {
+            throw new UnsupportedOperationException();
+        }
+
         public Future removeAsync(Object key) {
             throw new UnsupportedOperationException();
         }
@@ -653,6 +676,26 @@ public class MProxyImpl extends FactoryAwareNamedProxy implements MProxy, DataSe
             check(value);
             MPut mput = ThreadContext.get().getCallCache(factory).getMPut();
             Boolean result = mput.tryPut(name, key, value, timeout, -1);
+            mput.clearRequest();
+            mapOperationCounter.incrementPuts(System.currentTimeMillis() - begin);
+            return result;
+        }
+
+        public boolean tryPut(Object key, Object value, long ttl, TimeUnit ttlTimeunit, long timeout, TimeUnit timeunit) {
+            long begin = System.currentTimeMillis();
+            if (timeout < 0) {
+                throw new IllegalArgumentException("timeout value cannot be negative. " + timeout);
+            }
+            timeout = toMillis(timeout, timeunit);
+            if (ttl == 0) {
+                ttl = -1;
+            } else {
+                ttl = toMillis(ttl, ttlTimeunit);
+            }
+            check(key);
+            check(value);
+            MPut mput = ThreadContext.get().getCallCache(factory).getMPut();
+            Boolean result = mput.tryPut(name, key, value, timeout, ttl);
             mput.clearRequest();
             mapOperationCounter.incrementPuts(System.currentTimeMillis() - begin);
             return result;

--- a/hazelcast/src/main/java/com/hazelcast/query/Predicates.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/Predicates.java
@@ -1087,6 +1087,7 @@ public final class Predicates {
     }
 
     private static DateFormat getUtilDateFormat() {
-        return new SimpleDateFormat(dateFormat);
+        //PredicatesTest.testEqual throws exceptions if not US locale
+        return new SimpleDateFormat(dateFormat, Locale.US);
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/core/IMapAsyncTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/core/IMapAsyncTest.java
@@ -62,6 +62,22 @@ public class IMapAsyncTest {
     }
 
     @Test
+    public void testPutAsyncWithTTL() throws Exception {
+        IMap<String, String> map = Hazelcast.getMap("map:test:putAsyncTTL");
+        Future<String> f1 = map.putAsync(key, value1);
+        String f1Val = f1.get();
+        TestCase.assertNull(f1Val);
+        Future<String> f2 = map.putAsync(key, value2, 100, TimeUnit.MILLISECONDS);
+        String f2Val = f2.get();
+        TestCase.assertEquals(value1, f2Val);
+        String val = map.get(key);
+        TestCase.assertEquals(value2, val);
+        Thread.sleep(200);
+        val = map.get(key);
+        TestCase.assertNull(val);
+    }
+
+    @Test
     public void testRemoveAsync() throws Exception {
         IMap<String, String> map = Hazelcast.getMap("map:test:removeAsync");
         // populate map


### PR DESCRIPTION
Added tryPut with both ttl and timeout, added putAsync with ttl. Implementation is different from the one I submitted for master branch. It does not brake compatibility with old clients

Fixed bug in Predicates by setting US locale when parsing Date.toString result
