### PR TITLE
Removes SocketWritable.onEnqueue 

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/ascii/AbstractTextCommand.java
+++ b/hazelcast/src/main/java/com/hazelcast/ascii/AbstractTextCommand.java
@@ -62,10 +62,6 @@ public abstract class AbstractTextCommand implements TextCommand {
     }
 
     @Override
-    public void onEnqueue() {
-    }
-
-    @Override
     public boolean shouldReply() {
         return true;
     }

--- a/hazelcast/src/main/java/com/hazelcast/nio/SocketWritable.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/SocketWritable.java
@@ -18,11 +18,22 @@ package com.hazelcast.nio;
 
 import java.nio.ByteBuffer;
 
+/**
+ * Represents something that can be written to a {@link com.hazelcast.nio.Connection}.
+ *
+ * todo:
+ * Perhaps this class should be renamed to ConnectionWritable since it is written to a
+ * {@link com.hazelcast.nio.Connection#write(SocketWritable)}. This aligns the names.
+ */
 public interface SocketWritable {
 
+    /**
+     * Asks the SocketWritable to write its content to the destination ByteBuffer.
+     *
+     * @param destination the ByteBuffer to write to.
+     * @return todo: unclear what return value means.
+     */
     boolean writeTo(ByteBuffer destination);
-
-    void onEnqueue();
 
     /**
      * Checks if this SocketWritable is urgent.

--- a/hazelcast/src/main/java/com/hazelcast/nio/WriteHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/WriteHandler.java
@@ -89,7 +89,6 @@ public final class WriteHandler extends AbstractSelectionHandler implements Runn
     }
 
     public void enqueueSocketWritable(SocketWritable socketWritable) {
-        socketWritable.onEnqueue();
         if(socketWritable.isUrgent()){
             urgencyWriteQueue.offer(socketWritable);
         }else{

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/DataAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/DataAdapter.java
@@ -285,10 +285,6 @@ public class DataAdapter implements SocketWritable, SocketReadable {
         return isStatusSet(stAll);
     }
 
-    @Override
-    public void onEnqueue() {
-    }
-
     public void reset() {
         buffer = null;
         classId = 0;


### PR DESCRIPTION
Removes SocketWritable.onEnqueue method since not a single no-op implementation
of this method exists.

Also improved documentation.
