### PR TITLE
Overloading IMap.set(key, value)

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/MapClientProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/MapClientProxy.java
@@ -297,6 +297,10 @@ public class MapClientProxy<K, V> implements IMap<K, V>, EntryHolder {
         return (V) proxyHelper.doOp(ClusterOperation.CONCURRENT_MAP_PUT, key, value, ttl, timeunit);
     }
 
+    public void set(K key, V value) {
+        set(key, value, 0, TimeUnit.SECONDS);
+    }
+
     public void set(K key, V value, long ttl, TimeUnit timeunit) {
         check(key);
         check(value);

--- a/hazelcast/src/main/java/com/hazelcast/core/IMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/IMap.java
@@ -423,6 +423,21 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, Instance {
     V replace(K key, V value);
 
     /**
+     * Puts an entry into this map with ttl (time to live) set to 0.
+     * This means that the entry lives forever. Similar to put operation except that set
+     * doesn't return the old value which is more efficient.
+     * <p/>
+     * <p><b>Warning:</b></p>
+     * This method uses <tt>hashCode</tt> and <tt>equals</tt> of binary form of
+     * the <tt>key</tt>, not the actual implementations of <tt>hashCode</tt> and <tt>equals</tt>
+     * defined in <tt>key</tt>'s class.
+     *
+     * @param key      key of the entry
+     * @param value    value of the entry
+     */
+    void set(K key, V value);
+
+    /**
      * Puts an entry into this map with a given ttl (time to live) value.
      * Entry will expire and get evicted after the ttl. If ttl is 0, then
      * the entry lives forever. Similar to put operation except that set
@@ -438,7 +453,6 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, Instance {
      * @param ttl      maximum time for this entry to stay in the map
      *                 0 means infinite.
      * @param timeunit time unit for the ttl
-     * @return old value of the entry
      */
     void set(K key, V value, long ttl, TimeUnit timeunit);
 

--- a/hazelcast/src/main/java/com/hazelcast/impl/MProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/impl/MProxyImpl.java
@@ -242,6 +242,10 @@ public class MProxyImpl extends FactoryAwareNamedProxy implements MProxy, DataSe
         return dynamicProxy.tryPut(key, value, time, timeunit);
     }
 
+    public void set(Object key, Object value) {
+        dynamicProxy.set(key, value);
+    }
+
     public void set(Object key, Object value, long time, TimeUnit timeunit) {
         dynamicProxy.set(key, value, time, timeunit);
     }
@@ -634,6 +638,10 @@ public class MProxyImpl extends FactoryAwareNamedProxy implements MProxy, DataSe
             mapOperationCounter.incrementPuts(Clock.currentTimeMillis() - begin);
             return result;
         }
+
+		public void set(Object key, Object value) {
+			set(key, value, 0, TimeUnit.SECONDS);
+		}
 
         public void set(Object key, Object value, long ttl, TimeUnit timeunit) {
             long begin = Clock.currentTimeMillis();

--- a/hazelcast/src/test/java/com/hazelcast/core/HazelcastTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/core/HazelcastTest.java
@@ -215,6 +215,23 @@ public class HazelcastTest {
         map.set("1", "value", 1, TimeUnit.SECONDS);
     }
 
+	@Test
+	public void testSetOverloaded() {
+		IMap<String, String> map = Hazelcast.getMap("testSetOverloaded");
+		map.set("1", "value", 0, TimeUnit.SECONDS);
+
+		MapEntry one = map.getMapEntry("1");
+		assertEquals("1", one.getKey());
+		assertEquals("value", one.getValue());
+
+		map.remove("1");
+
+		map.set("1", "value");
+		MapEntry overloaded = map.getMapEntry("1");
+		assertEquals(overloaded.getKey(), one.getKey());
+		assertEquals(overloaded.getValue(), one.getValue());
+	}
+
     @Test
     public void testAtomicLong() {
         AtomicNumber an = Hazelcast.getAtomicNumber("testAtomicLong");


### PR DESCRIPTION
Based on Enes Akar blog post, I thought overloading IMap.set passing only key and value, like IMap.put, is a lot easier and beautiful than current 4 parameters.

http://blog.codepoly.com/hazelcast-tip-use-mapset-instead-of-mapput
