### PR TITLE
add a new 'hazelcast.partition.migration.activation.delay.seconds' config prop

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/instance/GroupProperties.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/GroupProperties.java
@@ -68,6 +68,7 @@ public class GroupProperties {
     public static final String PROP_MC_URL_CHANGE_ENABLED = "hazelcast.mc.url.change.enabled";
     public static final String PROP_CONNECTION_MONITOR_INTERVAL = "hazelcast.connection.monitor.interval";
     public static final String PROP_CONNECTION_MONITOR_MAX_FAULTS = "hazelcast.connection.monitor.max.faults";
+    public static final String PROP_PARTITION_MIGRATION_ACTIVATION_DELAY_SECONDS = "hazelcast.partition.migration.activation.delay.seconds";
     public static final String PROP_PARTITION_MIGRATION_INTERVAL = "hazelcast.partition.migration.interval";
     public static final String PROP_PARTITION_MIGRATION_TIMEOUT = "hazelcast.partition.migration.timeout";
     public static final String PROP_PARTITION_MIGRATION_ZIP_ENABLED = "hazelcast.partition.migration.zip.enabled";
@@ -177,6 +178,8 @@ public class GroupProperties {
 
     public final GroupProperty CONNECTION_MONITOR_MAX_FAULTS;
 
+    public final GroupProperty PARTITION_MIGRATION_ACTIVATION_DELAY_SECONDS;
+
     public final GroupProperty PARTITION_MIGRATION_INTERVAL;
 
     public final GroupProperty PARTITION_MIGRATION_TIMEOUT;
@@ -257,6 +260,7 @@ public class GroupProperties {
         MC_URL_CHANGE_ENABLED = new GroupProperty(config, PROP_MC_URL_CHANGE_ENABLED, "true");
         CONNECTION_MONITOR_INTERVAL = new GroupProperty(config, PROP_CONNECTION_MONITOR_INTERVAL, "100");
         CONNECTION_MONITOR_MAX_FAULTS = new GroupProperty(config, PROP_CONNECTION_MONITOR_MAX_FAULTS, "3");
+        PARTITION_MIGRATION_ACTIVATION_DELAY_SECONDS = new GroupProperty(config, PROP_PARTITION_MIGRATION_ACTIVATION_DELAY_SECONDS, "3");
         PARTITION_MIGRATION_INTERVAL = new GroupProperty(config, PROP_PARTITION_MIGRATION_INTERVAL, "0");
         PARTITION_MIGRATION_TIMEOUT = new GroupProperty(config, PROP_PARTITION_MIGRATION_TIMEOUT, "300");
         PARTITION_MIGRATION_ZIP_ENABLED = new GroupProperty(config, PROP_PARTITION_MIGRATION_ZIP_ENABLED, "true");

--- a/hazelcast/src/main/java/com/hazelcast/partition/PartitionServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/PartitionServiceImpl.java
@@ -293,15 +293,15 @@ public class PartitionServiceImpl implements PartitionService, ManagedService,
                 migrationQueue.offer(new RepartitioningTask());
             }
 
-            // Activate migration back after connectionDropTime x 10 milliseconds,
-            // thinking optimistically that all nodes notice the dead one in this period.
-            final long waitBeforeMigrationActivate = node.groupProperties.CONNECTION_MONITOR_INTERVAL.getLong()
-                    * node.groupProperties.CONNECTION_MONITOR_MAX_FAULTS.getInteger() * 10;
+            // Add a delay before activating migration, to give other nodes time to notice the dead one.
+            long migrationActivationDelaySeconds = node.groupProperties.PARTITION_MIGRATION_ACTIVATION_DELAY_SECONDS.getLong();
+            logger.info("Waiting " + migrationActivationDelaySeconds + " seconds before activating migration...");
+
             nodeEngine.getExecutionService().schedule(new Runnable() {
                 public void run() {
                     migrationActive.set(true);
                 }
-            }, waitBeforeMigrationActivate, TimeUnit.MILLISECONDS);
+            }, migrationActivationDelaySeconds, TimeUnit.SECONDS);
         } finally {
             lock.unlock();
         }


### PR DESCRIPTION
This prop allows more control over the delay between the master node completing a migration after a node has died, and the master node activating that migration. Set the prop's default value to 3 seconds.
