### PR TITLE
Converting some tests to HazelcastTestSupport

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/cluster/NodeShutdownEventsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/NodeShutdownEventsTest.java
@@ -25,6 +25,8 @@ import com.hazelcast.core.LifecycleListener;
 import com.hazelcast.instance.GroupProperties;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
+
+import org.junit.After;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -37,6 +39,11 @@ import static com.hazelcast.test.HazelcastTestSupport.assertOpenEventually;
 @RunWith(HazelcastParallelClassRunner.class)
 @Category(QuickTest.class)
 public class NodeShutdownEventsTest {
+
+    @After
+    public void shutdown() {
+        Hazelcast.shutdownAll();
+    }
 
     /**
      * When a node fails due to a join time out, it will be shutdowned.

--- a/hazelcast/src/test/java/com/hazelcast/collection/SetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/SetTest.java
@@ -18,21 +18,22 @@ package com.hazelcast.collection;
 
 import com.hazelcast.config.Config;
 import com.hazelcast.config.SetConfig;
-import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.ILock;
 import com.hazelcast.core.ISet;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ClientCompatibleTest;
 import com.hazelcast.test.annotation.QuickTest;
+
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -274,7 +275,7 @@ public class SetTest extends HazelcastTestSupport {
     @Test
     public void testContainsAll_whenSetNotContains() {
         ISet set = newSet();
-        ILock lock = Hazelcast.newHazelcastInstance().getLock("asd");
+
         Set contains = new HashSet();
         contains.add("item1");
         contains.add("item100");

--- a/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
@@ -17,11 +17,12 @@
 package com.hazelcast.config;
 
 import com.hazelcast.config.helpers.DummyMapStore;
-import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastException;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.QuickTest;
+
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
@@ -29,18 +30,13 @@ import java.io.InputStream;
 import java.io.PrintWriter;
 import java.net.URL;
 import java.util.List;
+
 import javax.xml.XMLConstants;
 import javax.xml.transform.Source;
 import javax.xml.transform.stream.StreamSource;
 import javax.xml.validation.Schema;
 import javax.xml.validation.SchemaFactory;
 import javax.xml.validation.Validator;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
-import org.xml.sax.SAXException;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -49,10 +45,18 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import org.xml.sax.SAXException;
+
 //it needs to run serial because some tests are relying on System properties they are setting themselves.
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class XMLConfigBuilderTest {
+public class XMLConfigBuilderTest extends HazelcastTestSupport {
 
     @After
     @Before
@@ -528,7 +532,7 @@ public class XMLConfigBuilderTest {
                         "</hazelcast>\n";
 
         Config config = buildConfig(xml);
-        HazelcastInstance hz = Hazelcast.newHazelcastInstance(config);
+        HazelcastInstance hz = createHazelcastInstance(config);
         hz.getMap(mapName);
 
         MapConfig mapConfig = hz.getConfig().getMapConfig(mapName);

--- a/hazelcast/src/test/java/com/hazelcast/map/MapTransactionStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapTransactionStressTest.java
@@ -4,7 +4,6 @@ import com.hazelcast.config.Config;
 import com.hazelcast.config.ServiceConfig;
 import com.hazelcast.config.ServicesConfig;
 import com.hazelcast.core.DistributedObject;
-import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.core.IQueue;
@@ -27,6 +26,7 @@ import com.hazelcast.transaction.TransactionalTask;
 import com.hazelcast.transaction.TransactionalTaskContext;
 import com.hazelcast.transaction.impl.TransactionLog;
 import com.hazelcast.transaction.impl.TransactionSupport;
+
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -53,7 +53,7 @@ public class MapTransactionStressTest extends HazelcastTestSupport {
 
     @Test
     public void testTransactionAtomicity_whenMapGetIsUsed_withTransaction() throws InterruptedException {
-        final HazelcastInstance hz = Hazelcast.newHazelcastInstance(createConfigWithDummyTxService());
+        final HazelcastInstance hz = createHazelcastInstance(createConfigWithDummyTxService());
         final String name = HazelcastTestSupport.generateRandomString(5);
         Thread producerThread = startProducerThread(hz, name);
         try {
@@ -84,7 +84,7 @@ public class MapTransactionStressTest extends HazelcastTestSupport {
 
     @Test
     public void testTransactionAtomicity_whenMapGetIsUsed_withoutTransaction() throws InterruptedException {
-        final HazelcastInstance hz = Hazelcast.newHazelcastInstance(createConfigWithDummyTxService());
+        final HazelcastInstance hz = createHazelcastInstance(createConfigWithDummyTxService());
         final String name = HazelcastTestSupport.generateRandomString(5);
         Thread producerThread = startProducerThread(hz, name);
         try {
@@ -107,7 +107,7 @@ public class MapTransactionStressTest extends HazelcastTestSupport {
 
     @Test
     public void testTransactionAtomicity_whenMapContainsKeyIsUsed_withTransaction() throws InterruptedException {
-        final HazelcastInstance hz = Hazelcast.newHazelcastInstance(createConfigWithDummyTxService());
+        final HazelcastInstance hz = createHazelcastInstance(createConfigWithDummyTxService());
         final String name = HazelcastTestSupport.generateRandomString(5);
         Thread producerThread = startProducerThread(hz, name);
         try {
@@ -137,7 +137,7 @@ public class MapTransactionStressTest extends HazelcastTestSupport {
 
     @Test
     public void testTransactionAtomicity_whenMapContainsKeyIsUsed_withoutTransaction() throws InterruptedException {
-        final HazelcastInstance hz = Hazelcast.newHazelcastInstance(createConfigWithDummyTxService());
+        final HazelcastInstance hz = createHazelcastInstance(createConfigWithDummyTxService());
         final String name = HazelcastTestSupport.generateRandomString(5);
         Thread producerThread = startProducerThread(hz, name);
         try {
@@ -159,7 +159,7 @@ public class MapTransactionStressTest extends HazelcastTestSupport {
 
     @Test
     public void testTransactionAtomicity_whenMapGetEntryViewIsUsed_withoutTransaction() throws InterruptedException {
-        final HazelcastInstance hz = Hazelcast.newHazelcastInstance(createConfigWithDummyTxService());
+        final HazelcastInstance hz = createHazelcastInstance(createConfigWithDummyTxService());
         final String name = HazelcastTestSupport.generateRandomString(5);
         Thread producerThread = startProducerThread(hz, name);
         try {

--- a/hazelcast/src/test/java/com/hazelcast/map/mapstore/MapLoaderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/mapstore/MapLoaderTest.java
@@ -3,13 +3,13 @@ package com.hazelcast.map.mapstore;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.config.MapStoreConfig;
-import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.MapLoader;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.QuickTest;
+
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -62,7 +62,7 @@ public class MapLoaderTest extends HazelcastTestSupport {
         mapConfig.setMapStoreConfig(mapStoreConfig);
 
         config.addMapConfig(mapConfig);
-        HazelcastInstance hz = Hazelcast.newHazelcastInstance(config);
+        HazelcastInstance hz = createHazelcastInstance(config);
         Map map = hz.getMap(mapConfig.getName());
 
         assertTrueAllTheTime(new AssertTask() {

--- a/hazelcast/src/test/java/com/hazelcast/multimap/MultiMapTransactionStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/multimap/MultiMapTransactionStressTest.java
@@ -19,7 +19,6 @@ package com.hazelcast.multimap;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.ServiceConfig;
 import com.hazelcast.config.ServicesConfig;
-import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IQueue;
 import com.hazelcast.core.MultiMap;
@@ -30,11 +29,13 @@ import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.NightlyTest;
 import com.hazelcast.transaction.TransactionContext;
 import com.hazelcast.transaction.TransactionException;
-import java.util.Collection;
-import java.util.concurrent.locks.LockSupport;
+
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+
+import java.util.Collection;
+import java.util.concurrent.locks.LockSupport;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -48,7 +49,7 @@ public class MultiMapTransactionStressTest extends HazelcastTestSupport {
 
     @Test
     public void testTransactionAtomicity_whenMultiMapGetIsUsed_withTransaction() throws InterruptedException {
-        final HazelcastInstance hz = Hazelcast.newHazelcastInstance(createConfigWithDummyTxService());
+        final HazelcastInstance hz = createHazelcastInstance(createConfigWithDummyTxService());
         final String name = HazelcastTestSupport.generateRandomString(5);
         Thread producerThread = startProducerThread(hz, name);
         try {
@@ -79,7 +80,7 @@ public class MultiMapTransactionStressTest extends HazelcastTestSupport {
 
     @Test
     public void testTransactionAtomicity_whenMultiMapGetIsUsed_withoutTransaction() throws InterruptedException {
-        final HazelcastInstance hz = Hazelcast.newHazelcastInstance(createConfigWithDummyTxService());
+        final HazelcastInstance hz = createHazelcastInstance(createConfigWithDummyTxService());
         final String name = HazelcastTestSupport.generateRandomString(5);
         Thread producerThread = startProducerThread(hz, name);
         try {
@@ -102,7 +103,7 @@ public class MultiMapTransactionStressTest extends HazelcastTestSupport {
 
     @Test
     public void testTransactionAtomicity_whenMultiMapContainsKeyIsUsed_withoutTransaction() throws InterruptedException {
-        final HazelcastInstance hz = Hazelcast.newHazelcastInstance(createConfigWithDummyTxService());
+        final HazelcastInstance hz = createHazelcastInstance(createConfigWithDummyTxService());
         final String name = HazelcastTestSupport.generateRandomString(5);
         Thread producerThread = startProducerThread(hz, name);
         try {
@@ -124,7 +125,7 @@ public class MultiMapTransactionStressTest extends HazelcastTestSupport {
 
     @Test
     public void testTransactionAtomicity_whenMultiMapContainsEntryIsUsed_withoutTransaction() throws InterruptedException {
-        final HazelcastInstance hz = Hazelcast.newHazelcastInstance(createConfigWithDummyTxService());
+        final HazelcastInstance hz = createHazelcastInstance(createConfigWithDummyTxService());
         final String name = HazelcastTestSupport.generateRandomString(5);
         Thread producerThread = startProducerThread(hz, name);
         try {
@@ -146,7 +147,7 @@ public class MultiMapTransactionStressTest extends HazelcastTestSupport {
 
     @Test
     public void testTransactionAtomicity_whenMultiMapValueCountIsUsed_withoutTransaction() throws InterruptedException {
-        final HazelcastInstance hz = Hazelcast.newHazelcastInstance(createConfigWithDummyTxService());
+        final HazelcastInstance hz = createHazelcastInstance(createConfigWithDummyTxService());
         final String name = HazelcastTestSupport.generateRandomString(5);
         Thread producerThread = startProducerThread(hz, name);
         try {
@@ -168,7 +169,7 @@ public class MultiMapTransactionStressTest extends HazelcastTestSupport {
 
     @Test
     public void testTransactionAtomicity_whenMultiMapValueCountIsUsed_withTransaction() throws InterruptedException {
-        final HazelcastInstance hz = Hazelcast.newHazelcastInstance(createConfigWithDummyTxService());
+        final HazelcastInstance hz = createHazelcastInstance(createConfigWithDummyTxService());
         final String name = HazelcastTestSupport.generateRandomString(5);
         Thread producerThread = startProducerThread(hz, name);
         try {


### PR DESCRIPTION
Converting some tests to HazelcastTestSupport with test instances.
Adding shutdownAll where instances are created.
Removed unused ilock.
