### PR TITLE
fix #2198

### DIFF
--- a/hazelcast-documentation/src/unused/SpringConfig.md
+++ b/hazelcast-documentation/src/unused/SpringConfig.md
@@ -62,7 +62,6 @@ After that you can configure Hazelcast instance (node) as shown below.
                 max-size="0"
                 eviction-percentage="30"
                 read-backup-data="true"
-                cache-value="true"
                 eviction-policy="NONE"
                 merge-policy="com.hazelcast.map.merge.PassThroughMergePolicy"/>
     </hz:config>


### PR DESCRIPTION
Fixes a bad map attribute in hz:map, cache-value no longer exists in 3.X.

This was showing in the a doc example.
