### PR TITLE
Map loading more items than specified in max size policy

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/DefaultRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/DefaultRecordStore.java
@@ -411,11 +411,8 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore implements 
         mapDataStore.reset();
     }
 
-
     @Override
     public Object evict(Data key, boolean backup) {
-        checkIfLoaded();
-
         return evictInternal(key, backup);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/eviction/MaxSizeChecker.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/eviction/MaxSizeChecker.java
@@ -211,7 +211,7 @@ public class MaxSizeChecker {
     /**
      * used when deciding evictable or not.
      */
-    private int getApproximateMaxSize(int maxSizeFromConfig) {
+    public static int getApproximateMaxSize(int maxSizeFromConfig) {
         // because not to exceed the max size much we start eviction early.
         // so decrease the max size with ratio .95 below
         return maxSizeFromConfig * EVICTION_START_THRESHOLD_PERCENTAGE / ONE_HUNDRED_PERCENT;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/BasicMapStoreContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/BasicMapStoreContext.java
@@ -42,6 +42,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.config.MaxSizeConfig.MaxSizePolicy.PER_NODE;
+import static com.hazelcast.map.impl.eviction.MaxSizeChecker.getApproximateMaxSize;
 import static com.hazelcast.map.impl.mapstore.MapStoreManagers.createWriteBehindManager;
 import static com.hazelcast.map.impl.mapstore.MapStoreManagers.createWriteThroughManager;
 import static com.hazelcast.map.impl.mapstore.StoreConstructor.createStore;
@@ -243,7 +244,8 @@ final class BasicMapStoreContext implements MapStoreContext {
         final Map<Data, Object> initialKeys = this.initialKeys;
         initialKeys.clear();
         final PartitioningStrategy partitioningStrategy = this.partitioningStrategy;
-        final int maxSizePerNode = getMaxSizePerNode();
+        int maxSizePerNode = getApproximateMaxSize(getMaxSizePerNode()) - 1;
+
         for (Object key : loadedKeys) {
             Data dataKey = mapServiceContext.toData(key, partitioningStrategy);
             // this node will load only owned keys

--- a/hazelcast/src/test/java/com/hazelcast/map/mapstore/MapStoreEvictionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/mapstore/MapStoreEvictionTest.java
@@ -1,10 +1,8 @@
 package com.hazelcast.map.mapstore;
 
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
 import com.hazelcast.config.Config;
+import com.hazelcast.config.EvictionPolicy;
 import com.hazelcast.config.GroupConfig;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.config.MapStoreConfig;
@@ -20,6 +18,12 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static com.hazelcast.test.TimeConstants.MINUTE;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -28,40 +32,42 @@ import org.junit.runner.RunWith;
 @Category(QuickTest.class)
 public class MapStoreEvictionTest extends HazelcastTestSupport {
 
-    private int mapStoreEntryCount = 10 * 1000;
+    private int mapStoreEntryCount = 1000;
     private int nodes = 2;
     private int maxSizePerNode = mapStoreEntryCount / 4;
     private int maxSizePerCluster = maxSizePerNode * nodes;
     private AtomicInteger loadedValueCount = new AtomicInteger();
     private TestHazelcastInstanceFactory nodeFactory = createHazelcastInstanceFactory(nodes);
 
-    @Test(timeout = 120000)
+    @Test(timeout = 2 * MINUTE)
     public void testLoadsAll_whenEvictionDisabled() throws Exception {
         Config cfg = newConfig("map", false);
 
-        HazelcastInstance instances[] = nodeFactory.newInstances(cfg);
-        assertClusterSizeEventually(nodes, instances[0]);
-        IMap<Object, Object> map = instances[0].getMap("map");
+        HazelcastInstance hz = nodeFactory.newInstances(cfg)[0];
+        assertClusterSizeEventually(nodes, hz);
+        IMap<Object, Object> map = hz.getMap("map");
+        waitClusterForSafeState(hz);
 
-        assertEquals(mapStoreEntryCount, loadedValueCount.get());
         assertEquals(mapStoreEntryCount, map.size());
+        assertEquals(mapStoreEntryCount, loadedValueCount.get());
     }
 
-    @Test(timeout = 120000)
+    @Test(timeout = 2 * MINUTE)
     public void testLoadsLessThanMaxSize_whenEvictionEnabled() throws Exception {
         Config cfg = newConfig("map", true);
 
-        HazelcastInstance instances[] = nodeFactory.newInstances(cfg);
-        assertClusterSizeEventually(nodes, instances[0]);
-        IMap<Object, Object> map = instances[0].getMap("map");
+        HazelcastInstance hz = nodeFactory.newInstances(cfg)[0];
+        assertClusterSizeEventually(nodes, hz);
+        IMap<Object, Object> map = hz.getMap("map");
+        waitAllForSafeState();
 
-        assertEquals(maxSizePerCluster, loadedValueCount.get());
+        assertFalse(map.isEmpty());
         assertTrue(maxSizePerCluster >= map.size());
+        assertTrue(maxSizePerCluster >= loadedValueCount.get());
     }
 
     private Config newConfig(String mapName, boolean sizeLimited) {
         Config cfg = new Config();
-
         cfg.setGroupConfig(new GroupConfig(getClass().getSimpleName()));
 
         MapStoreConfig mapStoreConfig = new MapStoreConfig()
@@ -73,6 +79,7 @@ public class MapStoreEvictionTest extends HazelcastTestSupport {
         if( sizeLimited ) {
             MaxSizeConfig maxSizeConfig = new MaxSizeConfig(maxSizePerNode, MaxSizeConfig.MaxSizePolicy.PER_NODE);
             mapConfig.setMaxSizeConfig(maxSizeConfig);
+            mapConfig.setEvictionPolicy(EvictionPolicy.LRU);
         }
 
         return cfg;


### PR DESCRIPTION
 Issue #4066
Adding LRU policy to eviction test. Removing isLoaded check when evicting.
