### PR TITLE
Fix/3.x/issue 3200

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/cluster/MemberListTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/MemberListTest.java
@@ -71,8 +71,8 @@ public class MemberListTest {
     public void testOutOfSyncMemberList() throws Exception {
         List<HazelcastInstance> instanceList = buildInstances(3, 35701);
         final HazelcastInstance h1 = instanceList.get(0);
-        final HazelcastInstance h2 = instanceList.get(0);
-        final HazelcastInstance h3 = instanceList.get(0);
+        final HazelcastInstance h2 = instanceList.get(1);
+        final HazelcastInstance h3 = instanceList.get(2);
 
         // All three nodes join into one cluster
         assertEquals(3, h1.getCluster().getMembers().size());
@@ -148,8 +148,8 @@ public class MemberListTest {
     public void testOutOfSyncMemberListTwoMasters() throws Exception {
         List<HazelcastInstance> instanceList = buildInstances(3, 35701);
         final HazelcastInstance h1 = instanceList.get(0);
-        final HazelcastInstance h2 = instanceList.get(0);
-        final HazelcastInstance h3 = instanceList.get(0);
+        final HazelcastInstance h2 = instanceList.get(1);
+        final HazelcastInstance h3 = instanceList.get(2);
 
         final MemberImpl m1 = (MemberImpl) h1.getCluster().getLocalMember();
         final MemberImpl m2 = (MemberImpl) h2.getCluster().getLocalMember();
@@ -190,8 +190,8 @@ public class MemberListTest {
     public void testSameMasterDifferentMemberList() throws Exception {
         List<HazelcastInstance> instanceList = buildInstances(3, 45701);
         final HazelcastInstance h1 = instanceList.get(0);
-        final HazelcastInstance h2 = instanceList.get(0);
-        final HazelcastInstance h3 = instanceList.get(0);
+        final HazelcastInstance h2 = instanceList.get(1);
+        final HazelcastInstance h3 = instanceList.get(2);
 
         final MemberImpl m1 = (MemberImpl) h1.getCluster().getLocalMember();
         final MemberImpl m2 = (MemberImpl) h2.getCluster().getLocalMember();


### PR DESCRIPTION
I could only reproduce this issue by running same tests at same time in different processes. I don't know how was this possible in our CI environment. 

To solve this issue, I check available ports for tests. "port-auto-increment" is not suitable for these test cases since these ports are also used for client configurations. So I check ports by myself and use these ports in both of instance and client configurations. 
