### PR TITLE
Bugfix HazelcastHttpSession.getAttribute - incorrect value was put in localCache

### DIFF
--- a/hazelcast-wm/src/main/java/com/hazelcast/web/WebFilter.java
+++ b/hazelcast-wm/src/main/java/com/hazelcast/web/WebFilter.java
@@ -456,7 +456,7 @@ public class WebFilter implements Filter {
                         cacheEntry.value = value;
                         cacheEntry.reload = false;
                     }
-                    localCache.put(name, NULL_ENTRY);
+                    localCache.put(name, cacheEntry);
                 }
                 return cacheEntry != NULL_ENTRY ? cacheEntry.value : null;
             }


### PR DESCRIPTION
HazelcastHttpSession.getAttribute loaded the value from the clusterMap, but
always put NULL_ENTRY in the localCache
