### PR TITLE
Restore Hazelcast to functioning on Servlet specs before 3.0

### DIFF
--- a/hazelcast-wm/src/main/java/com/hazelcast/web/WebFilter.java
+++ b/hazelcast-wm/src/main/java/com/hazelcast/web/WebFilter.java
@@ -550,7 +550,11 @@ public class WebFilter implements Filter {
         if (sessionCookieDomain != null) {
             sessionCookie.setDomain(sessionCookieDomain);
         }
-        sessionCookie.setHttpOnly(sessionCookieHttpOnly);
+		try {
+			sessionCookie.setHttpOnly(sessionCookieHttpOnly);
+		} catch (NoSuchMethodError e) {
+			// must be servlet spec before 3.0, don't worry about it!
+		}
         sessionCookie.setSecure(sessionCookieSecure);
         req.res.addCookie(sessionCookie);
     }


### PR DESCRIPTION
Ignoring the error for httpOnly on cookies so Hazelcast can continue to work on servlet specs before 3.0.
