### PR TITLE
Fixes a race problem on close and also a JMM violation.

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheProxy.java
@@ -847,7 +847,7 @@ public class CacheProxy<K, V>
 
     @Override
     public void close() {
-        if(!closed.compareAndSet(false,true)){
+        if (!closed.compareAndSet(false, true)) {
             return;
         }
 


### PR DESCRIPTION
the isClosed isn't volatile an there is no other synchronization mechanism; so it can safely be used in a multithreaded environment.

Also the close method itself is racy if multiple threads at the same time call close.
