### PR TITLE
Fix for issue #466

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/HazelcastClient.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/HazelcastClient.java
@@ -313,9 +313,9 @@ public class HazelcastClient implements HazelcastInstance {
     void doShutdown() {
         if (active.compareAndSet(true, false)) {
             logger.log(Level.INFO, "HazelcastClient[" + this.id + "] is shutting down.");
-            connectionManager.shutdown();
             out.shutdown();
             in.shutdown();
+            connectionManager.shutdown();
             listenerManager.shutdown();
             ClientThreadContext.shutdown();
             lsClients.remove(HazelcastClient.this);


### PR DESCRIPTION
Changed the execution order so that the connection manager is shut down after the runnables are, this should avoid the reconnection attempt and deadlock.

I tested this on our setup that used to hang and upon client shutdown and it's working now. It'd be great if this could be released in a 2.5.1 version.
