### PR TITLE
HealthMonitor displays ExecutorManager queue statistics

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/impl/NamedExecutorService.java
+++ b/hazelcast/src/main/java/com/hazelcast/impl/NamedExecutorService.java
@@ -49,4 +49,8 @@ public class NamedExecutorService {
     public ExecutionLoadBalancer getExecutionLoadBalancer() {
         return executionLoadBalancer;
     }
+
+    public int getQueueSize(){
+        return parallelExecutor.getQueueSize();
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/impl/executor/ParallelExecutor.java
+++ b/hazelcast/src/main/java/com/hazelcast/impl/executor/ParallelExecutor.java
@@ -27,4 +27,6 @@ public interface ParallelExecutor {
     int getPoolSize();
 
     int getActiveCount();
+
+    int getQueueSize();
 }

--- a/hazelcast/src/main/java/com/hazelcast/impl/executor/ParallelExecutorService.java
+++ b/hazelcast/src/main/java/com/hazelcast/impl/executor/ParallelExecutorService.java
@@ -93,6 +93,10 @@ public class ParallelExecutorService {
         public int getActiveCount() {
             return 0;
         }
+
+        public int getQueueSize() {
+            return -1;
+        }
     }
 
     private class ParallelExecutorImpl implements ParallelExecutor {
@@ -116,6 +120,14 @@ public class ParallelExecutorService {
             for (int i = 0; i < concurrencyLevel; i++) {
                 executionSegments[i] = new ExecutionSegment(segmentCapacity);
             }
+        }
+
+        public int getQueueSize() {
+            int result = 0;
+            for(ExecutionSegment segment: executionSegments){
+                 result+=segment.q.size();
+            }
+            return result;
         }
 
         public void execute(Runnable command) {

--- a/hazelcast/src/main/java/com/hazelcast/util/HealthMonitor.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/HealthMonitor.java
@@ -4,6 +4,7 @@ import com.hazelcast.cluster.ClusterService;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.impl.ExecutorManager;
 import com.hazelcast.impl.GroupProperties;
 import com.hazelcast.impl.Node;
 import com.hazelcast.logging.ILogger;
@@ -40,7 +41,6 @@ public class HealthMonitor extends Thread {
         this.osMxBean = ManagementFactory.getOperatingSystemMXBean();
         this.logLevel = logLevel;
         threadMxBean = ManagementFactory.getThreadMXBean();
-
     }
 
     public void run() {
@@ -91,6 +91,13 @@ public class HealthMonitor extends Thread {
         final int threadCount;
         final int peakThreadCount;
 
+        final int queryQueueSize;
+        final int mapLoaderExecutorQueueSize;
+        final int defaultExecutorQueueSize;
+        final int asyncExecutorQueueSize;
+        final int eventExecutorQueueSize;
+        final int mapStoreExecutorQueueSize;
+
         public HealthMetrics() {
             memoryFree = runtime.freeMemory();
             memoryTotal = runtime.totalMemory();
@@ -109,6 +116,14 @@ public class HealthMonitor extends Thread {
 
             this.threadCount = threadMxBean.getThreadCount();
             this.peakThreadCount = threadMxBean.getPeakThreadCount();
+
+            ExecutorManager.Statistics statistics = node.getExecutorManager().getStatistics();
+            this.queryQueueSize = statistics.queryQueueSize;
+            this.mapLoaderExecutorQueueSize = statistics.mapLoaderExecutorQueueSize;
+            this.defaultExecutorQueueSize = statistics.defaultExecutorQueueSize;
+            this.asyncExecutorQueueSize = statistics.asyncExecutorQueueSize;
+            this.eventExecutorQueueSize = statistics.eventExecutorQueueSize;
+            this.mapStoreExecutorQueueSize = statistics.mapStoreExecutorQueueSize;
         }
 
         public boolean exceedsTreshold() {
@@ -146,7 +161,15 @@ public class HealthMonitor extends Thread {
             sb.append("q.processable.size=").append(processableQueueSize).append(", ");
             sb.append("q.processablePriority.size=").append(processablePriorityQueueSize).append(", ");
             sb.append("thread.count=").append(threadCount).append(", ");
-            sb.append("thread.peakCount=").append(peakThreadCount);
+            sb.append("thread.peakCount=").append(peakThreadCount).append(", ");
+
+            sb.append("q.query.size=").append(queryQueueSize).append(", ");
+            sb.append("q.mapLoader.size=").append(mapLoaderExecutorQueueSize).append(", ");
+            sb.append("q.defaultExecutor.size=").append(defaultExecutorQueueSize).append(", ");
+            sb.append("q.asyncExecutor.size=").append(asyncExecutorQueueSize).append(", ");
+            sb.append("q.eventExecutor.size=").append(eventExecutorQueueSize).append(", ");
+            sb.append("q.mapStoreExecutor.size=").append(mapStoreExecutorQueueSize);
+
             return sb.toString();
         }
     }


### PR DESCRIPTION
The HealthMonitor now displays various qeueue statistics of the ExecutorManager.
This is done to help figure out which queues are taking up a lot of space (so
which are potentially overloaded).
