### PR TITLE
Near Cache can store entries owned by local node.

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/config/XmlClientConfigBuilder.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/config/XmlClientConfigBuilder.java
@@ -193,6 +193,8 @@ public class XmlClientConfigBuilder extends AbstractXmlConfigHelper {
                 nearCacheConfig.setInMemoryFormat(InMemoryFormat.valueOf(getTextContent(child)));
             } else if ("invalidate-on-change".equals(nodeName)){
                 nearCacheConfig.setInvalidateOnChange(Boolean.parseBoolean(getTextContent(child)));
+            } else if ("cache-local-entries".equals(nodeName)){
+                nearCacheConfig.setCacheLocalEntries(Boolean.parseBoolean(getTextContent(child)));
             }
         }
         clientConfig.addNearCacheConfig(name, nearCacheConfig);

--- a/hazelcast/src/main/java/com/hazelcast/config/NearCacheConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/NearCacheConfig.java
@@ -39,6 +39,8 @@ public class NearCacheConfig {
 
     private NearCacheConfigReadOnly readOnly;
 
+    private boolean cacheLocalEntries = false;
+
     public NearCacheConfig(int timeToLiveSeconds, int maxSize, String evictionPolicy, int maxIdleSeconds, boolean invalidateOnChange, InMemoryFormat inMemoryFormat) {
         this.timeToLiveSeconds = timeToLiveSeconds;
         this.maxSize = maxSize;
@@ -56,6 +58,7 @@ public class NearCacheConfig {
         maxIdleSeconds = config.getMaxIdleSeconds();
         maxSize = config.getMaxSize();
         timeToLiveSeconds = config.getTimeToLiveSeconds();
+        cacheLocalEntries = config.isCacheLocalEntries();
     }
 
     public NearCacheConfigReadOnly getAsReadOnly() {
@@ -130,6 +133,15 @@ public class NearCacheConfig {
         return this;
     }
 
+    public boolean isCacheLocalEntries() {
+        return cacheLocalEntries;
+    }
+
+    public NearCacheConfig setCacheLocalEntries(boolean cacheLocalEntries) {
+        this.cacheLocalEntries = cacheLocalEntries;
+        return this;
+    }
+
     // this setter is for reflection based configuration building
     public NearCacheConfig setInMemoryFormat(String inMemoryFormat) {
         this.inMemoryFormat = InMemoryFormat.valueOf(inMemoryFormat);
@@ -145,6 +157,7 @@ public class NearCacheConfig {
         sb.append(", maxIdleSeconds=").append(maxIdleSeconds);
         sb.append(", invalidateOnChange=").append(invalidateOnChange);
         sb.append(", inMemoryFormat=").append(inMemoryFormat);
+        sb.append(", cacheLocalEntries=").append(cacheLocalEntries);
         sb.append('}');
         return sb.toString();
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/proxy/MapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/proxy/MapProxySupport.java
@@ -21,7 +21,6 @@ import com.hazelcast.config.EntryListenerConfig;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.config.MapIndexConfig;
 import com.hazelcast.core.*;
-import com.hazelcast.executor.ExecutionCallbackAdapter;
 import com.hazelcast.instance.MemberImpl;
 import com.hazelcast.map.*;
 import com.hazelcast.map.operation.*;
@@ -32,8 +31,8 @@ import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.SerializationService;
 import com.hazelcast.partition.PartitionService;
 import com.hazelcast.partition.PartitionView;
-import com.hazelcast.query.PagingPredicateAccessor;
 import com.hazelcast.query.PagingPredicate;
+import com.hazelcast.query.PagingPredicateAccessor;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.impl.QueryResultEntry;
 import com.hazelcast.spi.*;
@@ -144,7 +143,7 @@ abstract class MapProxySupport extends AbstractDistributedObject<MapService> imp
         if (nearCacheEnabled) {
             int partitionId = nodeEngine.getPartitionService().getPartitionId(key);
             if (!nodeEngine.getPartitionService().getPartitionOwner(partitionId)
-                    .equals(nodeEngine.getClusterService().getThisAddress())) {
+                    .equals(nodeEngine.getClusterService().getThisAddress()) || mapConfig.getNearCacheConfig().isCacheLocalEntries()) {
                 mapService.putNearCache(name, key, result);
             }
         }

--- a/hazelcast/src/main/resources/hazelcast-config-3.2.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-3.2.xsd
@@ -783,6 +783,7 @@
             <xs:element name="eviction-policy" type="eviction-policy" minOccurs="0" maxOccurs="1" default="LRU"/>
             <xs:element name="invalidate-on-change" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true"/>
             <xs:element name="in-memory-format" type="in-memory-format" minOccurs="0" maxOccurs="1" default="BINARY"/>
+            <xs:element name="cache-local-entries" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false"/>
         </xs:sequence>
     </xs:complexType>
     <xs:simpleType name="eviction-policy">

--- a/hazelcast/src/main/resources/hazelcast-fullconfig.xml
+++ b/hazelcast/src/main/resources/hazelcast-fullconfig.xml
@@ -233,6 +233,7 @@
             <max-idle-seconds>0</max-idle-seconds>
             <eviction-policy>LFU</eviction-policy>
             <invalidate-on-change>true</invalidate-on-change>
+            <cache-local-entries>false</cache-local-entries>
         </near-cache>
 
         <wan-replication-ref name="my-wan-cluster">

--- a/hazelcast/src/test/java/com/hazelcast/map/NearCacheTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/NearCacheTest.java
@@ -250,4 +250,29 @@ public class NearCacheTest extends HazelcastTestSupport {
         assertEquals(map.containsKey("key5"), false);
     }
 
+    @Test
+    public void testCacheLocalEntries() {
+        int n = 2;
+        String mapName = "test";
+
+        Config config = new Config();
+        config.getMapConfig(mapName).setNearCacheConfig(new NearCacheConfig().setCacheLocalEntries(true));
+        HazelcastInstance instance = createHazelcastInstanceFactory(n).newInstances(config)[0];
+
+        IMap<String, String> map = instance.getMap(mapName);
+
+        int noOfEntries = 100;
+        for (int i = 0; i < noOfEntries; i++) {
+            map.put("key"+i, "value"+i);
+        }
+
+        //warm-up cache
+        for (int i = 0; i < noOfEntries; i++) {
+            map.get("key" + i);
+        }
+
+        NearCache nearCache = getNearCache(mapName, instance);
+        assertEquals(noOfEntries, nearCache.size());
+    }
+
 }


### PR DESCRIPTION
It can be handy eg. when it does different memory format than Map.
It's addressing https://github.com/hazelcast/hazelcast/issues/1438

I've choosen to expose a simple on/off switch rather than auto-logic based on memory format as it might be just confusing for users. 
