### PR TITLE
generic joiner

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
@@ -16,16 +16,6 @@
 
 package com.hazelcast.config;
 
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
-import com.hazelcast.nio.Address;
-
-import javax.xml.transform.OutputKeys;
-import javax.xml.transform.Source;
-import javax.xml.transform.Transformer;
-import javax.xml.transform.TransformerFactory;
-import javax.xml.transform.stream.StreamResult;
-import javax.xml.transform.stream.StreamSource;
 import java.io.StringReader;
 import java.io.StringWriter;
 import java.util.Collection;
@@ -33,6 +23,15 @@ import java.util.List;
 import java.util.Properties;
 import java.util.Set;
 import java.util.logging.Level;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Source;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.stream.StreamResult;
+import javax.xml.transform.stream.StreamSource;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
+import com.hazelcast.nio.Address;
 
 public class ConfigXmlGenerator {
 
@@ -131,6 +130,10 @@ public class ConfigXmlGenerator {
         xml.append("<tag-key>").append(awsConfig.getTagKey()).append("</tag-key>");
         xml.append("<tag-value>").append(awsConfig.getTagValue()).append("</tag-value>");
         xml.append("</aws>");
+        final GenericConfig genericConfig = join.getGenericConfig();
+        xml.append("<generic enabled=\"").append(genericConfig.isEnabled()).append("\">");
+        xml.append("<class-name>").append(genericConfig.getClassName()).append("</class-name>");
+        xml.append("</generic>");
         xml.append("</join>");
         final Interfaces interfaces = netCfg.getInterfaces();
         xml.append("<interfaces enabled=\"").append(interfaces.isEnabled()).append("\">");

--- a/hazelcast/src/main/java/com/hazelcast/config/GenericConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/GenericConfig.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2008-2012, Hazel Bilisim Ltd. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+public class GenericConfig {
+
+    private boolean enabled = false;
+    
+    private String className;
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+    
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public String getClassName() {
+        return className;
+    }
+
+    public GenericConfig setClassName(String className) {
+        this.className = className;
+        return this;
+    }
+
+    @Override
+    public String toString() {
+        return "GenericConfig{" + "enabled=" + enabled + ", className='" + className + '}';
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/config/Join.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/Join.java
@@ -16,11 +16,10 @@
 
 package com.hazelcast.config;
 
-import com.hazelcast.nio.DataSerializable;
-
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
+import com.hazelcast.nio.DataSerializable;
 
 public class Join implements DataSerializable {
 
@@ -29,6 +28,8 @@ public class Join implements DataSerializable {
     private TcpIpConfig tcpIpConfig = new TcpIpConfig();
 
     private AwsConfig awsConfig = new AwsConfig();
+
+    private GenericConfig genericConfig = new GenericConfig();
 
     /**
      * @return the multicastConfig
@@ -75,11 +76,28 @@ public class Join implements DataSerializable {
         return this;
     }
 
+    /**
+     * @return the genericConfig
+     */
+    public GenericConfig getGenericConfig() {
+        return genericConfig;
+    }
+
+    /**
+     * @param genericConfig the GenericConfig to set
+     */
+    public Join setGenericConfig(final GenericConfig genericConfig) {
+        this.genericConfig = genericConfig;
+        return this;
+    }
+
+    @Override
     public void writeData(DataOutput out) throws IOException {
         multicastConfig.writeData(out);
         tcpIpConfig.writeData(out);
     }
 
+    @Override
     public void readData(DataInput in) throws IOException {
         multicastConfig = new MulticastConfig();
         multicastConfig.readData(in);

--- a/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
@@ -16,18 +16,12 @@
 
 package com.hazelcast.config;
 
-import com.hazelcast.config.LoginModuleConfig.LoginModuleUsage;
-import com.hazelcast.config.MapConfig.StorageType;
-import com.hazelcast.config.PartitionGroupConfig.MemberGroupType;
-import com.hazelcast.config.PermissionConfig.PermissionType;
-import com.hazelcast.impl.Util;
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
-import org.w3c.dom.*;
-
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-import java.io.*;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.InputStream;
 import java.lang.reflect.Method;
 import java.net.URL;
 import java.util.Arrays;
@@ -35,6 +29,20 @@ import java.util.HashSet;
 import java.util.Properties;
 import java.util.Set;
 import java.util.logging.Level;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NamedNodeMap;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import com.hazelcast.config.LoginModuleConfig.LoginModuleUsage;
+import com.hazelcast.config.MapConfig.StorageType;
+import com.hazelcast.config.PartitionGroupConfig.MemberGroupType;
+import com.hazelcast.config.PermissionConfig.PermissionType;
+import com.hazelcast.impl.Util;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
 
 public class XmlConfigBuilder extends AbstractXmlConfigHelper implements ConfigBuilder {
 
@@ -114,6 +122,7 @@ public class XmlConfigBuilder extends AbstractXmlConfigHelper implements ConfigB
         }
     }
 
+    @Override
     public Config build() {
         Config config = new Config();
         config.getNetworkConfig().getJoin().getMulticastConfig().setEnabled(false);
@@ -294,6 +303,7 @@ public class XmlConfigBuilder extends AbstractXmlConfigHelper implements ConfigB
         }
     }
 
+    @Override
     protected String getTextContent(final Node node) {
         if (domLevel3) {
             return node.getTextContent();
@@ -442,6 +452,8 @@ public class XmlConfigBuilder extends AbstractXmlConfigHelper implements ConfigB
                 handleTcpIp(child);
             } else if ("aws".equals(name)) {
                 handleAWS(child);
+            } else if ("generic".equals(name)) {
+                handleGeneric(child);
             }
         }
     }
@@ -478,6 +490,24 @@ public class XmlConfigBuilder extends AbstractXmlConfigHelper implements ConfigB
         }
     }
 
+    private void handleGeneric(Node node) {
+        final Join join = config.getNetworkConfig().getJoin();
+        final NamedNodeMap atts = node.getAttributes();
+        for (int a = 0; a < atts.getLength(); a++) {
+            final Node att = atts.item(a);
+            final String value = getTextContent(att).trim();
+            if ("enabled".equalsIgnoreCase(att.getNodeName())) {
+                join.getGenericConfig().setEnabled(checkTrue(value));
+            }
+        }
+        for (org.w3c.dom.Node n : new IterableNodeList(node.getChildNodes())) {
+            final String value = getTextContent(n).trim();
+            if ("class-name".equals(cleanNodeName(n.getNodeName()))) {
+                join.getGenericConfig().setClassName(value);
+            }
+        }
+    }
+    
     private void handleMulticast(final org.w3c.dom.Node node) {
         final Join join = config.getNetworkConfig().getJoin();
         final NamedNodeMap atts = node.getAttributes();

--- a/hazelcast/src/main/resources/hazelcast-config-2.4.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-2.4.xsd
@@ -367,6 +367,14 @@
             <xs:attribute name="enabled" type="xs:boolean" use="optional" default="true"/>
         </xs:complexType>
     </xs:element>
+    <xs:element name="generic">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="class-name" minOccurs="0" maxOccurs="1"/>
+            </xs:sequence>
+            <xs:attribute name="enabled" type="xs:boolean" use="optional" default="true"/>
+        </xs:complexType>
+    </xs:element>
     <xs:element name="merge-policy" default="hz.ADD_NEW_ENTRY">
         <xs:annotation>
             <xs:documentation>

--- a/hazelcast/src/main/resources/hazelcast-default.xml
+++ b/hazelcast/src/main/resources/hazelcast-default.xml
@@ -52,6 +52,10 @@
                 <tag-key>type</tag-key>
                 <tag-value>hz-nodes</tag-value>
             </aws>
+            <generic enabled="false">
+                <!--fully qualified class name of the custom Joiner. -->
+                <class-name>com.example.hz.CustomJoiner</class-name>
+            </generic>
         </join>
         <interfaces enabled="false">
             <interface>10.10.1.*</interface>

--- a/hazelcast/src/main/resources/hazelcast-fullconfig.xml
+++ b/hazelcast/src/main/resources/hazelcast-fullconfig.xml
@@ -113,6 +113,10 @@
                 <tag-key>type</tag-key>
                 <tag-value>hz-nodes</tag-value>
             </aws>
+            <generic enabled="false">
+                <!--fully qualified class name of the custom Joiner. -->
+                <class-name>com.example.hz.CustomJoiner</class-name>
+            </generic>
         </join>
         <interfaces enabled="false">
             <interface>10.10.1.*</interface>


### PR DESCRIPTION
Some minor changes that allows the integration of a custom joiner that is instantiated similar to the AWS joiner. 

Besides the existing joiners, the class name of a generic joiner can be configured in hazelcast.xml. No additional configuration is done here, i.e. further configuration is handled by the custom joiner internally.

If the class defines a public constructor that takes a Node as argument, the joiner is instantiated using this constructor, otherwise the instance is created using the default constructor.
