### PR TITLE
[backport] Remove blocking calls to partition information on query operation. Block...

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/operation/QueryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/operation/QueryOperation.java
@@ -23,6 +23,7 @@ import com.hazelcast.map.MapServiceContext;
 import com.hazelcast.map.QueryResult;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.partition.InternalPartitionService;
 import com.hazelcast.query.PagingPredicate;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.impl.IndexService;
@@ -66,11 +67,13 @@ public class QueryOperation extends AbstractMapOperation {
     }
 
     public void run() throws Exception {
-        Collection<Integer> initialPartitions = mapService.getMapServiceContext().getOwnedPartitions();
+        NodeEngine nodeEngine = getNodeEngine();
+        InternalPartitionService partitionService = nodeEngine.getPartitionService();
+        Collection<Integer> initialPartitions = partitionService.getMemberPartitions(nodeEngine.getThisAddress());
         IndexService indexService = mapService.getMapServiceContext().getMapContainer(name).getIndexService();
         Set<QueryableEntry> entries = null;
         // TODO: fix
-        if (!getNodeEngine().getPartitionService().hasOnGoingMigration()) {
+        if (!partitionService.hasOnGoingMigration()) {
             entries = indexService.query(predicate);
         }
         result = new QueryResult();
@@ -86,7 +89,7 @@ public class QueryOperation extends AbstractMapOperation {
                 runParallel(initialPartitions);
             }
         }
-        Collection<Integer> finalPartitions = mapService.getMapServiceContext().getOwnedPartitions();
+        Collection<Integer> finalPartitions = partitionService.getMemberPartitions(nodeEngine.getThisAddress());
         if (initialPartitions.equals(finalPartitions)) {
             result.setPartitionIds(finalPartitions);
         }

--- a/hazelcast/src/test/java/com/hazelcast/map/query/QueryAdvancedTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/query/QueryAdvancedTest.java
@@ -34,15 +34,9 @@ import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
-import com.hazelcast.test.annotation.NightlyTest;
 import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.util.Clock;
 import com.hazelcast.util.UuidUtil;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
-
 import java.io.Serializable;
 import java.util.Collection;
 import java.util.HashMap;
@@ -55,6 +49,10 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import static com.hazelcast.map.query.QueryBasicTest.doFunctionalQueryTest;
 import static com.hazelcast.map.query.QueryBasicTest.doFunctionalSQLQueryTest;
@@ -531,7 +529,6 @@ public class QueryAdvancedTest extends HazelcastTestSupport {
      * test for issue #359
      */
     @Test(timeout = 1000 * 60 * 10)
-    @Category(NightlyTest.class)
     public void testIndexCleanupOnMigration() throws InterruptedException {
         final int n = 6;
         final int runCount = 500;


### PR DESCRIPTION
...ing calls can make a node unavailable if all of the operation threads running the query operation when the partition state comes from another node it cannot be processed because of the blocked query operation and that leads to a deadlock.
