### PR TITLE
When reading backup data, backup expiration delay should be omitted

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/DefaultRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/DefaultRecordStore.java
@@ -590,6 +590,23 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore implements 
         return value;
     }
 
+    @Override
+    public Data readBackupData(Data key) {
+        final long now = getNow();
+
+        final Record record = getRecord(key);
+        // expiration has delay on backups, but reading backup data should not be affected by this delay.
+        // this is the reason why we are passing `false` to isExpired() method.
+        final boolean expired = isExpired(record, now, false);
+        if (expired) {
+            return null;
+        }
+        final MapServiceContext mapServiceContext = this.mapServiceContext;
+        final Object value = record.getValue();
+        mapServiceContext.interceptAfterGet(name, value);
+        // this serialization step is needed not to expose the object, see issue 1292
+        return mapServiceContext.toData(value);
+    }
 
     @Override
     public MapEntrySet getAll(Set<Data> keys) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/RecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/RecordStore.java
@@ -71,6 +71,19 @@ public interface RecordStore {
      */
     Object get(Data dataKey, boolean backup);
 
+    /**
+     * Called when {@link com.hazelcast.config.MapConfig#isReadBackupData} is <code>true</code> from
+     * {@link com.hazelcast.map.impl.proxy.MapProxySupport#getInternal}
+     * <p/>
+     * Returns corresponding value for key as {@link com.hazelcast.nio.serialization.Data}.
+     * This adds an extra serialization step. For the reason of this behaviour please see issue 1292 on github.
+     *
+     * @param key key to be accessed
+     * @return value as {@link com.hazelcast.nio.serialization.Data}
+     * independent of {@link com.hazelcast.config.InMemoryFormat}
+     */
+    Data readBackupData(Data key);
+
     MapEntrySet getAll(Set<Data> keySet);
 
     boolean containsKey(Data dataKey);
@@ -151,7 +164,7 @@ public interface RecordStore {
      * {@link com.hazelcast.core.IMap#keySet(com.hazelcast.query.Predicate)},
      * this method can be used to return a read-only iterator.
      *
-     * @param now  current time in millis
+     * @param now    current time in millis
      * @param backup <code>true</code> if a backup partition, otherwise <code>false</code>.
      * @return read only iterator for map values.
      */

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
@@ -293,7 +293,7 @@ abstract class MapProxySupport extends AbstractDistributedObject<MapService> imp
         return NearCache.NULL_OBJECT.equals(cached);
     }
 
-    private Object readBackupDataOrNull(Data key) {
+    private Data readBackupDataOrNull(Data key) {
         final MapService mapService = getService();
         final MapServiceContext mapServiceContext = mapService.getMapServiceContext();
         final NodeEngine nodeEngine = mapServiceContext.getNodeEngine();
@@ -309,20 +309,7 @@ abstract class MapProxySupport extends AbstractDistributedObject<MapService> imp
         if (recordStore == null) {
             return null;
         }
-        final boolean owner = isOwner(partitionId);
-        final Object val = recordStore.get(key, !owner);
-        if (val != null) {
-            mapServiceContext.interceptAfterGet(name, val);
-            // this serialization step is needed not to expose the object, see issue 1292
-            return mapServiceContext.toData(val);
-        }
-        return null;
-    }
-
-    private boolean isOwner(int partitionId) {
-        final NodeEngine nodeEngine = getNodeEngine();
-        final Address owner = nodeEngine.getPartitionService().getPartitionOwner(partitionId);
-        return nodeEngine.getThisAddress().equals(owner);
+        return recordStore.readBackupData(key);
     }
 
     protected ICompletableFuture<Data> getAsyncInternal(final Data key) {


### PR DESCRIPTION
- Follow up #3810 
- Already have a test `testNumberOfEventsFired_withMaxIdleSeconds_whenReadBackupDataEnabled`
