### PR TITLE
Small fix to map/reduce LongMaxAggregation.

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/LongMaxAggregation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/LongMaxAggregation.java
@@ -40,7 +40,7 @@ public class LongMaxAggregation<Key, Value>
         return new Collator<Map.Entry<Key, Long>, Long>() {
             @Override
             public Long collate(Iterable<Map.Entry<Key, Long>> values) {
-                long max = Integer.MIN_VALUE;
+                long max = Long.MIN_VALUE;
                 for (Map.Entry<Key, Long> entry : values) {
                     long value = entry.getValue();
                     if (value > max) {


### PR DESCRIPTION
Updates LongMaxAggregation to use Long.MIN_VALUE in one place rather then Integer.MIN_VALUE.
