### PR TITLE
Difference ExecutorConfig default poolsize XML vs Programmatic

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/ExecutorConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ExecutorConfig.java
@@ -24,7 +24,7 @@ public class ExecutorConfig {
     /**
      * The number of executor threads per Member for the Executor based on this configuration.
      */
-    public static final int DEFAULT_POOL_SIZE = 8;
+    public static final int DEFAULT_POOL_SIZE = 16;
 
     /**
      * Capacity of Queue


### PR DESCRIPTION
There is a difference in default value for poolsize between XML and programmatic. XML = 16, programmatic = 8.

Currently I have changed the programmatic one. The question is: which one do we want to change.
