### PR TITLE
Fix HazelcastHttpSession's setAttribute() with null value

### DIFF
--- a/hazelcast-wm/src/main/java/com/hazelcast/web/WebFilter.java
+++ b/hazelcast-wm/src/main/java/com/hazelcast/web/WebFilter.java
@@ -628,7 +628,7 @@ public class WebFilter implements Filter {
                 throw new NullPointerException("name must not be null");
             }
             if (value == null) {
-                throw new IllegalArgumentException("value must not be null");
+                removeAttribute(name);
             }
             if (deferredWrite) {
                 LocalCacheEntry entry = localCache.get(name);


### PR DESCRIPTION
HttpSession.setAttribute() should work with null value the same as removeAttribute(). Changed from throwing an exception to delegate call to removeAttribute()
