### PR TITLE
ClientCallFuture does not return null when timeout, rethrows the exception

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientCallFuture.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientCallFuture.java
@@ -88,9 +88,8 @@ public class ClientCallFuture<V> implements ICompletableFuture<V>, Callback {
     public V get() throws InterruptedException, ExecutionException {
         try {
             return get(Long.MAX_VALUE, TimeUnit.MILLISECONDS);
-        } catch (TimeoutException e) {
-            e.printStackTrace();
-            return null;
+        } catch (TimeoutException exception) {
+            throw ExceptionUtil.rethrow(exception);
         }
     }
 


### PR DESCRIPTION
related to #2593
