### PR TITLE
[backport] change lockInterruptibly() implementation to throw java.lang.Interrupted...

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientLockProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientLockProxy.java
@@ -18,16 +18,15 @@ package com.hazelcast.client.proxy;
 
 import com.hazelcast.client.impl.client.ClientRequest;
 import com.hazelcast.client.spi.ClientProxy;
-import com.hazelcast.concurrent.lock.client.IsLockedRequest;
 import com.hazelcast.concurrent.lock.client.GetLockCountRequest;
 import com.hazelcast.concurrent.lock.client.GetRemainingLeaseRequest;
+import com.hazelcast.concurrent.lock.client.IsLockedRequest;
 import com.hazelcast.concurrent.lock.client.LockRequest;
 import com.hazelcast.concurrent.lock.client.UnlockRequest;
 import com.hazelcast.core.ICondition;
 import com.hazelcast.core.ILock;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.util.ThreadUtil;
-
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Condition;
 
@@ -88,7 +87,8 @@ public class ClientLockProxy extends ClientProxy implements ILock {
     }
 
     public void lockInterruptibly() throws InterruptedException {
-        lock();
+        LockRequest request = new LockRequest(getKeyData(), ThreadUtil.getThreadId(), Long.MAX_VALUE, -1);
+        invokeInterruptibly(request, getKeyData());
     }
 
     public boolean tryLock() {

--- a/hazelcast-client/src/test/java/com/hazelcast/client/lock/ClientLockTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/lock/ClientLockTest.java
@@ -23,6 +23,9 @@ import com.hazelcast.core.ILock;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.QuickTest;
+import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -30,10 +33,6 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
-
-import java.io.IOException;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -44,7 +43,7 @@ import static org.junit.Assert.assertTrue;
  */
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class ClientLockTest extends HazelcastTestSupport{
+public class ClientLockTest extends HazelcastTestSupport {
 
     static final String name = "test";
     static HazelcastInstance hz;
@@ -153,6 +152,7 @@ public class ClientLockTest extends HazelcastTestSupport{
         assertTrue(lockWithZeroTTL);
 
     }
+
     @Test
     public void testTryLockwithZeroTTLWithExistingLock() throws Exception {
 
@@ -161,10 +161,10 @@ public class ClientLockTest extends HazelcastTestSupport{
         new Thread() {
             public void run() {
                 try {
-                    if (!l.tryLock(0,TimeUnit.SECONDS)) {
+                    if (!l.tryLock(0, TimeUnit.SECONDS)) {
                         latch.countDown();
                     }
-               } catch (InterruptedException e) {
+                } catch (InterruptedException e) {
                 }
             }
         }.start();
@@ -232,4 +232,5 @@ public class ClientLockTest extends HazelcastTestSupport{
 
         assertFalse("Lock obtained by 2 client ", lockObtained);
     }
+
 }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockProxy.java
@@ -23,7 +23,6 @@ import com.hazelcast.nio.serialization.SerializationService;
 import com.hazelcast.spi.AbstractDistributedObject;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.ObjectNamespace;
-
 import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Condition;
@@ -78,7 +77,7 @@ public class LockProxy extends AbstractDistributedObject<LockServiceImpl> implem
 
     @Override
     public void lockInterruptibly() throws InterruptedException {
-        lock();
+        lockSupport.lockInterruptly(getNodeEngine(), key);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockProxySupport.java
@@ -26,7 +26,6 @@ import com.hazelcast.spi.InternalCompletableFuture;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.ObjectNamespace;
 import com.hazelcast.spi.Operation;
-
 import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.concurrent.lock.LockServiceImpl.SERVICE_NAME;
@@ -79,6 +78,20 @@ public final class LockProxySupport {
         InternalCompletableFuture<Boolean> f = invoke(nodeEngine, operation, key);
         if (!f.getSafely()) {
             throw new IllegalStateException();
+        }
+    }
+
+    public void lockInterruptly(NodeEngine nodeEngine, Data key) throws InterruptedException {
+        lockInterruptly(nodeEngine, key, -1);
+    }
+
+    public void lockInterruptly(NodeEngine nodeEngine, Data key, long ttl) throws InterruptedException {
+        LockOperation operation = new LockOperation(namespace, key, getThreadId(), ttl, -1);
+        InternalCompletableFuture<Boolean> f = invoke(nodeEngine, operation, key);
+        try {
+            f.get();
+        } catch (Throwable t) {
+            throw rethrowAllowInterrupted(t);
         }
     }
 


### PR DESCRIPTION
...Exception when interrupted. fixes #3969
