### PR TITLE
#2817 - Hazelcast Core JAR is now on a classpath when starting the example client

### DIFF
--- a/hazelcast/src/main/resources/client.sh
+++ b/hazelcast/src/main/resources/client.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-java -server -Djava.net.preferIPv4Stack=true -cp ../lib/hazelcast-client-${project.version}.jar com.hazelcast.client.examples.ClientTestApp
+java -server -Djava.net.preferIPv4Stack=true -cp ../lib/hazelcast-client-${project.version}.jar:../lib/hazelcast-${project.version}.jar com.hazelcast.client.examples.ClientTestApp


### PR DESCRIPTION
There is no client.sh in the current master.
