### PR TITLE
MapStoreConfig (and QueueStoreConfig) property copy problem

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/MapStoreConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MapStoreConfig.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.config;
 
+import com.hazelcast.util.ValidationUtil;
+
 import java.util.Properties;
 
 /**
@@ -44,9 +46,7 @@ public class MapStoreConfig {
         factoryClassName = config.getFactoryClassName();
         factoryImplementation = config.getFactoryImplementation();
         writeDelaySeconds = config.getWriteDelaySeconds();
-        if (config.getProperties() != null) {
-            properties.putAll(config.getProperties());
-        }
+        properties.putAll(config.getProperties());
     }
 
     public MapStoreConfigReadOnly getAsReadOnly() {
@@ -186,6 +186,7 @@ public class MapStoreConfig {
     }
 
     public MapStoreConfig setProperties(Properties properties) {
+        ValidationUtil.isNotNull(properties, "properties");
         this.properties = properties;
         return this;
     }

--- a/hazelcast/src/main/java/com/hazelcast/config/QueueStoreConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/QueueStoreConfig.java
@@ -18,6 +18,7 @@ package com.hazelcast.config;
 
 import com.hazelcast.core.QueueStore;
 import com.hazelcast.core.QueueStoreFactory;
+import com.hazelcast.util.ValidationUtil;
 
 import java.util.Properties;
 
@@ -43,9 +44,7 @@ public class QueueStoreConfig {
         storeImplementation = config.getStoreImplementation();
         factoryClassName = config.getFactoryClassName();
         factoryImplementation = config.getFactoryImplementation();
-        if (config.getProperties() != null) {
-            properties.putAll(config.getProperties());
-        }
+        properties.putAll(config.getProperties());
     }
 
     public QueueStore getStoreImplementation() {
@@ -87,6 +86,7 @@ public class QueueStoreConfig {
     }
 
     public QueueStoreConfig setProperties(Properties properties) {
+        ValidationUtil.isNotNull(properties, "properties");
         this.properties = properties;
         return this;
     }


### PR DESCRIPTION
The 3.1.3 version revealed a problem with some code that intended to make a copy of a java.util.Properties object. The code in question uses the following syntax:

``` java
public MapStoreConfig(MapStoreConfig config) {
    // ...
    properties = config.getProperties() != null 
        ? new Properties(config.getProperties()) 
        : null;
}
```

The new Properties(Properties) constructor does not do exactly what is intended here. It saves the map's properties as default values. The size() function will return 0 for example. To create a copy of Properties, we should use the putAll() function.
