### PR TITLE
Fix attempt to #2956: Make null check after getRecord 

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/operation/BasePutOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/operation/BasePutOperation.java
@@ -75,8 +75,11 @@ public abstract class BasePutOperation extends LockAwareOperation implements Bac
     }
 
     public Operation getBackupOperation() {
+        RecordInfo replicationInfo = null;
         Record record = recordStore.getRecord(dataKey);
-        RecordInfo replicationInfo = Records.buildRecordInfo(record);
+        if (record != null) {
+            replicationInfo = Records.buildRecordInfo(record);
+        }
         return new PutBackupOperation(name, dataKey, dataValue, replicationInfo);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/operation/MergeOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/operation/MergeOperation.java
@@ -25,6 +25,7 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.Operation;
+
 import java.io.IOException;
 
 public class MergeOperation extends BasePutOperation {
@@ -72,7 +73,11 @@ public class MergeOperation extends BasePutOperation {
         if (dataValue == null) {
             return new RemoveBackupOperation(name, dataKey);
         } else {
-            RecordInfo replicationInfo = Records.buildRecordInfo(recordStore.getRecord(dataKey));
+            RecordInfo replicationInfo = null;
+            final Record record = recordStore.getRecord(dataKey);
+            if (record != null) {
+                replicationInfo = Records.buildRecordInfo(record);
+            }
             return new PutBackupOperation(name, dataKey, dataValue, replicationInfo);
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/operation/MultipleEntryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/operation/MultipleEntryOperation.java
@@ -127,9 +127,11 @@ public class MultipleEntryOperation extends AbstractMapOperation
                 mapEventPublisher.publishWanReplicationRemove(name, key, Clock.currentTimeMillis());
             } else {
                 Record record = recordStore.getRecord(key);
-                Data tempValue = mapServiceContext.toData(dataValue);
-                final EntryView entryView = EntryViews.createSimpleEntryView(key, tempValue, record);
-                mapEventPublisher.publishWanReplicationUpdate(name, entryView);
+                if (record != null) {
+                    Data tempValue = mapServiceContext.toData(dataValue);
+                    final EntryView entryView = EntryViews.createSimpleEntryView(key, tempValue, record);
+                    mapEventPublisher.publishWanReplicationUpdate(name, entryView);
+                }
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/operation/PartitionWideEntryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/operation/PartitionWideEntryOperation.java
@@ -142,9 +142,11 @@ public class PartitionWideEntryOperation extends AbstractMapOperation
             if (EntryEventType.REMOVED.equals(eventType)) {
                 mapEventPublisher.publishWanReplicationRemove(name, dataKey, Clock.currentTimeMillis());
             } else {
-                Record r = recordStore.getRecord(dataKey);
-                final EntryView entryView = EntryViews.createSimpleEntryView(dataKey, dataValue, r);
-                mapEventPublisher.publishWanReplicationUpdate(name, entryView);
+                Record record = recordStore.getRecord(dataKey);
+                if (record != null) {
+                    final EntryView entryView = EntryViews.createSimpleEntryView(dataKey, dataValue, record);
+                    mapEventPublisher.publishWanReplicationUpdate(name, entryView);
+                }
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/operation/PutAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/operation/PutAllOperation.java
@@ -89,9 +89,11 @@ public class PutAllOperation extends AbstractMapOperation implements PartitionAw
                 keysToInvalidate.add(dataKey);
                 if (mapContainer.getWanReplicationPublisher() != null && mapContainer.getWanMergePolicy() != null) {
                     Record record = recordStore.getRecord(dataKey);
-                    final Data dataValueAsData = mapServiceContext.toData(dataValue);
-                    final EntryView entryView = EntryViews.createSimpleEntryView(dataKey, dataValueAsData, record);
-                    mapEventPublisher.publishWanReplicationUpdate(name, entryView);
+                    if (record != null) {
+                        final Data dataValueAsData = mapServiceContext.toData(dataValue);
+                        final EntryView entryView = EntryViews.createSimpleEntryView(dataKey, dataValueAsData, record);
+                        mapEventPublisher.publishWanReplicationUpdate(name, entryView);
+                    }
                 }
                 backupEntrySet.add(entry);
                 RecordInfo replicationInfo = Records.buildRecordInfo(recordStore.getRecord(dataKey));

--- a/hazelcast/src/main/java/com/hazelcast/map/operation/PutFromLoadAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/operation/PutFromLoadAllOperation.java
@@ -70,6 +70,9 @@ public class PutFromLoadAllOperation extends AbstractMapOperation implements Par
     }
 
     private void publishWanReplicationEvent(Data key, Data value, Record record) {
+        if (record == null) {
+            return;
+        }
         if (mapContainer.getWanReplicationPublisher() != null && mapContainer.getWanMergePolicy() != null) {
             final EntryView entryView = EntryViews.createSimpleEntryView(key, value, record);
             mapService.getMapServiceContext().getMapEventPublisher().publishWanReplicationUpdate(name, entryView);

--- a/hazelcast/src/main/java/com/hazelcast/map/tx/TxnSetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/tx/TxnSetOperation.java
@@ -28,6 +28,7 @@ import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.ResponseHandler;
 import com.hazelcast.spi.WaitNotifyKey;
+
 import java.io.IOException;
 
 /**
@@ -92,7 +93,11 @@ public class TxnSetOperation extends BasePutOperation implements MapTxnOperation
     }
 
     public Operation getBackupOperation() {
-        RecordInfo replicationInfo = Records.buildRecordInfo(recordStore.getRecord(dataKey));
+        final Record record = recordStore.getRecord(dataKey);
+        RecordInfo replicationInfo = null;
+        if (record != null) {
+            replicationInfo = Records.buildRecordInfo(record);
+        }
         return new PutBackupOperation(name, dataKey, dataValue, replicationInfo, true);
     }
 


### PR DESCRIPTION
This is a fix attempt to https://github.com/hazelcast/hazelcast/issues/2956
- One can get null as a result of expiration. So it may lead NPE.
