### PR TITLE
Adds missing statistics-enabled in xsd and parser

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
@@ -765,8 +765,6 @@ public class XmlConfigBuilder extends AbstractXmlConfigHelper implements ConfigB
                 mapConfig.setBackupCount(getIntegerValue("backup-count", value, MapConfig.DEFAULT_BACKUP_COUNT));
             } else if ("in-memory-format".equals(nodeName)) {
                 mapConfig.setInMemoryFormat(MapConfig.InMemoryFormat.valueOf(value));
-            } else if ("statistics-enabled".equals(nodeName)) {
-                mapConfig.setStatisticsEnabled(Boolean.valueOf(value));
             } else if ("async-backup-count".equals(nodeName)) {
                 mapConfig.setAsyncBackupCount(getIntegerValue("async-backup-count", value, MapConfig.MIN_BACKUP_COUNT));
             } else if ("eviction-policy".equals(nodeName)) {

--- a/hazelcast/src/main/resources/hazelcast-config-3.0.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-3.0.xsd
@@ -204,6 +204,8 @@
     </xs:simpleType>
     <xs:complexType name="queue">
         <xs:sequence>
+            <xs:element name="statistics-enabled" type="xs:boolean" minOccurs="0" maxOccurs="1"
+                        default="true"/>
             <xs:element name="max-size" type="xs:unsignedInt" minOccurs="0" maxOccurs="1" default="0">
                 <xs:annotation>
                     <xs:documentation>
@@ -232,6 +234,8 @@
     </xs:complexType>
     <xs:complexType name="multimap">
         <xs:sequence>
+            <xs:element name="statistics-enabled" type="xs:boolean" minOccurs="0" maxOccurs="1"
+                        default="true"/>
             <xs:element name="value-collection-type" minOccurs="0" maxOccurs="1">
                 <xs:simpleType>
                     <xs:restriction base="non-space-string">
@@ -256,6 +260,8 @@
     </xs:complexType>
     <xs:complexType name="topic">
         <xs:sequence>
+            <xs:element name="statistics-enabled" type="xs:boolean" minOccurs="0" maxOccurs="1"
+                        default="true"/>
             <xs:element name="message-listeners" minOccurs="0" maxOccurs="1">
                 <xs:complexType>
                     <xs:sequence>
@@ -397,6 +403,8 @@
     </xs:complexType>
     <xs:complexType name="executor-service">
         <xs:sequence>
+            <xs:element name="statistics-enabled" type="xs:boolean" minOccurs="0" maxOccurs="1"
+                        default="true"/>
             <xs:element name="pool-size" type="xs:unsignedShort" minOccurs="0" maxOccurs="1" default="8"/>
             <xs:element name="queue-capacity" type="xs:unsignedInt" minOccurs="0" maxOccurs="1" default="0">
                 <xs:annotation>


### PR DESCRIPTION
fixes #642

It added the statistics-enabled to the xsd, it also removed a duplicate statistics configuration from the map parsing inthe XmlConfigBuilder; there is no need to read the same element twice. 
