### PR TITLE
checkstyle/findbugs detected in validate phase

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -651,7 +651,7 @@
                         <version>${findbugs.maven.plugin.version}</version>
                         <executions>
                             <execution>
-                                <phase>validate</phase>
+                                <phase>compile</phase>
                                 <goals>
                                     <goal>check</goal>
                                 </goals>


### PR DESCRIPTION
I changed the phase to validate for checkstyle+findbugs.

This makes PR Builder fail faster for checkstyle+findbugs problems. Also,this enables us to change PR builder configuration from **mvn clean install** to **mvn clean test** .

 mvn install is already causing problems if the machine  is the same where unmerged pr is built + installed and man.center+hazelcast-enterprise is built.
