### PR TITLE
Memory Leak BackupAware operation and timeout

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/OperationServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/OperationServiceImpl.java
@@ -57,7 +57,7 @@ final class OperationServiceImpl implements OperationService {
     private final Node node;
     private final ILogger logger;
     private final AtomicLong callIdGen = new AtomicLong(0);
-    private final ConcurrentMap<Long, RemoteCall> remoteCalls;
+    final ConcurrentMap<Long, RemoteCall> remoteCalls;
     private final ExecutorService[] operationExecutors;
     private final BlockingQueue[] operationExecutorQueues;
 
@@ -65,7 +65,7 @@ final class OperationServiceImpl implements OperationService {
     private final ExecutorService responseExecutor;
     private final long defaultCallTimeout;
     private final Map<RemoteCallKey, RemoteCallKey> executingCalls;
-    private final ConcurrentMap<Long, Semaphore> backupCalls;
+    final ConcurrentMap<Long, Semaphore> backupCalls;
     private final int operationThreadCount;
     private final EntryTaskScheduler<Object, ScheduledBackup> backupScheduler;
     private final BlockingQueue<Runnable> responseWorkQueue = new LinkedBlockingQueue<Runnable>();
@@ -608,8 +608,6 @@ final class OperationServiceImpl implements OperationService {
         RemoteCall call = deregisterRemoteCall(callId);
         if (call != null) {
             call.offerResponse(response);
-        } else {
-            throw new HazelcastException("No call with id: " + callId + ", Response: " + response);
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/OperationServiceImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/OperationServiceImplTest.java
@@ -1,0 +1,70 @@
+package com.hazelcast.spi.impl;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IQueue;
+import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.HazelcastJUnit4ClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+
+@RunWith(HazelcastJUnit4ClassRunner.class)
+@Category(ParallelTest.class)
+public class OperationServiceImplTest extends HazelcastTestSupport {
+
+    //there was a memory leak caused by the invocation not releasing the backup registration when there is a timeout.
+    @Test
+    public void testTimeoutSingleMember() throws InterruptedException {
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(1);
+        HazelcastInstance hz = factory.newHazelcastInstance();
+        final IQueue<Object> q = hz.getQueue("queue");
+
+         for (int k = 0; k < 1000; k++) {
+            Object response = q.poll(1, TimeUnit.MILLISECONDS);
+            assertNull(response);
+        }
+
+        assertNoLitterInOpService(hz);
+    }
+
+    //there was a memory leak caused by the invocation not releasing the backup registration when there is a timeout.
+    @Test
+    public void testTimeoutWithMultiMemberCluster() throws InterruptedException {
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(2);
+        HazelcastInstance hz1 = factory.newHazelcastInstance();
+        HazelcastInstance hz2 = factory.newHazelcastInstance();
+        final IQueue<Object> q = hz1.getQueue("queue");
+
+        for (int k = 0; k < 1000; k++) {
+            Object response = q.poll(1, TimeUnit.MILLISECONDS);
+            assertNull(response);
+        }
+
+        assertNoLitterInOpService(hz1);
+        assertNoLitterInOpService(hz2);
+    }
+
+    private void assertNoLitterInOpService(HazelcastInstance hz) {
+        final OperationServiceImpl operationService = (OperationServiceImpl) getNode(hz).nodeEngine.getOperationService();
+
+        //we need to do this with an assertTrueEventually because it can happen that system calls are being send
+        //and this leads to the maps not being empty. But eventually they will be empty at some moment in time.
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() {
+                assertEquals("backup calls should be empty",0, operationService.backupCalls.size());
+                assertEquals("remote calls should be empty",0, operationService.remoteCalls.size());
+            }
+        });
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/AssertTask.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/AssertTask.java
@@ -1,0 +1,5 @@
+package com.hazelcast.test;
+
+public interface AssertTask {
+    void run();
+}


### PR DESCRIPTION
Fixes #1559

It is fixed by always removing backup calls and remote calls on future completion
so there is no garbage. In the future we need to have a better system so that the
operation service will cleanup calls itself.
