### PR TITLE
Solves problem with QueryBuilder and key

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/query/EntryObject.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/EntryObject.java
@@ -35,12 +35,7 @@ public class EntryObject {
     }
 
     public EntryObject key() {
-        if (qb.attribute == null) {
-            qb.attribute = KEY_ATTRIBUTE_NAME;
-        } else if (!qb.attribute.startsWith(KEY_ATTRIBUTE_NAME)) {
-            qb.attribute = KEY_ATTRIBUTE_NAME + "#" + qb.attribute;
-        }
-
+        qb.attribute = KEY_ATTRIBUTE_NAME;
         return this;
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/query/PredicateBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/PredicateBuilderTest.java
@@ -36,6 +36,7 @@ import static org.junit.Assert.assertTrue;
 @Category(ParallelTest.class)
 public class PredicateBuilderTest extends HazelcastTestSupport {
 
+
     @Test
     public void get_keyAttribute() {
         TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(1);


### PR DESCRIPTION
When a key is selected on the querybuilder, it isn't 'unset'. Meaning that all
gets are done on the key, not on the value. This commit fixes that problem
