### PR TITLE
3.x backport - ByteArrayObjectDataOutput when writing to an explicit location

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/ByteArrayObjectDataOutput.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/ByteArrayObjectDataOutput.java
@@ -103,7 +103,7 @@ class ByteArrayObjectDataOutput extends OutputStream implements BufferObjectData
 
     public void writeChar(int position, final int v) throws IOException {
         write(position, (v >>> 8) & 0xFF);
-        write(position, (v) & 0xFF);
+        write(position + 1, (v) & 0xFF);
     }
 
     public void writeChars(final String s) throws IOException {
@@ -178,7 +178,7 @@ class ByteArrayObjectDataOutput extends OutputStream implements BufferObjectData
 
     public void writeShort(int position, final int v) throws IOException {
         write(position, (v >>> 8) & 0xFF);
-        write(position, (v) & 0xFF);
+        write(position + 1, (v) & 0xFF);
     }
 
     public void writeUTF(final String str) throws IOException {

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/ByteArrayObjectDataOutputTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/ByteArrayObjectDataOutputTest.java
@@ -1,0 +1,58 @@
+package com.hazelcast.nio.serialization;
+
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import static org.mockito.Mockito.*;
+import static org.junit.Assert.*;
+
+import java.io.IOException;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category(QuickTest.class)
+public class ByteArrayObjectDataOutputTest {
+
+    private SerializationService mockSerializationService;
+
+    @Before
+    public void setUp() {
+        mockSerializationService = mock(SerializationService.class);
+    }
+
+    @Test
+    public void testWriteShort_explicitPosition() throws IOException {
+        for (short s : new short[]{Short.MIN_VALUE, 0, Short.MAX_VALUE}) {
+            ByteArrayObjectDataOutput dataOutput = new ByteArrayObjectDataOutput(2, mockSerializationService);
+            dataOutput.writeShort(0);
+            dataOutput.writeShort(0, s);
+
+            short actual = readShort(dataOutput.toByteArray());
+            assertEquals(s, actual);
+        }
+    }
+
+    @Test
+    public void testWriteChars() throws IOException {
+        String s = "fooo";
+
+        ByteArrayObjectDataOutput dataOutput = new ByteArrayObjectDataOutput(2, mockSerializationService);
+        dataOutput.writeChars(s);
+
+        ByteArrayObjectDataInput dataInput = new ByteArrayObjectDataInput(dataOutput.toByteArray(), mockSerializationService);
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < s.length(); i++) {
+            sb.append(dataInput.readChar());
+        }
+        assertEquals(s, sb.toString());
+    }
+
+    private short readShort(byte[] buffer) {
+        int mostSig = buffer[0] & 0xff;
+        int leastSig = buffer[1] & 0xff;
+        return (short) ((mostSig << 8) + leastSig);
+    }
+
+}


### PR DESCRIPTION
Backport of #2726
