### PR TITLE
DONT MERGE: Test/3.x/backedupmapdataloss

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/cluster/BackedupMapDataLossTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/BackedupMapDataLossTest.java
@@ -128,11 +128,6 @@ public class BackedupMapDataLossTest {
             System.out.println("3 -> "+m.get("ThreeKey"));
         }
 
-     /*   Thread.sleep(10000);
-        assertTrue(latch.await(30, TimeUnit.SECONDS));
-        assertEquals(3, h1.getCluster().getMembers().size());
-        assertEquals(3, h2.getCluster().getMembers().size());
-        assertEquals(3, h3.getCluster().getMembers().size()); */
     }
 
     private void closeConnectionBetween(HazelcastInstance h1, HazelcastInstance h2) {
@@ -143,3 +138,4 @@ public class BackedupMapDataLossTest {
        n2.clusterService.removeAddress(n1.address);
     }
 }
+


### PR DESCRIPTION
Committing a unit test for BackedMapDataLoss case

This pull request will fail because it contains a unit test that is going to fail. It will reproduce a bug we have in the system.
