### PR TITLE
static factory for ServiceConfig

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/ServiceConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ServiceConfig.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.config;
 
+import java.lang.reflect.Field;
 import java.util.Properties;
 
 /**
@@ -91,6 +92,24 @@ public class ServiceConfig {
 
     public Object getConfigObject() {
         return configObject;
+    }
+
+    private static final String SERVICE_NAME_FIELD_NAME = "SERVICE_NAME";
+
+    public static ServiceConfig fromClass(Class<?> clazz) {
+        String serviceName;
+        try {
+            Field serviceNameField = clazz.getField(SERVICE_NAME_FIELD_NAME);
+            serviceName = (String) serviceNameField.get(clazz.getClass());
+        } catch (NoSuchFieldException e) {
+            throw new IllegalArgumentException("Service class '"+clazz.getName()+"' does not have a field '"+SERVICE_NAME_FIELD_NAME+"'.");
+        } catch (IllegalAccessException e) {
+            throw new IllegalArgumentException("Service class '"+clazz.getName()+"' does not have a public field '"+SERVICE_NAME_FIELD_NAME+"'.");
+        }
+        if (serviceName == null || serviceName.isEmpty()) {
+            throw new IllegalArgumentException("Service class '"+clazz.getName()+"' does not have a non-empty field '"+SERVICE_NAME_FIELD_NAME+"'.");
+        }
+        return new ServiceConfig().setClassName(clazz.getName()).setName(serviceName).setEnabled(true);
     }
 
     @Override


### PR DESCRIPTION
Registering a new Service implemented via SPI is currently a bit cumbersome:

```
Config config = new Config();
ServiceConfig serviceConfig = new ServiceConfig();
serviceConfig.setName(LongMaxUpdaterService.SERVICE_NAME)
serviceConfig.setClassName(LongMaxUpdaterService.class.getName())
serviceConfig.setEnabled(true);
config.getServicesConfig().addServiceConfig(serviceConfig);
```

with this patch it can be as simple as

```
Config config = new Config();
config.getServicesConfig().addServiceConfig(fromClass(LongMaxUpdaterService.class));
```

I'm not sure if this is a _right_ approach, an alternative solution might be based either on annotation (a bit alien concept to HZ) or on a new interface, eg. NamedService (that would require additional changes in API)
