### PR TITLE
Fixed client scripts

### DIFF
--- a/hazelcast-client/src/main/resources/client.bat
+++ b/hazelcast-client/src/main/resources/client.bat
@@ -1,3 +1,3 @@
 @ECHO OFF
 
-java -jar ../lib/hazelcast-client-${project.version}.jar
+java -Djava.net.preferIPv4Stack=true -classpath ../lib/hazelcast-${project.version}.jar:../lib/hazelcast-client-${project.version}.jar com.hazelcast.client.examples.TestClientApp

--- a/hazelcast-client/src/main/resources/client.sh
+++ b/hazelcast-client/src/main/resources/client.sh
@@ -1,4 +1,3 @@
 #!/bin/sh
 
-java -Djava.net.preferIPv4Stack=true -jar ../lib/hazelcast-client-${project.version}.jar
-
+java -Djava.net.preferIPv4Stack=true -classpath ../lib/hazelcast-${project.version}.jar:../lib/hazelcast-client-${project.version}.jar com.hazelcast.client.examples.TestClientApp


### PR DESCRIPTION
Neither of the scripts appeared to work correctly as the classpath was not being set so classes not in the client jar were not being found. Exception below.

Exception in thread "main" java.lang.NoClassDefFoundError: com/hazelcast/core/HazelcastInstance
