### PR TITLE
Client retries if connection is not healthy(meaning its heartbeat is tim...

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientCallFuture.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientCallFuture.java
@@ -104,8 +104,8 @@ public class ClientCallFuture<V> implements ICompletableFuture<V>, Callback {
     public V get() throws InterruptedException, ExecutionException {
         try {
             return get(Long.MAX_VALUE, TimeUnit.MILLISECONDS);
-        } catch (TimeoutException ignored) {
-            return null;
+        } catch (TimeoutException exception) {
+            throw ExceptionUtil.rethrow(exception);
         }
     }
 
@@ -120,7 +120,7 @@ public class ClientCallFuture<V> implements ICompletableFuture<V>, Callback {
                         long elapsed = Clock.currentTimeMillis() - start;
                         waitMillis -= elapsed;
                         if (!isConnectionHealthy(elapsed)) {
-                            break;
+                            notify(new TargetDisconnectedException());
                         }
                     }
                 }


### PR DESCRIPTION
...ed out). ClientCallFuture does not return null when timeout, rethrows the exception.

fixes #2593 
