### PR TITLE
Allow WebFilter subclasses to override HazelcastHttpSession creation

### DIFF
--- a/hazelcast-wm/src/main/java/com/hazelcast/web/WebFilter.java
+++ b/hazelcast-wm/src/main/java/com/hazelcast/web/WebFilter.java
@@ -305,7 +305,7 @@ public class WebFilter implements Filter {
         }
 
         HttpSession originalSession = requestWrapper.getOriginalSession(true);
-        HazelcastHttpSession hazelcastSession = new HazelcastHttpSession(id, originalSession, deferredWrite);
+        HazelcastHttpSession hazelcastSession = createHazelcastHttpSession(id, originalSession, deferredWrite);
         if (existingSessionId == null) {
             hazelcastSession.setClusterWideNew(true);
             // If the session is being created for the first time, add its initial reference in the cluster-wide map.
@@ -316,6 +316,19 @@ public class WebFilter implements Filter {
         addSessionCookie(requestWrapper, id);
 
         return hazelcastSession;
+    }
+
+    /**
+     * {@code HazelcastHttpSession instance} creation is split off to a separate method to allow subclasses to return a
+     * customized / extended version of {@code HazelcastHttpSession}.
+     *
+     * @param id the session id
+     * @param originalSession the original session
+     * @param deferredWrite whether writes are deferred
+     * @return a new HazelcastHttpSession instance
+     */
+    protected HazelcastHttpSession createHazelcastHttpSession(String id, HttpSession originalSession, boolean deferredWrite) {
+        return new HazelcastHttpSession(id, originalSession, deferredWrite);
     }
 
     private void prepareReloadingSession(HazelcastHttpSession hazelcastSession) {


### PR DESCRIPTION
Split of creation of new HazelcastHttpSession instances to a protected method
to allow subclasses to return a customized version of HazelcastHttpSession.

We use `WebFilter` in an application where plugins (OSGI bundles) can access the
`HttpSession`. When these plugins store attributes in the session, we need to wrap
those attributes in a wrapper object to also persist the OSGI bundle information.
This allows us to set the correct class loader before deserializing the session attribute.

Here's how we'd override it

```
public class OsgiSafeWebFilter extends WebFilter {

    public OsgiSafe() {
    }

    public OsgiSafe(Properties properties) {
        super(properties);
    }

    /**
     * Extends Hazelcast's {@code HazelcastHttpSession} to wrap all attributes in a
     * {@link com.atlassian.hazelcast.serialization.OsgiSafe} wrapper. This ensures 
     * that plugins can safely store their data safely in the session without running into
     * class loading issues.
     */
    protected class OsgiSafeHazelcastHttpSession extends HazelcastHttpSession {

        public OsgiSafeHazelcastHttpSession(String id, HttpSession originalSession, boolean deferredWrite) {
            super(id, originalSession, deferredWrite);
        }

        @Override
        public Object getAttribute(String name) {
            return unwrap((OsgiSafe) super.getAttribute(name));
        }

        @Override
        public void setAttribute(String name, Object value) {
            super.setAttribute(name, wrap(value));
        }
    }
}

```
