### PR TITLE
Added the AtomicLong GetOperation

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/GetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/GetOperation.java
@@ -1,0 +1,24 @@
+package com.hazelcast.concurrent.atomiclong;
+
+public class GetOperation extends AtomicLongBaseOperation {
+
+    private long returnValue;
+
+    public GetOperation() {
+        super();
+    }
+
+    public GetOperation(String name) {
+        super(name);
+    }
+
+    @Override
+    public void run() throws Exception {
+        returnValue = getNumber().get();
+    }
+
+    @Override
+    public Object getResponse() {
+        return returnValue;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/proxy/AtomicLongProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/proxy/AtomicLongProxy.java
@@ -100,7 +100,14 @@ public class AtomicLongProxy extends AbstractDistributedObject<AtomicLongService
     }
 
     public long get() {
-        return getAndAdd(0);
+        try {
+            GetOperation operation = new GetOperation(name);
+            Invocation inv = getNodeEngine().getOperationService().createInvocationBuilder(AtomicLongService.SERVICE_NAME, operation, partitionId).build();
+            Future f = inv.invoke();
+            return (Long) f.get();
+        } catch (Throwable throwable) {
+            throw ExceptionUtil.rethrow(throwable);
+        }
     }
 
     public long incrementAndGet() {


### PR DESCRIPTION
The advantage of this class instead of relying on the AddAndGet is that the former doesnt
need to wait on backups and the latter does, so it will be more response and also cause
less load on the network and the backup member.
