### PR TITLE
Fixed joiner blacklist handling

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cluster/Joiner.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/Joiner.java
@@ -35,16 +35,34 @@ public interface Joiner {
     /**
      * Adds an address to the blacklist. Blacklist is useful if a node should ignore another node, e.g. when
      * the groupname of 2 machines is not the same and they should form different clusters.
-     *
+     * <p/>
+     * If blacklist is permanent, then this operation is write-once. It cannot be unblacklisted again.
+     * If blacklist is temporary, blacklist can be removed via {@link #unblacklist(com.hazelcast.nio.Address)}.
+     * <p/>
      * Method is thread-safe.
-     *
+     * <p/>
      * If the address already is blacklisted, the call is ignored
      *
-     * @param address the address to blacklist.
+     * @param address   the address to blacklist.
+     * @param permanent if blacklist is permanent or not
      * @throws java.lang.NullPointerException if address is null.
      * @see #isBlacklisted(com.hazelcast.nio.Address)
      */
-    void blacklist(Address address);
+    void blacklist(Address address, boolean permanent);
+
+    /**
+     * Removes an address from the blacklist if it's temporarily blacklisted.
+     * This method has no effect if given address is not blacklisted. Permanent blacklists
+     * cannot be undone.
+     * <p/>
+     * Method is thread-safe.
+     * <p/>
+     * If the address is not blacklisted, the call is ignored.
+     *
+     * @param address the address to unblacklist.
+     * @return true if address is unblacklisted, false otherwise.
+     */
+    boolean unblacklist(Address address);
 
     /**
      * Checks if an address is blacklisted.
@@ -54,7 +72,7 @@ public interface Joiner {
      * @param address the address to check.
      * @return true if blacklisted, false otherwise.
      * @throws java.lang.NullPointerException if address is null.
-     * @see #blacklist(com.hazelcast.nio.Address)
+     * @see #blacklist(com.hazelcast.nio.Address, boolean)
      */
     boolean isBlacklisted(Address address);
 }

--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/AbstractJoiner.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/AbstractJoiner.java
@@ -32,9 +32,8 @@ import com.hazelcast.util.Clock;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -50,8 +49,8 @@ public abstract class AbstractJoiner implements Joiner {
     private final ExceptionHandler whileWaitMergeExceptionHandler;
     private final AtomicLong joinStartTime = new AtomicLong(Clock.currentTimeMillis());
     private final AtomicInteger tryCount = new AtomicInteger(0);
-    protected final Set<Address> blacklistedAddresses
-            = Collections.newSetFromMap(new ConcurrentHashMap<Address, Boolean>());
+    // map blacklisted endpoints. Boolean value represents if blacklist is temporary or permanent
+    protected final ConcurrentMap<Address, Boolean> blacklistedAddresses = new ConcurrentHashMap<Address, Boolean>();
     protected final Config config;
     protected final Node node;
     protected final ILogger logger;
@@ -67,14 +66,23 @@ public abstract class AbstractJoiner implements Joiner {
     }
 
     @Override
-    public void blacklist(Address callerAddress) {
-        logger.info(callerAddress + " is added to the blacklist.");
-        blacklistedAddresses.add(callerAddress);
+    public void blacklist(Address address, boolean permanent) {
+        logger.info(address + " is added to the blacklist.");
+        blacklistedAddresses.putIfAbsent(address, permanent);
+    }
+
+    @Override
+    public boolean unblacklist(Address address) {
+        if (blacklistedAddresses.remove(address, Boolean.FALSE)) {
+            logger.info(address + " is removed from the blacklist.");
+            return true;
+        }
+        return false;
     }
 
     @Override
     public boolean isBlacklisted(Address address) {
-        return blacklistedAddresses.contains(address);
+        return blacklistedAddresses.containsKey(address);
     }
 
     public abstract void doJoin();

--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/operations/GroupMismatchOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/operations/GroupMismatchOperation.java
@@ -24,7 +24,7 @@ public class GroupMismatchOperation extends AbstractClusterOperation
                 + " Cause: the target cluster has a different group-name");
 
         Node node = nodeEngine.getNode();
-        node.getJoiner().blacklist(getCallerAddress());
+        node.getJoiner().blacklist(getCallerAddress(), true);
     }
 }
 

--- a/hazelcast/src/main/java/com/hazelcast/nio/IOService.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/IOService.java
@@ -68,6 +68,8 @@ public interface IOService {
 
     ThreadGroup getThreadGroup();
 
+    void onSuccessfulConnection(Address address);
+
     void onFailedConnection(Address address);
 
     void shouldConnectTo(Address address);

--- a/hazelcast/src/main/java/com/hazelcast/nio/NodeIOService.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/NodeIOService.java
@@ -148,9 +148,16 @@ public class NodeIOService implements IOService {
     }
 
     @Override
+    public void onSuccessfulConnection(Address address) {
+        if (!node.joined()) {
+            node.getJoiner().unblacklist(address);
+        }
+    }
+
+    @Override
     public void onFailedConnection(Address address) {
         if (!node.joined()) {
-            node.getJoiner().blacklist(address);
+            node.getJoiner().blacklist(address, false);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnectionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnectionManager.java
@@ -248,6 +248,7 @@ public class TcpIpConnectionManager implements ConnectionManager {
             return false;
         }
         connection.setEndPoint(remoteEndPoint);
+        ioService.onSuccessfulConnection(remoteEndPoint);
         if (reply) {
             sendBindRequest(connection, remoteEndPoint, false);
         }
@@ -314,6 +315,7 @@ public class TcpIpConnectionManager implements ConnectionManager {
 
     void sendBindRequest(TcpIpConnection connection, Address remoteEndPoint, boolean replyBack) {
         connection.setEndPoint(remoteEndPoint);
+        ioService.onSuccessfulConnection(remoteEndPoint);
         //make sure bind packet is the first packet sent to the end point.
         if (logger.isFinestEnabled()) {
             log(Level.FINEST, "Sending bind packet to " + remoteEndPoint);

--- a/hazelcast/src/test/java/com/hazelcast/test/TestNodeRegistry.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/TestNodeRegistry.java
@@ -210,7 +210,12 @@ final class TestNodeRegistry {
         }
 
         @Override
-        public void blacklist(Address callerAddress) {
+        public void blacklist(Address address, boolean permanent) {
+        }
+
+        @Override
+        public boolean unblacklist(Address address) {
+            return false;
         }
 
         @Override


### PR DESCRIPTION
Joiner blacklist entry for an endpoint should be removed after a successful connection, if it's blacklisted temporarily. Group mismatch blacklists should be permanent, since they are not recoverable.

Fixes #3888
