### PR TITLE
Fixed java.lang.IllegalArgumentException: Target cannot be null!. This was caused by the node.masterAddress being null.

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/partition/impl/InternalPartitionServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/impl/InternalPartitionServiceImpl.java
@@ -1017,8 +1017,11 @@ public class InternalPartitionServiceImpl implements InternalPartitionService, M
     }
 
     private boolean hasOnGoingMigrationMaster(Level level) {
-        Operation operation = new HasOngoingMigration();
         Address masterAddress = node.getMasterAddress();
+        if (masterAddress == null) {
+            return true;
+        }
+        Operation operation = new HasOngoingMigration();
         OperationService operationService = nodeEngine.getOperationService();
         InvocationBuilder invocationBuilder = operationService.createInvocationBuilder(SERVICE_NAME, operation,
                 masterAddress);


### PR DESCRIPTION
(Same as https://github.com/hazelcast/hazelcast/pull/4109, but targeting `master` instead of `maintenance-3.x`.)
This can happen after a cluster merge in the window of time between masterAddresses being cleared and repopulated.
