### PR TITLE
Fixed issue #4254

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/ReplicatedRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/ReplicatedRecord.java
@@ -33,18 +33,19 @@ import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
  * @param <K> key type
  * @param <V> value type
  */
-public class ReplicatedRecord<K, V>
-        implements IdentifiedDataSerializable {
+public class ReplicatedRecord<K, V> implements IdentifiedDataSerializable {
 
     private static final AtomicLongFieldUpdater<ReplicatedRecord> HITS_UPDATER = AtomicLongFieldUpdater
             .newUpdater(ReplicatedRecord.class, "hits");
     private static final AtomicLongFieldUpdater<ReplicatedRecord> LAST_ACCESS_TIME_UPDATER = AtomicLongFieldUpdater
-            .newUpdater(ReplicatedRecord.class, "hits");
+            .newUpdater(ReplicatedRecord.class, "lastAccessTime");
     private static final AtomicReferenceFieldUpdater<ReplicatedRecord, VectorClockTimestamp> VECTOR_CLOCK_UPDATER =
             AtomicReferenceFieldUpdater.newUpdater(ReplicatedRecord.class, VectorClockTimestamp.class, "vectorClockTimestamp");
 
     // These fields are only accessed through the updaters
+    @SuppressWarnings("unused")
     private volatile long hits;
+    @SuppressWarnings("unused")
     private volatile long lastAccessTime;
 
     private K key;
@@ -233,7 +234,6 @@ public class ReplicatedRecord<K, V>
         sb.append('}');
         return sb.toString();
     }
-
 }
 
 

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapBaseTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapBaseTest.java
@@ -1,0 +1,89 @@
+package com.hazelcast.replicatedmap;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.config.ReplicatedMapConfig;
+import com.hazelcast.core.ReplicatedMap;
+import com.hazelcast.replicatedmap.impl.ReplicatedMapProxy;
+import com.hazelcast.replicatedmap.impl.record.AbstractReplicatedRecordStore;
+import com.hazelcast.replicatedmap.impl.record.ReplicatedRecord;
+import com.hazelcast.replicatedmap.impl.record.ReplicationPublisher;
+import com.hazelcast.test.HazelcastTestSupport;
+
+import java.lang.reflect.Field;
+import java.util.AbstractMap;
+import java.util.Random;
+
+import static org.junit.Assert.fail;
+
+public abstract class ReplicatedMapBaseTest extends HazelcastTestSupport {
+
+    protected static Field REPLICATED_RECORD_STORE;
+
+    static {
+        try {
+            REPLICATED_RECORD_STORE = ReplicatedMapProxy.class.getDeclaredField("replicatedRecordStore");
+            REPLICATED_RECORD_STORE.setAccessible(true);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    protected Config buildConfig(InMemoryFormat inMemoryFormat, long replicationDelay) {
+        Config config = new Config();
+        ReplicatedMapConfig replicatedMapConfig = config.getReplicatedMapConfig("default");
+        replicatedMapConfig.setReplicationDelayMillis(replicationDelay);
+        replicatedMapConfig.setInMemoryFormat(inMemoryFormat);
+        return config;
+    }
+
+    protected void assertMatchSuccessfulOperationQuota(double quota, int completeOps, int... values) {
+        float[] quotas = new float[values.length];
+        Object[] args = new Object[values.length + 1];
+        args[0] = quota;
+
+        for (int i = 0; i < values.length; i++) {
+            quotas[i] = (float) values[i] / completeOps;
+            args[i + 1] = quotas[i];
+        }
+
+        boolean success = true;
+        for (int i = 0; i < values.length; i++) {
+            if (quotas[i] < quota) {
+                success = false;
+                break;
+            }
+        }
+
+        if (!success) {
+            StringBuilder sb = new StringBuilder("Quote (%s) for updates not reached,");
+            for (int i = 0; i < values.length; i++) {
+                sb.append(" map").append(i + 1).append(": %s,");
+            }
+            sb.deleteCharAt(sb.length() - 1);
+            fail(String.format(sb.toString(), args));
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    protected <K, V> ReplicatedRecord<K, V> getReplicatedRecord(ReplicatedMap<K, V> map, K key) throws Exception {
+        ReplicatedMapProxy<K, V> proxy = (ReplicatedMapProxy<K, V>) map;
+        return ((AbstractReplicatedRecordStore<K, V>) REPLICATED_RECORD_STORE.get(proxy)).getReplicatedRecord(key);
+    }
+
+    @SuppressWarnings("unchecked")
+    protected <K, V> ReplicationPublisher<K, V> getReplicationPublisher(ReplicatedMap<K, V> map) throws Exception {
+        ReplicatedMapProxy<K, V> proxy = (ReplicatedMapProxy<K, V>) map;
+        return ((AbstractReplicatedRecordStore<K, V>) REPLICATED_RECORD_STORE.get(proxy)).getReplicationPublisher();
+    }
+
+    @SuppressWarnings("unchecked")
+    protected AbstractMap.SimpleEntry<Integer, Integer>[] buildTestValues() {
+        Random random = new Random();
+        AbstractMap.SimpleEntry<Integer, Integer>[] testValues = new AbstractMap.SimpleEntry[100];
+        for (int i = 0; i < testValues.length; i++) {
+            testValues[i] = new AbstractMap.SimpleEntry<Integer, Integer>(random.nextInt(), random.nextInt());
+        }
+        return testValues;
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapHitsAndLastAccessTimeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapHitsAndLastAccessTimeTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2008-2013, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.replicatedmap;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.config.ReplicatedMapConfig;
+import com.hazelcast.core.EntryEventType;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.ReplicatedMap;
+import com.hazelcast.replicatedmap.impl.record.ReplicatedRecord;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.WatchedOperationExecutor;
+import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.util.Clock;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category(QuickTest.class)
+public class ReplicatedMapHitsAndLastAccessTimeTest extends ReplicatedMapBaseTest {
+
+    @Test
+    public void testHitsAndLastAccessTimeObjectDelay0() throws Exception {
+        testHitsAndLastAccessTime(buildConfig(InMemoryFormat.OBJECT, 0));
+    }
+
+    @Test
+    public void testHitsAndLastAccessTimeObjectDelayDefault() throws Exception {
+        testHitsAndLastAccessTime(buildConfig(InMemoryFormat.OBJECT, ReplicatedMapConfig.DEFAULT_REPLICATION_DELAY_MILLIS));
+    }
+
+    @Test
+    public void testHitsAndLastAccessTimeBinaryDelay0() throws Exception {
+        testHitsAndLastAccessTime(buildConfig(InMemoryFormat.BINARY, 0));
+    }
+
+    @Test
+    public void testHitsAndLastAccessTimeBinaryDelayDefault() throws Exception {
+        testHitsAndLastAccessTime(buildConfig(InMemoryFormat.BINARY, ReplicatedMapConfig.DEFAULT_REPLICATION_DELAY_MILLIS));
+    }
+
+    private void testHitsAndLastAccessTime(Config config) throws Exception {
+        long startTime = Clock.currentTimeMillis();
+
+        TestHazelcastInstanceFactory nodeFactory = createHazelcastInstanceFactory(2);
+
+        HazelcastInstance instance1 = nodeFactory.newHazelcastInstance(config);
+        HazelcastInstance instance2 = nodeFactory.newHazelcastInstance(config);
+
+        final ReplicatedMap<String, String> map1 = instance1.getReplicatedMap("default");
+        final ReplicatedMap<String, String> map2 = instance2.getReplicatedMap("default");
+
+        final int operations = 100;
+        WatchedOperationExecutor executor = new WatchedOperationExecutor();
+        executor.execute(new Runnable() {
+            @Override
+            public void run() {
+                for (int i = 0; i < operations; i++) {
+                    map1.put("foo-" + i, "bar");
+                }
+            }
+        }, 60, EntryEventType.ADDED, operations, 0.75, map1, map2);
+
+        for (Map.Entry<String, String> entry : map1.entrySet()) {
+            assertRecord(getReplicatedRecord(map1, entry.getKey()), startTime);
+        }
+
+        for (Map.Entry<String, String> entry : map2.entrySet()) {
+            assertRecord(getReplicatedRecord(map2, entry.getKey()), startTime);
+        }
+    }
+
+    private void assertRecord(ReplicatedRecord<String, String> record, long startTime) {
+        long hits = record.getHits();
+        long lastAccessTime = record.getLastAccessTime();
+        long now = Clock.currentTimeMillis();
+        assertEquals(
+                String.format("Hits should be %d but was %d", 1, hits),
+                1,
+                hits
+        );
+        assertTrue(
+                String.format("LastAccessTime should be greater than startTime: %d > %d", lastAccessTime, startTime),
+                lastAccessTime > startTime
+        );
+        assertTrue(
+                String.format("LastAccessTime should be less or equal than current time: %d <= %d", lastAccessTime, now),
+                lastAccessTime <= now
+        );
+    }
+}


### PR DESCRIPTION
As found by @rainerjung the AtomicLongFieldUpdater in ReplicatedRecord was updating the field "hits" when it should update "lastAccessTime". So it messed up both values (hits were overwritten with a timestamp).

I wrote new tests which check both attributes of the record. The tests failed before I fixed the bug.

In addition all warnings in ReplicatedMapTest have been removed. I also created a common base class for both test files. The class ReplicatedMapTest is still too big (over 1100 lines) and should be split up into several files per test group in a later PR.
