### PR TITLE
3025: Fixing condition.await race condition 

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/AwaitOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/AwaitOperation.java
@@ -47,8 +47,10 @@ public class AwaitOperation extends BaseLockOperation
 
     @Override
     public void beforeRun() throws Exception {
-        LockStoreImpl lockStore = getLockStore();
-        firstRun = lockStore.startAwaiting(key, conditionId, getCallerUuid(), threadId);
+        if (!expired) {
+            LockStoreImpl lockStore = getLockStore();
+            firstRun = lockStore.startAwaiting(key, conditionId, getCallerUuid(), threadId);
+        }
     }
 
     @Override


### PR DESCRIPTION
In `AwaitOperation.beforeRun()` it seems `lockStore.startAwaiting(...)` is called regardless of whether the await has already expired. `lockStore.startAwaiting(...)` expects a waiter to be present in the underlying condition. When expired (via `AwaitOperation.onWaitExpire()`) the waiter is removed from the condition. This causes the condition to throw the `IllegalStateException` because there is no waiter to run.

This fixes that by avoiding any work in `beforeRun()` if the await is already expired. Also including a unit test.
