### PR TITLE
finest logging should be guarded where appropriate

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/ClientEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/ClientEngineImpl.java
@@ -383,10 +383,12 @@ public class ClientEngineImpl implements ClientEngine, ConnectionListener, CoreS
                 }
             } catch (Throwable e) {
                 final Level level = nodeEngine.isActive() ? Level.SEVERE : Level.FINEST;
-                String message = request != null
-                        ? "While executing request: " + request + " -> " + e.getMessage()
-                        : e.getMessage();
-                logger.log(level, message, e);
+                if (logger.isLoggable(level)) {
+                    String message = request != null
+                            ? "While executing request: " + request + " -> " + e.getMessage()
+                            : e.getMessage();
+                    logger.log(level, message, e);
+                }
                 sendResponse(endpoint, e);
             }
         }

--- a/hazelcast/src/main/java/com/hazelcast/cluster/AbstractJoiner.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/AbstractJoiner.java
@@ -154,8 +154,10 @@ public abstract class AbstractJoiner implements Joiner {
                     for (Member member : node.getClusterService().getMembers()) {
                         MemberImpl memberImpl = (MemberImpl) member;
                         if (memberImpl.getAddress().equals(joinRequest.getAddress())) {
-                            logger.finest( "Should not merge to " + joinRequest.getAddress()
-                                    + ", because it is already member of this cluster.");
+                            if (logger.isFinestEnabled()) {
+                                logger.finest( "Should not merge to " + joinRequest.getAddress()
+                                        + ", because it is already member of this cluster.");
+                            }
                             return false;
                         }
                     }
@@ -165,7 +167,9 @@ public abstract class AbstractJoiner implements Joiner {
                         logger.info(node.getThisAddress() + " is merging to " + joinRequest.getAddress()
                                 + ", because : joinRequest.getMemberCount() > currentMemberCount ["
                                 + (joinRequest.getMemberCount() + " > " + currentMemberCount) + "]");
-                        logger.finest( joinRequest.toString());
+                        if (logger.isFinestEnabled()) {
+                            logger.finest( joinRequest.toString());
+                        }
                         shouldMerge = true;
                     } else if (joinRequest.getMemberCount() == currentMemberCount) {
                         // compare the hashes
@@ -173,12 +177,16 @@ public abstract class AbstractJoiner implements Joiner {
                             logger.info(node.getThisAddress() + " is merging to " + joinRequest.getAddress()
                                     + ", because : node.getThisAddress().hashCode() > joinRequest.address.hashCode() "
                                     + ", this node member count: " + currentMemberCount);
-                            logger.finest( joinRequest.toString());
+                            if (logger.isFinestEnabled()) {
+                                logger.finest( joinRequest.toString());
+                            }
                             shouldMerge = true;
                         } else {
-                            logger.finest( joinRequest.getAddress() + " should merge to this node "
-                                    + ", because : node.getThisAddress().hashCode() < joinRequest.address.hashCode() "
-                                    + ", this node member count: " + currentMemberCount);
+                            if (logger.isFinestEnabled()) {
+                                logger.finest( joinRequest.getAddress() + " should merge to this node "
+                                        + ", because : node.getThisAddress().hashCode() < joinRequest.address.hashCode() "
+                                        + ", this node member count: " + currentMemberCount);
+                            }
                         }
                     }
                 }
@@ -194,7 +202,9 @@ public abstract class AbstractJoiner implements Joiner {
         for (Address possibleAddress : colPossibleAddresses) {
             final Connection conn = node.connectionManager.getOrConnect(possibleAddress);
             if (conn != null) {
-                logger.finest( "sending join request for " + possibleAddress);
+                if (logger.isFinestEnabled()) {
+                    logger.finest( "sending join request for " + possibleAddress);
+                }
                 node.clusterService.sendJoinRequest(possibleAddress, true);
             }
         }

--- a/hazelcast/src/main/java/com/hazelcast/cluster/ClusterServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/ClusterServiceImpl.java
@@ -227,7 +227,9 @@ public final class ClusterServiceImpl implements ClusterService, ConnectionListe
             }
             if (deadAddresses != null) {
                 for (Address address : deadAddresses) {
-                    logger.finest( "No heartbeat should remove " + address);
+                    if (logger.isFinestEnabled()) {
+                        logger.finest( "No heartbeat should remove " + address);
+                    }
                     removeAddress(address);
                 }
             }
@@ -258,7 +260,9 @@ public final class ClusterServiceImpl implements ClusterService, ConnectionListe
                     if (conn != null) {
                         sendHeartbeat(address);
                     } else {
-                        logger.finest( "Could not connect to " + address + " to send heartbeat");
+                        if (logger.isFinestEnabled()) {
+                            logger.finest( "Could not connect to " + address + " to send heartbeat");
+                        }
                     }
                 }
             }
@@ -298,8 +302,10 @@ public final class ClusterServiceImpl implements ClusterService, ConnectionListe
         try {
             node.nodeEngine.getOperationService().send(new HeartbeatOperation(), target);
         } catch (Exception e) {
-            logger.finest( "Error while sending heartbeat -> "
-                    + e.getClass().getName() + "[" + e.getMessage() + "]");
+            if (logger.isFinestEnabled()) {
+                logger.finest( "Error while sending heartbeat -> "
+                        + e.getClass().getName() + "[" + e.getMessage() + "]");
+            }
         }
     }
 
@@ -422,9 +428,11 @@ public final class ClusterServiceImpl implements ClusterService, ConnectionListe
         try {
             final JoinRequest joinMessage = joinRequest.getMessage();
             final long now = Clock.currentTimeMillis();
-            String msg = "Handling join from " + joinMessage.getAddress() + ", inProgress: " + joinInProgress
-                    + (timeToStartJoin > 0 ? ", timeToStart: " + (timeToStartJoin - now) : "");
-            logger.finest( msg);
+            if (logger.isFinestEnabled()) {
+                String msg = "Handling join from " + joinMessage.getAddress() + ", inProgress: " + joinInProgress
+                        + (timeToStartJoin > 0 ? ", timeToStart: " + (timeToStartJoin - now) : "");
+                logger.finest(msg);
+            }
             boolean validJoinRequest;
             try {
                 validJoinRequest = validateJoinMessage(joinMessage);
@@ -436,8 +444,10 @@ public final class ClusterServiceImpl implements ClusterService, ConnectionListe
                 final MemberImpl member = getMember(joinMessage.getAddress());
                 if (member != null) {
                     if (joinMessage.getUuid().equals(member.getUuid())) {
-                        String message = "Ignoring join request, member already exists.. => " + joinMessage;
-                        logger.finest( message);
+                        if (logger.isFinestEnabled()) {
+                            String message = "Ignoring join request, member already exists.. => " + joinMessage;
+                            logger.finest(message);
+                        }
                         // send members update back to node trying to join again...
                         nodeEngine.getOperationService().send(new MemberInfoUpdateOperation(createMemberInfos(getMemberList()), getClusterTime(), false),
                                 member.getAddress());
@@ -520,7 +530,9 @@ public final class ClusterServiceImpl implements ClusterService, ConnectionListe
         lock.lock();
         try {
             if (!node.joined() && !node.getThisAddress().equals(masterAddress)) {
-                logger.finest( "Handling master response: " + this);
+                if (logger.isFinestEnabled()) {
+                    logger.finest( "Handling master response: " + this);
+                }
                 final Address currentMaster = node.getMasterAddress();
                 if (currentMaster != null && !currentMaster.equals(masterAddress)) {
                     final Connection conn = node.connectionManager.getConnection(currentMaster);
@@ -659,7 +671,9 @@ public final class ClusterServiceImpl implements ClusterService, ConnectionListe
                 try {
                     future.get(10, TimeUnit.SECONDS);
                 } catch (TimeoutException ignored) {
-                    logger.finest("Finalize join call timed-out: " + future);
+                    if (logger.isFinestEnabled()) {
+                        logger.finest("Finalize join call timed-out: " + future);
+                    }
                 } catch (Exception e) {
                     logger.warning("While waiting finalize join calls...", e);
                 }
@@ -739,7 +753,9 @@ public final class ClusterServiceImpl implements ClusterService, ConnectionListe
     }
 
     public void connectionRemoved(Connection connection) {
-        logger.finest( "Connection is removed " + connection.getEndPoint());
+        if (logger.isFinestEnabled()) {
+            logger.finest( "Connection is removed " + connection.getEndPoint());
+        }
         if (!node.joined()) {
             final Address masterAddress = node.getMasterAddress();
             if (masterAddress != null && masterAddress.equals(connection.getEndPoint())) {
@@ -759,7 +775,9 @@ public final class ClusterServiceImpl implements ClusterService, ConnectionListe
 
     private void setMembers(MemberImpl... members) {
         if (members == null || members.length == 0) return;
-        logger.finest("Updating members -> " + Arrays.toString(members));
+        if (logger.isFinestEnabled()) {
+            logger.finest("Updating members -> " + Arrays.toString(members));
+        }
         lock.lock();
         try {
             Map<Address, MemberImpl> oldMemberMap = membersRef.get();
@@ -812,7 +830,9 @@ public final class ClusterServiceImpl implements ClusterService, ConnectionListe
                 nodeEngine.onMemberLeft(deadMember);                  // sync call
                 sendMembershipEventNotifications(deadMember, Collections.unmodifiableSet(new LinkedHashSet<Member>(newMembers.values())), false); // async events
                 if (node.isMaster()) {
-                    logger.finest( deadMember + " is dead. Sending remove to all other members.");
+                    if (logger.isFinestEnabled()) {
+                        logger.finest( deadMember + " is dead. Sending remove to all other members.");
+                    }
                     invokeMemberRemoveOperation(deadMember.getAddress());
                 }
             }

--- a/hazelcast/src/main/java/com/hazelcast/cluster/FinalizeJoinOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/FinalizeJoinOperation.java
@@ -86,8 +86,10 @@ public class FinalizeJoinOperation extends MemberInfoUpdateOperation implements 
                     } catch (TimeoutException ignored) {
                     } catch (ExecutionException e) {
                         final ILogger logger = nodeEngine.getLogger(FinalizeJoinOperation.class);
-                        logger.finest( "Error while executing post-join operations -> "
-                                + e.getClass().getSimpleName() + "[" +e.getMessage() + "]");
+                        if (logger.isFinestEnabled()) {
+                            logger.finest( "Error while executing post-join operations -> "
+                                    + e.getClass().getSimpleName() + "[" +e.getMessage() + "]");
+                        }
                     }
                 }
             }

--- a/hazelcast/src/main/java/com/hazelcast/cluster/MemberRemoveOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/MemberRemoveOperation.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.cluster;
 
+import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
@@ -40,7 +41,10 @@ public class MemberRemoveOperation extends AbstractClusterOperation {
         final Address caller = getCallerAddress();
         if (caller != null &&
                 (caller.equals(deadAddress) || caller.equals(clusterService.getMasterAddress()))) {
-            getLogger().finest( "Removing " + deadAddress + ", called from " + caller);
+            ILogger logger = getLogger();
+            if (logger.isFinestEnabled()) {
+                logger.finest( "Removing " + deadAddress + ", called from " + caller);
+            }
             clusterService.removeAddress(deadAddress);
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/cluster/MulticastJoiner.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/MulticastJoiner.java
@@ -138,12 +138,16 @@ public class MulticastJoiner extends AbstractJoiner {
             throw new IllegalArgumentException();
         }
         Connection conn = node.connectionManager.getOrConnect(masterAddress);
-        logger.finest( "Master connection " + conn);
+        if (logger.isFinestEnabled()) {
+            logger.finest( "Master connection " + conn);
+        }
         systemLogService.logJoin("Master connection " + conn);
         if (conn != null) {
             return node.clusterService.sendJoinRequest(masterAddress, true);
         } else {
-            logger.finest( "Connecting to master node: " + masterAddress);
+            if (logger.isFinestEnabled()) {
+                logger.finest( "Connecting to master node: " + masterAddress);
+            }
             return false;
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/cluster/TcpIpJoiner.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/TcpIpJoiner.java
@@ -59,7 +59,9 @@ public class TcpIpJoiner extends AbstractJoiner {
             if (targetAddress == null) {
                 throw new IllegalArgumentException("Invalid target address -> NULL");
             }
-            logger.finest( "Joining over target member " + targetAddress);
+            if (logger.isFinestEnabled()) {
+                logger.finest( "Joining over target member " + targetAddress);
+            }
             if (targetAddress.equals(node.getThisAddress()) || isLocalAddress(targetAddress)) {
                 node.setAsMaster();
                 return;
@@ -73,7 +75,9 @@ public class TcpIpJoiner extends AbstractJoiner {
                     Thread.sleep(2000L);
                     continue;
                 }
-                logger.finest( "Sending joinRequest " + targetAddress);
+                if (logger.isFinestEnabled()) {
+                    logger.finest( "Sending joinRequest " + targetAddress);
+                }
                 node.clusterService.sendJoinRequest(targetAddress, true);
                 //noinspection BusyWait
                 Thread.sleep(3000L);
@@ -102,7 +106,9 @@ public class TcpIpJoiner extends AbstractJoiner {
                 approvedAsMaster = false;
                 logger.warning("This node requires MulticastJoin strategy!");
             }
-            logger.finest( "Sending '" + approvedAsMaster + "' for master claim of node: " + getCallerAddress());
+            if (logger.isFinestEnabled()) {
+                logger.finest( "Sending '" + approvedAsMaster + "' for master claim of node: " + getCallerAddress());
+            }
         }
 
         @Override
@@ -129,17 +135,23 @@ public class TcpIpJoiner extends AbstractJoiner {
             int numberOfSeconds = 0;
             final int connectionTimeoutSeconds = getConnTimeoutSeconds();
             while (!foundConnection && numberOfSeconds < connectionTimeoutSeconds) {
-                logger.finest( "Removing failedConnections: " + node.getFailedConnections());
+                if (logger.isFinestEnabled()) {
+                    logger.finest( "Removing failedConnections: " + node.getFailedConnections());
+                }
                 colPossibleAddresses.removeAll(node.getFailedConnections());
                 if (colPossibleAddresses.size() == 0) {
                     break;
                 }
-                logger.finest( "We are going to try to connect to each address" + colPossibleAddresses);
+                if (logger.isFinestEnabled()) {
+                    logger.finest( "We are going to try to connect to each address" + colPossibleAddresses);
+                }
                 for (Address possibleAddress : colPossibleAddresses) {
                     final Connection conn = node.connectionManager.getOrConnect(possibleAddress);
                     if (conn != null) {
                         foundConnection = true;
-                        logger.finest( "Found a connection and sending join request to " + possibleAddress);
+                        if (logger.isFinestEnabled()) {
+                            logger.finest( "Found a connection and sending join request to " + possibleAddress);
+                        }
                         node.clusterService.sendJoinRequest(possibleAddress, true);
                     }
                 }
@@ -148,7 +160,9 @@ public class TcpIpJoiner extends AbstractJoiner {
                     numberOfSeconds++;
                 }
             }
-            logger.finest( "FOUND " + foundConnection);
+            if (logger.isFinestEnabled()) {
+                logger.finest( "FOUND " + foundConnection);
+            }
             if (!foundConnection) {
                 logger.finest( "This node will assume master role since no possible member where connected to.");
                 node.setAsMaster();
@@ -160,7 +174,9 @@ public class TcpIpJoiner extends AbstractJoiner {
                         Thread.sleep(500L);
                         Address masterAddress = node.getMasterAddress();
                         if (masterAddress != null) {
-                            logger.finest( "Sending join request to " + masterAddress);
+                            if (logger.isFinestEnabled()) {
+                                logger.finest( "Sending join request to " + masterAddress);
+                            }
                             node.clusterService.sendJoinRequest(masterAddress, true);
                         }
                     }
@@ -209,9 +225,11 @@ public class TcpIpJoiner extends AbstractJoiner {
                                 }
                             }
                             if (allApprovedAsMaster) {
-                                logger.finest( node.getThisAddress() + " Setting myself as master! group "
-                                        + node.getConfig().getGroupConfig().getName() + " possible addresses "
-                                        + colPossibleAddresses.size() + " " + colPossibleAddresses);
+                                if (logger.isFinestEnabled()) {
+                                    logger.finest( node.getThisAddress() + " Setting myself as master! group "
+                                            + node.getConfig().getGroupConfig().getName() + " possible addresses "
+                                            + colPossibleAddresses.size() + " " + colPossibleAddresses);
+                                }
                                 node.setAsMaster();
                                 return;
                             } else {
@@ -246,11 +264,15 @@ public class TcpIpJoiner extends AbstractJoiner {
         colPossibleAddresses.removeAll(node.getFailedConnections());
         if (colPossibleAddresses.size() == 0) {
             node.setAsMaster();
-            logger.finest( node.getThisAddress() + " Setting myself as master! group " + node.getConfig().getGroupConfig().getName()
-                    + " no possible addresses without failed connection");
+            if (logger.isFinestEnabled()) {
+                logger.finest( node.getThisAddress() + " Setting myself as master! group " + node.getConfig().getGroupConfig().getName()
+                        + " no possible addresses without failed connection");
+            }
             return;
         }
-        logger.finest( node.getThisAddress() + " joining to master " + node.getMasterAddress() + ", group " + node.getConfig().getGroupConfig().getName());
+        if (logger.isFinestEnabled()) {
+            logger.finest( node.getThisAddress() + " joining to master " + node.getMasterAddress() + ", group " + node.getConfig().getGroupConfig().getName());
+        }
         while (node.isActive() && !node.joined()) {
             //noinspection BusyWait
             Thread.sleep(1000L);
@@ -262,7 +284,9 @@ public class TcpIpJoiner extends AbstractJoiner {
                     return;
                 }
             } else {
-                logger.finest( node.getThisAddress() + " couldn't find a master! but there was connections available: " + colPossibleAddresses);
+                if (logger.isFinestEnabled()) {
+                    logger.finest( node.getThisAddress() + " couldn't find a master! but there was connections available: " + colPossibleAddresses);
+                }
                 return;
             }
         }
@@ -391,7 +415,9 @@ public class TcpIpJoiner extends AbstractJoiner {
     private boolean isLocalAddress(final Address address) throws UnknownHostException {
         final Address thisAddress = node.getThisAddress();
         final boolean local = thisAddress.getInetSocketAddress().equals(address.getInetSocketAddress());
-        logger.finest( address + " is local? " + local);
+        if (logger.isFinestEnabled()) {
+            logger.finest( address + " is local? " + local);
+        }
         return local;
     }
 
@@ -427,7 +453,9 @@ public class TcpIpJoiner extends AbstractJoiner {
             return;
         }
         for (Address possibleAddress : colPossibleAddresses) {
-            logger.finest( node.getThisAddress() + " is connecting to " + possibleAddress);
+            if (logger.isFinestEnabled()) {
+                logger.finest( node.getThisAddress() + " is connecting to " + possibleAddress);
+            }
             node.connectionManager.getOrConnect(possibleAddress, true);
             try {
                 //noinspection BusyWait

--- a/hazelcast/src/main/java/com/hazelcast/nio/AbstractIOSelector.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/AbstractIOSelector.java
@@ -101,7 +101,9 @@ abstract class AbstractIOSelector extends Thread implements IOSelector {
             while (live) {
                 processSelectionQueue();
                 if (!live || isInterrupted()) {
-                    logger.finest( getName() + " is interrupted!");
+                    if (logger.isFinestEnabled()) {
+                        logger.finest( getName() + " is interrupted!");
+                    }
                     live = false;
                     return;
                 }
@@ -133,7 +135,9 @@ abstract class AbstractIOSelector extends Thread implements IOSelector {
             logger.warning("Unhandled exception in " + getName(), e);
         } finally {
             try {
-                logger.finest( "Closing selector " + getName());
+                if (logger.isFinestEnabled()) {
+                    logger.finest( "Closing selector " + getName());
+                }
                 selector.close();
             } catch (final Exception ignored) {
             }

--- a/hazelcast/src/main/java/com/hazelcast/nio/SocketAcceptor.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/SocketAcceptor.java
@@ -39,7 +39,9 @@ public class SocketAcceptor implements Runnable {
     public void run() {
         Selector selector = null;
         try {
-            log(Level.FINEST, "Starting SocketAcceptor on " + serverSocketChannel);
+            if (logger.isFinestEnabled()) {
+                log(Level.FINEST, "Starting SocketAcceptor on " + serverSocketChannel);
+            }
             selector = Selector.open();
             serverSocketChannel.configureBlocking(false);
             serverSocketChannel.register(selector, SelectionKey.OP_ACCEPT);
@@ -73,7 +75,9 @@ public class SocketAcceptor implements Runnable {
     private void closeSelector(Selector selector) {
         if (selector != null) {
             try {
-                logger.finest( "Closing selector " + Thread.currentThread().getName());
+                if (logger.isFinestEnabled()) {
+                    logger.finest( "Closing selector " + Thread.currentThread().getName());
+                }
                 selector.close();
             } catch (final Exception ignored) {
             }

--- a/hazelcast/src/main/java/com/hazelcast/nio/SocketConnector.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/SocketConnector.java
@@ -41,12 +41,16 @@ public class SocketConnector implements Runnable {
 
     public void run() {
         if (!connectionManager.isLive()) {
-            String message = "ConnectionManager is not live, connection attempt to " + address + " is cancelled!";
-            log(Level.FINEST, message);
+            if (logger.isFinestEnabled()) {
+                String message = "ConnectionManager is not live, connection attempt to " + address + " is cancelled!";
+                log(Level.FINEST, message);
+            }
             return;
         }
         try {
-            log(Level.FINEST, "Starting to connect to " + address);
+            if (logger.isFinestEnabled()) {
+                log(Level.FINEST, "Starting to connect to " + address);
+            }
             final Address thisAddress = connectionManager.ioService.getThisAddress();
             if (address.isIPv4()) {
                 // remote is IPv4; connect...
@@ -64,7 +68,9 @@ public class SocketConnector implements Runnable {
                 final Collection<Inet6Address> possibleInetAddresses = AddressUtil.getPossibleInetAddressesFor(
                         (Inet6Address) address.getInetAddress());
                 final Level level = silent ? Level.FINEST : Level.INFO;
-                log(level, "Trying to connect possible IPv6 addresses: " + possibleInetAddresses);
+                if (logger.isLoggable(level)) { //TODO: collection.toString() will likely not produce any useful output!
+                    log(level, "Trying to connect possible IPv6 addresses: " + possibleInetAddresses);
+                }
                 boolean connected = false;
                 Exception error = null;
                 for (Inet6Address inetAddress : possibleInetAddresses) {
@@ -94,10 +100,12 @@ public class SocketConnector implements Runnable {
         if (connectionManager.ioService.isSocketBind()) {
             bindSocket(socketChannel);
         }
-        final String message = "Connecting to " + socketAddress + ", timeout: " + timeout
-                + ", bind-any: " + connectionManager.ioService.isSocketBindAny();
         final Level level = silent ? Level.FINEST : Level.INFO;
-        log(level, message);
+        if (logger.isLoggable(level)) {
+            final String message = "Connecting to " + socketAddress + ", timeout: " + timeout
+                    + ", bind-any: " + connectionManager.ioService.isSocketBindAny();
+            log(level, message);
+        }
         try {
             socketChannel.configureBlocking(true);
             try {
@@ -112,12 +120,15 @@ public class SocketConnector implements Runnable {
                 newEx.setStackTrace(ex.getStackTrace());
                 throw newEx;
             }
-
-            log(Level.FINEST, "Successfully connected to: " + address + " using socket " + socketChannel.socket());
+            if (logger.isFinestEnabled()) {
+                log(Level.FINEST, "Successfully connected to: " + address + " using socket " + socketChannel.socket());
+            }
             final SocketChannelWrapper socketChannelWrapper = connectionManager.wrapSocketChannel(socketChannel, true);
             MemberSocketInterceptor memberSocketInterceptor = connectionManager.getMemberSocketInterceptor();
             if (memberSocketInterceptor != null) {
-                log(Level.FINEST, "Calling member socket interceptor: " + memberSocketInterceptor + " for " + socketChannel);
+                if (logger.isFinestEnabled()) {
+                    log(Level.FINEST, "Calling member socket interceptor: " + memberSocketInterceptor + " for " + socketChannel);
+                }
                 memberSocketInterceptor.onConnect(socketChannel.socket());
             }
 

--- a/hazelcast/src/main/java/com/hazelcast/nio/TcpIpConnection.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/TcpIpConnection.java
@@ -74,7 +74,9 @@ public final class TcpIpConnection implements Connection {
 
     public boolean write(SocketWritable packet) {
         if (!live) {
-            logger.finest( "Connection is closed, won't write packet -> " + packet);
+            if (logger.isFinestEnabled()) {
+                logger.finest( "Connection is closed, won't write packet -> " + packet);
+            }
             return false;
         }
         writeHandler.enqueueSocketWritable(packet);

--- a/hazelcast/src/main/java/com/hazelcast/nio/TcpIpConnectionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/TcpIpConnectionManager.java
@@ -227,7 +227,9 @@ public class TcpIpConnectionManager implements ConnectionManager {
     }
 
     public boolean bind(TcpIpConnection connection, Address remoteEndPoint, Address localEndpoint, final boolean replyBack) {
-        log(Level.FINEST, "Binding " + connection + " to " + remoteEndPoint + ", replyBack is " + replyBack);
+        if (logger.isFinestEnabled()) {
+            log(Level.FINEST, "Binding " + connection + " to " + remoteEndPoint + ", replyBack is " + replyBack);
+        }
         final Address thisAddress = ioService.getThisAddress();
         if (!connection.isClient() && !thisAddress.equals(localEndpoint)) {
             log(Level.WARNING, "Wrong bind request from " + remoteEndPoint + "! This node is not requested endpoint: " + localEndpoint);
@@ -241,7 +243,9 @@ public class TcpIpConnectionManager implements ConnectionManager {
         final Connection existingConnection = connectionsMap.get(remoteEndPoint);
         if (existingConnection != null && existingConnection.live()) {
             if (existingConnection != connection) {
-                log(Level.FINEST, existingConnection + " is already bound  to " + remoteEndPoint + ", new one is " + connection);
+                if (logger.isFinestEnabled()) {
+                    log(Level.FINEST, existingConnection + " is already bound  to " + remoteEndPoint + ", new one is " + connection);
+                }
                 activeConnections.add(connection);
             }
             return false;
@@ -337,7 +341,9 @@ public class TcpIpConnectionManager implements ConnectionManager {
         if (connection == null) {
             return;
         }
-        log(Level.FINEST, "Destroying " + connection);
+        if (logger.isFinestEnabled()) {
+            log(Level.FINEST, "Destroying " + connection);
+        }
         activeConnections.remove((TcpIpConnection) connection);
         final Address endPoint = connection.getEndPoint();
         if (endPoint != null) {
@@ -401,7 +407,9 @@ public class TcpIpConnectionManager implements ConnectionManager {
         } finally {
             if (serverSocketChannel != null) {
                 try {
-                    log(Level.FINEST, "Closing server socket channel: " + serverSocketChannel);
+                    if (logger.isFinestEnabled()) {
+                        log(Level.FINEST, "Closing server socket channel: " + serverSocketChannel);
+                    }
                     serverSocketChannel.close();
                 } catch (IOException ignore) {
                     logger.finest(ignore);
@@ -439,7 +447,9 @@ public class TcpIpConnectionManager implements ConnectionManager {
     }
 
     private synchronized void shutdownIOSelectors() {
-        log(Level.FINEST, "Shutting down IO selectors... Total: " + selectorThreadCount);
+        if (logger.isFinestEnabled()) {
+            log(Level.FINEST, "Shutting down IO selectors... Total: " + selectorThreadCount);
+        }
         for (int i = 0; i < selectorThreadCount; i++) {
             IOSelector ioSelector = inSelectors[i];
             if (ioSelector != null) {

--- a/hazelcast/src/main/java/com/hazelcast/partition/MigrationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/MigrationOperation.java
@@ -90,7 +90,9 @@ public final class MigrationOperation extends BaseMigrationOperation {
                 if (e instanceof IllegalStateException) {
                     level = Level.FINEST;
                 }
-                getLogger().log(level, e.getMessage(), e);
+                if (getLogger().isLoggable(level)) {
+                    getLogger().log(level, e.getMessage(), e);
+                }
                 success = false;
             } finally {
                 migrationInfo.doneProcessing();

--- a/hazelcast/src/main/java/com/hazelcast/partition/PartitionServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/PartitionServiceImpl.java
@@ -542,7 +542,9 @@ public class PartitionServiceImpl implements PartitionService, ManagedService,
                 if (oldMaster) {
                     logger.info("Finalizing migration instantiated by the old master -> " + oldMigration);
                 } else {
-                    logger.finest( "Finalizing previous migration -> " + oldMigration);
+                    if (logger.isFinestEnabled()) {
+                        logger.finest( "Finalizing previous migration -> " + oldMigration);
+                    }
                 }
                 finalizeActiveMigration(oldMigration);
                 activeMigrations.put(partitionId, newMigration);
@@ -1131,7 +1133,9 @@ public class PartitionServiceImpl implements PartitionService, ManagedService,
                 sendMigrationEvent(migrationInfo, MigrationStatus.STARTED);
                 Boolean result = Boolean.FALSE;
                 MemberImpl fromMember = getMember(migrationInfo.getSource());
-                logger.finest( "Started Migration : " + migrationInfo);
+                if (logger.isFinestEnabled()) {
+                    logger.finest( "Started Migration : " + migrationInfo);
+                }
                 systemLogService.logPartition("Started Migration : " + migrationInfo);
                 if (fromMember != null) {
                     Invocation inv = nodeEngine.getOperationService().createInvocationBuilder(SERVICE_NAME,
@@ -1150,8 +1154,9 @@ public class PartitionServiceImpl implements PartitionService, ManagedService,
                     result = Boolean.TRUE;
                 }
                 if (Boolean.TRUE.equals(result)) {
-                    logger.finest( "Finished Migration: " + migrationInfo);
-                    systemLogService.logPartition("Finished Migration: " + migrationInfo);
+                    String message =  "Finished Migration: " + migrationInfo;
+                    logger.finest(message);
+                    systemLogService.logPartition(message);
                     processMigrationResult();
                 } else {
                     final Level level = migrationInfo.isValid() ? Level.WARNING : Level.FINEST;

--- a/hazelcast/src/main/java/com/hazelcast/partition/PartitionStateGeneratorImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/PartitionStateGeneratorImpl.java
@@ -66,7 +66,9 @@ final class PartitionStateGeneratorImpl implements PartitionStateGenerator {
                 stateInitializer.initialize(state);
             } else if (result == TestResult.RETRY) {
                 tryCount++;
-                logger.finest( "Re-trying partition arrangement.. Count: " + tryCount);
+                if (logger.isFinestEnabled()) {
+                    logger.finest( "Re-trying partition arrangement.. Count: " + tryCount);
+                }
             }
         }
         if (result == TestResult.FAIL) {
@@ -335,8 +337,10 @@ final class PartitionStateGeneratorImpl implements PartitionStateGenerator {
                 }
                 if ((partitionCountOfGroup < avgPartitionPerGroup / ratio)
                         || (partitionCountOfGroup > avgPartitionPerGroup * ratio)) {
-                    logger.finest( "Replica: " + i + ", PartitionCount: "
-                            + partitionCountOfGroup + ", AvgPartitionCount: " + avgPartitionPerGroup);
+                    if (logger.isFinestEnabled()) {
+                        logger.finest( "Replica: " + i + ", PartitionCount: "
+                                + partitionCountOfGroup + ", AvgPartitionCount: " + avgPartitionPerGroup);
+                    }
                     return TestResult.RETRY;
                 }
             }
@@ -452,9 +456,11 @@ final class PartitionStateGeneratorImpl implements PartitionStateGenerator {
                 return false;
             }
             if (containsPartition(partitionId)) {
-                String error = "Partition[" + partitionId + "] is already owned by this group! " +
-                        "Duplicate!";
-                logger.finest( error);
+                if (logger.isFinestEnabled()) {
+                    String error = "Partition[" + partitionId + "] is already owned by this group! " +
+                            "Duplicate!";
+                    logger.finest( error);
+                }
                 return false;
             }
             groupPartitionTable.add(index, partitionId);
@@ -600,9 +606,11 @@ final class PartitionStateGeneratorImpl implements PartitionStateGenerator {
                 return false;
             }
             if (containsPartition(partitionId)) {
-                String error = "Partition[" + partitionId + "] is already owned by this node " +
-                        address + "! Duplicate!";
-                logger.finest( error);
+                if (logger.isFinestEnabled()) {
+                    String error = "Partition[" + partitionId + "] is already owned by this node " +
+                            address + "! Duplicate!";
+                    logger.finest( error);
+                }
                 return false;
             }
             return nodeTable.add(index, partitionId);

--- a/hazelcast/src/main/java/com/hazelcast/partition/ReplicaErrorLogger.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/ReplicaErrorLogger.java
@@ -37,7 +37,9 @@ public final class ReplicaErrorLogger {
                     || e instanceof TargetNotMemberException) {
                 level = Level.FINEST;
             }
-            logger.log(level, e.toString());
+            if (logger.isLoggable(level)) {
+                logger.log(level, e.toString());
+            }
         } else {
             logger.warning(e);
         }

--- a/hazelcast/src/main/java/com/hazelcast/partition/ReplicaSyncRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/ReplicaSyncRequest.java
@@ -74,9 +74,8 @@ public final class ReplicaSyncRequest extends Operation implements PartitionAwar
                     IOUtil.closeResource(out);
                 }
             } else {
-                final Level level = Level.FINEST;
-                if (logger.isLoggable(level)) {
-                    logger.log(level, "No replica data is found for partition: " + partitionId + ", replica: " + replicaIndex + "\n" + partitionService.getPartition(partitionId));
+                if (logger.isFinestEnabled()) {
+                    logger.finest("No replica data is found for partition: " + partitionId + ", replica: " + replicaIndex + "\n" + partitionService.getPartition(partitionId));
                 }
             }
 

--- a/hazelcast/src/main/java/com/hazelcast/partition/ReplicaSyncResponse.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/ReplicaSyncResponse.java
@@ -78,7 +78,9 @@ public class ReplicaSyncResponse extends Operation implements PartitionAwareOper
                         op.afterRun();
                     } catch (Throwable e) {
                         final Level level = nodeEngine.isActive() ? Level.WARNING : Level.FINEST;
-                        logger.log(level, "While executing " + op, e);
+                        if (logger.isLoggable(level)) {
+                            logger.log(level, "While executing " + op, e);
+                        }
                     }
                 }
             }

--- a/hazelcast/src/main/java/com/hazelcast/spi/Operation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/Operation.java
@@ -235,7 +235,9 @@ public abstract class Operation implements DataSerializable {
         final ILogger logger = getLogger();
         if (e instanceof RetryableException) {
             final Level level = returnsResponse() ? Level.FINEST : Level.WARNING;
-            logger.log(level, e.getClass().getName() + ": " + e.getMessage());
+            if (logger.isLoggable(level)) {
+                logger.log(level, e.getClass().getName() + ": " + e.getMessage());
+            }
         } else if (e instanceof OutOfMemoryError) {
             try {
                 logger.log(Level.SEVERE, e.getMessage(), e);
@@ -243,7 +245,9 @@ public abstract class Operation implements DataSerializable {
             }
         } else {
             final Level level = nodeEngine != null && nodeEngine.isActive() ? Level.SEVERE : Level.FINEST;
-            logger.log(level, e.getMessage(), e);
+            if (logger.isLoggable(level)) {
+                logger.log(level, e.getMessage(), e);
+            }
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/ExecutionServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/ExecutionServiceImpl.java
@@ -61,7 +61,9 @@ public final class ExecutionServiceImpl implements ExecutionService {
                 3, Integer.MAX_VALUE, 60L, TimeUnit.SECONDS,
                 new SynchronousQueue<Runnable>(), threadFactory, new RejectedExecutionHandler() {
             public void rejectedExecution(Runnable r, ThreadPoolExecutor executor) {
-                logger.finest( "Node is shutting down; discarding the task: " + r);
+                if (logger.isFinestEnabled()) {
+                    logger.finest( "Node is shutting down; discarding the task: " + r);
+                }
             }
         });
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/ServiceManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/ServiceManager.java
@@ -125,7 +125,9 @@ final class ServiceManager {
             final Object service = serviceInfo.getService();
             if (serviceInfo.isConfigurableService()) {
                 try {
-                    logger.finest( "Configuring service -> " + service);
+                    if (logger.isFinestEnabled()) {
+                        logger.finest( "Configuring service -> " + service);
+                    }
                     final Object configObject = serviceConfigObjects.get(serviceInfo.getName());
                     ((ConfigurableService) service).configure(configObject);
                 } catch (Throwable t) {
@@ -134,7 +136,9 @@ final class ServiceManager {
             }
             if (serviceInfo.isManagedService()) {
                 try {
-                    logger.finest( "Initializing service -> " + service);
+                    if (logger.isFinestEnabled()) {
+                        logger.finest( "Initializing service -> " + service);
+                    }
                     final Properties props = serviceProps.get(serviceInfo.getName());
                     ((ManagedService) service).init(nodeEngine, props != null ? props : new Properties());
                 } catch (Throwable t) {
@@ -181,7 +185,9 @@ final class ServiceManager {
     }
 
     private synchronized void registerService(String serviceName, Object service) {
-        logger.finest( "Registering service: '" + serviceName + "'");
+        if (logger.isFinestEnabled()) {
+            logger.finest( "Registering service: '" + serviceName + "'");
+        }
         final ServiceInfo serviceInfo = new ServiceInfo(serviceName, service);
         final ServiceInfo currentServiceInfo = services.putIfAbsent(serviceName, serviceInfo);
         if (currentServiceInfo != null) {


### PR DESCRIPTION
This should lead to less object allocation and subsequently to lower latencies introduced by GC.
It's addressing https://github.com/hazelcast/hazelcast/issues/1332
