### PR TITLE
modified StreamSerializer documentation so the XML example matches the l...

### DIFF
--- a/hazelcast-documentation/src/StreamSerializer.md
+++ b/hazelcast-documentation/src/StreamSerializer.md
@@ -54,7 +54,7 @@ And now, as the last step, let's register the `EmployeeStreamSerializer` in the 
 ```xml
 <serialization>
   <serializers>
-    <serializer type-class="Employee">EmployeeStreamSerializer</serializer>
+    <serializer type-class="Employee" class-name="EmployeeStreamSerializer"></serializer>
   </serializers>
 </serialization>
 ```
@@ -130,7 +130,7 @@ config.getSerializationConfig().addSerializerConfig(sc);
 <hazelcast>
   <serialization>
     <serializers>
-      <serializer type-class="com.www.Foo">com.www.FooXmlSerializer</serializer>
+      <serializer type-class="com.www.Foo" class-name="com.www.FooXmlSerializer"></serializer>
     </serializers>
   </serialization>
 </hazelcast>


### PR DESCRIPTION
I modified the StreamSerializer documentation to make the XML example matches the latest XSD (http://hazelcast.com/schema/spring/hazelcast-spring-3.3.xsd)

hazelcast-spring xsds (versions 3.0-3.3) seem to disallow text nodes inside of the serializer tag, instead exposing the attributes 'implementation' and 'class-name'

I updated the docs to use the class-name attribute instead of the inner text

I tried looking to see which XSD previously allowed the text node, but I couldn't find it, leading me to be curious of whether I am interpreting the XSD incorrectly (and the current doc is actually correct) or if the current doc was always wrong. Some insight on this would be appreciated, thanks!
