### PR TITLE
CacheManager should deregister its LifecycleListener when it's closed. 

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/HazelcastClientCacheManager.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/HazelcastClientCacheManager.java
@@ -43,6 +43,8 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
+import static com.hazelcast.util.ValidationUtil.checkNotNull;
+
 /**
  * CacheManager implementation for client side
  *
@@ -74,7 +76,7 @@ public final class HazelcastClientCacheManager extends AbstractHazelcastCacheMan
 
     private void enableStatisticManagementOnNodes(String cacheName, boolean statOrMan, boolean enabled) {
         checkIfManagerNotClosed();
-        checkIfNotNull(cacheName, "cacheName cannot be null");
+        checkNotNull(cacheName, "cacheName cannot be null");
         final ClientInvocationService invocationService = clientContext.getInvocationService();
         final Collection<MemberImpl> members = clientContext.getClusterService().getMemberList();
         final Collection<Future> futures = new ArrayList<Future>();

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/HazelcastServerCacheManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/HazelcastServerCacheManager.java
@@ -37,6 +37,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.util.FutureUtil.waitWithDeadline;
+import static com.hazelcast.util.ValidationUtil.checkNotNull;
 
 /**
  * Hazelcast {@link javax.cache.CacheManager} for server implementation. This subclass of
@@ -68,7 +69,7 @@ public class HazelcastServerCacheManager
     @Override
     public void enableManagement(String cacheName, boolean enabled) {
         checkIfManagerNotClosed();
-        checkIfNotNull(cacheName, "cacheName cannot be null");
+        checkNotNull(cacheName, "cacheName cannot be null");
         final String cacheNameWithPrefix = getCacheNameWithPrefix(cacheName);
         cacheService.setManagementEnabled(null, cacheNameWithPrefix, enabled);
         //ENABLE OTHER NODES
@@ -78,7 +79,7 @@ public class HazelcastServerCacheManager
     @Override
     public void enableStatistics(String cacheName, boolean enabled) {
         checkIfManagerNotClosed();
-        checkIfNotNull(cacheName, "cacheName cannot be null");
+        checkNotNull(cacheName, "cacheName cannot be null");
         final String cacheNameWithPrefix = getCacheNameWithPrefix(cacheName);
         cacheService.setStatisticsEnabled(null, cacheNameWithPrefix, enabled);
         //ENABLE OTHER NODES


### PR DESCRIPTION
(...Replaced checkIfNotNull() method with ValidationUtil.checkNotNull() to conform checkstyle max-method-count rule.)

Fixed a leak issue caused by #4333
