### PR TITLE
Fix HazelcastCache.get(Object, Class) to handle null values correctly

### DIFF
--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/cache/HazelcastCache.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/cache/HazelcastCache.java
@@ -56,7 +56,7 @@ public class HazelcastCache implements Cache {
     
     public <T> T get(Object key, Class<T> type) {
         Object value = fromStoreValue(this.map.get(key));
-        if (type != null && !type.isInstance(value)) {
+        if (type != null && value != null && !type.isInstance(value)) {
             throw new IllegalStateException("Cached value is not of required type [" + type.getName() + "]: " + value);
         }
         return (T) value;

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/cache/CacheMapLoader.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/cache/CacheMapLoader.java
@@ -55,21 +55,17 @@ public class CacheMapLoader implements MapStore, MapLoaderLifecycleSupport {
 
     @Override
     public void store(Object key, Object value) {
-        //To change body of implemented methods use File | Settings | File Templates.
     }
 
     @Override
     public void storeAll(Map map) {
-        //To change body of implemented methods use File | Settings | File Templates.
     }
 
     @Override
     public void delete(Object key) {
-        //To change body of implemented methods use File | Settings | File Templates.
     }
 
     @Override
     public void deleteAll(Collection keys) {
-        //To change body of implemented methods use File | Settings | File Templates.
     }
 }


### PR DESCRIPTION
Ran into this issue when using the HazelcastCacheManager with Spring 4. When a null value is retrieved from HazelcastCache.get(Object, Class), an IllegalStateException is thrown.
