### PR TITLE
Modify examples in the documentaion to reflect the fact that

### DIFF
--- a/hazelcast-documentation/src/DataAffinity.md
+++ b/hazelcast-documentation/src/DataAffinity.md
@@ -109,39 +109,42 @@ So instead, why not moving the computation over to the member (JVM) where your c
 Here is a sample code:
 
 ```java
+static Config cfg = new Config();
+static HazelcastInstance instance = Hazelcast.newHazelcastInstance(cfg);
+
 public static int removeOrder(long customerId, long orderId) throws Exception {
-    ExecutorService es = instance.getExecutorService();
+    IExecutorService es = instance.getExecutorService("ExecutorService");
     OrderDeletionTask task = new OrderDeletionTask(customerId, orderId);
-    Future future = es.submit(task);
+    Future<Integer> future = es.submit(task);
     int remainingOrders = future.get();
     return remainingOrders;
 }
 
 public static class OrderDeletionTask implements Callable<Integer>, PartitionAware, Serializable {
 
-   private long customerId;
-   private long orderId;
+    private long customerId;
+    private long orderId;
 
-   public OrderDeletionTask() {
-   }
-   public OrderDeletionTask(long customerId, long orderId) {
-       super();
-       this.customerId = customerId;
-       this.orderId = orderId;
-   }
-   public Integer call () {
-       IMap<Long, Customer> mapCustomers = Hazelcast.getMap("customers");
-       mapCustomers.lock (customerId);
-       Customer customer = mapCustomers. get(customerId);
-       customer.removeOrder (orderId);
-       mapCustomers.put(customerId, customer);
-       mapCustomers.unlock(customerId);
-       return customer.getOrderCount();
-   }
+    public OrderDeletionTask() {
+    }
+    public OrderDeletionTask(long customerId, long orderId) {
+        super();
+        this.customerId = customerId;
+        this.orderId = orderId;
+    }
+    public Integer call () {
+        IMap<Long, Customer> mapCustomers = instance.getMap("customers");
+        mapCustomers.lock (customerId);
+        Customer customer = mapCustomers.get(customerId);
+        customer.removeOrder (orderId);
+        mapCustomers.put(customerId, customer);
+        mapCustomers.unlock(customerId);
+        return customer.getOrderCount();
+    }
 
-   public Object getPartitionKey() {
-       return customerId;
-   }
+    public Object getPartitionKey() {
+        return customerId;
+    }
 }
 ```
 

--- a/hazelcast-documentation/src/Execution.md
+++ b/hazelcast-documentation/src/Execution.md
@@ -57,5 +57,5 @@ public void echoOnMembers(String input, Set<Member> members) throws Exception {
 }```
 
 
-Note that you can obtain the set of cluster members via `Hazelcast.getCluster().getMembers()` call.
+Note that you can obtain the set of cluster members via `HazelcastInstance#getCluster().getMembers()` call.
 

--- a/hazelcast-documentation/src/ExecutorService.md
+++ b/hazelcast-documentation/src/ExecutorService.md
@@ -19,12 +19,14 @@ public class Echo implements Callable<String>, Serializable {
     }
 
     public String call() {
-        return Hazelcast.getCluster().getLocalMember().toString() + ":" + input;
+        Config cfg = new Config();
+        HazelcastInstance instance = Hazelcast.newHazelcastInstance(cfg);
+        return instance.getCluster().getLocalMember().toString() + ":" + input;
     }
 }
 ```
 
-Echo callable above, for instance, in its `call()` method, is returning the local member and the input passed in. Remember that `Hazelcast.getCluster().getLocalMember()` returns the local member and `toString()` returns the member's address `(IP + port)` in String form, just to see which member actually executed the code for our example. Of course, `call()` method can do and return anything you like. Executing a task by using executor framework is very straight forward. Simply obtain a `ExecutorService` instance, generally via `Executors` and submit the task which returns a `Future`. After executing task, you do not have to wait for execution to complete, you can process other things and when ready use the future object to retrieve the result as show in code below.
+Echo callable above, for instance, in its `call()` method, is returning the local member and the input passed in. Remember that `instance.getCluster().getLocalMember()` returns the local member and `toString()` returns the member's address `(IP + port)` in String form, just to see which member actually executed the code for our example. Of course, `call()` method can do and return anything you like. Executing a task by using executor framework is very straight forward. Simply obtain a `ExecutorService` instance, generally via `Executors` and submit the task which returns a `Future`. After executing task, you do not have to wait for execution to complete, you can process other things and when ready use the future object to retrieve the result as show in code below.
 
 ```java
 ExecutorService executorService = Executors.newSingleThreadExecutor();

--- a/hazelcast-documentation/src/Lock.md
+++ b/hazelcast-documentation/src/Lock.md
@@ -18,7 +18,7 @@ try {
 } 
  
 ```
-`java.util.concurrent.locks.Lock.tryLock()` with timeout is also supported. All operations on the Lock that `Hazelcast.getLock(Object obj)` returns are cluster-wide and Lock behaves just like `java.util.concurrent.lock.ReentrantLock`.
+`java.util.concurrent.locks.Lock.tryLock()` with timeout is also supported. All operations on the Lock that `HazelcastInstance#getLock(Object obj)` returns are cluster-wide and Lock behaves just like `java.util.concurrent.lock.ReentrantLock`.
 
 ```java
 if (lock.tryLock (5000, TimeUnit.MILLISECONDS)) {

--- a/hazelcast-documentation/src/Logging.md
+++ b/hazelcast-documentation/src/Logging.md
@@ -59,7 +59,9 @@ LogListener listener = new LogListener() {
         // do something
     }
 }
-LoggingService loggingService = Hazelcast.getLoggingService();
+Config cfg = new Config();
+HazelcastInstance instance = Hazelcast.newHazelcastInstance(cfg);
+LoggingService loggingService = instance.getLoggingService();
 loggingService.addLogListener(Level.INFO, listener):
 ```
 Through the `LoggingService`, you can get the current used ILogger implementation and log your own messages, too.

--- a/hazelcast-documentation/src/Map.md
+++ b/hazelcast-documentation/src/Map.md
@@ -28,10 +28,14 @@ for (Customer customer : colCustomers) {
 
 ```java
 import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
 import java.util.concurrent.ConcurrentMap;
 
+Config cfg = new Config();
+HazelcastInstance instance = Hazelcast.newHazelcastInstance(cfg);
+
 Customer getCustomer (String id) {
-    ConcurrentMap<String, Customer> map = Hazelcast.getMap("customers");
+    ConcurrentMap<String, Customer> map = instance.getMap("customers");
     Customer customer = map.get(id);
     if (customer == null) {
         customer = new Customer (id);
@@ -41,12 +45,12 @@ Customer getCustomer (String id) {
 }               
 
 public boolean updateCustomer (Customer customer) {
-    ConcurrentMap<String, Customer> map = Hazelcast.getMap("customers");
+    ConcurrentMap<String, Customer> map = instance.getMap("customers");
     return (map.replace(customer.getId(), customer) != null);            
 }
                 
 public boolean removeCustomer (Customer customer) {
-    ConcurrentMap<String, Customer> map = Hazelcast.getMap("customers");
+    ConcurrentMap<String, Customer> map = instance.getMap("customers");
     return map.remove(customer.getId(), customer) );           
 }
 ```

--- a/hazelcast-documentation/src/Query.md
+++ b/hazelcast-documentation/src/Query.md
@@ -172,7 +172,9 @@ final IMap<Integer, Student> map = instance.getMap("students");
 Hazelcast distributed queries will run on each member in parallel and only results will return the conn. When a query runs on a member, Hazelcast will iterate through the entire owned entries and find the matching ones. This can be made faster by indexing the mostly queried fields. Just like you would do for your database. Of course, indexing will add overhead for each `write` operation but queries will be a lot faster. If you are querying your map a lot, make sure to add indexes for most frequently queried fields. So, if your `active and age < 30 ` query, for example, is used a lot, make sure you add index for `active` and `age` fields. Here is how:
 
 ```java
-IMap imap = Hazelcast.getMap("employees");
+Config cfg = new Config();
+HazelcastInstance instance = Hazelcast.newHazelcastInstance(cfg);
+IMap imap = instance.getMap("employees");
 imap.addIndex("age", true);        // ordered, since we have ranged queries for this field
 imap.addIndex("active", false);    // not ordered, because boolean field cannot have range
 ```

--- a/hazelcast-documentation/src/RestClient.md
+++ b/hazelcast-documentation/src/RestClient.md
@@ -69,7 +69,7 @@ You can use POST call to create an item on the queue. A sample is shown below.
 ```
 $ curl -v -X POST -H "Content-Type: text/plain" -d "foo" \http://10.20.17.1:5701/hazelcast/rest/queues/myEvents
 ```
-Above call is equivalent to `Hazelcast.getQueue("myEvents").offer("foo");`.
+Above call is equivalent to `HazelcastInstance#getQueue("myEvents").offer("foo");`.
 
 
 **Retrieving Items from a Queue**
@@ -79,7 +79,7 @@ DELETE call can be used for retrieving. Note that, poll timeout should be stated
 ```
 $ curl -v -X DELETE \http://10.20.17.1:5701/hazelcast/rest/queues/myEvents/10
 ```
-Above call is equivalent to `Hazelcast.getQueue("myEvents").poll(10, SECONDS);`. Below is the returns of above call.
+Above call is equivalent to `HazelcastInstance#getQueue("myEvents").poll(10, SECONDS);`. Below is the returns of above call.
 
 ```
 < HTTP/1.1 200 OK

--- a/hazelcast-documentation/src/unused/DistributedExecution.md
+++ b/hazelcast-documentation/src/unused/DistributedExecution.md
@@ -55,4 +55,4 @@ public void echoOnMembers(String input, Set<Member> members) throws Exception {
 }```
 
 
-Note that you can obtain the set of cluster members via `Hazelcast.getCluster().getMembers()` call.
+Note that you can obtain the set of cluster members via `HazelcastInstance#getCluster().getMembers()` call.

--- a/hazelcast-documentation/src/unused/Map.md
+++ b/hazelcast-documentation/src/unused/Map.md
@@ -27,10 +27,14 @@ for (Customer customer : colCustomers) {
 
 ```java
 import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
 import java.util.concurrent.ConcurrentMap;
 
+Config cfg = new Config();
+HazelcastInstance instance = Hazelcast.newHazelcastInstance(cfg);
+
 Customer getCustomer (String id) {
-    ConcurrentMap<String, Customer> map = Hazelcast.getMap("customers");
+    ConcurrentMap<String, Customer> map = instance.getMap("customers");
     Customer customer = map.get(id);
     if (customer == null) {
         customer = new Customer (id);
@@ -40,12 +44,12 @@ Customer getCustomer (String id) {
 }               
 
 public boolean updateCustomer (Customer customer) {
-    ConcurrentMap<String, Customer> map = Hazelcast.getMap("customers");
+    ConcurrentMap<String, Customer> map = instance.getMap("customers");
     return (map.replace(customer.getId(), customer) != null);            
 }
                 
 public boolean removeCustomer (Customer customer) {
-    ConcurrentMap<String, Customer> map = Hazelcast.getMap("customers");
+    ConcurrentMap<String, Customer> map = instance.getMap("customers");
     return map.remove(customer.getId(), customer) );           
 }
 ```

--- a/hazelcast-documentation/src/unused/MapIndex.md
+++ b/hazelcast-documentation/src/unused/MapIndex.md
@@ -4,7 +4,9 @@
 Hazelcast distributed queries will run on each member in parallel and only results will return the conn. When a query runs on a member, Hazelcast will iterate through the entire owned entries and find the matching ones. This can be made faster by indexing the mostly queried fields. Just like you would do for your database. Of course, indexing will add overhead for each `write` operation but queries will be a lot faster. If you are querying your map a lot, make sure to add indexes for most frequently queried fields. So, if your `active and age < 30 ` query, for example, is used a lot, make sure you add index for `active` and `age` fields. Here is how:
 
 ```java
-IMap imap = Hazelcast.getMap("employees");
+Config cfg = new Config();
+HazelcastInstance instance = Hazelcast.newHazelcastInstance(cfg);
+IMap imap = instance.getMap("employees");
 imap.addIndex("age", true);        // ordered, since we have ranged queries for this field
 imap.addIndex("active", false);    // not ordered, because boolean field cannot have range
 ```

--- a/hazelcast-documentation/src/unused/RestClient.md
+++ b/hazelcast-documentation/src/unused/RestClient.md
@@ -66,7 +66,7 @@ You can use POST call to create an item on the queue. A sample is shown below.
 ```
 $ curl -v -X POST -H "Content-Type: text/plain" -d "foo" \http://10.20.17.1:5701/hazelcast/rest/queues/myEvents
 ```
-Above call is equivalent to `Hazelcast.getQueue("myEvents").offer("foo");`.
+Above call is equivalent to `HazelcastInstance#getQueue("myEvents").offer("foo");`.
 
 
 **Retrieving Items from a Queue**
@@ -76,7 +76,7 @@ DELETE call can be used for retrieving. Note that, poll timeout should be stated
 ```
 $ curl -v -X DELETE \http://10.20.17.1:5701/hazelcast/rest/queues/myEvents/10
 ```
-Above call is equivalent to `Hazelcast.getQueue("myEvents").poll(10, SECONDS);`. Below is the returns of above call.
+Above call is equivalent to `HazelcastInstance#getQueue("myEvents").poll(10, SECONDS);`. Below is the returns of above call.
 
 ```
 < HTTP/1.1 200 OK


### PR DESCRIPTION
static Hazelcast.getXXX methods have been depricated
in favour of HazelcastInstance#getXXX methods.
