### PR TITLE
Some fixes in creating the ConsoleRequest:

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/management/ManagementCenterService.java
+++ b/hazelcast/src/main/java/com/hazelcast/management/ManagementCenterService.java
@@ -591,10 +591,11 @@ public class ManagementCenterService implements LifecycleListener, MembershipLis
                         final int taskId = input.readInt();
                         if(taskId > 0){
                             final int requestType = input.readInt();
-                            final ConsoleRequest request = consoleRequests.get(requestType).newInstance();
-                            if (request == null) {
+                            Class<? extends ConsoleRequest> requestClass = consoleRequests.get(requestType);
+                            if (requestClass == null) {
                                 throw new RuntimeException("Failed to find a request for requestType:" + requestType);
                             }
+                            final ConsoleRequest request = requestClass.newInstance();
                             request.readData(input);
                             sendResponse(taskId, request);
                         }


### PR DESCRIPTION
- There is no need anymore to have a predefined array with all the possible consolerequest
  instances. Instead a map is used with the index as key; the map can grow. The array not.
  So you don't need to worry anymore about the size of the array
- Instead of a shared ConsoleRequest instance that is reused, a new instance will be created
  for every deserialization.
