### PR TITLE
Improved Hazelcast reliability under load

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/ascii/AbstractTextCommand.java
+++ b/hazelcast/src/main/java/com/hazelcast/ascii/AbstractTextCommand.java
@@ -29,31 +29,43 @@ public abstract class AbstractTextCommand implements TextCommand {
         this.type = type;
     }
 
+    @Override
     public TextCommandType getType() {
         return type;
     }
 
+    @Override
     public SocketTextReader getSocketTextReader() {
         return socketTextReader;
     }
 
+    @Override
     public SocketTextWriter getSocketTextWriter() {
         return socketTextWriter;
     }
 
+    @Override
     public long getRequestId() {
         return requestId;
     }
 
+    @Override
     public void init(SocketTextReader socketTextReader, long requestId) {
         this.socketTextReader = socketTextReader;
         this.requestId = requestId;
         this.socketTextWriter = socketTextReader.getSocketTextWriter();
     }
 
+    @Override
+    public boolean isUrgent() {
+        return false;
+    }
+
+    @Override
     public void onEnqueue() {
     }
 
+    @Override
     public boolean shouldReply() {
         return true;
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/ClientDisconnectionOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/ClientDisconnectionOperation.java
@@ -20,7 +20,7 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.spi.AbstractOperation;
 import com.hazelcast.spi.ClientAwareService;
-import com.hazelcast.spi.SystemOperation;
+import com.hazelcast.spi.UrgentSystemOperation;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 
 import java.io.IOException;
@@ -30,7 +30,7 @@ import java.util.Set;
 /**
  * @author mdogan 2/11/13
  */
-public class ClientDisconnectionOperation extends AbstractOperation implements SystemOperation {
+public class ClientDisconnectionOperation extends AbstractOperation implements UrgentSystemOperation {
 
     private String clientUuid;
 

--- a/hazelcast/src/main/java/com/hazelcast/client/ClientReAuthOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/ClientReAuthOperation.java
@@ -19,7 +19,7 @@ package com.hazelcast.client;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.spi.AbstractOperation;
-import com.hazelcast.spi.SystemOperation;
+import com.hazelcast.spi.UrgentSystemOperation;
 
 import java.io.IOException;
 import java.util.Set;
@@ -27,7 +27,7 @@ import java.util.Set;
 /**
  * @author mdogan 5/7/13
  */
-public class ClientReAuthOperation extends AbstractOperation implements SystemOperation {
+public class ClientReAuthOperation extends AbstractOperation implements UrgentSystemOperation {
 
     private String clientUuid;
 

--- a/hazelcast/src/main/java/com/hazelcast/cluster/JoinOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/JoinOperation.java
@@ -20,11 +20,11 @@ package com.hazelcast.cluster;
  * @author mdogan 7/25/12
  */
 
-import com.hazelcast.spi.SystemOperation;
+import com.hazelcast.spi.UrgentSystemOperation;
 
 /**
  * Marker interface for join and post-join operations.
  */
-public interface JoinOperation extends SystemOperation {
+public interface JoinOperation extends UrgentSystemOperation {
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/cluster/PostJoinOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/PostJoinOperation.java
@@ -27,7 +27,7 @@ import java.util.Arrays;
 /**
  * @author mdogan 12/24/12
  */
-public class PostJoinOperation extends AbstractOperation implements SystemOperation {
+public class PostJoinOperation extends AbstractOperation implements UrgentSystemOperation {
 
     private transient Operation[] operations;
 

--- a/hazelcast/src/main/java/com/hazelcast/nio/ClientPacket.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/ClientPacket.java
@@ -45,6 +45,11 @@ public final class ClientPacket extends DataAdapter implements SocketWritable, S
     }
 
     @Override
+    public boolean isUrgent() {
+        return false;
+    }
+
+    @Override
     public String toString() {
         final StringBuilder sb = new StringBuilder("ClientPacket{");
         sb.append("conn=").append(conn);

--- a/hazelcast/src/main/java/com/hazelcast/nio/Packet.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/Packet.java
@@ -34,7 +34,7 @@ public final class Packet extends DataAdapter implements SocketWritable, SocketR
     public static final int HEADER_RESPONSE = 1;
     public static final int HEADER_EVENT = 2;
     public static final int HEADER_WAN_REPLICATION = 3;
-    public static final int HEADER_PRIORITY = 4;
+    public static final int HEADER_URGENT = 4;
 
     private short header;
     private int partitionId;
@@ -78,8 +78,9 @@ public final class Packet extends DataAdapter implements SocketWritable, SocketR
         return partitionId;
     }
 
-    public boolean isPriorityPacket(){
-        return isHeaderSet(HEADER_PRIORITY);
+    @Override
+    public boolean isUrgent(){
+        return isHeaderSet(HEADER_URGENT);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/nio/SocketWritable.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/SocketWritable.java
@@ -23,4 +23,15 @@ public interface SocketWritable {
     boolean writeTo(ByteBuffer destination);
 
     void onEnqueue();
+
+    /**
+     * Checks if this SocketWritable is urgent.
+     *
+     * SocketWritable that are urgent, have priority above regular SocketWritable. This is useful to implement
+     * System Operations so that they can be send faster than regular operations; especially when the system is
+     * under load you want these operations have precedence.
+     *
+     * @return true if urgent, false otherwise.
+     */
+    boolean isUrgent();
 }

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/DataAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/DataAdapter.java
@@ -64,11 +64,17 @@ public class DataAdapter implements SocketWritable, SocketReadable {
         this.context = context;
     }
 
+    @Override
+    public boolean isUrgent() {
+        return false;
+    }
+
     /**
      * WARNING:
      *
      * Should be in sync with {@link Data#writeData(com.hazelcast.nio.ObjectDataOutput)}
      */
+    @Override
     public boolean writeTo(ByteBuffer destination) {
         if (!isStatusSet(stType)) {
             if (destination.remaining() < 4) {
@@ -164,6 +170,7 @@ public class DataAdapter implements SocketWritable, SocketReadable {
      *
      * Should be in sync with {@link Data#readData(com.hazelcast.nio.ObjectDataInput)}
      */
+    @Override
     public boolean readFrom(ByteBuffer source) {
         if (data == null) {
             data = new Data();
@@ -278,6 +285,7 @@ public class DataAdapter implements SocketWritable, SocketReadable {
         return isStatusSet(stAll);
     }
 
+    @Override
     public void onEnqueue() {
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/partition/MigrationCycleOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/MigrationCycleOperation.java
@@ -16,12 +16,12 @@
 
 package com.hazelcast.partition;
 
-import com.hazelcast.spi.SystemOperation;
+import com.hazelcast.spi.UrgentSystemOperation;
 import com.hazelcast.spi.annotation.PrivateApi;
 
 /**
  * @author mdogan 12/6/12
  */
 @PrivateApi
-public interface MigrationCycleOperation extends SystemOperation {
+public interface MigrationCycleOperation extends UrgentSystemOperation {
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/UrgentSystemOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/UrgentSystemOperation.java
@@ -1,15 +1,15 @@
 package com.hazelcast.spi;
 
 /**
- * An Marker interface that signals that an operation is a System Operation.
+ * An Marker interface that signals that an operation is an urgent System Operation.
  *
- * System Operations can be executed by the {@link com.hazelcast.spi.OperationService} with a higher priority. This
+ * System Operations can be executed by the {@link com.hazelcast.spi.OperationService} with an urgency. This
  * is important because when a system is under load and its operation queues are filled up, you want the system to
- * deal with system operation like the ones needed for partition-migration, with a high priority. So that system
+ * deal with system operation like the ones needed for partition-migration, with a high urgency. So that system
  * remains responsive.
  *
  * In most cases this interface should not be used by normal user code because illegal usage of this interface,
  * can influence the health of the Hazelcast cluster negatively.
  */
-public interface SystemOperation {
+public interface UrgentSystemOperation {
 }


### PR DESCRIPTION
In the old approach, system operations like partition movement, member joining/leaving the cluster,
were put on the same queue as regular operations like map.put. The problem is that when the system
is overloaded and the queues are full, that the Hazelcast cluster will not be able to deal correctly
with cluster changes like members joining/leaving or moving partitions, because system operations can't be executed quickly.

This PR change that behavior by introducing the SystemOperation marker interface and executing these
operations with a higher priority than regular operations. On a technical level this is done by introducing additional queues which are checked before normal operation queues.
