### PR TITLE
Opps, java.lang.Exception: Method init() should not be static

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/countdownlatch/ClientCountDownLatchTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/countdownlatch/ClientCountDownLatchTest.java
@@ -45,7 +45,7 @@ public class ClientCountDownLatchTest {
     static ICountDownLatch l;
 
     @Before
-    public static void init() {
+    public void init() {
         Hazelcast.newHazelcastInstance();
         hz = HazelcastClient.newHazelcastClient(null);
         l = hz.getCountDownLatch(name);

--- a/hazelcast-client/src/test/java/com/hazelcast/client/topic/ClientTopicTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/topic/ClientTopicTest.java
@@ -44,7 +44,7 @@ public class ClientTopicTest {
     static ITopic t;
 
     @Before
-    public static void init(){
+    public void init(){
         server = Hazelcast.newHazelcastInstance();
         hz = HazelcastClient.newHazelcastClient(null);
         t = hz.getTopic(name);


### PR DESCRIPTION
Failed 
com.hazelcast.client.countdownlatch.ClientCountDownLatchTest.initializationError
com.hazelcast.client.topic.ClientTopicTest.initializationError

Opps, broken in the last Build, and since #255 where i made the first mistake. with thees 2 files
