### PR TITLE
deprecated IAtomicReference.setAndGet method

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/core/IAtomicReference.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/IAtomicReference.java
@@ -64,6 +64,7 @@ public interface IAtomicReference<E> extends DistributedObject {
      *
      * @param update the new value
      * @return  the new value
+     * @deprecated will be removed from Hazelcast 3.4 since it doesn't really serve a purpose.
      */
     E setAndGet(E update);
 


### PR DESCRIPTION
Deprecated method since it doesn't really serve a purpose. 
