### PR TITLE
Return cached value upon IMap.get() if near cache is enabled

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/MapService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/MapService.java
@@ -481,12 +481,15 @@ public class MapService implements ManagedService, MigrationAwareService,
         return ConcurrencyUtil.getOrPutIfAbsent(nearCacheMap, mapName, nearCacheConstructor);
     }
 
-    public void putNearCache(String mapName, Data key, Data value) {
+    // this operation returns the given value in near-cache memory format (data or object)
+    // if near-cache is not enabled, it returns null
+    public Object putNearCache(String mapName, Data key, Data value) {
+        // todo assert near-cache is enabled might be better
         if (!isNearCacheEnabled(mapName)) {
-            return;
+            return null;
         }
         NearCache nearCache = getNearCache(mapName);
-        nearCache.put(key, value);
+        return nearCache.put(key, value);
     }
 
     public void invalidateNearCache(String mapName, Data key) {

--- a/hazelcast/src/main/java/com/hazelcast/map/NearCache.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/NearCache.java
@@ -90,10 +90,16 @@ public class NearCache {
         NONE, LRU, LFU
     }
 
-    public void put(Data key, Data data) {
+    // this operation returns the given value in near-cache memory format (data or object)
+    public Object put(Data key, Data data) {
         fireTtlCleanup();
         if (evictionPolicy == EvictionPolicy.NONE && cache.size() >= maxSize) {
-            return;
+            // no more space in near-cache -> return given value in near-cache format
+            if (data == null) {
+                return null;
+            } else {
+                return inMemoryFormat.equals(InMemoryFormat.OBJECT) ? mapService.toObject(data) : data;
+            }
         }
         if (evictionPolicy != EvictionPolicy.NONE && cache.size() >= maxSize) {
             fireEvictCache();
@@ -107,6 +113,11 @@ public class NearCache {
         final CacheRecord record = new CacheRecord(key, value);
         cache.put(key, record);
         updateSizeEstimator(calculateCost(record));
+        if (NULL_OBJECT.equals(value)) {
+            return null;
+        } else {
+            return value;
+        }
     }
 
     public NearCacheStatsImpl getNearCacheStats() {

--- a/hazelcast/src/main/java/com/hazelcast/map/proxy/MapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/proxy/MapProxySupport.java
@@ -238,20 +238,7 @@ abstract class MapProxySupport extends AbstractDistributedObject<MapService> imp
             int partitionId = nodeEngine.getPartitionService().getPartitionId(key);
             if (!nodeEngine.getPartitionService().getPartitionOwner(partitionId)
                     .equals(nodeEngine.getClusterService().getThisAddress()) || mapConfig.getNearCacheConfig().isCacheLocalEntries()) {
-                mapService.putNearCache(name, key, result);
-                // return cached value
-                // this ensures the same behavior of a get() call which had to fetch the value and any following get() calls
-                // this also avoids a second deserialization if the near cache in-memory format is OBJECT
-                if (result != null) {
-                    Object cached = mapService.getFromNearCache(name, key);
-                    if (cached != null) {
-                        if (NearCache.NULL_OBJECT.equals(cached)) {
-                            cached = null;
-                        }
-                        mapService.interceptAfterGet(name, cached);
-                        return cached;
-                    }
-                }
+                return mapService.putNearCache(name, key, result);
             }
         }
         return result;


### PR DESCRIPTION
Hi,

currently, if a local near cache with in-memory format OBJECT is enabled, calling IMap.get() deserializes a map entry value twice: Once when putting the value into the near cache and once when returning the fetched value to the caller. If deserialization is expensive, this is quite bad.

This pull request fixes that.

However, as a (possibly nice) side-effect, it also changes the object instances that are returned for the first call to get() and any following calls to get() which make use of the near cache.

Before this change, the returned instances could be described like this:
1. call of get(): returned object instance = 1 (this is the instance which is fetched from the map)
2. call of get(): returned object instance = 2 (this is the instance which resides in the near cache)
3. call of get(): returned object instance = 2 (this is the instance which resides in the near cache)
...

With this pull request applied, the sequence would look like this:
1.  call of get(): returned object instance = 2 (this is the instance which resides in the near cache)
2.  call of get(): returned object instance = 2 (this is the instance which resides in the near cache)
3.  call of get(): returned object instance = 2 (this is the instance which resides in the near cache)
...

I think the second sequence is better for developers, because the returned instance does not change.

What do you think of this pull request?

Thanks and best,
Lukas
