### PR TITLE
Backport of #4275

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/queue/impl/QueueContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/queue/impl/QueueContainer.java
@@ -50,6 +50,7 @@ import java.util.concurrent.TimeUnit;
  * such as pool,peek,clear..
  */
 public class QueueContainer implements IdentifiedDataSerializable {
+    private static final int ID_PROMOTION_OFFSET = 100000;
 
     private LinkedList<QueueItem> itemQueue;
     private Map<Long, QueueItem> backupMap;
@@ -599,7 +600,7 @@ public class QueueContainer implements IdentifiedDataSerializable {
                 itemQueue.addAll(values);
                 final QueueItem lastItem = itemQueue.peekLast();
                 if (lastItem != null) {
-                    setId(lastItem.itemId);
+                    setId(lastItem.itemId + ID_PROMOTION_OFFSET);
                 }
                 backupMap.clear();
                 backupMap = null;


### PR DESCRIPTION
When a partition is promoted from a backup to a primary then QueueContainer iterates through collection of existing backup values and set its own IDGenerator to the highest itemID found in backups.

However chances are the backup collection doesn't contain all records created by the old primary as some backup operations can still be in-flight. This leads to duplicated IDs generated by the new primary.

 This fix simple adds an offset so the new owner always generates IDs significantly higher then the previous owner. The down-side is the generated ID are no longer continuous, but I don't see this as a problem.
(cherry picked from commit aadf683)
