### PR TITLE
#1795 Use ArrayList to build collection of keys in removeAll, instead of HashSet

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/DefaultRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/DefaultRecordStore.java
@@ -411,7 +411,7 @@ public class DefaultRecordStore implements RecordStore {
         keysToDelete.removeAll(lockedRecords.keySet());
 
         final MapStoreWrapper store = mapContainer.getStore();
-        Set<Object> keysObject = new HashSet<Object>();
+        Collection<Object> keysObject = new ArrayList<Object>();
         for (Data key : keysToDelete) {
             // todo ea have a clear(Keys) method for optimizations
             removeIndex(key);


### PR DESCRIPTION
Issue #1795 describes the problem with using HashSet here. Using ArrayList fixes the problem.
