### PR TITLE
Potential NPE caused by InteralPartition.getOwner 

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/MapService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/MapService.java
@@ -1111,7 +1111,10 @@ public class MapService implements ManagedService, MigrationAwareService,
         Address thisAddress = clusterService.getThisAddress();
         for (int partitionId = 0; partitionId < partitionService.getPartitionCount(); partitionId++) {
             InternalPartition partition = partitionService.getPartition(partitionId);
-            if (partition.getOwner().equals(thisAddress)) {
+            Address owner = partition.getOwner();
+            if(owner == null){
+                //no-op because no owner is set yet. Therefor we don't know anything about the map
+            }else if (owner.equals(thisAddress)) {
                 PartitionContainer partitionContainer = getPartitionContainer(partitionId);
                 RecordStore recordStore = partitionContainer.getRecordStore(mapName);
                 heapCost += recordStore.getHeapCost();

--- a/hazelcast/src/main/java/com/hazelcast/multimap/MultiMapService.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/MultiMapService.java
@@ -142,7 +142,7 @@ public class MultiMapService implements ManagedService, RemoteService,
             if (multiMapContainer == null) {
                 continue;
             }
-            if (partition.getOwner().equals(thisAddress)) {
+            if (thisAddress.equals(partition.getOwner())) {
                 keySet.addAll(multiMapContainer.keySet());
             }
         }
@@ -258,7 +258,10 @@ public class MultiMapService implements ManagedService, RemoteService,
             if (multiMapContainer == null) {
                 continue;
             }
-            if (partition.getOwner().equals(thisAddress)) {
+            Address owner = partition.getOwner();
+            if(owner == null){
+                //no-op because the owner is not yet set.
+            }else if (owner.equals(thisAddress)) {
                 lockedEntryCount += multiMapContainer.getLockedCount();
                 for (MultiMapWrapper wrapper : multiMapContainer.multiMapWrappers.values()) {
                     hits += wrapper.getHits();

--- a/hazelcast/src/main/java/com/hazelcast/partition/InternalPartition.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/InternalPartition.java
@@ -43,7 +43,7 @@ public interface InternalPartition {
     /**
      * Returns the Address of the owner of this partition.
      *
-     * If no owner has been set yet, null is returned.
+     * If no owner has been set yet, null is returned. So be careful with assuming that a non null value is returned.
      *
      * The value could be stale when returned.
      *

--- a/hazelcast/src/main/java/com/hazelcast/queue/QueueService.java
+++ b/hazelcast/src/main/java/com/hazelcast/queue/QueueService.java
@@ -206,7 +206,11 @@ public class QueueService implements ManagedService, MigrationAwareService, Tran
 
         Address thisAddress = nodeEngine.getClusterService().getThisAddress();
         InternalPartition partition = nodeEngine.getPartitionService().getPartition(partitionId);
-        if (thisAddress.equals(partition.getOwner())) {
+
+        Address owner = partition.getOwner();
+        if(owner == null){
+            //no-op because the owner is not yet set.
+        }else if (thisAddress.equals(owner)) {
             stats.setOwnedItemCount(container.size());
         } else {
             stats.setBackupItemCount(container.backupSize());


### PR DESCRIPTION
Internalpartition.getOwner can return null and not all code was dealing with it correctly (mostly statistics). This has been fixed in this pull request.
