### PR TITLE
SSLEngine.closeOutbound() should be called on writer thread. Added an op...

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/nio/ssl/SSLSocketChannelWrapper.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/ssl/SSLSocketChannelWrapper.java
@@ -17,15 +17,17 @@
 package com.hazelcast.nio.ssl;
 
 import com.hazelcast.nio.tcp.DefaultSocketChannelWrapper;
-import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.nio.channels.SocketChannel;
+import com.hazelcast.util.EmptyStatement;
+
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLEngineResult;
 import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLHandshakeException;
 import javax.net.ssl.SSLSession;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.SocketChannel;
 
 public class SSLSocketChannelWrapper extends DefaultSocketChannelWrapper {
 
@@ -87,7 +89,7 @@ public class SSLSocketChannelWrapper extends DefaultSocketChannelWrapper {
                         log("Begin UNWRAP");
                     }
                     netInBuffer.clear();
-                    while (socketChannel.read(netInBuffer) < 1) {
+                    while (socketChannel.read(netInBuffer) == 0) {
                         try {
                             if (DEBUG) {
                                 log("Spinning on channel read...");
@@ -189,6 +191,7 @@ public class SSLSocketChannelWrapper extends DefaultSocketChannelWrapper {
             sslEngineResult = sslEngine.wrap(input, netOutBuffer);
         }
         netOutBuffer.flip();
+
         int written = socketChannel.write(netOutBuffer);
         if (netOutBuffer.hasRemaining()) {
             netOutBuffer.compact();
@@ -248,12 +251,19 @@ public class SSLSocketChannelWrapper extends DefaultSocketChannelWrapper {
     }
 
     @Override
-    public void close() throws IOException {
+    public void closeOutbound() throws IOException {
+        super.closeOutbound();
+
         sslEngine.closeOutbound();
         try {
             writeInternal(emptyBuffer);
         } catch (Exception ignored) {
+            EmptyStatement.ignore(ignored);
         }
+    }
+
+    @Override
+    public void close() throws IOException {
         socketChannel.close();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/AbstractSelectionHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/AbstractSelectionHandler.java
@@ -44,9 +44,6 @@ abstract class AbstractSelectionHandler implements SelectionHandler {
         this.logger = connectionManager.ioService.getLogger(this.getClass().getName());
     }
 
-    protected void shutdown() {
-    }
-
     final void handleSocketException(Throwable e) {
         if (e instanceof OutOfMemoryError) {
             connectionManager.ioService.onOutOfMemory((OutOfMemoryError) e);

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/DefaultSocketChannelWrapper.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/DefaultSocketChannelWrapper.java
@@ -75,6 +75,14 @@ public class DefaultSocketChannelWrapper implements SocketChannelWrapper {
     }
 
     @Override
+    public void closeInbound() throws IOException {
+    }
+
+    @Override
+    public void closeOutbound() throws IOException {
+    }
+
+    @Override
     public void close() throws IOException {
         socketChannel.close();
     }

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/ReadHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/ReadHandler.java
@@ -134,4 +134,18 @@ final class ReadHandler extends AbstractSelectionHandler implements Runnable {
         ioSelector.addTask(this);
         ioSelector.wakeup();
     }
+
+    void shutdown() {
+        ioSelector.addTask(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    socketChannel.closeInbound();
+                } catch (IOException e) {
+                    logger.finest("Error while closing inbound", e);
+                }
+            }
+        });
+        ioSelector.wakeup();
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/SocketChannelWrapper.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/SocketChannelWrapper.java
@@ -47,5 +47,26 @@ public interface SocketChannelWrapper extends Closeable {
 
     boolean isOpen();
 
+    /**
+     * Closes inbound.
+     *
+     * <p>Not thread safe. Should be called in channel reader thread.</p>
+     * @throws IOException
+     */
+    void closeInbound() throws IOException;
+
+    /**
+     * Closes outbound.
+     *
+     * <p>Not thread safe. Should be called in channel writer thread.</p>
+     * @throws IOException
+     */
+    void closeOutbound() throws IOException;
+
+    /**
+     * Closes socket channel.
+     *
+     * @throws IOException
+     */
     void close() throws IOException;
 }

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnection.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnection.java
@@ -186,11 +186,12 @@ public final class TcpIpConnection implements Connection {
             return;
         }
         live = false;
+
         if (socketChannel != null && socketChannel.isOpen()) {
+            readHandler.shutdown();
+            writeHandler.shutdown();
             socketChannel.close();
         }
-        readHandler.shutdown();
-        writeHandler.shutdown();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/WriteHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/WriteHandler.java
@@ -21,7 +21,9 @@ import com.hazelcast.nio.Protocols;
 import com.hazelcast.nio.SocketWritable;
 import com.hazelcast.nio.ascii.SocketTextWriter;
 import com.hazelcast.util.Clock;
+import com.hazelcast.util.EmptyStatement;
 
+import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.SelectionKey;
 import java.util.Queue;
@@ -193,9 +195,28 @@ public final class WriteHandler extends AbstractSelectionHandler implements Runn
         registerOp(ioSelector.getSelector(), SelectionKey.OP_WRITE);
     }
 
-    @Override
     public void shutdown() {
         while (poll() != null) {
+        }
+
+        final CountDownLatch latch = new CountDownLatch(1);
+        ioSelector.addTask(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    socketChannel.closeOutbound();
+                } catch (IOException e) {
+                    logger.finest("Error while closing outbound", e);
+                } finally {
+                    latch.countDown();
+                }
+            }
+        });
+        ioSelector.wakeup();
+        try {
+            latch.await(TIMEOUT, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            EmptyStatement.ignore(e);
         }
     }
 


### PR DESCRIPTION
...tion to close inbound and outbound channels in reader and writer threads.

Fixes hazelcast/hazelcast-enterprise#35
