### PR TITLE
a fix for #3442

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/stress/MapUpdateStressTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/stress/MapUpdateStressTest.java
@@ -50,11 +50,10 @@ public class MapUpdateStressTest extends StressTestSupport {
 
     @After
     public void tearDown() {
-        super.tearDown();
-
         if (client != null) {
             client.shutdown();
         }
+        super.tearDown();
     }
 
     //@Test

--- a/hazelcast-client/src/test/java/com/hazelcast/client/stress/StressTestSupport.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/stress/StressTestSupport.java
@@ -50,6 +50,14 @@ public abstract class StressTestSupport extends HazelcastTestSupport {
 
     @After
     public void tearDown() {
+        stopTest = true;
+        if (killMemberThread != null) {
+            try {
+                killMemberThread.join(TimeUnit.SECONDS.toMillis(KILL_DELAY_SECONDS * 4));
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+        }
         for (HazelcastInstance hz : instances) {
             try {
                 hz.shutdown();


### PR DESCRIPTION
#3442

a race-condition fixed in stress tests. a test is now always waiting for KillMemberThread to finish.
