### PR TITLE
Changed backpressure sync window from 1000 to 100

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/instance/GroupProperties.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/GroupProperties.java
@@ -433,7 +433,7 @@ public class GroupProperties {
                 = new GroupProperty(config, PROP_MIGRATION_MIN_DELAY_ON_MEMBER_REMOVED_SECONDS, "5");
 
         BACKPRESSURE_ENABLED = new GroupProperty(config, PROP_BACKPRESSURE_ENABLED, "false");
-        BACKPRESSURE_SYNCWINDOW = new GroupProperty(config, PROP_BACKPRESSURE_SYNCWINDOW, "1000");
+        BACKPRESSURE_SYNCWINDOW = new GroupProperty(config, PROP_BACKPRESSURE_SYNCWINDOW, "100");
     }
 
     public static class GroupProperty {


### PR DESCRIPTION
1000 is an old value. According to our tests 100 has little impact on throughput and latency.
