### PR TITLE
Update MapContainer.nearCacheEnabled when the MapConfig is set

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapContainer.java
@@ -66,7 +66,6 @@ public class MapContainer extends MapContainerSupport {
     private final List<MapInterceptor> interceptors;
     private final Map<String, MapInterceptor> interceptorMap;
     private final IndexService indexService = new IndexService();
-    private volatile boolean nearCacheEnabled;
     private final SizeEstimator nearCacheSizeEstimator;
     private final PartitioningStrategy partitioningStrategy;
     private WanReplicationPublisher wanReplicationPublisher;
@@ -86,7 +85,6 @@ public class MapContainer extends MapContainerSupport {
         initWanReplication(nodeEngine);
         interceptors = new CopyOnWriteArrayList<MapInterceptor>();
         interceptorMap = new ConcurrentHashMap<String, MapInterceptor>();
-        nearCacheEnabled = mapConfig.getNearCacheConfig() != null;
         nearCacheSizeEstimator = SizeEstimators.createNearCacheSizeEstimator();
         mapStoreManager = createMapStoreManager(this);
         mapStoreManager.start();
@@ -105,12 +103,6 @@ public class MapContainer extends MapContainerSupport {
 
     public MapStoreManager getMapStoreManager() {
         return mapStoreManager;
-    }
-
-    @Override
-    public void setMapConfig(MapConfig mapConfig) {
-        super.setMapConfig(mapConfig);
-        nearCacheEnabled = mapConfig.getNearCacheConfig() != null;
     }
 
     private void initMapStoreOperations(NodeEngine nodeEngine) {
@@ -292,7 +284,7 @@ public class MapContainer extends MapContainerSupport {
     }
 
     public boolean isNearCacheEnabled() {
-        return nearCacheEnabled;
+        return mapConfig.isNearCacheEnabled();
     }
 
     public int getTotalBackupCount() {


### PR DESCRIPTION
The `MapContainer.nearCacheEnabled` field is marked as final and is not updated when `setMapConfig` is called. This prevents changes in the near cache configuration from being applied.
