### PR TITLE
Add a take() method to TransactionalQueue (for #2600)

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/txn/proxy/ClientTxnQueueProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/txn/proxy/ClientTxnQueueProxy.java
@@ -52,6 +52,11 @@ public class ClientTxnQueueProxy<E> extends ClientTxnProxy implements Transactio
         return result;
     }
 
+    @Override
+    public E take() throws InterruptedException {
+        return poll(-1, TimeUnit.MILLISECONDS);
+    }
+
     public E poll() {
         try {
             return poll(0, TimeUnit.MILLISECONDS);

--- a/hazelcast-client/src/test/java/com/hazelcast/client/txn/ClientTxnQueueTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/txn/ClientTxnQueueTest.java
@@ -24,19 +24,18 @@ import com.hazelcast.core.TransactionalQueue;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.transaction.TransactionContext;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
 import static com.hazelcast.test.HazelcastTestSupport.randomString;
 import static com.hazelcast.test.HazelcastTestSupport.sleepSeconds;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category(QuickTest.class)
@@ -85,6 +84,20 @@ public class ClientTxnQueueTest {
         context.commitTransaction();
 
         assertEquals(0, queue.size());
+    }
+
+    @Test
+    public void testTransactionalOfferTake() throws InterruptedException {
+        final String item = "offered";
+        final String queueName = randomString();
+
+        final TransactionContext context = client.newTransactionContext();
+        context.beginTransaction();
+        TransactionalQueue<String> txnQueue = context.getQueue(queueName);
+        assertTrue(txnQueue.offer(item));
+        assertEquals(1, txnQueue.size());
+        assertEquals(item, txnQueue.take());
+        context.commitTransaction();
     }
 
     @Test

--- a/hazelcast/src/main/java/com/hazelcast/core/BaseQueue.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/BaseQueue.java
@@ -57,6 +57,15 @@ public interface BaseQueue<E> extends DistributedObject {
     boolean offer(E e, long timeout, TimeUnit unit) throws InterruptedException;
 
     /**
+     * Retrieves and removes the head of this queue, waiting if necessary
+     * until an element becomes available.
+     *
+     * @return the head of this queue
+     * @throws InterruptedException if interrupted while waiting
+     */
+    E take() throws InterruptedException;
+
+    /**
      * Retrieves and removes the head of this queue,
      * or returns <tt>null</tt> if this queue is empty.
      *

--- a/hazelcast/src/main/java/com/hazelcast/core/TransactionalQueue.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/TransactionalQueue.java
@@ -42,6 +42,11 @@ public interface TransactionalQueue<E> extends TransactionalObject, BaseQueue<E>
     /**
      * {@inheritDoc}
      */
+    E take() throws InterruptedException;
+
+    /**
+     * {@inheritDoc}
+     */
     E poll();
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/queue/tx/TransactionalQueueProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/queue/tx/TransactionalQueueProxy.java
@@ -47,6 +47,11 @@ public class TransactionalQueueProxy<E> extends TransactionalQueueProxySupport i
     }
 
     @Override
+    public E take() throws InterruptedException {
+        return poll(-1, TimeUnit.MILLISECONDS);
+    }
+
+    @Override
     public E poll() {
         try {
             return poll(0, TimeUnit.MILLISECONDS);


### PR DESCRIPTION
I added `take()` to `BaseQueue` rather than just `TransactionalQueue` because `take()` now exists in all sub-interfaces of `BaseQueue` (it was already in `IQueue`).
