### PR TITLE
extra method on Logger that accepts a class

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/LifecycleServiceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/LifecycleServiceImpl.java
@@ -56,7 +56,7 @@ public final class LifecycleServiceImpl implements LifecycleService {
     }
 
     private ILogger getLogger() {
-        return Logger.getLogger(LifecycleService.class.getName());
+        return Logger.getLogger(LifecycleService.class);
     }
 
     public String addLifecycleListener(LifecycleListener lifecycleListener) {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/config/XmlClientConfigBuilder.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/config/XmlClientConfigBuilder.java
@@ -42,7 +42,7 @@ import java.util.logging.Level;
 
 public class XmlClientConfigBuilder extends AbstractXmlConfigHelper {
 
-    private final ILogger logger = Logger.getLogger(XmlClientConfigBuilder.class.getName());
+    private final ILogger logger = Logger.getLogger(XmlClientConfigBuilder.class);
 
     private ClientConfig clientConfig;
     private InputStream in;

--- a/hazelcast-cloud/src/main/java/com/hazelcast/aws/utility/CloudyUtility.java
+++ b/hazelcast-cloud/src/main/java/com/hazelcast/aws/utility/CloudyUtility.java
@@ -37,7 +37,7 @@ import java.util.logging.Level;
 import static com.hazelcast.config.AbstractXmlConfigHelper.cleanNodeName;
 
 public class CloudyUtility {
-    final static ILogger logger = Logger.getLogger(CloudyUtility.class.getName());
+    final static ILogger logger = Logger.getLogger(CloudyUtility.class);
 
     public static String getQueryString(Map<String, String> attributes) {
         StringBuilder query = new StringBuilder();

--- a/hazelcast-hibernate/hazelcast-hibernate3/src/main/java/com/hazelcast/hibernate/AbstractHazelcastCacheRegionFactory.java
+++ b/hazelcast-hibernate/hazelcast-hibernate3/src/main/java/com/hazelcast/hibernate/AbstractHazelcastCacheRegionFactory.java
@@ -33,7 +33,7 @@ import java.util.logging.Level;
 
 public abstract class AbstractHazelcastCacheRegionFactory implements RegionFactory {
 
-    private final ILogger LOG = Logger.getLogger(getClass().getName());
+    private final ILogger LOG = Logger.getLogger(getClass());
 
     private IHazelcastInstanceLoader instanceLoader = null;
     protected HazelcastInstance instance;

--- a/hazelcast-hibernate/hazelcast-hibernate3/src/main/java/com/hazelcast/hibernate/instance/HazelcastAccessor.java
+++ b/hazelcast-hibernate/hazelcast-hibernate3/src/main/java/com/hazelcast/hibernate/instance/HazelcastAccessor.java
@@ -33,7 +33,7 @@ import java.util.logging.Level;
  */
 public final class HazelcastAccessor {
 
-    static final ILogger logger = Logger.getLogger(HazelcastAccessor.class.getName());
+    static final ILogger logger = Logger.getLogger(HazelcastAccessor.class);
 
     /**
      * Tries to extract <code>HazelcastInstance</code> from <code>Session</code>.

--- a/hazelcast-hibernate/hazelcast-hibernate3/src/main/java/com/hazelcast/hibernate/instance/HazelcastClientLoader.java
+++ b/hazelcast-hibernate/hazelcast-hibernate3/src/main/java/com/hazelcast/hibernate/instance/HazelcastClientLoader.java
@@ -32,7 +32,7 @@ import java.util.logging.Level;
 
 class HazelcastClientLoader implements IHazelcastInstanceLoader {
 
-    private final static ILogger logger = Logger.getLogger(HazelcastInstanceFactory.class.getName());
+    private final static ILogger logger = Logger.getLogger(HazelcastInstanceFactory.class);
 
     private final Properties props = new Properties();
     private HazelcastInstance client;

--- a/hazelcast-hibernate/hazelcast-hibernate3/src/main/java/com/hazelcast/hibernate/instance/HazelcastInstanceLoader.java
+++ b/hazelcast-hibernate/hazelcast-hibernate3/src/main/java/com/hazelcast/hibernate/instance/HazelcastInstanceLoader.java
@@ -34,7 +34,7 @@ import java.util.logging.Level;
 
 class HazelcastInstanceLoader implements IHazelcastInstanceLoader {
 
-    private final static ILogger logger = Logger.getLogger(HazelcastInstanceFactory.class.getName());
+    private final static ILogger logger = Logger.getLogger(HazelcastInstanceFactory.class);
 
     private final Properties props = new Properties();
     private String instanceName = null;

--- a/hazelcast-hibernate/hazelcast-hibernate3/src/test/java/com/hazelcast/hibernate/HibernateTestSupport.java
+++ b/hazelcast-hibernate/hazelcast-hibernate3/src/test/java/com/hazelcast/hibernate/HibernateTestSupport.java
@@ -32,7 +32,7 @@ import java.util.logging.Level;
 
 public abstract class HibernateTestSupport {
 
-    private final ILogger logger = Logger.getLogger(getClass().getName());
+    private final ILogger logger = Logger.getLogger(getClass());
 
     @BeforeClass
     @AfterClass

--- a/hazelcast-hibernate/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/AbstractHazelcastCacheRegionFactory.java
+++ b/hazelcast-hibernate/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/AbstractHazelcastCacheRegionFactory.java
@@ -36,7 +36,7 @@ import java.util.logging.Level;
 
 public abstract class AbstractHazelcastCacheRegionFactory implements RegionFactory {
 
-    private final ILogger LOG = Logger.getLogger(getClass().getName());
+    private final ILogger LOG = Logger.getLogger(getClass());
 
     private IHazelcastInstanceLoader instanceLoader = null;
     protected HazelcastInstance instance;

--- a/hazelcast-hibernate/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/instance/HazelcastAccessor.java
+++ b/hazelcast-hibernate/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/instance/HazelcastAccessor.java
@@ -33,7 +33,7 @@ import java.util.logging.Level;
  */
 public final class HazelcastAccessor {
 
-    static final ILogger logger = Logger.getLogger(HazelcastAccessor.class.getName());
+    static final ILogger logger = Logger.getLogger(HazelcastAccessor.class);
 
     /**
      * Tries to extract <code>HazelcastInstance</code> from <code>Session</code>.

--- a/hazelcast-hibernate/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/instance/HazelcastClientLoader.java
+++ b/hazelcast-hibernate/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/instance/HazelcastClientLoader.java
@@ -32,7 +32,7 @@ import java.util.logging.Level;
 
 class HazelcastClientLoader implements IHazelcastInstanceLoader {
 
-    private final static ILogger logger = Logger.getLogger(HazelcastInstanceFactory.class.getName());
+    private final static ILogger logger = Logger.getLogger(HazelcastInstanceFactory.class);
 
     private final Properties props = new Properties();
     private HazelcastInstance client;

--- a/hazelcast-hibernate/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/instance/HazelcastInstanceLoader.java
+++ b/hazelcast-hibernate/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/instance/HazelcastInstanceLoader.java
@@ -34,7 +34,7 @@ import java.util.logging.Level;
 
 class HazelcastInstanceLoader implements IHazelcastInstanceLoader {
 
-    private final static ILogger logger = Logger.getLogger(HazelcastInstanceFactory.class.getName());
+    private final static ILogger logger = Logger.getLogger(HazelcastInstanceFactory.class);
 
     private final Properties props = new Properties();
     private String instanceName = null;

--- a/hazelcast-hibernate/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/HibernateTestSupport.java
+++ b/hazelcast-hibernate/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/HibernateTestSupport.java
@@ -32,7 +32,7 @@ import java.util.logging.Level;
 
 public abstract class HibernateTestSupport {
 
-    private final ILogger logger = Logger.getLogger(getClass().getName());
+    private final ILogger logger = Logger.getLogger(getClass());
 
     @BeforeClass
     @AfterClass

--- a/hazelcast-wm/src/main/java/com/hazelcast/web/HazelcastInstanceLoader.java
+++ b/hazelcast-wm/src/main/java/com/hazelcast/web/HazelcastInstanceLoader.java
@@ -39,7 +39,7 @@ import java.util.logging.Level;
 
 class HazelcastInstanceLoader {
 
-    private final static ILogger logger = Logger.getLogger(HazelcastInstanceLoader.class.getName());
+    private final static ILogger logger = Logger.getLogger(HazelcastInstanceLoader.class);
     public static final String INSTANCE_NAME = "instance-name";
     public static final String CONFIG_LOCATION = "config-location";
     public static final String USE_CLIENT = "use-client";

--- a/hazelcast-wm/src/main/java/com/hazelcast/web/WebFilter.java
+++ b/hazelcast-wm/src/main/java/com/hazelcast/web/WebFilter.java
@@ -39,7 +39,7 @@ import static com.hazelcast.web.HazelcastInstanceLoader.*;
 
 public class WebFilter implements Filter {
 
-    private static final ILogger logger = Logger.getLogger(WebFilter.class.getName());
+    private static final ILogger logger = Logger.getLogger(WebFilter.class);
 
     private static final String HAZELCAST_REQUEST = "*hazelcast-request";
 

--- a/hazelcast/src/main/java/com/hazelcast/config/ClasspathXmlConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ClasspathXmlConfig.java
@@ -24,7 +24,7 @@ import java.util.logging.Level;
 
 public class ClasspathXmlConfig extends Config {
 
-    private final ILogger logger = Logger.getLogger(ClasspathXmlConfig.class.getName());
+    private final ILogger logger = Logger.getLogger(ClasspathXmlConfig.class);
 
     public ClasspathXmlConfig() {
     }

--- a/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
@@ -36,7 +36,7 @@ import java.util.logging.Level;
 public class ConfigXmlGenerator {
 
     private final boolean formatted;
-    final ILogger logger = Logger.getLogger(this.getClass().getName());
+    final ILogger logger = Logger.getLogger(this.getClass());
 
     public ConfigXmlGenerator() {
         this(true);

--- a/hazelcast/src/main/java/com/hazelcast/config/FileSystemXmlConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/FileSystemXmlConfig.java
@@ -27,7 +27,7 @@ import java.util.logging.Level;
 
 public class FileSystemXmlConfig extends Config {
 
-    private final ILogger logger = Logger.getLogger(FileSystemXmlConfig.class.getName());
+    private final ILogger logger = Logger.getLogger(FileSystemXmlConfig.class);
 
     public FileSystemXmlConfig() {
     }

--- a/hazelcast/src/main/java/com/hazelcast/config/InMemoryXmlConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/InMemoryXmlConfig.java
@@ -25,7 +25,7 @@ import java.util.logging.Level;
 
 public class InMemoryXmlConfig extends Config {
 
-    private final ILogger logger = Logger.getLogger(InMemoryXmlConfig.class.getName());
+    private final ILogger logger = Logger.getLogger(InMemoryXmlConfig.class);
 
     public InMemoryXmlConfig() {
     }

--- a/hazelcast/src/main/java/com/hazelcast/config/UrlXmlConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/UrlXmlConfig.java
@@ -27,7 +27,7 @@ import java.util.logging.Level;
 
 public class UrlXmlConfig extends Config {
 
-    private final ILogger logger = Logger.getLogger(UrlXmlConfig.class.getName());
+    private final ILogger logger = Logger.getLogger(UrlXmlConfig.class);
 
     public UrlXmlConfig() {
     }

--- a/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
@@ -46,7 +46,7 @@ import java.util.logging.Level;
 
 public class XmlConfigBuilder extends AbstractXmlConfigHelper implements ConfigBuilder {
 
-    private final ILogger logger = Logger.getLogger(XmlConfigBuilder.class.getName());
+    private final ILogger logger = Logger.getLogger(XmlConfigBuilder.class);
     private Config config;
     private InputStream in;
     private File configurationFile;

--- a/hazelcast/src/main/java/com/hazelcast/instance/DefaultAddressPicker.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/DefaultAddressPicker.java
@@ -40,7 +40,7 @@ class DefaultAddressPicker implements AddressPicker {
 
     public DefaultAddressPicker(Node node) {
         this.node = node;
-        this.logger = Logger.getLogger(DefaultAddressPicker.class.getName());
+        this.logger = Logger.getLogger(DefaultAddressPicker.class);
     }
 
     public void pickAddress() throws Exception {

--- a/hazelcast/src/main/java/com/hazelcast/instance/NodeInitializerFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/NodeInitializerFactory.java
@@ -24,7 +24,7 @@ import java.util.logging.Level;
 
 public final class NodeInitializerFactory {
 
-    private static final ILogger logger = Logger.getLogger(NodeInitializerFactory.class.getName());
+    private static final ILogger logger = Logger.getLogger(NodeInitializerFactory.class);
     private static final String FACTORY_ID = "com.hazelcast.NodeInitializer";
 
     public static NodeInitializer create(ClassLoader classLoader) {

--- a/hazelcast/src/main/java/com/hazelcast/logging/Logger.java
+++ b/hazelcast/src/main/java/com/hazelcast/logging/Logger.java
@@ -22,6 +22,10 @@ public final class Logger {
     private static volatile LoggerFactory loggerFactory = null;
     private static final Object factoryLock = new Object();
 
+    public static ILogger getLogger(Class clazz){
+        return getLogger(clazz.getName());
+    }
+
     public static ILogger getLogger(String name) {
         //noinspection DoubleCheckedLocking
         if (loggerFactory == null) {

--- a/hazelcast/src/main/java/com/hazelcast/management/ThreadDumpGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/management/ThreadDumpGenerator.java
@@ -25,7 +25,7 @@ import java.util.logging.Level;
 
 public class ThreadDumpGenerator {
 
-    protected static final ILogger logger = Logger.getLogger(ThreadDumpGenerator.class.getName());
+    protected static final ILogger logger = Logger.getLogger(ThreadDumpGenerator.class);
 
     public static ThreadDumpGenerator newInstance() {
         return newInstance(ManagementFactory.getThreadMXBean());

--- a/hazelcast/src/main/java/com/hazelcast/nio/CipherHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/CipherHelper.java
@@ -33,7 +33,7 @@ import java.util.logging.Level;
 final class CipherHelper {
     private static SymmetricCipherBuilder symmetricCipherBuilder = null;
 
-    final static ILogger logger = Logger.getLogger(CipherHelper.class.getName());
+    final static ILogger logger = Logger.getLogger(CipherHelper.class);
 
     static {
         try {

--- a/hazelcast/src/main/java/com/hazelcast/partition/PartitionStateGeneratorImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/PartitionStateGeneratorImpl.java
@@ -27,7 +27,7 @@ import java.util.logging.Level;
 
 class PartitionStateGeneratorImpl implements PartitionStateGenerator {
 
-    private static final ILogger logger = Logger.getLogger(PartitionStateGenerator.class.getName());
+    private static final ILogger logger = Logger.getLogger(PartitionStateGenerator.class);
     private static final float RANGE_CHECK_RATIO = 1.1f;
     private static final int MAX_RETRY_COUNT = 3;
     private static final int AGGRESSIVE_RETRY_THRESHOLD = 1;

--- a/hazelcast/src/main/java/com/hazelcast/spi/Operation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/Operation.java
@@ -221,7 +221,7 @@ public abstract class Operation implements DataSerializable {
 
     protected final ILogger getLogger() {
         final NodeEngine ne = nodeEngine;
-        return ne != null ? ne.getLogger(getClass()) : Logger.getLogger(getClass().getName());
+        return ne != null ? ne.getLogger(getClass()) : Logger.getLogger(getClass());
     }
 
     public void logError(Throwable e) {

--- a/hazelcast/src/main/java/com/hazelcast/util/ServiceLoader.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/ServiceLoader.java
@@ -33,7 +33,7 @@ import java.util.logging.Level;
  */
 public class ServiceLoader {
 
-    private static final ILogger logger = Logger.getLogger(ServiceLoader.class.getName());
+    private static final ILogger logger = Logger.getLogger(ServiceLoader.class);
 
     public static <T> T load(Class<T> clazz, String factoryId, ClassLoader classLoader) throws Exception {
         final Iterator<T> iter = iterator(clazz, factoryId, classLoader);


### PR DESCRIPTION
- add an overloaded method to the Logger that accepts a class instead of...a String, this makes creating a Logger simpler since instead of
  
  ILogger logger = Logger.getLogger(Foo.class.getName())

one can write

```
ILogger logger = Logger.getLogger(Foo.class)
```
- also changed the existing call to make use of this overloaded method.
