### PR TITLE
Query: Remove excess serialization

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/query/Predicates.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/Predicates.java
@@ -841,7 +841,8 @@ public final class Predicates {
                 } else if (type != null) {
                     return type.getConverter().convert(attributeValue);
                 } else {
-                    throw new QueryException("Unknown attribute type: " + attributeValue.getClass());
+                    throw new QueryException("Unknown attribute type: " + attributeValue.getClass().getName()
+                            + " for attribute: " + attribute);
                 }
             }
         }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/QueryEntry.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/QueryEntry.java
@@ -17,12 +17,14 @@
 package com.hazelcast.query.impl;
 
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.nio.serialization.Portable;
 import com.hazelcast.nio.serialization.PortableContext;
 import com.hazelcast.nio.serialization.SerializationService;
 import com.hazelcast.query.QueryException;
 
 import static com.hazelcast.query.QueryConstants.KEY_ATTRIBUTE_NAME;
 import static com.hazelcast.query.QueryConstants.THIS_ATTRIBUTE_NAME;
+
 /**
  * Entry of the Query.
  */
@@ -30,9 +32,9 @@ public class QueryEntry implements QueryableEntry {
 
     private final SerializationService serializationService;
     private final Data indexKey;
-    private Data key;
+    private Data keyData;
     private Object keyObject;
-    private Data value;
+    private Data valueData;
     private Object valueObject;
 
     public QueryEntry(SerializationService serializationService, Data indexKey, Object key, Object value) {
@@ -42,32 +44,37 @@ public class QueryEntry implements QueryableEntry {
         if (key == null) {
             throw new IllegalArgumentException("keyData cannot be null");
         }
+
         this.indexKey = indexKey;
-        if (key instanceof Data) {
-            this.key = (Data) key;
-        } else {
-            keyObject = key;
-        }
         this.serializationService = serializationService;
-        if (value instanceof Data) {
-            this.value = (Data) value;
+
+        if (key instanceof Data) {
+            this.keyData = (Data) key;
         } else {
-            valueObject = value;
+            this.keyObject = key;
+        }
+
+        if (value instanceof Data) {
+            this.valueData = (Data) value;
+        } else {
+            this.valueObject = value;
         }
     }
 
     @Override
     public Object getValue() {
+        // TODO: What is serialization service is null??
         if (valueObject == null && serializationService != null) {
-            valueObject = serializationService.toObject(value);
+            valueObject = serializationService.toObject(valueData);
         }
         return valueObject;
     }
 
     @Override
     public Object getKey() {
+        // TODO: What is serialization service is null??
         if (keyObject == null && serializationService != null) {
-            keyObject = serializationService.toObject(key);
+            keyObject = serializationService.toObject(keyData);
         }
         return keyObject;
     }
@@ -80,19 +87,17 @@ public class QueryEntry implements QueryableEntry {
             return (Comparable) getValue();
         }
 
-        boolean key = attributeName.startsWith(KEY_ATTRIBUTE_NAME);
-        Data data;
-        if (key) {
-            attributeName = attributeName.substring(KEY_ATTRIBUTE_NAME.length() + 1);
-            data = getKeyData();
-        } else {
-            data = getValueData();
+        boolean isKey = isKey(attributeName);
+        attributeName = getAttributeName(isKey, attributeName);
+        Data targetData = getOptionalTargetData(isKey);
+
+        // if the content is available in 'Data' format and it is portable, we can directly
+        // extract the content from the targetData, without needing to deserialize
+        if (targetData != null && targetData.isPortable()) {
+            return extractViaPortable(attributeName, targetData);
         }
 
-        if (data != null && data.isPortable()) {
-            return extractViaPortable(attributeName, data);
-        }
-        return extractViaReflection(attributeName, key);
+        return extractViaReflection(attributeName, isKey);
     }
 
     private Comparable extractViaPortable(String attributeName, Data data) {
@@ -105,9 +110,12 @@ public class QueryEntry implements QueryableEntry {
         }
     }
 
-    private Comparable extractViaReflection(String attributeName, boolean key) {
+    // This method is very inefficient because:
+    // lot of time is spend on retrieving field/method and it isn't cached
+    // the actual invocation on the Field, Method is also is quite expensive.
+    private Comparable extractViaReflection(String attributeName, boolean isKey) {
         try {
-            Object obj = key ? getKey() : getValue();
+            Object obj = isKey ? getKey() : getValue();
             return ReflectionHelper.extractValue(obj, attributeName);
         } catch (QueryException e) {
             throw e;
@@ -124,36 +132,68 @@ public class QueryEntry implements QueryableEntry {
             return ReflectionHelper.getAttributeType(getValue().getClass());
         }
 
-        boolean key = attributeName.startsWith(KEY_ATTRIBUTE_NAME);
-        Data data;
-        if (key) {
-            attributeName = attributeName.substring(KEY_ATTRIBUTE_NAME.length() + 1);
-            data = getKeyData();
-        } else {
-            data = getValueData();
-        }
+        boolean isKey = isKey(attributeName);
+        attributeName = getAttributeName(isKey, attributeName);
+        Data data = getOptionalTargetData(isKey);
 
         if (data != null && data.isPortable()) {
             PortableContext portableContext = serializationService.getPortableContext();
             return PortableExtractor.getAttributeType(portableContext, data, attributeName);
         }
-        return ReflectionHelper.getAttributeType(key ? getKey() : getValue(), attributeName);
+        return ReflectionHelper.getAttributeType(isKey ? getKey() : getValue(), attributeName);
+    }
+
+    private String getAttributeName(boolean isKey, String attributeName) {
+        if (isKey) {
+            return attributeName.substring(KEY_ATTRIBUTE_NAME.length() + 1);
+        } else {
+            return attributeName;
+        }
+    }
+
+    /**
+     * Gets the target data if available.
+     *
+     * If the key/value is a Portable instance, we always serialize to Data. This is inefficient, but the query
+     * relies on the fields mentioned in the serialized data, not the deserialized data.
+     *
+     * @param isKey true if we need to key data, false for the value.
+     * @return the target Data. Could be null
+     */
+    private Data getOptionalTargetData(boolean isKey) {
+        if (isKey) {
+            if (keyObject instanceof Portable) {
+                return getKeyData();
+            } else {
+                return keyData;
+            }
+        } else {
+            if (valueObject instanceof Portable) {
+                return getValueData();
+            } else {
+                return valueData;
+            }
+        }
+    }
+
+    public boolean isKey(String attributeName) {
+        return attributeName.startsWith(KEY_ATTRIBUTE_NAME);
     }
 
     @Override
     public Data getKeyData() {
-        if (key == null && serializationService != null) {
-            key = serializationService.toData(keyObject);
+        if (keyData == null && serializationService != null) {
+            keyData = serializationService.toData(keyObject);
         }
-        return key;
+        return keyData;
     }
 
     @Override
     public Data getValueData() {
-        if (value == null && serializationService != null) {
-            value = serializationService.toData(valueObject);
+        if (valueData == null && serializationService != null) {
+            valueData = serializationService.toData(valueObject);
         }
-        return value;
+        return valueData;
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/QueryEntryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/QueryEntryTest.java
@@ -1,0 +1,138 @@
+package com.hazelcast.query.impl;
+
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.nio.serialization.DataSerializable;
+import com.hazelcast.nio.serialization.DefaultSerializationServiceBuilder;
+import com.hazelcast.nio.serialization.Portable;
+import com.hazelcast.nio.serialization.SerializationService;
+import com.hazelcast.query.QueryConstants;
+import com.hazelcast.query.SampleObjects;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category(QuickTest.class)
+public class QueryEntryTest extends HazelcastTestSupport {
+
+    private static SerializationService serializationService;
+
+    @Before
+    public void before() {
+        serializationService = new DefaultSerializationServiceBuilder().build();
+    }
+
+    @After
+    public void after() {
+        serializationService.destroy();
+    }
+
+    // ========================== getAttribute ===========================================
+
+    @Test
+    public void getAttribute_whenValueIsPortableObject_thenConvertedToData() {
+        Data indexedKey = serializationService.toData("indexedKey");
+
+        SerializableObject key = new SerializableObject();
+        Portable value = new SampleObjects.PortableEmployee(30, "peter");
+        QueryEntry queryEntry = new QueryEntry(serializationService, indexedKey, key, value);
+
+        // in the portable-data, the attribute 'name' is called 'n'. So if we can retrieve on n
+        // correctly it shows that we have used the Portable data, not the actual Portable object
+        Object result = queryEntry.getAttribute("n");
+
+        assertEquals("peter", result);
+    }
+
+    @Test
+    public void getAttribute_whenKeyIsPortableObject_thenConvertedToData() {
+        Data indexedKey = serializationService.toData("indexedKey");
+
+        Portable key = new SampleObjects.PortableEmployee(30, "peter");
+        SerializableObject value = new SerializableObject();
+        QueryEntry queryEntry = new QueryEntry(serializationService, indexedKey, key, value);
+
+        // in the portable-data, the attribute 'name' is called 'n'. So if we can retrieve on n
+        // correctly it shows that we have used the Portable data, not the actual Portable object
+        Object result = queryEntry.getAttribute(QueryConstants.KEY_ATTRIBUTE_NAME + ".n");
+
+        assertEquals("peter", result);
+    }
+
+    @Test
+    public void getAttribute_whenKeyPortableObjectThenConvertedToData() {
+        Data indexedKey = serializationService.toData("indexedKey");
+
+        Portable key = new SampleObjects.PortableEmployee(30, "peter");
+        SerializableObject value = new SerializableObject();
+        QueryEntry queryEntry = new QueryEntry(serializationService, indexedKey, key, value);
+
+        Object result = queryEntry.getAttribute(QueryConstants.KEY_ATTRIBUTE_NAME + ".n");
+
+        assertEquals("peter", result);
+    }
+
+    @Test
+    public void getAttribute_whenValueInObjectFormatThenNoSerialization() {
+        Data indexedKey = serializationService.toData("indexedKey");
+
+        SerializableObject key = new SerializableObject();
+        SerializableObject value = new SerializableObject();
+        value.name = "somename";
+        QueryEntry queryEntry = new QueryEntry(serializationService, indexedKey, key, value);
+
+        Object result = queryEntry.getAttribute("name");
+
+        assertEquals("somename", result);
+        assertEquals(0, value.deserializationCount);
+        assertEquals(0, value.serializationCount);
+        assertEquals(0, key.deserializationCount);
+        assertEquals(0, key.serializationCount);
+    }
+
+    @Test
+    public void getAttribute_whenKeyInObjectFormatThenNoSerialization() {
+        Data indexedKey = serializationService.toData("indexedKey");
+
+        SerializableObject key = new SerializableObject();
+        SerializableObject value = new SerializableObject();
+        value.name = "somename";
+        key.name = "somekey";
+        QueryEntry queryEntry = new QueryEntry(serializationService, indexedKey, key, value);
+
+        Object result = queryEntry.getAttribute(QueryConstants.KEY_ATTRIBUTE_NAME + ".name");
+
+        assertEquals(result, "somekey");
+        assertEquals(0, value.deserializationCount);
+        assertEquals(0, value.serializationCount);
+        assertEquals(0, key.deserializationCount);
+        assertEquals(0, key.serializationCount);
+    }
+
+    private static class SerializableObject implements DataSerializable {
+        private int serializationCount;
+        private int deserializationCount;
+        private String name;
+
+        @Override
+        public void writeData(ObjectDataOutput out) throws IOException {
+            serializationCount++;
+        }
+
+        @Override
+        public void readData(ObjectDataInput in) throws IOException {
+            deserializationCount++;
+        }
+    }
+}


### PR DESCRIPTION
This is a performance optimization for predicates (map queries).

When the key or value already is in 'object' form, it still is being serialized to retrieve an attribute. 

Forcing to serialize is correct behavior for Portable; but for other serialization techniques it is a waste since you want to have the object anyway.