### PR TITLE
Fix test failure #3278

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/spi/ClientProxyDestroyTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/spi/ClientProxyDestroyTest.java
@@ -27,13 +27,14 @@ public class ClientProxyDestroyTest {
 
     @BeforeClass
     public static void init() {
+        destroy();
         server = Hazelcast.newHazelcastInstance();
         client = HazelcastClient.newHazelcastClient();
     }
 
     @AfterClass
     public static void destroy() {
-        client.shutdown();
+        HazelcastClient.shutdownAll();
         Hazelcast.shutdownAll();
     }
 


### PR DESCRIPTION
Destroy all clients/servers that are still potentially running before the test. Perhaps this causes the test failure
Fixes issue #3278
