### PR TITLE
workaround for NPE in writeData() (#1019) 

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/MapValueCollection.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/MapValueCollection.java
@@ -32,7 +32,12 @@ public class MapValueCollection implements IdentifiedDataSerializable {
 
 
     public MapValueCollection(Collection<Data> values) {
-        this.values = values;
+        this.values = new ArrayList<Data>();
+        for (Data value : values) {
+            if (value != null) {
+                this.values.add(value);
+            }
+        }
     }
 
     public MapValueCollection() {


### PR DESCRIPTION
The NPE occurs when one of the items in the 'values' List is null.
