### PR TITLE
Event thread cleanup

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/EventServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/EventServiceImpl.java
@@ -78,7 +78,11 @@ public class EventServiceImpl implements EventService {
         this.eventQueueCapacity = groupProperties.EVENT_QUEUE_CAPACITY.getInteger();
         this.eventQueueTimeoutMs = groupProperties.EVENT_QUEUE_TIMEOUT_MILLIS.getInteger();
         this.eventExecutor = new StripedExecutor(
-                node.getLogger(EventServiceImpl.class),"eventServiceThread",eventThreadCount, eventQueueCapacity);
+                node.getLogger(EventServiceImpl.class),
+                node.getThreadNamePrefix("event"),
+                node.threadGroup,
+                eventThreadCount,
+                eventQueueCapacity);
         this.segments = new ConcurrentHashMap<String, EventServiceSegment>();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/ExecutionServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/ExecutionServiceImpl.java
@@ -222,11 +222,6 @@ public final class ExecutionServiceImpl implements ExecutionService {
         return getScheduledExecutor(name).scheduleWithFixedDelay(command, initialDelay, period, unit);
     }
 
-    @PrivateApi
-    public Executor getCachedExecutor() {
-        return new ExecutorDelegate(cachedExecutorService);
-    }
-
     @Override
     public ScheduledExecutorService getDefaultScheduledExecutor() {
         return defaultScheduledExecutorServiceDelegate;
@@ -339,19 +334,6 @@ public final class ExecutionServiceImpl implements ExecutionService {
                 return true;
             }
             return false;
-        }
-    }
-
-    private static class ExecutorDelegate implements Executor {
-        private final Executor executor;
-
-        private ExecutorDelegate(Executor executor) {
-            this.executor = executor;
-        }
-
-        @Override
-        public void execute(Runnable command) {
-            executor.execute(command);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/util/executor/StripedExecutor.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/executor/StripedExecutor.java
@@ -47,13 +47,13 @@ public final class StripedExecutor implements Executor {
     private final ILogger logger;
     private volatile boolean live = true;
 
-    public StripedExecutor(ILogger logger, String threadNamePrefix, int threadCount, int maximumQueueSize) {
+    public StripedExecutor(ILogger logger, String threadNamePrefix, ThreadGroup threadGroup, int threadCount, int maximumQueueSize) {
         this.logger = logger;
         this.maximumQueueSize = maximumQueueSize;
         this.size = threadCount;
         this.workers = new Worker[threadCount];
         for (int i = 0; i < threadCount; i++) {
-            Worker worker = new Worker(threadNamePrefix);
+            Worker worker = new Worker(threadGroup,threadNamePrefix);
             worker.start();
             workers[i] = worker;
         }
@@ -131,8 +131,8 @@ public final class StripedExecutor implements Executor {
 
         private final BlockingQueue<Runnable> workQueue = new LinkedBlockingQueue<Runnable>(maximumQueueSize);
 
-        private Worker(String threadNamePrefix) {
-            super(threadNamePrefix + "-" + THREAD_ID_GENERATOR.incrementAndGet());
+        private Worker(ThreadGroup threadGroup, String threadNamePrefix) {
+            super(threadGroup, threadNamePrefix+ "-" + THREAD_ID_GENERATOR.incrementAndGet());
         }
 
         private void schedule(Runnable command) {


### PR DESCRIPTION
Instead of the design with the striped executor being backed up by a cached executor, it now gets dedicated threads. This simplifies the design and probably makes it more performant since less queuing is involved and makes the behavior more predictable since there is not a shared workqueue anymore (the one of the cached executor).
