### PR TITLE
Fix #337

### DIFF
--- a/hazelcast-documentation/src/main/docbook/manual/content/j2ee/TransactionInterface.xml
+++ b/hazelcast-documentation/src/main/docbook/manual/content/j2ee/TransactionInterface.xml
@@ -51,7 +51,7 @@ try {
 ]]></programlisting>
 
         Isolation is always
-        <literal>READ_COMMITTED</literal>
+        <literal>REPEATABLE_READ</literal>
         . If you are in a transaction, you can read the data in your transaction and the data that is already committed
         and if not in a transaction, you can only read the committed data. Implementation is different for queue and
         map/set. For queue operations (offer,poll), offered and/or polled objects are copied to the next member in order

--- a/hazelcast/src/main/java/com/hazelcast/core/Hazelcast.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/Hazelcast.java
@@ -299,7 +299,7 @@ public final class Hazelcast {
      *    txn.rollback();
      *  }
      * </pre>
-     * Isolation is always <tt>READ_COMMITTED</tt> . If you are in
+     * Isolation is always <tt>REPEATABLE_READ</tt> . If you are in
      * a transaction, you can read the data in your transaction and the data that
      * is already committed and if not in a transaction, you can only read the
      * committed data. Implementation is different for queue and map/set. For

--- a/hazelcast/src/main/java/com/hazelcast/core/HazelcastInstance.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/HazelcastInstance.java
@@ -163,7 +163,7 @@ public interface HazelcastInstance {
      *    txn.rollback();
      *  }
      * </pre>
-     * Isolation is always <tt>READ_COMMITTED</tt> . If you are in
+     * Isolation is always <tt>REPEATABLE_READ</tt> . If you are in
      * a transaction, you can read the data in your transaction and the data that
      * is already committed and if not in a transaction, you can only read the
      * committed data. Implementation is different for queue and map/set. For


### PR DESCRIPTION
Isolation level improvement. Hazelcast supports repeatable read instead of read committed, due to the fact that map entries are locked when they are read. So updates to these map entries are not possible and therefor.. you will see the same read every time.
