### PR TITLE
There was a bug in the client where the config of the map was retrieved ...

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/MapClientProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/MapClientProxy.java
@@ -50,7 +50,7 @@ public class MapClientProxy<K, V> implements IMap<K, V>, EntryHolder {
         this.name = name;
         this.proxyHelper = new ProxyHelper(name, client);
         Config config = (Config) proxyHelper.doOp(ClusterOperation.GET_CONFIG, null, null);
-        MapConfig mapConfig = config.getMapConfig(name);
+        MapConfig mapConfig = config.getMapConfig(name.substring(Prefix.MAP.length()));
         NearCacheConfig ncc = mapConfig.getNearCacheConfig();
 
         boolean nearCacheEnabled = "true".equalsIgnoreCase(System.getProperty(PROP_CLIENT_NEAR_CACHE_CONFIG_ENABLED, "false"));


### PR DESCRIPTION
...on the full name including prefix.

And therefor the map config is not found and therefor the nearache was not found. So the fix makes sure that
the original map name is used to lookup the mapconfig from the config.

Fixes #620
