### PR TITLE
Added NAT support to configuration and node creation.

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/NetworkConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/NetworkConfig.java
@@ -28,6 +28,8 @@ public class NetworkConfig implements DataSerializable {
 
     private Join join = new Join();
 
+    private String returnAddress = null;
+    
     private SymmetricEncryptionConfig symmetricEncryptionConfig = null;
 
     private AsymmetricEncryptionConfig asymmetricEncryptionConfig = null;
@@ -65,6 +67,14 @@ public class NetworkConfig implements DataSerializable {
         this.join = join;
         return this;
     }
+    
+    public String getReturnAddress() {
+		return returnAddress;
+	}
+    
+    public void setReturnAddress(String returnAddress) {
+		this.returnAddress = returnAddress;
+	}
 
     public NetworkConfig setSocketInterceptorConfig(SocketInterceptorConfig socketInterceptorConfig) {
         this.socketInterceptorConfig = socketInterceptorConfig;

--- a/hazelcast/src/main/java/com/hazelcast/impl/Node.java
+++ b/hazelcast/src/main/java/com/hazelcast/impl/Node.java
@@ -143,16 +143,20 @@ public class Node {
         this.localNodeType = (liteMember) ? NodeType.LITE_MEMBER : NodeType.MEMBER;
         systemLogService = new SystemLogService(this);
         ServerSocketChannel serverSocketChannel = null;
-        Address localAddress = null;
+        // Address localAddress = null;
+        Address externalAddress = null;
+        // Address bindAddress = null;
         try {
             AddressPicker addressPicker = new AddressPicker(this);
             addressPicker.pickAddress();
-            localAddress = addressPicker.getAddress();
+            // localAddress = addressPicker.getExternalAddress();
+            externalAddress = addressPicker.getReturnAddress();
+            // bindAddress = addressPicker.getBindAddress();
             serverSocketChannel = addressPicker.getServerSocketChannel();
         } catch (Throwable e) {
             Util.throwUncheckedException(e);
         }
-        address = localAddress;
+        address = externalAddress;
         localMember = new MemberImpl(address, true, localNodeType, UUID.randomUUID().toString());
         String loggingType = groupProperties.LOGGING_TYPE.getString();
         loggingService = new LoggingServiceImpl(systemLogService, config.getGroupConfig().getName(), loggingType, localMember);


### PR DESCRIPTION
Hi, 

I'm currently working with a private Cloud based on OpenStack, and we found that Hazelcast is not compatible with the OpenStack network configuration. Basically OpenStack gives you one private IP per virtual machine, and sets a NAT Address for each enabled instance.

The problem is that te IP hazelcast uses to bind to is not the same IP that the cluster sees the virtual machine, and the vm itself doesn't know what is their public IP, so I've created a patch to allow you to customize this IP in configuration time (classic java -D option or Config class value).

Please take a look at it, here in Despegar we're already started using a fork of the version 2.2.

Regards.
