### PR TITLE
managedcontext local executed runnable

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/executor/BaseCallableTaskOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/executor/BaseCallableTaskOperation.java
@@ -17,8 +17,11 @@
 package com.hazelcast.executor;
 
 import com.hazelcast.core.HazelcastInstanceAware;
+import com.hazelcast.core.ManagedContext;
+import com.hazelcast.instance.HazelcastInstanceImpl;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.SerializationServiceImpl;
 import com.hazelcast.spi.Operation;
 
 import java.io.IOException;
@@ -44,8 +47,19 @@ abstract class BaseCallableTaskOperation extends Operation {
 
     @Override
     public final void beforeRun() throws Exception {
+        HazelcastInstanceImpl hazelcastInstance = (HazelcastInstanceImpl)getNodeEngine().getHazelcastInstance();
+        SerializationServiceImpl serializationService = (SerializationServiceImpl) hazelcastInstance.getSerializationService();
+        ManagedContext managedContext = serializationService.getManagedContext();
+
+        if(callable instanceof RunnableAdapter){
+            RunnableAdapter adapter = (RunnableAdapter)callable;
+            adapter.setRunnable((Runnable)managedContext.initialize(adapter.getRunnable()));
+        } else{
+            callable = (Callable)managedContext.initialize(callable);
+        }
+
         if (callable instanceof HazelcastInstanceAware) {
-            ((HazelcastInstanceAware) callable).setHazelcastInstance(getNodeEngine().getHazelcastInstance());
+            ((HazelcastInstanceAware) callable).setHazelcastInstance(hazelcastInstance);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/SerializationServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/SerializationServiceImpl.java
@@ -108,6 +108,10 @@ public final class SerializationServiceImpl implements SerializationService {
         registerClassDefinitions(classDefinitions, checkClassDefErrors);
     }
 
+    public ManagedContext getManagedContext(){
+        return managedContext;
+    }
+
     private void registerClassDefinitions(final Collection<ClassDefinition> classDefinitions, boolean checkClassDefErrors) {
         final Map<Integer, ClassDefinition> classDefMap = new HashMap<Integer, ClassDefinition>(classDefinitions.size());
         for (ClassDefinition cd : classDefinitions) {


### PR DESCRIPTION
ManagedContext is skipped in case of a Local executed runnable because serialization is skipped. This pr fixes that problem.
