### PR TITLE
Cleanup of client side for IMap.values() and IMap.values(predicate)

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/client/AbstractMapQueryRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/client/AbstractMapQueryRequest.java
@@ -18,7 +18,6 @@ package com.hazelcast.map.impl.client;
 
 import static com.hazelcast.map.impl.MapService.SERVICE_NAME;
 
-import com.hazelcast.client.ClientEndpoint;
 import com.hazelcast.client.impl.client.InvocationClientRequest;
 import com.hazelcast.client.impl.client.RetryableRequest;
 import com.hazelcast.client.impl.client.SecureRequest;
@@ -47,8 +46,8 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.Future;
 
-abstract class AbstractMapQueryRequest extends InvocationClientRequest implements Portable,
-        RetryableRequest, SecureRequest {
+abstract class AbstractMapQueryRequest extends InvocationClientRequest implements Portable, SecureRequest,
+        RetryableRequest {
 
     protected IterationType iterationType;
     private String name;
@@ -63,30 +62,79 @@ abstract class AbstractMapQueryRequest extends InvocationClientRequest implement
 
     @Override
     protected final void invoke() {
-        Collection<MemberImpl> members = getClientEngine().getClusterService().getMemberList();
-        int partitionCount = getClientEngine().getPartitionService().getPartitionCount();
-        Set<Integer> plist = new HashSet<Integer>(partitionCount);
-        final ClientEndpoint endpoint = getEndpoint();
         QueryResultSet result = new QueryResultSet(null, iterationType, true);
         try {
+            Predicate predicate = getPredicate();
+
+            Collection<MemberImpl> members = getClientEngine().getClusterService().getMemberList();
             List<Future> futures = new ArrayList<Future>();
-            final Predicate predicate = getPredicate();
             createInvocations(members, futures, predicate);
-            collectResults(plist, result, futures);
-            if (hasMissingPartitions(partitionCount, plist)) {
-                List<Integer> missingList = findMissingPartitions(partitionCount, plist);
+
+            int partitionCount = getClientEngine().getPartitionService().getPartitionCount();
+            Set<Integer> finishedPartitions = new HashSet<Integer>(partitionCount);
+            collectResults(result, futures, finishedPartitions);
+
+            if (hasMissingPartitions(finishedPartitions, partitionCount)) {
+                List<Integer> missingList = findMissingPartitions(finishedPartitions, partitionCount);
                 List<Future> missingFutures = new ArrayList<Future>(missingList.size());
-                createInvocationsForMissingPartitions(predicate, missingList, missingFutures);
+                createInvocationsForMissingPartitions(missingList, missingFutures, predicate);
                 collectResultsFromMissingPartitions(result, missingFutures);
             }
         } catch (Throwable t) {
             throw ExceptionUtil.rethrow(t);
         }
-        endpoint.sendResponse(result, getCallId());
+        getEndpoint().sendResponse(result, getCallId());
     }
 
-    private boolean hasMissingPartitions(int partitionCount, Set<Integer> plist) {
-        return plist.size() != partitionCount;
+    private void createInvocations(Collection<MemberImpl> members, List<Future> futures, Predicate predicate) {
+        for (MemberImpl member : members) {
+            Future future = createInvocationBuilder(SERVICE_NAME, new QueryOperation(name, predicate),
+                    member.getAddress()).invoke();
+            futures.add(future);
+        }
+    }
+
+    private void collectResults(QueryResultSet result, List<Future> futures, Set<Integer> finishedPartitions)
+            throws InterruptedException, java.util.concurrent.ExecutionException {
+
+        for (Future future : futures) {
+            QueryResult queryResult = (QueryResult) future.get();
+            if (queryResult != null) {
+                Collection<Integer> partitionIds = queryResult.getPartitionIds();
+                if (partitionIds != null) {
+                    finishedPartitions.addAll(partitionIds);
+                    result.addAll(queryResult.getResult());
+                }
+            }
+        }
+    }
+
+    private boolean hasMissingPartitions(Set<Integer> finishedPartitions, int partitionCount) {
+        return finishedPartitions.size() != partitionCount;
+    }
+
+    private List<Integer> findMissingPartitions(Set<Integer> finishedPartitions, int partitionCount) {
+        List<Integer> missingList = new ArrayList<Integer>();
+        for (int i = 0; i < partitionCount; i++) {
+            if (!finishedPartitions.contains(i)) {
+                missingList.add(i);
+            }
+        }
+        return missingList;
+    }
+
+    private void createInvocationsForMissingPartitions(List<Integer> missingPartitionsList, List<Future> futures,
+                                                       Predicate predicate) {
+        for (Integer partitionId : missingPartitionsList) {
+            QueryPartitionOperation queryPartitionOperation = new QueryPartitionOperation(name, predicate);
+            queryPartitionOperation.setPartitionId(partitionId);
+            try {
+                Future future = createInvocationBuilder(SERVICE_NAME, queryPartitionOperation, partitionId).invoke();
+                futures.add(future);
+            } catch (Throwable t) {
+                throw ExceptionUtil.rethrow(t);
+            }
+        }
     }
 
     private void collectResultsFromMissingPartitions(QueryResultSet result, List<Future> futures)
@@ -97,78 +145,17 @@ abstract class AbstractMapQueryRequest extends InvocationClientRequest implement
         }
     }
 
-    private void createInvocationsForMissingPartitions(Predicate predicate, List<Integer> missingList,
-                                                       List<Future> futures) {
-        for (Integer pid : missingList) {
-            QueryPartitionOperation queryPartitionOperation = new QueryPartitionOperation(name, predicate);
-            queryPartitionOperation.setPartitionId(pid);
-            try {
-                Future f = createInvocationBuilder(SERVICE_NAME, queryPartitionOperation, pid).invoke();
-                futures.add(f);
-            } catch (Throwable t) {
-                throw ExceptionUtil.rethrow(t);
-            }
-        }
-    }
-
-    private List<Integer> findMissingPartitions(int partitionCount, Set<Integer> plist) {
-        List<Integer> missingList = new ArrayList<Integer>();
-        for (int i = 0; i < partitionCount; i++) {
-            if (!plist.contains(i)) {
-                missingList.add(i);
-            }
-        }
-        return missingList;
-    }
-
-    private void collectResults(Set<Integer> plist, QueryResultSet result, List<Future> flist)
-            throws InterruptedException, java.util.concurrent.ExecutionException {
-        for (Future future : flist) {
-            QueryResult queryResult = (QueryResult) future.get();
-            if (queryResult != null) {
-                final Collection<Integer> partitionIds = queryResult.getPartitionIds();
-                if (partitionIds != null) {
-                    plist.addAll(partitionIds);
-                    result.addAll(queryResult.getResult());
-                }
-            }
-        }
-    }
-
-    private void createInvocations(Collection<MemberImpl> members, List<Future> flist, Predicate predicate) {
-        for (MemberImpl member : members) {
-            Future future = createInvocationBuilder(SERVICE_NAME, new QueryOperation(name, predicate),
-                    member.getAddress()).invoke();
-            flist.add(future);
-        }
-    }
-
-    protected abstract Predicate getPredicate();
-
-    public final String getServiceName() {
-        return MapService.SERVICE_NAME;
-    }
-
+    @Override
     public final int getFactoryId() {
         return MapPortableHook.F_ID;
     }
 
-    public void write(PortableWriter writer) throws IOException {
-        writer.writeUTF("n", name);
-        writer.writeUTF("t", iterationType.toString());
-        writePortableInner(writer);
+    @Override
+    public final String getServiceName() {
+        return MapService.SERVICE_NAME;
     }
 
-    protected abstract void writePortableInner(PortableWriter writer) throws IOException;
-
-    public void read(PortableReader reader) throws IOException {
-        name = reader.readUTF("n");
-        iterationType = IterationType.valueOf(reader.readUTF("t"));
-        readPortableInner(reader);
-    }
-
-    protected abstract void readPortableInner(PortableReader reader) throws IOException;
-
+    @Override
     public Permission getRequiredPermission() {
         return new MapPermission(name, ActionConstants.ACTION_READ);
     }
@@ -177,4 +164,24 @@ abstract class AbstractMapQueryRequest extends InvocationClientRequest implement
     public String getDistributedObjectName() {
         return name;
     }
+
+    @Override
+    public void write(PortableWriter writer) throws IOException {
+        writer.writeUTF("n", name);
+        writer.writeUTF("t", iterationType.toString());
+        writePortableInner(writer);
+    }
+
+    @Override
+    public void read(PortableReader reader) throws IOException {
+        name = reader.readUTF("n");
+        iterationType = IterationType.valueOf(reader.readUTF("t"));
+        readPortableInner(reader);
+    }
+
+    protected abstract Predicate getPredicate();
+
+    protected abstract void writePortableInner(PortableWriter writer) throws IOException;
+
+    protected abstract void readPortableInner(PortableReader reader) throws IOException;
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/client/MapQueryRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/client/MapQueryRequest.java
@@ -38,22 +38,8 @@ public final class MapQueryRequest extends AbstractMapQueryRequest {
     }
 
     @Override
-    protected Predicate getPredicate() {
-        return predicate;
-    }
-
     public int getClassId() {
         return MapPortableHook.QUERY;
-    }
-
-    protected void writePortableInner(PortableWriter writer) throws IOException {
-        final ObjectDataOutput out = writer.getRawDataOutput();
-        out.writeObject(predicate);
-    }
-
-    protected void readPortableInner(PortableReader reader) throws IOException {
-        final ObjectDataInput in = reader.getRawDataInput();
-        predicate = in.readObject();
     }
 
     @Override
@@ -71,5 +57,22 @@ public final class MapQueryRequest extends AbstractMapQueryRequest {
     @Override
     public Object[] getParameters() {
         return new Object[]{predicate};
+    }
+
+    @Override
+    protected Predicate getPredicate() {
+        return predicate;
+    }
+
+    @Override
+    protected void writePortableInner(PortableWriter writer) throws IOException {
+        final ObjectDataOutput out = writer.getRawDataOutput();
+        out.writeObject(predicate);
+    }
+
+    @Override
+    protected void readPortableInner(PortableReader reader) throws IOException {
+        final ObjectDataInput in = reader.getRawDataInput();
+        predicate = in.readObject();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/client/MapValuesRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/client/MapValuesRequest.java
@@ -36,7 +36,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-public class MapValuesRequest extends AllPartitionsClientRequest implements Portable, RetryableRequest, SecureRequest {
+public class MapValuesRequest extends AllPartitionsClientRequest implements Portable, SecureRequest, RetryableRequest {
 
     private String name;
 
@@ -62,27 +62,22 @@ public class MapValuesRequest extends AllPartitionsClientRequest implements Port
         return new MapValueCollection(values);
     }
 
-    public String getServiceName() {
-        return MapService.SERVICE_NAME;
-    }
-
     @Override
     public int getFactoryId() {
         return MapPortableHook.F_ID;
     }
 
+    @Override
     public int getClassId() {
         return MapPortableHook.VALUES;
     }
 
-    public void write(PortableWriter writer) throws IOException {
-        writer.writeUTF("n", name);
+    @Override
+    public String getServiceName() {
+        return MapService.SERVICE_NAME;
     }
 
-    public void read(PortableReader reader) throws IOException {
-        name = reader.readUTF("n");
-    }
-
+    @Override
     public Permission getRequiredPermission() {
         return new MapPermission(name, ActionConstants.ACTION_READ);
     }
@@ -95,5 +90,15 @@ public class MapValuesRequest extends AllPartitionsClientRequest implements Port
     @Override
     public String getMethodName() {
         return "values";
+    }
+
+    @Override
+    public void write(PortableWriter writer) throws IOException {
+        writer.writeUTF("n", name);
+    }
+
+    @Override
+    public void read(PortableReader reader) throws IOException {
+        name = reader.readUTF("n");
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapValuesOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapValuesOperation.java
@@ -31,6 +31,7 @@ public class MapValuesOperation extends AbstractMapOperation implements Partitio
         super(name);
     }
 
+    @SuppressWarnings("unused")
     public MapValuesOperation() {
     }
 
@@ -39,8 +40,7 @@ public class MapValuesOperation extends AbstractMapOperation implements Partitio
         final RecordStore recordStore = mapServiceContext.getRecordStore(getPartitionId(), name);
         values = recordStore.valuesData();
         if (mapContainer.getMapConfig().isStatisticsEnabled()) {
-            mapServiceContext.getLocalMapStatsProvider()
-                    .getLocalMapStatsImpl(name).incrementOtherOperations();
+            mapServiceContext.getLocalMapStatsProvider().getLocalMapStatsImpl(name).incrementOtherOperations();
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapValuesOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapValuesOperationFactory.java
@@ -24,9 +24,9 @@ import java.io.IOException;
 
 public class MapValuesOperationFactory implements OperationFactory {
 
-    String name;
+    private String name;
 
-
+    @SuppressWarnings("unused")
     public MapValuesOperationFactory() {
     }
 


### PR DESCRIPTION
Improved readability of code for IMap.values() and IMap.values(predicate), e.g. variable names, newlines, moved declarations closer to usage, same order of parameters for similar methods, new sub-method. Sorted methods per superclass and/or from public to private. Added @Override to methods.

This PR is a preparation for the "unbound return values"-PRD for HZ 3.5. It may look a bit scary in the diff, but most of the work was done via IDEA (renaming, movement of methods) and all tests passed on my machine :)