### PR TITLE
Enable partition events for partitions that are promoted from backup.

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/partition/impl/InternalPartitionServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/impl/InternalPartitionServiceImpl.java
@@ -434,6 +434,10 @@ public class InternalPartitionServiceImpl implements InternalPartitionService, M
                         .setValidateTarget(false)
                         .setService(this);
                 nodeEngine.getOperationService().executeOperation(op);
+
+                MigrationInfo migrationInfo = new MigrationInfo(partition.getPartitionId(), null, partition.getOwnerOrNull());
+                sendMigrationEvent(migrationInfo, MigrationStatus.STARTED);
+                sendMigrationEvent(migrationInfo, MigrationStatus.COMPLETED);
             }
         }
     }


### PR DESCRIPTION
As discussed in issue #2318, enables partition events for partitions that are promoted from backup.

Note: Each events MigrationInfo.source field is set to null.