### PR TITLE
[backport] add execution callback to getAsync() methods to update the near caches.

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
@@ -191,6 +191,7 @@ public final class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V
 
     @Override
     public Future<V> getAsync(final K key) {
+        initNearCache();
         final Data keyData = toData(key);
         if (nearCache != null) {
             Object cached = nearCache.get(keyData);
@@ -202,7 +203,20 @@ public final class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V
         final MapGetRequest request = new MapGetRequest(name, keyData);
         try {
             final ICompletableFuture future = getContext().getInvocationService().invokeOnKeyOwner(request, keyData);
-            return new DelegatingFuture<V>(future, getContext().getSerializationService());
+            final DelegatingFuture<V> delegatingFuture = new DelegatingFuture<V>(future, getContext().getSerializationService());
+            delegatingFuture.andThen(new ExecutionCallback<V>() {
+                @Override
+                public void onResponse(V response) {
+                    if (nearCache != null) {
+                        nearCache.put(keyData, response);
+                    }
+                }
+                @Override
+                public void onFailure(Throwable t) {
+
+                }
+            });
+            return delegatingFuture;
         } catch (Exception e) {
             throw ExceptionUtil.rethrow(e);
         }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/ClientNearCacheTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ClientNearCacheTest.java
@@ -179,8 +179,28 @@ public class ClientNearCacheTest {
         assertEquals(size, stats.getHits());
     }
 
-    //this test test fails but testNearCachePopulatedAndHitsGenerated2 passes
-    //the only diffrence is the looping ???
+    @Test
+    public void testGetAsyncPopulatesNearCache() throws Exception {
+        final IMap map = client.getMap(mapWithBasicCash +randomString());
+
+        int size = 1239;
+        for (int i = 0; i < size; i++) {
+            map.put(i, i);
+        }
+        //populate near cache
+        for (int i = 0; i < size; i++) {
+            Future async = map.getAsync(i);
+            async.get();
+        }
+        //generate near cache hits with async call
+        for (int i = 0; i < size; i++) {
+            map.get(i);
+        }
+        NearCacheStats stats = map.getLocalMapStats().getNearCacheStats();
+        assertEquals(size, stats.getOwnedEntryCount());
+        assertEquals(size, stats.getHits());
+    }
+
     @Test
     @Category(ProblematicTest.class)
     public void testNearCachePopulatedAndHitsGenerated() throws Exception {


### PR DESCRIPTION
Conflicts:
    hazelcast-client/src/test/java/com/hazelcast/client/ClientNearCacheTest.java
