### PR TITLE
Fix/3.0/unwanted usercontext sharing

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/Config.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/Config.java
@@ -476,6 +476,9 @@ public class Config {
     }
 
     public Config setUserContext(ConcurrentMap<String, Object> userContext) {
+        if(userContext == null){
+            throw new IllegalArgumentException("userContext can't be null");
+        }
         this.userContext = userContext;
         return this;
     }


### PR DESCRIPTION
- the user-context can't be set to a null value on the Config; an IllegalArgumentException will be thrown
- each HazelcastInstance will get its own user-context map that is a copy of the Config.user-context.
  So changes made to the user context in one HazelcastInstance, will not be visible to the user-context
  in another HazelcastInstance (that is created from the same Config).
