### PR TITLE
Add support for map/reduce style computation over maps.

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/core/IMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/IMap.java
@@ -16,7 +16,10 @@
 
 package com.hazelcast.core;
 
+import com.hazelcast.map.EntryMapper;
 import com.hazelcast.map.EntryProcessor;
+
+import com.hazelcast.map.EntryReducer;
 import com.hazelcast.map.MapInterceptor;
 import com.hazelcast.monitor.LocalMapStats;
 import com.hazelcast.query.Predicate;
@@ -943,4 +946,6 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, BaseMap<K, V> {
      */
     Map<K,Object> executeOnEntries(EntryProcessor entryProcessor);
 
+    <KEYIN,VALIN,KEYMAP,VALMAP,KEYRED,VALRED> Map<KEYRED,VALRED> mapReduce(EntryMapper<KEYIN,VALIN,KEYMAP,VALMAP> mapper, EntryReducer<KEYMAP,VALMAP,KEYRED,VALRED> reducer);
+    <KEYIN,VALIN,KEYMAP,VALMAP,KEYRED,VALRED> Map<KEYRED,VALRED> mapReduce(EntryMapper<KEYIN,VALIN,KEYMAP,VALMAP> mapper, EntryReducer<KEYMAP,VALMAP,KEYMAP,VALMAP> combiner, EntryReducer<KEYMAP,VALMAP,KEYRED,VALRED> reducer);
 }

--- a/hazelcast/src/main/java/com/hazelcast/jmx/InstanceMBean.java
+++ b/hazelcast/src/main/java/com/hazelcast/jmx/InstanceMBean.java
@@ -52,6 +52,7 @@ public class InstanceMBean extends HazelcastMBean<HazelcastInstanceImpl> {
     private final ManagedExecutorServiceMBean clientExecutorMBean;
     private final ManagedExecutorServiceMBean queryExecutorMBean;
     private final ManagedExecutorServiceMBean ioExecutorMBean;
+    private final ManagedExecutorServiceMBean mapredExecutorMBean;
     private final PartitionServiceMBean partitionServiceMBean;
 
     protected InstanceMBean(HazelcastInstanceImpl hazelcastInstance, ManagementService managementService) {
@@ -117,6 +118,10 @@ public class InstanceMBean extends HazelcastMBean<HazelcastInstanceImpl> {
         ioExecutorMBean = new ManagedExecutorServiceMBean(
                 hazelcastInstance, executionService.getExecutor(ExecutionService.IO_EXECUTOR), service);
         register(ioExecutorMBean);
+
+        mapredExecutorMBean = new ManagedExecutorServiceMBean(
+                hazelcastInstance, executionService.getExecutor(ExecutionService.MAPREDUCE_EXECUTOR), service);
+        register(mapredExecutorMBean);
     }
 
     public PartitionServiceMBean getPartitionServiceMBean() {

--- a/hazelcast/src/main/java/com/hazelcast/map/EntryMapper.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/EntryMapper.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2008-2013, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map;
+
+import java.io.Serializable;
+
+public interface EntryMapper<KEYIN, VALIN, KEYOUT, VALOUT> extends Serializable {
+    void process(KEYIN key, VALIN value, MapReduceOutput<KEYOUT,VALOUT> output);
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/EntryReducer.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/EntryReducer.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2008-2013, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map;
+
+import java.io.Serializable;
+
+public interface EntryReducer<KEYIN, VALIN, KEYOUT, VALOUT> extends Serializable {
+    void process(KEYIN key, Iterable<VALIN> values, MapReduceOutput<KEYOUT,VALOUT> output);
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/MapPortableHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/MapPortableHook.java
@@ -68,6 +68,7 @@ public class MapPortableHook implements PortableHook {
     public static final int DESTROY = 41;
     public static final int TXN_REQUEST = 42;
     public static final int TXN_REQUEST_WITH_SQL_QUERY = 43;
+    public static final int MAPCOMBINE_ON_ALL_KEYS = 44;
 
 
     public int getFactoryId() {
@@ -76,7 +77,7 @@ public class MapPortableHook implements PortableHook {
 
     public PortableFactory createFactory() {
         return new PortableFactory() {
-            final ConstructorFunction<Integer, Portable> constructors[] = new ConstructorFunction[TXN_REQUEST_WITH_SQL_QUERY+1];
+            final ConstructorFunction<Integer, Portable> constructors[] = new ConstructorFunction[MAPCOMBINE_ON_ALL_KEYS+1];
 
             {
                 constructors[GET] = new ConstructorFunction<Integer, Portable>() {
@@ -307,6 +308,11 @@ public class MapPortableHook implements PortableHook {
                     }
                 };
 
+                constructors[MAPCOMBINE_ON_ALL_KEYS] = new ConstructorFunction<Integer, Portable>() {
+                    public Portable createNew(Integer arg) {
+                        return new MapMapCombineOnAllKeysRequest();
+                    }
+                };
 
 
             }

--- a/hazelcast/src/main/java/com/hazelcast/map/MapReduceOutput.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/MapReduceOutput.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2008-2013, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map;
+
+public interface MapReduceOutput<KEY,VAL> {
+    void write(KEY key, VAL value);
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/client/MapMapCombineOnAllKeysRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/client/MapMapCombineOnAllKeysRequest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2008-2013, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.client;
+
+import com.hazelcast.client.AllPartitionsClientRequest;
+import com.hazelcast.client.InitializingObjectRequest;
+
+import com.hazelcast.map.EntryMapper;
+import com.hazelcast.map.EntryReducer;
+import com.hazelcast.map.MapEntrySet;
+import com.hazelcast.map.MapPortableHook;
+import com.hazelcast.map.MapService;
+import com.hazelcast.map.operation.MapCombineOperationFactory;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.nio.serialization.Portable;
+import com.hazelcast.nio.serialization.PortableReader;
+import com.hazelcast.nio.serialization.PortableWriter;
+import com.hazelcast.spi.OperationFactory;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Set;
+
+public class MapMapCombineOnAllKeysRequest extends AllPartitionsClientRequest implements Portable, InitializingObjectRequest {
+
+    private String name;
+    private EntryMapper mapper;
+    private EntryReducer combiner;
+
+    public MapMapCombineOnAllKeysRequest() {
+    }
+
+    public MapMapCombineOnAllKeysRequest(String name, EntryMapper mapper, EntryReducer combiner) {
+        this.name = name;
+        this.mapper = mapper;
+        this.combiner = combiner;
+    }
+
+    @Override
+    protected OperationFactory createOperationFactory() {
+        return new MapCombineOperationFactory(name, mapper, combiner);
+    }
+
+    @Override
+    protected Object reduce(Map<Integer, Object> map) {
+        MapEntrySet result = new MapEntrySet();
+        MapService mapService = getService();
+        for (Object o : map.values()) {
+            if (o != null) {
+                MapEntrySet entrySet = (MapEntrySet)mapService.toObject(o);
+                Set<Map.Entry<Data,Data>> entries = entrySet.getEntrySet();
+                for (Map.Entry<Data, Data> entry : entries) {
+                    result.add(entry);
+                }
+            }
+        }
+        return result;
+    }
+
+    public String getServiceName() {
+        return MapService.SERVICE_NAME;
+    }
+
+    @Override
+    public String getObjectName() {
+        return name;
+    }
+
+    @Override
+    public int getFactoryId() {
+        return MapPortableHook.F_ID;
+    }
+
+    public int getClassId() {
+        return MapPortableHook.MAPCOMBINE_ON_ALL_KEYS;
+    }
+
+    public void writePortable(PortableWriter writer) throws IOException {
+        writer.writeUTF("n", name);
+        final ObjectDataOutput out = writer.getRawDataOutput();
+        out.writeObject(mapper);
+        out.writeObject(combiner);
+    }
+
+    public void readPortable(PortableReader reader) throws IOException {
+        name = reader.readUTF("n");
+        final ObjectDataInput in = reader.getRawDataInput();
+        mapper = in.readObject();
+        combiner = in.readObject();
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/operation/MapCombineOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/operation/MapCombineOperation.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) 2008-2013, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.operation;
+
+import com.hazelcast.map.EntryMapper;
+import com.hazelcast.map.EntryReducer;
+import com.hazelcast.map.MapEntrySet;
+import com.hazelcast.map.MapReduceOutput;
+
+import com.hazelcast.map.MapService;
+import com.hazelcast.map.PartitionContainer;
+import com.hazelcast.map.RecordStore;
+import com.hazelcast.map.record.CachedDataRecord;
+import com.hazelcast.map.record.DataRecord;
+import com.hazelcast.map.record.Record;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.SerializationService;
+import com.hazelcast.spi.ExecutionService;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+
+public class MapCombineOperation extends AbstractMapOperation {
+    EntryMapper mapper;
+    EntryReducer combiner;
+    transient MapEntrySet response;
+
+    public MapCombineOperation(String name, EntryMapper mapper, EntryReducer combiner) {
+        super(name);
+        this.mapper = mapper;
+        this.combiner = combiner;
+    }
+
+    public MapCombineOperation() {
+    }
+
+    @Override
+    public void run() throws Exception {
+        response = new MapEntrySet();
+        List<Integer> initialPartitions = mapService.getOwnedPartitions().get();
+
+        runParallel(initialPartitions);
+        if (mapContainer.getMapConfig().isStatisticsEnabled()) {
+            ((MapService) getService()).getLocalMapStatsImpl(name).incrementOtherOperations();
+        }
+    }
+
+    private void runParallel(final List<Integer> initialPartitions) throws InterruptedException, ExecutionException {
+        final SerializationService ss = getNodeEngine().getSerializationService();
+        final ExecutorService executor = getNodeEngine().getExecutionService().getExecutor(ExecutionService.MAPREDUCE_EXECUTOR);
+        final List<Future<Map<Object,List<Object>>>> lsFutures = new ArrayList<Future<Map<Object,List<Object>>>>(initialPartitions.size());
+        for (final Integer partition : initialPartitions) {
+            Future<Map<Object,List<Object>>> f = executor.submit(new Callable<Map<Object,List<Object>>>() {
+                public Map<Object,List<Object>> call() {
+                    final PartitionContainer container = mapService.getPartitionContainer(partition);
+                    final RecordStore recordStore = container.getRecordStore(name);
+                    final MapReduceOutputImpl output = new MapReduceOutputImpl();
+                    ConcurrentMap<Object, Object> partitionResult = null;
+                    for (Record record : recordStore.getRecords().values()) {
+                        Object key = ss.toObject(record.getKey());
+                        Object value = null;
+                        if (record instanceof CachedDataRecord) {
+                            CachedDataRecord cachedDataRecord = (CachedDataRecord) record;
+                            value = cachedDataRecord.getCachedValue();
+                            if (value == null) {
+                                value = ss.toObject(cachedDataRecord.getValue());
+                                cachedDataRecord.setCachedValue(value);
+                            }
+                        } else if (record instanceof DataRecord) {
+                            value = ss.toObject(((DataRecord) record).getValue());
+                        } else {
+                            value = record.getValue();
+                        }
+
+                        if (value == null) {
+                            continue;
+                        }
+
+                        mapper.process(key, value, output);
+                    }
+
+                    return output.getStorage();
+                }
+            });
+
+            lsFutures.add(f);
+        }
+
+        Map<Object,List<Object>> temp = new HashMap<Object,List<Object>>();
+        for (Future<Map<Object,List<Object>>> future : lsFutures) {
+            final Map<Object,List<Object>> r = future.get();
+            for (Map.Entry<Object,List<Object>> entry : r.entrySet()) {
+                Object key = entry.getKey();
+                List<Object> values = entry.getValue();
+
+                List<Object> combined = temp.get(key);
+                if (combined == null) {
+                    combined = new ArrayList<Object>(values.size());
+                    temp.put(key, combined);
+                }
+
+                combined.addAll(values);
+            }
+        }
+
+        if (combiner != null) {
+            final MapReduceOutputImpl output = new MapReduceOutputImpl();
+            for (Map.Entry<Object,List<Object>> entry : temp.entrySet()) {
+                combiner.process(entry.getKey(), entry.getValue(), output);
+            }
+
+            temp = output.getStorage();
+        }
+
+        for (Map.Entry<Object,List<Object>> entry : temp.entrySet()) {
+            response.add(ss.toData(entry.getKey()), ss.toData(entry.getValue()));
+        }
+    }
+
+    @Override
+    public Object getResponse() {
+        return response;
+    }
+
+    @Override
+    protected void readInternal(ObjectDataInput in) throws IOException {
+        super.readInternal(in);
+        mapper = in.readObject();
+        combiner = in.readObject();
+    }
+
+    @Override
+    protected void writeInternal(ObjectDataOutput out) throws IOException {
+        super.writeInternal(out);
+        out.writeObject(mapper);
+        out.writeObject(combiner);
+    }
+
+    static final class MapReduceOutputImpl implements MapReduceOutput<Object, Object> {
+        private final Map<Object,List<Object>> storage = new HashMap<Object,List<Object>>();
+
+        @Override
+        public void write(Object key, Object value) {
+            List<Object> perkey = storage.get(key);
+            if (perkey == null) {
+                perkey = new ArrayList<Object>();
+                storage.put(key, perkey);
+            }
+
+            perkey.add(value);
+        }
+
+        public Map<Object,List<Object>> getStorage() {
+            return storage;
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/operation/MapCombineOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/operation/MapCombineOperationFactory.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2008-2013, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.operation;
+
+import com.hazelcast.map.EntryMapper;
+
+import com.hazelcast.map.EntryReducer;
+import com.hazelcast.map.MapInterceptor;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.OperationFactory;
+
+import java.io.IOException;
+
+public class MapCombineOperationFactory implements OperationFactory {
+
+    String name;
+    EntryMapper mapper;
+    EntryReducer combiner;
+
+    public MapCombineOperationFactory() {
+    }
+
+    public MapCombineOperationFactory(String name, EntryMapper mapper, EntryReducer combiner) {
+        this.name = name;
+        this.mapper = mapper;
+        this.combiner = combiner;
+    }
+
+    @Override
+    public Operation createOperation() {
+        return new MapCombineOperation(name, mapper, combiner);
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
+        out.writeUTF(name);
+        out.writeObject(mapper);
+        out.writeObject(combiner);
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) throws IOException {
+        name = in.readUTF();
+        mapper = in.readObject();
+        combiner = in.readObject();
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/ExecutionService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/ExecutionService.java
@@ -32,6 +32,7 @@ public interface ExecutionService {
     static final String CLIENT_EXECUTOR = "hz:client";
     static final String QUERY_EXECUTOR = "hz:query";
     static final String IO_EXECUTOR = "hz:io";
+    static final String MAPREDUCE_EXECUTOR= "hz:mapred";
 
     void execute(String name, Runnable command);
 

--- a/hazelcast/src/main/java/com/hazelcast/util/HealthMonitor.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/HealthMonitor.java
@@ -138,6 +138,7 @@ public class HealthMonitor extends Thread {
         private final int activeConnectionCount;
         private final int connectionCount;
         private final int ioExecutorQueueSize;
+        private final int mapredExecutorQueueSize;
 
         public HealthMetrics() {
             memoryFree = runtime.freeMemory();
@@ -158,6 +159,7 @@ public class HealthMonitor extends Thread {
             scheduledExecutorQueueSize = executionService.getExecutor(ExecutionService.SCHEDULED_EXECUTOR).queueSize();
             systemExecutorQueueSize = executionService.getExecutor(ExecutionService.SYSTEM_EXECUTOR).queueSize();
             ioExecutorQueueSize = executionService.getExecutor(ExecutionService.IO_EXECUTOR).queueSize();
+            mapredExecutorQueueSize = executionService.getExecutor(ExecutionService.MAPREDUCE_EXECUTOR).queueSize();
              eventQueueSize = eventService.getEventQueueSize();
             operationServiceOperationExecutorQueueSize = operationService.getOperationExecutorQueueSize();
             operationServiceOperationResponseQueueSize = operationService.getResponseQueueSize();
@@ -209,6 +211,7 @@ public class HealthMonitor extends Thread {
             sb.append("executor.q.query.size=").append(queryExecutorQueueSize).append(", ");
             sb.append("executor.q.scheduled.size=").append(scheduledExecutorQueueSize).append(", ");
             sb.append("executor.q.io.size=").append(ioExecutorQueueSize).append(", ");
+            sb.append("executor.q.mapred.size=").append(mapredExecutorQueueSize).append(", ");
             sb.append("executor.q.system.size=").append(systemExecutorQueueSize).append(", ");
             sb.append("executor.q.operation.size=").append(operationServiceOperationExecutorQueueSize).append(", ");
             sb.append("executor.q.response.size=").append(operationServiceOperationResponseQueueSize).append(", ");

--- a/hazelcast/src/test/java/com/hazelcast/map/MapReduceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapReduceTest.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2008-2013, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.core.*;
+import com.hazelcast.test.HazelcastJUnit4ClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.io.Serializable;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;;
+
+@RunWith(HazelcastJUnit4ClassRunner.class)
+@Category(ParallelTest.class)
+public class MapReduceTest extends HazelcastTestSupport {
+    @Test
+    public void testMapCombineReduceWithObject() throws InterruptedException {
+        doTest(true, MapConfig.InMemoryFormat.OBJECT);
+    }
+
+    @Test
+    public void testMapReduceWithObject() throws InterruptedException {
+        doTest(false, MapConfig.InMemoryFormat.OBJECT);
+    }
+
+    @Test
+    public void testMapCombineReduceWithCached() throws InterruptedException {
+        doTest(true, MapConfig.InMemoryFormat.CACHED);
+    }
+
+    @Test
+    public void testMapReduceWithCached() throws InterruptedException {
+        doTest(false, MapConfig.InMemoryFormat.CACHED);
+    }
+
+    @Test
+    public void testMapCombineReduceWithBinary() throws InterruptedException {
+        doTest(true, MapConfig.InMemoryFormat.BINARY);
+    }
+
+    @Test
+    public void testMapReduceWithBinary() throws InterruptedException {
+        doTest(false, MapConfig.InMemoryFormat.BINARY);
+    }
+
+    private void doTest(boolean useCombiner, MapConfig.InMemoryFormat format) {
+        TestHazelcastInstanceFactory nodeFactory = createHazelcastInstanceFactory(2);
+        Config cfg = new Config();
+        cfg.getMapConfig("default").setInMemoryFormat(format);
+        HazelcastInstance instance1 = nodeFactory.newHazelcastInstance(cfg);
+        HazelcastInstance instance2 = nodeFactory.newHazelcastInstance(cfg);
+        IMap<Integer, String> map = instance1.getMap("testMapEntryProcessor");
+        Map<Character,Long> expectedOutput = new HashMap<Character,Long>();
+
+        int size = 10000;
+        for (int i = 0; i < size; i++) {
+            String value = "this is a test: " + i;
+            map.put(i, value);
+
+            for (int ei = 0, ee = value.length(); ei < ee; ++ei) {
+                Character key = value.charAt(ei);
+                Long evalue = expectedOutput.get(key);
+                if (evalue == null) {
+                    evalue = 0L;
+                }
+
+                evalue = evalue + 1L;
+                expectedOutput.put(key, evalue);
+            }
+        }
+
+        EntryMapper<Integer,String,Character,Long> mapper = new TestMapper();
+        EntryReducer<Character,Long,Character,Long> combiner = new TestCombiner();
+        EntryReducer<Character,Long,Character,Long> reducer = new TestReducer();
+
+        Map<Character,Long> result = map.mapReduce(mapper, useCombiner ? combiner : null, reducer);
+
+        for (Map.Entry<Character,Long> entry : result.entrySet()) {
+            System.out.println("result: '" + entry.getKey() + "' = " + entry.getValue());
+
+            Long expected = expectedOutput.get(entry.getKey());
+            assertNotNull(expected);
+            assertEquals(expected, entry.getValue());
+        }
+
+        assertEquals(expectedOutput.keySet(), result.keySet());
+        instance1.getLifecycleService().shutdown();
+        instance2.getLifecycleService().shutdown();
+    }
+
+    private static class TestMapper implements EntryMapper<Integer,String,Character,Long>, Serializable {
+        private static final long serialVersionUID = 1610394521391949724L;
+
+        @Override
+        public void process(Integer key, String value, MapReduceOutput<Character,Long> output) {
+            for (int i = 0, e = value.length(); i < e; ++i) {
+                output.write(value.charAt(i), 1L);
+            }
+        }
+    }
+
+    private static class TestCombiner implements EntryReducer<Character,Long,Character,Long>, Serializable {
+        private static final long serialVersionUID = -7276573659756130691L;
+
+        @Override
+        public void process(Character key, Iterable<Long> values, MapReduceOutput<Character,Long> output) {
+            long num = 0L;
+            for (Long value : values) {
+                num += value.longValue();
+            }
+
+            output.write(key, num);
+        }
+    }
+
+    private static class TestReducer implements EntryReducer<Character,Long,Character,Long>, Serializable {
+        private static final long serialVersionUID = -5252182752495503851L;
+
+        @Override
+        public void process(Character key, Iterable<Long> values, MapReduceOutput<Character,Long> output) {
+            long num = 0L;
+            for (Long value : values) {
+                num += value.longValue();
+            }
+
+            output.write(key, num);
+        }
+    }
+}


### PR DESCRIPTION
I did not see any map/reduce style computation built in to the Hazelcast
distributed map so I took a shot at implementing one, partially to start
learning the internals of Hazelcast.

-- Commit message
This commits adds support for map/reduce style computation over
distributed maps. The map and combine operations execute locally on each
node in the cluster and the reduce operation runs on the node that
started the map/reduce operation. If the map/reduce operation is started
by the client then the reduce operation runs on the client.
