### PR TITLE
Improvement/3.0/cluster javadoc improvement

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/core/Cluster.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/Cluster.java
@@ -63,7 +63,7 @@ public interface Cluster {
     Member getLocalMember();
 
     /**
-     * Returns the cluster-wide time.
+     * Returns the cluster-wide time in milliseconds.
      * <p/>
      * Cluster tries to keep a cluster-wide time which is
      * might be different than the member's own system time.


### PR DESCRIPTION
Improvement javadoc cluster.getClusterTime. Added the time unit.
