### PR TITLE
Fix/get connected clients/maint3.x

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/AuthenticationRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/AuthenticationRequest.java
@@ -147,7 +147,7 @@ public final class AuthenticationRequest extends CallableClientRequest {
     private void reAuthLocal() {
         final Set<ClientEndpoint> endpoints = clientEngine.getEndpoints(principal.getUuid());
         for (ClientEndpoint endpoint : endpoints) {
-            endpoint.authenticated(principal, firstConnection);
+            endpoint.authenticated(principal);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/ClientEndpoint.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/ClientEndpoint.java
@@ -102,6 +102,12 @@ public final class ClientEndpoint implements Client {
         this.authenticated = true;
     }
 
+    void authenticated(ClientPrincipal principal) {
+        this.principal = principal;
+        this.uuid = principal.getUuid();
+        this.authenticated = true;
+    }
+
     public boolean isAuthenticated() {
         return authenticated;
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/ClientReAuthOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/ClientReAuthOperation.java
@@ -42,7 +42,7 @@ public class ClientReAuthOperation extends AbstractOperation implements UrgentSy
         Set<ClientEndpoint> endpoints = service.getEndpoints(clientUuid);
         for (ClientEndpoint endpoint : endpoints) {
             ClientPrincipal principal = new ClientPrincipal(clientUuid, getCallerUuid());
-            endpoint.authenticated(principal, firstConnection);
+            endpoint.authenticated(principal);
         }
     }
 


### PR DESCRIPTION
all ClientEnpoints isFirstConnection was set to true in reauth, which was breaking getConnectedClients. With this change firstConnection will not be touched, be leaved as it is.
