### PR TITLE
Member capabilities

### DIFF
--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/proxy/PartitionServiceProxy.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/proxy/PartitionServiceProxy.java
@@ -114,6 +114,12 @@ public final class PartitionServiceProxy implements PartitionService {
         throw new UnsupportedOperationException();
     }
 
+    @Override
+    public boolean drain(long timeout, TimeUnit timeunit) {
+        // Clients  cannot own partitions so there's nothing to drain.
+        return true;
+    }
+
     private static class ClientPartitionLostEventHandler extends ClientAddPartitionLostListenerCodec.AbstractEventHandler
             implements EventHandler<ClientMessage> {
 

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/PartitionServiceProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/PartitionServiceProxy.java
@@ -113,6 +113,12 @@ public final class PartitionServiceProxy implements PartitionService {
         throw new UnsupportedOperationException();
     }
 
+    @Override
+    public boolean drain(long timeout, TimeUnit timeunit) {
+        // Clients  cannot own partitions so there's nothing to drain.
+        return true;
+    }
+
     private static class ClientPartitionLostEventHandler implements EventHandler<PortablePartitionLostEvent> {
 
         private PartitionLostListener listener;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/MemberImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/MemberImpl.java
@@ -18,11 +18,13 @@ package com.hazelcast.client.impl;
 
 import com.hazelcast.core.Member;
 import com.hazelcast.instance.AbstractMember;
+import com.hazelcast.instance.Capability;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Address;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Client side specific Member implementation.
@@ -61,6 +63,11 @@ public final class MemberImpl
     @Override
     public boolean localMember() {
         return false;
+    }
+
+    @Override
+    public void updateCapabilities(Set<Capability> capabilities) {
+
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/ClusterServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/ClusterServiceImpl.java
@@ -1181,7 +1181,7 @@ public final class ClusterServiceImpl implements ClusterService, ConnectionListe
     private void notifyCapabilityUpdate(String uuid, Set<Capability> capabilities) {
         for (MemberImpl member : getMemberList()) {
             if (!member.localMember()) {
-                invokeClusterOperation(new MemberCapabilityChangedOperation(uuid, capabilities), member.getAddress());
+                nodeEngine.getOperationService().send(new MemberCapabilityChangedOperation(uuid, capabilities), member.getAddress());
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/operations/MemberCapabilityChangedOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/operations/MemberCapabilityChangedOperation.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.cluster.impl.operations;
+
+import com.hazelcast.cluster.impl.ClusterServiceImpl;
+import com.hazelcast.instance.Capability;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+
+import java.io.IOException;
+import java.util.Set;
+
+public class MemberCapabilityChangedOperation extends AbstractClusterOperation {
+
+
+    private String uuid;
+    private Set<Capability> capabilities;
+
+    public MemberCapabilityChangedOperation() {
+    }
+
+    public MemberCapabilityChangedOperation(String uuid, Set<Capability> capabilities) {
+        this.uuid = uuid;
+        this.capabilities = capabilities;
+    }
+
+    public String getUuid() {
+        return uuid;
+    }
+
+    public Set<Capability> getCapabilities() {
+        return capabilities;
+    }
+
+    @Override
+    public void run() throws Exception {
+        ((ClusterServiceImpl) getService()).updateMemberCapabilities(uuid, capabilities);
+    }
+
+    @Override
+    protected void writeInternal(ObjectDataOutput out) throws IOException {
+        super.writeInternal(out);
+        out.writeUTF(uuid);
+        Capability.writeCapabilities(out, capabilities);
+    }
+
+    @Override
+    protected void readInternal(ObjectDataInput in) throws IOException {
+        super.readInternal(in);
+        uuid = in.readUTF();
+
+        capabilities = Capability.readCapabilities(in);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/operations/MemberCapabilityUpdateException.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/operations/MemberCapabilityUpdateException.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.cluster.impl.operations;
+
+public class MemberCapabilityUpdateException extends RuntimeException {
+
+    public MemberCapabilityUpdateException(String message) {
+        super(message);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/operations/MemberCapabilityUpdateRequestOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/operations/MemberCapabilityUpdateRequestOperation.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.cluster.impl.operations;
+
+import com.hazelcast.instance.Capability;
+
+import java.util.Set;
+
+public class MemberCapabilityUpdateRequestOperation extends MemberCapabilityChangedOperation {
+
+    public MemberCapabilityUpdateRequestOperation() {
+    }
+
+    public MemberCapabilityUpdateRequestOperation(String uuid, Set<Capability> capabilities) {
+        super(uuid, capabilities);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/config/Config.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/Config.java
@@ -209,7 +209,7 @@ public class Config {
      * updated using {@link com.hazelcast.core.Member#updateCapabilities(java.util.Set)}
      * @param capabilities The capabilities to set in the instance.
      * @return This config instance.
-     * @since 3.4
+     * @since 3.6
      */
     public Config setCapabilities(Set<Capability> capabilities) {
         this.capabilities = capabilities;

--- a/hazelcast/src/main/java/com/hazelcast/config/Config.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/Config.java
@@ -19,12 +19,14 @@ package com.hazelcast.config;
 import com.hazelcast.config.matcher.MatchingPointConfigPatternMatcher;
 import com.hazelcast.core.HazelcastException;
 import com.hazelcast.core.ManagedContext;
+import com.hazelcast.instance.Capability;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 
 import java.io.File;
 import java.net.URL;
 import java.util.Collection;
+import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -40,7 +42,7 @@ import static java.text.MessageFormat.format;
 
 /**
  * Contains all the configuration to start a {@link com.hazelcast.core.HazelcastInstance}. A Config
- * can be created programmatically, but can also be configured using XML, see {@link com.hazelcast.config.XmlConfigBuilder}.
+ * can be created programmatically, but can also be configured using XML, see {@link XmlConfigBuilder}.
  * <p/>
  * Config instances can be shared between threads, but should not be modified after they are used to
  * create HazelcastInstances.
@@ -116,6 +118,8 @@ public class Config {
     private NativeMemoryConfig nativeMemoryConfig = new NativeMemoryConfig();
 
     private String licenseKey;
+
+    private Set<Capability> capabilities = EnumSet.allOf(Capability.class);
 
     public Config() {
     }
@@ -198,6 +202,25 @@ public class Config {
     public Config setInstanceName(String instanceName) {
         this.instanceName = instanceName;
         return this;
+    }
+
+    /**
+     * Sets the initial capabilities the Hazelcast instance should have in the cluster. These capabilities can later be
+     * updated using {@link com.hazelcast.core.Member#updateCapabilities(java.util.Set)}
+     * @param capabilities The capabilities to set in the instance.
+     * @return This config instance.
+     * @since 3.4
+     */
+    public Config setCapabilities(Set<Capability> capabilities) {
+        this.capabilities = capabilities;
+        return this;
+    }
+
+    /**
+     * @return the initial set of capabilities an instance must have when joining the cluster.
+     */
+    public Set<Capability> getCapabilities() {
+        return capabilities;
     }
 
     public GroupConfig getGroupConfig() {

--- a/hazelcast/src/main/java/com/hazelcast/core/Member.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/Member.java
@@ -16,10 +16,12 @@
 
 package com.hazelcast.core;
 
+import com.hazelcast.instance.Capability;
 import com.hazelcast.nio.serialization.DataSerializable;
 
 import java.net.InetSocketAddress;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Cluster member interface. The default implementation
@@ -48,6 +50,13 @@ public interface Member extends DataSerializable, Endpoint {
      */
     @Deprecated
     InetSocketAddress getInetSocketAddress();
+
+    /**
+     * Change the capabilities this member has in the cluster
+     * @param capabilities The new capabilities for this member.
+     * @since 3.4
+     */
+    void updateCapabilities(Set<Capability> capabilities);
 
     /**
      * Returns the socket address of this member.

--- a/hazelcast/src/main/java/com/hazelcast/core/Member.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/Member.java
@@ -54,7 +54,7 @@ public interface Member extends DataSerializable, Endpoint {
     /**
      * Change the capabilities this member has in the cluster
      * @param capabilities The new capabilities for this member.
-     * @since 3.4
+     * @since 3.6
      */
     void updateCapabilities(Set<Capability> capabilities);
 

--- a/hazelcast/src/main/java/com/hazelcast/core/PartitionService.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/PartitionService.java
@@ -174,7 +174,7 @@ public interface PartitionService {
      * @param timeout The time to wait for the migration before returning.
      * @param timeunit The unit in which the timeout was provided.
      * @return true if the local member owns no partition. false otherwise.
-     * @since 3.4
+     * @since 3.6
      */
     boolean drain(long timeout, TimeUnit timeunit);
 

--- a/hazelcast/src/main/java/com/hazelcast/core/PartitionService.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/PartitionService.java
@@ -165,4 +165,17 @@ public interface PartitionService {
      * @since 3.3
      */
     boolean forceLocalMemberToBeSafe(long timeout, TimeUnit unit);
+
+    /**
+     * Remove all of the partitions currently owned by the local member. Wait for a configurable amount of time
+     * until the local member doesn't own any partitions.
+     * This will cause the local member to loose the PARTITION_HOST capability
+     *
+     * @param timeout The time to wait for the migration before returning.
+     * @param timeunit The unit in which the timeout was provided.
+     * @return true if the local member owns no partition. false otherwise.
+     * @since 3.4
+     */
+    boolean drain(long timeout, TimeUnit timeunit);
+
 }

--- a/hazelcast/src/main/java/com/hazelcast/instance/Capability.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/Capability.java
@@ -26,7 +26,7 @@ import java.util.Set;
 /**
  * Defines the different capabilities a member can have in the cluster
  * A member with no capabilities has read and write access to the data in the cluster
- * @since 3.4
+ * @since 3.6
  */
 public enum Capability {
     /**

--- a/hazelcast/src/main/java/com/hazelcast/instance/Capability.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/Capability.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.instance;
+
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+
+import java.io.IOException;
+import java.util.EnumSet;
+import java.util.Set;
+
+/**
+ * Defines the different capabilities a member can have in the cluster
+ * A member with no capabilities has read and write access to the data in the cluster
+ * @since 3.4
+ */
+public enum Capability {
+    /**
+     * The PARTITION_HOST capability makes a member eligible to host data partitions / replicas
+     */
+    PARTITION_HOST(0);
+
+    private final int id;
+
+    Capability(int id) {
+        this.id = id;
+    }
+
+    public static Capability valueOf(int id) {
+        for (Capability capability : values()) {
+            if (capability.id == id) {
+                return capability;
+            }
+        }
+        throw new IllegalArgumentException(String.format("No capability with id [%d] could be found", id));
+    }
+
+    public static Set<Capability> readCapabilities(ObjectDataInput in) throws IOException {
+        int size = in.readInt();
+        EnumSet<Capability> capabilities = EnumSet.noneOf(Capability.class);
+        for (int i = 0; i < size; i++) {
+            capabilities.add(valueOf(in.readInt()));
+        }
+        return capabilities;
+    }
+
+    public static void writeCapabilities(ObjectDataOutput out, Set<Capability> capabilities) throws IOException {
+        out.writeInt(capabilities.size());
+        for (Capability capability : capabilities) {
+            out.writeInt(capability.id);
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/instance/Node.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/Node.java
@@ -149,7 +149,8 @@ public class Node {
         try {
             address = addressPicker.getPublicAddress();
             final Map<String, Object> memberAttributes = findMemberAttributes(config.getMemberAttributeConfig().asReadOnly());
-            localMember = new MemberImpl(address, true, UuidUtil.createMemberUuid(address), hazelcastInstance, memberAttributes);
+            localMember = new MemberImpl(address, true, UuidUtil.createMemberUuid(address), hazelcastInstance,
+                    config.getCapabilities(), memberAttributes);
             loggingService.setThisMember(localMember);
             logger = loggingService.getLogger(Node.class.getName());
             hazelcastThreadGroup = new HazelcastThreadGroup(
@@ -503,7 +504,7 @@ public class Node {
 
         return new JoinRequest(Packet.VERSION, buildInfo.getBuildNumber(), address,
                 localMember.getUuid(), createConfigCheck(), credentials, clusterService.getSize(), 0,
-                config.getMemberAttributeConfig().getAttributes());
+                localMember.getCapabilities(), config.getMemberAttributeConfig().getAttributes());
     }
 
     public ConfigCheck createConfigCheck() {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
@@ -265,8 +265,8 @@ abstract class MapProxySupport extends AbstractDistributedObject<MapService> imp
         final MapServiceContext mapServiceContext = mapService.getMapServiceContext();
         final NodeEngine nodeEngine = mapServiceContext.getNodeEngine();
         final int partitionId = nodeEngine.getPartitionService().getPartitionId(key);
-        return !nodeEngine.getPartitionService().getPartitionOwner(partitionId)
-                .equals(nodeEngine.getClusterService().getThisAddress());
+        return !nodeEngine.getClusterService().getThisAddress()
+                .equals(nodeEngine.getPartitionService().getPartitionOwner(partitionId));
     }
 
     private boolean cacheKeyAnyway() {

--- a/hazelcast/src/main/java/com/hazelcast/nio/Address.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/Address.java
@@ -167,6 +167,9 @@ public final class Address implements IdentifiedDataSerializable {
 
     @Override
     public boolean equals(Object o) {
+        if (o == null) {
+            return false;
+        }
         if (this == o) {
             return true;
         }

--- a/hazelcast/src/main/java/com/hazelcast/partition/InternalPartitionService.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/InternalPartitionService.java
@@ -148,9 +148,13 @@ public interface InternalPartitionService extends CoreService {
 
     void memberAdded(MemberImpl newMember);
 
+    void memberCapabilityUpdate(MemberImpl updatedMember);
+
     void memberRemoved(MemberImpl deadMember);
 
     boolean prepareToSafeShutdown(long timeout, TimeUnit seconds);
+
+    boolean drain(long timeout, TimeUnit timeunit);
 
     /**
      * Query and return if this member in a safe state or not.

--- a/hazelcast/src/main/java/com/hazelcast/partition/PartitionServiceProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/PartitionServiceProxy.java
@@ -173,6 +173,21 @@ public class PartitionServiceProxy implements com.hazelcast.core.PartitionServic
         return partitionService.prepareToSafeShutdown(timeout, unit);
     }
 
+    public boolean drain(long timeout, TimeUnit timeunit) {
+        if (timeunit == null) {
+            throw new NullPointerException();
+        }
+
+        if (timeout < 1L) {
+            throw new IllegalArgumentException();
+        }
+
+        if (!nodeActive()) {
+            return true;
+        }
+        return partitionService.drain(timeout, timeunit);
+    }
+
     private boolean nodeActive() {
         final Node node = getNode();
         return node.isActive();

--- a/hazelcast/src/main/java/com/hazelcast/partition/impl/InternalPartitionServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/impl/InternalPartitionServiceImpl.java
@@ -19,10 +19,10 @@ package com.hazelcast.partition.impl;
 import com.hazelcast.cluster.MemberInfo;
 import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.core.HazelcastException;
-import com.hazelcast.core.Member;
 import com.hazelcast.core.MigrationEvent;
 import com.hazelcast.core.MigrationEvent.MigrationStatus;
 import com.hazelcast.core.MigrationListener;
+import com.hazelcast.instance.Capability;
 import com.hazelcast.instance.MemberImpl;
 import com.hazelcast.instance.Node;
 import com.hazelcast.instance.OutOfMemoryErrorDispatcher;
@@ -71,6 +71,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -94,6 +95,7 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.logging.Level;
 
+import static com.hazelcast.instance.Capability.PARTITION_HOST;
 import static com.hazelcast.partition.impl.InternalPartitionServiceState.MIGRATION_LOCAL;
 import static com.hazelcast.partition.impl.InternalPartitionServiceState.MIGRATION_ON_MASTER;
 import static com.hazelcast.partition.impl.InternalPartitionServiceState.REPLICA_NOT_SYNC;
@@ -307,8 +309,7 @@ public class InternalPartitionServiceImpl implements InternalPartitionService, M
                     return;
                 }
                 PartitionStateGenerator psg = partitionStateGenerator;
-                final Set<Member> members = node.getClusterService().getMembers();
-                Collection<MemberGroup> memberGroups = memberGroupFactory.createMemberGroups(members);
+                Collection<MemberGroup> memberGroups = memberGroupFactory.createMemberGroups(getPartitionHosts());
                 if (memberGroups.isEmpty()) {
                     logger.warning("No member group is available to assign partition ownership...");
                     return;
@@ -335,8 +336,7 @@ public class InternalPartitionServiceImpl implements InternalPartitionService, M
     }
 
     private void updateMemberGroupsSize() {
-        Set<Member> members = node.getClusterService().getMembers();
-        final Collection<MemberGroup> groups = memberGroupFactory.createMemberGroups(members);
+        final Collection<MemberGroup> groups = memberGroupFactory.createMemberGroups(getPartitionHosts());
         int size = 0;
         for (MemberGroup group : groups) {
             if (group.size() > 0) {
@@ -374,6 +374,31 @@ public class InternalPartitionServiceImpl implements InternalPartitionService, M
                     Collection<MemberImpl> members = node.clusterService.getMemberList();
                     PartitionStateOperation op = new PartitionStateOperation(createPartitionState(members));
                     nodeEngine.getOperationService().send(op, member.getAddress());
+                }
+            } finally {
+                lock.unlock();
+            }
+        }
+    }
+
+    @Override
+    public void memberCapabilityUpdate(MemberImpl updatedMember) {
+        updateMemberGroupsSize();
+
+        lock.lock();
+        if (node.isMaster() && node.isActive()) {
+            try {
+                migrationQueue.clear();
+                if (!updatedMember.hasCapability(PARTITION_HOST) && !activeMigrations.isEmpty()) {
+                    for (MigrationInfo migrationInfo : activeMigrations.values()) {
+                        if (updatedMember.getAddress().equals(migrationInfo.getDestination())) {
+                            migrationInfo.invalidate();
+                        }
+                    }
+                }
+
+                if (initialized) {
+                    migrationQueue.add(new RepartitioningTask());
                 }
             } finally {
                 lock.unlock();
@@ -478,7 +503,7 @@ public class InternalPartitionServiceImpl implements InternalPartitionService, M
         try {
             List<MemberInfo> memberInfos = new ArrayList<MemberInfo>(members.size());
             for (MemberImpl member : members) {
-                MemberInfo memberInfo = new MemberInfo(member.getAddress(), member.getUuid(), member.getAttributes());
+                MemberInfo memberInfo = new MemberInfo(member);
                 memberInfos.add(memberInfo);
             }
             ArrayList<MigrationInfo> migrationInfos = new ArrayList<MigrationInfo>(completedMigrations);
@@ -544,16 +569,16 @@ public class InternalPartitionServiceImpl implements InternalPartitionService, M
             PartitionRuntimeState partitionState = createPartitionState(members);
             OperationService operationService = nodeEngine.getOperationService();
 
-            List<Future> calls = firePartitionStateOperation(members, partitionState, operationService);
+            List<Future> calls = firePartitionStateOperation(partitionState, operationService);
             waitWithDeadline(calls, 3, TimeUnit.SECONDS, partitionStateSyncTimeoutHandler);
         } finally {
             lock.unlock();
         }
     }
 
-    private List<Future> firePartitionStateOperation(Collection<MemberImpl> members,
-                                                     PartitionRuntimeState partitionState,
+    private List<Future> firePartitionStateOperation(PartitionRuntimeState partitionState,
                                                      OperationService operationService) {
+        Collection<MemberImpl> members = node.clusterService.getMemberList();
         List<Future> calls = new ArrayList<Future>(members.size());
         for (MemberImpl member : members) {
             if (!member.localMember()) {
@@ -1433,6 +1458,44 @@ public class InternalPartitionServiceImpl implements InternalPartitionService, M
         }
     }
 
+    @Override
+    public boolean drain(long timeout, TimeUnit timeunit) {
+        MemberImpl localMember = node.localMember;
+        if (localMember.hasCapability(PARTITION_HOST)) {
+            Set<Capability> capabilities = EnumSet.copyOf(localMember.getCapabilities());
+            capabilities.remove(PARTITION_HOST);
+
+            localMember.updateCapabilities(capabilities);
+        }
+
+        return awaitEmpty(timeout, timeunit);
+    }
+
+    private boolean awaitEmpty(long timeout, TimeUnit timeunit) {
+        Collection<MemberImpl> partitionHosts = getPartitionHosts();
+        if (partitionHosts.contains(node.getLocalMember()) && partitionHosts.size() == 1) {
+            // If local node is the only partition host then there's no node we can drain the partitions to.
+            return false;
+        }
+
+        boolean isEmpty = checkIsEmpty();
+        for (long timeoutInMillis = timeunit.toMillis(timeout); timeoutInMillis > 0 && !isEmpty; isEmpty = checkIsEmpty()) {
+            timeoutInMillis = sleepWithBusyWait(timeoutInMillis, DEFAULT_PAUSE_MILLIS);
+        }
+
+        return isEmpty;
+    }
+
+    private boolean checkIsEmpty() {
+        Address localAddress = node.localMember.getAddress();
+        for (int i = 0; i < partitionCount; i++) {
+            if (localAddress.equals(partitions[i].getOwnerOrNull())) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     public void pauseMigration() {
         migrationActive.set(false);
     }
@@ -1620,6 +1683,18 @@ public class InternalPartitionServiceImpl implements InternalPartitionService, M
         }
     }
 
+    private Collection<MemberImpl> getPartitionHosts() {
+        // Even though the Master's ClusterServiceImpl prevents a node from dropping the PARTITION_HOST Capability if
+        // there is no other node which can host partitions, at any point in time a node can simply close
+        // the connection and no longer be available. If that's the case the Master will have no choice but to
+        // host the partitions.
+        Collection<MemberImpl> members = node.getClusterService().getMemberList(PARTITION_HOST);
+        if (members.isEmpty()) {
+            members.add(nodeEngine.getClusterService().getMember(node.getMasterAddress()));
+        }
+        return members;
+    }
+
     private class RepartitioningTask implements Runnable {
         @Override
         public void run() {
@@ -1635,7 +1710,8 @@ public class InternalPartitionServiceImpl implements InternalPartitionService, M
 
                     migrationQueue.clear();
                     PartitionStateGenerator psg = partitionStateGenerator;
-                    Collection<MemberImpl> members = node.getClusterService().getMemberList();
+                    Collection<MemberImpl> members = getPartitionHosts();
+
                     Collection<MemberGroup> memberGroups = memberGroupFactory.createMemberGroups(members);
                     Address[][] newState = psg.reArrange(memberGroups, partitions);
 
@@ -1669,7 +1745,7 @@ public class InternalPartitionServiceImpl implements InternalPartitionService, M
                             currentPartition.setReplicaAddresses(replicas);
                         }
                     }
-                    syncPartitionRuntimeState(members);
+                    syncPartitionRuntimeState();
                     logMigrationStatistics(migrationCount, lostCount);
                 } finally {
                     lock.unlock();

--- a/hazelcast/src/test/java/com/hazelcast/cluster/MemberListTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/MemberListTest.java
@@ -22,6 +22,7 @@ import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.Member;
 import com.hazelcast.core.MemberLeftException;
+import com.hazelcast.instance.Capability;
 import com.hazelcast.instance.GroupProperties;
 import com.hazelcast.instance.HazelcastInstanceFactory;
 import com.hazelcast.instance.MemberImpl;
@@ -161,9 +162,12 @@ public class MemberListTest {
 
         // Simulates node2 getting an out of order member list. That causes node2 to think it's the master.
         List<MemberInfo> members = new ArrayList<MemberInfo>();
-        members.add(new MemberInfo(m2.getAddress(), m2.getUuid(), Collections. <String, Object> emptyMap()));
-        members.add(new MemberInfo(m3.getAddress(), m3.getUuid(), Collections. <String, Object> emptyMap()));
-        members.add(new MemberInfo(m1.getAddress(), m1.getUuid(), Collections. <String, Object> emptyMap()));
+        members.add(new MemberInfo(m2.getAddress(), m2.getUuid(), EnumSet.noneOf(Capability.class),
+                Collections. <String, Object> emptyMap()));
+        members.add(new MemberInfo(m3.getAddress(), m3.getUuid(), EnumSet.noneOf(Capability.class),
+                Collections. <String, Object> emptyMap()));
+        members.add(new MemberInfo(m1.getAddress(), m1.getUuid(), EnumSet.noneOf(Capability.class),
+                Collections. <String, Object> emptyMap()));
         n2.clusterService.updateMembers(members);
         n2.setMasterAddress(m2.getAddress());
 
@@ -201,8 +205,10 @@ public class MemberListTest {
         final Node n2 = TestUtil.getNode(h2);
         // Simulates node2 getting an out of order member list. That causes node2 to think it's the master.
         List<MemberInfo> members = new ArrayList<MemberInfo>();
-        members.add(new MemberInfo(m1.getAddress(), m1.getUuid(), Collections. <String, Object> emptyMap()));
-        members.add(new MemberInfo(m2.getAddress(), m2.getUuid(), Collections. <String, Object> emptyMap()));
+        members.add(new MemberInfo(m1.getAddress(), m1.getUuid(), EnumSet.noneOf(Capability.class),
+                Collections. <String, Object> emptyMap()));
+        members.add(new MemberInfo(m2.getAddress(), m2.getUuid(), EnumSet.noneOf(Capability.class),
+                Collections. <String, Object> emptyMap()));
         n2.clusterService.updateMembers(members);
 
         // Give the cluster some time to figure things out. The merge and heartbeat code should have kicked in by this point

--- a/hazelcast/src/test/java/com/hazelcast/instance/MemberImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/MemberImplTest.java
@@ -1,0 +1,40 @@
+package com.hazelcast.instance;
+
+import com.hazelcast.nio.Address;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.EnumSet;
+import java.util.Set;
+import java.util.UUID;
+
+import static com.hazelcast.instance.Capability.PARTITION_HOST;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(MockitoJUnitRunner.class)
+public class MemberImplTest {
+
+    private static final String MEMBER_UUID = UUID.randomUUID().toString();
+
+    @Test
+    public void testMemberCapability() throws Exception {
+        MemberImpl allCapabilitiesMember = createMember(EnumSet.allOf(Capability.class));
+
+        for (Capability capability : Capability.values()) {
+            assertTrue(allCapabilitiesMember.hasCapability(capability));
+        }
+
+        MemberImpl partitionHostMember = createMember(EnumSet.of(PARTITION_HOST));
+        assertTrue(partitionHostMember.hasCapability(PARTITION_HOST));
+
+        MemberImpl noCapabilityMember = createMember(EnumSet.noneOf(Capability.class));
+        assertFalse(noCapabilityMember.hasCapability(PARTITION_HOST));
+    }
+
+
+    private MemberImpl createMember(Set<Capability> capabilities) throws Exception {
+        return new MemberImpl(new Address("10.0.0.1", 5701), true, MEMBER_UUID, null, capabilities, null);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/instance/SimpleMemberImpl.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/SimpleMemberImpl.java
@@ -23,6 +23,7 @@ import com.hazelcast.nio.ObjectDataOutput;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * @author mdogan 25/08/14
@@ -48,6 +49,11 @@ public class SimpleMemberImpl implements Member {
     @Override
     public InetSocketAddress getInetSocketAddress() {
         return getSocketAddress();
+    }
+
+    @Override
+    public void updateCapabilities(Set<Capability> capabilities) {
+
     }
 
     @Override


### PR DESCRIPTION
This PR introduces the concept of member Capability. It defines the `PARTITION_HOST` capability. The `InternalPartitionServiceImpl` attempts to only use members with said capability when putting together member groups. Members attempting to change their capabilities send a `MemberCapabilityUpdateRequestOperation` to the master which decides if the update is accepted, and sends a `MemberCapabilityChangedOperation` to the other nodes.

Currently the `ClusterServiceImpl` in the master tries to always keep at least one member with the `PARTITION_HOST` capability. In the event that no `PARTITION_HOST` members are left (e.g.: if the only remaining one disconnects), the master takes ownership of all partitions.

A node joining the cluster can set its initial capabilities through the `Config` instance. A node leaving the cluster can request that all partitions be drained by calling `PartitionService.drain()` and providing a timeout.