### PR TITLE
Fixes #2324

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/util/EmptyArrays.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/EmptyArrays.java
@@ -1,0 +1,15 @@
+package com.hazelcast.util;
+
+/**
+ * Empty array constants.
+ */
+public final class EmptyArrays {
+    /**
+     * Two dimensional empty array.
+     */
+    public static final Object[][] EMPTY_2D_OBJECT_ARRAY = new Object[0][0];
+
+    private EmptyArrays() {
+    }
+
+}


### PR DESCRIPTION
Fixes #2324: Refactor map eviction manager code. (Hold references of key-value pairs not Record objects)
