### PR TITLE
Topology aware partition groups & Member Attribute XML config

### DIFF
--- a/hazelcast-spring/src/main/resources/hazelcast-spring-3.2.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-3.2.xsd
@@ -31,6 +31,7 @@
                         <xs:element name="license-key" type="xs:string" minOccurs="0" maxOccurs="1"/>
                         <xs:element name="management-center" type="management-center" minOccurs="0" maxOccurs="1"/>
                         <xs:element name="properties" type="properties" minOccurs="0" maxOccurs="1"/>
+                        <xs:element name="attributes" type="attributes" minOccurs="0" maxOccurs="1"/>
                         <xs:element name="wan-replication" type="wan-replication" minOccurs="0" maxOccurs="unbounded"/>
                         <xs:element name="network" type="network" minOccurs="0" maxOccurs="1"/>
                         <xs:element name="partition-group" type="partition-group" minOccurs="0" maxOccurs="1"/>
@@ -573,6 +574,28 @@
     <xs:complexType name="properties">
         <xs:sequence minOccurs="0" maxOccurs="unbounded">
             <xs:element name="property" type="property"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="attribute">
+        <xs:sequence>
+            <xs:choice>
+                <xs:element name="string-value" type="xs:string" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="double-value" type="xs:double" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="float-value" type="xs:float" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="short-value" type="xs:short" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="int-value" type="xs:int" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="long-value" type="xs:long" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="boolean-value" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="byte-value" type="xs:byte" minOccurs="0" maxOccurs="1"/>
+            </xs:choice>
+        </xs:sequence>
+        <xs:attribute name="key" use="required" type="xs:string"/>
+    </xs:complexType>
+
+    <xs:complexType name="attributes">
+        <xs:sequence minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="attribute" type="attribute"/>
         </xs:sequence>
     </xs:complexType>
 

--- a/hazelcast/src/main/java/com/hazelcast/config/MemberAttributeConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MemberAttributeConfig.java
@@ -114,4 +114,8 @@ public class MemberAttributeConfig {
         attributes.put(key, value);
     }
 
+    public void setAttributes(Map<String, Object> attributes) {
+        this.attributes.putAll(attributes);
+    }
+
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/PartitionGroupConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/PartitionGroupConfig.java
@@ -87,7 +87,7 @@ public class PartitionGroupConfig {
     private final List<MemberGroupConfig> memberGroupConfigs = new LinkedList<MemberGroupConfig>();
 
     public enum MemberGroupType {
-        HOST_AWARE, CUSTOM, PER_MEMBER
+        HOST_AWARE, CUSTOM, PER_MEMBER, TOPOLOGY_AWARE
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
@@ -263,6 +263,7 @@ public class XmlConfigBuilder extends AbstractXmlConfigHelper implements ConfigB
         node.setNodeValue(sb.toString());
     }
 
+
     private void handleConfig(final Element docElement) throws Exception {
         for (org.w3c.dom.Node node : new IterableNodeList(docElement.getChildNodes())) {
             final String nodeName = cleanNodeName(node.getNodeName());
@@ -272,6 +273,8 @@ public class XmlConfigBuilder extends AbstractXmlConfigHelper implements ConfigB
                 handleGroup(node);
             } else if ("properties".equals(nodeName)) {
                 fillProperties(node, config.getProperties());
+            } else if ("attributes".equals(nodeName)) {
+                handleMemberAttributes(node, config.getMemberAttributeConfig());
             } else if ("wan-replication".equals(nodeName)) {
                 handleWanReplication(node);
             } else if ("executor-service".equals(nodeName)) {
@@ -1313,4 +1316,43 @@ public class XmlConfigBuilder extends AbstractXmlConfigHelper implements ConfigB
             }
         }
     }
+
+    private void handleMemberAttributes(final Node node, MemberAttributeConfig memberAttributeConfig) {
+
+
+        for (org.w3c.dom.Node child : new IterableNodeList(node.getChildNodes())) {
+            final String nodeName = cleanNodeName(child.getNodeName());
+            if ("attribute".equals(nodeName)) {
+
+                final Node attName = child.getAttributes().getNamedItem("key");
+                final String key = getTextContent(attName);
+                //If the value is null, try and set it from System properties to match
+                //XmlConfigBuilder
+
+                //There should only be one child with the value in it
+                for (org.w3c.dom.Node valueChild : new IterableNodeList(child.getChildNodes())) {
+                    final String valueNodeName = cleanNodeName(valueChild.getNodeName());
+                    if ("string-value".equals(valueNodeName)) {
+                        memberAttributeConfig.setStringAttribute(key, String.valueOf(getTextContent(valueChild)));
+                    } else if ("int-value".equals(valueNodeName)) {
+                        memberAttributeConfig.setFloatAttribute(key, Integer.valueOf(getTextContent(valueChild)));
+                    } else if ("double-value".equals(valueNodeName)) {
+                        memberAttributeConfig.setDoubleAttribute(key, Double.valueOf(getTextContent(valueChild)));
+                    } else if ("float-value".equals(valueNodeName)) {
+                        memberAttributeConfig.setFloatAttribute(key, Float.valueOf(getTextContent(valueChild)));
+                    } else if ("boolean-value".equals(valueNodeName)) {
+                        memberAttributeConfig.setBooleanAttribute(key, Boolean.valueOf(getTextContent(valueChild)));
+                    } else if ("long-value".equals(valueNodeName)) {
+                        memberAttributeConfig.setLongAttribute(key, Long.valueOf(getTextContent(valueChild)));
+                    } else if ("short-value".equals(valueNodeName)) {
+                        memberAttributeConfig.setShortAttribute(key, Short.valueOf(getTextContent(valueChild)));
+                    } else if ("byte-value".equals(valueNodeName)) {
+                        memberAttributeConfig.setByteAttribute(key, Byte.valueOf(getTextContent(valueChild)));
+                    }
+                }
+            }
+        }
+
+    }
+
 }

--- a/hazelcast/src/main/java/com/hazelcast/instance/MemberImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/MemberImpl.java
@@ -343,8 +343,9 @@ public final class MemberImpl implements Member, HazelcastInstanceAware, Identif
         if (address == null) {
             if (other.address != null)
                 return false;
-        } else if (!address.equals(other.address))
+        } else if (!address.equals(other.address)) {
             return false;
+        }
         return true;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/partition/PartitionServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/PartitionServiceImpl.java
@@ -978,6 +978,8 @@ public class PartitionServiceImpl implements PartitionService, ManagedService,
                 return new ConfigMemberGroupFactory(partitionGroupConfig.getMemberGroupConfigs());
             case PER_MEMBER:
                 return new SingleMemberGroupFactory();
+            case TOPOLOGY_AWARE:
+                return new TopologyAwareMemberGroupFactory();
             default:
                 throw new RuntimeException("Unknown MemberGroupType:"+memberGroupType);
         }

--- a/hazelcast/src/main/java/com/hazelcast/partition/TopologyAwareMemberGroupFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/TopologyAwareMemberGroupFactory.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2008-2013, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.partition;
+
+import com.hazelcast.core.Member;
+import com.hazelcast.instance.MemberImpl;
+import com.hazelcast.nio.Address;
+
+import java.util.*;
+
+public class TopologyAwareMemberGroupFactory extends BackupSafeMemberGroupFactory implements MemberGroupFactory {
+
+    public static final String HAZELCAST_ADDRESS_SITE = "hazelcast.address.site";
+    public static final String HAZELCAST_ADDRESS_RACK = "hazelcast.address.rack";
+    public static final String HAZELCAST_ADDRESS_HOST = "hazelcast.address.host";
+    public static final String HAZELCAST_ADDRESS_PROCESS = "hazelcast.address.process";
+
+    protected Set<MemberGroup> createInternalMemberGroups(final Collection<Member> allMembers) {
+        final Map<String, MemberGroup> groups = new HashMap<String, MemberGroup>();
+        Map<String, MemberGroup> hostsMaps = new HashMap<String, MemberGroup>();
+
+
+        for (Member member : allMembers) {
+            Address address = ((MemberImpl) member).getAddress();
+
+            String siteAddress = null;
+            String rackAddress = null;
+            String hostAddress = null;
+            if (null != member.getAttributes()) {
+                siteAddress = (null == member.getAttributes()) ? null : (String)member.getAttributes().get(HAZELCAST_ADDRESS_SITE);
+                rackAddress = (null == member.getAttributes()) ? null : (String)member.getAttributes().get(HAZELCAST_ADDRESS_RACK);
+                hostAddress = (null == member.getAttributes()) ? null : (String)member.getAttributes().get(HAZELCAST_ADDRESS_HOST);
+            }
+
+
+            //Try and create MemberGroups by site
+            if (null != siteAddress) {
+                MemberGroup group = groups.get("Site:" + siteAddress);
+                if (group == null) {
+                    group = new DefaultMemberGroup();
+                    groups.put("Site:" + siteAddress, group);
+                }
+                group.addMember(member);
+            }
+            //Try and create MemberGroups by rack
+            else if (null != rackAddress) {
+                MemberGroup group = groups.get("Rack:" + rackAddress);
+                if (group == null) {
+                    group = new DefaultMemberGroup();
+                    groups.put("Rack:" + rackAddress, group);
+                }
+                group.addMember(member);
+            }
+            //Try and create MemberGroups by host
+            else {
+                //Lets try and get the HOST member attribute first. If that fails fall back to the IP address. We use
+                //host member attribute first as this should be common to the host, where as a single host can actually
+                //have multiple IP addresses.
+                if (null == hostAddress) {
+                    hostAddress = address.getHost();
+                }
+                MemberGroup group = hostsMaps.get("Host:" + hostAddress);
+                if (group == null) {
+                    group = new DefaultMemberGroup();
+                    hostsMaps.put("Host:" + hostAddress, group);
+                }
+                group.addMember(member);
+            }
+
+        }
+
+        //If there is only one entry in the hosts map,
+        //then we can potentially create a a number of groups if there
+        //are members running on different processes (JVMs). This
+        //creates a node safe configuration
+        //Then see if it can actually be grouped by process id
+        if (hostsMaps.size() == 1) {
+            Iterator<Member> members = hostsMaps.entrySet().iterator().next().getValue().iterator();
+            Map<String, MemberGroup> processesMap = new HashMap<String, MemberGroup>();
+            while (members.hasNext()) {
+
+                Member member = members.next();
+                String processAddress = (null == member.getAttributes()) ? null : (String)member.getAttributes().get(HAZELCAST_ADDRESS_PROCESS);
+                if (processAddress != null) {
+                    MemberGroup group = processesMap.get("Process:" + processAddress);
+                    if (group == null) {
+                        group = new DefaultMemberGroup();
+                        processesMap.put("Process:" + processAddress, group);
+                    }
+                    group.addMember(member);
+                }
+            }
+            groups.putAll(processesMap);
+        } else {
+            groups.putAll(hostsMaps);
+        }
+
+        return new HashSet<MemberGroup>(groups.values());
+    }
+}
+

--- a/hazelcast/src/main/resources/hazelcast-config-3.2.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-3.2.xsd
@@ -28,6 +28,7 @@
                 <xs:element name="license-key" type="xs:string" minOccurs="0" maxOccurs="1"/>
                 <xs:element name="management-center" type="management-center" minOccurs="0" maxOccurs="1"/>
                 <xs:element name="properties" type="properties" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="attributes" type="attributes" minOccurs="0" maxOccurs="1"/>
                 <xs:element name="wan-replication" type="wan-replication" minOccurs="0" maxOccurs="unbounded"/>
                 <xs:element name="network" type="network" minOccurs="0" maxOccurs="1"/>
                 <xs:element name="partition-group" type="partition-group" minOccurs="0" maxOccurs="1"/>
@@ -682,6 +683,7 @@
                     <xs:enumeration value="HOST_AWARE"/>
                     <xs:enumeration value="CUSTOM"/>
                     <xs:enumeration value="PER_MEMBER"/>
+                    <xs:enumeration value="TOPOLOGY_AWARE"/>
                 </xs:restriction>
             </xs:simpleType>
         </xs:attribute>
@@ -979,6 +981,29 @@
             <xs:element name="property" type="property"/>
         </xs:sequence>
     </xs:complexType>
+
+    <xs:complexType name="attribute">
+        <xs:sequence>
+            <xs:choice>
+                <xs:element name="string-value" type="xs:string" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="double-value" type="xs:double" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="float-value" type="xs:float" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="short-value" type="xs:short" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="int-value" type="xs:int" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="long-value" type="xs:long" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="boolean-value" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="byte-value" type="xs:byte" minOccurs="0" maxOccurs="1"/>
+            </xs:choice>
+        </xs:sequence>
+        <xs:attribute name="key" use="required" type="xs:string"/>
+    </xs:complexType>
+
+    <xs:complexType name="attributes">
+        <xs:sequence minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="attribute" type="attribute"/>
+        </xs:sequence>
+    </xs:complexType>
+
 
     <xs:simpleType name="topology-changed-strategy">
         <xs:restriction base="xs:string">

--- a/hazelcast/src/test/java/com/hazelcast/partition/TopologyAwareMemberGroupFactoryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/partition/TopologyAwareMemberGroupFactoryTest.java
@@ -1,0 +1,151 @@
+package com.hazelcast.partition;
+
+import com.hazelcast.core.Member;
+import com.hazelcast.instance.MemberImpl;
+import com.hazelcast.nio.Address;
+import org.junit.Test;
+
+import java.net.InetAddress;
+import java.util.*;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * User: grant
+ */
+public class TopologyAwareMemberGroupFactoryTest {
+
+
+    @Test
+    public void testCreateInternalMemberGroupsSites() throws Exception {
+
+        TopologyAwareMemberGroupFactory factory = new TopologyAwareMemberGroupFactory();
+        List<Member> members = new ArrayList<Member>();
+        Map<String, Object> attributes1 = new HashMap<String, Object>();
+        attributes1.put(TopologyAwareMemberGroupFactory.HAZELCAST_ADDRESS_SITE, "site1");
+        members.add(new MemberImpl(new Address("localhost", 5000), true, null, null, attributes1));
+        Map<String, Object> attributes2 = new HashMap<String, Object>();
+        attributes2.put(TopologyAwareMemberGroupFactory.HAZELCAST_ADDRESS_SITE, "site2");
+        members.add(new MemberImpl(new Address("localhost", 5001), true, null, null, attributes2));
+
+        Set<MemberGroup> result = factory.createInternalMemberGroups(members);
+        assertNotNull(result);
+        assertEquals(2, result.size());
+
+        MemberGroup group1 = result.iterator().next();
+        assertEquals(1, group1.size());
+
+        MemberGroup group2 = result.iterator().next();
+        assertEquals(1, group2.size());
+
+
+    }
+
+    @Test
+    public void testCreateInternalMemberGroupsRacks() throws Exception {
+        TopologyAwareMemberGroupFactory factory = new TopologyAwareMemberGroupFactory();
+        List<Member> members = new ArrayList<Member>();
+        Map<String, Object> attributes1 = new HashMap<String, Object>();
+        attributes1.put(TopologyAwareMemberGroupFactory.HAZELCAST_ADDRESS_RACK, "rack1");
+        members.add(new MemberImpl(new Address("localhost", 5000), true, null, null, attributes1));
+        Map<String, Object> attributes2 = new HashMap<String, Object>();
+        attributes2.put(TopologyAwareMemberGroupFactory.HAZELCAST_ADDRESS_RACK, "rack2");
+        members.add(new MemberImpl(new Address("localhost", 5001), true, null, null, attributes2));
+
+        Set<MemberGroup> result = factory.createInternalMemberGroups(members);
+        assertNotNull(result);
+        assertEquals(2, result.size());
+
+        MemberGroup group1 = result.iterator().next();
+        assertEquals(1, group1.size());
+
+        MemberGroup group2 = result.iterator().next();
+        assertEquals(1, group2.size());
+
+    }
+
+    @Test
+    public void testCreateInternalMemberGroupsHosts() throws Exception {
+        TopologyAwareMemberGroupFactory factory = new TopologyAwareMemberGroupFactory();
+        List<Member> members = new ArrayList<Member>();
+        members.add(new MemberImpl(new Address("localhost", 5000), true, null, null));
+        members.add(new MemberImpl(new Address(InetAddress.getLocalHost().getHostName(),5001), true, null, null));
+
+        Set<MemberGroup> result = factory.createInternalMemberGroups(members);
+        assertNotNull(result);
+        assertEquals(2, result.size());
+
+        MemberGroup group1 = result.iterator().next();
+        assertEquals(1, group1.size());
+
+        MemberGroup group2 = result.iterator().next();
+        assertEquals(1, group2.size());
+
+
+    }
+
+    @Test
+    public void testCreateInternalMemberGroupsProcesses() throws Exception {
+        TopologyAwareMemberGroupFactory factory = new TopologyAwareMemberGroupFactory();
+        List<Member> members = new ArrayList<Member>();
+
+        Map<String, Object> attributes1 = new HashMap<String, Object>();
+        attributes1.put(TopologyAwareMemberGroupFactory.HAZELCAST_ADDRESS_HOST, "host1");
+        members.add(new MemberImpl(new Address("localhost", 5000), true, null, null, attributes1));
+
+        Map<String, Object> attributes2 = new HashMap<String, Object>();
+        attributes2.put(TopologyAwareMemberGroupFactory.HAZELCAST_ADDRESS_HOST, "host2");
+        members.add(new MemberImpl(new Address("localhost", 5001), true, null, null, attributes2));
+
+        Set<MemberGroup> result = factory.createInternalMemberGroups(members);
+        assertNotNull(result);
+        assertEquals(2, result.size());
+
+        MemberGroup group1 = result.iterator().next();
+        assertEquals(1, group1.size());
+
+        MemberGroup group2 = result.iterator().next();
+        assertEquals(1, group2.size());
+
+
+    }
+
+
+
+    @Test
+    public void testCreateInternalMemberGroupsMixOfSitesAndRacks() throws Exception {
+        TopologyAwareMemberGroupFactory factory = new TopologyAwareMemberGroupFactory();
+        List<Member> members = new ArrayList<Member>();
+
+        Map<String, Object> attributes1 = new HashMap<String, Object>();
+        attributes1.put(TopologyAwareMemberGroupFactory.HAZELCAST_ADDRESS_HOST, "host1");
+        members.add(new MemberImpl(new Address("localhost", 5000), true, null, null, attributes1));
+
+        Map<String, Object> attributes2 = new HashMap<String, Object>();
+        attributes2.put(TopologyAwareMemberGroupFactory.HAZELCAST_ADDRESS_HOST, "host2");
+        members.add(new MemberImpl(new Address("localhost", 5001), true, null, null, attributes2));
+
+        Map<String, Object> attributes3 = new HashMap<String, Object>();
+        attributes3.put(TopologyAwareMemberGroupFactory.HAZELCAST_ADDRESS_RACK, "rack1");
+        members.add(new MemberImpl(new Address("localhost", 5002), true, null, null, attributes3));
+
+        Map<String, Object> attributes4 = new HashMap<String, Object>();
+        attributes4.put(TopologyAwareMemberGroupFactory.HAZELCAST_ADDRESS_RACK, "rack2");
+        members.add(new MemberImpl(new Address("localhost", 5003), true, null, null, attributes4));
+
+        Set<MemberGroup> result = factory.createInternalMemberGroups(members);
+        assertNotNull(result);
+        assertEquals(4, result.size());
+        MemberGroup group1 = result.iterator().next();
+        assertEquals(1, group1.size());
+        MemberGroup group2 = result.iterator().next();
+        assertEquals(1, group2.size());
+        MemberGroup group3 = result.iterator().next();
+        assertEquals(1, group3.size());
+        MemberGroup group4 = result.iterator().next();
+        assertEquals(1, group4.size());
+
+    }
+
+}


### PR DESCRIPTION
Reworked the topology aware partition group strategy to use the new member attributes in 3.2. 

Also added ability to confine member attributes through spring & standard xml config
