### PR TITLE
[Bug] TransactionalMap.putIfAbsent unlock

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/tx/TransactionalMapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/tx/TransactionalMapProxySupport.java
@@ -153,6 +153,8 @@ public abstract class TransactionalMapProxySupport extends AbstractDistributedOb
     public Data replaceInternal(Data key, Data value) {
         VersionedValue versionedValue = lockAndGet(key, tx.getTimeoutMillis());
         if (versionedValue.value == null){
+            TxnUnlockOperation operation = new TxnUnlockOperation(name, key, versionedValue.version);
+            tx.addTransactionLog(new MapTransactionLog(name, key, operation, versionedValue.version, tx.getOwnerUuid()));
             return null;
         }
         final TxnSetOperation op = new TxnSetOperation(name, key, value, versionedValue.version);
@@ -162,8 +164,11 @@ public abstract class TransactionalMapProxySupport extends AbstractDistributedOb
 
     public boolean replaceIfSameInternal(Data key, Object oldValue, Data newValue) {
         VersionedValue versionedValue = lockAndGet(key, tx.getTimeoutMillis());
-        if (!getService().compare(name, oldValue, versionedValue.value))
+        if (!getService().compare(name, oldValue, versionedValue.value)){
+            TxnUnlockOperation operation = new TxnUnlockOperation(name, key, versionedValue.version);
+            tx.addTransactionLog(new MapTransactionLog(name, key, operation, versionedValue.version, tx.getOwnerUuid()));
             return false;
+        }
         final TxnSetOperation op = new TxnSetOperation(name, key, newValue, versionedValue.version);
         tx.addTransactionLog(new MapTransactionLog(name, key, op, versionedValue.version, tx.getOwnerUuid()));
         return true;
@@ -178,6 +183,8 @@ public abstract class TransactionalMapProxySupport extends AbstractDistributedOb
     public boolean removeIfSameInternal(Data key, Object value) {
         VersionedValue versionedValue = lockAndGet(key, tx.getTimeoutMillis());
         if (!getService().compare(name, versionedValue.value, value)) {
+            TxnUnlockOperation operation = new TxnUnlockOperation(name, key, versionedValue.version);
+            tx.addTransactionLog(new MapTransactionLog(name, key, operation, versionedValue.version, tx.getOwnerUuid()));
             return false;
         }
         tx.addTransactionLog(new MapTransactionLog(name, key, new TxnDeleteOperation(name, key, versionedValue.version), versionedValue.version, tx.getOwnerUuid()));

--- a/hazelcast/src/test/java/com/hazelcast/map/MapTransactionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapTransactionTest.java
@@ -639,40 +639,66 @@ public class MapTransactionTest extends HazelcastTestSupport {
     @Test
     public void testTxnPutIfAbsentParallel() throws InterruptedException {
         final String TEST_MAP = "testMap";
+        final String key = "k";
         final TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(1);
-        final HazelcastInstance sharedDataService = factory.newHazelcastInstance(new Config());
-        final Object[] v = new Object[1];
-        Thread contender = new Thread(new Runnable() {
+        final HazelcastInstance hazelcastInstance = factory.newHazelcastInstance(new Config());
+
+        IMap<String, Object> map = hazelcastInstance.getMap(TEST_MAP);
+        map.put(key, "v");
+
+        hazelcastInstance.executeTransaction(new TransactionalTask<Object>() {
             @Override
-            public void run() {
-                TransactionContext transactionContext = sharedDataService.newTransactionContext();
-                transactionContext.beginTransaction();
+            public Object execute(TransactionalTaskContext transactionContext) throws TransactionException {
                 TransactionalMap<String, Object> map = transactionContext.getMap(TEST_MAP);
-                v[0] = map.putIfAbsent("k", "t");
-                transactionContext.commitTransaction();
+                map.putIfAbsent(key, "t");
+                return null;
             }
         });
+        assertFalse("Key is not locked", map.isLocked(key));
+    }
 
-        TransactionContext transactionContext;
-        TransactionalMap<String, Object> map;
-        transactionContext = sharedDataService.newTransactionContext();
-        transactionContext.beginTransaction();
-        map = transactionContext.getMap(TEST_MAP);
-        map.put("k", "v");
-        transactionContext.commitTransaction();
+    @Test
+    public void testTxnRemoveParallel() throws InterruptedException {
+        final String TEST_MAP = "testMap";
+        final String key = "k";
+        final String value = "v";
+        final TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(1);
+        final HazelcastInstance hazelcastInstance = factory.newHazelcastInstance(new Config());
 
+        IMap<String, Object> map = hazelcastInstance.getMap(TEST_MAP);
+        map.put(key, value);
 
-        contender.start();
-        contender.join(1000);
-        assertFalse("Contender thread finished", contender.isAlive());
-        assertNotNull(v[0]);
+        hazelcastInstance.executeTransaction(new TransactionalTask<Object>() {
+            @Override
+            public Object execute(TransactionalTaskContext transactionContext) throws TransactionException {
+                TransactionalMap<String, Object> map = transactionContext.getMap(TEST_MAP);
+                map.remove(key, value + "other");
+                return null;
+            }
+        });
+        assertFalse("Key is not locked", map.isLocked(key));
+    }
 
-        transactionContext = sharedDataService.newTransactionContext();
-        transactionContext.beginTransaction();
-        map = transactionContext.getMap(TEST_MAP);
-        map.delete("k");
-        transactionContext.commitTransaction();
+    @Test
+    public void testTxnReplaceParallel() throws InterruptedException {
+        final String TEST_MAP = "testMap";
+        final String key = "k";
+        final String value = "v";
+        final TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(1);
+        final HazelcastInstance hazelcastInstance = factory.newHazelcastInstance(new Config());
 
+        IMap<String, Object> map = hazelcastInstance.getMap(TEST_MAP);
+        map.put(key, value);
+
+        hazelcastInstance.executeTransaction(new TransactionalTask<Object>() {
+            @Override
+            public Object execute(TransactionalTaskContext transactionContext) throws TransactionException {
+                TransactionalMap<String, Object> map = transactionContext.getMap(TEST_MAP);
+                map.replace(key, value + "other", value);
+                return null;
+            }
+        });
+        assertFalse("Key is not locked", map.isLocked(key));
     }
 
 


### PR DESCRIPTION
TransactionalMap.putIfAbsent method locks value in map by lockAndGet and never releases lock if value in map already present.
Fix and test provided.

Fixes #3149 
