### PR TITLE
added an internal Executor for internal tasks

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/ClientExecutionService.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/ClientExecutionService.java
@@ -28,6 +28,8 @@ import java.util.concurrent.TimeUnit;
  */
 public interface ClientExecutionService {
 
+    void executeInternal(Runnable command);
+
     void execute(Runnable command);
 
     ICompletableFuture<?> submit(Runnable task);

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientCallFuture.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientCallFuture.java
@@ -171,7 +171,7 @@ public class ClientCallFuture<V> implements ICompletableFuture<V>, Callback {
     }
 
     public void andThen(ExecutionCallback<V> callback) {
-        andThen(callback, executionService.getExecutor());
+        andThen(callback, executionService.getAsyncExecutor());
     }
 
     public void andThen(ExecutionCallback<V> callback, Executor executor) {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientClusterServiceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientClusterServiceImpl.java
@@ -349,7 +349,7 @@ public final class ClientClusterServiceImpl implements ClientClusterService {
         }
 
         private void fireMembershipEvent(final MembershipEvent event) {
-            client.getClientExecutionService().execute(new Runnable() {
+            client.getClientExecutionService().executeInternal(new Runnable() {
                 public void run() {
                     for (MembershipListener listener : listeners.values()) {
                         if (event.getEventType() == MembershipEvent.MEMBER_ADDED) {
@@ -363,7 +363,7 @@ public final class ClientClusterServiceImpl implements ClientClusterService {
         }
 
         private void fireMemberAttributeEvent(final MemberAttributeEvent event) {
-            client.getClientExecutionService().execute(new Runnable() {
+            client.getClientExecutionService().executeInternal(new Runnable() {
                 @Override
                 public void run() {
                     for (MembershipListener listener : listeners.values()) {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientPartitionServiceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientPartitionServiceImpl.java
@@ -63,7 +63,7 @@ public final class ClientPartitionServiceImpl implements ClientPartitionService 
 
     public void refreshPartitions() {
         try {
-            client.getClientExecutionService().execute(new RefreshTask());
+            client.getClientExecutionService().executeInternal(new RefreshTask());
         } catch (RejectedExecutionException ignored) {
         }
     }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/io/ClientIOExecutorPoolSizeLowTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/io/ClientIOExecutorPoolSizeLowTest.java
@@ -3,10 +3,17 @@ package com.hazelcast.client.io;
 import com.hazelcast.client.HazelcastClient;
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.config.Config;
-import com.hazelcast.core.*;
+import com.hazelcast.core.EntryAdapter;
+import com.hazelcast.core.EntryEvent;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IExecutorService;
+import com.hazelcast.core.IMap;
+import com.hazelcast.core.ITopic;
+import com.hazelcast.core.Message;
+import com.hazelcast.core.MessageListener;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastSerialClassRunner;
-import com.hazelcast.test.annotation.ProblematicTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
 import org.junit.Before;
@@ -15,26 +22,27 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.hazelcast.test.HazelcastTestSupport.assertTrueEventually;
+import static com.hazelcast.test.HazelcastTestSupport.randomString;
 import static org.junit.Assert.assertEquals;
-
-/**
- * Created by danny on 12/16/13.
- */
+import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
 public class ClientIOExecutorPoolSizeLowTest {
 
+    static final int COUNT = 1000;
+    static final int TIMEOUT = 60 * 1000;
     static HazelcastInstance server1;
     static HazelcastInstance server2;
-    static HazelcastInstance server3;
     static HazelcastInstance client;
+    static IMap map;
 
     static final int executorPoolSize = 1;
 
@@ -42,143 +50,83 @@ public class ClientIOExecutorPoolSizeLowTest {
 
     @Before
     public void init() {
-
         Config config = new Config();
         server1 = Hazelcast.newHazelcastInstance(config);
-        server2 = Hazelcast.newHazelcastInstance(config);
-        server3 = Hazelcast.newHazelcastInstance(config);
 
         ClientConfig clientConfig = new ClientConfig();
         clientConfig.setExecutorPoolSize(executorPoolSize);
         client = HazelcastClient.newHazelcastClient(clientConfig);
 
+        server2 = Hazelcast.newHazelcastInstance(config);
 
-        final IMap<Object, Object> map = client.getMap("map");
-
-        //default to add 1 listener to use the 1 executor thread
+        map = client.getMap("map");
         entryCounterID = map.addEntryListener(new EntryCounter(), true);
     }
 
     @After
     public void destroy() {
-        client.shutdown();
+        HazelcastClient.shutdownAll();
         Hazelcast.shutdownAll();
     }
 
-
-    @Test(timeout=1000*60)
-    @Category(ProblematicTest.class)
-    //we destroy all the nodes and clients and then init them again but this time with the client init-ed between the nodes.
-    //the test hangs at client.getMap("map");  again only if the pool size is 1
-    public void initNodeAndClientOrderTest() throws InterruptedException, ExecutionException {
-
-        destroy();
-
-        server1 = Hazelcast.newHazelcastInstance();
-
-        ClientConfig clientConfig = new ClientConfig();
-        clientConfig.setExecutorPoolSize(executorPoolSize);
-        client = HazelcastClient.newHazelcastClient(clientConfig);
-
-        server2 = Hazelcast.newHazelcastInstance();
-        server3 = Hazelcast.newHazelcastInstance();
-
-        final IMap<Object, Object> map = client.getMap("map");
-
-        for (int i = 0; i < 1000; i++) {
-            map.put(i, i);
-        }
-        assertTrueEventually(new AssertTask() {
-            public void run() {
-                assertEquals(1000, map.size());
-            }
-        });
-    }
-
-    @Test(timeout=1000*60)
-    @Category(ProblematicTest.class)//the client hangs which executeOnKeyOwner pool size of 1
+    @Test(timeout = TIMEOUT)
     public void entryListenerWithMapOps_WithNodeTerminate() throws InterruptedException, ExecutionException {
-
-        final IMap<Object, Object> map = client.getMap("map");
-
-        for (int i = 0; i < 1000; i++) {
+        for (int i = 0; i < COUNT; i++) {
             map.put(i, i);
-            if(i==500){
+            if (i == COUNT / 2) {
                 server2.getLifecycleService().terminate();
             }
         }
-
-        assertTrueEventually(new AssertTask() {
-            public void run() {
-                assertEquals(1000, map.size());
-            }
-        });
+        assertEquals(COUNT, map.size());
     }
 
-    @Test(timeout=1000*60)
-    @Category(ProblematicTest.class)//the client Throws com.hazelcast.spi.exception.TargetDisconnectedException: Target[Address[127.0.0.1]:5702] disconnected. client seems to connect to server1 every time ?
+    @Test(timeout = TIMEOUT)
     public void entryListenerWithMapOps_WithClientConnectedNodeTerminate() throws InterruptedException, ExecutionException {
-
-        final IMap<Object, Object> map = client.getMap("map");
-
-        for (int i = 0; i < 1000; i++) {
+        for (int i = 0; i < COUNT; i++) {
             map.put(i, i);
-            if(i==500){
+            if (i == COUNT / 2) {
                 server1.getLifecycleService().terminate();
             }
         }
-
-        assertTrueEventually(new AssertTask() {
-            public void run() {
-                assertEquals(1000, map.size());
-            }
-        });
+        assertEquals(COUNT, map.size());
     }
 
-    @Test(timeout=1000*60)
-    @Category(ProblematicTest.class)//the client hangs which executeOnKeyOwner pool size of 1
+    @Test(timeout = TIMEOUT)
     public void entryListenerWithMapAsyncOps_WithNodeTerminate() throws InterruptedException, ExecutionException {
-
-        final IMap<Object, Object> map = client.getMap("map");
-
-        for (int i = 0; i < 1000; i++) {
-            map.putAsync(i, i);
-            if(i==500){
+        final ArrayList<Future> futures = new ArrayList<Future>();
+        for (int i = 0; i < COUNT; i++) {
+            final Future<Object> f = map.putAsync(i, i);
+            futures.add(f);
+            if (i == COUNT / 2) {
                 server2.getLifecycleService().terminate();
             }
         }
-
-        assertTrueEventually(new AssertTask() {
-            public void run() {
-                assertEquals(1000, map.size());
+        int total = 0;
+        for (Future f : futures) {
+            try {
+                f.get();
+                total++;
+            } catch (Exception ignored) {
             }
-        });
+        }
+        assertTrue(map.size() >= total);
     }
 
 
-    @Test(timeout=1000*60)
-    @Category(ProblematicTest.class)//the client hangs which executeOnKeyOwner pool size of 1
+    @Test(timeout = TIMEOUT)
     public void entryListenerWithAsyncMapOps_WithNodeTerminate() throws InterruptedException, ExecutionException {
-
-        final IMap<Object, Object> map = client.getMap("map");
-
-        for (int i = 0; i < 1000; i++) {
+        for (int i = 0; i < COUNT; i++) {
             map.putAsync(i, i);
         }
-
         assertTrueEventually(new AssertTask() {
             public void run() {
-                assertEquals(1000, map.size());
+                assertEquals(COUNT, map.size());
             }
         });
-
-
-        for (int i = 0; i < 1000; i++) {
-
+        for (int i = 0; i < COUNT; i++) {
             Future f = map.getAsync(i);
             assertEquals(i, f.get());
-
-            if(i==500){
+            if (i == 500) {
                 server2.getLifecycleService().terminate();
             }
         }
@@ -186,76 +134,57 @@ public class ClientIOExecutorPoolSizeLowTest {
 
     @Test
     public void removeListenerAfterAsyncOpp() throws InterruptedException {
-
-        final IMap<Object, Object> map = client.getMap("map");
-
-        for (int i = 0; i < 1000; i++) {
+        for (int i = 0; i < COUNT; i++) {
             map.putAsync(i, i);
             if (i == 500) {
                 map.removeEntryListener(entryCounterID);
             }
         }
-
         assertTrueEventually(new AssertTask() {
             public void run() {
                 assertEquals(1000, map.size());
             }
         });
-
     }
 
 
     @Test
     public void moreEntryListenersThanExecutorThreads() throws InterruptedException {
-
         final EntryCounter counter = new EntryCounter();
-
-        final IMap<Object, Object> map = client.getMap("map");
         map.addEntryListener(counter, true);//adding 2nd EntryListener
-
-        for (int i = 0; i < 1000; i++) {
+        for (int i = 0; i < COUNT; i++) {
             map.putAsync(i, i);
         }
-
         assertTrueEventually(new AssertTask() {
             public void run() {
-                assertEquals(1000, map.size());
+                assertEquals(COUNT, map.size());
             }
         });
-
         assertTrueEventually(new AssertTask() {
             public void run() {
-                assertEquals(1000, counter.count.get());
+                assertEquals(COUNT, counter.count.get());
             }
         });
-
     }
 
 
     @Test
     public void entryListenerWithAsyncMapOps() throws InterruptedException, ExecutionException {
-
-        final IMap<Object, Object> map = client.getMap("map");
-
-        for (int i = 0; i < 1000; i++) {
+        for (int i = 0; i < COUNT; i++) {
             map.putAsync(i, i);
         }
-
         assertTrueEventually(new AssertTask() {
             public void run() {
                 assertEquals(1000, map.size());
             }
         });
-
-        for (int i = 0; i < 1000; i++) {
+        for (int i = 0; i < COUNT; i++) {
             Future f = map.getAsync(i);
             assertEquals(i, f.get());
         }
-
-        for (int i = 0; i < 1000; i++) {
+        for (int i = 0; i < COUNT; i++) {
             map.removeAsync(i);
         }
-
         assertTrueEventually(new AssertTask() {
             public void run() {
                 assertEquals(0, map.size());
@@ -265,31 +194,24 @@ public class ClientIOExecutorPoolSizeLowTest {
 
     @Test
     public void entryListenerWithAsyncTopicOps() throws InterruptedException {
-
-        final ITopic<Object> t = client.getTopic("stuff");
-
+        final ITopic<Object> topic = client.getTopic(randomString());
         final MsgCounter counter = new MsgCounter();
-        t.addMessageListener(counter);
-
-        for (int i = 0; i < 1000; i++)
-            t.publish(i);
-
+        topic.addMessageListener(counter);
+        for (int i = 0; i < COUNT; i++) {
+            topic.publish(i);
+        }
         assertTrueEventually(new AssertTask() {
             public void run() {
-                assertEquals(1000, counter.count.get());
+                assertEquals(COUNT, counter.count.get());
             }
         });
-
     }
 
 
     @Test
     public void entryListenerWithExecutorService() throws ExecutionException, InterruptedException {
-
-        IExecutorService executor = client.getExecutorService("simple");
-
+        IExecutorService executor = client.getExecutorService(randomString());
         final Future<String> f = executor.submit(new BasicTestTask());
-
         assertTrueEventually(new AssertTask() {
             public void run() {
                 try {
@@ -321,23 +243,6 @@ public class ClientIOExecutorPoolSizeLowTest {
             count.getAndIncrement();
         }
     }
-
-
-    public class ItemCounter implements ItemListener {
-
-        public AtomicInteger count = new AtomicInteger(0);
-
-        public void itemAdded(ItemEvent itemEvent) {
-            count.getAndIncrement();
-        }
-
-        public void itemRemoved(ItemEvent item) {
-            count.getAndDecrement();
-        }
-    }
-
-    ;
-
 
     public class EntryCounter extends EntryAdapter {
 


### PR DESCRIPTION
added some wait for processing already came remote responses while closing connection
revised pool-size-low test
