### PR TITLE
Fixed remote exception and added unittest to show this is already fixed (backport)

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapLoadAllTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapLoadAllTest.java
@@ -1,0 +1,178 @@
+package com.hazelcast.client.map;
+
+import com.hazelcast.client.ClientRequest;
+import com.hazelcast.client.HazelcastClient;
+import com.hazelcast.config.Config;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.core.MapStore;
+import com.hazelcast.map.mapstore.MapStoreTest;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class ClientMapLoadAllTest extends HazelcastTestSupport {
+
+    @Test(timeout = 60000)
+    public void testGetMap_issue_3031() throws Exception {
+        final int itemCount = 1000;
+        final String mapName = randomMapName();
+
+        final AtomicBoolean breakMe = new AtomicBoolean(false);
+
+        final Config config = createNewConfig(mapName, new BrokenLoadSimpleStore(breakMe));
+        final HazelcastInstance server = Hazelcast.newHazelcastInstance(config);
+
+        try {
+            final IMap<Object, Object> map = server.getMap(mapName);
+            populateMap(map, itemCount);
+            map.clear();
+        } catch (Exception e) {
+            fail();
+        }
+
+        breakMe.set(true);
+
+        final HazelcastInstance client = HazelcastClient.newHazelcastClient();
+        try {
+            client.getMap(mapName);
+        } finally {
+            closeResources(client, server);
+        }
+    }
+
+    private static Config createNewConfig(String mapName) {
+        return createNewConfig(mapName, new SimpleStore());
+    }
+
+    private static Config createNewConfig(String mapName, MapStore mapStore) {
+        return MapStoreTest.newConfig(mapName, mapStore, 0);
+    }
+
+    private static void populateMap(IMap map, int itemCount) {
+        for (int i = 0; i < itemCount; i++) {
+            map.put(i, i);
+        }
+    }
+
+    private static Set selectKeysToLoad(int rangeStart, int rangeEnd) {
+        final Set keysToLoad = new HashSet();
+        for (int i = rangeStart; i < rangeEnd; i++) {
+            keysToLoad.add(i);
+        }
+        return keysToLoad;
+    }
+
+    private static void assertRangeLoaded(IMap map, int rangeStart, int rangeEnd) {
+        for (int i = rangeStart; i < rangeEnd; i++) {
+            assertEquals(i, map.get(i));
+        }
+    }
+
+    private static void closeResources(HazelcastInstance... instances) {
+        if (instances == null) {
+            return;
+        }
+        for (HazelcastInstance instance : instances) {
+            instance.shutdown();
+        }
+    }
+
+
+    private static class SimpleStore implements MapStore {
+        private ConcurrentMap store = new ConcurrentHashMap();
+
+        @Override
+        public void store(Object key, Object value) {
+            store.put(key, value);
+        }
+
+        @Override
+        public void storeAll(Map map) {
+            final Set<Map.Entry> entrySet = map.entrySet();
+            for (Map.Entry entry : entrySet) {
+                final Object key = entry.getKey();
+                final Object value = entry.getValue();
+                store(key, value);
+            }
+
+        }
+
+        @Override
+        public void delete(Object key) {
+
+        }
+
+        @Override
+        public void deleteAll(Collection keys) {
+
+        }
+
+        @Override
+        public Object load(Object key) {
+            return store.get(key);
+        }
+
+        @Override
+        public Map loadAll(Collection keys) {
+            final Map map = new HashMap();
+            for (Object key : keys) {
+                final Object value = load(key);
+                map.put(key, value);
+            }
+            return map;
+        }
+
+        @Override
+        public Set loadAllKeys() {
+            return store.keySet();
+        }
+    }
+
+    private static class BrokenLoadSimpleStore extends SimpleStore {
+
+        private final AtomicBoolean breakMe;
+
+        private BrokenLoadSimpleStore(AtomicBoolean breakMe) {
+            this.breakMe = breakMe;
+        }
+
+        @Override
+        public Object load(Object key) {
+            testClientRequest();
+            return null;
+        }
+
+        @Override
+        public Map loadAll(Collection keys) {
+            testClientRequest();
+            return null;
+        }
+
+        private boolean testClientRequest() {
+            if (breakMe.get()) {
+                throw new ClassCastException();
+            }
+            return false;
+        }
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/util/ExceptionUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/ExceptionUtil.java
@@ -86,25 +86,57 @@ public final class ExceptionUtil {
     private final static String EXCEPTION_SEPARATOR = "------ End remote and begin local stack-trace ------";
     private final static String EXCEPTION_MESSAGE_SEPARATOR = "------ %MSG% ------";
 
+    /**
+     * This method changes the given remote cause and adds the also given local stacktrace.<br/>
+     * If the remoteCause is an {@link java.util.concurrent.ExecutionException} and it has a non null inner
+     * cause, this inner cause is unwrapped and the local stacktrace and exception message are added to the
+     * that instead of the given remoteCause itself.
+     *
+     * @param remoteCause the remotely generated exception
+     * @param localSideStackTrace the local stacktrace to add to the exceptions stacktrace
+     */
     public static void fixRemoteStackTrace(Throwable remoteCause, StackTraceElement[] localSideStackTrace) {
-        StackTraceElement[] remoteStackTrace = remoteCause.getStackTrace();
+        Throwable throwable = remoteCause;
+        if (remoteCause instanceof ExecutionException && throwable.getCause() != null) {
+            throwable = throwable.getCause();
+        }
+
+        StackTraceElement[] remoteStackTrace = throwable.getStackTrace();
         StackTraceElement[] newStackTrace = new StackTraceElement[localSideStackTrace.length + remoteStackTrace.length];
         System.arraycopy(remoteStackTrace, 0, newStackTrace, 0, remoteStackTrace.length);
         newStackTrace[remoteStackTrace.length] = new StackTraceElement(EXCEPTION_SEPARATOR, "", null, -1);
         System.arraycopy(localSideStackTrace, 1, newStackTrace, remoteStackTrace.length + 1, localSideStackTrace.length - 1);
-        remoteCause.setStackTrace(newStackTrace);
+        throwable.setStackTrace(newStackTrace);
     }
 
-    public static void fixRemoteStackTrace(Throwable remoteCause, StackTraceElement[] localSideStackTrace, String localExceptionMessage) {
+    /**
+     * This method changes the given remote cause and adds the also given local stacktrace separated by the
+     * supplied exception message.<br/>
+     * If the remoteCause is an {@link java.util.concurrent.ExecutionException} and it has a non null inner
+     * cause, this inner cause is unwrapped and the local stacktrace and exception message are added to the
+     * that instead of the given remoteCause itself.
+     *
+     * @param remoteCause the remotely generated exception
+     * @param localSideStackTrace the local stacktrace to add to the exceptions stacktrace
+     * @param localExceptionMessage a special exception message which is added to the stacktrace
+     */
+    public static void fixRemoteStackTrace(Throwable remoteCause, StackTraceElement[] localSideStackTrace,
+                                           String localExceptionMessage) {
+
+        Throwable throwable = remoteCause;
+        if (remoteCause instanceof ExecutionException && throwable.getCause() != null) {
+            throwable = throwable.getCause();
+        }
+
         String msg = EXCEPTION_MESSAGE_SEPARATOR.replace("%MSG%", localExceptionMessage);
-        StackTraceElement[] remoteStackTrace = remoteCause.getStackTrace();
+        StackTraceElement[] remoteStackTrace = throwable.getStackTrace();
         StackTraceElement[] newStackTrace = new StackTraceElement[localSideStackTrace.length + remoteStackTrace.length + 1];
         System.arraycopy(remoteStackTrace, 0, newStackTrace, 0, remoteStackTrace.length);
         newStackTrace[remoteStackTrace.length] = new StackTraceElement(EXCEPTION_SEPARATOR, "", null, -1);
         StackTraceElement nextElement = localSideStackTrace[1];
         newStackTrace[remoteStackTrace.length + 1] = new StackTraceElement(msg, nextElement.getMethodName(), nextElement.getFileName(), nextElement.getLineNumber());
         System.arraycopy(localSideStackTrace, 1, newStackTrace, remoteStackTrace.length + 2, localSideStackTrace.length - 1);
-        remoteCause.setStackTrace(newStackTrace);
+        throwable.setStackTrace(newStackTrace);
     }
 
     //we don't want instances


### PR DESCRIPTION
Problems described by #3031 does not seem valid anymore on master / maintenance-3.x, added unittest to verify that problem.

Fixed remote exception (local stacktrace) when ExecutionException is given to ExeceptionUtil::fixRemoteExceptionStacktrace
