### PR TITLE
Optimizations - MapGetAllOperation doesn't have to be always invoked on ...

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/proxy/MapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/proxy/MapProxySupport.java
@@ -297,7 +297,7 @@ abstract class MapProxySupport extends AbstractDistributedObject<MapService> imp
         try {
             Invocation invocation =
                     nodeEngine.getOperationService().createInvocationBuilder(SERVICE_NAME, containsKeyOperation,
-                                                                             partitionId).build();
+                            partitionId).build();
             Future f = invocation.invoke();
             return (Boolean) getService().toObject(f.get());
         } catch (Throwable t) {
@@ -360,11 +360,11 @@ abstract class MapProxySupport extends AbstractDistributedObject<MapService> imp
     protected Map<Object, Object> getAllObjectInternal(final Set<Data> keys) {
         final NodeEngine nodeEngine = getNodeEngine();
         Map<Object, Object> result = new HashMap<Object, Object>();
-
+        Collection<Integer> partitions = getPartitionsForKeys(keys);
         Map<Integer, Object> responses = null;
         try {
             responses = nodeEngine.getOperationService()
-                    .invokeOnAllPartitions(SERVICE_NAME, new MapGetAllOperationFactory(name, keys));
+                    .invokeOnPartitions(SERVICE_NAME, new MapGetAllOperationFactory(name, keys), partitions);
             for (Object response : responses.values()) {
                 Set<Map.Entry<Data, Data>> entries = ((MapEntrySet) getService().toObject(response)).getEntrySet();
                 for (Entry<Data, Data> entry : entries) {
@@ -376,6 +376,20 @@ abstract class MapProxySupport extends AbstractDistributedObject<MapService> imp
         }
 
         return result;
+    }
+
+    private Collection<Integer> getPartitionsForKeys(Set<Data> keys) {
+        PartitionService partitionService = getNodeEngine().getPartitionService();
+        int partitions = partitionService.getPartitionCount();
+        int capacity = Math.min(partitions, keys.size()); //todo: is there better way to estimate size?
+        Set<Integer> partitionIds = new HashSet<Integer>(capacity);
+
+        Iterator<Data> iterator = keys.iterator();
+        while (iterator.hasNext() && partitionIds.size() < partitions){
+            Data key = iterator.next();
+            partitionIds.add(partitionService.getPartitionId(key));
+        }
+        return partitionIds;
     }
 
     protected void putAllInternal(final Map<? extends Object, ? extends Object> entries) {


### PR DESCRIPTION
...all partitions.

This PR is addressing https://github.com/hazelcast/hazelcast/issues/1375
I'm not sure if getPartitionsForKeys() belongs here or to PartitionService.
