### PR TITLE
Made loggers static where possible

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/config/XmlClientConfigBuilder.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/config/XmlClientConfigBuilder.java
@@ -42,7 +42,7 @@ import java.util.logging.Level;
 
 public class XmlClientConfigBuilder extends AbstractXmlConfigHelper {
 
-    private final ILogger logger = Logger.getLogger(XmlClientConfigBuilder.class.getName());
+    private final static ILogger logger = Logger.getLogger(XmlClientConfigBuilder.class.getName());
 
     private ClientConfig clientConfig;
     private InputStream in;

--- a/hazelcast-hibernate/hazelcast-hibernate3/src/main/java/com/hazelcast/hibernate/AbstractHazelcastCacheRegionFactory.java
+++ b/hazelcast-hibernate/hazelcast-hibernate3/src/main/java/com/hazelcast/hibernate/AbstractHazelcastCacheRegionFactory.java
@@ -33,7 +33,7 @@ import java.util.logging.Level;
 
 public abstract class AbstractHazelcastCacheRegionFactory implements RegionFactory {
 
-    private final ILogger LOG = Logger.getLogger(getClass().getName());
+    private final static ILogger logger = Logger.getLogger(AbstractHazelcastCacheRegionFactory.class.getName());
 
     private IHazelcastInstanceLoader instanceLoader = null;
     protected HazelcastInstance instance;
@@ -66,7 +66,7 @@ public abstract class AbstractHazelcastCacheRegionFactory implements RegionFacto
     }
 
     public void start(final Settings settings, final Properties properties) throws CacheException {
-        LOG.log(Level.INFO, "Starting up " + getClass().getSimpleName());
+        logger.log(Level.INFO, "Starting up " + getClass().getSimpleName());
         if (instance == null || !instance.getLifecycleService().isRunning()) {
             instanceLoader = HazelcastInstanceFactory.createInstanceLoader(properties);
             instance = instanceLoader.loadInstance();
@@ -75,7 +75,7 @@ public abstract class AbstractHazelcastCacheRegionFactory implements RegionFacto
 
     public void stop() {
         if (instanceLoader != null) {
-            LOG.log(Level.INFO, "Shutting down " + getClass().getSimpleName());
+            logger.log(Level.INFO, "Shutting down " + getClass().getSimpleName());
             instanceLoader.unloadInstance();
             instance = null;
             instanceLoader = null;

--- a/hazelcast/src/main/java/com/hazelcast/config/ClasspathXmlConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ClasspathXmlConfig.java
@@ -24,7 +24,7 @@ import java.util.logging.Level;
 
 public class ClasspathXmlConfig extends Config {
 
-    private final ILogger logger = Logger.getLogger(ClasspathXmlConfig.class.getName());
+    private final static ILogger logger = Logger.getLogger(ClasspathXmlConfig.class.getName());
 
     public ClasspathXmlConfig() {
     }

--- a/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
@@ -36,7 +36,7 @@ import java.util.logging.Level;
 public class ConfigXmlGenerator {
 
     private final boolean formatted;
-    final ILogger logger = Logger.getLogger(this.getClass().getName());
+    final static ILogger logger = Logger.getLogger(ConfigXmlGenerator.class.getName());
 
     public ConfigXmlGenerator() {
         this(true);

--- a/hazelcast/src/main/java/com/hazelcast/config/FileSystemXmlConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/FileSystemXmlConfig.java
@@ -27,7 +27,7 @@ import java.util.logging.Level;
 
 public class FileSystemXmlConfig extends Config {
 
-    private final ILogger logger = Logger.getLogger(FileSystemXmlConfig.class.getName());
+    private final static ILogger logger = Logger.getLogger(FileSystemXmlConfig.class.getName());
 
     public FileSystemXmlConfig() {
     }

--- a/hazelcast/src/main/java/com/hazelcast/config/InMemoryXmlConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/InMemoryXmlConfig.java
@@ -25,7 +25,7 @@ import java.util.logging.Level;
 
 public class InMemoryXmlConfig extends Config {
 
-    private final ILogger logger = Logger.getLogger(InMemoryXmlConfig.class.getName());
+    private final static ILogger logger = Logger.getLogger(InMemoryXmlConfig.class.getName());
 
     public InMemoryXmlConfig() {
     }

--- a/hazelcast/src/main/java/com/hazelcast/config/UrlXmlConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/UrlXmlConfig.java
@@ -27,7 +27,7 @@ import java.util.logging.Level;
 
 public class UrlXmlConfig extends Config {
 
-    private final ILogger logger = Logger.getLogger(UrlXmlConfig.class.getName());
+    private final static ILogger logger = Logger.getLogger(UrlXmlConfig.class.getName());
 
     public UrlXmlConfig() {
     }

--- a/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
@@ -46,7 +46,7 @@ import java.util.logging.Level;
 
 public class XmlConfigBuilder extends AbstractXmlConfigHelper implements ConfigBuilder {
 
-    private final ILogger logger = Logger.getLogger(XmlConfigBuilder.class.getName());
+    private final static ILogger logger = Logger.getLogger(XmlConfigBuilder.class.getName());
     private Config config;
     private InputStream in;
     private File configurationFile;

--- a/hazelcast/src/main/java/com/hazelcast/instance/DefaultAddressPicker.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/DefaultAddressPicker.java
@@ -32,15 +32,15 @@ import java.util.logging.Level;
 
 class DefaultAddressPicker implements AddressPicker {
 
+    private final static ILogger logger = Logger.getLogger(DefaultAddressPicker.class.getName());
+
     private final Node node;
-    private final ILogger logger;
     private ServerSocketChannel serverSocketChannel;
     private Address publicAddress;
     private Address bindAddress;
 
     public DefaultAddressPicker(Node node) {
         this.node = node;
-        this.logger = Logger.getLogger(DefaultAddressPicker.class.getName());
     }
 
     public void pickAddress() throws Exception {


### PR DESCRIPTION
Made the loggers static where possible. This prevents creating new logger instances every time a class is initialized. And makes code also more consistent since everywhere it is done in the same way.
