### PR TITLE
Socket Timeout was not being respected

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
@@ -285,14 +285,13 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
         if (socketOptions.getLingerSeconds() > 0) {
             socket.setSoLinger(true, socketOptions.getLingerSeconds());
         }
-        socket.setSoTimeout(5000);
         int bufferSize = socketOptions.getBufferSize() * KILO_BYTE;
         if (bufferSize < 0) {
             bufferSize = BUFFER_SIZE;
         }
         socket.setSendBufferSize(bufferSize);
         socket.setReceiveBufferSize(bufferSize);
-        socketChannel.connect(address.getInetSocketAddress());
+        socketChannel.socket().connect(address.getInetSocketAddress(), 5000);
         SocketChannelWrapper socketChannelWrapper = socketChannelWrapperFactory.wrapSocketChannel(socketChannel, true);
         final ClientConnection clientConnection = new ClientConnection(this, inSelector, outSelector,
                 connectionIdGen.incrementAndGet(), socketChannelWrapper, client.getClientExecutionService());

--- a/hazelcast-client/src/test/java/com/hazelcast/client/ClientTimeoutTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ClientTimeoutTest.java
@@ -1,0 +1,27 @@
+package com.hazelcast.client;
+
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IList;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class ClientTimeoutTest {
+
+    @Test(timeout = 20000, expected = IllegalStateException.class)
+    public void testTimeoutToOutsideNetwork() throws Exception {
+        ClientConfig clientConfig = new ClientConfig();
+        clientConfig.getGroupConfig().setName( "dev" ).setPassword( "dev-pass" );
+        clientConfig.getNetworkConfig().addAddress( "8.8.8.8:5701" );
+        HazelcastInstance client = HazelcastClient.newHazelcastClient( clientConfig );
+        IList<Object> list = client.getList( "test" );
+    }
+}


### PR DESCRIPTION
aparently, set the timeout in the underlying socket in socketChannel does not work.
removing this timeout and calling socketChannel.socket().connect(addr,timeout) instead seems to fix this issue.

this closes #2217 and refs #2220
