### PR TITLE
Fixed index cleanup during migration. Instead of clearing all index, onl...

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/MapService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/MapService.java
@@ -320,11 +320,9 @@ public class MapService implements ManagedService, MigrationAwareService,
     }
 
     public void commitMigration(PartitionMigrationEvent event) {
+        migrateIndex(event);
         if (event.getMigrationEndpoint() == MigrationEndpoint.SOURCE) {
-            migrateIndex(event);
             clearPartitionData(event.getPartitionId());
-        } else {
-            migrateIndex(event);
         }
         ownedPartitions.set(nodeEngine.getPartitionService().getMemberPartitions(nodeEngine.getThisAddress()));
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/PartitionRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/PartitionRecordStore.java
@@ -108,11 +108,13 @@ public class PartitionRecordStore implements RecordStore {
         if (lockService != null) {
             lockService.clearLockStore(partitionContainer.getPartitionId(), new DefaultObjectNamespace(MapService.SERVICE_NAME, name));
         }
-        records.clear();
         final IndexService indexService = mapContainer.getIndexService();
         if (indexService.hasIndex()) {
-            indexService.clear();
+            for (Data key : records.keySet()) {
+                indexService.removeEntryIndex(key);
+            }
         }
+        records.clear();
     }
 
     public int size() {

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/IndexService.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/IndexService.java
@@ -53,12 +53,6 @@ public class IndexService {
         return indexes.get();
     }
 
-    public void clear() {
-        for (Index index : indexes.get()) {
-            index.clear();
-        }
-    }
-
     public void removeEntryIndex(Data indexKey) throws QueryException {
         for (Index index : indexes.get()) {
             index.removeEntryIndex(indexKey);

--- a/hazelcast/src/test/java/com/hazelcast/map/QueryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/QueryTest.java
@@ -420,12 +420,15 @@ public class QueryTest extends HazelcastTestSupport {
             imap.putAll(temp);
         }
         assertEquals(50000, imap.size());
+        Set<Map.Entry> entries = imap.entrySet(new SqlPredicate("active=true and age>44"));
+        assertEquals(6400, entries.size());
+
         HazelcastInstance h2 = nodeFactory.newHazelcastInstance(cfg);
         HazelcastInstance h3 = nodeFactory.newHazelcastInstance(cfg);
         HazelcastInstance h4 = nodeFactory.newHazelcastInstance(cfg);
         long startNow = Clock.currentTimeMillis();
         while ((Clock.currentTimeMillis() - startNow) < 10000) {
-            Set<Map.Entry> entries = imap.entrySet(new SqlPredicate("active=true and age>44"));
+            entries = imap.entrySet(new SqlPredicate("active=true and age>44"));
             assertEquals(6400, entries.size());
         }
     }


### PR DESCRIPTION
...y interested partitions' indexes should be cleared.
