### PR TITLE
QueryBasicTest. Wait for cluster safe state before running the query

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/map/query/QueryBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/query/QueryBasicTest.java
@@ -780,6 +780,7 @@ public class QueryBasicTest extends HazelcastTestSupport {
 
         Object key = generateKeyOwnedBy(hz1);
         map.put(key, new ParentPortableObject(1L));
+        waitAllForSafeState();
 
         Collection<Object> values = map.values(new SqlPredicate("timestamp > 0"));
         assertEquals(1, values.size());


### PR DESCRIPTION
closes https://github.com/hazelcast/hazelcast/issues/4200
