### PR TITLE
Minor clean-up in operations invocation

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/BasicInvocation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/BasicInvocation.java
@@ -153,7 +153,7 @@ abstract class BasicInvocation implements ResponseHandler, Runnable {
         this.tryCount = tryCount;
         this.tryPauseMillis = tryPauseMillis;
         this.callTimeout = getCallTimeout(callTimeout);
-        this.invocationFuture = new BasicInvocationFuture(this, callback);
+        this.invocationFuture = new BasicInvocationFuture(operationService, this, callback);
         this.executorName = executorName;
         this.resultDeserialized = resultDeserialized;
     }
@@ -293,7 +293,7 @@ abstract class BasicInvocation implements ResponseHandler, Runnable {
         long callId = operationService.registerInvocation(this);
         boolean sent = operationService.send(op, invTarget);
         if (!sent) {
-            operationService.deregisterInvocation(callId);
+            operationService.deregisterInvocation(this);
             notify(new RetryableIOException("Packet not send to -> " + invTarget));
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/BasicInvocationFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/BasicInvocationFuture.java
@@ -36,9 +36,11 @@ final class BasicInvocationFuture<E> implements InternalCompletableFuture<E> {
     private BasicInvocation basicInvocation;
     private volatile ExecutionCallbackNode<E> callbackHead;
     private volatile Object response;
+    private final BasicOperationService operationService;
 
-    BasicInvocationFuture(BasicInvocation basicInvocation, final Callback<E> callback) {
+    BasicInvocationFuture(BasicOperationService operationService, BasicInvocation basicInvocation, final Callback<E> callback) {
         this.basicInvocation = basicInvocation;
+        this.operationService = operationService;
 
         if (callback != null) {
             ExecutorCallbackAdapter<E> adapter = new ExecutorCallbackAdapter<E>(callback);
@@ -126,9 +128,7 @@ final class BasicInvocationFuture<E> implements InternalCompletableFuture<E> {
             notifyAll();
         }
 
-        BasicOperationService operationService = (BasicOperationService) basicInvocation.nodeEngine.operationService;
-        operationService.deregisterInvocation(basicInvocation.op.getCallId());
-
+        operationService.deregisterInvocation(basicInvocation);
         notifyCallbacks(callbackChain);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/BasicOperationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/BasicOperationService.java
@@ -358,8 +358,8 @@ final class BasicOperationService implements InternalOperationService {
         return callId;
     }
 
-    public void deregisterInvocation(long id) {
-        invocations.remove(id);
+    public void deregisterInvocation(BasicInvocation invocation) {
+        invocations.remove(invocation.op.getCallId());
     }
 
     @PrivateApi


### PR DESCRIPTION
1. BasicOperationService::registerInvocation accepts BasicInvocation so deregisterInvocation() should be symetric.
2. BasicInvocationFuture explicitly declares its dependency on BasicOperationService rather than traversing fields invocation -> nodeEngine -> operationService and casting.
