### PR TITLE
Map loader key load process decoupled from map creation

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/AbstractRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/AbstractRecordStore.java
@@ -183,7 +183,7 @@ abstract class AbstractRecordStore implements RecordStore {
     }
 
     protected RecordStoreLoader createRecordStoreLoader() {
-        return mapContainer.getMapStoreContext().getStore() == null
+        return mapContainer.getMapStoreContext().getMapStoreWrapper() == null
                 ? RecordStoreLoader.EMPTY_LOADER : new BasicRecordStoreLoader(this);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/BasicRecordStoreLoader.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/BasicRecordStoreLoader.java
@@ -35,13 +35,22 @@ import java.util.concurrent.atomic.AtomicInteger;
  */
 class BasicRecordStoreLoader implements RecordStoreLoader {
 
+    private static final String MAP_INITIAL_LOAD_EXECUTOR = "hz:map-initialLoad";
+
     private final AtomicBoolean loaded;
+
     private final ILogger logger;
+
     private final String name;
+
     private final MapServiceContext mapServiceContext;
+
     private final MapDataStore mapDataStore;
+
     private final RecordStore recordStore;
+
     private final int partitionId;
+
     private volatile Throwable throwable;
 
     public BasicRecordStoreLoader(RecordStore recordStore) {
@@ -66,15 +75,19 @@ class BasicRecordStoreLoader implements RecordStoreLoader {
     }
 
     @Override
-    public void loadKeys(List<Data> keys, boolean replaceExistingValues) {
+    public void loadAll(List<Data> keys, boolean replaceExistingValues) {
         setLoaded(false);
-        final NodeEngine nodeEngine = mapServiceContext.getNodeEngine();
-        ExecutionService executionService = nodeEngine.getExecutionService();
-        executionService.submit(ExecutionService.MAP_LOAD_ALL_KEYS_EXECUTOR, new LoadAllKeysTask(keys, replaceExistingValues));
+
+        final Runnable task = new GivenKeysLoaderTask(keys, replaceExistingValues);
+        final String executorName = ExecutionService.MAP_LOAD_ALL_KEYS_EXECUTOR;
+        executeTask(executorName, task);
     }
 
+    /**
+     * Every partition (record-store) loads its own key set.
+     */
     @Override
-    public void loadAllKeys() {
+    public void loadInitialKeys() {
         if (isLoaded()) {
             return;
         }
@@ -82,8 +95,42 @@ class BasicRecordStoreLoader implements RecordStoreLoader {
             setLoaded(true);
             return;
         }
+
+        final Runnable task = new InitialKeysLoaderTask();
+        final String executorName = MAP_INITIAL_LOAD_EXECUTOR;
+        executeTask(executorName, task);
+    }
+
+    private final class InitialKeysLoaderTask implements Runnable {
+        @Override
+        public void run() {
+            try {
+                loadAllKeysInternal();
+            } catch (Throwable t) {
+                setLoaderException(t);
+            }
+        }
+    }
+
+    private void setLoaderException(Throwable t) {
+        BasicRecordStoreLoader.this.throwable = t;
+    }
+
+    private void executeTask(String executorName, Runnable task) {
+        getExecutionService().submit(executorName, task);
+
+    }
+
+    private ExecutionService getExecutionService() {
+        final NodeEngine nodeEngine = mapServiceContext.getNodeEngine();
+        return nodeEngine.getExecutionService();
+    }
+
+    private void loadAllKeysInternal() throws Exception {
         final MapContainer mapContainer = recordStore.getMapContainer();
         final MapStoreContext basicMapStoreContext = mapContainer.getMapStoreContext();
+        basicMapStoreContext.waitInitialLoadFinish();
+
         final Map<Data, Object> loadedKeys = basicMapStoreContext.getInitialKeys();
         if (loadedKeys == null || loadedKeys.isEmpty()) {
             setLoaded(true);
@@ -103,16 +150,17 @@ class BasicRecordStoreLoader implements RecordStoreLoader {
         return nodeEngine.getThisAddress().equals(partitionOwner);
     }
 
+
     /**
-     * Task for loading keys.
+     * Task for loading given keys.
      * This task is used to make load in an outer thread instead of partition thread.
      */
-    private final class LoadAllKeysTask implements Runnable {
+    private final class GivenKeysLoaderTask implements Runnable {
 
         private final List<Data> keys;
         private final boolean replaceExistingValues;
 
-        private LoadAllKeysTask(List<Data> keys, boolean replaceExistingValues) {
+        private GivenKeysLoaderTask(List<Data> keys, boolean replaceExistingValues) {
             this.keys = keys;
             this.replaceExistingValues = replaceExistingValues;
         }
@@ -318,11 +366,12 @@ class BasicRecordStoreLoader implements RecordStoreLoader {
         }
     }
 
+
     private Callback<Throwable> createCallbackForThrowable() {
         return new Callback<Throwable>() {
             @Override
             public void notify(Throwable throwable) {
-                BasicRecordStoreLoader.this.throwable = throwable;
+                setLoaderException(throwable);
             }
         };
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/DefaultMapServiceContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/DefaultMapServiceContext.java
@@ -1,5 +1,7 @@
 package com.hazelcast.map.impl;
 
+import com.hazelcast.config.Config;
+import com.hazelcast.config.MapConfig;
 import com.hazelcast.core.HazelcastException;
 import com.hazelcast.map.impl.eviction.EvictionOperator;
 import com.hazelcast.map.impl.eviction.ExpirationManager;
@@ -30,9 +32,10 @@ public class DefaultMapServiceContext extends AbstractMapServiceContextSupport i
     private final AtomicReference<Collection<Integer>> ownedPartitions;
     private final ConstructorFunction<String, MapContainer> mapConstructor = new ConstructorFunction<String, MapContainer>() {
         public MapContainer createNew(String mapName) {
-            final MapContainer mapContainer = new MapContainer(mapName, nodeEngine.getConfig().findMapConfig(mapName),
-                    getService().getMapServiceContext());
-            mapContainer.init();
+            final MapServiceContext mapServiceContext = getService().getMapServiceContext();
+            final Config config = nodeEngine.getConfig();
+            final MapConfig mapConfig = config.findMapConfig(mapName);
+            final MapContainer mapContainer = new MapContainer(mapName, mapConfig, mapServiceContext);
             return mapContainer;
         }
     };
@@ -126,7 +129,7 @@ public class DefaultMapServiceContext extends AbstractMapServiceContextSupport i
     @Override
     public void destroyMapStores() {
         for (MapContainer mapContainer : mapContainers.values()) {
-            MapStoreWrapper store = mapContainer.getMapStoreContext().getStore();
+            MapStoreWrapper store = mapContainer.getMapStoreContext().getMapStoreWrapper();
             if (store != null) {
                 store.destroy();
             }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/DefaultRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/DefaultRecordStore.java
@@ -21,6 +21,8 @@ import com.hazelcast.concurrent.lock.LockService;
 import com.hazelcast.concurrent.lock.LockStore;
 import com.hazelcast.core.EntryView;
 import com.hazelcast.map.impl.mapstore.MapDataStore;
+import com.hazelcast.map.impl.mapstore.MapStoreContext;
+import com.hazelcast.map.impl.mapstore.MapStoreManager;
 import com.hazelcast.map.impl.record.Record;
 import com.hazelcast.map.merge.MapMergePolicy;
 import com.hazelcast.nio.serialization.Data;
@@ -56,10 +58,12 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore implements 
     public DefaultRecordStore(MapContainer mapContainer, int partitionId) {
         super(mapContainer, partitionId);
         this.lockStore = createLockStore();
-        this.mapDataStore
-                = mapContainer.getMapStoreContext().getMapStoreManager().getMapDataStore(partitionId);
+        final MapStoreContext mapStoreContext = mapContainer.getMapStoreContext();
+        final MapStoreManager mapStoreManager = mapStoreContext.getMapStoreManager();
+        this.mapDataStore = mapStoreManager.getMapDataStore(partitionId);
+
         this.recordStoreLoader = createRecordStoreLoader();
-        this.recordStoreLoader.loadAllKeys();
+        this.recordStoreLoader.loadInitialKeys();
     }
 
     @Override
@@ -973,7 +977,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore implements 
         if (keys.isEmpty()) {
             return;
         }
-        recordStoreLoader.loadKeys(keys, replaceExistingValues);
+        recordStoreLoader.loadAll(keys, replaceExistingValues);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapContainer.java
@@ -71,6 +71,11 @@ public class MapContainer extends MapContainerSupport {
 
     private MapMergePolicy wanMergePolicy;
 
+    /**
+     * Operations which are done in this constructor should obey the rules defined
+     * in the method comment {@link com.hazelcast.spi.PostJoinAwareService#getPostJoinOperation()}
+     * Otherwise undesired situations, like deadlocks, may appear.
+     */
     public MapContainer(final String name, final MapConfig mapConfig, final MapServiceContext mapServiceContext) {
         super(name, mapConfig);
         this.mapServiceContext = mapServiceContext;
@@ -82,10 +87,6 @@ public class MapContainer extends MapContainerSupport {
         interceptorMap = new ConcurrentHashMap<String, MapInterceptor>();
         nearCacheSizeEstimator = createNearCacheSizeEstimator();
         mapStoreContext = createMapStoreContext(this);
-
-    }
-
-    public void init() {
         mapStoreContext.start();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/RecordStoreLoader.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/RecordStoreLoader.java
@@ -23,12 +23,12 @@ interface RecordStoreLoader {
         }
 
         @Override
-        public void loadKeys(List<Data> keys, boolean replaceExistingValues) {
+        public void loadAll(List<Data> keys, boolean replaceExistingValues) {
 
         }
 
         @Override
-        public void loadAllKeys() {
+        public void loadInitialKeys() {
 
         }
 
@@ -54,12 +54,12 @@ interface RecordStoreLoader {
      * @param keys                  keys to be loaded.
      * @param replaceExistingValues <code>true</code> if need to replace existing values otherwise <code>false</code>
      */
-    void loadKeys(List<Data> keys, boolean replaceExistingValues);
+    void loadAll(List<Data> keys, boolean replaceExistingValues);
 
     /**
-     * Loads all keys.
+     * Loads initial keys.
      */
-    void loadAllKeys();
+    void loadInitialKeys();
 
     /**
      * Picks and returns any one of throwables during load all process.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/MapStoreContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/MapStoreContext.java
@@ -1,7 +1,11 @@
 package com.hazelcast.map.impl.mapstore;
 
+import com.hazelcast.config.MapStoreConfig;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.map.impl.MapServiceContext;
 import com.hazelcast.map.impl.MapStoreWrapper;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.nio.serialization.SerializationService;
 
 import java.util.Map;
 
@@ -16,15 +20,27 @@ import java.util.Map;
  */
 public interface MapStoreContext {
 
-    MapStoreManager getMapStoreManager();
-
-    Map<Data, Object> getInitialKeys();
-
-    MapStoreWrapper getStore();
-
     void start();
 
     void stop();
 
+    MapStoreManager getMapStoreManager();
+
+    Map<Data, Object> getInitialKeys();
+
+    MapStoreWrapper getMapStoreWrapper();
+
     boolean isWriteBehindMapStoreEnabled();
+
+    SerializationService getSerializationService();
+
+    ILogger getLogger(Class clazz);
+
+    String getMapName();
+
+    MapServiceContext getMapServiceContext();
+
+    MapStoreConfig getMapStoreConfig();
+
+    void waitInitialLoadFinish() throws Exception;
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/MapStoreContextFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/MapStoreContextFactory.java
@@ -18,9 +18,12 @@ package com.hazelcast.map.impl.mapstore;
 
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.config.MapStoreConfig;
+import com.hazelcast.logging.ILogger;
 import com.hazelcast.map.impl.MapContainer;
+import com.hazelcast.map.impl.MapServiceContext;
 import com.hazelcast.map.impl.MapStoreWrapper;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.nio.serialization.SerializationService;
 
 import java.util.Collections;
 import java.util.Map;
@@ -28,7 +31,7 @@ import java.util.Map;
 import static com.hazelcast.map.impl.mapstore.MapStoreManagers.emptyMapStoreManager;
 
 /**
- * A factory which create {@link com.hazelcast.map.impl.mapstore.MapStoreContext} objects
+ * A factory which creates {@link com.hazelcast.map.impl.mapstore.MapStoreContext} objects
  * according to {@link com.hazelcast.config.MapStoreConfig}.
  */
 public final class MapStoreContextFactory {
@@ -47,7 +50,6 @@ public final class MapStoreContextFactory {
         return BasicMapStoreContext.create(mapContainer);
     }
 
-
     private static final class EmptyMapStoreContext implements MapStoreContext {
 
         @Override
@@ -61,7 +63,8 @@ public final class MapStoreContextFactory {
         }
 
         @Override
-        public MapStoreWrapper getStore() {
+        public MapStoreWrapper getMapStoreWrapper() {
+            // keep it null. do not throw exception.
             return null;
         }
 
@@ -78,6 +81,35 @@ public final class MapStoreContextFactory {
         @Override
         public boolean isWriteBehindMapStoreEnabled() {
             return false;
+        }
+
+        @Override
+        public SerializationService getSerializationService() {
+            throw new UnsupportedOperationException("This method should not be called. No defined map store exists.");
+        }
+
+        @Override
+        public ILogger getLogger(Class clazz) {
+            throw new UnsupportedOperationException("This method should not be called. No defined map store exists.");
+        }
+
+        @Override
+        public String getMapName() {
+            throw new UnsupportedOperationException("This method should not be called. No defined map store exists.");
+        }
+
+        @Override
+        public MapServiceContext getMapServiceContext() {
+            throw new UnsupportedOperationException("This method should not be called. No defined map store exists.");
+        }
+
+        @Override
+        public MapStoreConfig getMapStoreConfig() {
+            throw new UnsupportedOperationException("This method should not be called. No defined map store exists.");
+        }
+
+        @Override
+        public void waitInitialLoadFinish() {
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/MapStoreManagers.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/MapStoreManagers.java
@@ -1,6 +1,5 @@
 package com.hazelcast.map.impl.mapstore;
 
-import com.hazelcast.map.impl.MapContainer;
 import com.hazelcast.map.impl.mapstore.writebehind.WriteBehindManager;
 import com.hazelcast.map.impl.mapstore.writethrough.WriteThroughManager;
 
@@ -11,12 +10,12 @@ public final class MapStoreManagers {
     private MapStoreManagers() {
     }
 
-    public static MapStoreManager createWriteThroughManager(MapContainer mapContainer) {
-        return new WriteThroughManager(mapContainer);
+    public static MapStoreManager createWriteThroughManager(MapStoreContext mapStoreContext) {
+        return new WriteThroughManager(mapStoreContext);
     }
 
-    public static MapStoreManager createWriteBehindManager(MapContainer mapContainer) {
-        return new WriteBehindManager(mapContainer);
+    public static MapStoreManager createWriteBehindManager(MapStoreContext mapStoreContext) {
+        return new WriteBehindManager(mapStoreContext);
     }
 
     public static MapStoreManager emptyMapStoreManager() {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/StoreConstructor.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/StoreConstructor.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2008-2014, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.mapstore;
+
+import com.hazelcast.config.MapStoreConfig;
+import com.hazelcast.core.MapStoreFactory;
+import com.hazelcast.nio.ClassLoaderUtil;
+import com.hazelcast.util.ExceptionUtil;
+
+import java.util.Properties;
+
+import static com.hazelcast.util.StringUtil.isNullOrEmpty;
+
+/**
+ * Creates a map-store object from one of store-factory, store-class or store impl.
+ */
+final class StoreConstructor {
+
+    private StoreConstructor() {
+    }
+
+    static Object createStore(String name, MapStoreConfig mapStoreConfig, ClassLoader classLoader) {
+        // 1. Try to create store from `store factory` class.
+        Object store = getStoreFromFactoryOrNull(name, mapStoreConfig, classLoader);
+
+        // 2. Try to get store from `store impl.` object.
+        if (store == null) {
+            store = getStoreFromImplementationOrNull(mapStoreConfig);
+        }
+        // 3. Try to create store from `store impl.` class.
+        if (store == null) {
+            store = getStoreFromClassOrNull(mapStoreConfig, classLoader);
+        }
+        return store;
+    }
+
+    private static Object getStoreFromFactoryOrNull(String name, MapStoreConfig mapStoreConfig, ClassLoader classLoader) {
+        MapStoreFactory factory = (MapStoreFactory) mapStoreConfig.getFactoryImplementation();
+        if (factory == null) {
+            final String factoryClassName = mapStoreConfig.getFactoryClassName();
+            if (isNullOrEmpty(factoryClassName)) {
+                return null;
+            }
+
+            try {
+                factory = ClassLoaderUtil.newInstance(classLoader, factoryClassName);
+            } catch (Exception e) {
+                throw ExceptionUtil.rethrow(e);
+            }
+        }
+        if (factory == null) {
+            return null;
+        }
+
+        final Properties properties = mapStoreConfig.getProperties();
+        return factory.newMapStore(name, properties);
+
+    }
+
+    private static Object getStoreFromImplementationOrNull(MapStoreConfig mapStoreConfig) {
+        return mapStoreConfig.getImplementation();
+    }
+
+    private static Object getStoreFromClassOrNull(MapStoreConfig mapStoreConfig, ClassLoader classLoader) {
+        Object store;
+        String mapStoreClassName = mapStoreConfig.getClassName();
+        try {
+            store = ClassLoaderUtil.newInstance(classLoader, mapStoreClassName);
+        } catch (Exception e) {
+            throw ExceptionUtil.rethrow(e);
+        }
+        return store;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/DefaultWriteBehindProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/DefaultWriteBehindProcessor.java
@@ -18,7 +18,7 @@ package com.hazelcast.map.impl.mapstore.writebehind;
 
 import com.hazelcast.core.MapStore;
 import com.hazelcast.logging.ILogger;
-import com.hazelcast.map.impl.MapContainer;
+import com.hazelcast.map.impl.mapstore.MapStoreContext;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.SerializationService;
 
@@ -61,12 +61,12 @@ class DefaultWriteBehindProcessor implements WriteBehindProcessor<DelayedEntry> 
 
     private final int writeBatchSize;
 
-    DefaultWriteBehindProcessor(MapContainer mapContainer) {
-        this.serializationService = mapContainer.getMapServiceContext().getNodeEngine().getSerializationService();
-        this.mapStore = mapContainer.getMapStoreContext().getStore();
+    DefaultWriteBehindProcessor(MapStoreContext mapStoreContext) {
+        this.serializationService = mapStoreContext.getSerializationService();
+        this.mapStore = mapStoreContext.getMapStoreWrapper();
         this.storeListeners = new ArrayList<StoreListener>(2);
-        this.logger = mapContainer.getMapServiceContext().getNodeEngine().getLogger(DefaultWriteBehindProcessor.class);
-        this.writeBatchSize = mapContainer.getMapConfig().getMapStoreConfig().getWriteBatchSize();
+        this.logger = mapStoreContext.getLogger(DefaultWriteBehindProcessor.class);
+        this.writeBatchSize = mapStoreContext.getMapStoreConfig().getWriteBatchSize();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/StoreWorker.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/StoreWorker.java
@@ -17,10 +17,10 @@
 package com.hazelcast.map.impl.mapstore.writebehind;
 
 import com.hazelcast.cluster.ClusterService;
-import com.hazelcast.map.impl.MapContainer;
 import com.hazelcast.map.impl.MapServiceContext;
 import com.hazelcast.map.impl.PartitionContainer;
 import com.hazelcast.map.impl.RecordStore;
+import com.hazelcast.map.impl.mapstore.MapStoreContext;
 import com.hazelcast.nio.Address;
 import com.hazelcast.partition.InternalPartition;
 import com.hazelcast.partition.InternalPartitionService;
@@ -58,9 +58,9 @@ public class StoreWorker implements Runnable {
     private long lastRunTime;
 
 
-    public StoreWorker(MapContainer mapContainer, WriteBehindProcessor writeBehindProcessor) {
-        this.mapName = mapContainer.getName();
-        this.mapServiceContext = mapContainer.getMapServiceContext();
+    public StoreWorker(MapStoreContext mapStoreContext, WriteBehindProcessor writeBehindProcessor) {
+        this.mapName = mapStoreContext.getMapName();
+        this.mapServiceContext = mapStoreContext.getMapServiceContext();
         this.writeBehindProcessor = writeBehindProcessor;
         this.backupRunIntervalTime = getReplicaWaitTime();
         this.lastRunTime = Clock.currentTimeMillis();

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/WriteBehindProcessors.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/WriteBehindProcessors.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.map.impl.mapstore.writebehind;
 
-import com.hazelcast.map.impl.MapContainer;
+import com.hazelcast.map.impl.mapstore.MapStoreContext;
 
 /**
  * Static factory which creates a write behind processor.
@@ -26,7 +26,7 @@ public final class WriteBehindProcessors {
     private WriteBehindProcessors() {
     }
 
-    public static WriteBehindProcessor createWriteBehindProcessor(MapContainer mapContainer) {
-        return new DefaultWriteBehindProcessor(mapContainer);
+    public static WriteBehindProcessor createWriteBehindProcessor(MapStoreContext mapStoreContext) {
+        return new DefaultWriteBehindProcessor(mapStoreContext);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writethrough/WriteThroughManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writethrough/WriteThroughManager.java
@@ -1,8 +1,8 @@
 package com.hazelcast.map.impl.mapstore.writethrough;
 
-import com.hazelcast.map.impl.MapContainer;
 import com.hazelcast.map.impl.mapstore.MapDataStore;
 import com.hazelcast.map.impl.mapstore.MapDataStores;
+import com.hazelcast.map.impl.mapstore.MapStoreContext;
 import com.hazelcast.map.impl.mapstore.MapStoreManager;
 
 /**
@@ -12,8 +12,8 @@ public class WriteThroughManager implements MapStoreManager {
 
     private final MapDataStore mapDataStore;
 
-    public WriteThroughManager(MapContainer mapContainer) {
-        mapDataStore = MapDataStores.createWriteThroughStore(mapContainer);
+    public WriteThroughManager(MapStoreContext mapStoreContext) {
+        mapDataStore = MapDataStores.createWriteThroughStore(mapStoreContext);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
@@ -153,7 +153,7 @@ abstract class MapProxySupport extends AbstractDistributedObject<MapService> imp
         MapStoreConfig mapStoreConfig = getMapConfig().getMapStoreConfig();
         if (mapStoreConfig != null && mapStoreConfig.isEnabled()) {
             MapStoreConfig.InitialLoadMode initialLoadMode = mapStoreConfig.getInitialLoadMode();
-            if (initialLoadMode.equals(MapStoreConfig.InitialLoadMode.EAGER)) {
+            if (MapStoreConfig.InitialLoadMode.EAGER.equals(initialLoadMode)) {
                 waitUntilLoaded();
             }
         }
@@ -1132,7 +1132,7 @@ abstract class MapProxySupport extends AbstractDistributedObject<MapService> imp
         final MapService service = getService();
         final MapServiceContext mapServiceContext = service.getMapServiceContext();
         final MapContainer mapContainer = mapServiceContext.getMapContainer(name);
-        return mapContainer.getMapStoreContext().getStore();
+        return mapContainer.getMapStoreContext().getMapStoreWrapper();
 
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/PostJoinAwareService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/PostJoinAwareService.java
@@ -23,8 +23,9 @@ public interface PostJoinAwareService {
 
     /**
      * Post join operations must be lock free; means no locks at all;
-     * no partition locks, no key-based locks, no service level locks!
-     * <p/>
+     * no partition locks, no key-based locks, no service level locks or
+     * no database interaction!
+     * <p>
      * Post join operations should return response, at least a null response.
      */
     Operation getPostJoinOperation();

--- a/hazelcast/src/test/java/com/hazelcast/map/mapstore/MapCreationDelayWithMapStoreTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/mapstore/MapCreationDelayWithMapStoreTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2008-2014, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.mapstore;
+
+import com.hazelcast.core.IMap;
+import com.hazelcast.core.MapStoreAdapter;
+import com.hazelcast.map.mapstore.writebehind.TestMapUsingMapStoreBuilder;
+import com.hazelcast.monitor.LocalMapStats;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Collections;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class MapCreationDelayWithMapStoreTest extends HazelcastTestSupport {
+
+    @Test(timeout = 120000)
+    public void testMapCreation__notAffectedByUnresponsiveLoader() throws Exception {
+        final UnresponsiveLoader unresponsiveLoader = new UnresponsiveLoader<Integer, Integer>();
+        final IMap map = TestMapUsingMapStoreBuilder.create()
+                .withMapStore(unresponsiveLoader)
+                .withNodeCount(1)
+                .withNodeFactory(createHazelcastInstanceFactory(1))
+                .withPartitionCount(1)
+                .build();
+
+        final LocalMapStats stats = map.getLocalMapStats();
+        final long ownedEntryCount = stats.getOwnedEntryCount();
+
+        assertEquals(0, ownedEntryCount);
+    }
+
+
+    static class UnresponsiveLoader<K, V> extends MapStoreAdapter<K, V> {
+
+        private final CountDownLatch unreleasedLatch = new CountDownLatch(1);
+
+        @Override
+        public Set<K> loadAllKeys() {
+            try {
+                unreleasedLatch.await();
+            } catch (InterruptedException e) {
+                //ignore.
+            }
+            return Collections.emptySet();
+        }
+
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/map/mapstore/MapStoreTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/mapstore/MapStoreTest.java
@@ -1481,7 +1481,7 @@ public class MapStoreTest extends HazelcastTestSupport {
         MapProxyImpl map = (MapProxyImpl) hz.getMap(mapName);
         MapService mapService = (MapService) map.getService();
         MapContainer mapContainer = mapService.getMapServiceContext().getMapContainer(mapName);
-        MapStoreWrapper mapStoreWrapper = mapContainer.getMapStoreContext().getStore();
+        MapStoreWrapper mapStoreWrapper = mapContainer.getMapStoreContext().getMapStoreWrapper();
         Set keys = mapStoreWrapper.loadAllKeys();
         assertEquals(2, keys.size());
         assertEquals("true", mapStoreWrapper.load("my-prop-1"));


### PR DESCRIPTION
- closes https://github.com/hazelcast/hazelcast/issues/4024
- closes https://github.com/hazelcast/hazelcast/issues/3222

With this PR:
- Map creation should not be blocked by an unresponsive loader
- Node join process should not be blocked due to the reason above.
- Various refactorings
