### PR TITLE
Fixes #1024

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/EventServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/EventServiceImpl.java
@@ -471,7 +471,7 @@ public class EventServiceImpl implements EventService, PostJoinAwareService {
             }
             if (!registration.isLocal()) {
                 if (nodeEngine.getThisAddress().equals(registration.getSubscriber())) {
-                    logger.warning("Somethings seem wrong! Subscriber is local but listener instance is null! " + registration);
+                    logger.warning("Something seems wrong! Subscriber is local but listener instance is null! " + registration);
                 } else {
                     logger.warning("Invalid target for  " + registration);
                 }


### PR DESCRIPTION
When multiple nodes start simultaneously, post join process duplicates some event registrations and causes warning logs on each publish
