### PR TITLE
Fixes #1816

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/ClientReAuthOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/ClientReAuthOperation.java
@@ -49,7 +49,7 @@ public class ClientReAuthOperation extends AbstractOperation {
     }
 
     public boolean returnsResponse() {
-        return true;
+        return false;
     }
 
     public Object getResponse() {


### PR DESCRIPTION
Fixes #1816 

It is fixed by letting the ClientReAuthOperation not return a response,
since it will never return one.
