### PR TITLE
Ensure that factory is in ThreadContext before doing restart

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/impl/LifecycleServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/impl/LifecycleServiceImpl.java
@@ -116,6 +116,7 @@ public class LifecycleServiceImpl implements LifecycleService {
 
     public void restart() {
         synchronized (lifecycleLock) {
+            ThreadContext.get().setCurrentFactory(factory);
             fireLifecycleEvent(RESTARTING);
             paused.set(true);
             final Node node = factory.node;


### PR DESCRIPTION
Calling Hazelcast.getLifecycleService().restart() from a different thread than the one Hazelcast was started with results in three logged exceptions like the following.  The commit resolves this by ensuring that the factory object is in ThreadContext.

```
Sep 18, 2012 3:52:25 PM com.hazelcast.impl.ThreadContext
SEVERE: Factory is null
java.lang.Throwable
    at com.hazelcast.impl.ThreadContext.getHazelcastInstanceThreadContext(ThreadContext.java:141)
    at com.hazelcast.impl.ThreadContext.getCallContext(ThreadContext.java:168)
    at com.hazelcast.impl.ThreadContext.getThreadId(ThreadContext.java:241)
    at com.hazelcast.impl.BaseManager$AbstractCall.initCall(BaseManager.java:207)
    at com.hazelcast.impl.BaseManager$AbstractCall.<init>(BaseManager.java:198)
    at com.hazelcast.impl.BaseManager$RequestBasedCall.<init>(BaseManager.java:423)
    at com.hazelcast.impl.BaseManager$ResponseQueueCall.<init>(BaseManager.java:560)
    at com.hazelcast.impl.BaseManager$TargetAwareOp.<init>(BaseManager.java:823)
    at com.hazelcast.cluster.ClusterManager$AsyncRemotelyBooleanOp.<init>(ClusterManager.java:625)
    at com.hazelcast.cluster.ClusterManager.finalizeJoin(ClusterManager.java:695)
    at com.hazelcast.impl.AbstractJoiner.postJoin(AbstractJoiner.java:108)
    at com.hazelcast.impl.AbstractJoiner.join(AbstractJoiner.java:57)
    at com.hazelcast.impl.Node.join(Node.java:563)
    at com.hazelcast.impl.Node.rejoin(Node.java:552)
    at com.hazelcast.impl.LifecycleServiceImpl.restart(LifecycleServiceImpl.java:135)
    at com.hazelcast.core.HazelcastClusterTest$6.run(HazelcastClusterTest.java:432)
    at java.lang.Thread.run(Thread.java:680)
```
