### PR TITLE
If generated ObjectOutputStream.pos < 1024 after writing all data a OOS....

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/DefaultSerializers.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/DefaultSerializers.java
@@ -133,6 +133,8 @@ public class DefaultSerializers {
             out.writeUTF(obj.getClass().getName());
             final ObjectOutputStream objectOutputStream = new ObjectOutputStream((OutputStream) out);
             obj.writeExternal(objectOutputStream);
+            // Force flush if not yet written due to internal behavior if pos < 1024
+            objectOutputStream.flush();
         }
     }
 
@@ -181,6 +183,8 @@ public class DefaultSerializers {
             } else {
                 objectOutputStream.writeUnshared(obj);
             }
+            // Force flush if not yet written due to internal behavior if pos < 1024
+            objectOutputStream.flush();
         }
     }
 


### PR DESCRIPTION
...flush() is needed to write the cached data to the ObjectDataOutput.
