### PR TITLE
Fixed the Serialization of Subclassed Enumerations

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/DefaultSerializers.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/DefaultSerializers.java
@@ -217,7 +217,8 @@ public class DefaultSerializers {
         }
 
         public void write(ObjectDataOutput out, Enum obj) throws IOException {
-            out.writeUTF(obj.getClass().getName());
+            String name = obj.getDeclaringClass().getName();
+            out.writeUTF(name);
             out.writeUTF(obj.name());
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/EnumTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/EnumTest.java
@@ -52,16 +52,16 @@ public class EnumTest {
         test(RetentionPolicy.SOURCE);
     }
 
+    //the TimeUnit.SECONDS is a difficult once because a subclass is generated. So when this test runs, it indicates
+    //the we can safely deal with subclasses of an enumeration.
     @Test
-    @Category(ProblematicTest.class)
-    //TODO TimeUnit.SECONDS.getClass().isEnum() returns false!
     public void test4() throws IOException {
         test(TimeUnit.SECONDS);
     }
 
     private void test(Enum value) throws IOException {
         Data data = ss.toData(value);
-        Enum found = (Enum) ss.toObject(data);
+        Enum found = ss.toObject(data);
         assertSame(value, found);
     }
 }


### PR DESCRIPTION
Certain enumerations like TimeUnit rely on subclassing the enclosing enumeration.
This fix makes sure we can correctly deal with these types of enumerations.
