### PR TITLE
added mising completion event if condition fails for putIfAbsent, replace, remove

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheRecordStore.java
@@ -885,6 +885,7 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
                         now, disableWriteThrough, completionId) != null;
             } else {
                 result = false;
+                publishEvent(CacheEventType.COMPLETED, key, null, null, false, completionId);
             }
 
             onPutIfAbsent(key, value, expiryPolicy, caller, disableWriteThrough,
@@ -933,6 +934,7 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
         try {
             if (record == null || isExpired) {
                 replaced = false;
+                publishEvent(CacheEventType.COMPLETED, key, null, null, false, completionId);
             } else {
                 replaced = updateRecordWithExpiry(key, value, record, expiryPolicy,
                         now, false, completionId);
@@ -989,6 +991,9 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
                     replaced = false;
                 }
             }
+            if (!replaced) {
+                publishEvent(CacheEventType.COMPLETED, key, null, null, false, completionId);
+            }
 
             onReplace(key, oldValue, newValue, expiryPolicy, caller, false,
                     record, isExpired, replaced);
@@ -1025,6 +1030,7 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
             if (record == null || isExpired) {
                 obj = null;
                 replaced = false;
+                publishEvent(CacheEventType.COMPLETED, key, null, null, false, completionId);
             } else {
                 replaced = updateRecordWithExpiry(key, value, record, expiryPolicy,
                         now, false, completionId);
@@ -1174,6 +1180,7 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
             if (record == null || isExpired) {
                 obj = null;
                 removed = false;
+                publishEvent(CacheEventType.COMPLETED, key, null, null, false, completionId);
             } else {
                 obj = toValue(record);
                 removed = deleteRecord(key, completionId);

--- a/hazelcast/src/test/java/com/hazelcast/cache/JCacheListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/JCacheListenerTest.java
@@ -93,6 +93,148 @@ public class JCacheListenerTest extends HazelcastTestSupport {
         cachingProvider.close();
     }
 
+    @Test(timeout = 30000)
+    public void testPutIfAbsentWithSyncListener_whenEntryExists(){
+        CachingProvider cachingProvider = getCachingProvider();
+        CacheManager cacheManager = cachingProvider.getCacheManager();
+
+        CompleteConfiguration<String, String> config = new MutableConfiguration<String, String>()
+                .setTypes(String.class, String.class).addCacheEntryListenerConfiguration(
+                        new MutableCacheEntryListenerConfiguration<String, String>(
+                                FactoryBuilder.factoryOf(new TestListener(new AtomicInteger())), null, true, true));
+
+        Cache<String, String> cache = cacheManager.createCache(randomString(), config);
+        String key = randomString();
+        cache.put(key, randomString());
+        // there should not be any hanging due to sync listener
+        cache.putIfAbsent(key, randomString());
+    }
+
+    @Test(timeout = 30000)
+    public void testReplaceWithSyncListener_whenEntryNotExists(){
+        CachingProvider cachingProvider = getCachingProvider();
+        CacheManager cacheManager = cachingProvider.getCacheManager();
+
+        CompleteConfiguration<String, String> config = new MutableConfiguration<String, String>()
+                .setTypes(String.class, String.class).addCacheEntryListenerConfiguration(
+                        new MutableCacheEntryListenerConfiguration<String, String>(
+                                FactoryBuilder.factoryOf(new TestListener(new AtomicInteger())), null, true, true));
+
+        Cache<String, String> cache = cacheManager.createCache(randomString(), config);
+        // there should not be any hanging due to sync listener
+        cache.replace(randomString(), randomString());
+    }
+
+    @Test(timeout = 30000)
+    public void testReplaceIfSameWithSyncListener_whenEntryNotExists(){
+        CachingProvider cachingProvider = getCachingProvider();
+        CacheManager cacheManager = cachingProvider.getCacheManager();
+
+        CompleteConfiguration<String, String> config = new MutableConfiguration<String, String>()
+                .setTypes(String.class, String.class).addCacheEntryListenerConfiguration(
+                        new MutableCacheEntryListenerConfiguration<String, String>(
+                                FactoryBuilder.factoryOf(new TestListener(new AtomicInteger())), null, true, true));
+
+        Cache<String, String> cache = cacheManager.createCache(randomString(), config);
+        // there should not be any hanging due to sync listener
+        cache.replace(randomString(), randomString(), randomString());
+    }
+
+    @Test(timeout = 30000)
+    public void testReplaceIfSameWithSyncListener_whenValueIsNotSame(){
+        CachingProvider cachingProvider = getCachingProvider();
+        CacheManager cacheManager = cachingProvider.getCacheManager();
+
+        CompleteConfiguration<String, String> config = new MutableConfiguration<String, String>()
+                .setTypes(String.class, String.class).addCacheEntryListenerConfiguration(
+                        new MutableCacheEntryListenerConfiguration<String, String>(
+                                FactoryBuilder.factoryOf(new TestListener(new AtomicInteger())), null, true, true));
+
+        Cache<String, String> cache = cacheManager.createCache(randomString(), config);
+        String key = randomString();
+        cache.put(key, randomString());
+        // there should not be any hanging due to sync listener
+
+        cache.replace(key, randomString(), randomString());
+    }
+
+    @Test(timeout = 30000)
+    public void testRemoveWithSyncListener_whenEntryNotExists(){
+        CachingProvider cachingProvider = getCachingProvider();
+        CacheManager cacheManager = cachingProvider.getCacheManager();
+
+        CompleteConfiguration<String, String> config = new MutableConfiguration<String, String>()
+                .setTypes(String.class, String.class).addCacheEntryListenerConfiguration(
+                        new MutableCacheEntryListenerConfiguration<String, String>(
+                                FactoryBuilder.factoryOf(new TestListener(new AtomicInteger())), null, true, true));
+
+        Cache<String, String> cache = cacheManager.createCache(randomString(), config);
+        // there should not be any hanging due to sync listener
+        cache.remove(randomString());
+    }
+
+    @Test(timeout = 30000)
+    public void testRemoveIfSameWithSyncListener_whenEntryNotExists(){
+        CachingProvider cachingProvider = getCachingProvider();
+        CacheManager cacheManager = cachingProvider.getCacheManager();
+
+        CompleteConfiguration<String, String> config = new MutableConfiguration<String, String>()
+                .setTypes(String.class, String.class).addCacheEntryListenerConfiguration(
+                        new MutableCacheEntryListenerConfiguration<String, String>(
+                                FactoryBuilder.factoryOf(new TestListener(new AtomicInteger())), null, true, true));
+
+        Cache<String, String> cache = cacheManager.createCache(randomString(), config);
+        // there should not be any hanging due to sync listener
+        cache.remove(randomString(), randomString());
+    }
+
+    @Test(timeout = 30000)
+    public void testRemoveIfSameWithSyncListener_whenValueIsNotSame(){
+        CachingProvider cachingProvider = getCachingProvider();
+        CacheManager cacheManager = cachingProvider.getCacheManager();
+
+        CompleteConfiguration<String, String> config = new MutableConfiguration<String, String>()
+                .setTypes(String.class, String.class).addCacheEntryListenerConfiguration(
+                        new MutableCacheEntryListenerConfiguration<String, String>(
+                                FactoryBuilder.factoryOf(new TestListener(new AtomicInteger())), null, true, true));
+
+        Cache<String, String> cache = cacheManager.createCache(randomString(), config);
+        String key = randomString();
+        cache.put(key, randomString());
+        // there should not be any hanging due to sync listener
+        cache.remove(key, randomString());
+    }
+
+    @Test(timeout = 30000)
+    public void testGetAndReplaceWithSyncListener_whenEntryNotExists(){
+        CachingProvider cachingProvider = getCachingProvider();
+        CacheManager cacheManager = cachingProvider.getCacheManager();
+
+        CompleteConfiguration<String, String> config = new MutableConfiguration<String, String>()
+                .setTypes(String.class, String.class).addCacheEntryListenerConfiguration(
+                        new MutableCacheEntryListenerConfiguration<String, String>(
+                                FactoryBuilder.factoryOf(new TestListener(new AtomicInteger())), null, true, true));
+
+        Cache<String, String> cache = cacheManager.createCache(randomString(), config);
+        // there should not be any hanging due to sync listener
+        cache.getAndReplace(randomString(), randomString());
+    }
+
+    @Test(timeout = 30000)
+    public void testGetAndRemoveWithSyncListener_whenEntryNotExists(){
+        CachingProvider cachingProvider = getCachingProvider();
+        CacheManager cacheManager = cachingProvider.getCacheManager();
+
+        CompleteConfiguration<String, String> config = new MutableConfiguration<String, String>()
+                .setTypes(String.class, String.class).addCacheEntryListenerConfiguration(
+                        new MutableCacheEntryListenerConfiguration<String, String>(
+                                FactoryBuilder.factoryOf(new TestListener(new AtomicInteger())), null, true, true));
+
+        Cache<String, String> cache = cacheManager.createCache(randomString(), config);
+        // there should not be any hanging due to sync listener
+        cache.getAndRemove(randomString());
+    }
+
     public static class TestListener
             implements CacheEntryCreatedListener<String, String>,
                        CacheEntryUpdatedListener<String, String>,


### PR DESCRIPTION
fixes #4251 
Problem: if we use sync listener with putIfAbsent, replace and remove and if the condition fails like putIfAbsent to an existing entry, operation hangs.

Fix: while using sync listener, every operation waits for the appropriate event to come to the caller and executed. Since putIfAbsent, replace and remove are conditional, which means they may not trigger any event, we should send a 'completion' event.
