### PR TITLE
In the heartbeat algorithm, compensate for any abrupt jumps forward in the system clock.

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/ClusterServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/ClusterServiceImpl.java
@@ -73,10 +73,12 @@ import com.hazelcast.util.executor.ExecutorType;
 import javax.security.auth.login.LoginContext;
 import javax.security.auth.login.LoginException;
 import java.net.ConnectException;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Date;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -114,6 +116,7 @@ public final class ClusterServiceImpl implements ClusterService, ConnectionListe
 
     private static final String EXECUTOR_NAME = "hz:cluster";
     private static final int HEARTBEAT_INTERVAL = 500;
+    private static final long HEARTBEAT_LOG_THRESHOLD = 10000L;
     private static final int PING_INTERVAL = 5000;
 
     private final Node node;
@@ -151,7 +154,11 @@ public final class ClusterServiceImpl implements ClusterService, ConnectionListe
 
     private final AtomicBoolean preparingToMerge = new AtomicBoolean(false);
 
+    private long heartbeatInterval;
+
     private volatile boolean joinInProgress = false;
+
+    private long lastHeartBeat = 0L;
 
     private long timeToStartJoin = 0;
 
@@ -195,7 +202,7 @@ public final class ClusterServiceImpl implements ClusterService, ConnectionListe
         executionService.scheduleWithFixedDelay(EXECUTOR_NAME, new SplitBrainHandler(node),
                 mergeFirstRunDelay, mergeNextRunDelay, TimeUnit.MILLISECONDS);
 
-        long heartbeatInterval = node.groupProperties.HEARTBEAT_INTERVAL_SECONDS.getInteger();
+        heartbeatInterval = node.groupProperties.HEARTBEAT_INTERVAL_SECONDS.getInteger();
         heartbeatInterval = heartbeatInterval <= 0 ? 1 : heartbeatInterval;
         executionService.scheduleWithFixedDelay(EXECUTOR_NAME, new Runnable() {
             public void run() {
@@ -287,25 +294,41 @@ public final class ClusterServiceImpl implements ClusterService, ConnectionListe
             return;
         }
 
+        long now = Clock.currentTimeMillis();
+
+        /*
+         * Compensate for any abrupt jumps forward in the system clock.
+         */
+        long clockJump = 0L;
+        if (lastHeartBeat != 0L) {
+            clockJump = now - lastHeartBeat - TimeUnit.SECONDS.toMillis(heartbeatInterval);
+            if (Math.abs(clockJump) > HEARTBEAT_LOG_THRESHOLD) {
+                SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS");
+                logger.info("System clock apparently jumped from " + sdf.format(new Date(lastHeartBeat)) + " to " +
+                        sdf.format(new Date(now)) + " since last heartbeat (" + String.format("%+d", clockJump) + "ms).");
+            }
+            clockJump = Math.max(0L, clockJump);
+        }
+        lastHeartBeat = now;
+
         if (node.isMaster()) {
-            heartBeaterMaster();
+            heartBeaterMaster(now, clockJump);
         } else {
-            heartBeaterSlave();
+            heartBeaterSlave(now, clockJump);
         }
     }
 
-    private void heartBeaterMaster() {
-        long now = Clock.currentTimeMillis();
+    private void heartBeaterMaster(long now, long clockJump) {
         Collection<MemberImpl> members = getMemberList();
         for (MemberImpl member : members) {
             if (!member.localMember()) {
                 try {
                     logIfConnectionToEndpointIsMissing(now, member);
-                    if (removeMemberIfNotHeartBeating(now, member)) {
+                    if (removeMemberIfNotHeartBeating(now - clockJump, member)) {
                         continue;
                     }
 
-                    if (removeMemberIfMasterConfirmationExpired(now, member)) {
+                    if (removeMemberIfMasterConfirmationExpired(now - clockJump, member)) {
                         continue;
                     }
 
@@ -340,8 +363,7 @@ public final class ClusterServiceImpl implements ClusterService, ConnectionListe
         return false;
     }
 
-    private void heartBeaterSlave() {
-        long now = Clock.currentTimeMillis();
+    private void heartBeaterSlave(long now, long clockJump) {
         Collection<MemberImpl> members = getMemberList();
 
         for (MemberImpl member : members) {
@@ -350,7 +372,7 @@ public final class ClusterServiceImpl implements ClusterService, ConnectionListe
                     logIfConnectionToEndpointIsMissing(now, member);
 
                     if (isMaster(member)) {
-                        if (removeMemberIfNotHeartBeating(now, member)) {
+                        if (removeMemberIfNotHeartBeating(now - clockJump, member)) {
                             continue;
                         }
                     }
@@ -1264,14 +1286,12 @@ public final class ClusterServiceImpl implements ClusterService, ConnectionListe
 
     public void setMasterTime(long masterTime) {
         long diff = masterTime - Clock.currentTimeMillis();
-        if (Math.abs(diff) < Math.abs(clusterTimeDiff)) {
-            this.clusterTimeDiff = diff;
-        }
+        logger.finest("Setting cluster time diff to " + diff + "ms.");
+        this.clusterTimeDiff = diff;
     }
 
-    //todo: remove since unused?
-    public long getClusterTimeFor(long localTime) {
-        return localTime + ((clusterTimeDiff == Long.MAX_VALUE) ? 0 : clusterTimeDiff);
+    public long getClusterTimeDiff() {
+        return (clusterTimeDiff == Long.MAX_VALUE) ? 0 : clusterTimeDiff;
     }
 
     public String addMembershipListener(MembershipListener listener) {

--- a/hazelcast/src/main/java/com/hazelcast/util/HealthMonitor.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/HealthMonitor.java
@@ -17,6 +17,7 @@
 package com.hazelcast.util;
 
 import com.hazelcast.client.impl.ClientEngineImpl;
+import com.hazelcast.cluster.impl.ClusterServiceImpl;
 import com.hazelcast.instance.HazelcastInstanceImpl;
 import com.hazelcast.instance.Node;
 import com.hazelcast.instance.OutOfMemoryErrorDispatcher;
@@ -71,6 +72,7 @@ public class HealthMonitor extends Thread {
     private final Runtime runtime;
     private final HealthMonitorLevel logLevel;
     private final int delaySeconds;
+    private final ClusterServiceImpl clusterService;
     private final ExecutionService executionService;
     private final EventService eventService;
     private final OperationService operationService;
@@ -89,6 +91,7 @@ public class HealthMonitor extends Thread {
         this.logLevel = logLevel;
         this.delaySeconds = delaySeconds;
         this.threadMxBean = ManagementFactory.getThreadMXBean();
+        this.clusterService = node.getClusterService();
         this.executionService = node.nodeEngine.getExecutionService();
         this.eventService = node.nodeEngine.getEventService();
         this.operationService = node.nodeEngine.getOperationService();
@@ -148,6 +151,7 @@ public class HealthMonitor extends Thread {
         private final double systemCpuLoad;
         private final int threadCount;
         private final int peakThreadCount;
+        private final long clusterTimeDiff;
         private final int asyncExecutorQueueSize;
         private final int clientExecutorQueueSize;
         private final int queryExecutorQueueSize;
@@ -179,6 +183,7 @@ public class HealthMonitor extends Thread {
             systemCpuLoad = readLongAttribute("SystemCpuLoad", -1L);
             threadCount = threadMxBean.getThreadCount();
             peakThreadCount = threadMxBean.getPeakThreadCount();
+            clusterTimeDiff = clusterService.getClusterTimeDiff();
             asyncExecutorQueueSize = executionService.getExecutor(ExecutionService.ASYNC_EXECUTOR).getQueueSize();
             clientExecutorQueueSize = executionService.getExecutor(ExecutionService.CLIENT_EXECUTOR).getQueueSize();
             queryExecutorQueueSize = executionService.getExecutor(ExecutionService.QUERY_EXECUTOR).getQueueSize();
@@ -252,6 +257,7 @@ public class HealthMonitor extends Thread {
             sb.append("load.systemAverage=").append(format("%.2f", systemLoadAverage)).append("%, ");
             sb.append("thread.count=").append(threadCount).append(", ");
             sb.append("thread.peakCount=").append(peakThreadCount).append(", ");
+            sb.append("cluster.timeDiff=").append(clusterTimeDiff).append(", ");
             sb.append("event.q.size=").append(eventQueueSize).append(", ");
             sb.append("executor.q.async.size=").append(asyncExecutorQueueSize).append(", ");
             sb.append("executor.q.client.size=").append(clientExecutorQueueSize).append(", ");


### PR DESCRIPTION
In the heartbeat algorithm, compensate for any abrupt jumps forward in the system clock.
This can sometimes be an issue in virtualized environments if time synchronization between
the host OS and guest OS is misconfigured.

The effect of a large clock jump on some cluster node(s) but not others was that some nodes
were spuriously kicked out of the cluster.  This now no longer happens due merely to system clock
jumps (but, of course, continues to happen if heartbeats are repeatedly dropped, as before). 

In addition, fix the `clusterTimeDiff` calculation so that system clocks drifting in any
direction do not cause spurious timeouts.  Previously, `clusterTimeDiff` would converge
to zero, so that converging clocks were compensated but not diverging clocks.

Finally, include `cluster.timeDiff` in the `HealthMonitor` logging.
