### PR TITLE
#2064 Pass HazelcastInstance to LocalRegionCache constructors.

### DIFF
--- a/hazelcast-hibernate/hazelcast-hibernate3/src/main/java/com/hazelcast/hibernate/local/LocalRegionCache.java
+++ b/hazelcast-hibernate/hazelcast-hibernate3/src/main/java/com/hazelcast/hibernate/local/LocalRegionCache.java
@@ -27,11 +27,12 @@ import com.hazelcast.util.Clock;
 import org.hibernate.cache.CacheDataDescription;
 import org.hibernate.cache.access.SoftLock;
 
-import java.util.Map;
-import java.util.Iterator;
-import java.util.TreeSet;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
-import java.util.SortedSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -61,8 +62,32 @@ public class LocalRegionCache implements RegionCache {
     protected final Comparator versionComparator;
     protected MapConfig config;
 
+    /**
+     * @param name              the name for this region cache, which is also used to retrieve configuration/topic
+     * @param hazelcastInstance the {@code HazelcastInstance} to which this region cache belongs, used to retrieve
+     *                          configuration and to lookup an {@link ITopic} to register a {@link MessageListener}
+     *                          with (optional)
+     * @param metadata          metadata describing the cached data, used to compare data versions (optional)
+     */
     public LocalRegionCache(final String name, final HazelcastInstance hazelcastInstance,
                             final CacheDataDescription metadata) {
+        this(name, hazelcastInstance, metadata, true);
+    }
+
+    /**
+     * @param name              the name for this region cache, which is also used to retrieve configuration/topic
+     * @param hazelcastInstance the {@code HazelcastInstance} to which this region cache belongs, used to retrieve
+     *                          configuration and to lookup an {@link ITopic} to register a {@link MessageListener}
+     *                          with if {@code withTopic} is {@code true} (optional)
+     * @param metadata          metadata describing the cached data, used to compare data versions (optional)
+     * @param withTopic         {@code true} to register a {@link MessageListener} with the {@link ITopic} whose name
+     *                          matches this region cache <i>if</i> a {@code HazelcastInstance} was provided to look
+     *                          up the topic; otherwise, {@code false} not to register a listener even if an instance
+     *                          was provided
+     * @since 3.3
+     */
+    public LocalRegionCache(final String name, final HazelcastInstance hazelcastInstance,
+                            final CacheDataDescription metadata, final boolean withTopic) {
         try {
             config = hazelcastInstance != null ? hazelcastInstance.getConfig().findMapConfig(name) : null;
         } catch (UnsupportedOperationException ignored) {
@@ -71,7 +96,7 @@ public class LocalRegionCache implements RegionCache {
         cache = new ConcurrentHashMap<Object, Value>();
 
         messageListener = createMessageListener();
-        if (hazelcastInstance != null) {
+        if (withTopic && hazelcastInstance != null) {
             topic = hazelcastInstance.getTopic(name);
             topic.addMessageListener(messageListener);
         } else {
@@ -207,9 +232,10 @@ public class LocalRegionCache implements RegionCache {
             timeToLive = CacheEnvironment.getDefaultCacheTimeoutInMillis();
         }
 
-        if ((maxSize > 0 && maxSize != Integer.MAX_VALUE) || timeToLive > 0) {
+        boolean limitSize = maxSize > 0 && maxSize != Integer.MAX_VALUE;
+        if (limitSize || timeToLive > 0) {
             final Iterator<Entry<Object, Value>> iter = cache.entrySet().iterator();
-            SortedSet<EvictionEntry> entries = null;
+            List<EvictionEntry> entries = null;
             final long now = Clock.currentTimeMillis();
             while (iter.hasNext()) {
                 final Entry<Object, Value> e = iter.next();
@@ -220,22 +246,28 @@ public class LocalRegionCache implements RegionCache {
                 }
                 if (v.getCreationTime() + timeToLive < now) {
                     iter.remove();
-                } else if (maxSize > 0 && maxSize != Integer.MAX_VALUE) {
+                } else if (limitSize) {
                     if (entries == null) {
-                        entries = new TreeSet<EvictionEntry>();
+                        // Use a List rather than a Set for correctness. Using a Set, especially a TreeSet
+                        // based on EvictionEntry.compareTo, causes evictions to be processed incorrectly
+                        // when two or more entries in the map have the same timestamp. In such a case, the
+                        // _first_ entry at a given timestamp is the only one that can be evicted because
+                        // TreeSet does not add "equivalent" entries. A second benefit of using a List is
+                        // that the cost of sorting the entries is not incurred if eviction isn't performed
+                        entries = new ArrayList<EvictionEntry>(cache.size());
                     }
                     entries.add(new EvictionEntry(k, v));
                 }
             }
             final int diff = cache.size() - maxSize;
-            final int k = diff >= 0 ? (diff + maxSize * 20 / 100) : 0;
-            if (k > 0 && entries != null) {
-                int i = 0;
+            final int toRemove = diff >= 0 ? (diff + maxSize * 20 / 100) : 0;
+            if (toRemove > 0 && entries != null) {
+                // Only sort the entries if we're going to evict some
+                Collections.sort(entries);
+                int removed = 0;
                 for (EvictionEntry entry : entries) {
-                    if (cache.remove(entry.key, entry.value)) {
-                        if (++i == k) {
-                            break;
-                        }
+                    if (cache.remove(entry.key, entry.value) && ++removed == toRemove) {
+                        break;
                     }
                 }
             }
@@ -268,21 +300,13 @@ public class LocalRegionCache implements RegionCache {
 
             EvictionEntry that = (EvictionEntry) o;
 
-            if (key != null ? !key.equals(that.key) : that.key != null) {
-                return false;
-            }
-            if (value != null ? !value.equals(that.value) : that.value != null) {
-                return false;
-            }
-
-            return true;
+            return (key == null ? that.key == null : key.equals(that.key))
+                    && (value == null ? that.value == null : value.equals(that.value));
         }
 
         @Override
         public int hashCode() {
-            return key != null ? key.hashCode() : 0;
+            return key == null ? 0 : key.hashCode();
         }
     }
-
-
 }

--- a/hazelcast-hibernate/hazelcast-hibernate3/src/main/java/com/hazelcast/hibernate/region/HazelcastQueryResultsRegion.java
+++ b/hazelcast-hibernate/hazelcast-hibernate3/src/main/java/com/hazelcast/hibernate/region/HazelcastQueryResultsRegion.java
@@ -25,8 +25,10 @@ import java.util.Properties;
 public class HazelcastQueryResultsRegion extends AbstractGeneralRegion<LocalRegionCache> implements QueryResultsRegion {
 
     public HazelcastQueryResultsRegion(final HazelcastInstance instance, final String name, final Properties props) {
-        // Note: We can pass HazelcastInstance as null, because instead of invalidation
-        // timestamps cache can take care of outdated queries.
-        super(instance, name, props, new LocalRegionCache(name, null, null));
+        // Note: The HazelcastInstance _must_ be passed down here. Otherwise query caches
+        // cannot be configured and will always use defaults. However, even though we're
+        // passing the HazelcastInstance, we don't want to use an ITopic for invalidation
+        // because the timestamps cache can take care of outdated queries
+        super(instance, name, props, new LocalRegionCache(name, instance, null, false));
     }
 }

--- a/hazelcast-hibernate/hazelcast-hibernate3/src/test/java/com/hazelcast/hibernate/local/LocalRegionCacheTest.java
+++ b/hazelcast-hibernate/hazelcast-hibernate3/src/test/java/com/hazelcast/hibernate/local/LocalRegionCacheTest.java
@@ -1,0 +1,99 @@
+package com.hazelcast.hibernate.local;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.ITopic;
+import com.hazelcast.core.MessageListener;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.hibernate.cache.CacheDataDescription;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Comparator;
+
+import static org.mockito.Mockito.*;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+@SuppressWarnings("unchecked")
+public class LocalRegionCacheTest {
+
+    private static final String CACHE_NAME = "cache";
+
+    @Test
+    public void testConstructorIgnoresUnsupportedOperationExceptionsFromConfig() {
+        HazelcastInstance instance = mock(HazelcastInstance.class);
+        doThrow(UnsupportedOperationException.class).when(instance).getConfig();
+
+        new LocalRegionCache(CACHE_NAME, instance, null, false);
+    }
+
+    @Test
+    public void testConstructorIgnoresVersionComparatorForUnversionedData() {
+        CacheDataDescription description = mock(CacheDataDescription.class);
+        doThrow(AssertionError.class).when(description).getVersionComparator(); // Will fail the test if called
+
+        new LocalRegionCache(CACHE_NAME, null, description);
+        verify(description).isVersioned(); // Verify that the versioned flag was checked
+        verifyNoMoreInteractions(description);
+    }
+
+    @Test
+    public void testConstructorSetsVersionComparatorForVersionedData() {
+        Comparator<?> comparator = mock(Comparator.class);
+
+        CacheDataDescription description = mock(CacheDataDescription.class);
+        when(description.getVersionComparator()).thenReturn(comparator);
+        when(description.isVersioned()).thenReturn(true);
+
+        new LocalRegionCache(CACHE_NAME, null, description);
+        verify(description).getVersionComparator();
+        verify(description).isVersioned();
+    }
+
+    @Test
+    public void testFourArgConstructorDoesNotRegisterTopicListenerIfNotRequested() {
+        MapConfig mapConfig = mock(MapConfig.class);
+
+        Config config = mock(Config.class);
+        when(config.findMapConfig(eq(CACHE_NAME))).thenReturn(mapConfig);
+
+        HazelcastInstance instance = mock(HazelcastInstance.class);
+        when(instance.getConfig()).thenReturn(config);
+
+        new LocalRegionCache(CACHE_NAME, instance, null, false);
+        verify(config).findMapConfig(eq(CACHE_NAME));
+        verify(instance).getConfig();
+        verify(instance, never()).getTopic(anyString());
+    }
+
+    // Verifies that the three-argument constructor still registers a listener with a topic if the HazelcastInstance
+    // is provided. This ensures the old behavior has not been regressed by adding the new four argument constructor
+    @Test
+    public void testThreeArgConstructorRegistersTopicListener() {
+        MapConfig mapConfig = mock(MapConfig.class);
+
+        Config config = mock(Config.class);
+        when(config.findMapConfig(eq(CACHE_NAME))).thenReturn(mapConfig);
+
+        ITopic<Object> topic = mock(ITopic.class);
+        when(topic.addMessageListener(isNotNull(MessageListener.class))).thenReturn("ignored");
+
+        HazelcastInstance instance = mock(HazelcastInstance.class);
+        when(instance.getConfig()).thenReturn(config);
+        when(instance.getTopic(eq(CACHE_NAME))).thenReturn(topic);
+
+        new LocalRegionCache(CACHE_NAME, instance, null);
+        verify(config).findMapConfig(eq(CACHE_NAME));
+        verify(instance).getConfig();
+        verify(instance).getTopic(eq(CACHE_NAME));
+        verify(topic).addMessageListener(isNotNull(MessageListener.class));
+    }
+
+    public static void runCleanup(LocalRegionCache cache) {
+        cache.cleanup();
+    }
+}

--- a/hazelcast-hibernate/hazelcast-hibernate3/src/test/java/com/hazelcast/hibernate/region/HazelcastQueryResultsRegionTest.java
+++ b/hazelcast-hibernate/hazelcast-hibernate3/src/test/java/com/hazelcast/hibernate/region/HazelcastQueryResultsRegionTest.java
@@ -1,0 +1,71 @@
+package com.hazelcast.hibernate.region;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.config.MaxSizeConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.hibernate.local.LocalRegionCache;
+import com.hazelcast.hibernate.local.LocalRegionCacheTest;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class HazelcastQueryResultsRegionTest {
+
+    private static final String REGION_NAME = "query.test";
+
+    @Test
+    public void testCacheHonorsConfiguration() {
+        int maxSize = 50;
+        int timeout = 60;
+
+        MapConfig mapConfig = mock(MapConfig.class);
+        when(mapConfig.getMaxSizeConfig()).thenReturn(new MaxSizeConfig(maxSize, MaxSizeConfig.MaxSizePolicy.PER_NODE));
+        when(mapConfig.getTimeToLiveSeconds()).thenReturn(timeout);
+
+        Config config = mock(Config.class);
+        when(config.findMapConfig(eq(REGION_NAME))).thenReturn(mapConfig);
+
+        HazelcastInstance instance = mock(HazelcastInstance.class);
+        when(instance.getConfig()).thenReturn(config);
+
+        // Create the region and verify that it retrieved the MapConfig and set its timeout from
+        // the TTL. Also verify that the nested LocalRegionCache retrieved the configuration but
+        // did _not_ register a listener on any ITopic
+        HazelcastQueryResultsRegion region = new HazelcastQueryResultsRegion(instance, REGION_NAME, new Properties());
+        assertEquals(TimeUnit.SECONDS.toMillis(timeout), region.getTimeout());
+        verify(instance, atLeastOnce()).getConfig();
+        verify(instance, never()).getTopic(anyString()); // Ensure a topic is not requested
+        verify(config, atLeastOnce()).findMapConfig(eq(REGION_NAME));
+        verify(mapConfig, times(2)).getTimeToLiveSeconds(); // Should have been retrieved by the region itself
+
+        // Next, load the cache with more entries than the configured max size
+        LocalRegionCache regionCache = region.getCache();
+        assertNotNull(regionCache);
+
+        int oversized = maxSize * 2;
+        for (int i = 0; i < oversized; ++i) {
+            regionCache.put(i, i, i);
+        }
+        assertEquals(oversized, regionCache.size());
+
+        // Lastly run cleanup to apply the configured limits. Note that the TTL is not tested here
+        // simply for simplicity (and for the speed of this test)
+        LocalRegionCacheTest.runCleanup(regionCache);
+        // The default size is 100,000, so if the configuration is ignored no elements will be removed. But
+        // if the configuration is applied as expected
+        assertTrue(regionCache.size() <= 50);
+        verify(mapConfig).getMaxSizeConfig();
+        verify(mapConfig, times(3)).getTimeToLiveSeconds(); // Should have been retrieved a second time by the cache
+    }
+}

--- a/hazelcast-hibernate/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/region/HazelcastQueryResultsRegion.java
+++ b/hazelcast-hibernate/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/region/HazelcastQueryResultsRegion.java
@@ -25,8 +25,10 @@ import java.util.Properties;
 public class HazelcastQueryResultsRegion extends AbstractGeneralRegion<LocalRegionCache> implements QueryResultsRegion {
 
     public HazelcastQueryResultsRegion(final HazelcastInstance instance, final String name, final Properties props) {
-        // Note: We can pass HazelcastInstance as null, because instead of invalidation
-        // timestamps cache can take care of outdated queries.
-        super(instance, name, props, new LocalRegionCache(name, null, null));
+        // Note: The HazelcastInstance _must_ be passed down here. Otherwise query caches
+        // cannot be configured and will always use defaults. However, even though we're
+        // passing the HazelcastInstance, we don't want to use an ITopic for invalidation
+        // because the timestamps cache can take care of outdated queries
+        super(instance, name, props, new LocalRegionCache(name, instance, null, false));
     }
 }

--- a/hazelcast-hibernate/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/local/LocalRegionCacheTest.java
+++ b/hazelcast-hibernate/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/local/LocalRegionCacheTest.java
@@ -1,0 +1,99 @@
+package com.hazelcast.hibernate.local;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.ITopic;
+import com.hazelcast.core.MessageListener;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.hibernate.cache.spi.CacheDataDescription;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Comparator;
+
+import static org.mockito.Mockito.*;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+@SuppressWarnings("unchecked")
+public class LocalRegionCacheTest {
+
+    private static final String CACHE_NAME = "cache";
+
+    @Test
+    public void testConstructorIgnoresUnsupportedOperationExceptionsFromConfig() {
+        HazelcastInstance instance = mock(HazelcastInstance.class);
+        doThrow(UnsupportedOperationException.class).when(instance).getConfig();
+
+        new LocalRegionCache(CACHE_NAME, instance, null, false);
+    }
+
+    @Test
+    public void testConstructorIgnoresVersionComparatorForUnversionedData() {
+        CacheDataDescription description = mock(CacheDataDescription.class);
+        doThrow(AssertionError.class).when(description).getVersionComparator(); // Will fail the test if called
+
+        new LocalRegionCache(CACHE_NAME, null, description);
+        verify(description).isVersioned(); // Verify that the versioned flag was checked
+        verifyNoMoreInteractions(description);
+    }
+
+    @Test
+    public void testConstructorSetsVersionComparatorForVersionedData() {
+        Comparator<?> comparator = mock(Comparator.class);
+
+        CacheDataDescription description = mock(CacheDataDescription.class);
+        when(description.getVersionComparator()).thenReturn(comparator);
+        when(description.isVersioned()).thenReturn(true);
+
+        new LocalRegionCache(CACHE_NAME, null, description);
+        verify(description).getVersionComparator();
+        verify(description).isVersioned();
+    }
+
+    @Test
+    public void testFourArgConstructorDoesNotRegisterTopicListenerIfNotRequested() {
+        MapConfig mapConfig = mock(MapConfig.class);
+
+        Config config = mock(Config.class);
+        when(config.findMapConfig(eq(CACHE_NAME))).thenReturn(mapConfig);
+
+        HazelcastInstance instance = mock(HazelcastInstance.class);
+        when(instance.getConfig()).thenReturn(config);
+
+        new LocalRegionCache(CACHE_NAME, instance, null, false);
+        verify(config).findMapConfig(eq(CACHE_NAME));
+        verify(instance).getConfig();
+        verify(instance, never()).getTopic(anyString());
+    }
+
+    // Verifies that the three-argument constructor still registers a listener with a topic if the HazelcastInstance
+    // is provided. This ensures the old behavior has not been regressed by adding the new four argument constructor
+    @Test
+    public void testThreeArgConstructorRegistersTopicListener() {
+        MapConfig mapConfig = mock(MapConfig.class);
+
+        Config config = mock(Config.class);
+        when(config.findMapConfig(eq(CACHE_NAME))).thenReturn(mapConfig);
+
+        ITopic<Object> topic = mock(ITopic.class);
+        when(topic.addMessageListener(isNotNull(MessageListener.class))).thenReturn("ignored");
+
+        HazelcastInstance instance = mock(HazelcastInstance.class);
+        when(instance.getConfig()).thenReturn(config);
+        when(instance.getTopic(eq(CACHE_NAME))).thenReturn(topic);
+
+        new LocalRegionCache(CACHE_NAME, instance, null);
+        verify(config).findMapConfig(eq(CACHE_NAME));
+        verify(instance).getConfig();
+        verify(instance).getTopic(eq(CACHE_NAME));
+        verify(topic).addMessageListener(isNotNull(MessageListener.class));
+    }
+
+    public static void runCleanup(LocalRegionCache cache) {
+        cache.cleanup();
+    }
+}

--- a/hazelcast-hibernate/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/region/HazelcastQueryResultsRegionTest.java
+++ b/hazelcast-hibernate/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/region/HazelcastQueryResultsRegionTest.java
@@ -1,0 +1,71 @@
+package com.hazelcast.hibernate.region;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.config.MaxSizeConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.hibernate.local.LocalRegionCache;
+import com.hazelcast.hibernate.local.LocalRegionCacheTest;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class HazelcastQueryResultsRegionTest {
+
+    private static final String REGION_NAME = "query.test";
+
+    @Test
+    public void testCacheHonorsConfiguration() {
+        int maxSize = 50;
+        int timeout = 60;
+
+        MapConfig mapConfig = mock(MapConfig.class);
+        when(mapConfig.getMaxSizeConfig()).thenReturn(new MaxSizeConfig(maxSize, MaxSizeConfig.MaxSizePolicy.PER_NODE));
+        when(mapConfig.getTimeToLiveSeconds()).thenReturn(timeout);
+
+        Config config = mock(Config.class);
+        when(config.findMapConfig(eq(REGION_NAME))).thenReturn(mapConfig);
+
+        HazelcastInstance instance = mock(HazelcastInstance.class);
+        when(instance.getConfig()).thenReturn(config);
+
+        // Create the region and verify that it retrieved the MapConfig and set its timeout from
+        // the TTL. Also verify that the nested LocalRegionCache retrieved the configuration but
+        // did _not_ register a listener on any ITopic
+        HazelcastQueryResultsRegion region = new HazelcastQueryResultsRegion(instance, REGION_NAME, new Properties());
+        assertEquals(TimeUnit.SECONDS.toMillis(timeout), region.getTimeout());
+        verify(instance, atLeastOnce()).getConfig();
+        verify(instance, never()).getTopic(anyString()); // Ensure a topic is not requested
+        verify(config, atLeastOnce()).findMapConfig(eq(REGION_NAME));
+        verify(mapConfig, times(2)).getTimeToLiveSeconds(); // Should have been retrieved by the region itself
+
+        // Next, load the cache with more entries than the configured max size
+        LocalRegionCache regionCache = region.getCache();
+        assertNotNull(regionCache);
+
+        int oversized = maxSize * 2;
+        for (int i = 0; i < oversized; ++i) {
+            regionCache.put(i, i, i);
+        }
+        assertEquals(oversized, regionCache.size());
+
+        // Lastly run cleanup to apply the configured limits. Note that the TTL is not tested here
+        // simply for simplicity (and for the speed of this test)
+        LocalRegionCacheTest.runCleanup(regionCache);
+        // The default size is 100,000, so if the configuration is ignored no elements will be removed. But
+        // if the configuration is applied as expected
+        assertTrue(regionCache.size() <= 50);
+        verify(mapConfig).getMaxSizeConfig();
+        verify(mapConfig, times(3)).getTimeToLiveSeconds(); // Should have been retrieved a second time by the cache
+    }
+}


### PR DESCRIPTION
- Added a new constructor to LocalRegionCache to allow explicit control over whether an ITopic MessageListener should be registered
- Fixed a subtle bug in LocalRegionCache.cleanup() that prevented multiple entries with the same timestamp from being cleaned up
  - Using a TreeSet meant only a single entry at any given timestamp could be considered as a candidate for eviction; subsequent entries were "protected" because they weren't added to the TreeSet
- Updated HazelcastQueryResultsRegion to use the new constructor so that the HazelcastInstance can be passed on (allow query caches to inherit their MapConfigs) without registering a MessageListener
- Added unit tests to verify both LocalRegionCache constructors
- Added unit test to verify HazelcastQueryResultsRegion creates LocalRegionCaches which honor their configurations
