### PR TITLE
Fixed classloading if classes are not in the default classloader but tccl (backport)

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/nio/ClassLoaderUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/ClassLoaderUtil.java
@@ -93,8 +93,12 @@ public final class ClassLoaderUtil {
             try {
                 return theClassLoader.loadClass(className);
             } catch (ClassNotFoundException ignore) {
+
+                // Reset selected classloader and try with others
+                theClassLoader = null;
             }
         }
+
         // If failed and this is a Hazelcast class try again with our classloader
         if (className.startsWith(HAZELCAST_BASE_PACKAGE) || className.startsWith(HAZELCAST_ARRAY)) {
             theClassLoader = ClassLoaderUtil.class.getClassLoader();


### PR DESCRIPTION
Found by analysing play app
