### PR TITLE
Added the AbstractEntryProcessor

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/AbstractEntryProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/AbstractEntryProcessor.java
@@ -1,0 +1,27 @@
+package com.hazelcast.map;
+
+import java.util.Map;
+
+/**
+ * An abstract {@link EntryProcessor} that already has implemented the {@link #getBackupProcessor()}. In a most cases you
+ * want the same logic to be executed on the primary and on the backup. This implementation has this behavior.
+ *
+ * @param <K>
+ * @param <V>
+ */
+public abstract class AbstractEntryProcessor<K, V> implements EntryProcessor<K, V> {
+
+    private final EntryBackupProcessor<K,V> entryBackupProcessor = new EntryBackupProcessorImpl();
+
+    @Override
+    public final EntryBackupProcessor<K, V> getBackupProcessor() {
+         return entryBackupProcessor;
+    }
+
+    private class EntryBackupProcessorImpl implements EntryBackupProcessor<K,V>{
+        @Override
+        public void processBackup(Map.Entry<K, V> entry) {
+            process(entry);
+        }
+    }
+}


### PR DESCRIPTION
The AbstractEntryProcessor has implemented the getBackupProcessor so that both the primary and the backup will execute the same processing logic. A user only needs to implement the 'process' method 
