### PR TITLE
Attempting to pinpoint cause of test failure HazelcastTest.testNewInstanceByName #3785

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/core/HazelcastTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/core/HazelcastTest.java
@@ -16,21 +16,23 @@
 
 package com.hazelcast.core;
 
+import static com.hazelcast.core.Hazelcast.getAllHazelcastInstances;
+import static java.util.Collections.emptySet;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
 import com.hazelcast.config.Config;
-import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.QuickTest;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
@@ -40,6 +42,7 @@ public class HazelcastTest extends HazelcastTestSupport {
     @After
     public void cleanup(){
         Hazelcast.shutdownAll();
+        assertEquals(emptySet(), getAllHazelcastInstances());
     }
 
     @Test(expected = NullPointerException.class)
@@ -83,9 +86,11 @@ public class HazelcastTest extends HazelcastTestSupport {
     public void testNewInstanceByName() {
         Config config = new Config();
         config.setInstanceName("test");
+
         HazelcastInstance hc1 = Hazelcast.newHazelcastInstance(config);
         HazelcastInstance hc2 = Hazelcast.getHazelcastInstanceByName("test");
         HazelcastInstance hc3 = Hazelcast.getHazelcastInstanceByName(hc1.getName());
+
         assertTrue(hc1 == hc2);
         assertTrue(hc1 == hc3);
     }
@@ -97,4 +102,5 @@ public class HazelcastTest extends HazelcastTestSupport {
         Hazelcast.newHazelcastInstance(config);
         Hazelcast.newHazelcastInstance(config);
     }
+
 }


### PR DESCRIPTION
Attempting to pinpoint cause of test failure HazelcastTest.testNewInstanceByName. #3785
