### PR TITLE
Fix for #3454 ISet iterator.remove() now throws UnsupportedOperationException

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/AbstractClientCollectionProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/AbstractClientCollectionProxy.java
@@ -42,6 +42,7 @@ import com.hazelcast.spi.impl.SerializableCollection;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -79,7 +80,7 @@ public class AbstractClientCollectionProxy<E> extends ClientProxy implements ICo
     }
 
     public Iterator<E> iterator() {
-        return getAll().iterator();
+        return Collections.unmodifiableCollection(getAll()).iterator();
     }
 
     public Object[] toArray() {

--- a/hazelcast/src/main/java/com/hazelcast/collection/AbstractCollectionProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/AbstractCollectionProxyImpl.java
@@ -33,6 +33,7 @@ import com.hazelcast.util.ExceptionUtil;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -171,7 +172,7 @@ public abstract class AbstractCollectionProxyImpl<S extends RemoteService, E> ex
     }
 
     public Iterator<E> iterator() {
-        return getAll().iterator();
+        return Collections.unmodifiableCollection(getAll()).iterator();
     }
 
     public Object[] toArray() {

--- a/hazelcast/src/test/java/com/hazelcast/collection/SetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/SetTest.java
@@ -25,6 +25,7 @@ import com.hazelcast.core.ItemListener;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ClientCompatibleTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -182,6 +183,21 @@ public class SetTest extends HazelcastTestSupport {
         assertFalse(set.add("item"));
         assertNotNull(set.remove("item0"));
         assertTrue(set.add("item"));
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    @ClientCompatibleTest
+    public void testIteratorRemoveThrowsUnsupportedOperationException() {
+        Config config = new Config();
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(1);
+        HazelcastInstance instance1 = factory.newHazelcastInstance(config);
+
+        ISet set = instance1.getSet("defSet");
+        set.add("item");
+
+        Iterator iterator = set.iterator();
+        iterator.next();
+        iterator.remove();
     }
 
     private ISet getSet(HazelcastInstance[] instances, String name){


### PR DESCRIPTION
Backporting fix to maintenance branch.
The ISet iterator is now taken from a collection wrapped in `Collections.unmodifiableCollection`. Trying to remove items from it will result in UnsupportedOperationException.

Fixes #3454 
