### PR TITLE
For some reason, the SPI entries in the hazelcast jar are getting loaded...

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/DataSerializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/DataSerializer.java
@@ -62,7 +62,7 @@ final class DataSerializer implements StreamSerializer<DataSerializable> {
     private void register(int factoryId, DataSerializableFactory factory) {
         final DataSerializableFactory current = factories.get(factoryId);
         if (current != null && current != factory) {
-            throw new IllegalArgumentException("DataSerializableFactory[" + factoryId + "] is already registered! " + current + " -> " + factory);
+//            throw new IllegalArgumentException("DataSerializableFactory[" + factoryId + "] is already registered! " + current + " -> " + factory);
         }
         factories.put(factoryId, factory);
     }

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/PortableHookLoader.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/PortableHookLoader.java
@@ -75,7 +75,7 @@ final class PortableHookLoader {
     private void register(int factoryId, PortableFactory factory) {
         final PortableFactory current = factories.get(factoryId);
         if (current != null && current != factory) {
-            throw new IllegalArgumentException("PortableFactory[" + factoryId + "] is already registered! " + current + " -> " + factory);
+            //throw new IllegalArgumentException("PortableFactory[" + factoryId + "] is already registered! " + current + " -> " + factory);
         }
         factories.put(factoryId, factory);
     }

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/SerializationServiceBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/SerializationServiceBuilder.java
@@ -209,7 +209,7 @@ public final class SerializationServiceBuilder {
                 throw new IllegalArgumentException("DataSerializableFactory factoryId must be positive! -> " + entry.getValue());
             }
             if (dataSerializableFactories.containsKey(entry.getKey())) {
-                throw new IllegalArgumentException("DataSerializableFactory with factoryId '" + entry.getKey() + "' is already registered!");
+//                throw new IllegalArgumentException("DataSerializableFactory with factoryId '" + entry.getKey() + "' is already registered!");
             }
             dataSerializableFactories.put(entry.getKey(), entry.getValue());
         }
@@ -239,7 +239,7 @@ public final class SerializationServiceBuilder {
                 throw new IllegalArgumentException("PortableFactory factoryId must be positive! -> " + entry.getValue());
             }
             if (portableFactories.containsKey(entry.getKey())) {
-                throw new IllegalArgumentException("PortableFactory with factoryId '" + entry.getKey() + "' is already registered!");
+//                throw new IllegalArgumentException("PortableFactory with factoryId '" + entry.getKey() + "' is already registered!");
             }
             portableFactories.put(entry.getKey(), entry.getValue());
         }
@@ -250,7 +250,7 @@ public final class SerializationServiceBuilder {
                 throw new IllegalArgumentException("PortableFactory factoryId must be positive! -> " + entry.getValue());
             }
             if (portableFactories.containsKey(entry.getKey())) {
-                throw new IllegalArgumentException("PortableFactory with factoryId '" + entry.getKey() + "' is already registered!");
+//                throw new IllegalArgumentException("PortableFactory with factoryId '" + entry.getKey() + "' is already registered!");
             }
             PortableFactory f;
             try {

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/SerializationServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/SerializationServiceImpl.java
@@ -312,7 +312,7 @@ public final class SerializationServiceImpl implements SerializationService {
 
     public void registerGlobal(final Serializer serializer) {
         if (!global.compareAndSet(null, createSerializerAdapter(serializer))) {
-            throw new IllegalStateException("Fallback serializer is already registered!");
+//            throw new IllegalStateException("Fallback serializer is already registered!");
         }
     }
 


### PR DESCRIPTION
... and registered in my OSGi container (equinox) before I have created an instance.  So when I do create a HazelcastInstance, I get exceptions about them already being registered.  I don't think I see any benefit to throwing an exception if they are already registered (ignoring it should be fine right?).  Currently, I commented out the exception throws lines so I can get past the issue, but I'm hoping that maybe a warning could be logged instead since I think logging and ignoring the situation would cause no harm.
