### PR TITLE
Test Coverage on your local box.  run with a single test and see what lines are hit where

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -212,7 +212,7 @@
     <profiles>
 
         <profile>
-            <id>Coverage</id>
+            <id>test-coverage-Local</id>
             <build>
                 <plugins>
                     <plugin>
@@ -253,7 +253,7 @@
 
 
                             <includes>
-                                <include>**/ClientMapBasicTest.java</include>
+                                <include>**/YourTestFileHear.java</include>
                             </includes>
 
                         </configuration>


### PR DESCRIPTION
adding a profile for this maven plugin.
http://mojo.codehaus.org/cobertura-maven-plugin/index.html

for the Cobertura code coverage tool.
https://github.com/cobertura/cobertura

This should allow you to see while developing test, what lines your new test is covering

in the test-coverage-local profile, update the include section, with the test you want to run.
<include>**/YourTestFileHear.java</include>
use, the test-coverage-local profile, and run maven site.  

this should instrment the classes run you test class and produce a html output report in
hazelcast-client/target/site/cobertura/index.html
hazelcast/target/site/cobertura/index.html

an example report from Cobertura 
http://mojo.codehaus.org/cobertura-maven-plugin/sample-maven-shared-io-report/index.html

Limitations.

I can only limit the tests to be run, to one class file.  Not an individual test method in one class file
It would be nice to run only one test method, and see its coverage.

The coverage in working on Modules, e.g test in hazelcast-client,  only show coverage for classes in hazelcast-client.  to overcome this we need to force Cobertura to instrument all the classes some how.
