### PR TITLE
Adding Missing Spring 4 Cache Method

### DIFF
--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/cache/HazelcastCache.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/cache/HazelcastCache.java
@@ -53,6 +53,14 @@ public class HazelcastCache implements Cache {
         final Object value = map.get(key);
         return value != null ? new SimpleValueWrapper(fromStoreValue(value)) : null;
     }
+    
+    public <T> T get(Object key, Class<T> type) {
+        Object value = fromStoreValue(this.map.get(key));
+        if (type != null && !type.isInstance(value)) {
+            throw new IllegalStateException("Cached value is not of required type [" + type.getName() + "]: " + value);
+        }
+        return (T) value;
+    }
 
     public void put(final Object key, final Object value) {
         if (key != null) {


### PR DESCRIPTION
Spring 4 adds a method with signature:
public <T> T get(Object key, Class<T> type)
