### PR TITLE
Moved basic parts of the inner BasicCompletableFuture to AbstractComplet...

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/AbstractCompletableFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/AbstractCompletableFuture.java
@@ -115,23 +115,8 @@ public abstract class AbstractCompletableFuture<V> implements CompletableFuture<
         }
     }
 
-    private Object readResult() {
-        Object result = this.result;
-        if (result == NULL_VALUE) {
-            try {
-                result = readResult();
-            } catch (Throwable t) {
-                result = t;
-            }
-            if (resultUpdater.compareAndSet(this, NULL_VALUE, result)) {
-                return result;
-            }
-        }
-        return this.result;
-    }
-
     private void runAsynchronous(final ExecutionCallback<V> callback, final Executor executor) {
-        final Object result = readResult();
+        final Object result = this.result;
         executor.execute(new Runnable() {
             @Override
             public void run() {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/ExecutionServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/ExecutionServiceImpl.java
@@ -404,7 +404,12 @@ public final class ExecutionServiceImpl implements ExecutionService {
 
         @Override
         public boolean isDone() {
-            return super.isDone() || future.isDone();
+            boolean done = future.isDone();
+            if (done && !super.isDone()) {
+                forceSetResult();
+                return true;
+            }
+            return done || super.isDone();
         }
 
         @Override
@@ -415,6 +420,16 @@ public final class ExecutionServiceImpl implements ExecutionService {
                 setResult(result);
             }
             return result;
+        }
+
+        private void forceSetResult() {
+            Object result;
+            try {
+                result = future.get();
+            } catch (Throwable t) {
+                result = t;
+            }
+            setResult(result);
         }
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/executor/ExecutorServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/executor/ExecutorServiceTest.java
@@ -910,6 +910,10 @@ public class ExecutorServiceTest extends HazelcastTestSupport {
             });
 
             latch2.await(30, TimeUnit.SECONDS);
+            if (reference.get() instanceof Throwable) {
+                ((Throwable) reference.get()).printStackTrace();
+            }
+
             assertEquals("success", reference.get());
 
         } finally {


### PR DESCRIPTION
...ableFuture for reusing the async implementation in other parts of the sourcebase and fixed bug where the task is longer running the get(long, TimeUnit). Callbacks were not called in that situation.
