### PR TITLE
Improvement/3.x/serializerconfig class arguments

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/SerializationConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/SerializationConfig.java
@@ -23,6 +23,8 @@ import com.hazelcast.nio.serialization.PortableFactory;
 import java.nio.ByteOrder;
 import java.util.*;
 
+import static com.hazelcast.util.ValidationUtil.isNotNull;
+
 public class SerializationConfig {
 
     private int portableVersion = 0;
@@ -112,6 +114,11 @@ public class SerializationConfig {
         return this;
     }
 
+    public SerializationConfig addDataSerializableFactoryClass(int factoryId, Class<? extends DataSerializableFactory> dataSerializableFactoryClass) {
+       String factoryClassName = isNotNull(dataSerializableFactoryClass, "dataSerializableFactoryClass").getName();
+       return addDataSerializableFactoryClass(factoryId, factoryClassName);
+    }
+
     public Map<Integer, DataSerializableFactory> getDataSerializableFactories() {
         if (dataSerializableFactories == null) {
             dataSerializableFactories = new HashMap<Integer, DataSerializableFactory>();
@@ -139,6 +146,11 @@ public class SerializationConfig {
     public SerializationConfig setPortableFactoryClasses(Map<Integer, String> portableFactoryClasses) {
         this.portableFactoryClasses = portableFactoryClasses;
         return this;
+    }
+
+    public SerializationConfig addPortableFactoryClass(int factoryId, Class<? extends PortableFactory> portableFactoryClass) {
+        String portableFactoryClassName = isNotNull(portableFactoryClass, "portableFactoryClass").getName();
+        return addPortableFactoryClass(factoryId, portableFactoryClassName);
     }
 
     public SerializationConfig addPortableFactoryClass(int factoryId, String portableFactoryClass) {

--- a/hazelcast/src/main/java/com/hazelcast/config/SerializerConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/SerializerConfig.java
@@ -17,6 +17,7 @@
 package com.hazelcast.config;
 
 import com.hazelcast.nio.serialization.ByteArraySerializer;
+import com.hazelcast.nio.serialization.DataSerializableFactory;
 import com.hazelcast.nio.serialization.Serializer;
 import com.hazelcast.nio.serialization.StreamSerializer;
 
@@ -36,6 +37,11 @@ public class SerializerConfig {
 
     public String getClassName() {
         return className;
+    }
+
+    public SerializerConfig setClass(final Class<? extends Serializer> clazz) {
+        String className = clazz == null?null:clazz.getName();
+        return setClassName(className);
     }
 
     public SerializerConfig setClassName(final String className) {


### PR DESCRIPTION
Some overloaded methods with a class instead of a string. This makes calling a bit simpler and more typesafe

SerializerConfig c;
c.addPortableFactoryClass(1, PersonPortableFactory.class)

instead of 

c.addPortableFactoryClass(1, PersonPortableFactory.class.getName())
