### PR TITLE
Fix/client nearcache/maint3.x

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/nearcache/ClientNearCache.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/nearcache/ClientNearCache.java
@@ -106,6 +106,11 @@ public class ClientNearCache<K> {
                     public void handle(PortableEntryEvent event) {
                         cache.remove(event.getKey());
                     }
+
+                    @Override
+                    public void onListenerRegister() {
+                        cache.clear();
+                    }
                 };
             } else {
                 throw new IllegalStateException("Near cache is not available for this type of data structure");

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/AbstractClientCollectionProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/AbstractClientCollectionProxy.java
@@ -145,6 +145,11 @@ public class AbstractClientCollectionProxy<E> extends ClientProxy implements ICo
                     listener.itemRemoved(itemEvent);
                 }
             }
+
+            @Override
+            public void onListenerRegister() {
+
+            }
         };
         return listen(request, getPartitionKey(), eventHandler);
     }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
@@ -869,6 +869,11 @@ public final class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V
                         throw new IllegalArgumentException("Not a known event type " + event.getEventType());
                 }
             }
+
+            @Override
+            public void onListenerRegister() {
+
+            }
         };
     }
 

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMultiMapProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMultiMapProxy.java
@@ -295,6 +295,11 @@ public class ClientMultiMapProxy<K, V> extends ClientProxy implements MultiMap<K
                         throw new IllegalArgumentException("Not a known event type " + event.getEventType());
                 }
             }
+
+            @Override
+            public void onListenerRegister() {
+
+            }
         };
     }
 

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientQueueProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientQueueProxy.java
@@ -55,6 +55,11 @@ public final class ClientQueueProxy<E> extends ClientProxy implements IQueue<E>{
                     listener.itemRemoved(itemEvent);
                 }
             }
+
+            @Override
+            public void onListenerRegister() {
+
+            }
         };
         return listen(request, getPartitionKey(), eventHandler);
     }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientTopicProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientTopicProxy.java
@@ -58,6 +58,11 @@ public class ClientTopicProxy<E> extends ClientProxy implements ITopic<E> {
                 Message<E> message = new Message<E>(name, messageObject, event.getPublishTime(), member);
                 listener.onMessage(message);
             }
+
+            @Override
+            public void onListenerRegister() {
+
+            }
         };
         return listen(request, getKey(), handler);
     }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/EventHandler.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/EventHandler.java
@@ -18,4 +18,12 @@ package com.hazelcast.client.spi;
 
 public interface EventHandler<E> {
     void handle(E event);
+
+    /**
+     *  This method is called when registration request response is successfully returned from node.
+     *
+     *  Note that this method will also be called while first registered node is dead
+     *  and re-registering to a second node.
+     */
+    void onListenerRegister();
 }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/ProxyManager.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/ProxyManager.java
@@ -241,6 +241,11 @@ public final class ProxyManager {
                     listener.distributedObjectDestroyed(event);
                 }
             }
+
+            @Override
+            public void onListenerRegister() {
+
+            }
         };
         final ClientContext clientContext = new ClientContext(client, this);
         return ListenerUtil.listen(clientContext, request, null, eventHandler);

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientCallFuture.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientCallFuture.java
@@ -130,6 +130,11 @@ public class ClientCallFuture<V> implements ICompletableFuture<V>, Callback {
             if (this.response != null && handler == null) {
                 throw new IllegalArgumentException("The Future.set method can only be called once");
             }
+
+            if (handler != null && !(response instanceof Throwable)) {
+                handler.onListenerRegister();
+            }
+
             if (this.response != null && !(response instanceof Throwable)) {
                 String uuid = serializationService.toObject(this.response);
                 String alias = serializationService.toObject(response);

--- a/hazelcast-client/src/test/java/com/hazelcast/client/ClientIssueTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ClientIssueTest.java
@@ -20,6 +20,7 @@ import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.config.ClientSecurityConfig;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.ListenerConfig;
+import com.hazelcast.config.NearCacheConfig;
 import com.hazelcast.config.SerializationConfig;
 import com.hazelcast.core.DistributedObject;
 import com.hazelcast.core.EntryAdapter;
@@ -545,6 +546,35 @@ public class ClientIssueTest extends HazelcastTestSupport {
         public void readPortable(PortableReader reader) throws IOException {
             a = reader.readInt("a");
         }
+    }
+
+    @Test
+    public void testNearCache_WhenRegisteredNodeIsDead() {
+
+        final HazelcastInstance instance = Hazelcast.newHazelcastInstance();
+
+        final ClientConfig clientConfig = new ClientConfig();
+        final String mapName = randomMapName();
+
+        NearCacheConfig nearCacheConfig = new NearCacheConfig();
+
+        nearCacheConfig.setName(mapName);
+        nearCacheConfig.setInvalidateOnChange(true);
+        clientConfig.addNearCacheConfig(nearCacheConfig);
+
+        final HazelcastInstance client = HazelcastClient.newHazelcastClient(clientConfig);
+
+        final IMap<Object, Object> map = client.getMap(mapName);
+
+        map.put("a", "b");
+        map.get("a"); //put to nearCache
+
+        instance.shutdown();
+        Hazelcast.newHazelcastInstance();
+
+        assertEquals(null, map.get("a"));
+
+
     }
 
 }


### PR DESCRIPTION
Client NearCache is cleared after re-registering to a node , so that near cache will not have stale data because of lost invalidations between old registered nodes death and reregistering to new ones.
