### PR TITLE
Remove data from map when merge policy returns REMOVE_EXISTING 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,24 @@
-This is just a private FORK of Hazelcast.
+## Hazelcast is a clustering and highly scalable data distribution platform for Java.
 
-Please consult the master branch at https://github.com/hazelcast/hazelcast.
+With its various distributed data structures, distributed caching capabilities, elastic nature, memcache support,
+integration with Spring and Hibernate and more importantly with so many happy users, Hazelcast is feature-rich,
+enterprise-ready and developer-friendly in-memory data grid solution.
+
+### Features:
+
+* Distributed implementations of `java.util.{Queue, Set, List, Map}`
+* Distributed implementation of `java.util.concurrency.locks.Lock`
+* Distributed implementation of `java.util.concurrent.ExecutorService`
+* Distributed `MultiMap` for one-to-many relationships
+* Distributed `Topic` for publish/subscribe messaging
+* Transaction support and J2EE container integration via JCA
+* Socket level encryption support for secure clusters
+* Synchronous (write-through) and asynchronous (write-behind) persistence
+* Second level cache provider for Hibernate
+* Monitoring and management of the cluster via JMX
+* Dynamic HTTP session clustering
+* Support for cluster info and membership events
+* Dynamic discovery, scaling, partitioning with backups and fail-over
+
 
 Visit [www.hazelcast.com](http://www.hazelcast.com/) for more info.


### PR DESCRIPTION
Hi,

I patched the com.hazelcast.impl.ConcurrentMapManager.MergeOperationHandler.MergeLoader.doMapStoreOperation() so that it checks if the winner of the merge() call on the active MergePolicy is MergePolicy.REMOVE_EXISTING. If so it removes the object from the map.

I'm not sure if this was a bug. I found it when I implemented a custom merge policy that returned a MergePolicy.REMOVE_EXISTING object. When it was executed I got a strange serialization exception that says that the REMOVE_EXISTING Object was not serializable (which is obviously true). So I checked the Hazelcast code in ConcurrentMapManager and found out, that the merge-method of MergePolicy has 2 call references, of which only one checks if the result is a REMOVE_EXISTING instance. So I patched the other one and tested it. For me that works now.

Cheers,
Michael
