### PR TITLE
IMap.loadAll now triggers map loading on each node

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/BasicRecordStoreLoader.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/BasicRecordStoreLoader.java
@@ -8,6 +8,7 @@ import com.hazelcast.map.impl.operation.PutFromLoadAllOperation;
 import com.hazelcast.map.impl.record.Record;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.partition.InternalPartitionService;
 import com.hazelcast.spi.Callback;
 import com.hazelcast.spi.ExecutionService;
 import com.hazelcast.spi.NodeEngine;
@@ -87,7 +88,7 @@ class BasicRecordStoreLoader implements RecordStoreLoader {
      * Every partition (record-store) loads its own key set.
      */
     @Override
-    public void loadInitialKeys() {
+    public void loadInitialKeys(boolean replaceExisting) {
         if (isLoaded()) {
             return;
         }
@@ -96,16 +97,23 @@ class BasicRecordStoreLoader implements RecordStoreLoader {
             return;
         }
 
-        final Runnable task = new InitialKeysLoaderTask();
+        final Runnable task = new InitialKeysLoaderTask(replaceExisting);
         final String executorName = MAP_INITIAL_LOAD_EXECUTOR;
         executeTask(executorName, task);
     }
 
     private final class InitialKeysLoaderTask implements Runnable {
+
+        private final boolean replaceExisting;
+
+        public InitialKeysLoaderTask(boolean replaceExisting) {
+            this.replaceExisting = replaceExisting;
+        }
+
         @Override
         public void run() {
             try {
-                loadAllKeysInternal();
+                loadAllKeysInternal(replaceExisting);
             } catch (Throwable t) {
                 setLoaderException(t);
             }
@@ -124,19 +132,6 @@ class BasicRecordStoreLoader implements RecordStoreLoader {
     private ExecutionService getExecutionService() {
         final NodeEngine nodeEngine = mapServiceContext.getNodeEngine();
         return nodeEngine.getExecutionService();
-    }
-
-    private void loadAllKeysInternal() throws Exception {
-        final MapContainer mapContainer = recordStore.getMapContainer();
-        final MapStoreContext basicMapStoreContext = mapContainer.getMapStoreContext();
-        basicMapStoreContext.waitInitialLoadFinish();
-
-        final Map<Data, Object> loadedKeys = basicMapStoreContext.getInitialKeys();
-        if (loadedKeys == null || loadedKeys.isEmpty()) {
-            setLoaded(true);
-            return;
-        }
-        doChunkedLoad(loadedKeys, mapServiceContext.getNodeEngine());
     }
 
     @Override
@@ -169,6 +164,19 @@ class BasicRecordStoreLoader implements RecordStoreLoader {
         public void run() {
             loadKeysInternal(keys, replaceExistingValues);
         }
+    }
+
+    private void loadAllKeysInternal(boolean replaceExistingValues) throws Exception {
+        final MapContainer mapContainer = recordStore.getMapContainer();
+        final MapStoreContext basicMapStoreContext = mapContainer.getMapStoreContext();
+        basicMapStoreContext.waitInitialLoadFinish();
+
+        final Map<Data, Object> loadedKeys = basicMapStoreContext.getInitialKeys();
+        if (loadedKeys == null || loadedKeys.isEmpty()) {
+            setLoaded(true);
+            return;
+        }
+        doChunkedLoad(loadedKeys, mapServiceContext.getNodeEngine(), replaceExistingValues);
     }
 
     private void loadKeysInternal(List<Data> keys, boolean replaceExistingValues) {
@@ -325,17 +333,34 @@ class BasicRecordStoreLoader implements RecordStoreLoader {
         return Clock.currentTimeMillis();
     }
 
-    private void doChunkedLoad(Map<Data, Object> loadedKeys, NodeEngine nodeEngine) {
-        final int mapLoadChunkSize = getLoadBatchSize();
-        final Queue<Map> chunks = new LinkedList<Map>();
+    private boolean shouldLoad(Data key, boolean replaceExisting) {
+        Record record = recordStore.getRecord(key);
+
+        if (record != null) {
+            if (!mapDataStore.loadable(key, record.getLastUpdateTime(), getNow())) {
+                return false;
+            }
+
+            return replaceExisting;
+        }
+
+        return true;
+    }
+
+    private void doChunkedLoad(Map<Data, Object> loadedKeys, NodeEngine nodeEngine, boolean replaceExisting) {
+        int mapLoadChunkSize = getLoadBatchSize();
+        Queue<Map> chunks = new LinkedList<Map>();
         Map<Data, Object> partitionKeys = new HashMap<Data, Object>();
-        final int partitionId = this.partitionId;
+        InternalPartitionService partitionService = nodeEngine.getPartitionService();
         Iterator<Map.Entry<Data, Object>> iterator = loadedKeys.entrySet().iterator();
+
         while (iterator.hasNext()) {
             final Map.Entry<Data, Object> entry = iterator.next();
-            final Data data = entry.getKey();
-            if (partitionId == nodeEngine.getPartitionService().getPartitionId(data)) {
-                partitionKeys.put(data, entry.getValue());
+            final Data key = entry.getKey();
+
+            if (partitionId == partitionService.getPartitionId(key) && shouldLoad(key, replaceExisting)) {
+
+                partitionKeys.put(key, entry.getValue());
                 //split into chunks
                 if (partitionKeys.size() >= mapLoadChunkSize) {
                     chunks.add(partitionKeys);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/DefaultRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/DefaultRecordStore.java
@@ -77,6 +77,15 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore implements 
     }
 
     @Override
+    public void loadAllFromStore(boolean replaceExisting) {
+        if(replaceExisting) {
+            clear();
+        }
+        recordStoreLoader.setLoaded(false);
+        recordStoreLoader.loadInitialKeys();
+    }
+
+    @Override
     public void checkIfLoaded() {
         Throwable throwable = null;
         final RecordStoreLoader recordStoreLoader = this.recordStoreLoader;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/DefaultRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/DefaultRecordStore.java
@@ -78,7 +78,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore implements 
 
     @Override
     public void loadAllFromStore(boolean replaceExisting) {
-        if(replaceExisting) {
+        if (replaceExisting) {
             clear();
         }
         recordStoreLoader.setLoaded(false);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/DefaultRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/DefaultRecordStore.java
@@ -63,7 +63,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore implements 
         this.mapDataStore = mapStoreManager.getMapDataStore(partitionId);
 
         this.recordStoreLoader = createRecordStoreLoader();
-        this.recordStoreLoader.loadInitialKeys();
+        this.recordStoreLoader.loadInitialKeys(true);
     }
 
     @Override
@@ -78,11 +78,8 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore implements 
 
     @Override
     public void loadAllFromStore(boolean replaceExisting) {
-        if (replaceExisting) {
-            clear();
-        }
         recordStoreLoader.setLoaded(false);
-        recordStoreLoader.loadInitialKeys();
+        recordStoreLoader.loadInitialKeys(replaceExisting);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/RecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/RecordStore.java
@@ -250,7 +250,14 @@ public interface RecordStore {
     boolean isExpirable();
 
     /**
-     * Loads all keys from defined map store.
+     * Loads all keys from the map store.
+     *
+     * @param replaceExistingValues <code>true</code> if need to replace existing values otherwise <code>false</code>
+     */
+    void loadAllFromStore(boolean replaceExistingValues);
+
+    /**
+     * Loads all given keys from defined map store.
      *
      * @param keys                  keys to be loaded.
      * @param replaceExistingValues <code>true</code> if need to replace existing values otherwise <code>false</code>

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/RecordStoreLoader.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/RecordStoreLoader.java
@@ -28,7 +28,7 @@ interface RecordStoreLoader {
         }
 
         @Override
-        public void loadInitialKeys() {
+        public void loadInitialKeys(boolean replaceExisting) {
 
         }
 
@@ -58,8 +58,9 @@ interface RecordStoreLoader {
 
     /**
      * Loads initial keys.
+     * @param replaceExisting keys
      */
-    void loadInitialKeys();
+    void loadInitialKeys(boolean replaceExisting);
 
     /**
      * Picks and returns any one of throwables during load all process.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/eviction/MaxSizeChecker.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/eviction/MaxSizeChecker.java
@@ -17,6 +17,7 @@
 package com.hazelcast.map.impl.eviction;
 
 import com.hazelcast.config.MaxSizeConfig;
+import com.hazelcast.config.MaxSizeConfig.MaxSizePolicy;
 import com.hazelcast.map.impl.MapContainer;
 import com.hazelcast.map.impl.MapServiceContext;
 import com.hazelcast.map.impl.PartitionContainer;
@@ -211,10 +212,22 @@ public class MaxSizeChecker {
     /**
      * used when deciding evictable or not.
      */
-    public static int getApproximateMaxSize(int maxSizeFromConfig) {
+    private static int getApproximateMaxSize(int maxSizeFromConfig) {
         // because not to exceed the max size much we start eviction early.
         // so decrease the max size with ratio .95 below
         return maxSizeFromConfig * EVICTION_START_THRESHOLD_PERCENTAGE / ONE_HUNDRED_PERCENT;
+    }
+
+    /**
+     * Get max size setting form config for given policy
+     *
+     * @return max size or -1 if policy is different or not set
+     */
+    public static int getApproximateMaxSize(MaxSizeConfig maxSizeConfig, MaxSizePolicy policy) {
+        if (maxSizeConfig.getMaxSizePolicy() == policy) {
+            return getApproximateMaxSize(maxSizeConfig.getSize());
+        }
+        return -1;
     }
 
     private List<Integer> findPartitionIds() {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/BasicMapStoreContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/BasicMapStoreContext.java
@@ -81,6 +81,11 @@ final class BasicMapStoreContext implements MapStoreContext {
     public void start() {
         mapStoreManager.start();
 
+        triggerInitialKeyLoad();
+    }
+
+    @Override
+    public void triggerInitialKeyLoad() {
         final Callable<Boolean> task = new TriggerInitialKeyLoad();
         initialKeyLoader = executeTask(INITIAL_KEY_LOAD_EXECUTOR, task);
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/BasicMapStoreContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/BasicMapStoreContext.java
@@ -247,7 +247,7 @@ final class BasicMapStoreContext implements MapStoreContext {
     private void selectOwnedKeys(Iterable loadedKeys, MapServiceContext mapServiceContext) {
 
         initialKeys.clear();
-        int maxSizePerNode = getApproximateMaxSize(getMaxSizePerNode()) - 1;
+        int maxSizePerNode = getApproximateMaxSize(maxSizeConfig, PER_NODE) - 1;
 
         for (Object key : loadedKeys) {
             Data dataKey = mapServiceContext.toData(key, partitioningStrategy);
@@ -261,22 +261,6 @@ final class BasicMapStoreContext implements MapStoreContext {
                 }
             }
         }
-    }
-
-    /**
-     * Get max size per node setting form config
-     *
-     * @return max size or -1 if policy is not set
-     */
-    private int getMaxSizePerNode() {
-        final MaxSizeConfig maxSizeConfig = this.maxSizeConfig;
-        int maxSize = -1;
-
-        if (maxSizeConfig.getMaxSizePolicy() == PER_NODE) {
-            maxSize = maxSizeConfig.getSize();
-        }
-
-        return maxSize;
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/MapStoreContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/MapStoreContext.java
@@ -43,4 +43,6 @@ public interface MapStoreContext {
     MapStoreConfig getMapStoreConfig();
 
     void waitInitialLoadFinish() throws Exception;
+
+    void triggerInitialKeyLoad();
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/MapStoreContextFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/MapStoreContextFactory.java
@@ -84,6 +84,10 @@ public final class MapStoreContextFactory {
         }
 
         @Override
+        public void triggerInitialKeyLoad() {
+        }
+
+        @Override
         public SerializationService getSerializationService() {
             throw new UnsupportedOperationException("This method should not be called. No defined map store exists.");
         }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/LoadMapOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/LoadMapOperation.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2008-2014, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hazelcast.map.impl.operation;
+
+import com.hazelcast.map.impl.MapServiceContext;
+import com.hazelcast.map.impl.RecordStore;
+import com.hazelcast.map.impl.mapstore.MapStoreContext;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+
+import java.io.IOException;
+
+/**
+ * Triggers map loading from a map store
+ */
+public class LoadMapOperation extends AbstractMapOperation {
+
+    private boolean replaceExistingValues;
+
+    public LoadMapOperation() {
+    }
+
+    public LoadMapOperation(String name, boolean replaceExistingValues) {
+        super(name);
+        this.replaceExistingValues = replaceExistingValues;
+    }
+
+    @Override
+    public void run() throws Exception {
+
+        MapServiceContext mapServiceContext = mapService.getMapServiceContext();
+        MapStoreContext mapStoreContext = mapContainer.getMapStoreContext();
+
+        mapStoreContext.triggerInitialKeyLoad();
+
+        for(int partition :  mapServiceContext.getOwnedPartitions()) {
+            RecordStore recordStore = mapServiceContext.getRecordStore(partition, name);
+            recordStore.loadAllFromStore(replaceExistingValues);
+        }
+    }
+
+    @Override
+    protected void writeInternal(ObjectDataOutput out) throws IOException {
+        super.writeInternal(out);
+        out.writeBoolean(replaceExistingValues);
+    }
+
+    @Override
+    protected void readInternal(ObjectDataInput in) throws IOException {
+        super.readInternal(in);
+        replaceExistingValues = in.readBoolean();
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/LoadMapOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/LoadMapOperation.java
@@ -46,7 +46,7 @@ public class LoadMapOperation extends AbstractMapOperation {
 
         mapStoreContext.triggerInitialKeyLoad();
 
-        for(int partition :  mapServiceContext.getOwnedPartitions()) {
+        for (int partition :  mapServiceContext.getOwnedPartitions()) {
             RecordStore recordStore = mapServiceContext.getRecordStore(partition, name);
             recordStore.loadAllFromStore(replaceExistingValues);
         }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
@@ -24,7 +24,6 @@ import com.hazelcast.core.HazelcastException;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.ICompletableFuture;
 import com.hazelcast.core.IMap;
-import com.hazelcast.core.MapStore;
 import com.hazelcast.map.EntryProcessor;
 import com.hazelcast.map.MapInterceptor;
 import com.hazelcast.map.impl.MapService;
@@ -58,7 +57,6 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.map.impl.MapService.SERVICE_NAME;
-import static com.hazelcast.util.IterableUtil.nullToEmpty;
 import static com.hazelcast.util.ValidationUtil.checkNotNull;
 import static com.hazelcast.util.ValidationUtil.shouldBePositive;
 
@@ -499,11 +497,9 @@ public class MapProxyImpl<K, V> extends MapProxySupport implements IMap<K, V>, I
 
     @Override
     public void loadAll(boolean replaceExistingValues) {
-        MapStore<K, V> store = checkNotNull(getMapStore(), "First you should configure a map store");
+        checkNotNull(getMapStore(), "First you should configure a map store");
 
-        Iterable<K> keys = nullToEmpty(store.loadAllKeys());
-
-        loadAllInternal(keys, replaceExistingValues);
+        loadAllInternal(replaceExistingValues);
     }
 
     @Override
@@ -511,7 +507,7 @@ public class MapProxyImpl<K, V> extends MapProxySupport implements IMap<K, V>, I
         checkNotNull(getMapStore(), "First you should configure a map store");
         checkNotNull(keys, "Parameter keys should not be null.");
 
-        loadAllInternal(keys, replaceExistingValues);
+        loadInternal(keys, replaceExistingValues);
     }
 
     /**

--- a/hazelcast/src/test/java/com/hazelcast/map/mapstore/LoadAllTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/mapstore/LoadAllTest.java
@@ -83,6 +83,22 @@ public class LoadAllTest extends HazelcastTestSupport {
         assertEquals(itemCount, map.size());
     }
 
+    @Test
+    public void testAllItemsLoaded_whenLoadingAllOnMultipleInstances() throws Exception {
+        String mapName = randomMapName();
+        Config config = createNewConfig(mapName);
+
+        HazelcastInstance[] nodes = createHazelcastInstanceFactory(3).newInstances(config);
+        HazelcastInstance node = nodes[0];
+        IMap<Object, Object> map = node.getMap(mapName);
+
+        int itemCount = 1000;
+        populateMap(map, itemCount);
+        map.evictAll();
+        map.loadAll(true);
+
+        assertEquals(itemCount, map.size());
+    }
 
     @Test
     public void load_allKeys_preserveExistingKeys_firesEvent() throws Exception {

--- a/hazelcast/src/test/java/com/hazelcast/map/mapstore/LoadAllTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/mapstore/LoadAllTest.java
@@ -21,6 +21,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CountDownLatch;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -98,6 +100,25 @@ public class LoadAllTest extends HazelcastTestSupport {
         map.loadAll(true);
 
         assertEquals(itemCount, map.size());
+    }
+
+    @Test
+    public void testItemsNotOverwritten_whenLoadingWithoutReplacing() throws Exception {
+        String mapName = randomMapName();
+        Config config = createNewConfig(mapName);
+
+        HazelcastInstance[] nodes = createHazelcastInstanceFactory(3).newInstances(config);
+        HazelcastInstance node = nodes[0];
+        IMap<Object, Object> map = node.getMap(mapName);
+
+        int itemCount = 100;
+        populateMap(map, itemCount);
+        map.evictAll();
+        map.putTransient(0, -1, 0, SECONDS);
+        map.loadAll(false);
+
+        assertEquals(itemCount, map.size());
+        assertEquals(-1, map.get(0));
     }
 
     @Test


### PR DESCRIPTION
`IMap.loadAll` no longer loads all keys but instead sends an LoadMapOperation to all nodes. Each node then loads keys and values the same way as it does on node startup.