### PR TITLE
Build-Utils improvements (maintenance)

### DIFF
--- a/hazelcast-all/pom.xml
+++ b/hazelcast-all/pom.xml
@@ -77,6 +77,18 @@
                                 <transformer
                                         implementation="com.hazelcast.buildutils.HazelcastManifestTransformer">
                                     <mainClass>com.hazelcast.console.ConsoleApp</mainClass>
+
+                                    <overrideInstructions>
+                                        <Import-Package>
+                                            org.hibernate.*;resolution:=optional,
+                                            org.springframework.*;resolution:=optional,
+                                            javax.servlet.*;resolution:=optional,
+                                            javax.security.*;resolution:=optional,
+                                            org.slf4j.*;resolution:=optional,
+                                            org.apache.log4j.*;resolution:=optional,
+                                            javax.script.*;resolution:=optional
+                                        </Import-Package>
+                                    </overrideInstructions>
                                 </transformer>
                                 <transformer
                                         implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>

--- a/hazelcast-build-utils/pom.xml
+++ b/hazelcast-build-utils/pom.xml
@@ -87,6 +87,11 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>biz.aQute</groupId>
+            <artifactId>bndlib</artifactId>
+            <version>1.50.0</version>
+        </dependency>
+        <dependency>
             <groupId>net.sourceforge.findbugs</groupId>
             <artifactId>annotations</artifactId>
             <version>1.3.2</version>


### PR DESCRIPTION
The first try to shade OSGi metadata was way to simple in design, a lot more constraints had to be in mind. This new version collects uses clauses, favors versioned imports over non versioned ones and has the ability to override resolution constraints.
