### PR TITLE
pom parallel-tests profile to exclude ProblematicTest  - Maintenance 3.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -412,6 +412,8 @@
                                 -Dhazelcast.test.use.network=true
                             </argLine>
                             <groups>com.hazelcast.test.annotation.SerialTest</groups>
+                            <excludedGroups>com.hazelcast.test.annotation.ParallelTest</excludedGroups>
+                            <excludedGroups>com.hazelcast.test.annotation.ProblematicTest</excludedGroups>
                         </configuration>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
do we want the 3.x maintenance jenkins job to exclude problematic Test from now on ?

Hazelcast-3.maintenance build uses  clean deploy -Pparallel-test,release-snapshot
