### PR TITLE
Fixes #1736

### DIFF
--- a/hazelcast-client/pom.xml
+++ b/hazelcast-client/pom.xml
@@ -107,25 +107,6 @@
                     </execution>
                 </executions>
             </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <version>${maven.jar.plugin.version}</version>
-                <configuration>
-                    <archive>
-                        <index>true</index>
-                        <compress>true</compress>
-                        <manifest>
-                            <mainClass>com.hazelcast.client.examples.TestClientApp</mainClass>
-                            <addClasspath>false</addClasspath>
-                            <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
-                            <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
-                        </manifest>
-                        <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
-                    </archive>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 

--- a/hazelcast-client/src/main/resources/client.bat
+++ b/hazelcast-client/src/main/resources/client.bat
@@ -1,1 +1,0 @@
-java -Djava.net.preferIPv4Stack=true -jar ../lib/hazelcast-client-${project.version}.jar

--- a/hazelcast-client/src/main/resources/client.sh
+++ b/hazelcast-client/src/main/resources/client.sh
@@ -1,4 +1,0 @@
-#!/bin/sh
-
-java -Djava.net.preferIPv4Stack=true -jar ../lib/hazelcast-client-${project.version}.jar
-


### PR DESCRIPTION
Since the TestClientApp doesn't exist anymore, there is no need for
the shellscripts or making the client jar start up with the TestClientApp.
