### PR TITLE
More optimizations for UTF serializing / deserializing

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/ByteArrayObjectDataInput.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/ByteArrayObjectDataInput.java
@@ -38,6 +38,8 @@ class ByteArrayObjectDataInput extends PortableContextAwareInputStream implement
 
     final SerializationService service;
 
+    private final byte[] utfBuffer = new byte[1024];
+
     ByteArrayObjectDataInput(Data data, SerializationService service) {
         this(data.buffer, service);
         final ClassDefinition cd = data.classDefinition;
@@ -424,7 +426,7 @@ class ByteArrayObjectDataInput extends PortableContextAwareInputStream implement
      * @see java.io.DataInputStream#readUTF(java.io.DataInput)
      */
     public String readUTF() throws IOException {
-        return UTFUtil.readUTF(this);
+        return UTFUtil.readUTF(this, utfBuffer);
     }
 
     public Object readObject() throws IOException {

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/ByteArrayObjectDataOutput.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/ByteArrayObjectDataOutput.java
@@ -36,6 +36,8 @@ class ByteArrayObjectDataOutput extends OutputStream implements BufferObjectData
 
     final SerializationService service;
 
+    private final byte[] utfBuffer = new byte[1024];
+
     ByteArrayObjectDataOutput(int size, SerializationService service) {
         this.initialSize = size;
         this.buffer = new byte[size];
@@ -180,7 +182,7 @@ class ByteArrayObjectDataOutput extends OutputStream implements BufferObjectData
     }
 
     public void writeUTF(final String str) throws IOException {
-        UTFUtil.writeUTF(this, str);
+        UTFUtil.writeUTF(this, str, utfBuffer);
     }
 
     public void writeCharArray(char[] chars) throws IOException {

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/ByteBufferObjectDataInput.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/ByteBufferObjectDataInput.java
@@ -33,6 +33,8 @@ final class ByteBufferObjectDataInput extends PortableContextAwareInputStream im
 
     private final SerializationService service;
 
+    private final byte[] utfBuffer = new byte[1024];
+
     ByteBufferObjectDataInput(Data data, SerializationService service, ByteOrder order) {
         this(data.buffer, service, order);
         final ClassDefinition cd = data.classDefinition;
@@ -386,7 +388,7 @@ final class ByteBufferObjectDataInput extends PortableContextAwareInputStream im
      * @see java.io.DataInputStream#readUTF(java.io.DataInput)
      */
     public String readUTF() throws IOException {
-        return UTFUtil.readUTF(this);
+        return UTFUtil.readUTF(this, utfBuffer);
     }
 
     public Object readObject() throws IOException {

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/ByteBufferObjectDataOutput.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/ByteBufferObjectDataOutput.java
@@ -34,6 +34,8 @@ final class ByteBufferObjectDataOutput extends OutputStream implements BufferObj
 
     private final SerializationService service;
 
+    private final byte[] utfBuffer = new byte[1024];
+
     ByteBufferObjectDataOutput(int size, SerializationService service, ByteOrder order) {
         this.buffer = new DynamicByteBuffer(size, false);
         this.service = service;
@@ -206,7 +208,7 @@ final class ByteBufferObjectDataOutput extends OutputStream implements BufferObj
     }
 
     public void writeUTF(final String str) throws IOException {
-        UTFUtil.writeUTF(this, str);
+        UTFUtil.writeUTF(this, str, utfBuffer);
     }
 
     public void writeObject(Object object) throws IOException {

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/ObjectDataInputStream.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/ObjectDataInputStream.java
@@ -34,6 +34,8 @@ public class ObjectDataInputStream extends InputStream implements ObjectDataInpu
     private final DataInputStream dataInput;
     private final ByteOrder byteOrder;
 
+    private final byte[] utfBuffer = new byte[1024];
+
     public ObjectDataInputStream(InputStream in, SerializationService serializationService) {
         this(in, serializationService, ByteOrder.BIG_ENDIAN);
     }
@@ -208,7 +210,7 @@ public class ObjectDataInputStream extends InputStream implements ObjectDataInpu
     }
 
     public String readUTF() throws IOException {
-        return UTFUtil.readUTF(this);
+        return UTFUtil.readUTF(this, utfBuffer);
     }
 
     public void close() throws IOException {

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/ObjectDataOutputStream.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/ObjectDataOutputStream.java
@@ -34,6 +34,8 @@ public class ObjectDataOutputStream extends OutputStream implements ObjectDataOu
     private final DataOutputStream dataOut;
     private final ByteOrder byteOrder;
 
+    private final byte[] utfBuffer = new byte[1024];
+
     public ObjectDataOutputStream(OutputStream outputStream, SerializationService serializationService) {
         this(outputStream, serializationService, ByteOrder.BIG_ENDIAN);
     }
@@ -181,7 +183,7 @@ public class ObjectDataOutputStream extends OutputStream implements ObjectDataOu
     }
 
     public void writeUTF(String str) throws IOException {
-        UTFUtil.writeUTF(this, str);
+        UTFUtil.writeUTF(this, str, utfBuffer);
     }
 
     public void write(byte[] b) throws IOException {

--- a/hazelcast/src/test/java/com/hazelcast/nio/UTFUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/UTFUtilTest.java
@@ -39,17 +39,18 @@ public class UTFUtilTest {
 
     @Test
     public void testShortSizedText_1Chunk() throws Exception {
+        byte[] buffer = new byte[1024];
         for (int o = 0; o < BENCHMARK_ROUNDS; o++) {
             for (int i = 2; i < 100; i += 2) {
                 ByteArrayOutputStream baos = new ByteArrayOutputStream(500);
                 DataOutputStream dos = new DataOutputStream(baos);
 
                 String randomString = random(i * 100);
-                UTFUtil.writeUTF(dos, randomString);
+                UTFUtil.writeUTF(dos, randomString, buffer);
 
                 ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
                 DataInputStream dis = new DataInputStream(bais);
-                String result = UTFUtil.readUTF(dis);
+                String result = UTFUtil.readUTF(dis, buffer);
 
                 assertEquals(randomString, result);
             }
@@ -58,17 +59,18 @@ public class UTFUtilTest {
 
     @Test
     public void testMiddleSizedText_2Chunks() throws Exception {
+        byte[] buffer = new byte[1024];
         for (int o = 0; o < BENCHMARK_ROUNDS; o++) {
             for (int i = 170; i < 300; i += 2) {
                 ByteArrayOutputStream baos = new ByteArrayOutputStream(500);
                 DataOutputStream dos = new DataOutputStream(baos);
 
                 String randomString = random(i * 100);
-                UTFUtil.writeUTF(dos, randomString);
+                UTFUtil.writeUTF(dos, randomString, buffer);
 
                 ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
                 DataInputStream dis = new DataInputStream(bais);
-                String result = UTFUtil.readUTF(dis);
+                String result = UTFUtil.readUTF(dis, buffer);
 
                 assertEquals(randomString, result);
             }
@@ -77,17 +79,18 @@ public class UTFUtilTest {
 
     @Test
     public void testLongSizedText_min3Chunks() throws Exception {
+        byte[] buffer = new byte[1024];
         for (int o = 0; o < BENCHMARK_ROUNDS; o++) {
             for (int i = 330; i < 900; i += 5) {
                 ByteArrayOutputStream baos = new ByteArrayOutputStream(500);
                 DataOutputStream dos = new DataOutputStream(baos);
 
                 String randomString = random(i * 100);
-                UTFUtil.writeUTF(dos, randomString);
+                UTFUtil.writeUTF(dos, randomString, buffer);
 
                 ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
                 DataInputStream dis = new DataInputStream(bais);
-                String result = UTFUtil.readUTF(dis);
+                String result = UTFUtil.readUTF(dis, buffer);
 
                 assertEquals(randomString, result);
             }


### PR DESCRIPTION
As stated above, more optimizations :)
Every stream instance now has it's own utf buffer array (1024bytes) so it doesn't create a new one all the time while reading utf strings.
