### PR TITLE
The OutOfMemoryErrorDispatcher is now lock free

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/instance/OutOfMemoryErrorDispatcher.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/OutOfMemoryErrorDispatcher.java
@@ -19,80 +19,142 @@ package com.hazelcast.instance;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.OutOfMemoryHandler;
 
-/**
- * @author mdogan 8/16/12
- */
+import java.util.concurrent.atomic.AtomicReference;
+
+import static com.hazelcast.util.ValidationUtil.isNotNull;
+import static java.lang.System.arraycopy;
+
 public final class OutOfMemoryErrorDispatcher {
 
-    private static final HazelcastInstance[] instances = new HazelcastInstance[50];
-    private static int size = 0;
-    private static OutOfMemoryHandler handler = new DefaultOutOfMemoryHandler();
+    private static final int MAX_REGISTERED_INSTANCES = 50;
+    private static final HazelcastInstance[] EMPTY_INSTANCES = new HazelcastInstance[0];
 
-    public synchronized static void setHandler(OutOfMemoryHandler outOfMemoryHandler) {
-        OutOfMemoryErrorDispatcher.handler = outOfMemoryHandler;
+    private static final AtomicReference<HazelcastInstance[]> instancesRef =
+            new AtomicReference<HazelcastInstance[]>(EMPTY_INSTANCES);
+
+    private static volatile OutOfMemoryHandler handler = new DefaultOutOfMemoryHandler();
+
+    //for testing only
+    static HazelcastInstance[] current() {
+        return instancesRef.get();
     }
 
-    synchronized static boolean register(HazelcastInstanceImpl instance) {
-        if (size < instances.length - 1) {
-            instances[size++] = instance;
-            return true;
-        }
-        return false;
+    public static void setHandler(OutOfMemoryHandler outOfMemoryHandler) {
+        handler = outOfMemoryHandler;
     }
 
-    synchronized static boolean deregister(HazelcastInstanceImpl instance) {
-        for (int index = 0; index < instances.length; index++) {
-            HazelcastInstance hz = instances[index];
-            if (hz == instance) {
-                try {
-                    int numMoved = size - index - 1;
-                    if (numMoved > 0) {
-                        System.arraycopy(instances, index + 1, instances, index, numMoved);
-                    }
-                    instances[--size] = null;
-                    return true;
-                } catch (Throwable ignored) {
-                }
+    static void register(HazelcastInstance instance) {
+        isNotNull(instance, "instance");
+
+        for (; ; ) {
+            HazelcastInstance[] oldInstances = instancesRef.get();
+            if (oldInstances.length == MAX_REGISTERED_INSTANCES) {
+                return;
+            }
+
+            HazelcastInstance[] newInstances = new HazelcastInstance[oldInstances.length + 1];
+            arraycopy(oldInstances, 0, newInstances, 0, oldInstances.length);
+            newInstances[oldInstances.length] = instance;
+
+            if (instancesRef.compareAndSet(oldInstances, newInstances)) {
+                return;
             }
         }
-        return false;
     }
 
-    synchronized static void clear() {
-        for (int i = 0; i < instances.length; i++) {
-            instances[i] = null;
-            size = 0;
+    static void deregister(HazelcastInstance instance) {
+        isNotNull(instance, "instance");
+
+        for (; ; ) {
+            HazelcastInstance[] oldInstances = instancesRef.get();
+            int indexOf = indexOf(oldInstances, instance);
+            if (indexOf == -1) {
+                return;
+            }
+
+            HazelcastInstance[] newInstances;
+            if (oldInstances.length == 1) {
+                newInstances = EMPTY_INSTANCES;
+            } else {
+                newInstances = new HazelcastInstance[oldInstances.length - 1];
+                arraycopy(oldInstances, 0, newInstances, 0, indexOf);
+                if (indexOf < newInstances.length) {
+                    arraycopy(oldInstances, indexOf + 1, newInstances, indexOf, newInstances.length - indexOf);
+                }
+            }
+
+            if (instancesRef.compareAndSet(oldInstances, newInstances)) {
+                return;
+            }
         }
     }
 
-    public static void inspectOutputMemoryError(Throwable throwable){
-        if(throwable == null){
+    private static int indexOf(HazelcastInstance[] instances, HazelcastInstance instance) {
+        for (int k = 0; k < instances.length; k++) {
+            if (instance == instances[k]) {
+                return k;
+            }
+        }
+        return -1;
+    }
+
+    static void clear() {
+        instancesRef.set(EMPTY_INSTANCES);
+    }
+
+    public static void inspectOutputMemoryError(Throwable throwable) {
+        if (throwable == null) {
             return;
         }
 
-        if(throwable instanceof OutOfMemoryError){
-            onOutOfMemory((OutOfMemoryError)throwable);
+        if (throwable instanceof OutOfMemoryError) {
+            onOutOfMemory((OutOfMemoryError) throwable);
         }
     }
 
-    public synchronized static void onOutOfMemory(OutOfMemoryError oom) {
-        if (handler != null) {
-            try {
-                handler.onOutOfMemory(oom, instances);
-            } catch (Throwable ignored) {
+    /**
+     * Signals the OutOfMemoryErrorDispatcher that an OutOfMemoryError happened.
+     * <p/>
+     * If there are any registered instances, they are automatically unregistered. This is done to prevent creating
+     * new objects during the deregistration process while the system is suffering from a shortage of memory.
+     *
+     * @param outOfMemoryError the out of memory error
+     */
+    public static void onOutOfMemory(OutOfMemoryError outOfMemoryError) {
+        isNotNull(outOfMemoryError, "outOfMemoryError");
+
+        OutOfMemoryHandler h = handler;
+        if (h == null) {
+            return;
+        }
+
+        HazelcastInstance[] instances = removeRegisteredInstances();
+        if (instances.length == 0) {
+            return;
+        }
+
+        try {
+            h.onOutOfMemory(outOfMemoryError, instances);
+        } catch (Throwable ignored) {
+        }
+    }
+
+    private static HazelcastInstance[] removeRegisteredInstances() {
+        for (; ; ) {
+            HazelcastInstance[] instances = instancesRef.get();
+            if (instancesRef.compareAndSet(instances, EMPTY_INSTANCES)) {
+                return instances;
             }
         }
     }
 
     private static class DefaultOutOfMemoryHandler extends OutOfMemoryHandler {
 
-        public void onOutOfMemory(final OutOfMemoryError oom, final HazelcastInstance[] hazelcastInstances) {
+        public void onOutOfMemory(OutOfMemoryError oom, HazelcastInstance[] hazelcastInstances) {
             for (HazelcastInstance instance : hazelcastInstances) {
-                if (instance != null) {
-                    Helper.tryCloseConnections(instance);
-                    Helper.tryStopThreads(instance);
-                    Helper.tryShutdown(instance);
-                }
+                Helper.tryCloseConnections(instance);
+                Helper.tryStopThreads(instance);
+                Helper.tryShutdown(instance);
             }
             System.err.println(oom);
         }
@@ -103,13 +165,15 @@ public final class OutOfMemoryErrorDispatcher {
         private Helper() {
         }
 
-        public static void tryCloseConnections(final HazelcastInstance hazelcastInstance) {
-            if (hazelcastInstance == null) return;
-            final HazelcastInstanceImpl factory = (HazelcastInstanceImpl) hazelcastInstance;
+        public static void tryCloseConnections(HazelcastInstance hazelcastInstance) {
+            if (hazelcastInstance == null) {
+                return;
+            }
+            HazelcastInstanceImpl factory = (HazelcastInstanceImpl) hazelcastInstance;
             closeSockets(factory);
         }
 
-        private static void closeSockets(final HazelcastInstanceImpl factory) {
+        private static void closeSockets(HazelcastInstanceImpl factory) {
             if (factory.node.connectionManager != null) {
                 try {
                     factory.node.connectionManager.shutdown();
@@ -118,9 +182,11 @@ public final class OutOfMemoryErrorDispatcher {
             }
         }
 
-        public static void tryShutdown(final HazelcastInstance hazelcastInstance) {
-            if (hazelcastInstance == null) return;
-            final HazelcastInstanceImpl factory = (HazelcastInstanceImpl) hazelcastInstance;
+        public static void tryShutdown(HazelcastInstance hazelcastInstance) {
+            if (hazelcastInstance == null) {
+                return;
+            }
+            HazelcastInstanceImpl factory = (HazelcastInstanceImpl) hazelcastInstance;
             closeSockets(factory);
             try {
                 factory.node.shutdown(true);
@@ -128,15 +194,20 @@ public final class OutOfMemoryErrorDispatcher {
             }
         }
 
-        public static void inactivate(final HazelcastInstance hazelcastInstance) {
-            if (hazelcastInstance == null) return;
+        public static void inactivate(HazelcastInstance hazelcastInstance) {
+            if (hazelcastInstance == null) {
+                return;
+            }
             final HazelcastInstanceImpl factory = (HazelcastInstanceImpl) hazelcastInstance;
             factory.node.inactivate();
         }
 
-        public static void tryStopThreads(final HazelcastInstance hazelcastInstance) {
-            if (hazelcastInstance == null) return;
-            final HazelcastInstanceImpl factory = (HazelcastInstanceImpl) hazelcastInstance;
+        public static void tryStopThreads(HazelcastInstance hazelcastInstance) {
+            if (hazelcastInstance == null) {
+                return;
+            }
+
+            HazelcastInstanceImpl factory = (HazelcastInstanceImpl) hazelcastInstance;
             try {
                 factory.node.threadGroup.interrupt();
             } catch (Throwable ignored) {
@@ -144,5 +215,6 @@ public final class OutOfMemoryErrorDispatcher {
         }
     }
 
-    private OutOfMemoryErrorDispatcher() {}
+    private OutOfMemoryErrorDispatcher() {
+    }
 }

--- a/hazelcast/src/test/java/com/hazelcast/instance/OutOfMemoryErrorDispatcherTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/OutOfMemoryErrorDispatcherTest.java
@@ -1,0 +1,93 @@
+package com.hazelcast.instance;
+
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.OutOfMemoryHandler;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertArrayEquals;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class OutOfMemoryErrorDispatcherTest {
+
+    @Before
+    public void before() {
+        OutOfMemoryErrorDispatcher.clear();
+    }
+
+    @Test
+    public void onOutOfMemoryOutOfMemory(){
+        OutOfMemoryHandler handler = mock(OutOfMemoryHandler.class);
+        OutOfMemoryError oome = new OutOfMemoryError();
+        HazelcastInstance hz1 = mock(HazelcastInstance.class);
+
+        OutOfMemoryErrorDispatcher.register(hz1);
+        OutOfMemoryErrorDispatcher.setHandler(handler);
+
+        HazelcastInstance[] registeredInstances = OutOfMemoryErrorDispatcher.current();
+
+        OutOfMemoryErrorDispatcher.onOutOfMemory(oome);
+
+        //make sure the handler is called
+        verify(handler).onOutOfMemory(oome, registeredInstances);
+        //make sure that the registered instances are removed.
+        assertArrayEquals(new HazelcastInstance[]{}, OutOfMemoryErrorDispatcher.current());
+     }
+
+    @Test
+    public void register() {
+        HazelcastInstance hz1 = mock(HazelcastInstance.class);
+        HazelcastInstance hz2 = mock(HazelcastInstance.class);
+
+        OutOfMemoryErrorDispatcher.register(hz1);
+        assertArrayEquals(new HazelcastInstance[]{hz1}, OutOfMemoryErrorDispatcher.current());
+
+        OutOfMemoryErrorDispatcher.register(hz2);
+        assertArrayEquals(new HazelcastInstance[]{hz1, hz2}, OutOfMemoryErrorDispatcher.current());
+    }
+
+
+    @Test(expected = IllegalArgumentException.class)
+    public void register_whenNull() {
+        OutOfMemoryErrorDispatcher.register(null);
+    }
+
+    @Test
+    public void deregister_Existing() {
+        HazelcastInstance hz1 = mock(HazelcastInstance.class);
+        HazelcastInstance hz2 = mock(HazelcastInstance.class);
+        HazelcastInstance hz3 = mock(HazelcastInstance.class);
+        OutOfMemoryErrorDispatcher.register(hz1);
+        OutOfMemoryErrorDispatcher.register(hz2);
+        OutOfMemoryErrorDispatcher.register(hz3);
+
+        OutOfMemoryErrorDispatcher.deregister(hz2);
+        assertArrayEquals(new HazelcastInstance[]{hz1, hz3}, OutOfMemoryErrorDispatcher.current());
+
+        OutOfMemoryErrorDispatcher.deregister(hz1);
+        assertArrayEquals(new HazelcastInstance[]{hz3}, OutOfMemoryErrorDispatcher.current());
+
+        OutOfMemoryErrorDispatcher.deregister(hz3);
+        assertArrayEquals(new HazelcastInstance[]{}, OutOfMemoryErrorDispatcher.current());
+    }
+
+    @Test
+    public void deregister_nonExisting() {
+        HazelcastInstance instance = mock(HazelcastInstance.class);
+        OutOfMemoryErrorDispatcher.deregister(instance);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void deregister_null() {
+        OutOfMemoryErrorDispatcher.deregister(null);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         <junit.version>4.11</junit.version>
         <junit-benchmarks.version>0.7.2</junit-benchmarks.version>
         <h2.version>1.3.160</h2.version>
-        <mockito.all.version>1.8.2</mockito.all.version>
+        <mockito.all.version>1.9.5</mockito.all.version>
         <log4j.version>1.2.12</log4j.version>
         <slf4j.api.version>1.6.0</slf4j.api.version>
     </properties>
@@ -505,6 +505,12 @@
             <version>${junit.version}</version>
             <scope>test</scope>
             <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <version>${mockito.all.version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>log4j</groupId>


### PR DESCRIPTION
The old approach relied on locks, where a lock on a static class was hold during
calling the out of memory handler. This can lead to a deadlock; you don't want
to hold a lock while calling an alien method.
