### PR TITLE
Fixed java.lang.IllegalArgumentException: Target cannot be null! This was caused by the node.masterAddress being null.

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/partition/impl/InternalPartitionServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/impl/InternalPartitionServiceImpl.java
@@ -968,8 +968,11 @@ public class InternalPartitionServiceImpl implements InternalPartitionService, M
     }
 
     private boolean hasOnGoingMigrationMaster(Level level) {
-        Operation operation = new HasOngoingMigration();
         Address masterAddress = node.getMasterAddress();
+        if (masterAddress == null) {
+            return true;
+        }
+        Operation operation = new HasOngoingMigration();
         OperationService operationService = nodeEngine.getOperationService();
         InvocationBuilder invocationBuilder = operationService.createInvocationBuilder(SERVICE_NAME, operation,
                 masterAddress);


### PR DESCRIPTION
This can happen after a cluster merge in the window of time between masterAddresses being cleared and repopulated.
