### PR TITLE
SocketConnector should set connection endpoint before registering ReadHa...

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/nio/SocketAcceptor.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/SocketAcceptor.java
@@ -133,7 +133,7 @@ public class SocketAcceptor implements Runnable {
                 memberSocketInterceptor.onAccept(socketChannel.socket());
             }
             socketChannel.configureBlocking(false);
-            connectionManager.assignSocketChannel(socketChannel);
+            connectionManager.assignSocketChannel(socketChannel, null);
         } catch (Exception e) {
             log(Level.WARNING, e.getClass().getName() + ": " + e.getMessage(), e);
             IOUtil.closeResource(socketChannel);

--- a/hazelcast/src/main/java/com/hazelcast/nio/SocketConnector.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/SocketConnector.java
@@ -133,7 +133,7 @@ public class SocketConnector implements Runnable {
             }
 
             socketChannelWrapper.configureBlocking(false);
-            TcpIpConnection connection = connectionManager.assignSocketChannel(socketChannelWrapper);
+            TcpIpConnection connection = connectionManager.assignSocketChannel(socketChannelWrapper, address);
             connection.getWriteHandler().setProtocol(Protocols.CLUSTER);
             connectionManager.sendBindRequest(connection, address, true);
         } catch (Exception e) {

--- a/hazelcast/src/main/java/com/hazelcast/nio/TcpIpConnectionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/TcpIpConnectionManager.java
@@ -307,13 +307,16 @@ public class TcpIpConnectionManager implements ConnectionManager {
         return socketChannelWrapper;
     }
 
-    TcpIpConnection assignSocketChannel(SocketChannelWrapper channel) {
+    TcpIpConnection assignSocketChannel(SocketChannelWrapper channel, Address endpoint) {
         final int index = nextSelectorIndex();
-        final TcpIpConnection connection = new TcpIpConnection(this, inSelectors[index], outSelectors[index], connectionIdGen.incrementAndGet(), channel);
+        final TcpIpConnection connection = new TcpIpConnection(this, inSelectors[index],
+                outSelectors[index], connectionIdGen.incrementAndGet(), channel);
+        connection.setEndPoint(endpoint);
         activeConnections.add(connection);
         acceptedSockets.remove(channel);
         connection.getReadHandler().register();
-        log(Level.INFO, channel.socket().getLocalPort() + " accepted socket connection from " + channel.socket().getRemoteSocketAddress());
+        log(Level.INFO,  "Established socket connection between " + channel.socket().getLocalSocketAddress()
+                + " and " + channel.socket().getRemoteSocketAddress());
         return connection;
     }
 


### PR DESCRIPTION
...ndler. Otherwise when socket is closed between initial connection and bind, Connection to endpoint remains in progress forever.

Possibly; 
fixes #3248 
fixes #3054
fixes #3126 
