### PR TITLE
When reading backup data, backup expiration delay should be omitted

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/RecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/RecordStore.java
@@ -71,6 +71,19 @@ public interface RecordStore {
      */
     Object get(Data dataKey, boolean backup);
 
+    /**
+     * Called when {@link com.hazelcast.config.MapConfig#isReadBackupData} is <code>true</code> from
+     * {@link com.hazelcast.map.proxy.MapProxySupport#getInternal}
+     * <p/>
+     * Returns corresponding value for key as {@link com.hazelcast.nio.serialization.Data}.
+     * This adds an extra serialization step. For the reason of this behaviour please see issue 1292 on github.
+     *
+     * @param key key to be accessed
+     * @return value as {@link com.hazelcast.nio.serialization.Data}
+     * independent of {@link com.hazelcast.config.InMemoryFormat}
+     */
+    Data readBackupData(Data key);
+
     MapEntrySet getAll(Set<Data> keySet);
 
     boolean containsKey(Data dataKey);
@@ -151,7 +164,7 @@ public interface RecordStore {
      * {@link com.hazelcast.core.IMap#keySet(com.hazelcast.query.Predicate)},
      * this method can be used to return a read-only iterator.
      *
-     * @param now  current time in millis
+     * @param now    current time in millis
      * @param backup <code>true</code> if a backup partition, otherwise <code>false</code>.
      * @return read only iterator for map values.
      */

--- a/hazelcast/src/main/java/com/hazelcast/map/proxy/MapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/proxy/MapProxySupport.java
@@ -292,7 +292,7 @@ abstract class MapProxySupport extends AbstractDistributedObject<MapService> imp
         return NearCache.NULL_OBJECT.equals(cached);
     }
 
-    private Object readBackupDataOrNull(Data key) {
+    private Data readBackupDataOrNull(Data key) {
         final MapService mapService = getService();
         final MapServiceContext mapServiceContext = mapService.getMapServiceContext();
         final NodeEngine nodeEngine = mapServiceContext.getNodeEngine();
@@ -308,20 +308,7 @@ abstract class MapProxySupport extends AbstractDistributedObject<MapService> imp
         if (recordStore == null) {
             return null;
         }
-        final boolean owner = isOwner(partitionId);
-        final Object val = recordStore.get(key, !owner);
-        if (val != null) {
-            mapServiceContext.interceptAfterGet(name, val);
-            // this serialization step is needed not to expose the object, see issue 1292
-            return mapServiceContext.toData(val);
-        }
-        return null;
-    }
-
-    private boolean isOwner(int partitionId) {
-        final NodeEngine nodeEngine = getNodeEngine();
-        final Address owner = nodeEngine.getPartitionService().getPartitionOwner(partitionId);
-        return nodeEngine.getThisAddress().equals(owner);
+        return recordStore.readBackupData(key);
     }
 
     protected ICompletableFuture<Data> getAsyncInternal(final Data key) {


### PR DESCRIPTION
- Follow up #3810 
- Already have a test `testNumberOfEventsFired_withMaxIdleSeconds_whenReadBackupDataEnabled`
