### PR TITLE
Number of evicted events should not exceed map size when read backup data enabled

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/RecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/RecordStore.java
@@ -18,8 +18,8 @@ package com.hazelcast.map.impl;
 
 import com.hazelcast.core.EntryView;
 import com.hazelcast.map.impl.mapstore.MapDataStore;
-import com.hazelcast.map.merge.MapMergePolicy;
 import com.hazelcast.map.impl.record.Record;
+import com.hazelcast.map.merge.MapMergePolicy;
 import com.hazelcast.nio.serialization.Data;
 
 import java.util.Collection;
@@ -61,7 +61,13 @@ public interface RecordStore {
      */
     void removeBackup(Data dataKey);
 
-    Object get(Data dataKey);
+    /**
+     * Gets record from {@link com.hazelcast.map.impl.RecordStore}
+     * @param dataKey key.
+     * @param backup  <code>true</code> if a backup partition, otherwise <code>false</code>.
+     * @return value of an entry in {@link com.hazelcast.map.impl.RecordStore}
+     */
+    Object get(Data dataKey, boolean backup);
 
     MapEntrySet getAll(Set<Data> keySet);
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/GetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/GetOperation.java
@@ -34,7 +34,7 @@ public final class GetOperation extends KeyBasedMapOperation
     }
 
     public void run() {
-        result = mapService.getMapServiceContext().toData(recordStore.get(dataKey));
+        result = mapService.getMapServiceContext().toData(recordStore.get(dataKey, false));
     }
 
     public void afterRun() {


### PR DESCRIPTION
Fixes https://github.com/hazelcast/hazelcast/issues/3515

PR Contains:
- Rename `getRecord` to `getRecordOrNull`
- Fire eviction event when node is owner
