### PR TITLE
fix .gitignore to prevent some intellij metadata from getting checked in

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ target/
 .idea/
 .patch
 *.iml
+*.ipr
+*.iws
 .DS_Store
 reports/
 .directory


### PR DESCRIPTION
prevents *.ipr and *.iws files from being committed.
