### PR TITLE
Prevent IndexOutOfBoundsException when index reaches Integer.MAX_VALUE + 2

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/util/RoundRobinLB.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/util/RoundRobinLB.java
@@ -20,17 +20,18 @@ import com.hazelcast.client.LoadBalancer;
 import com.hazelcast.core.Member;
 import com.hazelcast.core.MembershipListener;
 
-import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class RoundRobinLB extends AbstractLoadBalancer implements LoadBalancer, MembershipListener {
 
-    private final AtomicLong index = new AtomicLong(0);
+    private final AtomicInteger index = new AtomicInteger(0);
 
     public Member next() {
         final Member[] members = getMembers();
         if (members == null || members.length == 0) {
             return null;
         }
-        return members[(int) (index.getAndAdd(1) % members.length)];
+        final int length = members.length;
+        return members[(index.getAndAdd(1) % length + length) % length];
     }
 }


### PR DESCRIPTION
When the cast to int (which is unneeded btw. if you use an Integer in the first place) returns a negative value, then modulo will be -1, which throws an IndexOutOfBoundsException.
Patch fixes this, by ensuring a positive value.

long longNumber = Integer.MAX_VALUE + 2;
int intNumber = (int)longNumber;
System.out.println("longNumber = " + longNumber);
System.out.println("intNumber = " + intNumber);
System.out.println("mod2 = " + intNumber % 2);
System.out.println("mod2 = " + (intNumber % 2 + 2) % 2);
