### PR TITLE
The InvalidateNearCacheOperation now returns the correct ServiceName

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/operation/InvalidateNearCacheOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/operation/InvalidateNearCacheOperation.java
@@ -53,6 +53,11 @@ public class InvalidateNearCacheOperation extends AbstractOperation {
     }
 
     @Override
+    public String getServiceName() {
+        return MapService.SERVICE_NAME;
+    }
+
+    @Override
     public void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
         mapName = in.readUTF();


### PR DESCRIPTION
Fixes #1254 
