### PR TITLE
IdGenerator can now be initialised with 0 to get id 1. #3533

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientIdGeneratorProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientIdGeneratorProxy.java
@@ -45,7 +45,7 @@ public class ClientIdGeneratorProxy extends ClientProxy implements IdGenerator {
     }
 
     public boolean init(long id) {
-        if (id <= 0) {
+        if (id < 0) {
             return false;
         }
         long step = (id / BLOCK_SIZE);

--- a/hazelcast-client/src/test/java/com/hazelcast/client/idgenerator/ClientIdGeneratorTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/idgenerator/ClientIdGeneratorTest.java
@@ -16,21 +16,22 @@
 
 package com.hazelcast.client.idgenerator;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
 import com.hazelcast.client.HazelcastClient;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IdGenerator;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 /**
  * @author ali 5/28/13
@@ -39,21 +40,27 @@ import static org.junit.Assert.assertTrue;
 @Category(QuickTest.class)
 public class ClientIdGeneratorTest {
 
-    static final String name = "test";
-    static HazelcastInstance hz;
-    static IdGenerator i;
+    private final String name = "test";
+    private HazelcastInstance hz;
+    private IdGenerator i;
 
-    @BeforeClass
-    public static void init() {
+    @Before
+    public void init() {
         Hazelcast.newHazelcastInstance();
         hz = HazelcastClient.newHazelcastClient(null);
         i = hz.getIdGenerator(name);
     }
 
-    @AfterClass
-    public static void destroy() {
+    @After
+    public void destroy() {
         hz.shutdown();
         Hazelcast.shutdownAll();
+    }
+
+    @Test
+    public void testInit0_GivesId1() throws Exception {
+        assertTrue( i.init(0) );
+        assertEquals(1, i.newId());
     }
 
     @Test
@@ -62,6 +69,5 @@ public class ClientIdGeneratorTest {
         assertFalse(i.init(4569));
         assertEquals(3570, i.newId());
     }
-
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/idgen/IdGeneratorProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/idgen/IdGeneratorProxy.java
@@ -48,7 +48,7 @@ public class IdGeneratorProxy
 
     @Override
     public boolean init(long id) {
-        if (id <= 0) {
+        if (id < 0) {
             return false;
         }
         long step = (id / BLOCK_SIZE);

--- a/hazelcast/src/main/java/com/hazelcast/core/IdGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/IdGenerator.java
@@ -25,7 +25,7 @@ public interface IdGenerator extends DistributedObject {
      * Try to initialize this IdGenerator instance with given id. The first
      * generated id will be 1 bigger than id.
      *
-     * @return true if initialization success. If id is equal or smaller
+     * @return true if initialization succeeded. If id is smaller
      * than 0, then false is returned.
      */
     boolean init(long id);

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/idgen/IdGeneratorProxyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/idgen/IdGeneratorProxyTest.java
@@ -1,0 +1,83 @@
+package com.hazelcast.concurrent.idgen;
+
+import static com.hazelcast.mock.IAtomicLongMocks.mockIAtomicLong;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.UUID;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import com.hazelcast.core.IAtomicLong;
+import com.hazelcast.core.IdGenerator;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category(QuickTest.class)
+public class IdGeneratorProxyTest {
+
+    private IdGenerator idGenerator = createIdGenerator();
+
+    @Test
+    public void testInitIncrements() {
+        assertNewIdAfterInit(0);
+        assertNewIdAfterInit(1);
+        assertNewIdAfterInit(10);
+    }
+
+    @Test
+    public void testInitFailsOnNegativeValues() {
+        assertFalse( idGenerator.init(-1) );
+    }
+
+    @Test
+    public void testInitFailsWhenAlreadyInitialized() {
+        long first = idGenerator.newId();
+
+        assertFalse( idGenerator.init(10) );
+
+        assertEquals(first + 1, idGenerator.newId());
+    }
+
+    @Test
+    public void testNewId_withExplicitInit() {
+
+        assertTrue( idGenerator.init(10) );
+
+        long result = idGenerator.newId();
+        assertEquals(11, result);
+    }
+
+    @Test
+    public void testNewId0_withoutExplictInit() {
+        long result = idGenerator.newId();
+        assertEquals(0, result);
+    }
+
+    @Test
+    public void testGeneratingMultipleBlocks() {
+        for (int k = 0; k < 3 * IdGeneratorProxy.BLOCK_SIZE; k++) {
+            assertEquals(k, idGenerator.newId());
+        }
+    }
+
+	private static void assertNewIdAfterInit(int initialValue) {
+	    IdGenerator idGenerator = createIdGenerator();
+
+	    assertTrue( idGenerator.init(initialValue) );
+
+	    assertEquals(initialValue+1, idGenerator.newId());
+	}
+
+	private static IdGenerator createIdGenerator() {
+		String name = "id-" + UUID.randomUUID().toString();
+
+		IAtomicLong blockGenerator = mockIAtomicLong();
+
+		return new IdGeneratorProxy(blockGenerator, name, null, null);
+	}
+}

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/idgen/IdGeneratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/idgen/IdGeneratorTest.java
@@ -1,20 +1,21 @@
 package com.hazelcast.concurrent.idgen;
 
-import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.IdGenerator;
-import com.hazelcast.test.HazelcastParallelClassRunner;
-import com.hazelcast.test.HazelcastTestSupport;
-import com.hazelcast.test.annotation.QuickTest;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.UUID;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import java.util.UUID;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IdGenerator;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.QuickTest;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category(QuickTest.class)
@@ -29,8 +30,8 @@ public class IdGeneratorTest extends HazelcastTestSupport {
 
     @Test
     public void testInit() {
-        testInit(0, false, 0);
         testInit(-1, false, 0);
+        testInit(0, true, 1);
         testInit(1, true, 2);
         testInit(10, true, 11);
     }

--- a/hazelcast/src/test/java/com/hazelcast/mock/IAtomicLongMocks.java
+++ b/hazelcast/src/test/java/com/hazelcast/mock/IAtomicLongMocks.java
@@ -1,0 +1,24 @@
+package com.hazelcast.mock;
+
+import static com.hazelcast.mock.MockUtil.delegateTo;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+import com.hazelcast.core.IAtomicLong;
+
+public class IAtomicLongMocks {
+
+    /** Creates mocks IAtomicLong which wraps an AtomicLong **/
+    public static IAtomicLong mockIAtomicLong() {
+        final AtomicLong atomicLong = new AtomicLong(); // keeps actual value
+        IAtomicLong iAtomicLong = mock(IAtomicLong.class);
+
+        when( iAtomicLong.getAndIncrement() ).then( delegateTo(atomicLong) );
+        when( iAtomicLong.compareAndSet(anyLong(), anyLong()) ).then( delegateTo(atomicLong) );
+
+        return iAtomicLong;
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/mock/MockUtil.java
+++ b/hazelcast/src/test/java/com/hazelcast/mock/MockUtil.java
@@ -1,0 +1,38 @@
+package com.hazelcast.mock;
+
+import java.lang.reflect.Method;
+
+import org.mockito.AdditionalAnswers;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+public class MockUtil {
+
+    @SuppressWarnings("unchecked")
+    /** Delegate calls to another object **/
+    public static <T> Answer<T> delegateTo(Object delegate) {
+        return (Answer<T>) new DelegatingAnswer(delegate);
+    }
+
+    /**
+     * Mockito Answer that delegates invocations to another object. Similar to
+     * {@link AdditionalAnswers#delegatesTo(Object)} but also supports objects
+     * of different Class.
+     **/
+    static class DelegatingAnswer implements Answer<Object> {
+
+        private Object delegated;
+
+        public DelegatingAnswer(Object delegated) {
+            this.delegated = delegated;
+        }
+
+        @Override
+        public Object answer(InvocationOnMock inv) throws Throwable {
+            Method m = inv.getMethod();
+            Method rm = delegated.getClass().getMethod(m.getName(),
+                    m.getParameterTypes());
+            return rm.invoke(delegated, inv.getArguments());
+        }
+    }
+}


### PR DESCRIPTION
IdGenerator can now be initialised with 0 to get new id 1. Issue #3533
- Created standalone unit test for IdGeneratorProxy
- Updated javadoc
