### PR TITLE
Migrating tests to HazelcastTestSupport managed instances 

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/map/MapEvictAllTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapEvictAllTest.java
@@ -9,13 +9,14 @@ import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.QuickTest;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
 
 import java.util.concurrent.CountDownLatch;
 
 import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category(QuickTest.class)
@@ -83,7 +84,7 @@ public class MapEvictAllTest extends HazelcastTestSupport {
         int numberOfEntries = 10000;
         String mapName = randomMapName();
         final CountDownLatch countDownLatch = new CountDownLatch(numberOfEntries);
-        TestHazelcastInstanceFactory instanceFactory = new TestHazelcastInstanceFactory(5);
+        TestHazelcastInstanceFactory instanceFactory = createHazelcastInstanceFactory(5);
         HazelcastInstance node1 = instanceFactory.newHazelcastInstance();
         HazelcastInstance node2 = instanceFactory.newHazelcastInstance();
         final IMap<Integer, Integer> map1 = node1.getMap(mapName);

--- a/hazelcast/src/test/java/com/hazelcast/map/MapInstanceSharingTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapInstanceSharingTest.java
@@ -1,16 +1,10 @@
 package com.hazelcast.map;
 
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.IAtomicReference;
 import com.hazelcast.core.IMap;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
-import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.QuickTest;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
 
 import java.io.Serializable;
 import java.util.UUID;
@@ -19,17 +13,22 @@ import java.util.concurrent.ExecutionException;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
 
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
 @RunWith(HazelcastParallelClassRunner.class)
 @Category(QuickTest.class)
 public class MapInstanceSharingTest extends HazelcastTestSupport {
 
-    private static HazelcastInstance[] instances;
-    private static HazelcastInstance local;
-    private static HazelcastInstance remote;
+    private HazelcastInstance[] instances;
+    private HazelcastInstance local;
+    private HazelcastInstance remote;
 
-    @BeforeClass
-    public static void setUp() {
-        instances = new TestHazelcastInstanceFactory(2).newInstances();
+    @Before
+    public void setUp() {
+        instances = createHazelcastInstanceFactory(2).newInstances();
         warmUpPartitions(instances);
         local = instances[0];
         remote = instances[1];

--- a/hazelcast/src/test/java/com/hazelcast/map/mapstore/LoadAllTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/mapstore/LoadAllTest.java
@@ -10,9 +10,6 @@ import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.QuickTest;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -26,6 +23,10 @@ import java.util.concurrent.CountDownLatch;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
@@ -132,7 +133,7 @@ public class LoadAllTest extends HazelcastTestSupport {
         final int rangeEnd = 9001;
         final String mapName = randomMapName();
         final Config config = createNewConfig(mapName);
-        final TestHazelcastInstanceFactory instanceFactory = new TestHazelcastInstanceFactory(2);
+        final TestHazelcastInstanceFactory instanceFactory = createHazelcastInstanceFactory(2);
         final HazelcastInstance node1 = instanceFactory.newHazelcastInstance(config);
         final HazelcastInstance node2 = instanceFactory.newHazelcastInstance(config);
         final IMap<Object, Object> map1 = node1.getMap(mapName);

--- a/hazelcast/src/test/java/com/hazelcast/map/mapstore/MapStoreTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/mapstore/MapStoreTest.java
@@ -56,10 +56,6 @@ import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.transaction.TransactionContext;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
 
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -90,6 +86,11 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 
 /**
@@ -1393,6 +1394,7 @@ public class MapStoreTest extends HazelcastTestSupport {
         final IMap<Object, Object> map = TestMapUsingMapStoreBuilder.create()
                 .withMapStore(mapStore)
                 .withNodeCount(1)
+                .withNodeFactory(createHazelcastInstanceFactory(1))
                 .build();
 
         try {
@@ -1408,6 +1410,7 @@ public class MapStoreTest extends HazelcastTestSupport {
         final IMap<Object, Object> map = TestMapUsingMapStoreBuilder.create()
                 .withMapStore(mapStore)
                 .withNodeCount(1)
+                .withNodeFactory(createHazelcastInstanceFactory(1))
                 .build();
 
         map.remove(1);

--- a/hazelcast/src/test/java/com/hazelcast/map/mapstore/writebehind/TestMapUsingMapStoreBuilder.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/mapstore/writebehind/TestMapUsingMapStoreBuilder.java
@@ -33,6 +33,8 @@ public class TestMapUsingMapStoreBuilder<K, V> {
 
     private int backupDelaySeconds = 10;
 
+    private TestHazelcastInstanceFactory instanceFactory;
+
     private TestMapUsingMapStoreBuilder() {
     }
 
@@ -54,6 +56,11 @@ public class TestMapUsingMapStoreBuilder<K, V> {
             throw new IllegalArgumentException("nodeCount < 1");
         }
         this.nodeCount = nodeCount;
+        return this;
+    }
+
+    public TestMapUsingMapStoreBuilder<K, V> withNodeFactory(TestHazelcastInstanceFactory factory) {
+        this.instanceFactory = factory;
         return this;
     }
 
@@ -128,8 +135,10 @@ public class TestMapUsingMapStoreBuilder<K, V> {
                     String.valueOf(backupCount));
         }
         // nodes.
-        final TestHazelcastInstanceFactory instanceFactory = new TestHazelcastInstanceFactory(nodeCount);
-        nodes = instanceFactory.newInstances(config);
+        nodes = new HazelcastInstance[nodeCount];
+        for(int i = 0; i < nodeCount; i++) {
+            nodes[i] = instanceFactory.newHazelcastInstance(config);
+        }
         return nodes[0].getMap(mapName);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/map/mapstore/writebehind/WriteBehindItemCounterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/mapstore/writebehind/WriteBehindItemCounterTest.java
@@ -5,12 +5,13 @@ import com.hazelcast.core.IMap;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.QuickTest;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category(QuickTest.class)
@@ -22,6 +23,7 @@ public class WriteBehindItemCounterTest extends HazelcastTestSupport {
         final TestMapUsingMapStoreBuilder builder = TestMapUsingMapStoreBuilder.create()
                 .withMapStore(mapStore)
                 .withNodeCount(1)
+                .withNodeFactory(createHazelcastInstanceFactory(1))
                 .withBackupCount(0)
                 .withWriteDelaySeconds(100);
         final IMap<Object, Object> map = builder.build();
@@ -39,6 +41,7 @@ public class WriteBehindItemCounterTest extends HazelcastTestSupport {
         final TestMapUsingMapStoreBuilder builder = TestMapUsingMapStoreBuilder.create()
                 .withMapStore(mapStore)
                 .withNodeCount(nodeCount)
+                .withNodeFactory(createHazelcastInstanceFactory(nodeCount))
                 .withBackupCount(0)
                 .withWriteDelaySeconds(100);
         final IMap<Object, Object> map = builder.build();

--- a/hazelcast/src/test/java/com/hazelcast/map/mapstore/writebehind/WriteBehindMapStoreWithEvictionsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/mapstore/writebehind/WriteBehindMapStoreWithEvictionsTest.java
@@ -5,9 +5,6 @@ import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.QuickTest;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -16,6 +13,10 @@ import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category(QuickTest.class)
@@ -27,6 +28,7 @@ public class WriteBehindMapStoreWithEvictionsTest extends HazelcastTestSupport {
         final IMap<Object, Object> map = TestMapUsingMapStoreBuilder.create()
                 .withMapStore(mapStore)
                 .withNodeCount(1)
+                .withNodeFactory(createHazelcastInstanceFactory(1))
                 .withBackupCount(0)
                 .withWriteDelaySeconds(100)
                 .withPartitionCount(1)
@@ -44,6 +46,7 @@ public class WriteBehindMapStoreWithEvictionsTest extends HazelcastTestSupport {
         final IMap<Object, Object> map = TestMapUsingMapStoreBuilder.create()
                 .withMapStore(mapStore)
                 .withNodeCount(1)
+                .withNodeFactory(createHazelcastInstanceFactory(1))
                 .withBackupCount(0)
                 .withWriteDelaySeconds(3)
                 .withPartitionCount(1)
@@ -63,6 +66,7 @@ public class WriteBehindMapStoreWithEvictionsTest extends HazelcastTestSupport {
         final IMap<Object, Object> map = TestMapUsingMapStoreBuilder.create()
                 .withMapStore(mapStore)
                 .withNodeCount(1)
+                .withNodeFactory(createHazelcastInstanceFactory(1))
                 .withBackupCount(0)
                 .withWriteDelaySeconds(100)
                 .withPartitionCount(1)
@@ -83,6 +87,7 @@ public class WriteBehindMapStoreWithEvictionsTest extends HazelcastTestSupport {
         final IMap<Object, Object> map = TestMapUsingMapStoreBuilder.create()
                 .withMapStore(mapStore)
                 .withNodeCount(1)
+                .withNodeFactory(createHazelcastInstanceFactory(1))
                 .withBackupCount(0)
                 .withWriteDelaySeconds(100)
                 .withPartitionCount(1)
@@ -104,6 +109,7 @@ public class WriteBehindMapStoreWithEvictionsTest extends HazelcastTestSupport {
         final IMap<Object, Object> map = TestMapUsingMapStoreBuilder.create()
                 .withMapStore(mapStore)
                 .withNodeCount(1)
+                .withNodeFactory(createHazelcastInstanceFactory(1))
                 .withBackupCount(0)
                 .withWriteDelaySeconds(100)
                 .withPartitionCount(1)
@@ -131,6 +137,7 @@ public class WriteBehindMapStoreWithEvictionsTest extends HazelcastTestSupport {
         final IMap<Object, Object> map = TestMapUsingMapStoreBuilder.create()
                 .withMapStore(mapStore)
                 .withNodeCount(1)
+                .withNodeFactory(createHazelcastInstanceFactory(1))
                 .withBackupCount(0)
                 .withWriteDelaySeconds(100)
                 .withPartitionCount(1)

--- a/hazelcast/src/test/java/com/hazelcast/map/mapstore/writebehind/WriteBehindMapStoreWithLoadAllTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/mapstore/writebehind/WriteBehindMapStoreWithLoadAllTest.java
@@ -5,14 +5,15 @@ import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.QuickTest;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
 
 import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category(QuickTest.class)
@@ -24,6 +25,7 @@ public class WriteBehindMapStoreWithLoadAllTest extends HazelcastTestSupport {
         final IMap<Object, Object> map = TestMapUsingMapStoreBuilder.create()
                 .withMapStore(mapStore)
                 .withNodeCount(1)
+                .withNodeFactory(createHazelcastInstanceFactory(1))
                 .withBackupCount(0)
                 .withWriteDelaySeconds(100)
                 .withPartitionCount(1)

--- a/hazelcast/src/test/java/com/hazelcast/map/mapstore/writebehind/WriteBehindOnBackupsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/mapstore/writebehind/WriteBehindOnBackupsTest.java
@@ -29,11 +29,12 @@ import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.QuickTest;
+
+import static org.junit.Assert.assertEquals;
+
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
-
-import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category(QuickTest.class)
@@ -55,6 +56,7 @@ public class WriteBehindOnBackupsTest extends HazelcastTestSupport {
                 .mapName(mapName)
                 .withMapStore(mapStore)
                 .withNodeCount(2)
+                .withNodeFactory(createHazelcastInstanceFactory(2))
                 .withWriteDelaySeconds(1)
                 .withBackupCount(1)
                 .withPartitionCount(1)

--- a/hazelcast/src/test/java/com/hazelcast/map/mapstore/writebehind/WriteBehindWithEntryProcessorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/mapstore/writebehind/WriteBehindWithEntryProcessorTest.java
@@ -9,9 +9,6 @@ import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.QuickTest;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
 
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -22,6 +19,10 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category(QuickTest.class)
@@ -50,6 +51,7 @@ public class WriteBehindWithEntryProcessorTest extends HazelcastTestSupport {
         final TestMapUsingMapStoreBuilder builder = TestMapUsingMapStoreBuilder.create()
                 .withMapStore(mapStore)
                 .withNodeCount(1)
+                .withNodeFactory(createHazelcastInstanceFactory(1))
                 .withBackupCount(0)
                 .withWriteDelaySeconds(3)
                 .withInMemoryFormat(InMemoryFormat.OBJECT);

--- a/hazelcast/src/test/java/com/hazelcast/map/mapstore/writebehind/WriteBehindWriteBatchingTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/mapstore/writebehind/WriteBehindWriteBatchingTest.java
@@ -5,11 +5,12 @@ import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.QuickTest;
+
+import static org.junit.Assert.assertTrue;
+
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
-
-import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
@@ -22,6 +23,7 @@ public class WriteBehindWriteBatchingTest extends HazelcastTestSupport {
         final IMap<Object, Object> map = TestMapUsingMapStoreBuilder.create()
                 .withMapStore(mapStore)
                 .withNodeCount(1)
+                .withNodeFactory(createHazelcastInstanceFactory(1))
                 .withWriteDelaySeconds(3)
                 .withPartitionCount(1)
                 .withWriteBatchSize(writeBatchSize)

--- a/hazelcast/src/test/java/com/hazelcast/partition/SafeClusterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/partition/SafeClusterTest.java
@@ -6,13 +6,14 @@ import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.QuickTest;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
 
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 // TODO tests are not sufficient. add more tests.
 /**
@@ -32,7 +33,7 @@ public class SafeClusterTest extends HazelcastTestSupport {
 
     @Test
     public void isClusterSafe_multiNode() throws Exception {
-        final TestHazelcastInstanceFactory factory = new TestHazelcastInstanceFactory(2);
+        final TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(2);
         final HazelcastInstance node1 = factory.newHazelcastInstance();
         final HazelcastInstance node2 = factory.newHazelcastInstance();
         final boolean safe1 = node1.getPartitionService().isClusterSafe();
@@ -52,7 +53,7 @@ public class SafeClusterTest extends HazelcastTestSupport {
 
     @Test
     public void isLocalMemberSafe_multiNode() throws Exception {
-        final TestHazelcastInstanceFactory factory = new TestHazelcastInstanceFactory(2);
+        final TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(2);
         final HazelcastInstance node1 = factory.newHazelcastInstance();
         final HazelcastInstance node2 = factory.newHazelcastInstance();
         final boolean safe1 = node1.getPartitionService().isLocalMemberSafe();

--- a/hazelcast/src/test/java/com/hazelcast/spi/InvocationFutureGetNewInstanceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/InvocationFutureGetNewInstanceTest.java
@@ -8,12 +8,7 @@ import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
-import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.QuickTest;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
 
 import java.io.IOException;
 import java.io.Serializable;
@@ -24,6 +19,11 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertTrue;
 
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
 /**
  * This test verifies that instances returned by the InvocationFuture, are always copied instances.
  * We don't want instances to be shared unexpectedly. In the future there might be some sharing going
@@ -33,13 +33,13 @@ import static org.junit.Assert.assertTrue;
 @Category(QuickTest.class)
 public class InvocationFutureGetNewInstanceTest extends HazelcastTestSupport {
 
-    private static HazelcastInstance[] instances;
-    private static HazelcastInstance local;
-    private static HazelcastInstance remote;
+    private HazelcastInstance[] instances;
+    private HazelcastInstance local;
+    private HazelcastInstance remote;
 
-    @BeforeClass
-    public static void setUp() {
-        instances = new TestHazelcastInstanceFactory(2).newInstances();
+    @Before
+    public void setUp() {
+        instances = createHazelcastInstanceFactory(2).newInstances();
         warmUpPartitions(instances);
         local = instances[0];
         remote = instances[1];


### PR DESCRIPTION
Migrating tests to HazelcastTestSupport managed instances so that they are shut down at the end of the test.
