### PR TITLE
Find bug2

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/ListKeyValueSource.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/ListKeyValueSource.java
@@ -101,13 +101,12 @@ public class ListKeyValueSource<V>
 
     @Override
     public Map.Entry<String, V> element() {
-
-        Data valueObj = nextElement.getValue();
-        if (valueObj != null) {
-            valueObj = ss.toObject(valueObj);
+        Data value = nextElement.getValue();
+        if (value != null) {
+            value = ss.toObject(value);
         }
         simpleEntry.setKey(listName);
-        simpleEntry.setValue((V) valueObj);
+        simpleEntry.setValue((V) value);
         return simpleEntry;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/SetKeyValueSource.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/SetKeyValueSource.java
@@ -100,9 +100,9 @@ public class SetKeyValueSource<V>
 
     @Override
     public Map.Entry<String, V> element() {
-        Object value = nextElement.getValue();
-        if (value instanceof Data) {
-            value = ss.toObject((Data) value);
+        Data value = nextElement.getValue();
+        if (value != null) {
+            value = ss.toObject(value);
         }
         simpleEntry.setKey(setName);
         simpleEntry.setValue((V) value);


### PR DESCRIPTION
…zelcast.mapreduce.impl.ListKeyValueSource.element(), since all com.hazelcast.nio.serialization.Data are instances of com.hazelcast.nio.serialization.Data

```
 CollectionItem nextElement.getValue() defined as public Data getValue()
```

so an explicit null check, is better than the implicit null check performed by instanceof  
