### PR TITLE
Hazelcast-Hibernate: cache flush leaves ClientMapProxy in the inconsitent state

### DIFF
--- a/hazelcast-hibernate/hazelcast-hibernate3/src/main/java/com/hazelcast/hibernate/distributed/IMapRegionCache.java
+++ b/hazelcast-hibernate/hazelcast-hibernate3/src/main/java/com/hazelcast/hibernate/distributed/IMapRegionCache.java
@@ -119,12 +119,7 @@ public class IMapRegionCache implements RegionCache {
     }
 
     public void clear() {
-        // clear all cache and destroy proxies
-        // when a new operation done over this proxy
-        // Hazelcast will initialize and create map again.
-        map.destroy();
-        // create Hazelcast internal proxies, has no effect on map operations
-        hazelcastInstance.getMap(name);
+        map.evictAll();
     }
 
     public long size() {

--- a/hazelcast-hibernate/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/distributed/IMapRegionCache.java
+++ b/hazelcast-hibernate/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/distributed/IMapRegionCache.java
@@ -119,12 +119,7 @@ public class IMapRegionCache implements RegionCache {
     }
 
     public void clear() {
-        // clear all cache and destroy proxies
-        // when a new operation done over this proxy
-        // Hazelcast will initialize and create map again.
-        map.destroy();
-        // create Hazelcast internal proxies, has no effect on map operations
-        hazelcastInstance.getMap(name);
+        map.evictAll();
     }
 
     public long size() {


### PR DESCRIPTION
fixes #3004
