### PR TITLE
Make TrackableJobFuture.setResult() more robust

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/TrackableJobFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/TrackableJobFuture.java
@@ -16,14 +16,6 @@
 
 package com.hazelcast.mapreduce.impl.task;
 
-import java.util.Arrays;
-import java.util.Map;
-import java.util.concurrent.CancellationException;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-
 import com.hazelcast.core.ICompletableFuture;
 import com.hazelcast.mapreduce.Collator;
 import com.hazelcast.mapreduce.JobCompletableFuture;
@@ -37,6 +29,14 @@ import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.impl.AbstractCompletableFuture;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.util.ValidationUtil;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 /**
  * This is the node based implementation of the job's reactive {@link com.hazelcast.core.ICompletableFuture}


### PR DESCRIPTION
By putting the `latch.countDown();` method in a finally block we ensure that the latch is correctly updated whatever happens inside the method
