### PR TITLE
Spurious wakeup when waiting for a response is now handled properly.

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/BasicInvocation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/BasicInvocation.java
@@ -716,14 +716,7 @@ abstract class BasicInvocation implements Callback<Object>, BackupCompletionCall
                 long lastPollTime = 0;
                 pollCount++;
                 try {
-                    //we should only wait if there is any timeout. We can't call wait with 0, because it is interpreted as infinite.
-                    if (pollTimeoutMs > 0) {
-                        synchronized (this) {
-                            if (response == null || response == WAIT_RESPONSE) {
-                                this.wait(pollTimeoutMs);
-                            }
-                        }
-                    }
+                    pollResponse(pollTimeoutMs);
                     lastPollTime = Clock.currentTimeMillis() - startMs;
                     timeoutMs = decrementTimeout(timeoutMs, lastPollTime);
 
@@ -762,6 +755,20 @@ abstract class BasicInvocation implements Callback<Object>, BackupCompletionCall
                 }
             }
             return TIMEOUT_RESPONSE;
+        }
+
+        private void pollResponse(final long pollTimeoutMs) throws InterruptedException {
+            //we should only wait if there is any timeout. We can't call wait with 0, because it is interpreted as infinite.
+            if (pollTimeoutMs > 0) {
+                long currentTimeoutMs = pollTimeoutMs;
+                final long waitStart = Clock.currentTimeMillis();
+                synchronized (this) {
+                    while (currentTimeoutMs > 0 && (response == null || response == WAIT_RESPONSE)) {
+                        wait(currentTimeoutMs);
+                        currentTimeoutMs = pollTimeoutMs - (Clock.currentTimeMillis() - waitStart);
+                    }
+                }
+            }
         }
 
         private Object newOperationTimeoutException(int pollCount, long pollTimeoutMs) {


### PR DESCRIPTION
Backport of https://github.com/hazelcast/hazelcast/pull/3207
(cherry picked from commit b3c85cc)
