### PR TITLE
fixes #3198 + unit test

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapTest.java
@@ -118,7 +118,7 @@ public class ClientMapTest {
             public void entryEvicted(EntryEvent event) {
                 final Object value = event.getValue();
                 final Object oldValue = event.getOldValue();
-                if (value != null) {
+                if (value == null) {
                     nullLatch.countDown();
                 }
                 if (oldValue != null) {

--- a/hazelcast/src/main/java/com/hazelcast/map/MapEventPublisherSupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/MapEventPublisherSupport.java
@@ -77,7 +77,6 @@ class MapEventPublisherSupport implements MapEventPublisher {
         if (registrationsWithValue.isEmpty() && registrationsWithoutValue.isEmpty()) {
             return;
         }
-        dataValue = pickDataValue(eventType, dataOldValue, dataValue);
         final EntryEventData eventData = createEntryEventData(mapName, caller,
                 dataKey, dataValue, dataOldValue, eventType.getType());
         final int orderKey = pickOrderKey(dataKey);
@@ -100,10 +99,6 @@ class MapEventPublisherSupport implements MapEventPublisher {
 
     private int pickOrderKey(Data key) {
         return key == null ? -1 : key.hashCode();
-    }
-
-    private Data pickDataValue(EntryEventType eventType, Data dataOldValue, Data dataValue) {
-        return dataValue;
     }
 
 

--- a/hazelcast/src/test/java/com/hazelcast/map/BasicMapTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/BasicMapTest.java
@@ -208,11 +208,11 @@ public class BasicMapTest extends HazelcastTestSupport {
         final CountDownLatch latch2 = new CountDownLatch(1);
         map.addEntryListener(new EntryAdapter<String, String>() {
             public void entryEvicted(EntryEvent<String, String> event) {
-                if (value1.equals(event.getValue())) {
-                    newList.add(event.getValue());
+                if (value1.equals(event.getOldValue())) {
+                    newList.add(event.getOldValue());
                     latch1.countDown();
-                } else if (value2.equals(event.getValue())) {
-                    newList.add(event.getValue());
+                } else if (value2.equals(event.getOldValue())) {
+                    newList.add(event.getOldValue());
                     latch2.countDown();
                 }
             }
@@ -244,7 +244,7 @@ public class BasicMapTest extends HazelcastTestSupport {
 
             public void entryRemoved(EntryEvent event) {
                 assertEquals("hello", event.getKey());
-                assertEquals("new world", event.getValue());
+                assertEquals("new world", event.getOldValue());
                 latchRemoved.countDown();
             }
 

--- a/hazelcast/src/test/java/com/hazelcast/map/EntryProcessorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/EntryProcessorTest.java
@@ -29,7 +29,8 @@ import com.hazelcast.core.HazelcastInstanceAware;
 import com.hazelcast.core.IMap;
 import com.hazelcast.core.MapEvent;
 import com.hazelcast.core.MapLoader;
-import com.hazelcast.instance.HazelcastInstanceFactory;
+import static com.hazelcast.map.TempData.DeleteEntryProcessor;
+import static com.hazelcast.map.TempData.LoggingEntryProcessor;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.DataSerializable;
@@ -43,11 +44,6 @@ import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.QuickTest;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
-
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -61,15 +57,15 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-
-import static com.hazelcast.map.TempData.DeleteEntryProcessor;
-import static com.hazelcast.map.TempData.LoggingEntryProcessor;
 import static junit.framework.Assert.assertFalse;
 import static junit.framework.Assert.assertNull;
 import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.fail;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category(QuickTest.class)
@@ -656,7 +652,7 @@ public class EntryProcessorTest extends HazelcastTestSupport {
             public void entryRemoved(EntryEvent<Integer, Integer> event) {
                 removeCount.incrementAndGet();
                 if (event.getKey() == 1) {
-                    removeKey1Sum.addAndGet(event.getValue());
+                    removeKey1Sum.addAndGet(event.getOldValue());
                 }
                 latch.countDown();
             }


### PR DESCRIPTION
- fix for issue 3198.
- unit test for issue 3198.
- update for other tests.

*when removed entry from map, then listener event.getValue must return null, event.getOldValue must return removed value.
