### PR TITLE
Added SerializationConfig for supporting custom serialization in HazelcastClient connections

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/HazelcastClient.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/HazelcastClient.java
@@ -80,7 +80,7 @@ public final class HazelcastClient implements HazelcastInstance {
     private final ClientConfig config;
     private final ThreadGroup threadGroup;
     private final LifecycleServiceImpl lifecycleService;
-    private final SerializationServiceImpl serializationService = (SerializationServiceImpl) new SerializationServiceBuilder().build();
+    private final SerializationServiceImpl serializationService;
     private final ClientConnectionManager connectionManager;
     private final ClientClusterServiceImpl clusterService;
     private final ClientPartitionServiceImpl partitionService;
@@ -98,6 +98,8 @@ public final class HazelcastClient implements HazelcastInstance {
         proxyManager = new ProxyManager(this);
         executionService = new ClientExecutionServiceImpl(name, threadGroup, Thread.currentThread().getContextClassLoader());
         clusterService = new ClientClusterServiceImpl(this);
+        serializationService = (SerializationServiceImpl) new SerializationServiceBuilder()
+            .setClassLoader( config.getClassLoader() ).setConfig( config.getSerializationConfig() ).build();
         LoadBalancer loadBalancer = config.getLoadBalancer();
         if (loadBalancer == null) {
             loadBalancer = new RoundRobinLB();

--- a/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientConfig.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientConfig.java
@@ -19,6 +19,7 @@ package com.hazelcast.client.config;
 import com.hazelcast.client.LoadBalancer;
 import com.hazelcast.client.util.RoundRobinLB;
 import com.hazelcast.config.GroupConfig;
+import com.hazelcast.config.SerializationConfig;
 import com.hazelcast.nio.SocketInterceptor;
 import com.hazelcast.security.Credentials;
 import com.hazelcast.security.UsernamePasswordCredentials;
@@ -96,7 +97,8 @@ public class ClientConfig {
 
     private final SocketOptions socketOptions = new SocketOptions();
 
-
+    private final SerializationConfig serializationConfig = new SerializationConfig();
+    
     private final ProxyFactoryConfig proxyFactoryConfig = new ProxyFactoryConfig();
 
     /**
@@ -104,6 +106,8 @@ public class ClientConfig {
      */
     private SocketInterceptor socketInterceptor = null;
 
+    private ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+    
     /**
      * Can be used instead of {@link GroupConfig} in Hazelcast EE.
      */
@@ -240,7 +244,20 @@ public class ClientConfig {
         return socketOptions;
     }
 
+    public ClassLoader getClassLoader() {
+        return classLoader;
+    }
+
+    public void setClassLoader(ClassLoader classLoader) {
+        this.classLoader = classLoader;
+    }
+
     public ProxyFactoryConfig getProxyFactoryConfig() {
         return proxyFactoryConfig;
+    }
+
+    public SerializationConfig getSerializationConfig()
+    {
+        return serializationConfig;
     }
 }


### PR DESCRIPTION
Since HazelcastClient and ClientConfig does not feature custom serialization support I added the config for defining SerializationConfig and ClassLoader in ClientConfig and made creation of SerializationService aware of them.
