### PR TITLE
[backport] Fixed joiner blacklist handling

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cluster/GroupMismatchOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/GroupMismatchOperation.java
@@ -24,7 +24,7 @@ public class GroupMismatchOperation extends AbstractClusterOperation
                 + " Cause: the target cluster has a different group-name");
 
         Node node = nodeEngine.getNode();
-        node.getJoiner().blacklist(getCallerAddress());
+        node.getJoiner().blacklist(getCallerAddress(), true);
     }
 }
 

--- a/hazelcast/src/main/java/com/hazelcast/cluster/Joiner.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/Joiner.java
@@ -35,16 +35,34 @@ public interface Joiner {
     /**
      * Adds an address to the blacklist. Blacklist is useful if a node should ignore another node, e.g. when
      * the groupname of 2 machines is not the same and they should form different clusters.
-     *
+     * <p/>
+     * If blacklist is permanent, then this operation is write-once. It cannot be unblacklisted again.
+     * If blacklist is temporary, blacklist can be removed via {@link #unblacklist(com.hazelcast.nio.Address)}.
+     * <p/>
      * Method is thread-safe.
-     *
+     * <p/>
      * If the address already is blacklisted, the call is ignored
      *
-     * @param address the address to blacklist.
+     * @param address   the address to blacklist.
+     * @param permanent if blacklist is permanent or not
      * @throws java.lang.NullPointerException if address is null.
      * @see #isBlacklisted(com.hazelcast.nio.Address)
      */
-    void blacklist(Address address);
+    void blacklist(Address address, boolean permanent);
+
+    /**
+     * Removes an address from the blacklist if it's temporarily blacklisted.
+     * This method has no effect if given address is not blacklisted. Permanent blacklists
+     * cannot be undone.
+     * <p/>
+     * Method is thread-safe.
+     * <p/>
+     * If the address is not blacklisted, the call is ignored.
+     *
+     * @param address the address to unblacklist.
+     * @return true if address is unblacklisted, false otherwise.
+     */
+    boolean unblacklist(Address address);
 
     /**
      * Checks if an address is blacklisted.
@@ -54,7 +72,7 @@ public interface Joiner {
      * @param address the address to check.
      * @return true if blacklisted, false otherwise.
      * @throws java.lang.NullPointerException if address is null.
-     * @see #blacklist(com.hazelcast.nio.Address)
+     * @see #blacklist(com.hazelcast.nio.Address, boolean)
      */
     boolean isBlacklisted(Address address);
 }

--- a/hazelcast/src/main/java/com/hazelcast/cluster/TcpIpJoiner.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/TcpIpJoiner.java
@@ -45,7 +45,7 @@ import static com.hazelcast.util.AddressUtil.AddressHolder;
 public class TcpIpJoiner extends AbstractJoiner {
 
     private static final int MAX_PORT_TRIES = 3;
-    public static final long JOIN_RETRY_WAIT_TIME = 1000L;
+    private static final long JOIN_RETRY_WAIT_TIME = 1000L;
 
     private volatile boolean claimingMaster = false;
 
@@ -117,8 +117,6 @@ public class TcpIpJoiner extends AbstractJoiner {
             Collection<Address> possibleAddresses = getPossibleAddresses();
 
             boolean foundConnection = tryInitialConnection(possibleAddresses);
-            removeBlacklistedAddresses(possibleAddresses);
-
             if (!foundConnection) {
                 logger.finest("This node will assume master role since no possible member where connected to.");
                 node.setAsMaster();
@@ -135,8 +133,7 @@ public class TcpIpJoiner extends AbstractJoiner {
                     return;
                 }
 
-                removeBlacklistedAddresses(possibleAddresses);
-                if (possibleAddresses.size() == 0) {
+                if (isAllBlacklisted(possibleAddresses)) {
                     logger.finest(
                             "This node will assume master role since none of the possible members accepted join request.");
                     node.setAsMaster();
@@ -148,8 +145,10 @@ public class TcpIpJoiner extends AbstractJoiner {
                     boolean consensus = claimMastership(possibleAddresses);
                     if (consensus) {
                         if (logger.isFinestEnabled()) {
+                            Set<Address> votingEndpoints = new HashSet<Address>(possibleAddresses);
+                            votingEndpoints.removeAll(blacklistedAddresses.keySet());
                             logger.finest("Setting myself as master after consensus! " +
-                                    "Voting endpoints: " + possibleAddresses);
+                                    "Voting endpoints: " + votingEndpoints);
                         }
                         node.setAsMaster();
                         claimingMaster = false;
@@ -170,6 +169,9 @@ public class TcpIpJoiner extends AbstractJoiner {
         claimingMaster = true;
         Collection<Future<Boolean>> responses = new LinkedList<Future<Boolean>>();
         for (Address address : possibleAddresses) {
+            if (isBlacklisted(address)) {
+                continue;
+            }
             if (node.getConnectionManager().getConnection(address) != null) {
                 Future future = node.nodeEngine.getOperationService()
                         .createInvocationBuilder(ClusterServiceImpl.SERVICE_NAME,
@@ -221,9 +223,8 @@ public class TcpIpJoiner extends AbstractJoiner {
         long start = Clock.currentTimeMillis();
 
         while (!node.joined() && Clock.currentTimeMillis() - start < connectionTimeoutMillis) {
-
             Address masterAddress = node.getMasterAddress();
-            if (possibleAddresses.isEmpty() && masterAddress == null) {
+            if (isAllBlacklisted(possibleAddresses) && masterAddress == null) {
                 return;
             }
 
@@ -233,7 +234,6 @@ public class TcpIpJoiner extends AbstractJoiner {
                 }
                 node.clusterService.sendJoinRequest(masterAddress, true);
             } else {
-                removeBlacklistedAddresses(possibleAddresses);
                 sendMasterQuestion(possibleAddresses);
             }
 
@@ -243,20 +243,11 @@ public class TcpIpJoiner extends AbstractJoiner {
         }
     }
 
-    private void removeBlacklistedAddresses(Collection<Address> possibleAddresses) {
-        if (!blacklistedAddresses.isEmpty()) {
-            if (logger.isFinestEnabled()) {
-                logger.finest("Removing failedConnections: " + blacklistedAddresses);
-            }
-            possibleAddresses.removeAll(blacklistedAddresses);
-        }
-    }
-
     private boolean tryInitialConnection(Collection<Address> possibleAddresses) throws InterruptedException {
         long connectionTimeoutMillis = getConnTimeoutSeconds() * 1000L;
         long start = Clock.currentTimeMillis();
         while (Clock.currentTimeMillis() - start < connectionTimeoutMillis) {
-            if (possibleAddresses.isEmpty()) {
+            if (isAllBlacklisted(possibleAddresses)) {
                 return false;
             }
             if (logger.isFinestEnabled()) {
@@ -266,9 +257,12 @@ public class TcpIpJoiner extends AbstractJoiner {
                 return true;
             }
             Thread.sleep(JOIN_RETRY_WAIT_TIME);
-            removeBlacklistedAddresses(possibleAddresses);
         }
         return false;
+    }
+
+    private boolean isAllBlacklisted(Collection<Address> possibleAddresses) {
+        return blacklistedAddresses.keySet().containsAll(possibleAddresses);
     }
 
     private void lookForMaster(Collection<Address> possibleAddresses) throws InterruptedException {
@@ -277,8 +271,7 @@ public class TcpIpJoiner extends AbstractJoiner {
             sendMasterQuestion(possibleAddresses);
             //noinspection BusyWait
             Thread.sleep(JOIN_RETRY_WAIT_TIME);
-            possibleAddresses.removeAll(blacklistedAddresses);
-            if (possibleAddresses.size() == 0) {
+            if (isAllBlacklisted(possibleAddresses)) {
                 break;
             }
         }
@@ -287,7 +280,7 @@ public class TcpIpJoiner extends AbstractJoiner {
             return;
         }
 
-        if (possibleAddresses.size() == 0 && node.getMasterAddress() == null) {
+        if (isAllBlacklisted(possibleAddresses) && node.getMasterAddress() == null) {
             if (logger.isFinestEnabled()) {
                 logger.finest("Setting myself as master! No possible addresses remaining to connect...");
             }
@@ -326,8 +319,14 @@ public class TcpIpJoiner extends AbstractJoiner {
     }
 
     private boolean sendMasterQuestion(Collection<Address> possibleAddresses) {
+        if (logger.isFinestEnabled()) {
+            logger.finest("NOT sending master question to blacklisted endpoints: " + blacklistedAddresses);
+        }
         boolean sent = false;
         for (Address address : possibleAddresses) {
+            if (isBlacklisted(address)) {
+                continue;
+            }
             if (logger.isFinestEnabled()) {
                 logger.finest("Sending master question to " + address);
             }

--- a/hazelcast/src/main/java/com/hazelcast/nio/IOService.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/IOService.java
@@ -64,6 +64,8 @@ public interface IOService {
 
     ThreadGroup getThreadGroup();
 
+    void onSuccessfulConnection(Address address);
+
     void onFailedConnection(Address address);
 
     void shouldConnectTo(Address address);

--- a/hazelcast/src/main/java/com/hazelcast/nio/NodeIOService.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/NodeIOService.java
@@ -144,9 +144,16 @@ public class NodeIOService implements IOService {
     }
 
     @Override
+    public void onSuccessfulConnection(Address address) {
+        if (!node.joined()) {
+            node.getJoiner().unblacklist(address);
+        }
+    }
+
+    @Override
     public void onFailedConnection(Address address) {
         if (!node.joined()) {
-            node.getJoiner().blacklist(address);
+            node.getJoiner().blacklist(address, false);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnectionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnectionManager.java
@@ -219,6 +219,7 @@ public class TcpIpConnectionManager implements ConnectionManager {
             return false;
         }
         connection.setEndPoint(remoteEndPoint);
+        ioService.onSuccessfulConnection(remoteEndPoint);
         if (reply) {
             sendBindRequest(connection, remoteEndPoint, false);
         }
@@ -285,6 +286,7 @@ public class TcpIpConnectionManager implements ConnectionManager {
 
     void sendBindRequest(final TcpIpConnection connection, final Address remoteEndPoint, final boolean replyBack) {
         connection.setEndPoint(remoteEndPoint);
+        ioService.onSuccessfulConnection(remoteEndPoint);
         //make sure bind packet is the first packet sent to the end point.
         final BindOperation bind = new BindOperation(ioService.getThisAddress(), remoteEndPoint, replyBack);
         final Data bindData = ioService.toData(bind);

--- a/hazelcast/src/test/java/com/hazelcast/test/TestNodeRegistry.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/TestNodeRegistry.java
@@ -331,7 +331,12 @@ final class TestNodeRegistry {
             }
 
             @Override
-            public void blacklist(Address callerAddress) {
+            public void blacklist(Address address, boolean permanent) {
+            }
+
+            @Override
+            public boolean unblacklist(Address address) {
+                return false;
             }
 
             @Override


### PR DESCRIPTION
Joiner blacklist entry for an endpoint should be removed after a successful connection, if it's blacklisted temporarily. Group mismatch blacklists should be permanent, since they are not recoverable.

Fixes #3888
