### PR TITLE
Tests for queries with indexes on null fields

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/map/query/QueryAdvancedTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/query/QueryAdvancedTest.java
@@ -32,18 +32,17 @@ import com.hazelcast.query.EntryObject;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.PredicateBuilder;
 import com.hazelcast.query.SampleObjects;
+import com.hazelcast.query.SampleObjects.Employee;
+import com.hazelcast.query.SampleObjects.Value;
+import com.hazelcast.query.SampleObjects.ValueType;
 import com.hazelcast.query.SqlPredicate;
 import com.hazelcast.test.AssertTask;
-import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.util.Clock;
 import com.hazelcast.util.UuidUtil;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
 
 import java.io.Serializable;
 import java.util.Collection;
@@ -60,14 +59,16 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.hazelcast.map.query.QueryBasicTest.doFunctionalQueryTest;
 import static com.hazelcast.map.query.QueryBasicTest.doFunctionalSQLQueryTest;
-import static com.hazelcast.query.SampleObjects.Employee;
-import static com.hazelcast.query.SampleObjects.Value;
-import static com.hazelcast.query.SampleObjects.ValueType;
+
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
-@RunWith(HazelcastParallelClassRunner.class)
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
 public class QueryAdvancedTest extends HazelcastTestSupport {
 
@@ -328,59 +329,6 @@ public class QueryAdvancedTest extends HazelcastTestSupport {
         imap.addIndex("active", false);
         doFunctionalSQLQueryTest(imap);
     }
-
-    @Test(timeout = 1000 * 60)
-    public void testNullIndexing() {
-        TestHazelcastInstanceFactory nodeFactory = createHazelcastInstanceFactory(2);
-        HazelcastInstance h1 = nodeFactory.newHazelcastInstance();
-        HazelcastInstance h2 = nodeFactory.newHazelcastInstance();
-
-        EntryObject e = new PredicateBuilder().getEntryObject();
-        Predicate predicate = e.is("active").and(e.get("name").equal(null).and(e.get("city").isNull()));
-
-        IMap imap1 = h1.getMap("employees");
-        IMap imap2 = h2.getMap("employees");
-
-        for (int i = 0; i < 5000; i++) {
-            boolean test = i % 2 == 0;
-            imap1.put(String.valueOf(i), new Employee(test ? null : "name" + i,
-                    test ? null : "city" + i, i % 60, true, (double) i));
-        }
-        long start = Clock.currentTimeMillis();
-        Set<Map.Entry> entries = imap2.entrySet(predicate);
-        long tookWithout = (Clock.currentTimeMillis() - start);
-        assertEquals(2500, entries.size());
-        for (Map.Entry entry : entries) {
-            Employee c = (Employee) entry.getValue();
-            assertNull(c.getName());
-            assertNull(c.getCity());
-        }
-        imap1.destroy();
-
-        imap1 = h1.getMap("employees2");
-        imap2 = h2.getMap("employees2");
-        imap1.addIndex("name", false);
-        imap1.addIndex("city", true);
-        imap1.addIndex("age", true);
-        imap1.addIndex("active", false);
-
-        for (int i = 0; i < 5000; i++) {
-            boolean test = i % 2 == 0;
-            imap1.put(String.valueOf(i), new Employee(test ? null : "name" + i,
-                    test ? null : "city" + i, i % 60, true, (double) i));
-        }
-        start = Clock.currentTimeMillis();
-        entries = imap2.entrySet(predicate);
-        long tookWithIndex = (Clock.currentTimeMillis() - start);
-        assertEquals(2500, entries.size());
-        for (Map.Entry entry : entries) {
-            Employee c = (Employee) entry.getValue();
-            assertNull(c.getName());
-            assertNull(c.getCity());
-        }
-        assertTrue("WithIndex: " + tookWithIndex + ", without: " + tookWithout, tookWithIndex < tookWithout);
-    }
-
 
     @Test(timeout = 1000 * 60)
     public void testTwoMembers() {

--- a/hazelcast/src/test/java/com/hazelcast/map/query/QueryIndexingTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/query/QueryIndexingTest.java
@@ -1,0 +1,173 @@
+package com.hazelcast.map.query;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.SerializerConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.StreamSerializer;
+import com.hazelcast.query.EntryObject;
+import com.hazelcast.query.Predicate;
+import com.hazelcast.query.PredicateBuilder;
+import com.hazelcast.query.SampleObjects.Employee;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.QuickTest;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+import static java.util.Collections.emptyList;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import org.mockito.Mockito;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category(QuickTest.class)
+public class QueryIndexingTest extends HazelcastTestSupport {
+
+    private int count = 5000;
+    private Map<Integer, Employee> employees = newEmployees(count);
+    private Config conf = newConfig(employees);
+
+    private TestHazelcastInstanceFactory nodeFactory = createHazelcastInstanceFactory(2);
+    private HazelcastInstance h1 = nodeFactory.newHazelcastInstance(conf);
+    private HazelcastInstance h2 = nodeFactory.newHazelcastInstance(conf);
+
+    private EntryObject e = new PredicateBuilder().getEntryObject();
+    private Predicate predicate = e.get("name").equal(null).and(e.get("city").isNull());
+
+    @Before
+    public void waitForCluster() {
+        assertClusterSizeEventually(2, h1);
+        waitClusterForSafeState(h1);
+    }
+
+    @Test
+    public void testResultsHaveNullFields_whenPredicateTestsForNull() throws Exception {
+
+        IMap<Integer, Employee> imap1 = h1.getMap("employees");
+        imap1.putAll(employees);
+
+        Collection<Employee> matchingEntries = runQueryNTimes(3, h2.<String, Employee>getMap("employees"));
+
+        assertEquals(count/2, matchingEntries.size());
+        // N queries result in getters called N times
+        assertGettersCalledNTimes(matchingEntries, 3);
+        assertFieldsAreNull(matchingEntries);
+    }
+
+    @Test
+    public void testResultsHaveNullFields_whenUsingIndexes()  throws Exception  {
+
+        IMap<Integer, Employee> imap1 = h1.getMap("employees");
+
+        imap1.addIndex("name", false);
+        imap1.addIndex("city", true);
+
+        imap1.putAll(employees);
+
+        Collection<Employee> matchingEntries = runQueryNTimes(3, h2.<String, Employee>getMap("employees"));
+        assertEquals(count/2, matchingEntries.size());
+
+        // N queries result in getters called only 1 time, when indexing
+        assertGettersCalledNTimes(matchingEntries, 1);
+        assertFieldsAreNull(matchingEntries);
+    }
+
+    private Collection<Employee> runQueryNTimes(int nTimes, IMap<String, Employee> imap2) {
+        Collection<Employee> result = emptyList();
+        for(int i = 0; i < nTimes; i++) {
+            result = imap2.values(predicate);
+        }
+        return result;
+    }
+
+    private static void assertGettersCalledNTimes(Collection<Employee> matchingEmployees, int n) {
+        for(Employee employee : matchingEmployees) {
+            verify(employee, times(n)).getCity();
+            verify(employee, times(n)).getName();
+        }
+    }
+
+    private static void assertFieldsAreNull(Collection<Employee> matchingEmployees) {
+        for(Employee employee : matchingEmployees) {
+            assertNull("city", employee.getCity());
+            assertNull("name", employee.getName());
+        }
+    }
+
+    private static Config newConfig(final Map<Integer, Employee> employees) {
+        Config conf = new Config();
+        conf.getMapConfig("employees").setBackupCount(0);
+
+        SerializerConfig serializerConfig = new SerializerConfig();
+        serializerConfig.setTypeClass(Employee.class);
+        // serialize list index because employees are wrapped in Mockito.spy
+        serializerConfig.setImplementation(new EmployeeIdSerializer(employees));
+
+        conf.getSerializationConfig().addSerializerConfig(serializerConfig);
+        return conf;
+    }
+
+    private static Map<Integer, Employee> newEmployees(int employeeCount) {
+        Map<Integer, Employee> employees = new HashMap<Integer, Employee>();
+        for (int i = 0; i < employeeCount; i++) {
+            Employee val;
+            if(i % 2 == 0) {
+                val = new Employee(i, null, null, 0, true, i);
+            } else {
+                val = new Employee(i, "name" + i, "city" + i, 0, true, i);
+            }
+            employees.put(i, Mockito.spy(val));
+        }
+        return employees;
+    }
+
+    /**
+     * Serializes only employee id and deserializes to existing instance.
+     * For testing purposes does not serialize actual objects.
+     */
+    static class EmployeeIdSerializer implements StreamSerializer<Employee> {
+
+        private Map<Integer, Employee> employees;
+
+        public EmployeeIdSerializer(Map<Integer, Employee> employees) {
+            this.employees = employees;
+        }
+
+        @Override
+        public void write(ObjectDataOutput out, Employee employee) throws IOException {
+            out.writeInt((int)employee.getId());
+        }
+
+        @Override
+        public Employee read(ObjectDataInput in) throws IOException {
+            return employees.get(in.readInt());
+        }
+
+        @Override
+        public int getTypeId() {
+            return 123;
+        }
+
+        @Override
+        public void destroy() {
+        }
+    }
+
+}


### PR DESCRIPTION
Issue #3621.
Refactored testNullIndexing test and moved from QueryAdvancedTest into QueryIndexingTest.
Replaced execution time checking with invocation count checking using Mockito.
Counting how many times fields are accessed with indexes and how many times without.
