### PR TITLE
pom update for sonar hibernate failures

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -295,7 +295,6 @@
                     <plugin>
                         <groupId>org.jacoco</groupId>
                         <artifactId>jacoco-maven-plugin</artifactId>
-                        <version>0.7.1.201405082137</version>
                         <configuration>
                             <excludes>
                                 <exclude>**DummyProperty**</exclude>


### PR DESCRIPTION
currently jacoco (test coverage tool), includes every java class to its synthetic fields. so somehow our hibernate tests fail almost every sonar build.
i tried to exclude test classes from jacoco. (tests will run, only jacoco doesn't add its synthetic fields to some test classes. also it is meaningless for test classes.)

as a result;
in my local jenkins hibernate tests pass with not excluding test classes. (60.7 %) [hibernate-module]
in hazelcast jenkins hibernate tests will pass with exluding test classes. (60.6 %) [hibernate-module]
