### PR TITLE
Hazelcast Client NearCache is only working if Maximum Size is defined which is not default

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/GuavaNearCacheImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/GuavaNearCacheImpl.java
@@ -30,7 +30,8 @@ public class GuavaNearCacheImpl<K,V> implements NearCache<K,V> {
 
     public GuavaNearCacheImpl(NearCacheConfig nc, final MapClientProxy<K,V> map) {
         this.map = map;
-        CacheBuilder cacheBuilder = CacheBuilder.newBuilder().maximumSize(nc.getMaxSize());
+        CacheBuilder cacheBuilder = CacheBuilder.newBuilder();
+        if (nc.getMaxSize() > 0) cacheBuilder.maximumSize(nc.getMaxSize());
         if (nc.getTimeToLiveSeconds() > 0)
             cacheBuilder.expireAfterWrite(nc.getTimeToLiveSeconds(), TimeUnit.SECONDS);
         if (nc.getMaxIdleSeconds() > 0) cacheBuilder.expireAfterAccess(nc.getMaxIdleSeconds(), TimeUnit.SECONDS);


### PR DESCRIPTION
Hazelcast & Guava have a different behaviour if maximum cache size is zero (Hazelcast default). Hazelcast has no limit and Guava Cache is not working at all.

This patch sets the maximum size only if the size is greater than zero. 
