### PR TITLE
fixes #1019

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/instance/GroupProperties.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/GroupProperties.java
@@ -34,7 +34,6 @@ public class GroupProperties {
     public static final String PROP_MEMCACHE_ENABLED = "hazelcast.memcache.enabled";
     public static final String PROP_REST_ENABLED = "hazelcast.rest.enabled";
     public static final String PROP_MAP_LOAD_CHUNK_SIZE = "hazelcast.map.load.chunk.size";
-    public static final String PROP_CACHED_NULL_TTL_SECONDS = "hazelcast.cached.null.ttl.seconds";
     public static final String PROP_MERGE_FIRST_RUN_DELAY_SECONDS = "hazelcast.merge.first.run.delay.seconds";
     public static final String PROP_MERGE_NEXT_RUN_DELAY_SECONDS = "hazelcast.merge.next.run.delay.seconds";
     public static final String PROP_OPERATION_CALL_TIMEOUT_MILLIS = "hazelcast.operation.call.timeout.millis";
@@ -111,8 +110,6 @@ public class GroupProperties {
     public final GroupProperty REST_ENABLED;
 
     public final GroupProperty MAP_LOAD_CHUNK_SIZE;
-
-    public final GroupProperty CACHED_NULL_TTL_SECONDS;
 
     public final GroupProperty MERGE_FIRST_RUN_DELAY_SECONDS;
 
@@ -226,7 +223,6 @@ public class GroupProperties {
         MEMCACHE_ENABLED = new GroupProperty(config, PROP_MEMCACHE_ENABLED, "true");
         REST_ENABLED = new GroupProperty(config, PROP_REST_ENABLED, "true");
         MAP_LOAD_CHUNK_SIZE = new GroupProperty(config, PROP_MAP_LOAD_CHUNK_SIZE, "1000");
-        CACHED_NULL_TTL_SECONDS = new GroupProperty(config, PROP_CACHED_NULL_TTL_SECONDS, "1");
         MERGE_FIRST_RUN_DELAY_SECONDS = new GroupProperty(config, PROP_MERGE_FIRST_RUN_DELAY_SECONDS, "300");
         MERGE_NEXT_RUN_DELAY_SECONDS = new GroupProperty(config, PROP_MERGE_NEXT_RUN_DELAY_SECONDS, "120");
         OPERATION_CALL_TIMEOUT_MILLIS = new GroupProperty(config, PROP_OPERATION_CALL_TIMEOUT_MILLIS, "60000");

--- a/hazelcast/src/main/java/com/hazelcast/map/operation/MapReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/operation/MapReplicationOperation.java
@@ -73,7 +73,6 @@ public class MapReplicationOperation extends AbstractOperation {
                 Data key = recordEntry.getKey();
                 Record record = recordEntry.getValue();
                 if (record.getValue() == null) {
-                    // see optimization at DefaultRecordStore.get(Data dataKey)
                     continue;
                 }
                 RecordReplicationInfo recordReplicationInfo;

--- a/hazelcast/src/test/java/com/hazelcast/map/mapstore/MapStoreTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/mapstore/MapStoreTest.java
@@ -764,7 +764,6 @@ public class MapStoreTest extends HazelcastTestSupport {
         final ConcurrentMap<String, String> store = new ConcurrentHashMap<String, String>();
         final MapStore<String, String> myMapStore = new SimpleMapStore<String, String>(store);
         Config config = new Config();
-        config.setProperty(GroupProperties.PROP_CACHED_NULL_TTL_SECONDS, "0");
         config
                 .getMapConfig("testIssue806CustomTTLForNull")
                 .setMapStoreConfig(new MapStoreConfig()
@@ -810,6 +809,24 @@ public class MapStoreTest extends HazelcastTestSupport {
         map.put("key", "value");
         Thread.sleep(2000);
         assertEquals("value", map.get("key"));
+    }
+
+    @Test
+    public void testIssue1019() {
+        Config config = new Config();
+        MapStoreConfig mapStoreConfig = new MapStoreConfig();
+        mapStoreConfig.setImplementation(new MapStoreAdapter<String,String>());
+        config.getMapConfig("map").setMapStoreConfig(mapStoreConfig);
+        HazelcastInstance instance = Hazelcast.newHazelcastInstance(config);
+        HazelcastInstance instance2 = Hazelcast.newHazelcastInstance(config);
+        final IMap map = instance.getMap("map");
+        for (int i = 0; i < 1000; i++) {
+            map.put(i,i);
+        }
+        for (int i = 10000; i < 10100; i++) {
+            map.get(i);
+        }
+        assertEquals(1000, map.values().size());
     }
 
     public static Config newConfig(Object storeImpl, int writeDelaySeconds) {


### PR DESCRIPTION
removed the optimization: putting evictable null when mapstore.load() returns null
users can easily add such optimization to their mapstore implementation.
meanwhile internal optimization causes bugs
