### PR TITLE
Hazelcast-2829: Use a single thread executorService to run heartbeat task.

### DIFF
--- a/hazelcast-all/pom.xml
+++ b/hazelcast-all/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.hazelcast</groupId>
         <artifactId>hazelcast-root</artifactId>
-        <version>2.6</version>
+        <version>2.6_TM1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/hazelcast-client/pom.xml
+++ b/hazelcast-client/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.hazelcast</groupId>
         <artifactId>hazelcast-root</artifactId>
-        <version>2.6</version>
+        <version>2.6_TM1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/hazelcast-cloud/pom.xml
+++ b/hazelcast-cloud/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.hazelcast</groupId>
         <artifactId>hazelcast-root</artifactId>
-        <version>2.6</version>
+        <version>2.6_TM1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/hazelcast-documentation/pom.xml
+++ b/hazelcast-documentation/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.hazelcast</groupId>
         <artifactId>hazelcast-root</artifactId>
-        <version>2.6</version>
+        <version>2.6_TM1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/hazelcast-hibernate/pom.xml
+++ b/hazelcast-hibernate/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.hazelcast</groupId>
         <artifactId>hazelcast-root</artifactId>
-        <version>2.6</version>
+        <version>2.6_TM1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/hazelcast-ra/pom.xml
+++ b/hazelcast-ra/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.hazelcast</groupId>
         <artifactId>hazelcast-root</artifactId>
-        <version>2.6</version>
+        <version>2.6_TM1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/hazelcast-spring/pom.xml
+++ b/hazelcast-spring/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.hazelcast</groupId>
         <artifactId>hazelcast-root</artifactId>
-        <version>2.6</version>
+        <version>2.6_TM1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/hazelcast-wm/pom.xml
+++ b/hazelcast-wm/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.hazelcast</groupId>
         <artifactId>hazelcast-root</artifactId>
-        <version>2.6</version>
+        <version>2.6_TM1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/hazelcast/pom.xml
+++ b/hazelcast/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.hazelcast</groupId>
         <artifactId>hazelcast-root</artifactId>
-        <version>2.6</version>
+        <version>2.6_TM1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <groupId>com.hazelcast</groupId>
     <artifactId>hazelcast-root</artifactId>
     <packaging>pom</packaging>
-    <version>2.6</version>
+    <version>2.6_TM1-SNAPSHOT</version>
     <name>Hazelcast Root</name>
     <description>Hazelcast In-Memory DataGrid</description>
     <url>http://www.hazelcast.com/</url>


### PR DESCRIPTION
The Hazelcast server creates a new CallContext object for every calling
thread that performs an operation. Because the ConnectionManager uses a
new thread for every heartbeat execution (every 6-10 seconds), this
results is a memory leak of CallContext objects on the server. Instead,
use a single thread executor service to run the heartbeat check. Since
this check is only performed if the last response was not within the
timeout, it is safe to use a single thread.

(Only the code change in ConnectionManager.java is needed)

More information:
https://github.com/hazelcast/hazelcast/issues/2829
