### PR TITLE
 When master receives a join request it should send finalize join operat...

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/ClusterServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/ClusterServiceImpl.java
@@ -675,7 +675,11 @@ public final class ClusterServiceImpl implements ClusterService, ConnectionListe
                     logger.finest(message);
                 }
                 // send members update back to node trying to join again...
-                Operation op = new MemberInfoUpdateOperation(createMemberInfos(getMemberList(), true),
+                final Operation[] postJoinOps = nodeEngine.getPostJoinOperations();
+                final PostJoinOperation postJoinOp = postJoinOps != null && postJoinOps.length > 0
+                        ? new PostJoinOperation(postJoinOps) : null;
+
+                Operation op = new FinalizeJoinOperation(createMemberInfos(getMemberList(), true), postJoinOp,
                         getClusterTime(), false);
                 nodeEngine.getOperationService().send(op, target);
             } else {

--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/operations/FinalizeJoinOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/operations/FinalizeJoinOperation.java
@@ -51,6 +51,12 @@ public class FinalizeJoinOperation extends MemberInfoUpdateOperation implements 
         this.postJoinOp = postJoinOp;
     }
 
+    public FinalizeJoinOperation(Collection<MemberInfo> members, PostJoinOperation postJoinOp,
+                                 long masterTime, boolean sendResponse) {
+        super(members, masterTime, sendResponse);
+        this.postJoinOp = postJoinOp;
+    }
+
     @Override
     public void run() throws Exception {
         if (!isValid()) {


### PR DESCRIPTION
...ion always, so that if a previous join request is done on master but could not finalized, it can be finalized with later join request.
