### PR TITLE
Allow BasicOperation to be interrupted

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/BasicInvocationFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/BasicInvocationFuture.java
@@ -214,6 +214,11 @@ final class BasicInvocationFuture<E> implements InternalCompletableFuture<E> {
                 }
             } catch (InterruptedException e) {
                 interrupted = true;
+                if (response == null) {
+                    Thread.currentThread().interrupt();
+                    response = BasicInvocation.INTERRUPTED_RESPONSE;
+                    return response;
+                }
             }
 
             if (!interrupted && longPolling) {


### PR DESCRIPTION
This fixes an issue encountered while interrupting a thread that was blocked
in IMap.tryLock. The resulting InterruptedException was caught in
BasicInvocationFuture, a flag was set and the future continued waiting for a
response.

