### PR TITLE
Optimized the Cluster.getMember functionality 

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/instance/NodeShutdownLatch.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/NodeShutdownLatch.java
@@ -39,7 +39,7 @@ final class NodeShutdownLatch {
         localMember = node.localMember;
         Collection<MemberImpl> memberList = node.clusterService.getMemberList();
         registrations = new HashMap<String, HazelcastInstanceImpl>(3);
-        Set<MemberImpl> members = memberList instanceof Set ? (Set<MemberImpl>) memberList : new HashSet<MemberImpl>(memberList);
+        Set<MemberImpl> members = new HashSet<MemberImpl>(memberList);
         members.remove(localMember);
 
         if (!members.isEmpty()) {


### PR DESCRIPTION
Optimized the getMember functionality so that not every time a new collection
is build. This collection is now build when set and later can be retrieved using
a simple volatile read. Also did some cleanup so that null check is needed
anymore.
