### PR TITLE
Improves performance of PartitionView.getReplicaAddress

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/partition/PartitionServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/PartitionServiceImpl.java
@@ -1349,7 +1349,8 @@ public class PartitionServiceImpl implements PartitionService, ManagedService,
         private final int partitionId;
 
         //The content of this array will never be updated, so it can be safely read using a volatile read.
-        //Writing to 'addresses' is done using a 'addressUpdated' which involves a cas to prevent lost updates.
+        //Writing to 'addresses' is done using the 'addressUpdater' AtomicReferenceFieldUpdater which involves a
+        //cas to prevent lost updates.
         //The old approach relied on a AtomicReferenceArray, but this performed a lot slower that the current approach.
         //Number of reads will outweigh the number of writes to the field.
         volatile Address[] addresses = new Address[MAX_REPLICA_COUNT];


### PR DESCRIPTION
In the old implementation an AtomicReferenceArray was used which popped up in the profiler to
consume 33% of the time in my own branch. This fixes the issue by changing it to an array
stored in a volatile field, and where the whole array is updated using a cas.

Bit more expensive for writing, but writes don't happen often.
