### PR TITLE
allow proxied clustering

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/impl/Node.java
+++ b/hazelcast/src/main/java/com/hazelcast/impl/Node.java
@@ -168,7 +168,7 @@ public class Node {
         clusterService = new ClusterService(this);
         clusterService.start();
         executorManager = new ExecutorManager(this);
-        connectionManager = new ConnectionManager(new NodeIOService(this), serverSocketChannel);
+        connectionManager = new ConnectionManager(this, new NodeIOService(this), serverSocketChannel);
         clusterManager = new ClusterManager(this);
         clientHandlerService = new ClientHandlerService(this);
         concurrentMapManager = new ConcurrentMapManager(this);

--- a/hazelcast/src/main/java/com/hazelcast/nio/ConnectionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/ConnectionManager.java
@@ -20,6 +20,7 @@ import com.hazelcast.cluster.Bind;
 import com.hazelcast.config.SSLConfig;
 import com.hazelcast.config.SocketInterceptorConfig;
 import com.hazelcast.impl.ClusterOperation;
+import com.hazelcast.impl.Node;
 import com.hazelcast.impl.ThreadContext;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.ssl.BasicSSLContextFactory;
@@ -88,8 +89,11 @@ public class ConnectionManager {
     private final LinkedList<Integer> outboundPorts = new LinkedList<Integer>();  // accessed only in synchronized block
 
     private Thread socketAcceptorThread; // accessed only in synchronized block
+    
+    private Node node;
 
-    public ConnectionManager(IOService ioService, ServerSocketChannel serverSocketChannel) {
+    public ConnectionManager(Node node, IOService ioService, ServerSocketChannel serverSocketChannel) {
+    	this.node = node;
         this.ioService = ioService;
         this.serverSocketChannel = serverSocketChannel;
         this.logger = ioService.getLogger(ConnectionManager.class.getName());
@@ -184,6 +188,10 @@ public class ConnectionManager {
 
     public IOService getIOHandler() {
         return ioService;
+    }
+    
+    public Node getNode() {
+    	return node;
     }
 
     public MemberSocketInterceptor getMemberSocketInterceptor() {

--- a/hazelcast/src/main/java/com/hazelcast/nio/SocketConnector.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/SocketConnector.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.nio;
 
+import com.hazelcast.config.Config;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.util.AddressUtil;
 
@@ -88,12 +89,23 @@ public class SocketConnector implements Runnable {
             connectionManager.failedConnection(address, e, silent);
         }
     }
+    
+    private boolean bindClientSocket(Config config) throws UnknownHostException {
+    	String bind = config.getProperty("hazelcast.local.bindClientSocket");
+    	
+    	if (bind != null && bind.trim().length() > 0)
+    		return Boolean.parseBoolean(bind);
+    	else
+    		return true;
+    }
 
     private void tryToConnect(final InetSocketAddress socketAddress, final int timeout)
             throws Exception {
         final SocketChannel socketChannel = SocketChannel.open();
         connectionManager.initSocket(socketChannel.socket());
-        bindSocket(socketChannel);
+        
+        if (bindClientSocket(connectionManager.getNode().getConfig()))
+        		bindSocket(socketChannel);
         final String message = "Connecting to " + socketAddress
                                + ", timeout: " + timeout
                                + ", bind-any: " + connectionManager.ioService.isSocketBindAny();


### PR DESCRIPTION
In order to support proxied clustering:
1) There needs to be separate configuration for the address used to bind and the address sent to other nodes for communication back
2) Client sockets cannot be explicitly bound if the local bind address is a loopback and the destination is a remote address.

The driver for this request is using Hazelcast (under Vert.x) on OpenShift.
