### PR TITLE
Cut of a TopologyAwareMemberGroupFactory for review

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/PartitionGroupConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/PartitionGroupConfig.java
@@ -87,7 +87,7 @@ public class PartitionGroupConfig {
     private final List<MemberGroupConfig> memberGroupConfigs = new LinkedList<MemberGroupConfig>();
 
     public enum MemberGroupType {
-        HOST_AWARE, CUSTOM, PER_MEMBER
+        HOST_AWARE, CUSTOM, PER_MEMBER, TOPOLOGY_AWARE
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/nio/Address.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/Address.java
@@ -37,6 +37,9 @@ public final class Address implements IdentifiedDataSerializable, Endpoint {
 
     private int port = -1;
     private String host;
+    private String site;
+    private String rack;
+    private String process;
     private byte type;
 
     private transient String scopeId;
@@ -45,21 +48,46 @@ public final class Address implements IdentifiedDataSerializable, Endpoint {
     public Address() {
     }
 
-    public Address(String host, int port) throws UnknownHostException {
-        this(host, InetAddress.getByName(host), port) ;
+    public Address(String site, String rack, String host, String process, int port) throws UnknownHostException {
+        this(site, rack, host, InetAddress.getByName(host), process, port) ;
         hostSet = !AddressUtil.isIpAddress(host);
     }
 
-    public Address(InetAddress inetAddress, int port) {
-        this(null, inetAddress, port);
+
+    public Address(String host, int port) throws UnknownHostException {
+        this(null, null,
+                host,
+                InetAddress.getByName(host),
+                null,
+                port) ;
+        hostSet = !AddressUtil.isIpAddress(host);
+    }
+
+    public Address(String site, String rack, InetAddress inetAddress, int port) {
+        this(site, rack, null, inetAddress, null, port);
         hostSet = false;
     }
 
-    public Address(InetSocketAddress inetSocketAddress) {
-        this(inetSocketAddress.getAddress(), inetSocketAddress.getPort());
+    public Address(InetAddress inetAddress, int port) {
+        this(null, null, inetAddress, port);
+        hostSet = false;
     }
 
-    private Address(final String hostname, final InetAddress inetAddress, final int port) {
+
+    public Address(String site, String rack, InetSocketAddress inetSocketAddress) {
+        this(site, rack, inetSocketAddress.getAddress(), inetSocketAddress.getPort());
+    }
+
+    public Address(InetSocketAddress inetSocketAddress) {
+        this(null, null,
+                System.getProperty("hazelcast.address.rack"),
+                inetSocketAddress.getAddress(),
+                null,
+                inetSocketAddress.getPort());
+    }
+
+
+    private Address(final String site, final String rack, final String hostname, final InetAddress inetAddress, final String process, final int port) {
         this.type = (inetAddress instanceof Inet4Address) ? IPv4 : IPv6;
         final String[] addressArgs = inetAddress.getHostAddress().split("\\%");
         this.host = hostname != null ? hostname : addressArgs[0];
@@ -68,9 +96,15 @@ public final class Address implements IdentifiedDataSerializable, Endpoint {
 
         }
         this.port = port;
+        this.site = site == null ? System.getProperty("hazelcast.address.site") : site;
+        this.rack = rack == null ? System.getProperty("hazelcast.address.rack") : rack;
+        this.process = (process == null) ? System.getProperty("hazelcast.address.process") : process;
+        this.process = this.process == null ? ProcessIDFactory.getUuid() : this.process;
     }
 
     public Address(Address address) {
+        this.site = address.site;
+        this.rack = address.rack;
         this.host = address.host;
         this.port = address.port;
         this.type = address.type;
@@ -81,6 +115,20 @@ public final class Address implements IdentifiedDataSerializable, Endpoint {
     public void writeData(ObjectDataOutput out) throws IOException {
         out.writeInt(port);
         out.write(type);
+        if (site != null) {
+            byte[] address = site.getBytes();
+            out.writeInt(address.length);
+            out.write(address);
+        } else {
+            out.writeInt(0);
+        }
+        if (rack != null) {
+            byte[] address = rack.getBytes();
+            out.writeInt(address.length);
+            out.write(address);
+        } else {
+            out.writeInt(0);
+        }
         if (host != null) {
             byte[] address = host.getBytes();
             out.writeInt(address.length);
@@ -97,6 +145,18 @@ public final class Address implements IdentifiedDataSerializable, Endpoint {
         if (len > 0) {
             byte[] address = new byte[len];
             in.readFully(address);
+            site = new String(address);
+        }
+        len = in.readInt();
+        if (len > 0) {
+            byte[] address = new byte[len];
+            in.readFully(address);
+            rack = new String(address);
+        }
+        len = in.readInt();
+        if (len > 0) {
+            byte[] address = new byte[len];
+            in.readFully(address);
             host = new String(address);
         }
     }
@@ -107,7 +167,13 @@ public final class Address implements IdentifiedDataSerializable, Endpoint {
 
     @Override
     public String toString() {
-        return "Address[" + getHost() + "]:" + port;
+        return "Address[" +
+                "site='" + site + '\'' +
+                ", rack='" + rack + '\'' +
+                ", host='" + host + '\'' +
+                ", process='" + process + '\'' +
+                ", port=" + port +
+                ']';
     }
 
     public int getPort() {
@@ -125,14 +191,26 @@ public final class Address implements IdentifiedDataSerializable, Endpoint {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof Address)) return false;
-        final Address address = (Address) o;
-        return port == address.port && this.type == address.type && this.host.equals(address.host);
+        if (o == null || getClass() != o.getClass()) return false;
+
+        Address address = (Address) o;
+
+        if (port != address.port) return false;
+        if (type != address.type) return false;
+        if (host != null ? !host.equals(address.host) : address.host != null) return false;
+        if (rack != null ? !rack.equals(address.rack) : address.rack != null) return false;
+        if (site != null ? !site.equals(address.site) : address.site != null) return false;
+        return !(process != null ? !process.equals(address.process) : address.process != null);
+
     }
 
     @Override
     public int hashCode() {
-        return hash(host.getBytes()) * 29 + port;
+        int result  = hash(host.getBytes()) * 29 + port;
+        result = 29 * result + (site != null ? site.hashCode() : 0);
+        result = 29 * result + (rack != null ? rack.hashCode() : 0);
+        result = 29 * result + (process != null ? process.hashCode() : 0);
+        return result;
     }
 
     private int hash(byte[] bytes) {
@@ -174,5 +252,17 @@ public final class Address implements IdentifiedDataSerializable, Endpoint {
     @Override
     public int getId() {
         return ID;
+    }
+
+    public String getSite() {
+        return site;
+    }
+
+    public String getRack() {
+        return rack;
+    }
+
+    public String getProcess() {
+        return process;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/nio/ProcessIDFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/ProcessIDFactory.java
@@ -1,0 +1,15 @@
+package com.hazelcast.nio;
+
+import java.util.UUID;
+
+/**
+ * User: grant
+ */
+public class ProcessIDFactory {
+
+    private static final String uuid = UUID.randomUUID().toString();
+
+    public static String getUuid() {
+        return uuid;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/partition/PartitionServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/PartitionServiceImpl.java
@@ -1365,6 +1365,8 @@ public class PartitionServiceImpl implements PartitionService, ManagedService,
                 return new ConfigMemberGroupFactory(partitionGroupConfig.getMemberGroupConfigs());
             case PER_MEMBER:
                 return new SingleMemberGroupFactory();
+            case TOPOLOGY_AWARE:
+                return new TopologyAwareMemberGroupFactory();
             default:
                 throw new RuntimeException("Unknown MemberGroupType:"+memberGroupType);
         }

--- a/hazelcast/src/main/java/com/hazelcast/partition/TopologyAwareMemberGroupFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/TopologyAwareMemberGroupFactory.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2008-2013, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.partition;
+
+import com.hazelcast.core.Member;
+import com.hazelcast.instance.MemberImpl;
+import com.hazelcast.nio.Address;
+
+import java.util.*;
+
+public class TopologyAwareMemberGroupFactory extends BackupSafeMemberGroupFactory implements MemberGroupFactory {
+
+    protected Set<MemberGroup> createInternalMemberGroups(final Collection<Member> allMembers) {
+        final Map<String, MemberGroup> groups = new HashMap<String, MemberGroup>();
+        Map<String, MemberGroup> hostsMaps = new HashMap<String, MemberGroup>();
+
+        //Firstly try and create MemberGroups by site
+        for (Member member : allMembers) {
+            Address address = ((MemberImpl) member).getAddress();
+
+            if (address.getSite() != null) {
+                MemberGroup group = groups.get("Site:" + address.getSite());
+                if (group == null) {
+                    group = new DefaultMemberGroup();
+                    groups.put("Site:" + address.getSite(), group);
+                }
+                group.addMember(member);
+            }
+            else if (address.getRack() != null) {
+                MemberGroup group = groups.get("Rack:" + address.getRack());
+                if (group == null) {
+                    group = new DefaultMemberGroup();
+                    groups.put("Rack:" + address.getRack(), group);
+                }
+                group.addMember(member);
+            }
+            else {
+
+                MemberGroup group = hostsMaps.get("Host:" + address.getHost());
+                if (group == null) {
+                    group = new DefaultMemberGroup();
+                    hostsMaps.put("Host:" + address.getHost(), group);
+                }
+                group.addMember(member);
+            }
+
+        }
+
+        //If there is only one entry in the hosts map,
+        //then we can potentially create a a number of groups if there
+        //are members running on different processes (JVMs). This
+        //creates a node safe configuration
+        //Then see if it can actually be grouped by process id
+        if (hostsMaps.size() == 1) {
+            Iterator<Member> members = hostsMaps.entrySet().iterator().next().getValue().iterator();
+            Map<String, MemberGroup> processesMap = new HashMap<String, MemberGroup>();
+            while (members.hasNext()) {
+                Member member = members.next();
+                Address address = ((MemberImpl) member).getAddress();
+                MemberGroup group = processesMap.get("Process:" + address.getProcess());
+                if (group == null) {
+                    group = new DefaultMemberGroup();
+                    processesMap.put("Process:" + address.getProcess(), group);
+                }
+                group.addMember(member);
+            }
+            groups.putAll(processesMap);
+        } else {
+            groups.putAll(hostsMaps);
+        }
+        return new HashSet<MemberGroup>(groups.values());
+    }
+}
+

--- a/hazelcast/src/test/java/com/hazelcast/partition/TopologyAwareMemberGroupFactoryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/partition/TopologyAwareMemberGroupFactoryTest.java
@@ -1,0 +1,126 @@
+package com.hazelcast.partition;
+
+import com.hazelcast.core.Member;
+import com.hazelcast.instance.MemberImpl;
+import com.hazelcast.nio.Address;
+import org.junit.Test;
+
+import java.net.InetAddress;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.Assert.*;
+
+/**
+ * User: grant
+ */
+public class TopologyAwareMemberGroupFactoryTest {
+
+
+    @Test
+    public void testCreateInternalMemberGroups_Sites() throws Exception {
+        TopologyAwareMemberGroupFactory factory = new TopologyAwareMemberGroupFactory();
+        List<Member> members = new ArrayList<Member>();
+        members.add(new MemberImpl(new Address("site1", "rack1", "localhost", "process1", 5000), true));
+        members.add(new MemberImpl(new Address("site2", "rack1", "localhost", "process1", 5000), true));
+
+        Set<MemberGroup> result = factory.createInternalMemberGroups(members);
+        assertNotNull(result);
+        assertEquals(2, result.size());
+
+        MemberGroup group1 = result.iterator().next();
+        assertEquals(1, group1.size());
+
+        MemberGroup group2 = result.iterator().next();
+        assertEquals(1, group2.size());
+
+
+    }
+
+    @Test
+    public void testCreateInternalMemberGroups_Racks() throws Exception {
+        TopologyAwareMemberGroupFactory factory = new TopologyAwareMemberGroupFactory();
+        List<Member> members = new ArrayList<Member>();
+        members.add(new MemberImpl(new Address(null, "rack1", "localhost", "process1", 5000), true));
+        members.add(new MemberImpl(new Address(null, "rack2", "localhost", "process1", 5000), true));
+
+        Set<MemberGroup> result = factory.createInternalMemberGroups(members);
+        assertNotNull(result);
+        assertEquals(2, result.size());
+
+        MemberGroup group1 = result.iterator().next();
+        assertEquals(1, group1.size());
+
+        MemberGroup group2 = result.iterator().next();
+        assertEquals(1, group2.size());
+
+
+    }
+
+    @Test
+    public void testCreateInternalMemberGroups_Hosts() throws Exception {
+        TopologyAwareMemberGroupFactory factory = new TopologyAwareMemberGroupFactory();
+        List<Member> members = new ArrayList<Member>();
+        members.add(new MemberImpl(new Address(null, null, "localhost", "process1", 5000), true));
+        members.add(new MemberImpl(new Address(null, null, InetAddress.getLocalHost().getHostName(), "process1", 5000), true));
+
+        Set<MemberGroup> result = factory.createInternalMemberGroups(members);
+        assertNotNull(result);
+        assertEquals(2, result.size());
+
+        MemberGroup group1 = result.iterator().next();
+        assertEquals(1, group1.size());
+
+        MemberGroup group2 = result.iterator().next();
+        assertEquals(1, group2.size());
+
+
+    }
+
+    @Test
+    public void testCreateInternalMemberGroups_Processes() throws Exception {
+        TopologyAwareMemberGroupFactory factory = new TopologyAwareMemberGroupFactory();
+        List<Member> members = new ArrayList<Member>();
+        members.add(new MemberImpl(new Address(null, null, "localhost", "process1", 5000), true));
+        members.add(new MemberImpl(new Address(null, null, "localhost", "process2", 5000), true));
+
+        Set<MemberGroup> result = factory.createInternalMemberGroups(members);
+        assertNotNull(result);
+        assertEquals(2, result.size());
+
+        MemberGroup group1 = result.iterator().next();
+        assertEquals(1, group1.size());
+
+        MemberGroup group2 = result.iterator().next();
+        assertEquals(1, group2.size());
+
+
+    }
+
+
+
+    @Test
+    public void testCreateInternalMemberGroups_MixOfSitesAndRacks() throws Exception {
+        TopologyAwareMemberGroupFactory factory = new TopologyAwareMemberGroupFactory();
+        List<Member> members = new ArrayList<Member>();
+        members.add(new MemberImpl(new Address("site1", "rack1", "localhost", "process1", 5000), true));
+        members.add(new MemberImpl(new Address("site2", "rack1", "localhost", "process1", 5000), true));
+        members.add(new MemberImpl(new Address(null, "rack1", "localhost", "process1", 5000), true));
+        members.add(new MemberImpl(new Address(null, "rack2", "localhost", "process1", 5000), true));
+
+        Set<MemberGroup> result = factory.createInternalMemberGroups(members);
+        assertNotNull(result);
+        assertEquals(4, result.size());
+        MemberGroup group1 = result.iterator().next();
+        assertEquals(1, group1.size());
+        MemberGroup group2 = result.iterator().next();
+        assertEquals(1, group2.size());
+        MemberGroup group3 = result.iterator().next();
+        assertEquals(1, group3.size());
+        MemberGroup group4 = result.iterator().next();
+        assertEquals(1, group4.size());
+
+    }
+
+}


### PR DESCRIPTION
I've worked a fair bit in Oracle Coherence and one of the things that would stop me moving to Hazelcast at the enterprise level is a way to have the backup partition on a different site/rack/host/node based on the existing topology the cluster is running on. So if there are different sites then the backup node should be in another data centre, if there is only one datacenter but multiple racks in that datacenter the the data should be backed up to a different rack etc.

From what I can see this is possible with custom group partitions, however this appears to be mainly IP address based and makes it awkward to configure for different environments.

This is the a pull request for those changes. This is the first time I've really looked at the Hazelcast code base in any real way so please excuse me it this isn't the right way to do it!

What I've done is fairly similar to what happens in Coherence. System properties are defined for the site, rack and potentially process identifiers. I've also created a static process identifier factory that can be used to get the UUID of that process if a system property isn't available.

So when starting the each JVM you could (but not required) declare the following:

hazelcast.address.site
hazelcast.address.rack
hazelcast.address.process

In the config you then set the partition group type to TOPOLOGY_AWARE

The factory will group members in the same site, then rack, then host and finally node if all of the members are on the same host. 

I'm not sure if this is the right way to do it as I'm not that familiar with the code, but I'm wondering what sort of appetite there is to include something like this?

Specifically I'm not sure what you guys define as an "Address", ie is this a specific class to represent a simple network address or can it represent more than that. If it is the former then maybe the changes for rack, site etc belong in something like the Member/MemberInfo classes.

As I say I'm new to the project code base so some guidance there would be good.
