### PR TITLE
Fixed utf serialization for substrings. On jdk6 substrings share the sam...

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/nio/UTFEncoderDecoder.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/UTFEncoderDecoder.java
@@ -17,6 +17,7 @@
 package com.hazelcast.nio;
 
 import com.hazelcast.logging.Logger;
+import com.hazelcast.util.EmptyStatement;
 import com.hazelcast.util.QuickMath;
 
 import java.io.DataInput;
@@ -35,56 +36,31 @@ public final class UTFEncoderDecoder {
     private static final int STRING_CHUNK_SIZE = 16 * 1024;
 
     private static final UTFEncoderDecoder INSTANCE;
-    private static final StringValueArrayProviderFactory STRING_VALUE_ARRAY_PROVIDER_FACTORY;
 
-    // TODO Currently ASCII state support is disabled as default because of some failing unit tests.
     // Because this flag is not set for Non-Buffered Data Output classes
     // but results may be compared in unit tests.
     // Buffered Data Output may set this flag
     // but Non-Buffered Data Output class always set this flag to "false".
     // So their results may be different.
     private static final boolean ASCII_AWARE =
-            Boolean.parseBoolean(
-                    System.getProperty("hazelcast.nio.asciiaware", "false"));
-
-    private static final CharArrayBasedUtfWriter CHAR_ARRAY_BASED_UTF_WRITER =
-            new CharArrayBasedUtfWriter();
-    private static final StringBasedUtfWriter STRING_BASED_UTF_WRITER =
-            new StringBasedUtfWriter();
+            Boolean.parseBoolean(System.getProperty("hazelcast.nio.asciiaware", "false"));
 
     static {
         INSTANCE = buildUTFUtil();
-
-        // Try Unsafe based implementation
-        StringValueArrayProviderFactory stringValueArrayProviderFactory =
-                new UnsafeBasedStringCharProviderFactory();
-        // If Unsafe based implementation is not available for usage
-        if (!stringValueArrayProviderFactory.isAvailable()) {
-            // Try Reflection based implementation
-            stringValueArrayProviderFactory = new ReflectionBasedStringCharProviderFactory();
-            // If Reflection based implementation is not available for usage
-            if (!stringValueArrayProviderFactory.isAvailable()) {
-                stringValueArrayProviderFactory = null;
-            }
-        }
-        STRING_VALUE_ARRAY_PROVIDER_FACTORY = stringValueArrayProviderFactory;
     }
 
     private final StringCreator stringCreator;
+    private final UtfWriter utfWriter;
     private final boolean hazelcastEnterpriseActive;
 
-    private UTFEncoderDecoder(boolean fastStringCreator) {
-        this(fastStringCreator ? buildFastStringCreator() : new DefaultStringCreator(), false);
+    UTFEncoderDecoder(StringCreator stringCreator, UtfWriter utfWriter) {
+        this(stringCreator, utfWriter, false);
     }
 
-    private UTFEncoderDecoder(StringCreator stringCreator,
-                                       boolean hazelcastEnterpriseActive) {
+    UTFEncoderDecoder(StringCreator stringCreator, UtfWriter utfWriter, boolean hazelcastEnterpriseActive) {
         this.stringCreator = stringCreator;
+        this.utfWriter = utfWriter;
         this.hazelcastEnterpriseActive = hazelcastEnterpriseActive;
-    }
-
-    public StringCreator getStringCreator() {
-        return stringCreator;
     }
 
     public boolean isHazelcastEnterpriseActive() {
@@ -117,15 +93,6 @@ public final class UTFEncoderDecoder {
             return;
         }
 
-        final StringValueArrayProvider stringValueArrayProvider =
-                STRING_VALUE_ARRAY_PROVIDER_FACTORY != null
-                        ? STRING_VALUE_ARRAY_PROVIDER_FACTORY.create(str)
-                        : null;
-        final UtfWriter utfWriter =
-                stringValueArrayProvider != null
-                        ? CHAR_ARRAY_BASED_UTF_WRITER
-                        : STRING_BASED_UTF_WRITER;
-
         int length = str.length();
         out.writeInt(length);
         out.writeInt(length);
@@ -134,128 +101,16 @@ public final class UTFEncoderDecoder {
             for (int i = 0; i < chunkSize; i++) {
                 int beginIndex = Math.max(0, i * STRING_CHUNK_SIZE - 1);
                 int endIndex = Math.min((i + 1) * STRING_CHUNK_SIZE - 1, length);
-                utfWriter.writeShortUTF(stringValueArrayProvider, out, str, beginIndex, endIndex, buffer);
+                utfWriter.writeShortUTF(out, str, beginIndex, endIndex, buffer);
             }
         }
     }
 
     // ********************************************************************* //
 
-    private interface StringValueArrayProviderFactory {
+    interface UtfWriter {
 
-        boolean isAvailable();
-        StringValueArrayProvider create(String str);
-
-    }
-
-    private static class UnsafeBasedStringCharProviderFactory
-            implements StringValueArrayProviderFactory {
-
-        private static long stringValueFieldOffset = -1;
-        private static sun.misc.Unsafe unsafe;
-
-        static {
-            if (UnsafeHelper.UNSAFE_AVAILABLE) {
-                unsafe = UnsafeHelper.UNSAFE;
-                try {
-                    stringValueFieldOffset =
-                            unsafe.objectFieldOffset(String.class.getDeclaredField("value"));
-                } catch (Throwable t) {
-                    t.printStackTrace();
-                }
-            }
-        }
-
-        @Override
-        public StringValueArrayProvider create(String str) {
-            return new UnsafeBasedStringCharProvider(unsafe, stringValueFieldOffset, str);
-        }
-
-        @Override
-        public boolean isAvailable() {
-            return unsafe != null && stringValueFieldOffset != -1;
-        }
-
-    }
-
-    private static class ReflectionBasedStringCharProviderFactory
-            implements StringValueArrayProviderFactory {
-
-        private static Field valueArrayField;
-
-        static {
-            try {
-                valueArrayField = String.class.getDeclaredField("value");
-                valueArrayField.setAccessible(true);
-            } catch (Throwable t) {
-                t.printStackTrace();
-                valueArrayField = null;
-            }
-        }
-
-        @Override
-        public StringValueArrayProvider create(String str) {
-            return new ReflectionBasedStringCharProvider(valueArrayField, str);
-        }
-
-        @Override
-        public boolean isAvailable() {
-            return valueArrayField != null;
-        }
-
-    }
-
-    // ********************************************************************* //
-
-    private interface StringValueArrayProvider {
-
-        char[] value();
-
-    }
-
-    private static class UnsafeBasedStringCharProvider
-            implements StringValueArrayProvider {
-
-        private char[] value;
-
-        UnsafeBasedStringCharProvider(sun.misc.Unsafe unsafe,
-                                      long stringValueFieldOffset, String str) {
-            this.value = (char[]) unsafe.getObject(str, stringValueFieldOffset);
-        }
-
-        @Override
-        public char[] value() {
-            return value;
-        }
-
-    }
-
-    private static class ReflectionBasedStringCharProvider
-            implements StringValueArrayProvider {
-
-        private char[] value;
-
-        ReflectionBasedStringCharProvider(Field valueArrayField, String str) {
-            try {
-                this.value = (char[]) valueArrayField.get(str);
-            } catch (IllegalAccessException e) {
-                throw new IllegalStateException(e);
-            }
-        }
-
-        @Override
-        public char[] value() {
-            return value;
-        }
-
-    }
-
-    // ********************************************************************* //
-
-    private interface UtfWriter {
-
-        void writeShortUTF(final StringValueArrayProvider stringCharProvider,
-                           final DataOutput out,
+        void writeShortUTF(final DataOutput out,
                            final String str,
                            final int beginIndex,
                            final int endIndex,
@@ -263,12 +118,11 @@ public final class UTFEncoderDecoder {
 
     }
 
-    private static class CharArrayBasedUtfWriter implements UtfWriter {
+    private abstract static class AbstractCharArrayUtfWriter implements UtfWriter {
 
         //CHECKSTYLE:OFF
         @Override
-        public void writeShortUTF(final StringValueArrayProvider stringCharProvider,
-                                  final DataOutput out,
+        public final void writeShortUTF(final DataOutput out,
                                   final String str,
                                   final int beginIndex,
                                   final int endIndex,
@@ -276,7 +130,7 @@ public final class UTFEncoderDecoder {
             final boolean isBufferObjectDataOutput = out instanceof BufferObjectDataOutput;
             final BufferObjectDataOutput bufferObjectDataOutput =
                     isBufferObjectDataOutput ? (BufferObjectDataOutput) out : null;
-            final char[] value = stringCharProvider.value();
+            final char[] value = getCharArray(str);
 
             int i;
             int c;
@@ -410,16 +264,93 @@ public final class UTFEncoderDecoder {
                 }
             }
         }
-        //CHECKSTYLE:ON
 
+        protected abstract boolean isAvailable();
+
+        protected abstract char[] getCharArray(String str);
+        //CHECKSTYLE:ON
     }
 
-    private static class StringBasedUtfWriter implements UtfWriter {
+    static class UnsafeBasedCharArrayUtfWriter extends AbstractCharArrayUtfWriter {
+
+        private static final sun.misc.Unsafe UNSAFE = UnsafeHelper.UNSAFE;
+        private static final long VALUE_FIELD_OFFSET;
+
+        static {
+            long offset = -1;
+            if (UnsafeHelper.UNSAFE_AVAILABLE) {
+                try {
+                    offset = UNSAFE.objectFieldOffset(String.class.getDeclaredField("value"));
+                } catch (Throwable t) {
+                    EmptyStatement.ignore(t);
+                }
+            }
+            VALUE_FIELD_OFFSET = offset;
+        }
+
+        @Override
+        public boolean isAvailable() {
+            return UnsafeHelper.UNSAFE_AVAILABLE && VALUE_FIELD_OFFSET != -1;
+        }
+
+        @Override
+        protected char[] getCharArray(String str) {
+            char[] chars = (char[]) UNSAFE.getObject(str, VALUE_FIELD_OFFSET);
+            if (chars.length > str.length()) {
+                // substring detected!
+                // jdk6 substring shares the same value array
+                // with the original string (this is not the case for jdk7+)
+                // we need to get copy of substring array
+                chars = str.toCharArray();
+            }
+            return chars;
+        }
+    }
+
+    static class ReflectionBasedCharArrayUtfWriter extends AbstractCharArrayUtfWriter {
+
+        private static final Field VALUE_FIELD;
+
+        static {
+            Field field;
+            try {
+                field = String.class.getDeclaredField("value");
+                field.setAccessible(true);
+            } catch (Throwable t) {
+                EmptyStatement.ignore(t);
+                field = null;
+            }
+            VALUE_FIELD = field;
+        }
+
+        @Override
+        public boolean isAvailable() {
+            return VALUE_FIELD != null;
+        }
+
+        @Override
+        protected char[] getCharArray(String str) {
+            try {
+                char[] chars = (char[]) VALUE_FIELD.get(str);
+                if (chars.length > str.length()) {
+                    // substring detected!
+                    // jdk6 substring shares the same value array
+                    // with the original string (this is not the case for jdk7+)
+                    // we need to get copy of substring array
+                    chars = str.toCharArray();
+                }
+                return chars;
+            } catch (IllegalAccessException e) {
+                throw new IllegalStateException(e);
+            }
+        }
+    }
+
+    static class StringBasedUtfWriter implements UtfWriter {
 
         //CHECKSTYLE:OFF
         @Override
-        public void writeShortUTF(final StringValueArrayProvider stringValueArrayProvider,
-                                  final DataOutput out,
+        public void writeShortUTF(final DataOutput out,
                                   final String str,
                                   final int beginIndex,
                                   final int endIndex,
@@ -779,44 +710,63 @@ public final class UTFEncoderDecoder {
         }
     }
 
-    public static boolean useOldStringConstructor() {
+    private static boolean useOldStringConstructor() {
         try {
             Class<String> clazz = String.class;
             clazz.getDeclaredConstructor(int.class, int.class, char[].class);
             return true;
         } catch (Throwable t) {
-            Logger.
-                    getLogger(UTFEncoderDecoder.class).
+            Logger.getLogger(UTFEncoderDecoder.class).
                     finest("Old String constructor doesn't seem available", t);
         }
         return false;
     }
 
     private static UTFEncoderDecoder buildUTFUtil() {
+        UtfWriter utfWriter = createUtfWriter();
         try {
-            Class<?> clazz =
-                    Class.forName("com.hazelcast.nio.utf8.EnterpriseStringCreator");
+            Class<?> clazz = Class.forName("com.hazelcast.nio.utf8.EnterpriseStringCreator");
             Method method = clazz.getDeclaredMethod("findBestStringCreator");
-            return new UTFEncoderDecoder(
-                    (StringCreator) method.invoke(clazz), true);
+            return new UTFEncoderDecoder((StringCreator) method.invoke(clazz), utfWriter, true);
         } catch (Throwable t) {
-            Logger.
-                    getLogger(UTFEncoderDecoder.class).
+            Logger.getLogger(UTFEncoderDecoder.class).
                     finest("EnterpriseStringCreator not available on classpath", t);
         }
-        boolean faststringEnabled =
-                Boolean.parseBoolean(
-                        System.getProperty("hazelcast.nio.faststring", "true"));
-        return new UTFEncoderDecoder(
-                faststringEnabled
-                        ? buildFastStringCreator()
-                        : new DefaultStringCreator(), false);
+        StringCreator stringCreator = createStringCreator();
+        return new UTFEncoderDecoder(stringCreator, utfWriter, false);
+    }
+
+    static StringCreator createStringCreator() {
+        boolean fastStringEnabled = Boolean.parseBoolean(System.getProperty("hazelcast.nio.faststring", "true"));
+        return createStringCreator(fastStringEnabled);
+    }
+
+    static StringCreator createStringCreator(boolean fastStringEnabled) {
+        return fastStringEnabled ? buildFastStringCreator() : new DefaultStringCreator();
+    }
+
+    static UtfWriter createUtfWriter() {
+        // Try Unsafe based implementation
+        UnsafeBasedCharArrayUtfWriter unsafeBasedUtfWriter = new UnsafeBasedCharArrayUtfWriter();
+        if (unsafeBasedUtfWriter.isAvailable()) {
+            return unsafeBasedUtfWriter;
+        }
+
+        // If Unsafe based implementation is not available for usage
+        // Try Reflection based implementation
+        ReflectionBasedCharArrayUtfWriter reflectionBasedUtfWriter = new ReflectionBasedCharArrayUtfWriter();
+        if (reflectionBasedUtfWriter.isAvailable()) {
+            return reflectionBasedUtfWriter;
+        }
+
+        // If Reflection based implementation is not available for usage
+        return new StringBasedUtfWriter();
     }
 
     private static StringCreator buildFastStringCreator() {
         try {
             // Give access to the package private String constructor
-            Constructor<String> constructor = null;
+            Constructor<String> constructor;
             if (UTFEncoderDecoder.useOldStringConstructor()) {
                 constructor =
                         String.class.getDeclaredConstructor(int.class, int.class, char[].class);
@@ -836,16 +786,18 @@ public final class UTFEncoderDecoder {
         return null;
     }
 
-    private static class DefaultStringCreator implements UTFEncoderDecoder.StringCreator {
+    interface StringCreator {
+        String buildString(final char[] chars);
+    }
 
+    private static class DefaultStringCreator implements StringCreator {
         @Override
         public String buildString(final char[] chars) {
             return new String(chars);
         }
-
     }
 
-    private static class FastStringCreator implements UTFEncoderDecoder.StringCreator {
+    private static class FastStringCreator implements StringCreator {
 
         private final Constructor<String> constructor;
         private final boolean useOldStringConstructor;
@@ -869,11 +821,4 @@ public final class UTFEncoderDecoder {
         }
 
     }
-
-    public interface StringCreator {
-
-        String buildString(final char[] chars);
-
-    }
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/nio/UTFEncoderDecoderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/UTFEncoderDecoderTest.java
@@ -28,9 +28,18 @@ import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
-import java.io.*;
-import java.lang.reflect.Constructor;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutput;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UTFDataFormatException;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -38,10 +47,8 @@ import java.util.List;
 import java.util.Random;
 import java.util.Set;
 
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
-
+import static com.hazelcast.nio.UTFEncoderDecoder.ReflectionBasedCharArrayUtfWriter;
+import static com.hazelcast.nio.UTFEncoderDecoder.UnsafeBasedCharArrayUtfWriter;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
@@ -71,29 +78,42 @@ public class UTFEncoderDecoderTest extends HazelcastTestSupport {
 
     @Test
     public void testEmptyText_Default() throws Exception {
-        byte[] buffer = new byte[1024];
-
-        UTFEncoderDecoder utfEncoderDecoder = newUTFEncoderDecoder(false);
-        ByteArrayOutputStream baos = new ByteArrayOutputStream(500);
-        DataOutputStream dos = new DataOutputStream(baos);
-
-        utfEncoderDecoder.writeUTF0(dos, "", buffer);
-        utfEncoderDecoder.writeUTF0(dos, "some other value", buffer);
-
-        ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
-        DataInputStream dis = new DataInputStream(bais);
-        String result1 = utfEncoderDecoder.readUTF0(dis, buffer);
-        String result2 = utfEncoderDecoder.readUTF0(dis, buffer);
-
-        assertEquals("", result1);
-        assertEquals("some other value", result2);
+       testEmptyText(false, UtfWriterType.DEFAULT);
     }
 
     @Test
-    public void testEmptyText_Fast() throws Exception {
-        byte[] buffer = new byte[1024];
+    public void testEmptyText_Unsafe() throws Exception {
+        testEmptyText(false, UtfWriterType.UNSAFE);
+    }
 
-        UTFEncoderDecoder utfEncoderDecoder = newUTFEncoderDecoder(true);
+    @Test
+    public void testEmptyText_Reflection() throws Exception {
+        testEmptyText(false, UtfWriterType.REFLECTION);
+    }
+
+    @Test
+    public void testEmptyText_Fast_Default() throws Exception {
+        testEmptyText(true, UtfWriterType.DEFAULT);
+    }
+
+    @Test
+    public void testEmptyText_Fast_Unsafe() throws Exception {
+        testEmptyText(true, UtfWriterType.UNSAFE);
+    }
+
+    @Test
+    public void testEmptyText_Fast_Reflection() throws Exception {
+        testEmptyText(true, UtfWriterType.REFLECTION);
+    }
+
+    private void testEmptyText(boolean fastStringEnabled, UtfWriterType utfWriterType) throws Exception {
+        UTFEncoderDecoder utfEncoderDecoder = newUTFEncoderDecoder(fastStringEnabled, utfWriterType);
+        if (utfEncoderDecoder == null) {
+            System.err.println("Ignoring test... " + utfWriterType + " is not available!");
+            return;
+        }
+
+        byte[] buffer = new byte[1024];
         ByteArrayOutputStream baos = new ByteArrayOutputStream(500);
         DataOutputStream dos = new DataOutputStream(baos);
 
@@ -111,36 +131,42 @@ public class UTFEncoderDecoderTest extends HazelcastTestSupport {
 
     @Test
     public void testMultipleTextsInARow_Default() throws Exception {
-        byte[] buffer = new byte[1024];
-
-        UTFEncoderDecoder utfEncoderDecoder = newUTFEncoderDecoder(false);
-
-        for (int i = 0; i < 100; i++) {
-            ByteArrayOutputStream baos = new ByteArrayOutputStream(500);
-            DataOutputStream dos = new DataOutputStream(baos);
-
-            String[] values = new String[10];
-            for (int o = 0; o < 10; o++) {
-                values[o] = random(i);
-                utfEncoderDecoder.writeUTF0(dos, values[o], buffer);
-            }
-
-            ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
-            DataInputStream dis = new DataInputStream(bais);
-
-            for (int o = 0; o < 10; o++) {
-                String result = utfEncoderDecoder.readUTF0(dis, buffer);
-                assertEquals(values[o], result);
-            }
-        }
+        testMultipleTextsInARow(false, UtfWriterType.DEFAULT);
     }
 
     @Test
-    public void testMultipleTextsInARow_fast() throws Exception {
+    public void testMultipleTextsInARow_Unsafe() throws Exception {
+        testMultipleTextsInARow(false, UtfWriterType.UNSAFE);
+    }
+
+    @Test
+    public void testMultipleTextsInARow_Reflection() throws Exception {
+        testMultipleTextsInARow(false, UtfWriterType.REFLECTION);
+    }
+
+    @Test
+    public void testMultipleTextsInARow_Fast_Default() throws Exception {
+       testMultipleTextsInARow(true, UtfWriterType.DEFAULT);
+    }
+
+    @Test
+    public void testMultipleTextsInARow_Fast_Unsafe() throws Exception {
+        testMultipleTextsInARow(true, UtfWriterType.UNSAFE);
+    }
+
+    @Test
+    public void testMultipleTextsInARow_Fast_Reflection() throws Exception {
+        testMultipleTextsInARow(true, UtfWriterType.REFLECTION);
+    }
+
+    private void testMultipleTextsInARow(boolean fastStringEnabled, UtfWriterType utfWriterType) throws Exception {
+        UTFEncoderDecoder utfEncoderDecoder = newUTFEncoderDecoder(fastStringEnabled, utfWriterType);
+        if (utfEncoderDecoder == null) {
+            System.err.println("Ignoring test... " + utfWriterType + " is not available!");
+            return;
+        }
+
         byte[] buffer = new byte[1024];
-
-        UTFEncoderDecoder utfEncoderDecoder = newUTFEncoderDecoder(true);
-
         for (int i = 0; i < 100; i++) {
             ByteArrayOutputStream baos = new ByteArrayOutputStream(500);
             DataOutputStream dos = new DataOutputStream(baos);
@@ -184,33 +210,42 @@ public class UTFEncoderDecoderTest extends HazelcastTestSupport {
 
     @Test
     public void testShortSizedText_1Chunk_Default() throws Exception {
-        byte[] buffer = new byte[1024];
-
-        UTFEncoderDecoder utfEncoderDecoder = newUTFEncoderDecoder(false);
-        for (int o = 0; o < BENCHMARK_ROUNDS; o++) {
-            for (int i = 2; i < 100; i += 2) {
-                ByteArrayOutputStream baos = new ByteArrayOutputStream(500);
-                DataOutputStream dos = new DataOutputStream(baos);
-
-                String randomString = random(i * 100);
-                utfEncoderDecoder.writeUTF0(dos, randomString, buffer);
-
-                ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
-                DataInputStream dis = new DataInputStream(bais);
-                String result = utfEncoderDecoder.readUTF0(dis, buffer);
-
-                assertEquals(randomString, result);
-            }
-        }
+        testShortSizedText_1Chunk(false, UtfWriterType.DEFAULT);
     }
 
     @Test
-    public void testShortSizedText_1Chunk_Fast() throws Exception {
+    public void testShortSizedText_1Chunk_Unsafe() throws Exception {
+        testShortSizedText_1Chunk(false, UtfWriterType.UNSAFE);
+    }
+
+    @Test
+    public void testShortSizedText_1Chunk_Reflection() throws Exception {
+        testShortSizedText_1Chunk(false, UtfWriterType.REFLECTION);
+    }
+
+    @Test
+    public void testShortSizedText_1Chunk_Fast_Default() throws Exception {
+        testShortSizedText_1Chunk(true, UtfWriterType.DEFAULT);
+    }
+
+    @Test
+    public void testShortSizedText_1Chunk_Fast_Unsafe() throws Exception {
+        testShortSizedText_1Chunk(true, UtfWriterType.UNSAFE);
+    }
+
+    @Test
+    public void testShortSizedText_1Chunk_Fast_Reflection() throws Exception {
+        testShortSizedText_1Chunk(true, UtfWriterType.REFLECTION);
+    }
+
+    private void testShortSizedText_1Chunk(boolean fastStringEnabled, UtfWriterType utfWriterType) throws Exception {
+        UTFEncoderDecoder utfEncoderDecoder = newUTFEncoderDecoder(fastStringEnabled, utfWriterType);
+        if (utfEncoderDecoder == null) {
+            System.err.println("Ignoring test... " + utfWriterType + " is not available!");
+            return;
+        }
+
         byte[] buffer = new byte[1024];
-
-        UTFEncoderDecoder utfEncoderDecoder = newUTFEncoderDecoder(true);
-        assertContains(utfEncoderDecoder.getStringCreator().getClass().toString(), "FastStringCreator");
-
         for (int o = 0; o < BENCHMARK_ROUNDS; o++) {
             for (int i = 2; i < 100; i += 2) {
                 ByteArrayOutputStream baos = new ByteArrayOutputStream(500);
@@ -230,33 +265,42 @@ public class UTFEncoderDecoderTest extends HazelcastTestSupport {
 
     @Test
     public void testMiddleSizedText_2Chunks_Default() throws Exception {
-        byte[] buffer = new byte[1024];
-
-        UTFEncoderDecoder utfEncoderDecoder = newUTFEncoderDecoder(false);
-        for (int o = 0; o < BENCHMARK_ROUNDS; o++) {
-            for (int i = 170; i < 300; i += 2) {
-                ByteArrayOutputStream baos = new ByteArrayOutputStream(500);
-                DataOutputStream dos = new DataOutputStream(baos);
-
-                String randomString = random(i * 100);
-                utfEncoderDecoder.writeUTF0(dos, randomString, buffer);
-
-                ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
-                DataInputStream dis = new DataInputStream(bais);
-                String result = utfEncoderDecoder.readUTF0(dis, buffer);
-
-                assertEquals(randomString, result);
-            }
-        }
+        testMiddleSizedText_2Chunks(false, UtfWriterType.DEFAULT);
     }
 
     @Test
-    public void testMiddleSizedText_2Chunks_Fast() throws Exception {
+    public void testMiddleSizedText_2Chunks_Unsafe() throws Exception {
+        testMiddleSizedText_2Chunks(false, UtfWriterType.UNSAFE);
+    }
+
+    @Test
+    public void testMiddleSizedText_2Chunks_Reflection() throws Exception {
+        testMiddleSizedText_2Chunks(false, UtfWriterType.REFLECTION);
+    }
+
+    @Test
+    public void testMiddleSizedText_2Chunks_Fast_Default() throws Exception {
+        testMiddleSizedText_2Chunks(true, UtfWriterType.DEFAULT);
+    }
+
+    @Test
+    public void testMiddleSizedText_2Chunks_Fast_Unsafe() throws Exception {
+        testMiddleSizedText_2Chunks(true, UtfWriterType.UNSAFE);
+    }
+
+    @Test
+    public void testMiddleSizedText_2Chunks_Fast_Reflection() throws Exception {
+        testMiddleSizedText_2Chunks(true, UtfWriterType.REFLECTION);
+    }
+
+    private void testMiddleSizedText_2Chunks(boolean fastStringEnabled, UtfWriterType utfWriterType) throws Exception {
+        UTFEncoderDecoder utfEncoderDecoder = newUTFEncoderDecoder(fastStringEnabled, utfWriterType);
+        if (utfEncoderDecoder == null) {
+            System.err.println("Ignoring test... " + utfWriterType + " is not available!");
+            return;
+        }
+
         byte[] buffer = new byte[1024];
-
-        UTFEncoderDecoder utfEncoderDecoder = newUTFEncoderDecoder(true);
-        assertContains(utfEncoderDecoder.getStringCreator().getClass().toString(), "FastStringCreator");
-
         for (int o = 0; o < BENCHMARK_ROUNDS; o++) {
             for (int i = 170; i < 300; i += 2) {
                 ByteArrayOutputStream baos = new ByteArrayOutputStream(500);
@@ -276,33 +320,42 @@ public class UTFEncoderDecoderTest extends HazelcastTestSupport {
 
     @Test
     public void testLongSizedText_min3Chunks_Default() throws Exception {
-        byte[] buffer = new byte[1024];
-
-        UTFEncoderDecoder utfEncoderDecoder = newUTFEncoderDecoder(false);
-        for (int o = 0; o < BENCHMARK_ROUNDS; o++) {
-            for (int i = 330; i < 900; i += 5) {
-                ByteArrayOutputStream baos = new ByteArrayOutputStream(500);
-                DataOutputStream dos = new DataOutputStream(baos);
-
-                String randomString = random(i * 100);
-                utfEncoderDecoder.writeUTF0(dos, randomString, buffer);
-
-                ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
-                DataInputStream dis = new DataInputStream(bais);
-                String result = utfEncoderDecoder.readUTF0(dis, buffer);
-
-                assertEquals(randomString, result);
-            }
-        }
+        testLongSizedText_min3Chunks(false, UtfWriterType.DEFAULT);
     }
 
     @Test
-    public void testLongSizedText_min3Chunks_Fast() throws Exception {
+    public void testLongSizedText_min3Chunks_Unsafe() throws Exception {
+        testLongSizedText_min3Chunks(false, UtfWriterType.UNSAFE);
+    }
+
+    @Test
+    public void testLongSizedText_min3Chunks_Reflection() throws Exception {
+        testLongSizedText_min3Chunks(false, UtfWriterType.REFLECTION);
+    }
+
+    @Test
+    public void testLongSizedText_min3Chunks_Fast_Default() throws Exception {
+        testLongSizedText_min3Chunks(true, UtfWriterType.DEFAULT);
+    }
+
+    @Test
+    public void testLongSizedText_min3Chunks_Fast_Unsafe() throws Exception {
+        testLongSizedText_min3Chunks(true, UtfWriterType.UNSAFE);
+    }
+
+    @Test
+    public void testLongSizedText_min3Chunks_Fast_Reflection() throws Exception {
+        testLongSizedText_min3Chunks(true, UtfWriterType.REFLECTION);
+    }
+
+    private void testLongSizedText_min3Chunks(boolean fastStringEnabled, UtfWriterType utfWriterType) throws Exception {
+        UTFEncoderDecoder utfEncoderDecoder = newUTFEncoderDecoder(fastStringEnabled, utfWriterType);
+        if (utfEncoderDecoder == null) {
+            System.err.println("Ignoring test... " + utfWriterType + " is not available!");
+            return;
+        }
+
         byte[] buffer = new byte[1024];
-
-        UTFEncoderDecoder utfEncoderDecoder = newUTFEncoderDecoder(true);
-        assertContains(utfEncoderDecoder.getStringCreator().getClass().toString(), "FastStringCreator");
-
         for (int o = 0; o < BENCHMARK_ROUNDS; o++) {
             for (int i = 330; i < 900; i += 5) {
                 ByteArrayOutputStream baos = new ByteArrayOutputStream(500);
@@ -374,6 +427,59 @@ public class UTFEncoderDecoderTest extends HazelcastTestSupport {
         fail("HazelcastSerializationException is expected");
     }
 
+    @Test
+    public void testSubstring_Default() throws IOException {
+        testSubstring(false, UtfWriterType.DEFAULT);
+    }
+
+    @Test
+    public void testSubstring_Unsafe() throws IOException {
+        testSubstring(false, UtfWriterType.UNSAFE);
+    }
+
+    @Test
+    public void testSubstring_Reflection() throws IOException {
+        testSubstring(false, UtfWriterType.REFLECTION);
+    }
+
+    @Test
+    public void testSubstring_Fast_Default() throws IOException {
+        testSubstring(true, UtfWriterType.DEFAULT);
+    }
+
+    @Test
+    public void testSubstring_Fast_Unsafe() throws IOException {
+        testSubstring(true, UtfWriterType.UNSAFE);
+    }
+
+    @Test
+    public void testSubstring_Fast_Reflection() throws IOException {
+        testSubstring(true, UtfWriterType.REFLECTION);
+    }
+
+    private void testSubstring(boolean fastStringEnabled, UtfWriterType utfWriterType) throws IOException {
+        UTFEncoderDecoder utfEncoderDecoder = newUTFEncoderDecoder(fastStringEnabled, utfWriterType);
+        if (utfEncoderDecoder == null) {
+            System.err.println("Ignoring test... " + utfWriterType + " is not available!");
+            return;
+        }
+
+        byte[] buffer = new byte[64];
+        String original = "1234abcd";
+        String str = original.substring(4);
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        DataOutputStream dos = new DataOutputStream(baos);
+        utfEncoderDecoder.writeUTF0(dos, str, buffer);
+
+        byte[] bytes = baos.toByteArray();
+        ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
+        DataInputStream dis = new DataInputStream(bais);
+        String result = utfEncoderDecoder.readUTF0(dis, buffer);
+
+        assertEquals(str, result);
+    }
+
     private String createString(int length) {
         char[] c = new char[length];
         for (int i = 0; i < c.length; i++) {
@@ -394,14 +500,35 @@ public class UTFEncoderDecoderTest extends HazelcastTestSupport {
         return random(count, 0, 0, true, true, null, RANDOM);
     }
 
-    private static UTFEncoderDecoder newUTFEncoderDecoder(boolean fastStringCreator) {
-        try {
-            Constructor<UTFEncoderDecoder> constructor = UTFEncoderDecoder.class.getDeclaredConstructor(boolean.class);
-            constructor.setAccessible(true);
-            return constructor.newInstance(fastStringCreator);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
+    private static UTFEncoderDecoder newUTFEncoderDecoder(boolean fastStringEnabled, UtfWriterType utfWriterType) {
+        UTFEncoderDecoder.UtfWriter utfWriter;
+        switch (utfWriterType) {
+            case UNSAFE:
+                UnsafeBasedCharArrayUtfWriter unsafeBasedWriter = new UnsafeBasedCharArrayUtfWriter();
+                if (!unsafeBasedWriter.isAvailable()) {
+                    return null;
+                }
+                utfWriter = unsafeBasedWriter;
+                break;
+
+            case REFLECTION:
+                ReflectionBasedCharArrayUtfWriter reflectionBasedWriter = new ReflectionBasedCharArrayUtfWriter();
+                if (!reflectionBasedWriter.isAvailable()) {
+                    return null;
+                }
+                utfWriter = reflectionBasedWriter;
+                break;
+
+            default:
+                utfWriter = new UTFEncoderDecoder.StringBasedUtfWriter();
         }
+
+        UTFEncoderDecoder.StringCreator stringCreator = UTFEncoderDecoder.createStringCreator(fastStringEnabled);
+        if (fastStringEnabled) {
+            assertContains(stringCreator.getClass().toString(), "FastStringCreator");
+        }
+
+        return new UTFEncoderDecoder(stringCreator, utfWriter);
     }
 
     private static ComplexUtf8Object buildComplexUtf8Object() {
@@ -489,6 +616,12 @@ public class UTFEncoderDecoderTest extends HazelcastTestSupport {
             //}
         }
         return new String(buffer);
+    }
+
+    private enum UtfWriterType {
+        UNSAFE,
+        REFLECTION,
+        DEFAULT
     }
 
     public static class User implements DataSerializable {

--- a/hazelcast/src/test/java/com/hazelcast/partition/PartitionControlledIdTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/partition/PartitionControlledIdTest.java
@@ -26,7 +26,6 @@ import com.hazelcast.concurrent.lock.LockStore;
 import com.hazelcast.concurrent.semaphore.SemaphoreService;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.PartitioningStrategyConfig;
-import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.HazelcastInstanceAware;
 import com.hazelcast.core.IAtomicLong;
@@ -42,6 +41,7 @@ import com.hazelcast.core.IdGenerator;
 import com.hazelcast.core.Member;
 import com.hazelcast.core.Partition;
 import com.hazelcast.core.PartitioningStrategy;
+import com.hazelcast.instance.HazelcastInstanceFactory;
 import com.hazelcast.instance.Node;
 import com.hazelcast.instance.TestUtil;
 import com.hazelcast.partition.strategy.StringAndPartitionAwarePartitioningStrategy;
@@ -73,10 +73,7 @@ public class PartitionControlledIdTest extends HazelcastTestSupport {
     private static HazelcastInstance[] instances;
 
     @BeforeClass
-    @AfterClass
-    public static void killAllHazelcastInstances() throws Exception {
-        Hazelcast.shutdownAll();
-
+    public static void startHazelcastInstances() throws Exception {
         Config config = new Config();
         PartitioningStrategy partitioningStrategy = StringAndPartitionAwarePartitioningStrategy.INSTANCE;
         config.getMapConfig("default")
@@ -88,9 +85,15 @@ public class PartitionControlledIdTest extends HazelcastTestSupport {
         warmUpPartitions(instances);
     }
 
+    @AfterClass
+    public static void killHazelcastInstances() {
+        HazelcastInstanceFactory.terminateAll();
+    }
+
     private HazelcastInstance getHazelcastInstance(String partitionKey) {
         Partition partition = instances[0].getPartitionService().getPartition(partitionKey);
         Member owner = partition.getOwner();
+        assertNotNull(owner);
 
         HazelcastInstance hz = null;
         for (HazelcastInstance instance : instances) {


### PR DESCRIPTION
...e value array with original string. Accessing internal array directly using unsafe or reflection causes wrong data to be written. Additionally refactored internal classes to avoid creating junk objects.

Fixes #3652 
Fixes #3653 
- Main issue is https://github.com/hazelcast/hazelcast/issues/3483
