### PR TITLE
Resources(Lock etc...) were not cleaning properly, when client and owner node of client dies together.

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/AuthenticationRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/AuthenticationRequest.java
@@ -118,7 +118,7 @@ public final class AuthenticationRequest extends CallableClientRequest {
 
     private Object handleUnauthenticated() {
         ClientEngineImpl clientEngine = getService();
-        clientEngine.removeEndpoint(endpoint.getConnection());
+        clientEngine.removeEndpoint(endpoint);
         return new AuthenticationException("Invalid credentials!");
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/ClientDisconnectionOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/ClientDisconnectionOperation.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.client;
 
-import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.spi.AbstractOperation;
@@ -44,9 +43,9 @@ public class ClientDisconnectionOperation extends AbstractOperation implements U
         ClientEngineImpl engine = getService();
         Set<ClientEndpoint> endpoints = engine.getEndpoints(clientUuid);
         for (ClientEndpoint endpoint : endpoints) {
-            Connection connection = endpoint.getConnection();
-            engine.removeEndpoint(connection, true);
+            engine.removeEndpoint(endpoint, true);
         }
+        engine.removeOwnershipMapping(clientUuid);
 
         NodeEngineImpl nodeEngine = (NodeEngineImpl) getNodeEngine();
         nodeEngine.onClientDisconnected(clientUuid);

--- a/hazelcast/src/main/java/com/hazelcast/client/ClientEndpoint.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/ClientEndpoint.java
@@ -96,16 +96,15 @@ public final class ClientEndpoint implements Client {
     }
 
     void authenticated(ClientPrincipal principal, boolean firstConnection) {
-        this.principal = principal;
-        this.uuid = principal.getUuid();
+        authenticated(principal);
         this.firstConnection = firstConnection;
-        this.authenticated = true;
     }
 
     void authenticated(ClientPrincipal principal) {
         this.principal = principal;
         this.uuid = principal.getUuid();
         this.authenticated = true;
+        clientEngine.addOwnershipMapping(uuid, principal.getOwnerUuid());
     }
 
     public boolean isAuthenticated() {

--- a/hazelcast/src/main/java/com/hazelcast/client/ClientEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/ClientEngineImpl.java
@@ -51,6 +51,7 @@ import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.OperationFactory;
 import com.hazelcast.spi.OperationService;
+import com.hazelcast.spi.PostJoinAwareService;
 import com.hazelcast.spi.ProxyService;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.transaction.TransactionManagerService;
@@ -74,12 +75,13 @@ import java.util.logging.Level;
 
 import static com.hazelcast.spi.impl.ResponseHandlerFactory.createEmptyResponseHandler;
 
-public class ClientEngineImpl implements ClientEngine, CoreService,
-        ManagedService, MembershipAwareService, EventPublishingService<ClientEndpoint, ClientListener> {
+public class ClientEngineImpl
+        implements ClientEngine, CoreService, ManagedService, MembershipAwareService,
+        EventPublishingService<ClientEndpoint, ClientListener>, PostJoinAwareService {
 
     public static final String SERVICE_NAME = "hz:core:clientEngine";
     public static final int DESTROY_ENDPOINT_DELAY_MS = 1111;
-    public static final int ENDPOINT_REMOVE_DELAY_MS = 10;
+    public static final int ENDPOINT_REMOVE_DELAY = 10;
     public static final int THREADS_PER_CORE = 10;
     public static final int RIDICULOUS_THREADS_PER_CORE = 100000;
 
@@ -91,6 +93,8 @@ public class ClientEngineImpl implements ClientEngine, CoreService,
     private final SerializationService serializationService;
     private final ConcurrentMap<Connection, ClientEndpoint> endpoints =
             new ConcurrentHashMap<Connection, ClientEndpoint>();
+    // client uuid -> member uuid
+    private final ConcurrentMap<String, String> ownershipMappings = new ConcurrentHashMap<String, String>();
     private final ILogger logger;
     private final ConnectionListener connectionListener = new ConnectionListenerImpl();
 
@@ -249,47 +253,40 @@ public class ClientEngineImpl implements ClientEngine, CoreService,
         return endpoint;
     }
 
-    ClientEndpoint removeEndpoint(final Connection connection) {
-        return removeEndpoint(connection, false);
+    void removeEndpoint(ClientEndpoint endpoint) {
+        removeEndpoint(endpoint, false);
     }
 
-    ClientEndpoint removeEndpoint(final Connection connection, boolean closeImmediately) {
-        final ClientEndpoint endpoint = endpoints.remove(connection);
-        destroyEndpoint(endpoint, closeImmediately);
-        return endpoint;
-    }
+    void removeEndpoint(ClientEndpoint endpoint, boolean destroyImmediately) {
+        logger.info("Destroying " + endpoint);
+        endpoints.remove(endpoint.getConnection());
+        try {
+            endpoint.destroy();
+        } catch (LoginException e) {
+            logger.warning(e);
+        }
 
-    private void destroyEndpoint(ClientEndpoint endpoint, boolean closeImmediately) {
-        if (endpoint != null) {
-            logger.info("Destroying " + endpoint);
+        final Connection connection = endpoint.getConnection();
+        if (destroyImmediately) {
             try {
-                endpoint.destroy();
-            } catch (LoginException e) {
-                logger.warning(e);
+                connection.close();
+            } catch (Throwable e) {
+                logger.warning("While closing client connection: " + connection, e);
             }
-
-            final Connection connection = endpoint.getConnection();
-            if (closeImmediately) {
-                try {
-                    connection.close();
-                } catch (Throwable e) {
-                    logger.warning("While closing client connection: " + connection, e);
-                }
-            } else {
-                nodeEngine.getExecutionService().schedule(new Runnable() {
-                    public void run() {
-                        if (connection.live()) {
-                            try {
-                                connection.close();
-                            } catch (Throwable e) {
-                                logger.warning("While closing client connection: " + e.toString());
-                            }
+        } else {
+            nodeEngine.getExecutionService().schedule(new Runnable() {
+                public void run() {
+                    if (connection.live()) {
+                        try {
+                            connection.close();
+                        } catch (Throwable e) {
+                            logger.warning("While closing client connection: " + e.toString());
                         }
                     }
-                }, DESTROY_ENDPOINT_DELAY_MS, TimeUnit.MILLISECONDS);
-            }
-            sendClientEvent(endpoint);
+                }
+            }, DESTROY_ENDPOINT_DELAY_MS, TimeUnit.MILLISECONDS);
         }
+        sendClientEvent(endpoint);
     }
 
     @Override
@@ -334,22 +331,10 @@ public class ClientEngineImpl implements ClientEngine, CoreService,
             return;
         }
 
-        final String uuid = event.getMember().getUuid();
+        final String deadMemberUuid = event.getMember().getUuid();
         try {
-            nodeEngine.getExecutionService().schedule(new Runnable() {
-                @Override
-                public void run() {
-                    Iterator<ClientEndpoint> iterator = endpoints.values().iterator();
-                    while (iterator.hasNext()) {
-                        ClientEndpoint endpoint = iterator.next();
-                        String ownerUuid = endpoint.getPrincipal().getOwnerUuid();
-                        if (uuid.equals(ownerUuid)) {
-                            iterator.remove();
-                            destroyEndpoint(endpoint, true);
-                        }
-                    }
-                }
-            }, ENDPOINT_REMOVE_DELAY_MS, TimeUnit.SECONDS);
+            nodeEngine.getExecutionService().schedule(new DestroyEndpointTask(deadMemberUuid),
+                    ENDPOINT_REMOVE_DELAY, TimeUnit.SECONDS);
         } catch (RejectedExecutionException e) {
             if (logger.isFinestEnabled()) {
                 logger.finest(e);
@@ -415,6 +400,15 @@ public class ClientEngineImpl implements ClientEngine, CoreService,
             }
         }
         endpoints.clear();
+        ownershipMappings.clear();
+    }
+
+    void addOwnershipMapping(String clientUuid, String ownerUuid) {
+        ownershipMappings.put(clientUuid, ownerUuid);
+    }
+
+    void removeOwnershipMapping(String clientUuid) {
+        ownershipMappings.remove(clientUuid);
     }
 
     private final class ClientPacketProcessor implements Runnable {
@@ -445,7 +439,7 @@ public class ClientEngineImpl implements ClientEngine, CoreService,
                 } else if (endpoint.isAuthenticated()) {
                     processRequest(endpoint, request);
                 } else {
-                    handleAuthenticationFailure(conn, endpoint, request);
+                    handleAuthenticationFailure(endpoint, request);
                 }
             } catch (Throwable e) {
                 handleProcessingFailure(endpoint, request, e);
@@ -525,17 +519,17 @@ public class ClientEngineImpl implements ClientEngine, CoreService,
             request.setService(service);
         }
 
-        private void handleAuthenticationFailure(Connection conn, ClientEndpoint endpoint, ClientRequest request) {
+        private void handleAuthenticationFailure(ClientEndpoint endpoint, ClientRequest request) {
             Exception exception;
             if (nodeEngine.isActive()) {
-                String message = "Client " + conn + " must authenticate before any operation.";
+                String message = "Client " + endpoint + " must authenticate before any operation.";
                 logger.severe(message);
                 exception = new AuthenticationException(message);
             } else {
                 exception = new HazelcastInstanceNotActiveException();
             }
             endpoint.sendResponse(exception, request.getCallId());
-            removeEndpoint(conn);
+            removeEndpoint(endpoint);
         }
     }
 
@@ -556,37 +550,85 @@ public class ClientEngineImpl implements ClientEngine, CoreService,
                     return;
                 }
 
+                if (!endpoint.isFirstConnection()) {
+                    return;
+                }
+
                 String localMemberUuid = node.getLocalMember().getUuid();
                 String ownerUuid = endpoint.getPrincipal().getOwnerUuid();
                 if (localMemberUuid.equals(ownerUuid)) {
-                    doRemoveEndpoint(connection, endpoint);
+                    callDisconnectionOperation(endpoint);
                 }
             }
         }
 
-        private void doRemoveEndpoint(Connection connection, ClientEndpoint endpoint) {
-            removeEndpoint(connection, true);
-            if (!endpoint.isFirstConnection()) {
-                return;
-            }
-
-            NodeEngine nodeEngine = node.nodeEngine;
+        private void callDisconnectionOperation(ClientEndpoint endpoint) {
             Collection<MemberImpl> memberList = nodeEngine.getClusterService().getMemberList();
             OperationService operationService = nodeEngine.getOperationService();
-            for (MemberImpl member : memberList) {
-                ClientDisconnectionOperation op = new ClientDisconnectionOperation(endpoint.getUuid());
-                op.setNodeEngine(nodeEngine)
-                        .setServiceName(SERVICE_NAME)
-                        .setService(ClientEngineImpl.this)
-                        .setResponseHandler(createEmptyResponseHandler());
+            ClientDisconnectionOperation op = createClientDisconnectionOperation(endpoint.getUuid());
+            operationService.runOperation(op);
 
-                if (member.localMember()) {
-                    operationService.runOperation(op);
-                } else {
+            for (MemberImpl member : memberList) {
+                if (!member.localMember()) {
+                    op = createClientDisconnectionOperation(endpoint.getUuid());
                     operationService.send(op, member.getAddress());
                 }
             }
         }
     }
 
+    private ClientDisconnectionOperation createClientDisconnectionOperation(String clientUuid) {
+        ClientDisconnectionOperation op = new ClientDisconnectionOperation(clientUuid);
+        op.setNodeEngine(nodeEngine)
+                .setServiceName(SERVICE_NAME)
+                .setService(this)
+                .setResponseHandler(createEmptyResponseHandler());
+        return op;
+    }
+
+    private class DestroyEndpointTask implements Runnable {
+        private final String deadMemberUuid;
+
+        public DestroyEndpointTask(String deadMemberUuid) {
+            this.deadMemberUuid = deadMemberUuid;
+        }
+
+        @Override
+        public void run() {
+            removeEndpoints();
+            removeMappings();
+        }
+
+        private void removeEndpoints() {
+            Iterator<ClientEndpoint> iterator = endpoints.values().iterator();
+            while (iterator.hasNext()) {
+                ClientEndpoint endpoint = iterator.next();
+                String ownerUuid = endpoint.getPrincipal().getOwnerUuid();
+                if (deadMemberUuid.equals(ownerUuid)) {
+                    iterator.remove();
+                    removeEndpoint(endpoint, true);
+                }
+            }
+        }
+
+        private void removeMappings() {
+            Iterator<Map.Entry<String, String>> iterator = ownershipMappings.entrySet().iterator();
+            while (iterator.hasNext()) {
+                Map.Entry<String, String> entry = iterator.next();
+                String clientUuid = entry.getKey();
+                String memberUuid = entry.getValue();
+                if (deadMemberUuid.equals(memberUuid)) {
+                    iterator.remove();
+                    ClientDisconnectionOperation op = createClientDisconnectionOperation(clientUuid);
+                    nodeEngine.getOperationService().runOperation(op);
+                }
+            }
+
+        }
+    }
+
+    @Override
+    public Operation getPostJoinOperation() {
+        return ownershipMappings.isEmpty() ? null : new PostJoinClientOperation(ownershipMappings);
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/ClientReAuthOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/ClientReAuthOperation.java
@@ -39,11 +39,13 @@ public class ClientReAuthOperation extends AbstractOperation implements UrgentSy
 
     public void run() throws Exception {
         ClientEngineImpl service = getService();
+        String memberUuid = getCallerUuid();
         Set<ClientEndpoint> endpoints = service.getEndpoints(clientUuid);
         for (ClientEndpoint endpoint : endpoints) {
-            ClientPrincipal principal = new ClientPrincipal(clientUuid, getCallerUuid());
+            ClientPrincipal principal = new ClientPrincipal(clientUuid, memberUuid);
             endpoint.authenticated(principal);
         }
+        service.addOwnershipMapping(clientUuid, memberUuid);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/PostJoinClientOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/PostJoinClientOperation.java
@@ -1,0 +1,68 @@
+package com.hazelcast.client;
+
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.spi.AbstractOperation;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+public class PostJoinClientOperation extends AbstractOperation {
+
+    private Map<String, String> mappings;
+
+    public PostJoinClientOperation() {
+    }
+
+    public PostJoinClientOperation(Map<String, String> mappings) {
+        this.mappings = mappings;
+    }
+
+    @Override
+    public void run() throws Exception {
+        if (mappings != null) {
+            ClientEngineImpl engine = getService();
+            for (Map.Entry<String, String> entry : mappings.entrySet()) {
+                engine.addOwnershipMapping(entry.getKey(), entry.getValue());
+            }
+        }
+    }
+
+    @Override
+    public String getServiceName() {
+        return ClientEngineImpl.SERVICE_NAME;
+    }
+
+    @Override
+    public boolean returnsResponse() {
+        return false;
+    }
+
+    @Override
+    protected void writeInternal(ObjectDataOutput out) throws IOException {
+        super.writeInternal(out);
+        if (mappings == null) {
+            out.writeInt(0);
+            return;
+        }
+        int len = mappings.size();
+        out.writeInt(len);
+        for (Map.Entry<String, String> entry : mappings.entrySet()) {
+            out.writeUTF(entry.getKey());
+            out.writeUTF(entry.getValue());
+        }
+    }
+
+    @Override
+    protected void readInternal(ObjectDataInput in) throws IOException {
+        super.readInternal(in);
+        int len = in.readInt();
+        mappings = new HashMap<String, String>(len);
+        for (int i = 0; i < len; i++) {
+            String clientUuid = in.readUTF();
+            String ownerUuid = in.readUTF();
+            mappings.put(clientUuid, ownerUuid);
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockServiceImpl.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.concurrent.lock;
 
+import com.hazelcast.concurrent.lock.operations.LocalLockCleanupOperation;
 import com.hazelcast.concurrent.lock.operations.LockReplicationOperation;
 import com.hazelcast.concurrent.lock.operations.UnlockOperation;
 import com.hazelcast.core.DistributedObject;
@@ -200,13 +201,14 @@ public final class LockServiceImpl implements LockService, ManagedService, Remot
     }
 
     private void sendUnlockOperation(LockStoreContainer container, LockStoreImpl lockStore, Data key) {
-        UnlockOperation op = new UnlockOperation(lockStore.getNamespace(), key, -1, true);
+        UnlockOperation op = new LocalLockCleanupOperation(lockStore.getNamespace(), key, -1);
         op.setAsyncBackup(true);
         op.setNodeEngine(nodeEngine);
         op.setServiceName(SERVICE_NAME);
         op.setService(LockServiceImpl.this);
         op.setResponseHandler(ResponseHandlerFactory.createEmptyResponseHandler());
         op.setPartitionId(container.getPartitionId());
+        op.setValidateTarget(false);
         nodeEngine.getOperationService().executeOperation(op);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/LocalLockCleanupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/LocalLockCleanupOperation.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2008-2013, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.concurrent.lock.operations;
+
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.partition.InternalPartition;
+import com.hazelcast.partition.InternalPartitionService;
+import com.hazelcast.spi.BackupAwareOperation;
+import com.hazelcast.spi.NodeEngine;
+import com.hazelcast.spi.Notifier;
+import com.hazelcast.spi.ObjectNamespace;
+
+import java.io.IOException;
+
+public class LocalLockCleanupOperation extends UnlockOperation implements Notifier, BackupAwareOperation {
+
+    public LocalLockCleanupOperation() {
+    }
+
+    public LocalLockCleanupOperation(ObjectNamespace namespace, Data key, long threadId) {
+        super(namespace, key, threadId, true);
+    }
+
+    @Override
+    public boolean shouldBackup() {
+        final NodeEngine nodeEngine = getNodeEngine();
+        InternalPartitionService partitionService = nodeEngine.getPartitionService();
+        InternalPartition partition = partitionService.getPartition(getPartitionId());
+        return nodeEngine.getThisAddress().equals(partition.getOwner())
+                && Boolean.TRUE.equals(response);
+    }
+
+    @Override
+    protected void writeInternal(ObjectDataOutput out) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected void readInternal(ObjectDataInput in) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/client/MockSimpleClient.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/MockSimpleClient.java
@@ -17,7 +17,11 @@
 package com.hazelcast.client;
 
 import com.hazelcast.core.HazelcastException;
-import com.hazelcast.nio.*;
+import com.hazelcast.nio.Address;
+import com.hazelcast.nio.ClientPacket;
+import com.hazelcast.nio.Connection;
+import com.hazelcast.nio.ConnectionType;
+import com.hazelcast.nio.SocketWritable;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.DataAdapter;
 import com.hazelcast.nio.serialization.SerializationService;
@@ -74,7 +78,8 @@ public class MockSimpleClient implements SimpleClient {
     }
 
     public void close() {
-        clientEngine.removeEndpoint(connection, true);
+        ClientEndpoint endpoint = clientEngine.getEndpoint(connection);
+        clientEngine.removeEndpoint(endpoint, true);
         connection.close();
     }
 


### PR DESCRIPTION
With this pr, all nodes will have a cluster wide sync "clientUuuid => ownerUuid map". These map is copied to new joined members. And will be updated in client connected and disconnected operations. Resources of a  
a dead client in a node is cleaned with following ways.
-- Node is owner of the client and client disconnects.
-- Node gets client disconnected operation from owner node of the client.
-- When owner node is  removed from cluster, its clients are checked via "clientUuuid => ownerUuid map" and resources of all clients that dead node is master of is cleaned. 
