### PR TITLE
Resolves a findbugs issue in the ExecutorServiceProxy

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/executor/impl/ExecutorServiceProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/executor/impl/ExecutorServiceProxy.java
@@ -469,13 +469,15 @@ public class ExecutorServiceProxy
                 }
             }
             done = wait(timeoutNanos, futures, result);
+            return result;
         } catch (Throwable t) {
             logger.severe(t);
+            // todo: should an exception not be thrown?
+            return result;
         } finally {
             if (!done) {
                 cancelAll(result);
             }
-            return result;
         }
     }
 


### PR DESCRIPTION
[INFO] Dead store to i$ in com.hazelcast.executor.impl.ExecutorServiceProxy.invokeAll(Collection, long, TimeUnit) ["com.hazelcast.executor.impl.ExecutorServiceProxy"] At ExecutorServiceProxy.java:[lines 73-628]
