### PR TITLE
Fixed put to nearcache

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientReplicatedMapProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientReplicatedMapProxy.java
@@ -90,7 +90,9 @@ public class ClientReplicatedMapProxy<K, V> extends ClientProxy implements Repli
         }
 
         ReplicatedMapGetResponse response = invoke(new ClientReplicatedMapGetRequest(getName(), key));
-        // TODO add near caching
+        if (nearCache != null) {
+            nearCache.put(key, response.getValue());
+        }
         return (V) response.getValue();
     }
 


### PR DESCRIPTION
Fixed missing nearcache::put(key, value) in ClientReplicatedMapProxy::get()
