### PR TITLE
LocalMapStats::getLastUpdateTime() restored

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/jmx/MapMBean.java
+++ b/hazelcast/src/main/java/com/hazelcast/jmx/MapMBean.java
@@ -116,6 +116,12 @@ public class MapMBean extends HazelcastMBean<IMap> {
         return managedObject.getLocalMapStats().getLastAccessTime();
     }
 
+    @ManagedAnnotation("localLastUpdateTime")
+    @ManagedDescription("the last update time of the locally owned entries.")
+    public long getLocalLastUpdateTime(){
+        return managedObject.getLocalMapStats().getLastUpdateTime();
+    }
+
     @ManagedAnnotation("localHits")
     @ManagedDescription("the number of hits (reads) of the locally owned entries.")
     public long getLocalHits(){

--- a/hazelcast/src/main/java/com/hazelcast/jmx/MultiMapMBean.java
+++ b/hazelcast/src/main/java/com/hazelcast/jmx/MultiMapMBean.java
@@ -71,6 +71,12 @@ public class MultiMapMBean extends HazelcastMBean<MultiMap> {
         return managedObject.getLocalMultiMapStats().getLastAccessTime();
     }
 
+    @ManagedAnnotation("localLastUpdateTime")
+    @ManagedDescription("the last update time of the locally owned entries.")
+    public long getLocalLastUpdateTime(){
+        return managedObject.getLocalMultiMapStats().getLastUpdateTime();
+    }
+
     @ManagedAnnotation("localHits")
     @ManagedDescription("the number of hits (reads) of the locally owned entries.")
     public long getLocalHits(){

--- a/hazelcast/src/main/java/com/hazelcast/map/MapService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/MapService.java
@@ -1078,6 +1078,7 @@ public class MapService implements ManagedService, MigrationAwareService,
                     ownedEntryCount++;
                     ownedEntryMemoryCost += record.getCost();
                     localMapStats.setLastAccessTime(stats.getLastAccessTime());
+                    localMapStats.setLastUpdateTime(stats.getLastUpdateTime());
                     hits += stats.getHits();
                     if (recordStore.isLocked(record.getKey())) {
                         lockedEntryCount++;

--- a/hazelcast/src/main/java/com/hazelcast/monitor/LocalMapStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/LocalMapStats.java
@@ -74,6 +74,14 @@ public interface LocalMapStats extends LocalInstanceStats {
      */
     long getLastAccessTime();
 
+
+    /**
+     * Returns the last update time of the locally owned entries.
+     *
+     * @return last update time.
+     */
+    long getLastUpdateTime();
+
     /**
      * Returns the number of hits (reads) of the locally owned entries.
      *

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalMapStatsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalMapStatsImpl.java
@@ -28,6 +28,7 @@ import java.util.concurrent.atomic.AtomicLong;
 
 public class LocalMapStatsImpl implements LocalMapStats, IdentifiedDataSerializable {
     private final AtomicLong lastAccessTime = new AtomicLong(0);
+    private final AtomicLong lastUpdateTime = new AtomicLong(0);
     private final AtomicLong hits = new AtomicLong(0);
     private final AtomicLong numberOfOtherOperations = new AtomicLong(0);
     private final AtomicLong numberOfEvents = new AtomicLong(0);
@@ -62,6 +63,7 @@ public class LocalMapStatsImpl implements LocalMapStats, IdentifiedDataSerializa
         out.writeLong(numberOfOtherOperations.get());
         out.writeLong(numberOfEvents.get());
         out.writeLong(lastAccessTime.get());
+        out.writeLong(lastUpdateTime.get());
         out.writeLong(hits.get());
         out.writeLong(ownedEntryCount);
         out.writeLong(backupEntryCount);
@@ -87,6 +89,7 @@ public class LocalMapStatsImpl implements LocalMapStats, IdentifiedDataSerializa
         numberOfOtherOperations.set(in.readLong());
         numberOfEvents.set(in.readLong());
         lastAccessTime.set(in.readLong());
+        lastUpdateTime.set(in.readLong());
         hits.set(in.readLong());
         ownedEntryCount = in.readLong();
         backupEntryCount = in.readLong();
@@ -155,6 +158,14 @@ public class LocalMapStatsImpl implements LocalMapStats, IdentifiedDataSerializa
 
     public void setLastAccessTime(long lastAccessTime) {
         this.lastAccessTime.set(Math.max(this.lastAccessTime.get(), lastAccessTime));
+    }
+
+    public long getLastUpdateTime() {
+        return lastUpdateTime.get();
+    }
+
+    public void setLastUpdateTime(long lastUpdateTime) {
+        this.lastUpdateTime.set(Math.max(this.lastUpdateTime.get(), lastUpdateTime));
     }
 
     public long getHits() {
@@ -266,6 +277,7 @@ public class LocalMapStatsImpl implements LocalMapStats, IdentifiedDataSerializa
     public String toString() {
         return "LocalMapStatsImpl{" +
                 "lastAccessTime=" + lastAccessTime +
+                ", lastUpdateTime=" + lastUpdateTime +
                 ", hits=" + hits +
                 ", numberOfOtherOperations=" + numberOfOtherOperations +
                 ", numberOfEvents=" + numberOfEvents +

--- a/hazelcast/src/test/java/com/hazelcast/map/LocalMapStatsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/LocalMapStatsTest.java
@@ -1,0 +1,42 @@
+package com.hazelcast.map;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.monitor.LocalMapStats;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.*;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category(QuickTest.class)
+public class LocalMapStatsTest extends HazelcastTestSupport {
+
+    private final String name = "fooMap";
+
+    @Test
+    public void testLastAccessTime() throws InterruptedException {
+        long startTime = System.currentTimeMillis();
+
+        HazelcastInstance h1 = createHazelcastInstanceFactory(1).newHazelcastInstance(new Config());
+        IMap<String, String> map1 = h1.getMap(name);
+
+        String key = "key";
+        map1.put(key, "value");
+
+        long lastUpdateTime = map1.getLocalMapStats().getLastUpdateTime();
+        assertTrue(lastUpdateTime >= startTime);
+
+        Thread.sleep(5);
+        map1.put(key, "value2");
+        long lastUpdateTime2 = map1.getLocalMapStats().getLastUpdateTime();
+        assertTrue(lastUpdateTime2 > lastUpdateTime);
+    }
+
+}


### PR DESCRIPTION
It's to resolve https://github.com/hazelcast/hazelcast/issues/1336
I apologize if there is a good reason why it has been disabled.
