### PR TITLE
Close proxies before any other services are closed.

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/ClientIssueTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ClientIssueTest.java
@@ -698,4 +698,22 @@ public class ClientIssueTest extends HazelcastTestSupport {
             foo = in.readInt();
         }
     }
+
+    @Test
+    public void testNearCache_shutdownClient() {
+        final ClientConfig clientConfig = new ClientConfig();
+        NearCacheConfig invalidateConfig = new NearCacheConfig();
+        final String mapName = randomMapName();
+        invalidateConfig.setName(mapName);
+        invalidateConfig.setInvalidateOnChange(true);
+        clientConfig.addNearCacheConfig(invalidateConfig);
+        Hazelcast.newHazelcastInstance();
+        final HazelcastInstance client = HazelcastClient.newHazelcastClient(clientConfig);
+
+        final IMap<Integer, Integer> map = client.getMap(mapName);
+
+        map.get(1);
+        //test should finish without throwing any exception.
+        client.shutdown();
+    }
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/ClientNearCacheTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ClientNearCacheTest.java
@@ -494,14 +494,4 @@ public class ClientNearCacheTest {
             map.get(i);
         }
     }
-
-    @Test
-    public void testNearCache_shutdownClient() {
-        final String mapName = randomMapName(NEAR_CACHE_WITH_INVALIDATION);
-        final IMap<Integer, Integer> map = client.getMap(mapName);
-
-        map.get(1);
-        //test should finish without throwing any exception.
-        client.shutdown();
-    }
 }


### PR DESCRIPTION
This was causing near cache listener not being remove successfully upon client shutdown. fixes #3669
