### PR TITLE
Some new http session cookie options for WebFilter

### DIFF
--- a/hazelcast-documentation/src/main/docbook/manual/content/HttpSessionClustering.xml
+++ b/hazelcast-documentation/src/main/docbook/manual/content/HttpSessionClustering.xml
@@ -27,7 +27,7 @@
     Say you have more than one web servers (A, B, C) with a load balancer in front of them. If server A goes down
     then your users on that server will be directed to one of the live servers (B or C) but their sessions will be lost!
     So we have to have all these sessions backed up somewhere if we don't want to lose the sessions upon server crashes.
-    Hazelcast WM allows you to cluster user http sessions automatically. Followings are required for enabling
+    Hazelcast WM allows you to cluster user http sessions automatically. The following are required for enabling
     Hazelcast Session Clustering:
     <itemizedlist>
         <listitem>
@@ -96,6 +96,27 @@
     <init-param>
         <param-name>cookie-name</param-name>
         <param-value>hazelcast.sessionId</param-value>
+    </init-param>
+    <!--
+        Domain of session id cookie. Default is based on incoming request.
+    -->
+    <init-param>
+        <param-name>cookie-domain</param-name>
+        <param-value>.mywebsite.com</param-value>
+    </init-param>
+    <!--
+        Should cookie only be sent using a secure protocol? Default is false.
+    -->
+    <init-param>
+        <param-name>cookie-secure</param-name>
+        <param-value>false</param-value>
+    </init-param>
+    <!--
+        Should HttpOnly attribute be set on cookie ? Default is false.
+    -->
+    <init-param>
+        <param-name>cookie-http-only</param-name>
+        <param-value>false</param-value>
     </init-param>
     <!--
         Are you debugging? Default is false.

--- a/hazelcast-wm/src/main/java/com/hazelcast/web/WebFilter.java
+++ b/hazelcast-wm/src/main/java/com/hazelcast/web/WebFilter.java
@@ -52,6 +52,12 @@ public class WebFilter implements Filter {
 
     private String sessionCookieName = HAZELCAST_SESSION_COOKIE_NAME;
 
+    private String sessionCookieDomain = null;
+
+    private boolean sessionCookieSecure = false;
+
+    private boolean sessionCookieHttpOnly = false;
+
     private boolean stickySession = true;
 
     private boolean debug = false;
@@ -89,6 +95,18 @@ public class WebFilter implements Filter {
         String cookieName = getParam("cookie-name");
         if (cookieName != null) {
             sessionCookieName = cookieName;
+        }
+        String cookieDomain = getParam("cookie-domain");
+        if (cookieDomain != null) {
+          sessionCookieDomain = cookieDomain;
+        }
+        String cookieSecure = getParam("cookie-secure");
+        if (cookieSecure != null) {
+          sessionCookieSecure = Boolean.valueOf(cookieSecure);
+        }
+        String cookieHttpOnly = getParam("cookie-http-only");
+        if (cookieHttpOnly != null) {
+          sessionCookieHttpOnly = Boolean.valueOf(cookieHttpOnly);
         }
         String stickySessionParam = getParam("sticky-session");
         if (stickySessionParam != null) {
@@ -537,6 +555,11 @@ public class WebFilter implements Filter {
         }
         sessionCookie.setPath(path);
         sessionCookie.setMaxAge(-1);
+        if (sessionCookieDomain != null) {
+          sessionCookie.setDomain(sessionCookieDomain);
+        }
+        sessionCookie.setHttpOnly(sessionCookieHttpOnly);
+        sessionCookie.setSecure(sessionCookieSecure);
         req.res.addCookie(sessionCookie);
     }
 


### PR DESCRIPTION
Added a cookie-subdomain option. Useful for wildcard subdomains like ".mywebsite.com".
Added a cookie-secure option defaulting to false.
Added a cookie-http-only option with default false.
Updated documentation.
