### PR TITLE
[forwardport] Fixed throwable stack trace accumulation issue during invocation failure...

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/spi/impl/ClientInvocationTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/spi/impl/ClientInvocationTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2008-2014, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.spi.impl;
+
+import com.hazelcast.client.HazelcastClient;
+import com.hazelcast.config.Config;
+import com.hazelcast.core.ExecutionCallback;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.instance.HazelcastInstanceFactory;
+import com.hazelcast.instance.TestUtil;
+import com.hazelcast.map.EntryBackupProcessor;
+import com.hazelcast.map.EntryProcessor;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.LockSupport;
+
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class ClientInvocationTest {
+
+    @Before
+    @After
+    public void cleanup() {
+        HazelcastClient.shutdownAll();
+        HazelcastInstanceFactory.terminateAll();
+    }
+
+    /**
+     * When a async operation fails because of a node termination,
+     * failure stack trace is copied incrementally for each async invocation/future
+     *
+     * see https://github.com/hazelcast/hazelcast/issues/4192
+     */
+    @Test
+    public void executionCallback_TooLongThrowableStackTrace() throws InterruptedException {
+        Config config = new Config();
+        config.getNetworkConfig().getJoin().getMulticastConfig().setEnabled(false);
+        config.getNetworkConfig().getJoin().getTcpIpConfig().setEnabled(true);
+        HazelcastInstance server = Hazelcast.newHazelcastInstance(config);
+
+        HazelcastInstance client = HazelcastClient.newHazelcastClient();
+        IMap<Object, Object> map = client.getMap("test");
+
+        DummyEntryProcessor ep = new DummyEntryProcessor();
+
+        int count = 100;
+        FailureExecutionCallback[] callbacks = new FailureExecutionCallback[count];
+        for (int i = 0; i < count; i++) {
+            callbacks[i] = new FailureExecutionCallback();
+            map.submitToKey("key", ep, callbacks[i]);
+        }
+
+        // crash the server
+        TestUtil.getNode(server).getConnectionManager().shutdown();
+        server.getLifecycleService().terminate();
+
+        for (FailureExecutionCallback callback : callbacks) {
+            assertTrue("Callback should be notified on time!", callback.latch.await(1, TimeUnit.MINUTES));
+
+            Throwable failure = callback.failure;
+            if (failure == null) {
+                continue;
+            }
+            int stackTraceLength = failure.getStackTrace().length;
+            assertTrue("Failure stack trace should not be too long! Current: "
+                    + stackTraceLength, stackTraceLength < 50);
+
+            Throwable cause = failure.getCause();
+            if (cause == null) {
+                continue;
+            }
+            stackTraceLength = cause.getStackTrace().length;
+            assertTrue("Cause stack trace should not be too long! Current: "
+                    + stackTraceLength, stackTraceLength < 50);
+        }
+    }
+
+    private static class DummyEntryProcessor implements EntryProcessor {
+        @Override
+        public Object process(Map.Entry entry) {
+            LockSupport.parkNanos(10000);
+            return null;
+        }
+
+        @Override
+        public EntryBackupProcessor getBackupProcessor() {
+            return null;
+        }
+    }
+
+
+    private static class FailureExecutionCallback implements ExecutionCallback {
+        final CountDownLatch latch = new CountDownLatch(1);
+        volatile Throwable failure;
+
+        @Override
+        public void onResponse(Object response) {
+            latch.countDown();
+        }
+
+        @Override
+        public void onFailure(Throwable t) {
+            failure = t;
+            latch.countDown();
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/BasicOperationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/BasicOperationService.java
@@ -431,10 +431,9 @@ final class BasicOperationService implements InternalOperationService {
     public void shutdown() {
         shutdown = true;
         logger.finest("Stopping operation threads...");
-        final Object response = new HazelcastInstanceNotActiveException();
         for (BasicInvocation invocation : invocations.values()) {
             try {
-                invocation.notify(response);
+                invocation.notify(new HazelcastInstanceNotActiveException());
             } catch (Throwable e) {
                 logger.warning(invocation + " could not be notified with shutdown message -> " + e.getMessage());
             }


### PR DESCRIPTION
.... ExceptionUtil.fixRemoteStackTrace() is used to merge local and remote stack traces. When the same/shared throwable instance is used for multiple future notifications, they all modify the throwable's stack trace and that causes an invalid and too long stack trace being generated.

Fixes https://github.com/hazelcast/hazelcast/issues/4192
