### PR TITLE
Adding thread name to test logging output

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastParallelClassRunner.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastParallelClassRunner.java
@@ -57,7 +57,7 @@ public class HazelcastParallelClassRunner extends AbstractHazelcastClassRunner {
             }
         }
         numThreads.incrementAndGet();
-        new Thread(new TestRunner(method, notifier)).start();
+        new Thread(new TestRunner(method, notifier), method.getName()).start();
     }
 
     @Override

--- a/hazelcast/src/test/resources/log4j.properties
+++ b/hazelcast/src/test/resources/log4j.properties
@@ -18,7 +18,7 @@
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.Target=System.out
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=%d{ABSOLUTE} %5p [%c{1}] - %m%n
+log4j.appender.stdout.layout.ConversionPattern=%d{ABSOLUTE} %5p [%c{1}] %t - %m%n
 
 #log4j.logger.com.hazelcast=debug
 #log4j.logger.com.hazelcast.cluster=debug


### PR DESCRIPTION
When tests are run in parallel logging output is intertwined. 
Adding thread name to test logging output and naming each thread after the test it is executing.
