### PR TITLE
Number of evicted events should not exceed map size when read backup data enabled

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/DefaultRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/DefaultRecordStore.java
@@ -87,7 +87,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore implements 
     public void flush() {
         final Collection<Data> processedKeys = mapDataStore.flush();
         for (Data key : processedKeys) {
-            final Record record = getRecord(key, false);
+            final Record record = getRecordOrNull(key, false);
             if (record != null) {
                 record.onStore();
             }
@@ -124,7 +124,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore implements 
         final long now = getNow();
         markRecordStoreExpirable(ttl);
 
-        Record record = getRecord(key, true);
+        Record record = getRecordOrNull(key, true);
         if (record == null) {
             record = createRecord(key, value, ttl, now);
             records.put(key, record);
@@ -277,9 +277,9 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore implements 
     @Override
     public Map.Entry<Data, Object> getMapEntry(Data key) {
         checkIfLoaded();
-        Record record = getRecord(key, false);
+        Record record = getRecordOrNull(key, false);
         if (record == null) {
-            record = loadRecordOrNull(key, true);
+            record = loadRecordOrNull(key, false);
         } else {
             accessRecord(record);
         }
@@ -292,9 +292,9 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore implements 
     @Override
     public Map.Entry<Data, Object> getMapEntryForBackup(Data dataKey) {
         checkIfLoaded();
-        Record record = getRecord(dataKey, true);
+        Record record = getRecordOrNull(dataKey, true);
         if (record == null) {
-            record = loadRecordOrNull(dataKey, false);
+            record = loadRecordOrNull(dataKey, true);
         } else {
             accessRecord(record);
         }
@@ -302,13 +302,13 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore implements 
         return new AbstractMap.SimpleImmutableEntry<Data, Object>(dataKey, data);
     }
 
-    private Record loadRecordOrNull(Data key, boolean enableIndex) {
+    private Record loadRecordOrNull(Data key, boolean backup) {
         Record record = null;
         final Object value = mapDataStore.load(key);
         if (value != null) {
             record = createRecord(key, value, getNow());
             records.put(key, record);
-            if (enableIndex) {
+            if (!backup) {
                 saveIndex(record);
             }
             updateSizeEstimator(calculateRecordHeapCost(record));
@@ -352,7 +352,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore implements 
         final Map<Data, Record> lockedRecords = new HashMap<Data, Record>(lockedKeys.size());
         // Locked records should not be removed!
         for (Data key : lockedKeys) {
-            Record record = getRecord(key, false);
+            Record record = getRecordOrNull(key, false);
             if (record != null) {
                 lockedRecords.put(key, record);
                 updateSizeEstimator(calculateRecordHeapCost(record));
@@ -460,7 +460,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore implements 
         final Map<Data, Record> lockedRecords = new HashMap<Data, Record>(lockedKeys.size());
         // Locked records should not be removed!
         for (Data key : lockedKeys) {
-            Record record = getRecord(key, backup);
+            Record record = getRecordOrNull(key, backup);
             if (record != null) {
                 lockedRecords.put(key, record);
             }
@@ -472,7 +472,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore implements 
     public void removeBackup(Data key) {
         final long now = getNow();
 
-        final Record record = getRecord(key, true);
+        final Record record = getRecordOrNull(key, true);
         if (record == null) {
             return;
         }
@@ -488,7 +488,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore implements 
         checkIfLoaded();
         final long now = getNow();
 
-        final Record record = getRecord(key, false);
+        final Record record = getRecordOrNull(key, false);
         Object oldValue;
         if (record == null) {
             oldValue = mapDataStore.load(key);
@@ -508,7 +508,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore implements 
         checkIfLoaded();
         final long now = getNow();
 
-        Record record = getRecord(key, false);
+        Record record = getRecordOrNull(key, false);
         Object oldValue;
         boolean removed = false;
         if (record == null) {
@@ -538,7 +538,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore implements 
         checkIfLoaded();
         final long now = getNow();
 
-        Record record = getRecord(key, false);
+        Record record = getRecordOrNull(key, false);
         if (record == null) {
             removeIndex(key);
             mapDataStore.remove(key, now);
@@ -550,13 +550,13 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore implements 
     }
 
     @Override
-    public Object get(Data key) {
+    public Object get(Data key, boolean backup) {
         checkIfLoaded();
         long now = getNow();
 
-        Record record = getRecord(key, false);
+        Record record = getRecordOrNull(key, backup);
         if (record == null) {
-            record = loadRecordOrNull(key, true);
+            record = loadRecordOrNull(key, backup);
         } else {
             accessRecord(record, now);
         }
@@ -578,7 +578,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore implements 
         final Iterator<Data> iterator = keys.iterator();
         while (iterator.hasNext()) {
             final Data key = iterator.next();
-            Record record = getRecord(key, false);
+            Record record = getRecordOrNull(key, false);
             if (record != null) {
                 addMapEntrySet(record.getKey(), record.getValue(), mapEntrySet);
                 accessRecord(record);
@@ -612,7 +612,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore implements 
         checkIfLoaded();
         final long now = getNow();
 
-        Record record = getRecord(key, false);
+        Record record = getRecordOrNull(key, false);
         if (record == null) {
             Object value = mapDataStore.load(key);
             if (value != null) {
@@ -637,7 +637,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore implements 
 
         Data key = entry.getKey();
         Object value = entry.getValue();
-        Record record = getRecord(key, false);
+        Record record = getRecordOrNull(key, false);
         if (record == null) {
             value = mapServiceContext.interceptPut(name, null, value);
             value = mapDataStore.add(key, value, now);
@@ -667,7 +667,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore implements 
         final long now = getNow();
         markRecordStoreExpirable(ttl);
 
-        Record record = getRecord(key, false);
+        Record record = getRecordOrNull(key, false);
         Object oldValue;
         if (record == null) {
             oldValue = mapDataStore.load(key);
@@ -700,7 +700,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore implements 
         final long now = getNow();
         markRecordStoreExpirable(ttl);
 
-        Record record = getRecord(key, false);
+        Record record = getRecordOrNull(key, false);
         boolean newRecord = false;
         if (record == null) {
             value = mapServiceContext.interceptPut(name, null, value);
@@ -729,7 +729,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore implements 
     public boolean merge(Data key, EntryView mergingEntry, MapMergePolicy mergePolicy) {
         checkIfLoaded();
         final long now = getNow();
-        Record record = getRecord(key, false);
+        Record record = getRecordOrNull(key, false);
         Object newValue;
         if (record == null) {
             final Object notExistingKey = mapServiceContext.toObject(key);
@@ -779,7 +779,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore implements 
         checkIfLoaded();
         final long now = getNow();
 
-        Record record = getRecord(key, false);
+        Record record = getRecordOrNull(key, false);
         Object oldValue;
         if (record != null && record.getValue() != null) {
             oldValue = record.getValue();
@@ -802,7 +802,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore implements 
         checkIfLoaded();
         final long now = getNow();
 
-        Record record = getRecord(key, false);
+        Record record = getRecordOrNull(key, false);
         if (record == null) {
             return false;
         }
@@ -827,7 +827,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore implements 
         final long now = getNow();
         markRecordStoreExpirable(ttl);
 
-        Record record = getRecord(key, false);
+        Record record = getRecordOrNull(key, false);
         if (record == null) {
             value = mapServiceContext.interceptPut(name, null, value);
             record = createRecord(key, value, ttl, now);
@@ -855,7 +855,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore implements 
         final long now = getNow();
         markRecordStoreExpirable(ttl);
 
-        Record record = getRecord(key, false);
+        Record record = getRecordOrNull(key, false);
         Object oldValue = null;
         if (record == null) {
             value = mapServiceContext.interceptPut(name, null, value);
@@ -881,7 +881,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore implements 
         final long now = getNow();
         markRecordStoreExpirable(ttl);
 
-        Record record = getRecord(key, false);
+        Record record = getRecordOrNull(key, false);
         if (record == null) {
             value = mapServiceContext.interceptPut(name, null, value);
             value = mapDataStore.add(key, value, now);
@@ -908,7 +908,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore implements 
         final long now = getNow();
         markRecordStoreExpirable(ttl);
 
-        Record record = getRecord(key, false);
+        Record record = getRecordOrNull(key, false);
         Object oldValue;
         if (record == null) {
             oldValue = mapDataStore.load(key);
@@ -963,8 +963,11 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore implements 
         return oldValue;
     }
 
-    private Record getRecord(Data key, boolean backup) {
+    private Record getRecordOrNull(Data key, boolean backup) {
         Record record = records.get(key);
+        if (record == null) {
+            return null;
+        }
         return getOrNullIfExpired(record, backup);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/RecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/RecordStore.java
@@ -61,7 +61,14 @@ public interface RecordStore {
      */
     void removeBackup(Data dataKey);
 
-    Object get(Data dataKey);
+    /**
+     * Gets record from {@link com.hazelcast.map.RecordStore}
+     *
+     * @param dataKey key.
+     * @param backup  <code>true</code> if a backup partition, otherwise <code>false</code>.
+     * @return value of an entry in {@link com.hazelcast.map.RecordStore}
+     */
+    Object get(Data dataKey, boolean backup);
 
     MapEntrySet getAll(Set<Data> keySet);
 

--- a/hazelcast/src/main/java/com/hazelcast/map/operation/GetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/operation/GetOperation.java
@@ -34,7 +34,7 @@ public final class GetOperation extends KeyBasedMapOperation
     }
 
     public void run() {
-        result = mapService.getMapServiceContext().toData(recordStore.get(dataKey));
+        result = mapService.getMapServiceContext().toData(recordStore.get(dataKey, false));
     }
 
     public void afterRun() {


### PR DESCRIPTION
Fixes https://github.com/hazelcast/hazelcast/issues/3515

PR Contains:
- Rename `getRecord` to `getRecordOrNull`
- Fire eviction event when node is owner
