### PR TITLE
Made InvocationBuilder Abstract + Inlines InvocationBuilder creation

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/BasicInvocationBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/BasicInvocationBuilder.java
@@ -26,19 +26,7 @@ import com.hazelcast.spi.Operation;
 /**
  * An {@link com.hazelcast.spi.InvocationBuilder} that is tied to the {@link com.hazelcast.spi.impl.BasicOperationService}.
  */
-public class BasicInvocationBuilder implements InvocationBuilder {
-
-    private final NodeEngineImpl nodeEngine;
-    private final String serviceName;
-    private final Operation op;
-    private final int partitionId;
-    private final Address target;
-    private Callback<Object> callback;
-    private long callTimeout = -1L;
-    private int replicaIndex = 0;
-    private int tryCount = 250;
-    private long tryPauseMillis = 500;
-    private String executorName;
+public class BasicInvocationBuilder extends InvocationBuilder {
 
     public BasicInvocationBuilder(NodeEngineImpl nodeEngine, String serviceName, Operation op, int partitionId) {
         this(nodeEngine, serviceName, op, partitionId, null);
@@ -50,101 +38,7 @@ public class BasicInvocationBuilder implements InvocationBuilder {
 
     private BasicInvocationBuilder(NodeEngineImpl nodeEngine, String serviceName, Operation op,
                                    int partitionId, Address target) {
-        this.nodeEngine = nodeEngine;
-        this.serviceName = serviceName;
-        this.op = op;
-        this.partitionId = partitionId;
-        this.target = target;
-    }
-
-    @Override
-    public String getExecutorName() {
-        return executorName;
-    }
-
-    @Override
-    public InvocationBuilder setExecutorName(String executorName) {
-        this.executorName = executorName;
-        return this;
-    }
-
-    @Override
-    public InvocationBuilder setReplicaIndex(int replicaIndex) {
-        if (replicaIndex < 0 || replicaIndex >= PartitionView.MAX_REPLICA_COUNT) {
-            throw new IllegalArgumentException("Replica index is out of range [0-"
-                    + (PartitionView.MAX_REPLICA_COUNT - 1) + "]");
-        }
-        this.replicaIndex = replicaIndex;
-        return this;
-    }
-
-    @Override
-    public InvocationBuilder setTryCount(int tryCount) {
-        this.tryCount = tryCount;
-        return this;
-    }
-
-    @Override
-    public InvocationBuilder setTryPauseMillis(long tryPauseMillis) {
-        this.tryPauseMillis = tryPauseMillis;
-        return this;
-    }
-
-    @Override
-    public InvocationBuilder setCallTimeout(long callTimeout) {
-        this.callTimeout = callTimeout;
-        return this;
-    }
-
-    @Override
-    public String getServiceName() {
-        return serviceName;
-    }
-
-    @Override
-    public Operation getOp() {
-        return op;
-    }
-
-    @Override
-    public int getReplicaIndex() {
-        return replicaIndex;
-    }
-
-    @Override
-    public int getTryCount() {
-        return tryCount;
-    }
-
-    @Override
-    public long getTryPauseMillis() {
-        return tryPauseMillis;
-    }
-
-    @Override
-    public Address getTarget() {
-        return target;
-    }
-
-    @Override
-    public int getPartitionId() {
-        return partitionId;
-    }
-
-    @Override
-    public long getCallTimeout() {
-        return callTimeout;
-    }
-
-    @Override
-    public Callback getCallback() {
-        return callback;
-    }
-
-    @Override
-    public InvocationBuilder setCallback(Callback<Object> callback) {
-        this.callback = callback;
-        return this;
+        super(nodeEngine,serviceName,op,partitionId,target);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/BasicOperationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/BasicOperationService.java
@@ -294,17 +294,20 @@ final class BasicOperationService implements InternalOperationService {
 
      @Override
     public <E> InternalCompletableFuture<E> invokeOnPartition(String serviceName, Operation op, int partitionId) {
-        return createInvocationBuilder(serviceName, op, partitionId).invoke();
+         return new BasicPartitionInvocation(nodeEngine, serviceName, op, partitionId, InvocationBuilder.DEFAULT_REPLICA_INDEX,
+                 InvocationBuilder.DEFAULT_TRY_COUNT, InvocationBuilder.DEFAULT_TRY_PAUSE_MILLIS, InvocationBuilder.DEFAULT_CALL_TIMEOUT, null, null).invoke();
     }
 
     @Override
     public <E> InternalCompletableFuture<E> invokeOnTarget(String serviceName, Operation op, Address target) {
-        return createInvocationBuilder(serviceName, op, target).invoke();
+        return new BasicTargetInvocation(nodeEngine, serviceName, op, target, InvocationBuilder.DEFAULT_TRY_COUNT, InvocationBuilder.DEFAULT_TRY_PAUSE_MILLIS,
+                InvocationBuilder.DEFAULT_CALL_TIMEOUT, null, null).invoke();
     }
 
     @Override
     public <E> InternalCompletableFuture<E> invokeOnPartition(String serviceName, Operation op, int partitionId, Callback callback) {
-        return createInvocationBuilder(serviceName, op, partitionId).setCallback(callback).invoke();
+        return new BasicPartitionInvocation(nodeEngine, serviceName, op, partitionId, InvocationBuilder.DEFAULT_REPLICA_INDEX,
+                InvocationBuilder.DEFAULT_TRY_COUNT, InvocationBuilder.DEFAULT_TRY_PAUSE_MILLIS, InvocationBuilder.DEFAULT_CALL_TIMEOUT, callback, null).invoke();
     }
 
     /**


### PR DESCRIPTION
This PR contains the following 2 fixes:
- The InvocationBuilder is now abstract; this makes it easier to introduce
  new fields and simplifies the code
- The InvocationBuilder is not created very every call anymore. So if
  custom configuration needs to be done, the InvocationBuilder can be created
  but a direct invoke on the OperationService doesn't need the InvocationBuilder
  to be created. This will help to speed up performance since less objects
  are being created and less code is being executed.
