### PR TITLE
Removing near cache on destroying MapProxy

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/MapService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/MapService.java
@@ -511,7 +511,13 @@ public class MapService implements ManagedService, MigrationAwareService,
     }
 
     public void destroyDistributedObject(String name) {
-        mapContainers.remove(name);
+        MapContainer mapContainer = mapContainers.remove(name);
+        if (mapContainer != null && mapContainer.isNearCacheEnabled()) {
+            NearCache nearCache = nearCacheMap.remove(name);
+            if (nearCache != null) {
+                nearCache.clear();
+            }
+        }
         final PartitionContainer[] containers = partitionContainers;
         for (PartitionContainer container : containers) {
             if (container != null) {


### PR DESCRIPTION
I think near cache should be deleted when a map proxy is destroyed. This could be a possible resource leak.
