### PR TITLE
Remove blocking calls to partition information on query operation. Block...

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/map/query/QueryAdvancedTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/query/QueryAdvancedTest.java
@@ -34,15 +34,9 @@ import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
-import com.hazelcast.test.annotation.NightlyTest;
 import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.util.Clock;
 import com.hazelcast.util.UuidUtil;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
-
 import java.io.Serializable;
 import java.util.Collection;
 import java.util.HashMap;
@@ -55,6 +49,10 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import static com.hazelcast.map.query.QueryBasicTest.doFunctionalQueryTest;
 import static com.hazelcast.map.query.QueryBasicTest.doFunctionalSQLQueryTest;
@@ -531,7 +529,6 @@ public class QueryAdvancedTest extends HazelcastTestSupport {
      * test for issue #359
      */
     @Test(timeout = 1000 * 60 * 10)
-    @Category(NightlyTest.class)
     public void testIndexCleanupOnMigration() throws InterruptedException {
         final int n = 6;
         final int runCount = 500;


### PR DESCRIPTION
...ing calls can make a node unavailable if all of the operation threads running the query operation when the partition state comes from another node it cannot be processed because of the blocked query operation and that leads to a deadlock. fixes #3057 
