### PR TITLE
osgi: removed com.eclipsesource.json from Import-Packages

### DIFF
--- a/hazelcast/pom.xml
+++ b/hazelcast/pom.xml
@@ -132,6 +132,7 @@
                                 </Export-Package>
                                 <Import-Package>
                                     !org.junit,
+                                    !com.eclipsesource.json,
                                     sun.misc;resolution:=optional,
                                     org.apache.log4j;resolution:=optional,
                                     org.apache.logging.log4j;resolution:=optional,


### PR DESCRIPTION
com.eclipsesource.json should not appear in the list of
imported packages since it is relocated by the maven
shade plugin as com.hazelcast.com.eclipsesource.json
