### PR TITLE
Management center default update interval has been decreased to 3 secs

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/ManagementCenterConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ManagementCenterConfig.java
@@ -21,7 +21,7 @@ package com.hazelcast.config;
  */
 public class ManagementCenterConfig {
 
-    private static final int UPDATE_INTERVAL = 5;
+    static final int UPDATE_INTERVAL = 3;
 
     private boolean enabled;
 

--- a/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
@@ -58,7 +58,6 @@ public class XmlConfigBuilder extends AbstractXmlConfigHelper implements ConfigB
 
     private static final int DEFAULT_VALUE = 5;
     private static final int THOUSAND_FACTOR = 5;
-    private static final int FIVE = 5;
 
     private Config config;
     private InputStream in;
@@ -1137,7 +1136,7 @@ public class XmlConfigBuilder extends AbstractXmlConfigHelper implements ConfigB
 
         final Node intervalNode = attrs.getNamedItem("update-interval");
         final int interval = intervalNode != null ? getIntegerValue("update-interval",
-                getTextContent(intervalNode), DEFAULT_VALUE) : FIVE;
+                getTextContent(intervalNode), ManagementCenterConfig.UPDATE_INTERVAL) : ManagementCenterConfig.UPDATE_INTERVAL;
 
         final String url = getTextContent(node);
         ManagementCenterConfig managementCenterConfig = config.getManagementCenterConfig();

--- a/hazelcast/src/main/java/com/hazelcast/management/ManagementCenterService.java
+++ b/hazelcast/src/main/java/com/hazelcast/management/ManagementCenterService.java
@@ -84,7 +84,7 @@ public class ManagementCenterService {
     static final int HTTP_SUCCESS = 200;
     static final int CONNECTION_TIMEOUT_MILLIS = 5000;
     static final long SLEEP_BETWEEN_POLL_MILLIS = 1000;
-    static final long DEFAULT_UPDATE_INTERVAL = 5000;
+    static final long DEFAULT_UPDATE_INTERVAL = 3000;
 
     private final HazelcastInstanceImpl instance;
     private final TaskPollThread taskPollThread;


### PR DESCRIPTION
Management center aggregates statistics for a 5 seconds interval, sending updates from Hazelcast in also 5 seconds causes incorrect statistics in case of slightest network latency. (Some of the cluster members might miss the related 5 seconds window)
After changing this interval to 3 secs, now management center should be able to handle network latency cases better.
