### PR TITLE
Fix NPE when registrations is null

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/EventServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/EventServiceImpl.java
@@ -417,7 +417,7 @@ public class EventServiceImpl implements EventService {
         }
         private boolean hasRegistrations(String topic) {
             Collection<Registration> topicRegistrations = registrations.get(topic);
-            return !(topicRegistrations == null && topicRegistrations.isEmpty());
+            return !(topicRegistrations == null || topicRegistrations.isEmpty());
         }
 
 


### PR DESCRIPTION
Looks like this is fixed in master, but we're running into this on 3.2.4. It'd be awesome if you could merge or backport the fix from master.
