### PR TITLE
Bad attempt to compute absolute value of signed random integer in new co...

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/management/ManagementCenterService.java
+++ b/hazelcast/src/main/java/com/hazelcast/management/ManagementCenterService.java
@@ -117,7 +117,7 @@ public class ManagementCenterService implements LifecycleListener, MembershipLis
                     IAtomicReference<String> clusterIdAtomicLong = instance.getAtomicReference("___clusterIdGenerator");
                     String id = clusterIdAtomicLong.get();
                     if (id == null) {
-                        id = UUID.randomUUID().toString();
+                        id = com.hazelcast.util.UuidUtil.buildRandomUuidString();
                         if (!clusterIdAtomicLong.compareAndSet(null, id)) {
                             id = clusterIdAtomicLong.get();
                         }


### PR DESCRIPTION
...m.hazelcast.management.ManagementCenterService(HazelcastInstanceImpl)

and

Bad practice - Random object created and used only once

public static long abs(long a)
Returns the absolute value of a long value. If the argument is not negative, the argument is returned. If the argument is negative, the negation of the argument is returned.
Note that if the argument is equal to the value of Long.MIN_VALUE, the most negative representable long value, the result is that same value, which is negative.
