### PR TITLE
Support for indexes on custom attribute types

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/query/impl/IdentityConverter.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/IdentityConverter.java
@@ -1,0 +1,15 @@
+package com.hazelcast.query.impl;
+
+import com.hazelcast.query.impl.TypeConverters.TypeConverter;
+
+/**
+ * Converts to the same value
+ **/
+public class IdentityConverter implements TypeConverter {
+
+    @Override
+    public Comparable convert(final Comparable value) {
+        return value;
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/IndexImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/IndexImpl.java
@@ -18,6 +18,7 @@ package com.hazelcast.query.impl;
 
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.query.QueryException;
+import com.hazelcast.query.impl.TypeConverters.TypeConverter;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -40,7 +41,7 @@ public class IndexImpl implements Index {
     private final String attribute;
     private final boolean ordered;
 
-    private volatile AttributeType attributeType;
+    private volatile TypeConverter converter;
 
     public IndexImpl(String attribute, boolean ordered) {
         this.attribute = attribute;
@@ -60,8 +61,8 @@ public class IndexImpl implements Index {
     public void clear() {
         recordValues.clear();
         indexStore.clear();
-        // Clear attribute type
-        attributeType = null;
+        // Clear converter
+        converter = null;
     }
 
     ConcurrentMap<Data, QueryableEntry> getRecordMap(Comparable indexValue) {
@@ -71,16 +72,18 @@ public class IndexImpl implements Index {
     @Override
     public void saveEntryIndex(QueryableEntry e) throws QueryException {
         /*
-         * At first, check if attribute type is not initialized, initialize it before saving an entry index
+         * At first, check if converter is not initialized, initialize it before saving an entry index
          * Because, if entity index is saved before,
-         * that thread can be blocked before executing attribute type setting code block,
-         * another thread can query over indexes without knowing attribute type and
+         * that thread can be blocked before executing converter setting code block,
+         * another thread can query over indexes without knowing the converter and
          * this causes to class cast exceptions.
          */
-        if (attributeType == null) {
+        if (converter == null) {
             // Initialize attribute type by using entry index
-            attributeType = e.getAttributeType(attribute);
+            AttributeType attributeType = e.getAttributeType(attribute);
+            converter = attributeType == null ? new IdentityConverter() : attributeType.getConverter();
         }
+
         Data key = e.getIndexKey();
         Comparable oldValue = recordValues.remove(key);
         Comparable newValue = e.getAttribute(attribute);
@@ -96,22 +99,20 @@ public class IndexImpl implements Index {
         } else {
             // update
             indexStore.updateIndex(oldValue, newValue, e);
-            //indexStore.removeIndex(oldValue, key);
-            //indexStore.newIndex(newValue, e);
         }
     }
 
     @Override
     public Set<QueryableEntry> getRecords(Comparable[] values) {
         if (values.length == 1) {
-            if (attributeType != null) {
+            if (converter != null) {
                 return indexStore.getRecords(convert(values[0]));
             } else {
                 return new SingleResultSet(null);
             }
         } else {
             MultiResultSet results = new MultiResultSet();
-            if (attributeType != null) {
+            if (converter != null) {
                 Set<Comparable> convertedValues = new HashSet<Comparable>(values.length);
                 for (Comparable value : values) {
                     convertedValues.add(convert(value));
@@ -124,7 +125,7 @@ public class IndexImpl implements Index {
 
     @Override
     public Set<QueryableEntry> getRecords(Comparable value) {
-        if (attributeType != null) {
+        if (converter != null) {
             return indexStore.getRecords(convert(value));
         } else {
             return new SingleResultSet(null);
@@ -134,7 +135,7 @@ public class IndexImpl implements Index {
     @Override
     public Set<QueryableEntry> getSubRecordsBetween(Comparable from, Comparable to) {
         MultiResultSet results = new MultiResultSet();
-        if (attributeType != null) {
+        if (converter != null) {
             indexStore.getSubRecordsBetween(results, convert(from), convert(to));
         }
         return results;
@@ -143,17 +144,14 @@ public class IndexImpl implements Index {
     @Override
     public Set<QueryableEntry> getSubRecords(ComparisonType comparisonType, Comparable searchedValue) {
         MultiResultSet results = new MultiResultSet();
-        if (attributeType != null) {
+        if (converter != null) {
             indexStore.getSubRecords(results, comparisonType, convert(searchedValue));
         }
         return results;
     }
 
     private Comparable convert(Comparable value) {
-        if (attributeType == null) {
-            return value;
-        }
-        return attributeType.getConverter().convert(value);
+        return converter.convert(value);
     }
 
     public ConcurrentMap<Data, Comparable> getRecordValues() {

--- a/hazelcast/src/main/java/com/hazelcast/util/HashUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/HashUtil.java
@@ -20,6 +20,7 @@ import com.hazelcast.nio.UnsafeHelper;
 import sun.misc.Unsafe;
 
 import java.nio.ByteOrder;
+import java.util.Arrays;
 
 @edu.umd.cs.findbugs.annotations.SuppressWarnings({"SF_SWITCH_FALLTHROUGH", "SF_SWITCH_NO_DEFAULT"})
 public final class HashUtil {
@@ -373,6 +374,13 @@ public final class HashUtil {
         k *= 0xc4ceb9fe1a85ec53L;
         k ^= k >>> 33;
         return k;
+    }
+
+    /**
+     * Hash code for multiple objects using {@link Arrays#hashCode(Object[])}.
+     **/
+    public static int hashCode(Object ... objects) {
+        return Arrays.hashCode(objects);
     }
 
     private HashUtil(){}

--- a/hazelcast/src/test/java/com/hazelcast/map/query/CustomAttribute.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/query/CustomAttribute.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2008-2013, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hazelcast.map.query;
+
+import com.hazelcast.util.HashUtil;
+
+import java.io.Serializable;
+
+public class CustomAttribute implements Serializable, Comparable<CustomAttribute> {
+
+    private int age;
+    private long height;
+
+    public CustomAttribute(int age, long height) {
+        this.age = age;
+        this.height = height;
+    }
+
+    public int compareTo(CustomAttribute o) {
+        return age - o.age;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        CustomAttribute that = (CustomAttribute) o;
+
+        if (age != that.age) return false;
+        if (height != that.height) return false;
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return HashUtil.hashCode(age, height);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/map/query/CustomObject.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/query/CustomObject.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2008-2013, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hazelcast.map.query;
+
+import com.hazelcast.util.HashUtil;
+
+import java.io.Serializable;
+import java.util.UUID;
+
+public class CustomObject implements Serializable {
+
+    private String name;
+    private UUID uuid;
+    private CustomAttribute attribute;
+
+    public CustomObject(String name, UUID uuid, CustomAttribute attribute) {
+        this.name = name;
+        this.uuid = uuid;
+        this.attribute = attribute;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public UUID getUuid() {
+        return uuid;
+    }
+
+    public CustomAttribute getAttribute() {
+        return attribute;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        CustomObject that = (CustomObject) o;
+
+        if (attribute != null ? !attribute.equals(that.attribute) : that.attribute != null) return false;
+        if (name != null ? !name.equals(that.name) : that.name != null) return false;
+        if (uuid != null ? !uuid.equals(that.uuid) : that.uuid != null) return false;
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return HashUtil.hashCode(name, uuid, attribute);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/map/query/QueryBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/query/QueryBasicTest.java
@@ -6,19 +6,26 @@ import com.hazelcast.config.MapConfig;
 import com.hazelcast.config.MapIndexConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
-import com.hazelcast.query.*;
+import com.hazelcast.nio.serialization.PortableTest.ChildPortableObject;
+import com.hazelcast.nio.serialization.PortableTest.GrandParentPortableObject;
+import com.hazelcast.nio.serialization.PortableTest.ParentPortableObject;
+import com.hazelcast.query.EntryObject;
+import com.hazelcast.query.Predicate;
+import com.hazelcast.query.PredicateBuilder;
+import com.hazelcast.query.Predicates;
+import com.hazelcast.query.QueryException;
+import com.hazelcast.query.SampleObjects;
+import com.hazelcast.query.SampleObjects.Employee;
+import com.hazelcast.query.SampleObjects.State;
+import com.hazelcast.query.SampleObjects.Value;
+import com.hazelcast.query.SampleObjects.ValueType;
+import com.hazelcast.query.SqlPredicate;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.QuickTest;
-import com.hazelcast.util.IterationType;
 import com.hazelcast.util.UuidUtil;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
 
-import java.io.Serializable;
-import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
@@ -29,21 +36,17 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.UUID;
 
-import static com.hazelcast.nio.serialization.PortableTest.ChildPortableObject;
-import static com.hazelcast.nio.serialization.PortableTest.GrandParentPortableObject;
-import static com.hazelcast.nio.serialization.PortableTest.ParentPortableObject;
-import static com.hazelcast.query.SampleObjects.Employee;
-import static com.hazelcast.query.SampleObjects.State;
-import static com.hazelcast.query.SampleObjects.Value;
-import static com.hazelcast.query.SampleObjects.ValueType;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category(QuickTest.class)
@@ -63,64 +66,6 @@ public class QueryBasicTest extends HazelcastTestSupport {
         final Predicate predicate = new PredicateBuilder().getEntryObject().get("name").in(emptyArray);
         final Collection<Value> values = map.values(predicate);
         assertEquals(values.size(), 0);
-    }
-
-    @Test(timeout = 1000 * 60)
-    public void testInnerIndex() {
-        HazelcastInstance instance = createHazelcastInstance();
-        IMap<String, SampleObjects.Value> map = instance.getMap("default");
-        map.addIndex("name", false);
-        map.addIndex("type.typeName", false);
-        for (int i = 0; i < 10; i++) {
-            Value v = new Value("name" + i, i < 5 ? null : new ValueType("type" + i), i);
-            map.put("" + i, v);
-        }
-        Predicate predicate = new PredicateBuilder().getEntryObject().get("type.typeName").in("type8", "type6");
-        Collection<SampleObjects.Value> values = map.values(predicate);
-        assertEquals(2, values.size());
-        List<String> typeNames = new ArrayList<String>();
-        for (Value configObject : values) {
-            typeNames.add(configObject.getType().getTypeName());
-        }
-        String[] array = typeNames.toArray(new String[0]);
-        Arrays.sort(array);
-        assertArrayEquals(typeNames.toString(), new String[]{"type6", "type8"}, array);
-    }
-
-    @Test(timeout = 1000 * 60)
-    public void testInnerIndexSql() {
-        HazelcastInstance instance = createHazelcastInstance();
-        IMap<String, SampleObjects.Value> map = instance.getMap("default");
-        map.addIndex("name", false);
-        map.addIndex("type.typeName", false);
-        for (int i = 0; i < 4; i++) {
-            Value v = new Value("name" + i, new ValueType("type" + i), i);
-            map.put("" + i, v);
-        }
-        Predicate predicate = new SqlPredicate("type.typeName='type1'");
-        Collection<SampleObjects.Value> values = map.values(predicate);
-        assertEquals(1, values.size());
-        List<String> typeNames = new ArrayList<String>();
-        for (Value configObject : values) {
-            typeNames.add(configObject.getType().getTypeName());
-        }
-        assertArrayEquals(typeNames.toString(), new String[]{"type1"}, typeNames.toArray(new String[0]));
-    }
-
-
-    @Test(timeout = 1000 * 60)
-    public void issue685RemoveIndexesOnClear() {
-        HazelcastInstance instance = createHazelcastInstance();
-        IMap<String, SampleObjects.Value> map = instance.getMap("default");
-        map.addIndex("name", true);
-        for (int i = 0; i < 4; i++) {
-            Value v = new Value("name" + i);
-            map.put("" + i, v);
-        }
-        map.clear();
-        Predicate predicate = new SqlPredicate("name='name0'");
-        Collection<SampleObjects.Value> values = map.values(predicate);
-        assertEquals(0, values.size());
     }
 
     @Test(timeout = 1000 * 60)
@@ -306,20 +251,6 @@ public class QueryBasicTest extends HazelcastTestSupport {
         String[] array = names.toArray(new String[0]);
         Arrays.sort(array);
         assertArrayEquals(names.toString(), expectedValues, array);
-    }
-
-    @Test(timeout = 1000 * 60)
-    public void testOneIndexedFieldsWithTwoCriteriaField() throws Exception {
-        HazelcastInstance h1 = createHazelcastInstance();
-        IMap imap = h1.getMap("employees");
-        imap.addIndex("name", false);
-//        imap.addIndex("age", false);
-        imap.put("1", new Employee(1L, "joe", 30, true, 100D));
-        EntryObject e = new PredicateBuilder().getEntryObject();
-        PredicateBuilder a = e.get("name").equal("joe");
-        Predicate b = e.get("age").equal("30");
-        Collection<Object> actual = imap.values(a.and(b));
-        assertEquals(1, actual.size());
     }
 
     @Test(timeout = 1000 * 60)
@@ -531,99 +462,11 @@ public class QueryBasicTest extends HazelcastTestSupport {
         CustomObject object2 = new CustomObject("name2", UuidUtil.buildRandomUUID(), attribute);
         map.put(2, object2);
 
-        assertEquals(object, map.values(new PredicateBuilder().getEntryObject().get("uuid").equal(object.uuid)).iterator().next());
+        assertEquals(object, map.values(new PredicateBuilder().getEntryObject().get("uuid").equal(object.getUuid())).iterator().next());
         assertEquals(2, map.values(new PredicateBuilder().getEntryObject().get("attribute").equal(attribute)).size());
 
-        assertEquals(object2, map.values(new PredicateBuilder().getEntryObject().get("uuid").in(object2.uuid)).iterator().next());
+        assertEquals(object2, map.values(new PredicateBuilder().getEntryObject().get("uuid").in(object2.getUuid())).iterator().next());
         assertEquals(2, map.values(new PredicateBuilder().getEntryObject().get("attribute").in(attribute)).size());
-    }
-
-    private static class CustomObject implements Serializable {
-        private String name;
-        private UUID uuid;
-        private CustomAttribute attribute;
-
-        private CustomObject(String name, UUID uuid, CustomAttribute attribute) {
-            this.name = name;
-            this.uuid = uuid;
-            this.attribute = attribute;
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
-
-            CustomObject that = (CustomObject) o;
-
-            if (attribute != null ? !attribute.equals(that.attribute) : that.attribute != null) return false;
-            if (name != null ? !name.equals(that.name) : that.name != null) return false;
-            if (uuid != null ? !uuid.equals(that.uuid) : that.uuid != null) return false;
-
-            return true;
-        }
-
-        @Override
-        public int hashCode() {
-            int result = name != null ? name.hashCode() : 0;
-            result = 31 * result + (uuid != null ? uuid.hashCode() : 0);
-            result = 31 * result + (attribute != null ? attribute.hashCode() : 0);
-            return result;
-        }
-    }
-
-    private static class CustomAttribute implements Serializable, Comparable {
-        private int age;
-        private long height;
-
-        private CustomAttribute(int age, long height) {
-            this.age = age;
-            this.height = height;
-        }
-
-        public int compareTo(Object o) {
-            return 0;
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
-
-            CustomAttribute that = (CustomAttribute) o;
-
-            if (age != that.age) return false;
-            if (height != that.height) return false;
-
-            return true;
-        }
-
-        @Override
-        public int hashCode() {
-            int result = age;
-            result = 31 * result + (int) (height ^ (height >>> 32));
-            return result;
-        }
-    }
-
-    @Test(timeout = 1000 * 60)
-    public void testPredicateNotEqualWithIndex() {
-        HazelcastInstance instance = createHazelcastInstance();
-        IMap map1 = instance.getMap("testPredicateNotEqualWithIndex-ordered");
-        IMap map2 = instance.getMap("testPredicateNotEqualWithIndex-unordered");
-        testPredicateNotEqualWithIndex(map1, true);
-        testPredicateNotEqualWithIndex(map2, false);
-    }
-
-    private void testPredicateNotEqualWithIndex(IMap map, boolean ordered) {
-        map.addIndex("name", ordered);
-        map.put(1, new Value("abc", 1));
-        map.put(2, new Value("xyz", 2));
-        map.put(3, new Value("aaa", 3));
-        assertEquals(3, map.values(new SqlPredicate("name != 'aac'")).size());
-        assertEquals(2, map.values(new SqlPredicate("index != 2")).size());
-        assertEquals(3, map.values(new PredicateBuilder().getEntryObject().get("name").notEqual("aac")).size());
-        assertEquals(2, map.values(new PredicateBuilder().getEntryObject().get("index").notEqual(2)).size());
     }
 
     public static void doFunctionalSQLQueryTest(IMap imap) {
@@ -928,29 +771,6 @@ public class QueryBasicTest extends HazelcastTestSupport {
         testQueryUsingPortableObject(config, name);
     }
 
-    @Test
-    public void testQueryPortableObjectWithIndex() {
-        String name = randomMapName();
-        Config config = new Config();
-        MapConfig mapConfig = new MapConfig(name)
-                .addMapIndexConfig(new MapIndexConfig("timestamp", true));
-        config.addMapConfig(mapConfig);
-
-        testQueryUsingPortableObject(config, name);
-    }
-
-    @Test
-    public void testQueryPortableObjectWithIndexAndOptimizeQueries() {
-        String name = randomMapName();
-        Config config = new Config();
-        MapConfig mapConfig = new MapConfig(name)
-                .setOptimizeQueries(true)
-                .addMapIndexConfig(new MapIndexConfig("timestamp", true));
-        config.addMapConfig(mapConfig);
-
-        testQueryUsingPortableObject(config, name);
-    }
-
     private void testQueryUsingPortableObject(Config config, String mapName) {
         TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(2);
         HazelcastInstance hz1 = factory.newHazelcastInstance(config);
@@ -990,6 +810,29 @@ public class QueryBasicTest extends HazelcastTestSupport {
         testQueryUsingNestedPortableObject(config, name);
     }
 
+    @Test
+    public void testQueryPortableObjectWithIndex() {
+        String name = randomMapName();
+        Config config = new Config();
+        MapConfig mapConfig = new MapConfig(name)
+                .addMapIndexConfig(new MapIndexConfig("timestamp", true));
+        config.addMapConfig(mapConfig);
+
+        testQueryUsingPortableObject(config, name);
+    }
+
+    @Test
+    public void testQueryPortableObjectWithIndexAndOptimizeQueries() {
+        String name = randomMapName();
+        Config config = new Config();
+        MapConfig mapConfig = new MapConfig(name)
+                .setOptimizeQueries(true)
+                .addMapIndexConfig(new MapIndexConfig("timestamp", true));
+        config.addMapConfig(mapConfig);
+
+        testQueryUsingPortableObject(config, name);
+    }
+
     private void testQueryUsingNestedPortableObject(Config config, String name) {
         TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(2);
         HazelcastInstance hz1 = factory.newHazelcastInstance(config);
@@ -1005,121 +848,6 @@ public class QueryBasicTest extends HazelcastTestSupport {
 
         values = map.values(new SqlPredicate("child.child.timestamp > 0"));
         assertEquals(1, values.size());
-    }
-
-    @Test
-    public void testIndexedNullValueOnUnorderedIndexStoreWithLessPredicate() {
-        final List<Long> dates =
-                queryIndexedDateFieldAsNullValue(false,
-                                                 Predicates.lessThan("date", 5000000L));
-        assertEquals(2, dates.size());
-        assertTrue(dates.containsAll(Arrays.asList(2000000L, 4000000L)));
-    }
-
-    @Test
-    public void testIndexedNullValueOnUnorderedIndexStoreWithLessEqualPredicate() {
-        final List<Long> dates =
-                queryIndexedDateFieldAsNullValue(false,
-                                                 Predicates.lessEqual("date", 5000000L));
-        assertEquals(2, dates.size());
-        assertTrue(dates.containsAll(Arrays.asList(2000000L, 4000000L)));
-    }
-
-    @Test
-    public void testIndexedNullValueOnUnorderedIndexStoreWithGreaterPredicate() {
-        final List<Long> dates =
-                queryIndexedDateFieldAsNullValue(false,
-                                                 Predicates.greaterThan("date", 5000000L));
-        assertEquals(3, dates.size());
-        assertTrue(dates.containsAll(Arrays.asList(6000000L, 8000000L, 10000000L)));
-    }
-
-    @Test
-    public void testIndexedNullValueOnUnorderedIndexStoreWithGreaterEqualPredicate() {
-        final List<Long> dates =
-                queryIndexedDateFieldAsNullValue(false,
-                                                 Predicates.greaterEqual("date", 6000000L));
-        assertEquals(3, dates.size());
-        assertTrue(dates.containsAll(Arrays.asList(6000000L, 8000000L, 10000000L)));
-    }
-
-    @Test
-    public void testIndexedNullValueOnUnorderedIndexStoreWithNotEqualPredicate() {
-        final List<Long> dates =
-                queryIndexedDateFieldAsNullValue(false,
-                                                 Predicates.notEqual("date", 2000000L));
-        assertEquals(4, dates.size());
-        assertTrue(dates.containsAll(
-                Arrays.asList(4000000L, 6000000L, 8000000L, 10000000L)));
-    }
-
-    @Test
-    public void testIndexedNullValueOnOrderedIndexStoreWithLessPredicate() {
-        final List<Long> dates =
-                queryIndexedDateFieldAsNullValue(true,
-                                                 Predicates.lessThan("date", 5000000L));
-        assertEquals(2, dates.size());
-        assertTrue(dates.containsAll(Arrays.asList(2000000L, 4000000L)));
-    }
-
-    @Test
-    public void testIndexedNullValueOnOrderedIndexStoreWithLessEqualPredicate() {
-        final List<Long> dates =
-                queryIndexedDateFieldAsNullValue(true,
-                                                 Predicates.lessEqual("date", 5000000L));
-        assertEquals(2, dates.size());
-        assertTrue(dates.containsAll(Arrays.asList(2000000L, 4000000L)));
-    }
-
-    @Test
-    public void testIndexedNullValueOnOrderedIndexStoreWithGreaterPredicate() {
-        final List<Long> dates =
-                queryIndexedDateFieldAsNullValue(true,
-                                                 Predicates.greaterThan("date", 5000000L));
-        assertEquals(3, dates.size());
-        assertTrue(dates.containsAll(Arrays.asList(6000000L, 8000000L, 10000000L)));
-    }
-
-    @Test
-    public void testIndexedNullValueOnOrderedIndexStoreWithGreaterEqualPredicate() {
-        final List<Long> dates =
-                queryIndexedDateFieldAsNullValue(true,
-                                                 Predicates.greaterEqual("date", 6000000L));
-        assertEquals(3, dates.size());
-        assertTrue(dates.containsAll(Arrays.asList(6000000L, 8000000L, 10000000L)));
-    }
-
-    @Test
-    public void testIndexedNullValueOnOrderedIndexStoreWithNotEqualPredicate() {
-        final List<Long> dates =
-                queryIndexedDateFieldAsNullValue(true,
-                                                 Predicates.notEqual("date", 2000000L));
-        assertEquals(4, dates.size());
-        assertTrue(dates.containsAll(
-                Arrays.asList(4000000L, 6000000L, 8000000L, 10000000L)));
-    }
-
-    private List<Long> queryIndexedDateFieldAsNullValue(boolean ordered, Predicate pred) {
-        final HazelcastInstance instance = createHazelcastInstance();
-        final IMap<Integer, SampleObjects.Employee> map = instance.getMap("default");
-
-        map.addIndex("date", ordered);
-        for (int i = 10; i >= 1; i--) {
-            Employee employee = new Employee(i, "name-" + i, i, true, i * 100);
-            if (i % 2 == 0) {
-                employee.setDate(new Timestamp(i * 1000000));
-            } else {
-                employee.setDate(null);
-            }
-            map.put(i, employee);
-        }
-
-        final List<Long> dates = new ArrayList<Long>();
-        for (SampleObjects.Employee employee : map.values(pred)) {
-            dates.add(employee.getDate().getTime());
-        }
-
-        return dates;
     }
 
 }

--- a/hazelcast/src/test/java/com/hazelcast/map/query/QueryIndexTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/query/QueryIndexTest.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2008-2013, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.query;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.query.EntryObject;
+import com.hazelcast.query.Predicate;
+import com.hazelcast.query.PredicateBuilder;
+import com.hazelcast.query.SampleObjects;
+import com.hazelcast.query.SampleObjects.Employee;
+import com.hazelcast.query.SampleObjects.Value;
+import com.hazelcast.query.SampleObjects.ValueType;
+import com.hazelcast.query.SqlPredicate;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.QuickTest;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import static java.util.UUID.randomUUID;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category(QuickTest.class)
+public class QueryIndexTest extends HazelcastTestSupport {
+
+    @Test
+    public void testResultsReturned_whenCustomAttributeIndexed() throws Exception {
+
+        HazelcastInstance h1 = createHazelcastInstance();
+
+        IMap<String, CustomObject> imap = h1.getMap("objects");
+        imap.addIndex("attribute", true);
+
+        for (int i = 0; i < 10; i++) {
+            CustomAttribute attr = new CustomAttribute(i, 200);
+            CustomObject object = new CustomObject("o" + i, randomUUID(), attr);
+            imap.put(object.getName(), object);
+        }
+
+        EntryObject entry = new PredicateBuilder().getEntryObject();
+        Predicate predicate = entry.get("attribute").greaterEqual(new CustomAttribute(5, 200));
+
+        Collection<CustomObject> values = imap.values(predicate);
+        assertEquals(5, values.size());
+    }
+
+    @Test(timeout = 1000 * 60)
+    public void testInnerIndex() {
+        HazelcastInstance instance = createHazelcastInstance();
+        IMap<String, SampleObjects.Value> map = instance.getMap("default");
+        map.addIndex("name", false);
+        map.addIndex("type.typeName", false);
+        for (int i = 0; i < 10; i++) {
+            Value v = new Value("name" + i, i < 5 ? null : new ValueType("type" + i), i);
+            map.put("" + i, v);
+        }
+        Predicate predicate = new PredicateBuilder().getEntryObject().get("type.typeName").in("type8", "type6");
+        Collection<SampleObjects.Value> values = map.values(predicate);
+        assertEquals(2, values.size());
+        List<String> typeNames = new ArrayList<String>();
+        for (Value configObject : values) {
+            typeNames.add(configObject.getType().getTypeName());
+        }
+        String[] array = typeNames.toArray(new String[0]);
+        Arrays.sort(array);
+        assertArrayEquals(typeNames.toString(), new String[]{"type6", "type8"}, array);
+    }
+
+    @Test(timeout = 1000 * 60)
+    public void testInnerIndexSql() {
+        HazelcastInstance instance = createHazelcastInstance();
+        IMap<String, SampleObjects.Value> map = instance.getMap("default");
+        map.addIndex("name", false);
+        map.addIndex("type.typeName", false);
+        for (int i = 0; i < 4; i++) {
+            Value v = new Value("name" + i, new ValueType("type" + i), i);
+            map.put("" + i, v);
+        }
+        Predicate predicate = new SqlPredicate("type.typeName='type1'");
+        Collection<SampleObjects.Value> values = map.values(predicate);
+        assertEquals(1, values.size());
+        List<String> typeNames = new ArrayList<String>();
+        for (Value configObject : values) {
+            typeNames.add(configObject.getType().getTypeName());
+        }
+        assertArrayEquals(typeNames.toString(), new String[]{"type1"}, typeNames.toArray(new String[0]));
+    }
+
+    @Test(timeout = 1000 * 60)
+    public void issue685RemoveIndexesOnClear() {
+        HazelcastInstance instance = createHazelcastInstance();
+        IMap<String, SampleObjects.Value> map = instance.getMap("default");
+        map.addIndex("name", true);
+        for (int i = 0; i < 4; i++) {
+            Value v = new Value("name" + i);
+            map.put("" + i, v);
+        }
+        map.clear();
+        Predicate predicate = new SqlPredicate("name='name0'");
+        Collection<SampleObjects.Value> values = map.values(predicate);
+        assertEquals(0, values.size());
+    }
+
+    @Test(timeout = 1000 * 60)
+        public void testOneIndexedFieldsWithTwoCriteriaField() throws Exception {
+            HazelcastInstance h1 = createHazelcastInstance();
+            IMap imap = h1.getMap("employees");
+            imap.addIndex("name", false);
+    //        imap.addIndex("age", false);
+            imap.put("1", new Employee(1L, "joe", 30, true, 100D));
+            EntryObject e = new PredicateBuilder().getEntryObject();
+            PredicateBuilder a = e.get("name").equal("joe");
+            Predicate b = e.get("age").equal("30");
+            Collection<Object> actual = imap.values(a.and(b));
+            assertEquals(1, actual.size());
+        }
+
+    @Test(timeout = 1000 * 60)
+    public void testPredicateNotEqualWithIndex() {
+        HazelcastInstance instance = createHazelcastInstance();
+        IMap map1 = instance.getMap("testPredicateNotEqualWithIndex-ordered");
+        IMap map2 = instance.getMap("testPredicateNotEqualWithIndex-unordered");
+        testPredicateNotEqualWithIndex(map1, true);
+        testPredicateNotEqualWithIndex(map2, false);
+    }
+
+    private void testPredicateNotEqualWithIndex(IMap map, boolean ordered) {
+        map.addIndex("name", ordered);
+        map.put(1, new Value("abc", 1));
+        map.put(2, new Value("xyz", 2));
+        map.put(3, new Value("aaa", 3));
+        assertEquals(3, map.values(new SqlPredicate("name != 'aac'")).size());
+        assertEquals(2, map.values(new SqlPredicate("index != 2")).size());
+        assertEquals(3, map.values(new PredicateBuilder().getEntryObject().get("name").notEqual("aac")).size());
+        assertEquals(2, map.values(new PredicateBuilder().getEntryObject().get("index").notEqual(2)).size());
+    }
+
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/map/query/QueryNullIndexingTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/query/QueryNullIndexingTest.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2008-2013, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hazelcast.map.query;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.query.Predicate;
+import com.hazelcast.query.Predicates;
+import com.hazelcast.query.SampleObjects;
+import com.hazelcast.query.SampleObjects.Employee;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.QuickTest;
+
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category(QuickTest.class)
+public class QueryNullIndexingTest extends HazelcastTestSupport {
+
+    @Test
+    public void testIndexedNullValueOnUnorderedIndexStoreWithLessPredicate() {
+        final List<Long> dates =
+                queryIndexedDateFieldAsNullValue(false,
+                                                 Predicates.lessThan("date", 5000000L));
+        assertEquals(2, dates.size());
+        assertTrue(dates.containsAll(Arrays.asList(2000000L, 4000000L)));
+    }
+
+    @Test
+    public void testIndexedNullValueOnUnorderedIndexStoreWithLessEqualPredicate() {
+        final List<Long> dates =
+                queryIndexedDateFieldAsNullValue(false,
+                                                 Predicates.lessEqual("date", 5000000L));
+        assertEquals(2, dates.size());
+        assertTrue(dates.containsAll(Arrays.asList(2000000L, 4000000L)));
+    }
+
+    @Test
+    public void testIndexedNullValueOnUnorderedIndexStoreWithGreaterPredicate() {
+        final List<Long> dates =
+                queryIndexedDateFieldAsNullValue(false,
+                                                 Predicates.greaterThan("date", 5000000L));
+        assertEquals(3, dates.size());
+        assertTrue(dates.containsAll(Arrays.asList(6000000L, 8000000L, 10000000L)));
+    }
+
+    @Test
+    public void testIndexedNullValueOnUnorderedIndexStoreWithGreaterEqualPredicate() {
+        final List<Long> dates =
+                queryIndexedDateFieldAsNullValue(false,
+                                                 Predicates.greaterEqual("date", 6000000L));
+        assertEquals(3, dates.size());
+        assertTrue(dates.containsAll(Arrays.asList(6000000L, 8000000L, 10000000L)));
+    }
+
+    @Test
+    public void testIndexedNullValueOnUnorderedIndexStoreWithNotEqualPredicate() {
+        final List<Long> dates =
+                queryIndexedDateFieldAsNullValue(false,
+                                                 Predicates.notEqual("date", 2000000L));
+        assertEquals(4, dates.size());
+        assertTrue(dates.containsAll(
+                Arrays.asList(4000000L, 6000000L, 8000000L, 10000000L)));
+    }
+
+    @Test
+    public void testIndexedNullValueOnOrderedIndexStoreWithLessPredicate() {
+        final List<Long> dates =
+                queryIndexedDateFieldAsNullValue(true,
+                                                 Predicates.lessThan("date", 5000000L));
+        assertEquals(2, dates.size());
+        assertTrue(dates.containsAll(Arrays.asList(2000000L, 4000000L)));
+    }
+
+    @Test
+    public void testIndexedNullValueOnOrderedIndexStoreWithLessEqualPredicate() {
+        final List<Long> dates =
+                queryIndexedDateFieldAsNullValue(true,
+                                                 Predicates.lessEqual("date", 5000000L));
+        assertEquals(2, dates.size());
+        assertTrue(dates.containsAll(Arrays.asList(2000000L, 4000000L)));
+    }
+
+    @Test
+    public void testIndexedNullValueOnOrderedIndexStoreWithGreaterPredicate() {
+        final List<Long> dates =
+                queryIndexedDateFieldAsNullValue(true,
+                                                 Predicates.greaterThan("date", 5000000L));
+        assertEquals(3, dates.size());
+        assertTrue(dates.containsAll(Arrays.asList(6000000L, 8000000L, 10000000L)));
+    }
+
+    @Test
+    public void testIndexedNullValueOnOrderedIndexStoreWithGreaterEqualPredicate() {
+        final List<Long> dates =
+                queryIndexedDateFieldAsNullValue(true,
+                                                 Predicates.greaterEqual("date", 6000000L));
+        assertEquals(3, dates.size());
+        assertTrue(dates.containsAll(Arrays.asList(6000000L, 8000000L, 10000000L)));
+    }
+
+    @Test
+    public void testIndexedNullValueOnOrderedIndexStoreWithNotEqualPredicate() {
+        final List<Long> dates =
+                queryIndexedDateFieldAsNullValue(true,
+                                                 Predicates.notEqual("date", 2000000L));
+        assertEquals(4, dates.size());
+        assertTrue(dates.containsAll(
+                Arrays.asList(4000000L, 6000000L, 8000000L, 10000000L)));
+    }
+
+    private List<Long> queryIndexedDateFieldAsNullValue(boolean ordered, Predicate pred) {
+        final HazelcastInstance instance = createHazelcastInstance();
+        final IMap<Integer, SampleObjects.Employee> map = instance.getMap("default");
+
+        map.addIndex("date", ordered);
+        for (int i = 10; i >= 1; i--) {
+            Employee employee = new Employee(i, "name-" + i, i, true, i * 100);
+            if (i % 2 == 0) {
+                employee.setDate(new Timestamp(i * 1000000));
+            } else {
+                employee.setDate(null);
+            }
+            map.put(i, employee);
+        }
+
+        final List<Long> dates = new ArrayList<Long>();
+        for (SampleObjects.Employee employee : map.values(pred)) {
+            dates.add(employee.getDate().getTime());
+        }
+
+        return dates;
+    }
+
+}


### PR DESCRIPTION
closes #3857
Fix for indexes on custom object types that do not resolve to any AttributeType but implement Comparable.
Key change is at IndexImpl.saveEntryIndex (lines 80-85). Even if attribute type is null we can still use an index.
Test: QueryIndexTest.testResultsReturned_whenCustomAttributeIndexed
Split up QueryBasicTest into multiple files.
