### PR TITLE
Added findbugs to maven

### DIFF
--- a/hazelcast/findbugs/findbugs-exclude.xml
+++ b/hazelcast/findbugs/findbugs-exclude.xml
@@ -5,5 +5,110 @@
         <Package name="com.hazelcast.examples" />
     </Match>
 
+    <Match>
+        <Package name="com.hazelcast.ascii" />
+        <Package name="com.hazelcast.ascii.rest" />
+        <Package name="com.hazelcast.ascii.memcache" />
+    </Match>
+    <Match>
+        <Package name="com.hazelcast.ascii.rest" />
+    </Match>
+    <Match>
+        <Package name="com.hazelcast.ascii.memcache" />
+    </Match>
+    <Match>
+        <Package name="com.hazelcast.util" />
+    </Match>
+    <Match>
+        <Package name="com.hazelcast.monitor" />
+    </Match>
+    <Match>
+        <Package name="com.hazelcast.transaction.impl" />
+    </Match>
+    <Match>
+        <Package name="com.hazelcast.management.request" />
+    </Match>
+    <Match>
+        <Package name="com.hazelcast.mapreduce.impl.task" />
+    </Match>
+    <Match>
+        <Package name="com.hazelcast.instance" />
+    </Match>
+    <Match>
+        <Package name="com.hazelcast.core" />
+    </Match>
+    <Match>
+        <Package name="com.hazelcast.nio.ssl" />
+    </Match>
+    <Match>
+        <Package name="com.hazelcast.nio.partition" />
+    </Match>
+    <Match>
+        <Package name="com.hazelcast.spi.impl" />
+    </Match>
+    <Match>
+        <Package name="com.hazelcast.nio.serialization" />
+    </Match>
+    <Match>
+        <Package name="com.hazelcast.security" />
+    </Match>
+    <Match>
+        <Package name="com.hazelcast.config" />
+    </Match>
+    <Match>
+        <Package name="com.hazelcast.osgi" />
+    </Match>
+    <Match>
+        <Package name="com.hazelcast.map" />
+    </Match>
+    <Match>
+        <Package name="com.hazelcast.util.executor" />
+    </Match>
+    <Match>
+        <Package name="com.hazelcast.cluster.client" />
+    </Match>
+    <Match>
+        <Package name="com.hazelcast.mapreduce.client" />
+    </Match>
+    <Match>
+        <Package name="com.hazelcast.mapreduce.impl" />
+    </Match>
+    <Match>
+        <Package name="com.hazelcast.replicatedmap.messages" />
+    </Match>
+    <Match>
+        <Package name="com.hazelcast.cluster" />
+    </Match>
+    <Match>
+        <Package name="com.hazelcast.nio.ascii" />
+    </Match>
+    <Match>
+        <Package name="com.hazelcast.partition" />
+    </Match>
+    <Match>
+        <Package name="com.hazelcast.partition.client" />
+    </Match>
+    <Match>
+        <Package name="com.hazelcast.management" />
+    </Match>
+    <Match>
+        <Package name="com.hazelcast.map.proxy" />
+    </Match>
+    <Match>
+        <Package name="com.hazelcast.replicatedmap.operation" />
+    </Match>
+    <Match>
+        <Package name="com.hazelcast.replicatedmap.record" />
+    </Match>
+    <Match>
+        <Package name="com.hazelcast.wan" />
+    </Match>
+    <Match>
+        <Package name="com.hazelcast.ascii" />
+    </Match>
+    <Match>
+        <Package name="com.hazelcast.query.impl" />
+    </Match>
+
 
 </FindBugsFilter>

--- a/hazelcast/pom.xml
+++ b/hazelcast/pom.xml
@@ -153,7 +153,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>2.11</version>
+                <version>${checkstyle.maven.plugin.version}</version>
                 <executions>
                     <execution>
                         <phase>install</phase>
@@ -174,6 +174,24 @@
                     <includeTestSourceDirectory>false</includeTestSourceDirectory>
                     <enableRulesSummary>true</enableRulesSummary>
                     <propertyExpansion>basedir=${basedir}</propertyExpansion>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>findbugs-maven-plugin</artifactId>
+                <version>${findbugs.maven.plugin.version}</version>
+                <executions>
+                    <execution>
+                        <phase>install</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <failOnError>true</failOnError>
+                    <excludeFilterFile>${basedir}/findbugs/findbugs-exclude.xml</excludeFilterFile>
                 </configuration>
             </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,8 @@
         <maven.javadoc.plugin.version>2.9</maven.javadoc.plugin.version>
         <maven.rar.plugin.version>2.2</maven.rar.plugin.version>
         <maven.bundle.plugin.version>2.3.7</maven.bundle.plugin.version>
-        <findbugs.maven.plugin.version>2.5.2</findbugs.maven.plugin.version>
+        <checkstyle.maven.plugin.version>2.11</checkstyle.maven.plugin.version>
+        <findbugs.maven.plugin.version>2.5.3</findbugs.maven.plugin.version>
         <maven.dependency.plugin.version>2.6</maven.dependency.plugin.version>
         <junit.version>4.11</junit.version>
         <junit-benchmarks.version>0.7.2</junit-benchmarks.version>
@@ -144,6 +145,7 @@
                     <appendAssemblyId>false</appendAssemblyId>
                 </configuration>
             </plugin>
+
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>findbugs-maven-plugin</artifactId>


### PR DESCRIPTION
Maven will now fail if it finds findbugs problems.
I have added all the findbugs problems in the exclude file so we can build.
The idea is that the exclude file is going to be empty at the end of the
release.

The build time is going to increase with this build. So probably findbugs is going to be moved to a profile which is always going to be triggered from the merge build, but not by default of you do a mvn clean install locally.
