### PR TITLE
Number of available slots is always set to the exact value as received i...

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnection.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnection.java
@@ -348,18 +348,10 @@ public class ClientConnection implements Connection, Closeable {
 //            logger.info("Received empty claim response from " + toString() + ". Next attempt in " + backoffState + " ms.");
         } else {
 //            logger.info("Received " + claimResponse + "slots for " + toString());
+            availableSlots.set(claimResponse);
             backoffState = BackoffPolicy.EMPTY_STATE;
         }
-
-        for (;;) {
-            int currentAvailableSlots = this.availableSlots.get();
-            if (currentAvailableSlots > 0) {
-                //we are going to ignore any claimResponses if the availableSlots is bigger than zero
-                break;
-            } else {
-                availableSlots.set(claimResponse);
-            }
-        }
+        waitingForSlotResponse.set(false);
     }
 
     public SocketChannelWrapper getSocketChannelWrapper() {

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnection.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnection.java
@@ -244,22 +244,10 @@ public final class TcpIpConnection implements Connection {
             //    logger.info("Received empty claim response from " + toString() + ". Next attempt in " + backoffState + " ms.");
         } else {
             //    logger.info("Received " + claimResponse + "slots for " + toString());
+            availableSlots.set(claimResponse);
             backoffState = BackoffPolicy.EMPTY_STATE;
         }
-
-        for (;;) {
-            int currentAvailableSlots = this.availableSlots.get();
-            if (currentAvailableSlots > 0) {
-                //we are going to ignore any claimResponses if the availableSlots is bigger than zero
-                break;
-            } else {
-                int newAvailableSlots = currentAvailableSlots + claimResponse;
-                if (availableSlots.compareAndSet(currentAvailableSlots, newAvailableSlots)) {
-                    waitingForSlotResponse.set(false);
-                    break;
-                }
-            }
-        }
+        waitingForSlotResponse.set(false);
     }
 
     @Override


### PR DESCRIPTION
...n a claim response.

There is no reason to treat the claim response as a delta/offset to the current number of slots available.
