### PR TITLE
Cluster quorum implementation

### DIFF
--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
@@ -79,6 +79,7 @@ import com.hazelcast.mapreduce.impl.MapReduceService;
 import com.hazelcast.multimap.impl.MultiMapService;
 import com.hazelcast.nio.ClassLoaderUtil;
 import com.hazelcast.nio.serialization.SerializationService;
+import com.hazelcast.quorum.QuorumService;
 import com.hazelcast.replicatedmap.impl.ReplicatedMapService;
 import com.hazelcast.security.Credentials;
 import com.hazelcast.security.UsernamePasswordCredentials;
@@ -409,6 +410,11 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance {
     @Override
     public PartitionService getPartitionService() {
         return new PartitionServiceProxy(partitionService, listenerService);
+    }
+
+    @Override
+    public QuorumService getQuorumService() {
+        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/impl/HazelcastClientProxy.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/impl/HazelcastClientProxy.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.client.impl;
 
-import com.hazelcast.client.HazelcastClient;
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.Client;
@@ -46,11 +45,11 @@ import com.hazelcast.instance.TerminatedLifecycleService;
 import com.hazelcast.logging.LoggingService;
 import com.hazelcast.mapreduce.JobTracker;
 import com.hazelcast.nio.serialization.SerializationService;
+import com.hazelcast.quorum.QuorumService;
 import com.hazelcast.transaction.TransactionContext;
 import com.hazelcast.transaction.TransactionException;
 import com.hazelcast.transaction.TransactionOptions;
 import com.hazelcast.transaction.TransactionalTask;
-
 import java.util.Collection;
 import java.util.concurrent.ConcurrentMap;
 
@@ -206,6 +205,11 @@ public final class HazelcastClientProxy implements HazelcastInstance {
     @Override
     public PartitionService getPartitionService() {
         return getClient().getPartitionService();
+    }
+
+    @Override
+    public QuorumService getQuorumService() {
+        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/hazelcast-client-new/src/test/java/com/hazelcast/client/ClientSplitBrainTest.java
+++ b/hazelcast-client-new/src/test/java/com/hazelcast/client/ClientSplitBrainTest.java
@@ -10,22 +10,19 @@ import com.hazelcast.core.IMap;
 import com.hazelcast.core.LifecycleEvent;
 import com.hazelcast.core.LifecycleListener;
 import com.hazelcast.instance.GroupProperties;
-import com.hazelcast.instance.Node;
-import com.hazelcast.instance.TestUtil;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.NightlyTest;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
-import org.junit.Ignore;
-
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -141,11 +138,4 @@ public class ClientSplitBrainTest extends HazelcastTestSupport {
         };
     }
 
-    private void closeConnectionBetween(HazelcastInstance h1, HazelcastInstance h2) {
-        if (h1 == null || h2 == null) return;
-        final Node n1 = TestUtil.getNode(h1);
-        final Node n2 = TestUtil.getNode(h2);
-        n1.clusterService.removeAddress(n2.address);
-        n2.clusterService.removeAddress(n1.address);
-    }
 }

--- a/hazelcast-client-new/src/test/java/com/hazelcast/client/quorum/ClientMapReadQuorumTest.java
+++ b/hazelcast-client-new/src/test/java/com/hazelcast/client/quorum/ClientMapReadQuorumTest.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.hazelcast.client.quorum;
+
+import com.hazelcast.client.HazelcastClient;
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.instance.HazelcastInstanceFactory;
+import com.hazelcast.nio.Address;
+import com.hazelcast.quorum.PartitionedCluster;
+import com.hazelcast.config.QuorumConfig;
+import com.hazelcast.quorum.QuorumException;
+import com.hazelcast.quorum.QuorumType;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static com.hazelcast.test.HazelcastTestSupport.getNode;
+import static com.hazelcast.test.HazelcastTestSupport.randomMapName;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+@Ignore
+public class ClientMapReadQuorumTest {
+
+    static PartitionedCluster cluster;
+    static IMap<Object, Object> map1;
+    static IMap<Object, Object> map2;
+    static IMap<Object, Object> map3;
+    static IMap<Object, Object> map4;
+    static IMap<Object, Object> map5;
+
+    static HazelcastInstance c1;
+    static HazelcastInstance c2;
+    static HazelcastInstance c3;
+    static HazelcastInstance c4;
+    static HazelcastInstance c5;
+
+    private static final String MAP_NAME_PREFIX = "quorum";
+    private static final String QUORUM_ID = "threeNodeQuorumRule";
+
+    @BeforeClass
+    public static void initialize() throws InterruptedException {
+        QuorumConfig quorumConfig = new QuorumConfig();
+        quorumConfig.setName(QUORUM_ID);
+        quorumConfig.setEnabled(true);
+        quorumConfig.setSize(3);
+        quorumConfig.setType(QuorumType.READ);
+        MapConfig mapConfig = new MapConfig(MAP_NAME_PREFIX + "*");
+        mapConfig.setQuorumName(QUORUM_ID);
+        cluster = new PartitionedCluster().partitionFiveMembersThreeAndTwo(mapConfig, quorumConfig);
+        initializeClients();
+    }
+
+    private static void initializeClients() {
+        c1 = HazelcastClient.newHazelcastClient(getClientConfig(cluster.h1));
+        c2 = HazelcastClient.newHazelcastClient(getClientConfig(cluster.h2));
+        c3 = HazelcastClient.newHazelcastClient(getClientConfig(cluster.h3));
+        c4 = HazelcastClient.newHazelcastClient(getClientConfig(cluster.h4));
+        c5 = HazelcastClient.newHazelcastClient(getClientConfig(cluster.h5));
+    }
+
+    private static ClientConfig getClientConfig(HazelcastInstance instance) {
+        ClientConfig clientConfig = new ClientConfig();
+        Address address = getNode(instance).address;
+        clientConfig.getNetworkConfig().addAddress(address.getHost() + ":" + address.getPort());
+        clientConfig.getGroupConfig().setName(instance.getConfig().getGroupConfig().getName());
+        return clientConfig;
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        String mapName = randomMapName(MAP_NAME_PREFIX);
+        map1 = c1.getMap(mapName);
+        map2 = c2.getMap(mapName);
+        map3 = c3.getMap(mapName);
+        map4 = c4.getMap(mapName);
+        map5 = c5.getMap(mapName);
+    }
+
+    @AfterClass
+    public static void killAllHazelcastInstances() throws IOException {
+        HazelcastInstanceFactory.terminateAll();
+    }
+
+    @Test
+    public void testGetOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.get("foo");
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testGetOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.get("foo");
+    }
+
+    @Test
+    public void testGetAsyncOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        Future<Object> foo = map1.getAsync("foo");
+        foo.get();
+    }
+
+    @Test(expected = ExecutionException.class)
+    public void testGetAsyncOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        Future<Object> foo = map4.getAsync("foo");
+        foo.get();
+    }
+
+    @Test
+    public void testGetAllOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        HashSet<Object> keys = new HashSet<Object>();
+        keys.add("foo");
+        map1.getAll(keys);
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testGetAllOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        HashSet<Object> keys = new HashSet<Object>();
+        keys.add("foo");
+        map4.getAll(keys);
+    }
+
+    @Test
+    public void testGetEntryViewOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.getEntryView("foo");
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testGetEntryViewOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.getEntryView("foo");
+    }
+
+
+    @Test
+    public void testContainsKeyOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.containsKey("foo");
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testContainsKeyOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.containsKey("foo");
+    }
+
+    @Test
+    public void testContainsValueOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.containsValue("foo");
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testContainsValueOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.containsValue("foo");
+    }
+
+    @Test
+    public void testKeySetOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.keySet();
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testKeySetOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.keySet();
+    }
+
+    @Test
+    public void testValuesOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.values();
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testValuesOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.values();
+    }
+
+    @Test
+    public void testEntrySetOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.entrySet();
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testEntrySetOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.entrySet();
+    }
+
+
+}

--- a/hazelcast-client-new/src/test/java/com/hazelcast/client/quorum/ClientMapReadWriteQuorumTest.java
+++ b/hazelcast-client-new/src/test/java/com/hazelcast/client/quorum/ClientMapReadWriteQuorumTest.java
@@ -1,0 +1,509 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.hazelcast.client.quorum;
+
+import com.hazelcast.client.HazelcastClient;
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.instance.HazelcastInstanceFactory;
+import com.hazelcast.nio.Address;
+import com.hazelcast.quorum.PartitionedCluster;
+import com.hazelcast.config.QuorumConfig;
+import com.hazelcast.quorum.QuorumException;
+import com.hazelcast.quorum.QuorumType;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static com.hazelcast.map.InterceptorTest.SimpleInterceptor;
+import static com.hazelcast.map.TempData.LoggingEntryProcessor;
+import static com.hazelcast.test.HazelcastTestSupport.getNode;
+import static com.hazelcast.test.HazelcastTestSupport.randomMapName;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+@Ignore
+public class ClientMapReadWriteQuorumTest {
+
+    static PartitionedCluster cluster;
+    static IMap<Object, Object> map1;
+    static IMap<Object, Object> map2;
+    static IMap<Object, Object> map3;
+    static IMap<Object, Object> map4;
+    static IMap<Object, Object> map5;
+
+    static HazelcastInstance c1;
+    static HazelcastInstance c2;
+    static HazelcastInstance c3;
+    static HazelcastInstance c4;
+    static HazelcastInstance c5;
+
+    private static final String MAP_NAME_PREFIX = "quorum";
+    private static final String QUORUM_ID = "threeNodeQuorumRule";
+
+    @BeforeClass
+    public static void initialize() throws InterruptedException {
+        QuorumConfig quorumConfig = new QuorumConfig();
+        quorumConfig.setName(QUORUM_ID);
+        quorumConfig.setEnabled(true);
+        quorumConfig.setSize(3);
+        quorumConfig.setType(QuorumType.READ_WRITE);
+        MapConfig mapConfig = new MapConfig(MAP_NAME_PREFIX + "*");
+        mapConfig.setQuorumName(QUORUM_ID);
+        cluster = new PartitionedCluster().partitionFiveMembersThreeAndTwo(mapConfig, quorumConfig);
+        initializeClients();
+    }
+
+    private static void initializeClients() {
+        c1 = HazelcastClient.newHazelcastClient(getClientConfig(cluster.h1));
+        c2 = HazelcastClient.newHazelcastClient(getClientConfig(cluster.h2));
+        c3 = HazelcastClient.newHazelcastClient(getClientConfig(cluster.h3));
+        c4 = HazelcastClient.newHazelcastClient(getClientConfig(cluster.h4));
+        c5 = HazelcastClient.newHazelcastClient(getClientConfig(cluster.h5));
+    }
+
+    private static ClientConfig getClientConfig(HazelcastInstance instance) {
+        ClientConfig clientConfig = new ClientConfig();
+        Address address = getNode(instance).address;
+        clientConfig.getNetworkConfig().addAddress(address.getHost() + ":" + address.getPort());
+        clientConfig.getGroupConfig().setName(instance.getConfig().getGroupConfig().getName());
+        return clientConfig;
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        String mapName = randomMapName(MAP_NAME_PREFIX);
+        map1 = c1.getMap(mapName);
+        map2 = c2.getMap(mapName);
+        map3 = c3.getMap(mapName);
+        map4 = c4.getMap(mapName);
+        map5 = c5.getMap(mapName);
+    }
+
+    @AfterClass
+    public static void killAllHazelcastInstances() throws IOException {
+        HazelcastInstanceFactory.terminateAll();
+    }
+
+    @Test
+    public void testPutOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.put("foo", "bar");
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testPutOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.put("foo", "bar");
+    }
+
+
+    @Test
+    public void testTryPutOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.tryPut("foo", "bar", 5, TimeUnit.SECONDS);
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testTryPutOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.tryPut("foo", "bar", 5, TimeUnit.SECONDS);
+    }
+
+    @Test
+    public void testPutTransientOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.putTransient("foo", "bar", 5, TimeUnit.SECONDS);
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testPutTransientOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.putTransient("foo", "bar", 5, TimeUnit.SECONDS);
+    }
+
+    @Test
+    public void testPutIfAbsentOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.putIfAbsent("foo", "bar");
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testPutIfAbsentOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.putIfAbsent("foo", "bar");
+    }
+
+    @Test
+    public void testPutAsyncOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        Future<Object> foo = map1.putAsync("foo", "bar");
+        foo.get();
+    }
+
+    @Test(expected = ExecutionException.class)
+    public void testPutAsyncOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        Future<Object> foo = map4.putAsync("foo", "bar");
+        foo.get();
+    }
+
+    @Test
+    public void testPutAllOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        HashMap<Object, Object> map = new HashMap<Object, Object>();
+        map.put("foo", "bar");
+        map1.putAll(map);
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testPutAllOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        HashMap<Object, Object> map = new HashMap<Object, Object>();
+        map.put("foo", "bar");
+        map4.putAll(map);
+    }
+
+    @Test
+    public void testGetOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.get("foo");
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testGetOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.get("foo");
+    }
+
+    @Test
+    public void testGetAsyncOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        Future<Object> foo = map1.getAsync("foo");
+        foo.get();
+    }
+
+    @Test(expected = ExecutionException.class)
+    public void testGetAsyncOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        Future<Object> foo = map4.getAsync("foo");
+        foo.get();
+    }
+
+    @Test
+    public void testGetAllOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        HashSet<Object> keys = new HashSet<Object>();
+        keys.add("foo");
+        map1.getAll(keys);
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testGetAllOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        HashSet<Object> keys = new HashSet<Object>();
+        keys.add("foo");
+        map4.getAll(keys);
+    }
+
+    @Test
+    public void testGetEntryViewOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.getEntryView("foo");
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testGetEntryViewOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.getEntryView("foo");
+    }
+
+    @Test
+    public void testRemoveOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.remove("foo");
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testRemoveOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.remove("foo");
+    }
+
+    @Test
+    public void testRemoveIfHasValueOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.remove("foo", "bar");
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testRemoveIfHasValueOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.remove("foo", "bar");
+    }
+
+    @Test
+    public void testRemoveAsyncOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        Future<Object> foo = map1.removeAsync("foo");
+        foo.get();
+    }
+
+    @Test(expected = ExecutionException.class)
+    public void testRemoveAsyncOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        Future<Object> foo = map4.removeAsync("foo");
+        foo.get();
+    }
+
+    @Test
+    public void testDeleteOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.delete("foo");
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testDeleteOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.delete("foo");
+    }
+
+    @Test
+    public void testClearOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.clear();
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testClearOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.clear();
+    }
+
+    @Test
+    public void testSetOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.set("foo", "bar");
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testSetOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.set("foo", "bar");
+    }
+
+    @Test
+    public void testReplaceOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.replace("foo", "bar");
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testReplaceOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.replace("foo", "bar");
+    }
+
+    @Test
+    public void testReplaceIfOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.replace("foo", "bar", "baz");
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testReplaceIfOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.replace("foo", "bar", "baz");
+    }
+
+    @Test
+    public void testTryRemoveOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.tryRemove("foo", 5, TimeUnit.SECONDS);
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testTryRemoveOperationThrowsExceptionWhenQuorumSizeNotMet() {
+        map4.tryRemove("foo", 5, TimeUnit.SECONDS);
+    }
+
+    @Test
+    public void testFlushOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.flush();
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testFlushOperationThrowsExceptionWhenQuorumSizeNotMet() {
+        map4.flush();
+    }
+
+    @Test
+    public void testEvictAllOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.evictAll();
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testEvictAllOperationThrowsExceptionWhenQuorumSizeNotMet() {
+        map4.evictAll();
+    }
+
+    @Test
+    public void testEvictOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.evict("foo");
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testEvictOperationThrowsExceptionWhenQuorumSizeNotMet() {
+        map4.evict("foo");
+    }
+
+    @Test
+    public void testContainsKeyOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.containsKey("foo");
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testContainsKeyOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.containsKey("foo");
+    }
+
+    @Test
+    public void testContainsValueOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.containsValue("foo");
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testContainsValueOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.containsValue("foo");
+    }
+
+    @Test
+    public void testKeySetOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.keySet();
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testKeySetOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.keySet();
+    }
+
+
+    @Test
+    public void testValuesOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.values();
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testValuesOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.values();
+    }
+
+    @Test
+    public void testEntrySetOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.entrySet();
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testEntrySetOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.entrySet();
+    }
+
+    @Test
+    public void testAddIndexOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.addIndex("foo", false);
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testAddIndexOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.addIndex("foo", false);
+    }
+
+    @Test
+    public void testAddInterceptorOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.addInterceptor(new SimpleInterceptor());
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testAddInterceptorOperationThrowsExceptionWhenQuorumSizeNotMet() {
+        map4.addInterceptor(new SimpleInterceptor());
+    }
+
+    @Test
+    public void testRemoveInterceptorOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.removeInterceptor("foo");
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testRemoveInterceptorOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.removeInterceptor("foo");
+    }
+
+    @Test
+    public void testExecuteOnKeyOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.executeOnKey("foo", new LoggingEntryProcessor());
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testExecuteOnKeyOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.executeOnKey("foo", new LoggingEntryProcessor());
+    }
+
+    @Test
+    public void testExecuteOnKeysOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        HashSet<Object> keys = new HashSet<Object>();
+        keys.add("foo");
+        map1.executeOnKey(keys, new LoggingEntryProcessor());
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testExecuteOnKeysOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        HashSet<Object> keys = new HashSet<Object>();
+        keys.add("foo");
+        map4.executeOnKey(keys, new LoggingEntryProcessor());
+    }
+
+    @Test
+    public void testExecuteOnEntriesOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.executeOnEntries(new LoggingEntryProcessor());
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testExecuteOnEntriesOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.executeOnEntries(new LoggingEntryProcessor());
+    }
+
+    @Test
+    public void testSubmmitToKeyOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        Future foo = map1.submitToKey("foo", new LoggingEntryProcessor());
+        foo.get();
+    }
+
+    @Test(expected = ExecutionException.class)
+    public void testSubmmitToKeyOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        Future foo = map4.submitToKey("foo", new LoggingEntryProcessor());
+        foo.get();
+    }
+
+    @Ignore
+    @Test(expected = QuorumException.class)
+    public void testLockOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.lock("foo");
+    }
+
+    @Ignore
+    @Test(expected = QuorumException.class)
+    public void testTryLockOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.tryLock("foo");
+    }
+
+    @Ignore
+    @Test(expected = QuorumException.class)
+    public void testUnlockOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.unlock("foo");
+    }
+
+    @Ignore
+    @Test(expected = QuorumException.class)
+    public void testIsLockedOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.isLocked("foo");
+    }
+
+    @Ignore
+    @Test(expected = QuorumException.class)
+    public void testForceUnlockOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.forceUnlock("foo");
+    }
+
+
+}

--- a/hazelcast-client-new/src/test/java/com/hazelcast/client/quorum/ClientMapWriteQuorumTest.java
+++ b/hazelcast-client-new/src/test/java/com/hazelcast/client/quorum/ClientMapWriteQuorumTest.java
@@ -1,0 +1,381 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.hazelcast.client.quorum;
+
+import com.hazelcast.client.HazelcastClient;
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.instance.HazelcastInstanceFactory;
+import com.hazelcast.nio.Address;
+import com.hazelcast.quorum.PartitionedCluster;
+import com.hazelcast.config.QuorumConfig;
+import com.hazelcast.quorum.QuorumException;
+import com.hazelcast.quorum.QuorumType;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static com.hazelcast.map.InterceptorTest.SimpleInterceptor;
+import static com.hazelcast.map.TempData.LoggingEntryProcessor;
+import static com.hazelcast.test.HazelcastTestSupport.getNode;
+import static com.hazelcast.test.HazelcastTestSupport.randomMapName;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+@Ignore
+public class ClientMapWriteQuorumTest {
+
+    static PartitionedCluster cluster;
+    static IMap<Object, Object> map1;
+    static IMap<Object, Object> map2;
+    static IMap<Object, Object> map3;
+    static IMap<Object, Object> map4;
+    static IMap<Object, Object> map5;
+
+    static HazelcastInstance c1;
+    static HazelcastInstance c2;
+    static HazelcastInstance c3;
+    static HazelcastInstance c4;
+    static HazelcastInstance c5;
+
+    private static final String MAP_NAME_PREFIX = "quorum";
+    private static final String QUORUM_ID = "threeNodeQuorumRule";
+
+    @BeforeClass
+    public static void initialize() throws InterruptedException {
+        QuorumConfig quorumConfig = new QuorumConfig();
+        quorumConfig.setName(QUORUM_ID);
+        quorumConfig.setEnabled(true);
+        quorumConfig.setSize(3);
+        quorumConfig.setType(QuorumType.WRITE);
+        MapConfig mapConfig = new MapConfig(MAP_NAME_PREFIX + "*");
+        mapConfig.setQuorumName(QUORUM_ID);
+        cluster = new PartitionedCluster().partitionFiveMembersThreeAndTwo(mapConfig, quorumConfig);
+        initializeClients();
+    }
+
+    private static void initializeClients() {
+        c1 = HazelcastClient.newHazelcastClient(getClientConfig(cluster.h1));
+        c2 = HazelcastClient.newHazelcastClient(getClientConfig(cluster.h2));
+        c3 = HazelcastClient.newHazelcastClient(getClientConfig(cluster.h3));
+        c4 = HazelcastClient.newHazelcastClient(getClientConfig(cluster.h4));
+        c5 = HazelcastClient.newHazelcastClient(getClientConfig(cluster.h5));
+    }
+
+    private static ClientConfig getClientConfig(HazelcastInstance instance) {
+        ClientConfig clientConfig = new ClientConfig();
+        Address address = getNode(instance).address;
+        clientConfig.getNetworkConfig().addAddress(address.getHost() + ":" + address.getPort());
+        clientConfig.getGroupConfig().setName(instance.getConfig().getGroupConfig().getName());
+        return clientConfig;
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        String mapName = randomMapName(MAP_NAME_PREFIX);
+        map1 = c1.getMap(mapName);
+        map2 = c2.getMap(mapName);
+        map3 = c3.getMap(mapName);
+        map4 = c4.getMap(mapName);
+        map5 = c5.getMap(mapName);
+    }
+
+    @AfterClass
+    public static void killAllHazelcastInstances() throws IOException {
+        HazelcastInstanceFactory.terminateAll();
+    }
+    @Test
+    public void testPutOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.put("foo", "bar");
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testPutOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.put("foo", "bar");
+    }
+
+
+    @Test
+    public void testTryPutOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.tryPut("foo", "bar", 5, TimeUnit.SECONDS);
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testTryPutOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.tryPut("foo", "bar", 5, TimeUnit.SECONDS);
+    }
+
+    @Test
+    public void testPutTransientOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.putTransient("foo", "bar", 5, TimeUnit.SECONDS);
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testPutTransientOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.putTransient("foo", "bar", 5, TimeUnit.SECONDS);
+    }
+
+    @Test
+    public void testPutIfAbsentOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.putIfAbsent("foo", "bar");
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testPutIfAbsentOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.putIfAbsent("foo", "bar");
+    }
+
+    @Test
+    public void testPutAsyncOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        Future<Object> foo = map1.putAsync("foo", "bar");
+        foo.get();
+    }
+
+    @Test(expected = ExecutionException.class)
+    public void testPutAsyncOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        Future<Object> foo = map4.putAsync("foo", "bar");
+        foo.get();
+    }
+
+    @Test
+    public void testPutAllOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        HashMap<Object, Object> map = new HashMap<Object, Object>();
+        map.put("foo", "bar");
+        map1.putAll(map);
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testPutAllOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        HashMap<Object, Object> map = new HashMap<Object, Object>();
+        map.put("foo", "bar");
+        map4.putAll(map);
+    }
+
+    @Test
+    public void testRemoveOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.remove("foo");
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testRemoveOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.remove("foo");
+    }
+
+    @Test
+    public void testRemoveIfHasValueOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.remove("foo", "bar");
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testRemoveIfHasValueOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.remove("foo", "bar");
+    }
+
+    @Test
+    public void testRemoveAsyncOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        Future<Object> foo = map1.removeAsync("foo");
+        foo.get();
+    }
+
+    @Test(expected = ExecutionException.class)
+    public void testRemoveAsyncOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        Future<Object> foo = map4.removeAsync("foo");
+        foo.get();
+    }
+
+    @Test
+    public void testDeleteOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.delete("foo");
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testDeleteOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.delete("foo");
+    }
+
+    @Test
+    public void testClearOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.clear();
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testClearOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.clear();
+    }
+
+    @Test
+    public void testSetOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.set("foo", "bar");
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testSetOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.set("foo", "bar");
+    }
+
+    @Test
+    public void testReplaceOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.replace("foo", "bar");
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testReplaceOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.replace("foo", "bar");
+    }
+
+    @Test
+    public void testReplaceIfOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.replace("foo", "bar", "baz");
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testReplaceIfOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.replace("foo", "bar", "baz");
+    }
+
+    @Test
+    public void testTryRemoveOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.tryRemove("foo", 5, TimeUnit.SECONDS);
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testTryRemoveOperationThrowsExceptionWhenQuorumSizeNotMet() {
+        map4.tryRemove("foo", 5, TimeUnit.SECONDS);
+    }
+
+    @Test
+    public void testFlushOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.flush();
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testFlushOperationThrowsExceptionWhenQuorumSizeNotMet() {
+        map4.flush();
+    }
+
+    @Test
+    public void testEvictAllOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.evictAll();
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testEvictAllOperationThrowsExceptionWhenQuorumSizeNotMet() {
+        map4.evictAll();
+    }
+
+    @Test
+    public void testEvictOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.evict("foo");
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testEvictOperationThrowsExceptionWhenQuorumSizeNotMet() {
+        map4.evict("foo");
+    }
+
+    @Test
+    public void testAddIndexOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.addIndex("foo", false);
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testAddIndexOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.addIndex("foo", false);
+    }
+
+    @Test
+    public void testAddInterceptorOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.addInterceptor(new SimpleInterceptor());
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testAddInterceptorOperationThrowsExceptionWhenQuorumSizeNotMet() {
+        map4.addInterceptor(new SimpleInterceptor());
+    }
+
+    @Test
+    public void testRemoveInterceptorOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.removeInterceptor("foo");
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testRemoveInterceptorOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.removeInterceptor("foo");
+    }
+
+    @Test
+    public void testExecuteOnKeyOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.executeOnKey("foo", new LoggingEntryProcessor());
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testExecuteOnKeyOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.executeOnKey("foo", new LoggingEntryProcessor());
+    }
+
+    @Test
+    public void testExecuteOnKeysOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        HashSet<Object> keys = new HashSet<Object>();
+        keys.add("foo");
+        map1.executeOnKey(keys, new LoggingEntryProcessor());
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testExecuteOnKeysOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        HashSet<Object> keys = new HashSet<Object>();
+        keys.add("foo");
+        map4.executeOnKey(keys, new LoggingEntryProcessor());
+    }
+
+    @Test
+    public void testExecuteOnEntriesOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.executeOnEntries(new LoggingEntryProcessor());
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testExecuteOnEntriesOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.executeOnEntries(new LoggingEntryProcessor());
+    }
+
+    @Test
+    public void testSubmmitToKeyOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        Future foo = map1.submitToKey("foo", new LoggingEntryProcessor());
+        foo.get();
+    }
+
+    @Test(expected = ExecutionException.class)
+    public void testSubmmitToKeyOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        Future foo = map4.submitToKey("foo", new LoggingEntryProcessor());
+        foo.get();
+    }
+
+
+}

--- a/hazelcast-client-new/src/test/java/com/hazelcast/client/quorum/ClientTransactionalMapQuorumTest.java
+++ b/hazelcast-client-new/src/test/java/com/hazelcast/client/quorum/ClientTransactionalMapQuorumTest.java
@@ -1,0 +1,288 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.hazelcast.client.quorum;
+
+import com.hazelcast.client.HazelcastClient;
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.TransactionalMap;
+import com.hazelcast.instance.HazelcastInstanceFactory;
+import com.hazelcast.nio.Address;
+import com.hazelcast.query.TruePredicate;
+import com.hazelcast.quorum.PartitionedCluster;
+import com.hazelcast.config.QuorumConfig;
+import com.hazelcast.test.HazelcastTestRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.test.annotation.RunParallel;
+import com.hazelcast.transaction.TransactionContext;
+import com.hazelcast.transaction.TransactionException;
+import com.hazelcast.transaction.TransactionOptions;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.concurrent.TimeUnit;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import static com.hazelcast.test.HazelcastTestSupport.getNode;
+import static com.hazelcast.test.HazelcastTestSupport.randomMapName;
+import static com.hazelcast.transaction.TransactionOptions.TransactionType.LOCAL;
+import static com.hazelcast.transaction.TransactionOptions.TransactionType.TWO_PHASE;
+
+@RunParallel
+@RunWith(HazelcastTestRunner.class)
+@Category(QuickTest.class)
+@Ignore
+public class ClientTransactionalMapQuorumTest {
+
+    static PartitionedCluster cluster;
+    private static final String MAP_NAME_PREFIX = "quorum";
+    private static final String QUORUM_ID = "threeNodeQuorumRule";
+    static HazelcastInstance c1;
+    static HazelcastInstance c2;
+    static HazelcastInstance c3;
+    static HazelcastInstance c4;
+    static HazelcastInstance c5;
+
+
+    @Parameterized.Parameter(0)
+    public TransactionOptions options;
+
+
+    @Parameterized.Parameters(name = "Executing: {0}")
+    public static Collection<Object[]> parameters() {
+
+        TransactionOptions localOption = TransactionOptions.getDefault();
+        localOption.setTransactionType(LOCAL);
+
+        TransactionOptions twoPhaseOption = TransactionOptions.getDefault();
+        twoPhaseOption.setTransactionType(TWO_PHASE);
+
+        return Arrays.asList(
+                new Object[]{twoPhaseOption}, //
+                new Object[]{localOption} //
+        );
+    }
+
+    @BeforeClass
+    public static void initialize() throws InterruptedException {
+        QuorumConfig quorumConfig = new QuorumConfig();
+        quorumConfig.setEnabled(true);
+        quorumConfig.setSize(3);
+        quorumConfig.setName(QUORUM_ID);
+
+        MapConfig mapConfig = new MapConfig(MAP_NAME_PREFIX + "*");
+        mapConfig.setQuorumName(QUORUM_ID);
+        cluster = new PartitionedCluster().partitionFiveMembersThreeAndTwo(mapConfig, quorumConfig);
+        initializeClients();
+    }
+
+    private static void initializeClients() {
+        c1 = HazelcastClient.newHazelcastClient(getClientConfig(cluster.h1));
+        c2 = HazelcastClient.newHazelcastClient(getClientConfig(cluster.h2));
+        c3 = HazelcastClient.newHazelcastClient(getClientConfig(cluster.h3));
+        c4 = HazelcastClient.newHazelcastClient(getClientConfig(cluster.h4));
+        c5 = HazelcastClient.newHazelcastClient(getClientConfig(cluster.h5));
+    }
+
+    private static ClientConfig getClientConfig(HazelcastInstance instance) {
+        ClientConfig clientConfig = new ClientConfig();
+        Address address = getNode(instance).address;
+        clientConfig.getNetworkConfig().addAddress(address.getHost() + ":" + address.getPort());
+        clientConfig.getGroupConfig().setName(instance.getConfig().getGroupConfig().getName());
+        return clientConfig;
+    }
+
+
+    @AfterClass
+    public static void killAllHazelcastInstances() throws IOException {
+        HazelcastInstanceFactory.terminateAll();
+    }
+
+
+    @Test(expected = TransactionException.class)
+    public void testTxPutThrowsExceptionWhenQuorumSizeNotMet() {
+        TransactionContext transactionContext = c4.newTransactionContext(options);
+        transactionContext.beginTransaction();
+        TransactionalMap<Object, Object> map = transactionContext.getMap(randomMapName(MAP_NAME_PREFIX));
+        map.put("foo", "bar");
+        transactionContext.commitTransaction();
+    }
+
+    @Test(expected = TransactionException.class)
+    public void testTxGetThrowsExceptionWhenQuorumSizeNotMet() {
+        TransactionContext transactionContext = c4.newTransactionContext(options);
+        transactionContext.beginTransaction();
+        TransactionalMap<Object, Object> map = transactionContext.getMap(randomMapName(MAP_NAME_PREFIX));
+        map.get("foo");
+        transactionContext.commitTransaction();
+    }
+
+
+    @Test(expected = TransactionException.class)
+    public void testTxGetForUpdateThrowsExceptionWhenQuorumSizeNotMet() {
+        TransactionContext transactionContext = c4.newTransactionContext(options);
+        transactionContext.beginTransaction();
+        TransactionalMap<Object, Object> map = transactionContext.getMap(randomMapName(MAP_NAME_PREFIX));
+        map.getForUpdate("foo");
+        transactionContext.commitTransaction();
+    }
+
+    @Test(expected = TransactionException.class)
+    public void testTxRemoveThrowsExceptionWhenQuorumSizeNotMet() {
+        TransactionContext transactionContext = c4.newTransactionContext(options);
+        transactionContext.beginTransaction();
+        TransactionalMap<Object, Object> map = transactionContext.getMap(randomMapName(MAP_NAME_PREFIX));
+        map.remove("foo");
+        transactionContext.commitTransaction();
+    }
+
+
+    @Test(expected = TransactionException.class)
+    public void testTxRemoveValueThrowsExceptionWhenQuorumSizeNotMet() {
+        TransactionContext transactionContext = c4.newTransactionContext(options);
+        transactionContext.beginTransaction();
+        TransactionalMap<Object, Object> map = transactionContext.getMap(randomMapName(MAP_NAME_PREFIX));
+        map.remove("foo", "bar");
+        transactionContext.commitTransaction();
+    }
+
+    @Test(expected = TransactionException.class)
+    public void testTxDeleteThrowsExceptionWhenQuorumSizeNotMet() {
+        TransactionContext transactionContext = c4.newTransactionContext(options);
+        transactionContext.beginTransaction();
+        TransactionalMap<Object, Object> map = transactionContext.getMap(randomMapName(MAP_NAME_PREFIX));
+        map.delete("foo");
+        transactionContext.commitTransaction();
+    }
+
+    @Test(expected = TransactionException.class)
+    public void testTxSetThrowsExceptionWhenQuorumSizeNotMet() {
+        TransactionContext transactionContext = c4.newTransactionContext(options);
+        transactionContext.beginTransaction();
+        TransactionalMap<Object, Object> map = transactionContext.getMap(randomMapName(MAP_NAME_PREFIX));
+        map.set("foo", "bar");
+        transactionContext.commitTransaction();
+    }
+
+    @Test(expected = TransactionException.class)
+    public void testTxPutWithTTLThrowsExceptionWhenQuorumSizeNotMet() {
+        TransactionContext transactionContext = c4.newTransactionContext(options);
+        transactionContext.beginTransaction();
+        TransactionalMap<Object, Object> map = transactionContext.getMap(randomMapName(MAP_NAME_PREFIX));
+        map.put("foo", "bar", 10, TimeUnit.SECONDS);
+        transactionContext.commitTransaction();
+    }
+
+    @Test(expected = TransactionException.class)
+    public void testTxPutIfAbsentThrowsExceptionWhenQuorumSizeNotMet() {
+        TransactionContext transactionContext = c4.newTransactionContext(options);
+        transactionContext.beginTransaction();
+        TransactionalMap<Object, Object> map = transactionContext.getMap(randomMapName(MAP_NAME_PREFIX));
+        map.putIfAbsent("foo", "bar");
+        transactionContext.commitTransaction();
+    }
+
+    @Test(expected = TransactionException.class)
+    public void testTxReplaceThrowsExceptionWhenQuorumSizeNotMet() {
+        TransactionContext transactionContext = c4.newTransactionContext(options);
+        transactionContext.beginTransaction();
+        TransactionalMap<Object, Object> map = transactionContext.getMap(randomMapName(MAP_NAME_PREFIX));
+        map.replace("foo", "bar");
+        transactionContext.commitTransaction();
+    }
+
+    @Test(expected = TransactionException.class)
+    public void testTxReplaceExpectedValueThrowsExceptionWhenQuorumSizeNotMet() {
+        TransactionContext transactionContext = c4.newTransactionContext(options);
+        transactionContext.beginTransaction();
+        TransactionalMap<Object, Object> map = transactionContext.getMap(randomMapName(MAP_NAME_PREFIX));
+        map.replace("foo", "bar", "baz");
+        transactionContext.commitTransaction();
+    }
+
+    @Test(expected = TransactionException.class)
+    public void testTxSizeThrowsExceptionWhenQuorumSizeNotMet() {
+        TransactionContext transactionContext = c4.newTransactionContext(options);
+        transactionContext.beginTransaction();
+        TransactionalMap<Object, Object> map = transactionContext.getMap(randomMapName(MAP_NAME_PREFIX));
+        map.size();
+        transactionContext.commitTransaction();
+    }
+
+    @Test(expected = TransactionException.class)
+    public void testTxContainsKeyThrowsExceptionWhenQuorumSizeNotMet() {
+        TransactionContext transactionContext = c4.newTransactionContext(options);
+        transactionContext.beginTransaction();
+        TransactionalMap<Object, Object> map = transactionContext.getMap(randomMapName(MAP_NAME_PREFIX));
+        map.containsKey("foo");
+        transactionContext.commitTransaction();
+    }
+
+
+    @Test(expected = TransactionException.class)
+    public void testTxIsEmptyThrowsExceptionWhenQuorumSizeNotMet() {
+        TransactionContext transactionContext = c4.newTransactionContext(options);
+        transactionContext.beginTransaction();
+        TransactionalMap<Object, Object> map = transactionContext.getMap(randomMapName(MAP_NAME_PREFIX));
+        map.isEmpty();
+        transactionContext.commitTransaction();
+    }
+
+    @Test(expected = TransactionException.class)
+    public void testTxKeySetThrowsExceptionWhenQuorumSizeNotMet() {
+        TransactionContext transactionContext = c4.newTransactionContext(options);
+        transactionContext.beginTransaction();
+        TransactionalMap<Object, Object> map = transactionContext.getMap(randomMapName(MAP_NAME_PREFIX));
+        map.keySet();
+        transactionContext.commitTransaction();
+    }
+
+    @Test(expected = TransactionException.class)
+    public void testTxKeySetWithPredicateThrowsExceptionWhenQuorumSizeNotMet() {
+        TransactionContext transactionContext = c4.newTransactionContext(options);
+        transactionContext.beginTransaction();
+        TransactionalMap<Object, Object> map = transactionContext.getMap(randomMapName(MAP_NAME_PREFIX));
+        map.keySet(TruePredicate.INSTANCE);
+        transactionContext.commitTransaction();
+    }
+
+    @Test(expected = TransactionException.class)
+    public void testTxValuesThrowsExceptionWhenQuorumSizeNotMet() {
+        TransactionContext transactionContext = c4.newTransactionContext(options);
+        transactionContext.beginTransaction();
+        TransactionalMap<Object, Object> map = transactionContext.getMap(randomMapName(MAP_NAME_PREFIX));
+        map.values();
+        transactionContext.commitTransaction();
+    }
+
+    @Test(expected = TransactionException.class)
+    public void testTxValuesWithPredicateThrowsExceptionWhenQuorumSizeNotMet() {
+        TransactionContext transactionContext = c4.newTransactionContext(options);
+        transactionContext.beginTransaction();
+        TransactionalMap<Object, Object> map = transactionContext.getMap(randomMapName(MAP_NAME_PREFIX));
+        map.values(TruePredicate.INSTANCE);
+        transactionContext.commitTransaction();
+    }
+
+}

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
@@ -78,6 +78,7 @@ import com.hazelcast.nio.ClassLoaderUtil;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.SerializationService;
 import com.hazelcast.collection.impl.queue.QueueService;
+import com.hazelcast.quorum.QuorumService;
 import com.hazelcast.replicatedmap.impl.ReplicatedMapService;
 import com.hazelcast.security.Credentials;
 import com.hazelcast.security.UsernamePasswordCredentials;
@@ -405,6 +406,11 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance {
     @Override
     public PartitionService getPartitionService() {
         return new PartitionServiceProxy(partitionService, listenerService);
+    }
+
+    @Override
+    public QuorumService getQuorumService() {
+        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientProxy.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.client.impl;
 
-import com.hazelcast.client.HazelcastClient;
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.Client;
@@ -46,11 +45,11 @@ import com.hazelcast.instance.TerminatedLifecycleService;
 import com.hazelcast.logging.LoggingService;
 import com.hazelcast.mapreduce.JobTracker;
 import com.hazelcast.nio.serialization.SerializationService;
+import com.hazelcast.quorum.QuorumService;
 import com.hazelcast.transaction.TransactionContext;
 import com.hazelcast.transaction.TransactionException;
 import com.hazelcast.transaction.TransactionOptions;
 import com.hazelcast.transaction.TransactionalTask;
-
 import java.util.Collection;
 import java.util.concurrent.ConcurrentMap;
 
@@ -206,6 +205,11 @@ public final class HazelcastClientProxy implements HazelcastInstance {
     @Override
     public PartitionService getPartitionService() {
         return getClient().getPartitionService();
+    }
+
+    @Override
+    public QuorumService getQuorumService() {
+        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientClusterProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientClusterProxy.java
@@ -21,7 +21,6 @@ import com.hazelcast.core.Cluster;
 import com.hazelcast.core.Member;
 import com.hazelcast.core.MembershipListener;
 import com.hazelcast.instance.MemberImpl;
-
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashSet;
@@ -63,4 +62,5 @@ public class ClientClusterProxy implements Cluster {
     public long getClusterTime() {
         return clusterService.getClusterTime();
     }
+
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/ClientSplitBrainTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ClientSplitBrainTest.java
@@ -139,11 +139,4 @@ public class ClientSplitBrainTest extends HazelcastTestSupport {
         };
     }
 
-    private void closeConnectionBetween(HazelcastInstance h1, HazelcastInstance h2) {
-        if (h1 == null || h2 == null) return;
-        final Node n1 = TestUtil.getNode(h1);
-        final Node n2 = TestUtil.getNode(h2);
-        n1.clusterService.removeAddress(n2.address);
-        n2.clusterService.removeAddress(n1.address);
-    }
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/ClientMapReadQuorumTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/ClientMapReadQuorumTest.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.hazelcast.client.quorum;
+
+import com.hazelcast.client.HazelcastClient;
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.instance.HazelcastInstanceFactory;
+import com.hazelcast.nio.Address;
+import com.hazelcast.quorum.PartitionedCluster;
+import com.hazelcast.config.QuorumConfig;
+import com.hazelcast.quorum.QuorumException;
+import com.hazelcast.quorum.QuorumType;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static com.hazelcast.test.HazelcastTestSupport.getNode;
+import static com.hazelcast.test.HazelcastTestSupport.randomMapName;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class ClientMapReadQuorumTest {
+
+    static PartitionedCluster cluster;
+    static IMap<Object, Object> map1;
+    static IMap<Object, Object> map2;
+    static IMap<Object, Object> map3;
+    static IMap<Object, Object> map4;
+    static IMap<Object, Object> map5;
+
+    static HazelcastInstance c1;
+    static HazelcastInstance c2;
+    static HazelcastInstance c3;
+    static HazelcastInstance c4;
+    static HazelcastInstance c5;
+
+    private static final String MAP_NAME_PREFIX = "quorum";
+    private static final String QUORUM_ID = "threeNodeQuorumRule";
+
+    @BeforeClass
+    public static void initialize() throws InterruptedException {
+        QuorumConfig quorumConfig = new QuorumConfig();
+        quorumConfig.setName(QUORUM_ID);
+        quorumConfig.setEnabled(true);
+        quorumConfig.setSize(3);
+        quorumConfig.setType(QuorumType.READ);
+        MapConfig mapConfig = new MapConfig(MAP_NAME_PREFIX + "*");
+        mapConfig.setQuorumName(QUORUM_ID);
+        cluster = new PartitionedCluster().partitionFiveMembersThreeAndTwo(mapConfig, quorumConfig);
+        initializeClients();
+    }
+
+    private static void initializeClients() {
+        c1 = HazelcastClient.newHazelcastClient(getClientConfig(cluster.h1));
+        c2 = HazelcastClient.newHazelcastClient(getClientConfig(cluster.h2));
+        c3 = HazelcastClient.newHazelcastClient(getClientConfig(cluster.h3));
+        c4 = HazelcastClient.newHazelcastClient(getClientConfig(cluster.h4));
+        c5 = HazelcastClient.newHazelcastClient(getClientConfig(cluster.h5));
+    }
+
+    private static ClientConfig getClientConfig(HazelcastInstance instance) {
+        ClientConfig clientConfig = new ClientConfig();
+        Address address = getNode(instance).address;
+        clientConfig.getNetworkConfig().addAddress(address.getHost() + ":" + address.getPort());
+        clientConfig.getGroupConfig().setName(instance.getConfig().getGroupConfig().getName());
+        return clientConfig;
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        String mapName = randomMapName(MAP_NAME_PREFIX);
+        map1 = c1.getMap(mapName);
+        map2 = c2.getMap(mapName);
+        map3 = c3.getMap(mapName);
+        map4 = c4.getMap(mapName);
+        map5 = c5.getMap(mapName);
+    }
+
+    @AfterClass
+    public static void killAllHazelcastInstances() throws IOException {
+        HazelcastInstanceFactory.terminateAll();
+    }
+
+    @Test
+    public void testGetOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.get("foo");
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testGetOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.get("foo");
+    }
+
+    @Test
+    public void testGetAsyncOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        Future<Object> foo = map1.getAsync("foo");
+        foo.get();
+    }
+
+    @Test(expected = ExecutionException.class)
+    public void testGetAsyncOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        Future<Object> foo = map4.getAsync("foo");
+        foo.get();
+    }
+
+    @Test
+    public void testGetAllOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        HashSet<Object> keys = new HashSet<Object>();
+        keys.add("foo");
+        map1.getAll(keys);
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testGetAllOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        HashSet<Object> keys = new HashSet<Object>();
+        keys.add("foo");
+        map4.getAll(keys);
+    }
+
+    @Test
+    public void testGetEntryViewOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.getEntryView("foo");
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testGetEntryViewOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.getEntryView("foo");
+    }
+
+
+    @Test
+    public void testContainsKeyOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.containsKey("foo");
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testContainsKeyOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.containsKey("foo");
+    }
+
+    @Test
+    public void testContainsValueOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.containsValue("foo");
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testContainsValueOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.containsValue("foo");
+    }
+
+    @Test
+    public void testKeySetOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.keySet();
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testKeySetOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.keySet();
+    }
+
+    @Test
+    public void testValuesOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.values();
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testValuesOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.values();
+    }
+
+    @Test
+    public void testEntrySetOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.entrySet();
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testEntrySetOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.entrySet();
+    }
+
+
+}

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/ClientMapReadWriteQuorumTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/ClientMapReadWriteQuorumTest.java
@@ -1,0 +1,508 @@
+/*
+ * Copyright (c) 2008-2014, Hazelcast, Inc. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.hazelcast.client.quorum;
+
+import com.hazelcast.client.HazelcastClient;
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.instance.HazelcastInstanceFactory;
+import com.hazelcast.nio.Address;
+import com.hazelcast.quorum.PartitionedCluster;
+import com.hazelcast.config.QuorumConfig;
+import com.hazelcast.quorum.QuorumException;
+import com.hazelcast.quorum.QuorumType;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static com.hazelcast.map.InterceptorTest.SimpleInterceptor;
+import static com.hazelcast.map.TempData.LoggingEntryProcessor;
+import static com.hazelcast.test.HazelcastTestSupport.getNode;
+import static com.hazelcast.test.HazelcastTestSupport.randomMapName;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class ClientMapReadWriteQuorumTest {
+
+    static PartitionedCluster cluster;
+    static IMap<Object, Object> map1;
+    static IMap<Object, Object> map2;
+    static IMap<Object, Object> map3;
+    static IMap<Object, Object> map4;
+    static IMap<Object, Object> map5;
+
+    static HazelcastInstance c1;
+    static HazelcastInstance c2;
+    static HazelcastInstance c3;
+    static HazelcastInstance c4;
+    static HazelcastInstance c5;
+
+    private static final String MAP_NAME_PREFIX = "quorum";
+    private static final String QUORUM_ID = "threeNodeQuorumRule";
+
+    @BeforeClass
+    public static void initialize() throws InterruptedException {
+        QuorumConfig quorumConfig = new QuorumConfig();
+        quorumConfig.setName(QUORUM_ID);
+        quorumConfig.setEnabled(true);
+        quorumConfig.setSize(3);
+        quorumConfig.setType(QuorumType.READ_WRITE);
+        MapConfig mapConfig = new MapConfig(MAP_NAME_PREFIX + "*");
+        mapConfig.setQuorumName(QUORUM_ID);
+        cluster = new PartitionedCluster().partitionFiveMembersThreeAndTwo(mapConfig, quorumConfig);
+        initializeClients();
+    }
+
+    private static void initializeClients() {
+        c1 = HazelcastClient.newHazelcastClient(getClientConfig(cluster.h1));
+        c2 = HazelcastClient.newHazelcastClient(getClientConfig(cluster.h2));
+        c3 = HazelcastClient.newHazelcastClient(getClientConfig(cluster.h3));
+        c4 = HazelcastClient.newHazelcastClient(getClientConfig(cluster.h4));
+        c5 = HazelcastClient.newHazelcastClient(getClientConfig(cluster.h5));
+    }
+
+    private static ClientConfig getClientConfig(HazelcastInstance instance) {
+        ClientConfig clientConfig = new ClientConfig();
+        Address address = getNode(instance).address;
+        clientConfig.getNetworkConfig().addAddress(address.getHost() + ":" + address.getPort());
+        clientConfig.getGroupConfig().setName(instance.getConfig().getGroupConfig().getName());
+        return clientConfig;
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        String mapName = randomMapName(MAP_NAME_PREFIX);
+        map1 = c1.getMap(mapName);
+        map2 = c2.getMap(mapName);
+        map3 = c3.getMap(mapName);
+        map4 = c4.getMap(mapName);
+        map5 = c5.getMap(mapName);
+    }
+
+    @AfterClass
+    public static void killAllHazelcastInstances() throws IOException {
+        HazelcastInstanceFactory.terminateAll();
+    }
+
+    @Test
+    public void testPutOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.put("foo", "bar");
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testPutOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.put("foo", "bar");
+    }
+
+
+    @Test
+    public void testTryPutOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.tryPut("foo", "bar", 5, TimeUnit.SECONDS);
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testTryPutOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.tryPut("foo", "bar", 5, TimeUnit.SECONDS);
+    }
+
+    @Test
+    public void testPutTransientOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.putTransient("foo", "bar", 5, TimeUnit.SECONDS);
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testPutTransientOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.putTransient("foo", "bar", 5, TimeUnit.SECONDS);
+    }
+
+    @Test
+    public void testPutIfAbsentOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.putIfAbsent("foo", "bar");
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testPutIfAbsentOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.putIfAbsent("foo", "bar");
+    }
+
+    @Test
+    public void testPutAsyncOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        Future<Object> foo = map1.putAsync("foo", "bar");
+        foo.get();
+    }
+
+    @Test(expected = ExecutionException.class)
+    public void testPutAsyncOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        Future<Object> foo = map4.putAsync("foo", "bar");
+        foo.get();
+    }
+
+    @Test
+    public void testPutAllOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        HashMap<Object, Object> map = new HashMap<Object, Object>();
+        map.put("foo", "bar");
+        map1.putAll(map);
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testPutAllOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        HashMap<Object, Object> map = new HashMap<Object, Object>();
+        map.put("foo", "bar");
+        map4.putAll(map);
+    }
+
+    @Test
+    public void testGetOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.get("foo");
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testGetOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.get("foo");
+    }
+
+    @Test
+    public void testGetAsyncOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        Future<Object> foo = map1.getAsync("foo");
+        foo.get();
+    }
+
+    @Test(expected = ExecutionException.class)
+    public void testGetAsyncOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        Future<Object> foo = map4.getAsync("foo");
+        foo.get();
+    }
+
+    @Test
+    public void testGetAllOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        HashSet<Object> keys = new HashSet<Object>();
+        keys.add("foo");
+        map1.getAll(keys);
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testGetAllOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        HashSet<Object> keys = new HashSet<Object>();
+        keys.add("foo");
+        map4.getAll(keys);
+    }
+
+    @Test
+    public void testGetEntryViewOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.getEntryView("foo");
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testGetEntryViewOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.getEntryView("foo");
+    }
+
+    @Test
+    public void testRemoveOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.remove("foo");
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testRemoveOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.remove("foo");
+    }
+
+    @Test
+    public void testRemoveIfHasValueOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.remove("foo", "bar");
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testRemoveIfHasValueOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.remove("foo", "bar");
+    }
+
+    @Test
+    public void testRemoveAsyncOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        Future<Object> foo = map1.removeAsync("foo");
+        foo.get();
+    }
+
+    @Test(expected = ExecutionException.class)
+    public void testRemoveAsyncOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        Future<Object> foo = map4.removeAsync("foo");
+        foo.get();
+    }
+
+    @Test
+    public void testDeleteOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.delete("foo");
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testDeleteOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.delete("foo");
+    }
+
+    @Test
+    public void testClearOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.clear();
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testClearOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.clear();
+    }
+
+    @Test
+    public void testSetOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.set("foo", "bar");
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testSetOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.set("foo", "bar");
+    }
+
+    @Test
+    public void testReplaceOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.replace("foo", "bar");
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testReplaceOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.replace("foo", "bar");
+    }
+
+    @Test
+    public void testReplaceIfOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.replace("foo", "bar", "baz");
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testReplaceIfOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.replace("foo", "bar", "baz");
+    }
+
+    @Test
+    public void testTryRemoveOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.tryRemove("foo", 5, TimeUnit.SECONDS);
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testTryRemoveOperationThrowsExceptionWhenQuorumSizeNotMet() {
+        map4.tryRemove("foo", 5, TimeUnit.SECONDS);
+    }
+
+    @Test
+    public void testFlushOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.flush();
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testFlushOperationThrowsExceptionWhenQuorumSizeNotMet() {
+        map4.flush();
+    }
+
+    @Test
+    public void testEvictAllOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.evictAll();
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testEvictAllOperationThrowsExceptionWhenQuorumSizeNotMet() {
+        map4.evictAll();
+    }
+
+    @Test
+    public void testEvictOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.evict("foo");
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testEvictOperationThrowsExceptionWhenQuorumSizeNotMet() {
+        map4.evict("foo");
+    }
+
+    @Test
+    public void testContainsKeyOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.containsKey("foo");
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testContainsKeyOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.containsKey("foo");
+    }
+
+    @Test
+    public void testContainsValueOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.containsValue("foo");
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testContainsValueOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.containsValue("foo");
+    }
+
+    @Test
+    public void testKeySetOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.keySet();
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testKeySetOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.keySet();
+    }
+
+
+    @Test
+    public void testValuesOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.values();
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testValuesOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.values();
+    }
+
+    @Test
+    public void testEntrySetOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.entrySet();
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testEntrySetOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.entrySet();
+    }
+
+    @Test
+    public void testAddIndexOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.addIndex("foo", false);
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testAddIndexOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.addIndex("foo", false);
+    }
+
+    @Test
+    public void testAddInterceptorOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.addInterceptor(new SimpleInterceptor());
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testAddInterceptorOperationThrowsExceptionWhenQuorumSizeNotMet() {
+        map4.addInterceptor(new SimpleInterceptor());
+    }
+
+    @Test
+    public void testRemoveInterceptorOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.removeInterceptor("foo");
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testRemoveInterceptorOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.removeInterceptor("foo");
+    }
+
+    @Test
+    public void testExecuteOnKeyOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.executeOnKey("foo", new LoggingEntryProcessor());
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testExecuteOnKeyOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.executeOnKey("foo", new LoggingEntryProcessor());
+    }
+
+    @Test
+    public void testExecuteOnKeysOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        HashSet<Object> keys = new HashSet<Object>();
+        keys.add("foo");
+        map1.executeOnKey(keys, new LoggingEntryProcessor());
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testExecuteOnKeysOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        HashSet<Object> keys = new HashSet<Object>();
+        keys.add("foo");
+        map4.executeOnKey(keys, new LoggingEntryProcessor());
+    }
+
+    @Test
+    public void testExecuteOnEntriesOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.executeOnEntries(new LoggingEntryProcessor());
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testExecuteOnEntriesOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.executeOnEntries(new LoggingEntryProcessor());
+    }
+
+    @Test
+    public void testSubmmitToKeyOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        Future foo = map1.submitToKey("foo", new LoggingEntryProcessor());
+        foo.get();
+    }
+
+    @Test(expected = ExecutionException.class)
+    public void testSubmmitToKeyOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        Future foo = map4.submitToKey("foo", new LoggingEntryProcessor());
+        foo.get();
+    }
+
+    @Ignore
+    @Test(expected = QuorumException.class)
+    public void testLockOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.lock("foo");
+    }
+
+    @Ignore
+    @Test(expected = QuorumException.class)
+    public void testTryLockOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.tryLock("foo");
+    }
+
+    @Ignore
+    @Test(expected = QuorumException.class)
+    public void testUnlockOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.unlock("foo");
+    }
+
+    @Ignore
+    @Test(expected = QuorumException.class)
+    public void testIsLockedOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.isLocked("foo");
+    }
+
+    @Ignore
+    @Test(expected = QuorumException.class)
+    public void testForceUnlockOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.forceUnlock("foo");
+    }
+
+
+}

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/ClientMapWriteQuorumTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/ClientMapWriteQuorumTest.java
@@ -1,0 +1,379 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.hazelcast.client.quorum;
+
+import com.hazelcast.client.HazelcastClient;
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.instance.HazelcastInstanceFactory;
+import com.hazelcast.nio.Address;
+import com.hazelcast.quorum.PartitionedCluster;
+import com.hazelcast.config.QuorumConfig;
+import com.hazelcast.quorum.QuorumException;
+import com.hazelcast.quorum.QuorumType;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static com.hazelcast.map.InterceptorTest.SimpleInterceptor;
+import static com.hazelcast.map.TempData.LoggingEntryProcessor;
+import static com.hazelcast.test.HazelcastTestSupport.getNode;
+import static com.hazelcast.test.HazelcastTestSupport.randomMapName;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class ClientMapWriteQuorumTest {
+
+    static PartitionedCluster cluster;
+    static IMap<Object, Object> map1;
+    static IMap<Object, Object> map2;
+    static IMap<Object, Object> map3;
+    static IMap<Object, Object> map4;
+    static IMap<Object, Object> map5;
+
+    static HazelcastInstance c1;
+    static HazelcastInstance c2;
+    static HazelcastInstance c3;
+    static HazelcastInstance c4;
+    static HazelcastInstance c5;
+
+    private static final String MAP_NAME_PREFIX = "quorum";
+    private static final String QUORUM_ID = "threeNodeQuorumRule";
+
+    @BeforeClass
+    public static void initialize() throws InterruptedException {
+        QuorumConfig quorumConfig = new QuorumConfig();
+        quorumConfig.setName(QUORUM_ID);
+        quorumConfig.setEnabled(true);
+        quorumConfig.setSize(3);
+        quorumConfig.setType(QuorumType.WRITE);
+        MapConfig mapConfig = new MapConfig(MAP_NAME_PREFIX + "*");
+        mapConfig.setQuorumName(QUORUM_ID);
+        cluster = new PartitionedCluster().partitionFiveMembersThreeAndTwo(mapConfig, quorumConfig);
+        initializeClients();
+    }
+
+    private static void initializeClients() {
+        c1 = HazelcastClient.newHazelcastClient(getClientConfig(cluster.h1));
+        c2 = HazelcastClient.newHazelcastClient(getClientConfig(cluster.h2));
+        c3 = HazelcastClient.newHazelcastClient(getClientConfig(cluster.h3));
+        c4 = HazelcastClient.newHazelcastClient(getClientConfig(cluster.h4));
+        c5 = HazelcastClient.newHazelcastClient(getClientConfig(cluster.h5));
+    }
+
+    private static ClientConfig getClientConfig(HazelcastInstance instance) {
+        ClientConfig clientConfig = new ClientConfig();
+        Address address = getNode(instance).address;
+        clientConfig.getNetworkConfig().addAddress(address.getHost() + ":" + address.getPort());
+        clientConfig.getGroupConfig().setName(instance.getConfig().getGroupConfig().getName());
+        return clientConfig;
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        String mapName = randomMapName(MAP_NAME_PREFIX);
+        map1 = c1.getMap(mapName);
+        map2 = c2.getMap(mapName);
+        map3 = c3.getMap(mapName);
+        map4 = c4.getMap(mapName);
+        map5 = c5.getMap(mapName);
+    }
+
+    @AfterClass
+    public static void killAllHazelcastInstances() throws IOException {
+        HazelcastInstanceFactory.terminateAll();
+    }
+    @Test
+    public void testPutOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.put("foo", "bar");
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testPutOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.put("foo", "bar");
+    }
+
+
+    @Test
+    public void testTryPutOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.tryPut("foo", "bar", 5, TimeUnit.SECONDS);
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testTryPutOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.tryPut("foo", "bar", 5, TimeUnit.SECONDS);
+    }
+
+    @Test
+    public void testPutTransientOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.putTransient("foo", "bar", 5, TimeUnit.SECONDS);
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testPutTransientOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.putTransient("foo", "bar", 5, TimeUnit.SECONDS);
+    }
+
+    @Test
+    public void testPutIfAbsentOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.putIfAbsent("foo", "bar");
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testPutIfAbsentOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.putIfAbsent("foo", "bar");
+    }
+
+    @Test
+    public void testPutAsyncOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        Future<Object> foo = map1.putAsync("foo", "bar");
+        foo.get();
+    }
+
+    @Test(expected = ExecutionException.class)
+    public void testPutAsyncOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        Future<Object> foo = map4.putAsync("foo", "bar");
+        foo.get();
+    }
+
+    @Test
+    public void testPutAllOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        HashMap<Object, Object> map = new HashMap<Object, Object>();
+        map.put("foo", "bar");
+        map1.putAll(map);
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testPutAllOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        HashMap<Object, Object> map = new HashMap<Object, Object>();
+        map.put("foo", "bar");
+        map4.putAll(map);
+    }
+
+    @Test
+    public void testRemoveOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.remove("foo");
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testRemoveOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.remove("foo");
+    }
+
+    @Test
+    public void testRemoveIfHasValueOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.remove("foo", "bar");
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testRemoveIfHasValueOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.remove("foo", "bar");
+    }
+
+    @Test
+    public void testRemoveAsyncOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        Future<Object> foo = map1.removeAsync("foo");
+        foo.get();
+    }
+
+    @Test(expected = ExecutionException.class)
+    public void testRemoveAsyncOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        Future<Object> foo = map4.removeAsync("foo");
+        foo.get();
+    }
+
+    @Test
+    public void testDeleteOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.delete("foo");
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testDeleteOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.delete("foo");
+    }
+
+    @Test
+    public void testClearOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.clear();
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testClearOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.clear();
+    }
+
+    @Test
+    public void testSetOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.set("foo", "bar");
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testSetOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.set("foo", "bar");
+    }
+
+    @Test
+    public void testReplaceOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.replace("foo", "bar");
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testReplaceOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.replace("foo", "bar");
+    }
+
+    @Test
+    public void testReplaceIfOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.replace("foo", "bar", "baz");
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testReplaceIfOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.replace("foo", "bar", "baz");
+    }
+
+    @Test
+    public void testTryRemoveOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.tryRemove("foo", 5, TimeUnit.SECONDS);
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testTryRemoveOperationThrowsExceptionWhenQuorumSizeNotMet() {
+        map4.tryRemove("foo", 5, TimeUnit.SECONDS);
+    }
+
+    @Test
+    public void testFlushOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.flush();
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testFlushOperationThrowsExceptionWhenQuorumSizeNotMet() {
+        map4.flush();
+    }
+
+    @Test
+    public void testEvictAllOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.evictAll();
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testEvictAllOperationThrowsExceptionWhenQuorumSizeNotMet() {
+        map4.evictAll();
+    }
+
+    @Test
+    public void testEvictOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.evict("foo");
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testEvictOperationThrowsExceptionWhenQuorumSizeNotMet() {
+        map4.evict("foo");
+    }
+
+    @Test
+    public void testAddIndexOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.addIndex("foo", false);
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testAddIndexOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.addIndex("foo", false);
+    }
+
+    @Test
+    public void testAddInterceptorOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.addInterceptor(new SimpleInterceptor());
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testAddInterceptorOperationThrowsExceptionWhenQuorumSizeNotMet() {
+        map4.addInterceptor(new SimpleInterceptor());
+    }
+
+    @Test
+    public void testRemoveInterceptorOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.removeInterceptor("foo");
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testRemoveInterceptorOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.removeInterceptor("foo");
+    }
+
+    @Test
+    public void testExecuteOnKeyOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.executeOnKey("foo", new LoggingEntryProcessor());
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testExecuteOnKeyOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.executeOnKey("foo", new LoggingEntryProcessor());
+    }
+
+    @Test
+    public void testExecuteOnKeysOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        HashSet<Object> keys = new HashSet<Object>();
+        keys.add("foo");
+        map1.executeOnKey(keys, new LoggingEntryProcessor());
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testExecuteOnKeysOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        HashSet<Object> keys = new HashSet<Object>();
+        keys.add("foo");
+        map4.executeOnKey(keys, new LoggingEntryProcessor());
+    }
+
+    @Test
+    public void testExecuteOnEntriesOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.executeOnEntries(new LoggingEntryProcessor());
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testExecuteOnEntriesOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.executeOnEntries(new LoggingEntryProcessor());
+    }
+
+    @Test
+    public void testSubmmitToKeyOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        Future foo = map1.submitToKey("foo", new LoggingEntryProcessor());
+        foo.get();
+    }
+
+    @Test(expected = ExecutionException.class)
+    public void testSubmmitToKeyOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        Future foo = map4.submitToKey("foo", new LoggingEntryProcessor());
+        foo.get();
+    }
+
+
+}

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/ClientTransactionalMapQuorumTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/ClientTransactionalMapQuorumTest.java
@@ -1,0 +1,286 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.hazelcast.client.quorum;
+
+import com.hazelcast.client.HazelcastClient;
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.TransactionalMap;
+import com.hazelcast.instance.HazelcastInstanceFactory;
+import com.hazelcast.nio.Address;
+import com.hazelcast.query.TruePredicate;
+import com.hazelcast.quorum.PartitionedCluster;
+import com.hazelcast.config.QuorumConfig;
+import com.hazelcast.test.HazelcastTestRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.test.annotation.RunParallel;
+import com.hazelcast.transaction.TransactionContext;
+import com.hazelcast.transaction.TransactionException;
+import com.hazelcast.transaction.TransactionOptions;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.concurrent.TimeUnit;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import static com.hazelcast.test.HazelcastTestSupport.getNode;
+import static com.hazelcast.test.HazelcastTestSupport.randomMapName;
+import static com.hazelcast.transaction.TransactionOptions.TransactionType.LOCAL;
+import static com.hazelcast.transaction.TransactionOptions.TransactionType.TWO_PHASE;
+
+@RunParallel
+@RunWith(HazelcastTestRunner.class)
+@Category(QuickTest.class)
+public class ClientTransactionalMapQuorumTest {
+
+    static PartitionedCluster cluster;
+    private static final String MAP_NAME_PREFIX = "quorum";
+    private static final String QUORUM_ID = "threeNodeQuorumRule";
+    static HazelcastInstance c1;
+    static HazelcastInstance c2;
+    static HazelcastInstance c3;
+    static HazelcastInstance c4;
+    static HazelcastInstance c5;
+
+
+    @Parameterized.Parameter(0)
+    public TransactionOptions options;
+
+
+    @Parameterized.Parameters(name = "Executing: {0}")
+    public static Collection<Object[]> parameters() {
+
+        TransactionOptions localOption = TransactionOptions.getDefault();
+        localOption.setTransactionType(LOCAL);
+
+        TransactionOptions twoPhaseOption = TransactionOptions.getDefault();
+        twoPhaseOption.setTransactionType(TWO_PHASE);
+
+        return Arrays.asList(
+                new Object[]{twoPhaseOption}, //
+                new Object[]{localOption} //
+        );
+    }
+
+    @BeforeClass
+    public static void initialize() throws InterruptedException {
+        QuorumConfig quorumConfig = new QuorumConfig();
+        quorumConfig.setEnabled(true);
+        quorumConfig.setSize(3);
+        quorumConfig.setName(QUORUM_ID);
+
+        MapConfig mapConfig = new MapConfig(MAP_NAME_PREFIX + "*");
+        mapConfig.setQuorumName(QUORUM_ID);
+        cluster = new PartitionedCluster().partitionFiveMembersThreeAndTwo(mapConfig, quorumConfig);
+        initializeClients();
+    }
+
+    private static void initializeClients() {
+        c1 = HazelcastClient.newHazelcastClient(getClientConfig(cluster.h1));
+        c2 = HazelcastClient.newHazelcastClient(getClientConfig(cluster.h2));
+        c3 = HazelcastClient.newHazelcastClient(getClientConfig(cluster.h3));
+        c4 = HazelcastClient.newHazelcastClient(getClientConfig(cluster.h4));
+        c5 = HazelcastClient.newHazelcastClient(getClientConfig(cluster.h5));
+    }
+
+    private static ClientConfig getClientConfig(HazelcastInstance instance) {
+        ClientConfig clientConfig = new ClientConfig();
+        Address address = getNode(instance).address;
+        clientConfig.getNetworkConfig().addAddress(address.getHost() + ":" + address.getPort());
+        clientConfig.getGroupConfig().setName(instance.getConfig().getGroupConfig().getName());
+        return clientConfig;
+    }
+
+
+    @AfterClass
+    public static void killAllHazelcastInstances() throws IOException {
+        HazelcastInstanceFactory.terminateAll();
+    }
+
+
+    @Test(expected = TransactionException.class)
+    public void testTxPutThrowsExceptionWhenQuorumSizeNotMet() {
+        TransactionContext transactionContext = c4.newTransactionContext(options);
+        transactionContext.beginTransaction();
+        TransactionalMap<Object, Object> map = transactionContext.getMap(randomMapName(MAP_NAME_PREFIX));
+        map.put("foo", "bar");
+        transactionContext.commitTransaction();
+    }
+
+    @Test(expected = TransactionException.class)
+    public void testTxGetThrowsExceptionWhenQuorumSizeNotMet() {
+        TransactionContext transactionContext = c4.newTransactionContext(options);
+        transactionContext.beginTransaction();
+        TransactionalMap<Object, Object> map = transactionContext.getMap(randomMapName(MAP_NAME_PREFIX));
+        map.get("foo");
+        transactionContext.commitTransaction();
+    }
+
+
+    @Test(expected = TransactionException.class)
+    public void testTxGetForUpdateThrowsExceptionWhenQuorumSizeNotMet() {
+        TransactionContext transactionContext = c4.newTransactionContext(options);
+        transactionContext.beginTransaction();
+        TransactionalMap<Object, Object> map = transactionContext.getMap(randomMapName(MAP_NAME_PREFIX));
+        map.getForUpdate("foo");
+        transactionContext.commitTransaction();
+    }
+
+    @Test(expected = TransactionException.class)
+    public void testTxRemoveThrowsExceptionWhenQuorumSizeNotMet() {
+        TransactionContext transactionContext = c4.newTransactionContext(options);
+        transactionContext.beginTransaction();
+        TransactionalMap<Object, Object> map = transactionContext.getMap(randomMapName(MAP_NAME_PREFIX));
+        map.remove("foo");
+        transactionContext.commitTransaction();
+    }
+
+
+    @Test(expected = TransactionException.class)
+    public void testTxRemoveValueThrowsExceptionWhenQuorumSizeNotMet() {
+        TransactionContext transactionContext = c4.newTransactionContext(options);
+        transactionContext.beginTransaction();
+        TransactionalMap<Object, Object> map = transactionContext.getMap(randomMapName(MAP_NAME_PREFIX));
+        map.remove("foo", "bar");
+        transactionContext.commitTransaction();
+    }
+
+    @Test(expected = TransactionException.class)
+    public void testTxDeleteThrowsExceptionWhenQuorumSizeNotMet() {
+        TransactionContext transactionContext = c4.newTransactionContext(options);
+        transactionContext.beginTransaction();
+        TransactionalMap<Object, Object> map = transactionContext.getMap(randomMapName(MAP_NAME_PREFIX));
+        map.delete("foo");
+        transactionContext.commitTransaction();
+    }
+
+    @Test(expected = TransactionException.class)
+    public void testTxSetThrowsExceptionWhenQuorumSizeNotMet() {
+        TransactionContext transactionContext = c4.newTransactionContext(options);
+        transactionContext.beginTransaction();
+        TransactionalMap<Object, Object> map = transactionContext.getMap(randomMapName(MAP_NAME_PREFIX));
+        map.set("foo", "bar");
+        transactionContext.commitTransaction();
+    }
+
+    @Test(expected = TransactionException.class)
+    public void testTxPutWithTTLThrowsExceptionWhenQuorumSizeNotMet() {
+        TransactionContext transactionContext = c4.newTransactionContext(options);
+        transactionContext.beginTransaction();
+        TransactionalMap<Object, Object> map = transactionContext.getMap(randomMapName(MAP_NAME_PREFIX));
+        map.put("foo", "bar", 10, TimeUnit.SECONDS);
+        transactionContext.commitTransaction();
+    }
+
+    @Test(expected = TransactionException.class)
+    public void testTxPutIfAbsentThrowsExceptionWhenQuorumSizeNotMet() {
+        TransactionContext transactionContext = c4.newTransactionContext(options);
+        transactionContext.beginTransaction();
+        TransactionalMap<Object, Object> map = transactionContext.getMap(randomMapName(MAP_NAME_PREFIX));
+        map.putIfAbsent("foo", "bar");
+        transactionContext.commitTransaction();
+    }
+
+    @Test(expected = TransactionException.class)
+    public void testTxReplaceThrowsExceptionWhenQuorumSizeNotMet() {
+        TransactionContext transactionContext = c4.newTransactionContext(options);
+        transactionContext.beginTransaction();
+        TransactionalMap<Object, Object> map = transactionContext.getMap(randomMapName(MAP_NAME_PREFIX));
+        map.replace("foo", "bar");
+        transactionContext.commitTransaction();
+    }
+
+    @Test(expected = TransactionException.class)
+    public void testTxReplaceExpectedValueThrowsExceptionWhenQuorumSizeNotMet() {
+        TransactionContext transactionContext = c4.newTransactionContext(options);
+        transactionContext.beginTransaction();
+        TransactionalMap<Object, Object> map = transactionContext.getMap(randomMapName(MAP_NAME_PREFIX));
+        map.replace("foo", "bar", "baz");
+        transactionContext.commitTransaction();
+    }
+
+    @Test(expected = TransactionException.class)
+    public void testTxSizeThrowsExceptionWhenQuorumSizeNotMet() {
+        TransactionContext transactionContext = c4.newTransactionContext(options);
+        transactionContext.beginTransaction();
+        TransactionalMap<Object, Object> map = transactionContext.getMap(randomMapName(MAP_NAME_PREFIX));
+        map.size();
+        transactionContext.commitTransaction();
+    }
+
+    @Test(expected = TransactionException.class)
+    public void testTxContainsKeyThrowsExceptionWhenQuorumSizeNotMet() {
+        TransactionContext transactionContext = c4.newTransactionContext(options);
+        transactionContext.beginTransaction();
+        TransactionalMap<Object, Object> map = transactionContext.getMap(randomMapName(MAP_NAME_PREFIX));
+        map.containsKey("foo");
+        transactionContext.commitTransaction();
+    }
+
+
+    @Test(expected = TransactionException.class)
+    public void testTxIsEmptyThrowsExceptionWhenQuorumSizeNotMet() {
+        TransactionContext transactionContext = c4.newTransactionContext(options);
+        transactionContext.beginTransaction();
+        TransactionalMap<Object, Object> map = transactionContext.getMap(randomMapName(MAP_NAME_PREFIX));
+        map.isEmpty();
+        transactionContext.commitTransaction();
+    }
+
+    @Test(expected = TransactionException.class)
+    public void testTxKeySetThrowsExceptionWhenQuorumSizeNotMet() {
+        TransactionContext transactionContext = c4.newTransactionContext(options);
+        transactionContext.beginTransaction();
+        TransactionalMap<Object, Object> map = transactionContext.getMap(randomMapName(MAP_NAME_PREFIX));
+        map.keySet();
+        transactionContext.commitTransaction();
+    }
+
+    @Test(expected = TransactionException.class)
+    public void testTxKeySetWithPredicateThrowsExceptionWhenQuorumSizeNotMet() {
+        TransactionContext transactionContext = c4.newTransactionContext(options);
+        transactionContext.beginTransaction();
+        TransactionalMap<Object, Object> map = transactionContext.getMap(randomMapName(MAP_NAME_PREFIX));
+        map.keySet(TruePredicate.INSTANCE);
+        transactionContext.commitTransaction();
+    }
+
+    @Test(expected = TransactionException.class)
+    public void testTxValuesThrowsExceptionWhenQuorumSizeNotMet() {
+        TransactionContext transactionContext = c4.newTransactionContext(options);
+        transactionContext.beginTransaction();
+        TransactionalMap<Object, Object> map = transactionContext.getMap(randomMapName(MAP_NAME_PREFIX));
+        map.values();
+        transactionContext.commitTransaction();
+    }
+
+    @Test(expected = TransactionException.class)
+    public void testTxValuesWithPredicateThrowsExceptionWhenQuorumSizeNotMet() {
+        TransactionContext transactionContext = c4.newTransactionContext(options);
+        transactionContext.beginTransaction();
+        TransactionalMap<Object, Object> map = transactionContext.getMap(randomMapName(MAP_NAME_PREFIX));
+        map.values(TruePredicate.INSTANCE);
+        transactionContext.commitTransaction();
+    }
+
+}

--- a/hazelcast-documentation/src/ClusterQuorum.md
+++ b/hazelcast-documentation/src/ClusterQuorum.md
@@ -2,9 +2,9 @@
 
 Hazelcast Cluster Quorum enables you to define the minimum number of machines required in a cluster for the cluster to remain in an operational state. If the number of machines is below the defined minimum at any time, the operations are rejected and the rejected operations return a `QuorumException` to their callers.
 
-When a network partitioning happens, Hazelcast behaves as an AP solution (Availability and Partitioning Tolerance). With Cluster Quorum, you can tune your Hazelcast instance towards a CP solution (Consistency and Partitioning Tolerance), by rejecting updates with a minimum threshold.
+When a network partitioning happens, by default Hazelcast chooses to be available. With Cluster Quorum, you can tune your Hazelcast instance towards to achieve better consistency, by rejecting updates with a minimum threshold, this reduces the chance that number of concurrent updates to an entry from two partitioned clusters . Note that the consistency defined here is best effort not full or strong consistency.
 
-By default, Hazelcast invokes Cluster Quorum when any change happens on the member list. You can manually trigger Cluster Quorum at any time.
+By default, Hazelcast invokes a quorum when a change happens on the member list. You can also provide quorum results to the quorum service over the `Quorum` instance and hazelcast can act on them.
 
 ![image](images/NoteSmall.jpg) ***NOTE:*** *Currently cluster quorum only applies to the Map and Transactional Map, support for other data structures will be added soon.*
 
@@ -50,50 +50,11 @@ config.addMapConfig(mapConfig);
 ```
 
 
-#### Custom Quorum Resolvers
-Cluster Quorum lets you provide custom quorum resolvers. With custom resolvers, instead of sticking to a fixed size (as in calling `quorumConfig.setSize()` in the example above), you can implement any quorum resolution logic of your own to resolve the size. Cluster Quorum will call your quorum resolver when a quorum happens on the member.
-
-Your custom resolver must implement the `QuorumResolver` interface that can be seen below.
-
-```java
-public interface QuorumResolver {
-    boolean resolve(MembershipEvent membershipEvent);
-}
-```
-
-You can configure custom resolvers like below.
-```java
-QuorumConfig quorumConfig = new QuorumConfig();
-quorumConfig.setName("quorumRuleWithThreeNodes")
-quorumConfig.setEnabled(true);
-
-// You can either provide a class name of your implementation,
-// or you can directly set instance of your implementation
-quorumConfig.setQuorumResolverClassName("com.user.CustomQuorumResolver");
-quorumConfig.setQuorumResolverImplementation(new CustomQuorumResolver() {
-  @Override
-  public boolean resolve(MembershipEvent membershipEvent) {
-    if (membershipEvent.getMembers().size() > 3) {
-      return true;
-    }
-    return false;
-  }
-})
-
-MapConfig mapConfig = new MapConfig();
-mapConfig.setQuorumName("quorumRuleWithThreeNodes");
-
-Config config = new Config();
-config.addQuorumConfig(quorumConfig);
-config.addMapConfig(mapConfig);
-
-```
-
 #### Quorum Listeners
-You can register quorum listeners to be notified about quorum results. Quorum listeners are local to the node that they are registered, so they receive only events occurred on that local node. 
+You can register quorum listeners to be notified about quorum results. Quorum listeners are local to the node that they are registered, so they receive only events occurred on that local node.
 
-You can configure quorum listeners via declarative or programmatic configuration. The following are example configurations.
- 
+Quorum listeners can be configured via declarative or programmatic configuration. The following are the example configurations.
+
 ##### Declarative Configuration
 
 ```xml
@@ -101,7 +62,7 @@ You can configure quorum listeners via declarative or programmatic configuration
 ....
 <quorum name="quorumRuleWithThreeNodes" enabled=true>
   <quorum-size>3</quorum-size>
-  <quorum-listeners> 
+  <quorum-listeners>
     <quorum-listener>com.company.quorum.ThreeNodeQuorumListener </quorum-listener>
   </quorum-listeners>
 </quorum>
@@ -120,11 +81,12 @@ QuorumListenerConfig listenerConfig = new QuorumListenerConfig();
 // You can either directly set quorum listener implementation of your own
 listenerConfig.setImplementation(new QuorumListener() {
             @Override
-            public void onQuorumSuccess(QuorumEvent quorumEvent) {
-            }
-
-            @Override
-            public void onQuorumFailure(QuorumEvent quorumEvent) {
+            public void onChange(QuorumEvent quorumEvent) {
+              if (QuorumResult.PRESENT.equals(quorumEvent.getType())) {
+                // handle quorum presence
+              } else if (QuorumResult.ABSENT.equals(quorumEvent.getType())) {
+                // handle quorum absence
+              }
             }
         });
 // Or you can give the name of the class that implements QuorumListener interface.
@@ -146,6 +108,74 @@ config.addMapConfig(mapConfig);
 ```
 
 
-#### Manually Triggering Cluster Quorum
-???
 
+
+#### Quorum Service
+Quorum service gives an ability to provide quorum results of your own over the `Quorum` instances. With quorum instances, instead of sticking to a fixed size quorum check, you can implement any quorum resolution logic of your own. You just need to notify the result to hazelcast. Hazelcast will allow or reject operations that requires quorum based on the provided quorum result.
+
+
+##### Quorum
+
+Quorum instances let you to provide quorum result of your own to the hazelcast quorum service.
+
+Here is the Quorum interface that you can interact with.
+```java
+/**
+ * {@link Quorum} can be used to notify quorum service for a particular quorum result that originated externally.
+ */
+public interface Quorum {
+    /**
+     * Returns latest presence/absence of the quorum.
+     *
+     * @return boolean presence of the quorum
+     */
+    boolean isPresent();
+
+    /**
+     * Sets given quorum result as the result of the quorum locally.
+     * Quorum aware operations on this node will see this result
+     *
+     * @param presence
+     */
+    void setLocalResult(boolean presence);
+
+    /**
+     * Sets given quorum result as the result of the quorum on all cluster members.
+     * Quorum aware operations on the cluster will see this result
+     * <p/>
+     * Note: This method is not thread-safe. You should be providing quorum results from single place,
+     * If you update quorum state from multiple nodes with different values, you might see inconsistent quorum
+     * states between cluster members.
+     *
+     * @param presence
+     */
+    void setGlobalResult(boolean presence);
+}
+}
+```
+You can retrieve quorum instance for a particular quorum over the quorum service. An example can be seen below
+
+```java
+String quorumName = "at-least-one-storage-member";
+QuorumConfig quorumConfig = new QuorumConfig();
+quorumConfig.setName(quorumName)
+quorumConfig.setEnabled(true);
+
+MapConfig mapConfig = new MapConfig();
+mapConfig.setQuorumName(quorumName);
+
+Config config = new Config();
+config.addQuorumConfig(quorumConfig);
+config.addMapConfig(mapConfig);
+
+HazelcastInstance hazelcastInstance = Hazelcast.newHazelcastInstance(config);
+QuorumService quorumService = hazelcastInstance.getQuorumService();
+Quorum quorum = quorumService.getQuorum(quorumName);
+
+// from now on you can listen to any event in the cluster that you might be interested, make quorum then notify the hazelcast with the result.
+quorum.setResult(false); // this will reject operations for the particular quorum.
+
+```
+
+
+Imagine that you have a use case like in your cluster there is a special member which has an ability to make heavy calculations, and if that special member is not present in the cluster you don't want to try processing entries. You can achieve to implement such scenario with quorums.  

--- a/hazelcast-ra/hazelcast-jca/src/main/java/com/hazelcast/jca/HazelcastConnectionImpl.java
+++ b/hazelcast-ra/hazelcast-jca/src/main/java/com/hazelcast/jca/HazelcastConnectionImpl.java
@@ -46,6 +46,7 @@ import com.hazelcast.core.TransactionalQueue;
 import com.hazelcast.core.TransactionalSet;
 import com.hazelcast.logging.LoggingService;
 import com.hazelcast.mapreduce.JobTracker;
+import com.hazelcast.quorum.QuorumService;
 import com.hazelcast.transaction.TransactionContext;
 import com.hazelcast.transaction.TransactionException;
 import com.hazelcast.transaction.TransactionOptions;
@@ -207,6 +208,11 @@ public class HazelcastConnectionImpl implements HazelcastConnection {
     @Override
     public PartitionService getPartitionService() {
         return getHazelcastInstance().getPartitionService();
+    }
+
+    @Override
+    public QuorumService getQuorumService() {
+        return getHazelcastInstance().getQuorumService();
     }
 
     @Override

--- a/hazelcast-spring/src/main/resources/hazelcast-spring-3.5.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-3.5.xsd
@@ -220,6 +220,7 @@
                                             </xs:sequence>
                                         </xs:complexType>
                                     </xs:element>
+                                    <xs:element name="quorum-ref" minOccurs="0" maxOccurs="1"/>
                                 </xs:sequence>
                                 <xs:attribute name="name" use="required" type="xs:string"/>
                                 <xs:attribute name="in-memory-format" use="optional" type="xs:string" default="BINARY">
@@ -378,6 +379,7 @@
                                         </xs:documentation>
                                     </xs:annotation>
                                 </xs:attribute>
+
                             </xs:complexType>
                         </xs:element>
                         <xs:element name="cache" minOccurs="0" maxOccurs="unbounded">
@@ -872,6 +874,8 @@
                             </xs:unique>
                         </xs:element>
                         <xs:element name="services" type="services" minOccurs="0" maxOccurs="1"/>
+                        <xs:element name="quorum" type="quorum" minOccurs="0" maxOccurs="1"/>
+
                     </xs:sequence>
                 </xs:extension>
             </xs:complexContent>
@@ -2033,4 +2037,47 @@
             <xs:enumeration value="POOLED"/>
         </xs:restriction>
     </xs:simpleType>
+
+
+    <xs:complexType name="quorum">
+        <xs:all>
+            <xs:element name="quorum-size" type="quorum-size" maxOccurs="1"/>
+            <xs:element name="quorum-type" type="quorum-type" maxOccurs="1"/>
+            <xs:element name="quorum-function-class-name" type="xs:string" maxOccurs="1"/>
+            <xs:element name="quorum-listeners" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="quorum-listener" type="quorum-listener" maxOccurs="unbounded"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+        </xs:all>
+        <xs:attribute name="enabled" type="xs:boolean" use="required"/>
+        <xs:attribute name="name" use="required">
+            <xs:simpleType>
+                <xs:restriction base="xs:string"/>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:simpleType name="quorum-type">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="READ"/>
+            <xs:enumeration value="WRITE"/>
+            <xs:enumeration value="READ_WRITE"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="quorum-size">
+        <xs:restriction base="xs:int">
+            <xs:minInclusive value="0"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="quorum-listener">
+        <xs:complexContent>
+            <xs:extension base="listener">
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
 </xs:schema>

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/DummyQuorumFunction.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/DummyQuorumFunction.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spring;
+
+import com.hazelcast.core.Member;
+import com.hazelcast.quorum.QuorumFunction;
+import java.util.Collection;
+
+public class DummyQuorumFunction implements QuorumFunction {
+    @Override
+    public boolean apply(Collection<Member> members) {
+        return false;
+    }
+}

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/DummyQuorumListener.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/DummyQuorumListener.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.hazelcast.spring;
+
+import com.hazelcast.quorum.QuorumEvent;
+import com.hazelcast.quorum.QuorumListener;
+
+public class DummyQuorumListener implements QuorumListener {
+
+    @Override
+    public void onChange(QuorumEvent quorumEvent) {
+
+    }
+}

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
@@ -78,6 +78,8 @@ import com.hazelcast.nio.serialization.DataSerializableFactory;
 import com.hazelcast.nio.serialization.PortableFactory;
 import com.hazelcast.nio.serialization.StreamSerializer;
 import com.hazelcast.nio.ssl.SSLContextFactory;
+import com.hazelcast.config.QuorumConfig;
+import com.hazelcast.quorum.QuorumType;
 import com.hazelcast.spring.serialization.DummyDataSerializableFactory;
 import com.hazelcast.spring.serialization.DummyPortableFactory;
 import com.hazelcast.test.annotation.QuickTest;
@@ -238,6 +240,7 @@ public class TestFullApplicationContext {
                 fail("unknown index!");
             }
         }
+        assertEquals("my-quorum" , testMapConfig.getQuorumName());
 
         // Test that the testMapConfig has a mapStoreConfig and it is correct
         MapStoreConfig testMapStoreConfig = testMapConfig.getMapStoreConfig();
@@ -664,5 +667,21 @@ public class TestFullApplicationContext {
                 assertTrue(listener.isIncludeValue());
             }
         }
+    }
+
+    @Test
+    public void testQuorumConfig() throws Exception {
+        assertNotNull(config);
+        assertEquals(1, config.getQuorumConfigs().size());
+        QuorumConfig quorumConfig = config.getQuorumConfig("my-quorum");
+        assertNotNull(quorumConfig);
+        assertEquals("my-quorum", quorumConfig.getName());
+        assertEquals("com.hazelcast.spring.DummyQuorumFunction", quorumConfig.getQuorumFunctionClassName());
+        assertEquals(true, quorumConfig.isEnabled());
+        assertEquals(2, quorumConfig.getSize());
+        assertEquals(2, quorumConfig.getListenerConfigs().size());
+        assertEquals(QuorumType.READ, quorumConfig.getType());
+        assertEquals("com.hazelcast.spring.DummyQuorumListener", quorumConfig.getListenerConfigs().get(0).getClassName());
+        assertNotNull(quorumConfig.getListenerConfigs().get(1).getImplementation());
     }
 }

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullcacheconfig-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullcacheconfig-applicationContext-hazelcast.xml
@@ -148,6 +148,7 @@
                     <hz:index attribute="name"/>
                     <hz:index attribute="age" ordered="true"/>
                 </hz:indexes>
+                <hz:quorum-ref>my-quorum</hz:quorum-ref>
             </hz:map>
             <hz:map name="testMap2"
                     backup-count="2"
@@ -267,7 +268,8 @@
                 </hz:serializers>
             </hz:serialization>
 
-            <hz:native-memory enabled="false" allocator-type="POOLED" metadata-space-percentage="10.2" min-block-size="10"
+            <hz:native-memory enabled="false" allocator-type="POOLED" metadata-space-percentage="10.2"
+                              min-block-size="10"
                               page-size="20">
                 <hz:size unit="MEGABYTES" value="256"/>
             </hz:native-memory>
@@ -300,6 +302,15 @@
                 </hz:service>
             </hz:services>
 
+            <hz:quorum enabled="true" name="my-quorum">
+                <hz:quorum-size>2</hz:quorum-size>
+                <hz:quorum-type>READ</hz:quorum-type>
+                <hz:quorum-function-class-name>com.hazelcast.spring.DummyQuorumFunction</hz:quorum-function-class-name>
+                <hz:quorum-listeners>
+                    <hz:quorum-listener class-name="com.hazelcast.spring.DummyQuorumListener"/>
+                    <hz:quorum-listener implementation="dummyQuorumListener"/>
+                </hz:quorum-listeners>
+            </hz:quorum>
         </hz:config>
     </hz:hazelcast>
 
@@ -328,6 +339,7 @@
     <bean id="dummyWanReplication" class="com.hazelcast.spring.DummyWanReplication"/>
     <bean id="dummyMembershipListener" class="com.hazelcast.spring.DummyMembershipListener"/>
     <bean id="dummyEntryListener" class="com.hazelcast.spring.DummyEntryListener"/>
+    <bean id="dummyQuorumListener" class="com.hazelcast.spring.DummyQuorumListener"/>
     <bean id="dummySSLContextFactory" class="com.hazelcast.spring.DummySSLContextFactory"/>
     <bean id="dummySocketInterceptor" class="com.hazelcast.spring.DummySocketInterceptor"/>
 

--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/ClusterProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/ClusterProxy.java
@@ -19,7 +19,6 @@ package com.hazelcast.cluster.impl;
 import com.hazelcast.core.Cluster;
 import com.hazelcast.core.Member;
 import com.hazelcast.core.MembershipListener;
-
 import java.util.Set;
 
 public class ClusterProxy implements Cluster {

--- a/hazelcast/src/main/java/com/hazelcast/config/MapConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MapConfig.java
@@ -18,7 +18,6 @@ package com.hazelcast.config;
 
 import com.hazelcast.map.merge.PutIfAbsentMapMergePolicy;
 import com.hazelcast.partition.InternalPartition;
-
 import java.util.ArrayList;
 import java.util.List;
 
@@ -128,6 +127,8 @@ public class MapConfig {
 
     private PartitioningStrategyConfig partitioningStrategyConfig;
 
+    private String quorumName;
+
     private MapConfigReadOnly readOnly;
 
     public MapConfig(String name) {
@@ -137,6 +138,7 @@ public class MapConfig {
     public MapConfig() {
     }
 
+    //CHECKSTYLE:OFF
     public MapConfig(MapConfig config) {
         this.name = config.name;
         this.backupCount = config.backupCount;
@@ -161,7 +163,9 @@ public class MapConfig {
         this.mapIndexConfigs = new ArrayList<MapIndexConfig>(config.getMapIndexConfigs());
         this.partitioningStrategyConfig = config.partitioningStrategyConfig != null
                 ? new PartitioningStrategyConfig(config.getPartitioningStrategyConfig()) : null;
+        this.quorumName = config.quorumName;
     }
+    //CHECKSTYLE:ON
 
     public MapConfigReadOnly getAsReadOnly() {
         if (readOnly == null) {
@@ -559,6 +563,14 @@ public class MapConfig {
                 && this.readBackupData == other.readBackupData;
     }
 
+    public String getQuorumName() {
+        return quorumName;
+    }
+
+    public void setQuorumName(String quorumName) {
+        this.quorumName = quorumName;
+    }
+
     @Override
     public int hashCode() {
         final int prime = 31;
@@ -642,6 +654,7 @@ public class MapConfig {
         sb.append(", wanReplicationRef=").append(wanReplicationRef);
         sb.append(", entryListenerConfigs=").append(entryListenerConfigs);
         sb.append(", mapIndexConfigs=").append(mapIndexConfigs);
+        sb.append(", quorumName=").append(quorumName);
         sb.append('}');
         return sb.toString();
     }

--- a/hazelcast/src/main/java/com/hazelcast/config/QuorumConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/QuorumConfig.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+import com.hazelcast.quorum.QuorumFunction;
+import com.hazelcast.quorum.QuorumType;
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.hazelcast.quorum.QuorumType.READ_WRITE;
+
+/**
+ * Contains the configuration for cluster quorum.
+ */
+public class QuorumConfig {
+
+    private String name;
+    private boolean enabled;
+    private int size;
+    private List<QuorumListenerConfig> listenerConfigs = new ArrayList<QuorumListenerConfig>();
+    private QuorumType type = READ_WRITE;
+    private String quorumFunctionClassName;
+    private QuorumFunction quorumFunctionImplementation;
+
+    public QuorumConfig() {
+    }
+
+    public QuorumConfig(String name, boolean enabled) {
+        this.name = name;
+        this.enabled = enabled;
+    }
+
+    public QuorumConfig(String name, boolean enabled, int size) {
+        this.name = name;
+        this.enabled = enabled;
+        this.size = size;
+    }
+
+    public QuorumConfig(QuorumConfig quorumConfig) {
+        this.name = quorumConfig.name;
+        this.enabled = quorumConfig.enabled;
+        this.size = quorumConfig.size;
+        this.listenerConfigs = quorumConfig.listenerConfigs;
+        this.type = quorumConfig.type;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public QuorumConfig setName(String name) {
+        this.name = name;
+        return this;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public QuorumConfig setEnabled(boolean enabled) {
+        this.enabled = enabled;
+        return this;
+    }
+
+    public int getSize() {
+        return size;
+    }
+
+    public QuorumConfig setSize(int size) {
+        if (size < 2) {
+            throw new InvalidConfigurationException("Minimum quorum size cannot be less than 2");
+        }
+        this.size = size;
+        return this;
+    }
+
+    public QuorumType getType() {
+        return type;
+    }
+
+    public QuorumConfig setType(QuorumType type) {
+        this.type = type;
+        return this;
+    }
+
+    public List<QuorumListenerConfig> getListenerConfigs() {
+        return listenerConfigs;
+    }
+
+
+    public QuorumConfig setListenerConfigs(List<QuorumListenerConfig> listenerConfigs) {
+        this.listenerConfigs = listenerConfigs;
+        return this;
+    }
+
+    public QuorumConfig addListenerConfig(QuorumListenerConfig listenerConfig) {
+        this.listenerConfigs.add(listenerConfig);
+        return this;
+    }
+
+    public String getQuorumFunctionClassName() {
+        return quorumFunctionClassName;
+    }
+
+    public QuorumConfig setQuorumFunctionClassName(String quorumFunctionClassName) {
+        this.quorumFunctionClassName = quorumFunctionClassName;
+        return this;
+    }
+
+    public QuorumFunction getQuorumFunctionImplementation() {
+        return quorumFunctionImplementation;
+    }
+
+    public QuorumConfig setQuorumFunctionImplementation(QuorumFunction quorumFunctionImplementation) {
+        this.quorumFunctionImplementation = quorumFunctionImplementation;
+        return this;
+    }
+
+    @Override
+    public String toString() {
+        return "QuorumConfig{"
+                + "name='" + name + '\''
+                + ", enabled=" + enabled
+                + ", size=" + size
+                + ", listenerConfigs=" + listenerConfigs
+                + ", quorumFunctionClassName=" + quorumFunctionClassName
+                + ", quorumFunctionImplementation=" + quorumFunctionImplementation
+                + ", type=" + type + '}';
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/config/QuorumListenerConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/QuorumListenerConfig.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+import com.hazelcast.quorum.QuorumListener;
+
+/**
+ * Confiquration class for {@link QuorumListener}
+ */
+public class QuorumListenerConfig extends ListenerConfig {
+
+    public QuorumListenerConfig() {
+    }
+
+    public QuorumListenerConfig(String className) {
+        super(className);
+    }
+
+    public QuorumListenerConfig(QuorumListener implementation) {
+        super(implementation);
+    }
+
+    @Override
+    public QuorumListener getImplementation() {
+        return (QuorumListener) implementation;
+    }
+
+    public ListenerConfig setImplementation(QuorumListener implementation) {
+        return super.setImplementation(implementation);
+    }
+
+    @Override
+    public boolean isIncludeValue() {
+        return false;
+    }
+
+    @Override
+    public boolean isLocal() {
+        return true;
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/config/XmlElements.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/XmlElements.java
@@ -42,7 +42,8 @@ enum XmlElements {
     SERVICES("services", false),
     SECURITY("security", false),
     MEMBER_ATTRIBUTES("member-attributes", false),
-    NATIVE_MEMORY("native-memory", false);
+    NATIVE_MEMORY("native-memory", false),
+    QUORUM("quorum", true);
 
     final String name;
     final boolean multipleOccurrence;

--- a/hazelcast/src/main/java/com/hazelcast/core/Cluster.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/Cluster.java
@@ -85,4 +85,5 @@ public interface Cluster {
      * @return cluster-wide time
      */
     long getClusterTime();
+
 }

--- a/hazelcast/src/main/java/com/hazelcast/core/HazelcastInstance.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/HazelcastInstance.java
@@ -19,6 +19,7 @@ package com.hazelcast.core;
 import com.hazelcast.config.Config;
 import com.hazelcast.logging.LoggingService;
 import com.hazelcast.mapreduce.JobTracker;
+import com.hazelcast.quorum.QuorumService;
 import com.hazelcast.transaction.TransactionContext;
 import com.hazelcast.transaction.TransactionException;
 import com.hazelcast.transaction.TransactionOptions;
@@ -309,6 +310,16 @@ public interface HazelcastInstance {
      * @return the partition service of this Hazelcast instance
      */
     PartitionService getPartitionService();
+
+    /**
+     * Returns the quorum service of this Hazelcast instance.
+     * <p/>
+     * Quorum service can be used to retrieve quorum callbacks which let you to notify quorum results of your own to
+     * the cluster quorum service.
+     *
+     * @return the quorum service of this Hazelcast instance
+     */
+    QuorumService getQuorumService();
 
     /**
      * Returns the client service of this Hazelcast instance.

--- a/hazelcast/src/main/java/com/hazelcast/instance/GroupProperties.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/GroupProperties.java
@@ -255,6 +255,7 @@ public class GroupProperties {
     public static final String PROP_MIGRATION_MIN_DELAY_ON_MEMBER_REMOVED_SECONDS
             = "hazelcast.migration.min.delay.on.member.removed.seconds";
 
+
     /**
      * Using back pressure one can prevent an overload of pending asynchronous backups. Imagine there is a map with a
      * single asynchronous backup, it could happen that producing asynchronous backups happens at a higher rate than
@@ -650,7 +651,6 @@ public class GroupProperties {
         CLIENT_HEARTBEAT_TIMEOUT_SECONDS = new GroupProperty(config, PROP_CLIENT_MAX_NO_HEARTBEAT_SECONDS, "300");
         MIGRATION_MIN_DELAY_ON_MEMBER_REMOVED_SECONDS
                 = new GroupProperty(config, PROP_MIGRATION_MIN_DELAY_ON_MEMBER_REMOVED_SECONDS, "5");
-
         BACKPRESSURE_ENABLED
                 = new GroupProperty(config, PROP_BACKPRESSURE_ENABLED, "false");
         BACKPRESSURE_SYNCWINDOW

--- a/hazelcast/src/main/java/com/hazelcast/instance/HazelcastInstanceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/HazelcastInstanceImpl.java
@@ -64,6 +64,7 @@ import com.hazelcast.mapreduce.impl.MapReduceService;
 import com.hazelcast.memory.MemoryStats;
 import com.hazelcast.multimap.impl.MultiMapService;
 import com.hazelcast.nio.serialization.SerializationService;
+import com.hazelcast.quorum.QuorumService;
 import com.hazelcast.replicatedmap.impl.ReplicatedMapService;
 import com.hazelcast.spi.ProxyService;
 import com.hazelcast.spi.annotation.PrivateApi;
@@ -75,7 +76,6 @@ import com.hazelcast.transaction.TransactionOptions;
 import com.hazelcast.transaction.TransactionalTask;
 import com.hazelcast.util.EmptyStatement;
 import com.hazelcast.util.ExceptionUtil;
-
 import java.util.Collection;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -331,6 +331,11 @@ public class HazelcastInstanceImpl implements HazelcastInstance {
     @Override
     public PartitionService getPartitionService() {
         return node.partitionService.getPartitionServiceProxy();
+    }
+
+    @Override
+    public QuorumService getQuorumService() {
+        return node.nodeEngine.getQuorumService();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/instance/HazelcastInstanceProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/HazelcastInstanceProxy.java
@@ -43,6 +43,7 @@ import com.hazelcast.core.ReplicatedMap;
 import com.hazelcast.logging.LoggingService;
 import com.hazelcast.mapreduce.JobTracker;
 import com.hazelcast.nio.serialization.SerializationService;
+import com.hazelcast.quorum.QuorumService;
 import com.hazelcast.transaction.TransactionContext;
 import com.hazelcast.transaction.TransactionException;
 import com.hazelcast.transaction.TransactionOptions;
@@ -189,6 +190,11 @@ public final class HazelcastInstanceProxy implements HazelcastInstance {
     @Override
     public PartitionService getPartitionService() {
         return getOriginal().getPartitionService();
+    }
+
+    @Override
+    public QuorumService getQuorumService() {
+        return getOriginal().getQuorumService();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/AbstractMapService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/AbstractMapService.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl;
+
+import com.hazelcast.spi.EventPublishingService;
+import com.hazelcast.spi.ManagedService;
+import com.hazelcast.spi.MigrationAwareService;
+import com.hazelcast.spi.PartitionAwareService;
+import com.hazelcast.spi.PostJoinAwareService;
+import com.hazelcast.spi.QuorumAwareService;
+import com.hazelcast.spi.RemoteService;
+import com.hazelcast.spi.ReplicationSupportingService;
+import com.hazelcast.spi.SplitBrainHandlerService;
+import com.hazelcast.spi.StatisticsAwareService;
+import com.hazelcast.spi.TransactionalService;
+
+/**
+ * Base class contains service definitions and initialization methods for {@link com.hazelcast.map.impl.MapService}
+ */
+public abstract class AbstractMapService implements ManagedService, MigrationAwareService,
+        TransactionalService, RemoteService, EventPublishingService<EventData, ListenerAdapter>,
+        PostJoinAwareService, SplitBrainHandlerService, ReplicationSupportingService, StatisticsAwareService,
+        PartitionAwareService, QuorumAwareService {
+
+    protected ManagedService managedService;
+    protected MigrationAwareService migrationAwareService;
+    protected TransactionalService transactionalService;
+    protected RemoteService remoteService;
+    protected EventPublishingService eventPublishingService;
+    protected PostJoinAwareService postJoinAwareService;
+    protected SplitBrainHandlerService splitBrainHandlerService;
+    protected ReplicationSupportingService replicationSupportingService;
+    protected StatisticsAwareService statisticsAwareService;
+    protected PartitionAwareService mapPartitionAwareService;
+    protected QuorumAwareService mapQuorumAwareService;
+    protected MapServiceContext mapServiceContext;
+
+    public void setMapServiceContext(MapServiceContext mapServiceContext) {
+        this.mapServiceContext = mapServiceContext;
+    }
+
+    void setManagedService(ManagedService managedService) {
+        this.managedService = managedService;
+    }
+
+    void setMigrationAwareService(MigrationAwareService migrationAwareService) {
+        this.migrationAwareService = migrationAwareService;
+    }
+
+    void setTransactionalService(TransactionalService transactionalService) {
+        this.transactionalService = transactionalService;
+    }
+
+    void setRemoteService(RemoteService remoteService) {
+        this.remoteService = remoteService;
+    }
+
+    void setEventPublishingService(EventPublishingService eventPublishingService) {
+        this.eventPublishingService = eventPublishingService;
+    }
+
+    void setPostJoinAwareService(PostJoinAwareService postJoinAwareService) {
+        this.postJoinAwareService = postJoinAwareService;
+    }
+
+    void setSplitBrainHandlerService(SplitBrainHandlerService splitBrainHandlerService) {
+        this.splitBrainHandlerService = splitBrainHandlerService;
+    }
+
+    void setReplicationSupportingService(ReplicationSupportingService replicationSupportingService) {
+        this.replicationSupportingService = replicationSupportingService;
+    }
+
+    void setStatisticsAwareService(StatisticsAwareService statisticsAwareService) {
+        this.statisticsAwareService = statisticsAwareService;
+    }
+
+    public void setMapPartitionAwareService(PartitionAwareService mapPartitionAwareService) {
+        this.mapPartitionAwareService = mapPartitionAwareService;
+    }
+
+    public void setMapQuorumAwareService(QuorumAwareService quorumAwareService) {
+        this.mapQuorumAwareService = quorumAwareService;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/AbstractMapServiceFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/AbstractMapServiceFactory.java
@@ -21,6 +21,7 @@ import com.hazelcast.spi.ManagedService;
 import com.hazelcast.spi.MigrationAwareService;
 import com.hazelcast.spi.PartitionAwareService;
 import com.hazelcast.spi.PostJoinAwareService;
+import com.hazelcast.spi.QuorumAwareService;
 import com.hazelcast.spi.RemoteService;
 import com.hazelcast.spi.ReplicationSupportingService;
 import com.hazelcast.spi.SplitBrainHandlerService;
@@ -118,6 +119,15 @@ abstract class AbstractMapServiceFactory implements MapServiceFactory {
     abstract PartitionAwareService createPartitionAwareService();
 
     /**
+     * Creates a new {@link QuorumAwareService} for {@link MapService}.
+     *
+     * @return Creates a new {@link PartitionAwareService} implementation.
+     * @see com.hazelcast.spi.PartitionAwareService
+     */
+    abstract QuorumAwareService createQuorumAwareService();
+
+
+    /**
      * Returns a {@link MapService} object by populating it with required
      * auxiliary services.
      *
@@ -136,6 +146,7 @@ abstract class AbstractMapServiceFactory implements MapServiceFactory {
         ReplicationSupportingService replicationSupportingService = createReplicationSupportingService();
         StatisticsAwareService statisticsAwareService = createStatisticsAwareService();
         PartitionAwareService partitionAwareService = createPartitionAwareService();
+        QuorumAwareService quorumAwareService = createQuorumAwareService();
 
         checkNotNull(mapServiceContext, "mapServiceContext should not be null");
         checkNotNull(managedService, "managedService should not be null");
@@ -148,6 +159,7 @@ abstract class AbstractMapServiceFactory implements MapServiceFactory {
         checkNotNull(replicationSupportingService, "replicationSupportingService should not be null");
         checkNotNull(statisticsAwareService, "statisticsAwareService should not be null");
         checkNotNull(partitionAwareService, "partitionAwareService should not be null");
+        checkNotNull(quorumAwareService, "quorumAwareService should not be null");
 
         MapService mapService = new MapService();
         mapService.setManagedService(managedService);
@@ -161,6 +173,7 @@ abstract class AbstractMapServiceFactory implements MapServiceFactory {
         mapService.setStatisticsAwareService(statisticsAwareService);
         mapService.setMapServiceContext(mapServiceContext);
         mapService.setMapPartitionAwareService(partitionAwareService);
+        mapService.setMapQuorumAwareService(quorumAwareService);
         mapServiceContext.setService(mapService);
         return mapService;
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/DefaultMapServiceFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/DefaultMapServiceFactory.java
@@ -20,6 +20,7 @@ import com.hazelcast.spi.EventPublishingService;
 import com.hazelcast.spi.ManagedService;
 import com.hazelcast.spi.MigrationAwareService;
 import com.hazelcast.spi.PostJoinAwareService;
+import com.hazelcast.spi.QuorumAwareService;
 import com.hazelcast.spi.RemoteService;
 import com.hazelcast.spi.ReplicationSupportingService;
 import com.hazelcast.spi.SplitBrainHandlerService;
@@ -100,6 +101,11 @@ class DefaultMapServiceFactory extends AbstractMapServiceFactory {
     @Override
     MapPartitionAwareService createPartitionAwareService() {
         return new MapPartitionAwareService(mapServiceContext);
+    }
+
+    @Override
+    QuorumAwareService createQuorumAwareService() {
+        return new MapQuorumAwareService(getMapServiceContext());
     }
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapContainer.java
@@ -35,7 +35,6 @@ import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.util.ExceptionUtil;
 import com.hazelcast.wan.WanReplicationPublisher;
 import com.hazelcast.wan.WanReplicationService;
-
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -81,6 +80,8 @@ public class MapContainer {
 
     private final String name;
 
+    private final String quorumName;
+
     /**
      * Operations which are done in this constructor should obey the rules defined
      * in the method comment {@link com.hazelcast.spi.PostJoinAwareService#getPostJoinOperation()}
@@ -93,6 +94,7 @@ public class MapContainer {
         this.ttlMillisFromConfig = calculateTTLMillis(mapConfig);
         this.mapServiceContext = mapServiceContext;
         this.partitioningStrategy = createPartitioningStrategy();
+        this.quorumName = mapConfig.getQuorumName();
         final NodeEngine nodeEngine = mapServiceContext.getNodeEngine();
         recordFactory = createRecordFactory(nodeEngine);
         initWanReplication(nodeEngine);
@@ -254,6 +256,10 @@ public class MapContainer {
 
     public String getName() {
         return name;
+    }
+
+    public String getQuorumName() {
+        return quorumName;
     }
 }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapQuorumAwareService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapQuorumAwareService.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl;
+
+import com.hazelcast.spi.QuorumAwareService;
+
+/**
+ * Quorum service will ask map service about whether map has defined quorum or not.
+ */
+public class MapQuorumAwareService implements QuorumAwareService {
+
+    private final MapServiceContext mapServiceContext;
+
+    public MapQuorumAwareService(MapServiceContext mapServiceContext) {
+        this.mapServiceContext = mapServiceContext;
+    }
+
+    @Override
+    public String getQuorumName(String name) {
+        MapContainer mapContainer = mapServiceContext.getMapContainer(name);
+        return mapContainer.getQuorumName();
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapService.java
@@ -19,24 +19,13 @@ package com.hazelcast.map.impl;
 import com.hazelcast.core.DistributedObject;
 import com.hazelcast.monitor.LocalMapStats;
 import com.hazelcast.partition.InternalPartitionLostEvent;
-import com.hazelcast.spi.EventPublishingService;
-import com.hazelcast.spi.ManagedService;
-import com.hazelcast.spi.MigrationAwareService;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.Operation;
-import com.hazelcast.spi.PartitionAwareService;
 import com.hazelcast.spi.PartitionMigrationEvent;
 import com.hazelcast.spi.PartitionReplicationEvent;
-import com.hazelcast.spi.PostJoinAwareService;
-import com.hazelcast.spi.RemoteService;
-import com.hazelcast.spi.ReplicationSupportingService;
-import com.hazelcast.spi.SplitBrainHandlerService;
-import com.hazelcast.spi.StatisticsAwareService;
-import com.hazelcast.spi.TransactionalService;
 import com.hazelcast.transaction.TransactionalObject;
 import com.hazelcast.transaction.impl.TransactionSupport;
 import com.hazelcast.wan.WanReplicationEvent;
-
 import java.util.Map;
 import java.util.Properties;
 
@@ -53,30 +42,16 @@ import java.util.Properties;
  * @see MapReplicationSupportingService
  * @see MapStatisticsAwareService
  * @see MapPartitionAwareService
+ * @see MapQuorumAwareService
  * @see MapServiceContext
  */
-public class MapService implements ManagedService, MigrationAwareService,
-        TransactionalService, RemoteService, EventPublishingService<EventData, ListenerAdapter>,
-        PostJoinAwareService, SplitBrainHandlerService, ReplicationSupportingService, StatisticsAwareService,
-        PartitionAwareService {
+public class MapService extends AbstractMapService  {
 
     /**
      * Service name of map service used
      * to register {@link com.hazelcast.spi.impl.ServiceManager#registerService}
      */
     public static final String SERVICE_NAME = "hz:impl:mapService";
-
-    private ManagedService managedService;
-    private MigrationAwareService migrationAwareService;
-    private TransactionalService transactionalService;
-    private RemoteService remoteService;
-    private EventPublishingService eventPublishingService;
-    private PostJoinAwareService postJoinAwareService;
-    private SplitBrainHandlerService splitBrainHandlerService;
-    private ReplicationSupportingService replicationSupportingService;
-    private StatisticsAwareService statisticsAwareService;
-    private PartitionAwareService mapPartitionAwareService;
-    private MapServiceContext mapServiceContext;
 
     public MapService() {
     }
@@ -171,51 +146,13 @@ public class MapService implements ManagedService, MigrationAwareService,
         return statisticsAwareService.getStats();
     }
 
-    public void setMapServiceContext(MapServiceContext mapServiceContext) {
-        this.mapServiceContext = mapServiceContext;
+    @Override
+    public String getQuorumName(String name) {
+        return mapQuorumAwareService.getQuorumName(name);
     }
 
     public MapServiceContext getMapServiceContext() {
         return mapServiceContext;
     }
 
-    void setManagedService(ManagedService managedService) {
-        this.managedService = managedService;
-    }
-
-    void setMigrationAwareService(MigrationAwareService migrationAwareService) {
-        this.migrationAwareService = migrationAwareService;
-    }
-
-    void setTransactionalService(TransactionalService transactionalService) {
-        this.transactionalService = transactionalService;
-    }
-
-    void setRemoteService(RemoteService remoteService) {
-        this.remoteService = remoteService;
-    }
-
-    void setEventPublishingService(EventPublishingService eventPublishingService) {
-        this.eventPublishingService = eventPublishingService;
-    }
-
-    void setPostJoinAwareService(PostJoinAwareService postJoinAwareService) {
-        this.postJoinAwareService = postJoinAwareService;
-    }
-
-    void setSplitBrainHandlerService(SplitBrainHandlerService splitBrainHandlerService) {
-        this.splitBrainHandlerService = splitBrainHandlerService;
-    }
-
-    void setReplicationSupportingService(ReplicationSupportingService replicationSupportingService) {
-        this.replicationSupportingService = replicationSupportingService;
-    }
-
-    void setStatisticsAwareService(StatisticsAwareService statisticsAwareService) {
-        this.statisticsAwareService = statisticsAwareService;
-    }
-
-    public void setMapPartitionAwareService(PartitionAwareService mapPartitionAwareService) {
-        this.mapPartitionAwareService = mapPartitionAwareService;
-    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
@@ -33,7 +33,6 @@ import com.hazelcast.spi.EventRegistration;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.util.ConcurrencyUtil;
 import com.hazelcast.util.ConstructorFunction;
-
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashSet;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/AbstractMultipleEntryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/AbstractMultipleEntryOperation.java
@@ -36,15 +36,15 @@ import com.hazelcast.monitor.impl.LocalMapStatsImpl;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.partition.InternalPartitionService;
 import com.hazelcast.spi.EventService;
+import com.hazelcast.spi.impl.MutatingOperation;
 import com.hazelcast.util.Clock;
-
 import java.util.AbstractMap;
 import java.util.Map;
 
 import static com.hazelcast.map.impl.EntryViews.createSimpleEntryView;
 import static com.hazelcast.map.impl.MapService.SERVICE_NAME;
 
-abstract class AbstractMultipleEntryOperation extends AbstractMapOperation {
+abstract class AbstractMultipleEntryOperation extends AbstractMapOperation implements MutatingOperation {
 
     protected MapEntrySet responses;
     protected EntryProcessor entryProcessor;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/AddIndexOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/AddIndexOperation.java
@@ -27,14 +27,14 @@ import com.hazelcast.nio.serialization.SerializationService;
 import com.hazelcast.query.impl.Index;
 import com.hazelcast.query.impl.IndexService;
 import com.hazelcast.query.impl.QueryEntry;
+import com.hazelcast.spi.impl.MutatingOperation;
 import com.hazelcast.spi.PartitionAwareOperation;
 import com.hazelcast.spi.impl.AbstractNamedOperation;
 import com.hazelcast.util.Clock;
-
 import java.io.IOException;
 import java.util.Iterator;
 
-public class AddIndexOperation extends AbstractNamedOperation implements PartitionAwareOperation {
+public class AddIndexOperation extends AbstractNamedOperation implements PartitionAwareOperation, MutatingOperation {
 
     private String attributeName;
     private boolean ordered;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/AddInterceptorOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/AddInterceptorOperation.java
@@ -22,9 +22,11 @@ import com.hazelcast.map.impl.MapService;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.spi.AbstractOperation;
+import com.hazelcast.spi.impl.MutatingOperation;
+import com.hazelcast.spi.NamedOperation;
 import java.io.IOException;
 
-public class AddInterceptorOperation extends AbstractOperation {
+public class AddInterceptorOperation extends AbstractOperation implements MutatingOperation, NamedOperation {
 
     private MapService mapService;
     private String id;
@@ -78,4 +80,8 @@ public class AddInterceptorOperation extends AbstractOperation {
         return "AddInterceptorOperation{}";
     }
 
+    @Override
+    public String getName() {
+        return mapName;
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/BasePutOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/BasePutOperation.java
@@ -26,12 +26,13 @@ import com.hazelcast.map.impl.record.Record;
 import com.hazelcast.map.impl.record.RecordInfo;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.BackupAwareOperation;
+import com.hazelcast.spi.impl.MutatingOperation;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.ResponseHandler;
 
 import static com.hazelcast.map.impl.record.Records.buildRecordInfo;
 
-public abstract class BasePutOperation extends LockAwareOperation implements BackupAwareOperation {
+public abstract class BasePutOperation extends LockAwareOperation implements BackupAwareOperation, MutatingOperation {
 
     protected transient Data dataOldValue;
     protected transient EntryEventType eventType;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/BaseRemoveOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/BaseRemoveOperation.java
@@ -21,10 +21,11 @@ import com.hazelcast.map.impl.MapEventPublisher;
 import com.hazelcast.map.impl.MapServiceContext;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.BackupAwareOperation;
+import com.hazelcast.spi.impl.MutatingOperation;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.util.Clock;
 
-public abstract class BaseRemoveOperation extends LockAwareOperation implements BackupAwareOperation {
+public abstract class BaseRemoveOperation extends LockAwareOperation implements BackupAwareOperation, MutatingOperation {
 
     protected transient Data dataOldValue;
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ClearBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ClearBackupOperation.java
@@ -20,9 +20,10 @@ import com.hazelcast.map.impl.MapService;
 import com.hazelcast.map.impl.RecordStore;
 import com.hazelcast.nio.serialization.DataSerializable;
 import com.hazelcast.spi.BackupOperation;
+import com.hazelcast.spi.impl.MutatingOperation;
 import com.hazelcast.spi.impl.AbstractNamedOperation;
 
-public class ClearBackupOperation extends AbstractNamedOperation implements BackupOperation, DataSerializable {
+public class ClearBackupOperation extends AbstractNamedOperation implements BackupOperation, MutatingOperation, DataSerializable {
 
     private MapService mapService;
     private RecordStore recordStore;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ClearExpiredOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ClearExpiredOperation.java
@@ -24,17 +24,17 @@ import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.spi.AbstractOperation;
+import com.hazelcast.spi.impl.MutatingOperation;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.PartitionAwareOperation;
 import com.hazelcast.util.Clock;
-
 import java.io.IOException;
 import java.util.concurrent.ConcurrentMap;
 
 /**
  * Clear expired records.
  */
-public class ClearExpiredOperation extends AbstractOperation implements PartitionAwareOperation {
+public class ClearExpiredOperation extends AbstractOperation implements PartitionAwareOperation, MutatingOperation {
 
     private int expirationPercentage;
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ClearOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ClearOperation.java
@@ -19,12 +19,14 @@ package com.hazelcast.map.impl.operation;
 import com.hazelcast.map.impl.MapServiceContext;
 import com.hazelcast.map.impl.RecordStore;
 import com.hazelcast.spi.BackupAwareOperation;
+import com.hazelcast.spi.impl.MutatingOperation;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.PartitionAwareOperation;
 
 import static com.hazelcast.map.impl.MapService.SERVICE_NAME;
 
-public class ClearOperation extends AbstractMapOperation implements BackupAwareOperation, PartitionAwareOperation {
+public class ClearOperation extends AbstractMapOperation implements BackupAwareOperation,
+        PartitionAwareOperation, MutatingOperation {
 
     boolean shouldBackup = true;
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ContainsKeyOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ContainsKeyOperation.java
@@ -26,7 +26,7 @@ import com.hazelcast.spi.ResponseHandler;
 import com.hazelcast.spi.WaitNotifyKey;
 import com.hazelcast.spi.WaitSupport;
 
-public class ContainsKeyOperation extends KeyBasedMapOperation implements ReadonlyOperation, WaitSupport {
+public class ContainsKeyOperation extends KeyBasedMapOperation implements  ReadonlyOperation, WaitSupport {
 
     private boolean containsKey;
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ContainsValueOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ContainsValueOperation.java
@@ -24,10 +24,10 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.PartitionAwareOperation;
-
+import com.hazelcast.spi.ReadonlyOperation;
 import java.io.IOException;
 
-public class ContainsValueOperation extends AbstractMapOperation implements PartitionAwareOperation {
+public class ContainsValueOperation extends AbstractMapOperation implements PartitionAwareOperation, ReadonlyOperation {
 
     private boolean contains;
     private Data testValue;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryBackupOperation.java
@@ -25,12 +25,12 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.BackupOperation;
+import com.hazelcast.spi.impl.MutatingOperation;
 import com.hazelcast.util.Clock;
-
 import java.io.IOException;
 import java.util.Map;
 
-public class EntryBackupOperation extends KeyBasedMapOperation implements BackupOperation {
+public class EntryBackupOperation extends KeyBasedMapOperation implements BackupOperation, MutatingOperation {
 
     protected transient Object oldValue;
     private EntryBackupProcessor entryProcessor;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOperation.java
@@ -36,9 +36,9 @@ import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.SerializationService;
 import com.hazelcast.spi.BackupAwareOperation;
 import com.hazelcast.spi.EventService;
+import com.hazelcast.spi.impl.MutatingOperation;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.util.Clock;
-
 import java.io.IOException;
 import java.util.AbstractMap;
 import java.util.Map;
@@ -49,7 +49,7 @@ import static com.hazelcast.map.impl.MapService.SERVICE_NAME;
 /**
  * GOTCHA : This operation LOADS missing keys from map-store, in contrast with PartitionWideEntryOperation.
  */
-public class EntryOperation extends LockAwareOperation implements BackupAwareOperation {
+public class EntryOperation extends LockAwareOperation implements BackupAwareOperation, MutatingOperation {
 
     protected Object oldValue;
     private EntryProcessor entryProcessor;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EvictAllBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EvictAllBackupOperation.java
@@ -20,11 +20,13 @@ import com.hazelcast.map.impl.MapServiceContext;
 import com.hazelcast.map.impl.RecordStore;
 import com.hazelcast.nio.serialization.DataSerializable;
 import com.hazelcast.spi.BackupOperation;
+import com.hazelcast.spi.impl.MutatingOperation;
 
 /**
  * Operation which evicts all keys except locked ones.
  */
-public class EvictAllBackupOperation extends AbstractMapOperation implements BackupOperation, DataSerializable {
+public class EvictAllBackupOperation extends AbstractMapOperation implements BackupOperation, MutatingOperation,
+        DataSerializable {
 
     public EvictAllBackupOperation() {
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EvictAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EvictAllOperation.java
@@ -21,6 +21,7 @@ import com.hazelcast.map.impl.RecordStore;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.spi.BackupAwareOperation;
+import com.hazelcast.spi.impl.MutatingOperation;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.PartitionAwareOperation;
 import java.io.IOException;
@@ -28,7 +29,8 @@ import java.io.IOException;
 /**
  * Operation which evicts all keys except locked ones.
  */
-public class EvictAllOperation extends AbstractMapOperation implements BackupAwareOperation, PartitionAwareOperation {
+public class EvictAllOperation extends AbstractMapOperation implements BackupAwareOperation,
+        MutatingOperation, PartitionAwareOperation {
 
     private boolean shouldRunOnBackup;
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EvictOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EvictOperation.java
@@ -23,11 +23,11 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.BackupAwareOperation;
+import com.hazelcast.spi.impl.MutatingOperation;
 import com.hazelcast.spi.Operation;
-
 import java.io.IOException;
 
-public class EvictOperation extends LockAwareOperation implements BackupAwareOperation {
+public class EvictOperation extends LockAwareOperation implements MutatingOperation, BackupAwareOperation {
 
     private boolean evicted;
     private boolean asyncBackup;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/GetAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/GetAllOperation.java
@@ -23,13 +23,14 @@ import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.partition.InternalPartitionService;
 import com.hazelcast.spi.PartitionAwareOperation;
+import com.hazelcast.spi.ReadonlyOperation;
 import com.hazelcast.util.Clock;
 
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
 
-public class GetAllOperation extends AbstractMapOperation implements PartitionAwareOperation {
+public class GetAllOperation extends AbstractMapOperation implements ReadonlyOperation, PartitionAwareOperation {
 
     private Set<Data> keys = new HashSet<Data>();
     private MapEntrySet entrySet;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/GetEntryViewOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/GetEntryViewOperation.java
@@ -27,10 +27,11 @@ import com.hazelcast.map.impl.record.Record;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.DefaultObjectNamespace;
 import com.hazelcast.spi.ResponseHandler;
+import com.hazelcast.spi.ReadonlyOperation;
 import com.hazelcast.spi.WaitNotifyKey;
 import com.hazelcast.spi.WaitSupport;
 
-public class GetEntryViewOperation extends KeyBasedMapOperation implements WaitSupport {
+public class GetEntryViewOperation extends KeyBasedMapOperation implements ReadonlyOperation, WaitSupport {
 
     private EntryView<Data, Data> result;
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/GetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/GetOperation.java
@@ -30,7 +30,7 @@ import com.hazelcast.spi.WaitNotifyKey;
 import com.hazelcast.spi.WaitSupport;
 
 public final class GetOperation extends KeyBasedMapOperation
-        implements IdentifiedDataSerializable, ReadonlyOperation, WaitSupport {
+        implements IdentifiedDataSerializable,  WaitSupport, ReadonlyOperation {
 
     private Data result;
 
@@ -71,6 +71,7 @@ public final class GetOperation extends KeyBasedMapOperation
         ResponseHandler responseHandler = getResponseHandler();
         responseHandler.sendResponse(new OperationTimeoutException("Cannot read transactionally locked entry!"));
     }
+
     @Override
     public Object getResponse() {
         return result;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/InvalidateNearCacheOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/InvalidateNearCacheOperation.java
@@ -22,9 +22,10 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.AbstractOperation;
+import com.hazelcast.spi.impl.MutatingOperation;
 import java.io.IOException;
 
-public class InvalidateNearCacheOperation extends AbstractOperation {
+public class InvalidateNearCacheOperation extends AbstractOperation implements MutatingOperation {
 
     private Data key;
     private String mapName;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/IsEmptyOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/IsEmptyOperationFactory.java
@@ -20,7 +20,6 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.OperationFactory;
-
 import java.io.IOException;
 
 public class IsEmptyOperationFactory implements OperationFactory {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/KeyBasedMapOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/KeyBasedMapOperation.java
@@ -24,13 +24,13 @@ import com.hazelcast.map.impl.RecordStore;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.spi.NamedOperation;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.PartitionAwareOperation;
 import com.hazelcast.util.Clock;
-
 import java.io.IOException;
 
-public abstract class KeyBasedMapOperation extends Operation implements PartitionAwareOperation {
+public abstract class KeyBasedMapOperation extends Operation implements PartitionAwareOperation, NamedOperation {
 
     protected String name;
     protected Data dataKey;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/LoadAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/LoadAllOperation.java
@@ -22,8 +22,8 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.partition.InternalPartitionService;
+import com.hazelcast.spi.impl.MutatingOperation;
 import com.hazelcast.spi.PartitionAwareOperation;
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -33,7 +33,7 @@ import java.util.List;
 /**
  * Triggers map store load of all given keys.
  */
-public class LoadAllOperation extends AbstractMapOperation implements PartitionAwareOperation {
+public class LoadAllOperation extends AbstractMapOperation implements PartitionAwareOperation, MutatingOperation {
 
     private List<Data> keys;
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapEntrySetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapEntrySetOperation.java
@@ -26,8 +26,9 @@ import com.hazelcast.spi.PartitionAwareOperation;
 
 import java.util.Map;
 import java.util.Set;
+import com.hazelcast.spi.ReadonlyOperation;
 
-public class MapEntrySetOperation extends AbstractMapOperation implements PartitionAwareOperation {
+public class MapEntrySetOperation extends AbstractMapOperation implements PartitionAwareOperation, ReadonlyOperation {
     private Set<Map.Entry<Data, Data>> entrySet;
 
     public MapEntrySetOperation(String name) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapFlushOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapFlushOperation.java
@@ -18,9 +18,10 @@ package com.hazelcast.map.impl.operation;
 
 import com.hazelcast.map.impl.MapServiceContext;
 import com.hazelcast.map.impl.RecordStore;
+import com.hazelcast.spi.impl.MutatingOperation;
 import com.hazelcast.spi.PartitionAwareOperation;
 
-public class MapFlushOperation extends AbstractMapOperation implements PartitionAwareOperation {
+public class MapFlushOperation extends AbstractMapOperation implements PartitionAwareOperation, MutatingOperation {
 
     public MapFlushOperation() {
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapIsEmptyOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapIsEmptyOperation.java
@@ -20,8 +20,9 @@ import com.hazelcast.map.impl.MapServiceContext;
 import com.hazelcast.map.impl.RecordStore;
 import com.hazelcast.monitor.impl.LocalMapStatsImpl;
 import com.hazelcast.spi.PartitionAwareOperation;
+import com.hazelcast.spi.ReadonlyOperation;
 
-public class MapIsEmptyOperation extends AbstractMapOperation implements PartitionAwareOperation {
+public class MapIsEmptyOperation extends AbstractMapOperation implements PartitionAwareOperation, ReadonlyOperation {
 
     private boolean empty;
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapKeySetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapKeySetOperation.java
@@ -24,9 +24,10 @@ import com.hazelcast.map.impl.RecordStore;
 import com.hazelcast.monitor.impl.LocalMapStatsImpl;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.PartitionAwareOperation;
+import com.hazelcast.spi.ReadonlyOperation;
 import java.util.Set;
 
-public class MapKeySetOperation extends AbstractMapOperation implements PartitionAwareOperation {
+public class MapKeySetOperation extends AbstractMapOperation implements PartitionAwareOperation, ReadonlyOperation {
     private Set<Data> keySet;
 
     public MapKeySetOperation(String name) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapLoadAllOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapLoadAllOperationFactory.java
@@ -21,7 +21,6 @@ import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.OperationFactory;
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapReplicationOperation.java
@@ -33,8 +33,8 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.AbstractOperation;
+import com.hazelcast.spi.impl.MutatingOperation;
 import com.hazelcast.util.Clock;
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -48,7 +48,7 @@ import java.util.Set;
 
 import static com.hazelcast.map.impl.record.Records.applyRecordInfo;
 
-public class MapReplicationOperation extends AbstractOperation {
+public class MapReplicationOperation extends AbstractOperation implements MutatingOperation {
 
     private Map<String, Set<RecordReplicationInfo>> data;
     private Map<String, Collection<DelayedEntry>> delayedEntries;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapSizeOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapSizeOperation.java
@@ -21,8 +21,9 @@ import com.hazelcast.map.impl.MapServiceContext;
 import com.hazelcast.map.impl.RecordStore;
 import com.hazelcast.monitor.impl.LocalMapStatsImpl;
 import com.hazelcast.spi.PartitionAwareOperation;
+import com.hazelcast.spi.ReadonlyOperation;
 
-public class MapSizeOperation extends AbstractMapOperation implements PartitionAwareOperation {
+public class MapSizeOperation extends AbstractMapOperation implements PartitionAwareOperation, ReadonlyOperation {
 
     private int size;
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapValuesOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapValuesOperation.java
@@ -23,10 +23,10 @@ import com.hazelcast.map.impl.RecordStore;
 import com.hazelcast.monitor.impl.LocalMapStatsImpl;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.PartitionAwareOperation;
-
+import com.hazelcast.spi.ReadonlyOperation;
 import java.util.Collection;
 
-public class MapValuesOperation extends AbstractMapOperation implements PartitionAwareOperation {
+public class MapValuesOperation extends AbstractMapOperation implements PartitionAwareOperation, ReadonlyOperation {
     private Collection<Data> values;
 
     public MapValuesOperation(String name) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MultipleEntryBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MultipleEntryBackupOperation.java
@@ -21,7 +21,6 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.BackupOperation;
-
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.Map;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MultipleEntryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MultipleEntryOperation.java
@@ -25,7 +25,6 @@ import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.SerializationService;
 import com.hazelcast.spi.BackupAwareOperation;
 import com.hazelcast.spi.Operation;
-
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.Map;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/NearCacheKeySetInvalidationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/NearCacheKeySetInvalidationOperation.java
@@ -24,10 +24,11 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.AbstractOperation;
+import com.hazelcast.spi.impl.MutatingOperation;
 import java.io.IOException;
 import java.util.Set;
 
-public class NearCacheKeySetInvalidationOperation extends AbstractOperation {
+public class NearCacheKeySetInvalidationOperation extends AbstractOperation implements MutatingOperation {
     private MapService mapService;
     private MapKeySet mapKeySet;
     private String mapName;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionCheckIfLoadedOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionCheckIfLoadedOperation.java
@@ -19,8 +19,9 @@ package com.hazelcast.map.impl.operation;
 import com.hazelcast.map.impl.MapServiceContext;
 import com.hazelcast.map.impl.RecordStore;
 import com.hazelcast.spi.PartitionAwareOperation;
+import com.hazelcast.spi.ReadonlyOperation;
 
-public class PartitionCheckIfLoadedOperation extends AbstractMapOperation implements PartitionAwareOperation {
+public class PartitionCheckIfLoadedOperation extends AbstractMapOperation implements PartitionAwareOperation, ReadonlyOperation {
 
     private boolean isFinished;
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryBackupOperation.java
@@ -25,7 +25,6 @@ import com.hazelcast.nio.serialization.SerializationService;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.impl.QueryEntry;
 import com.hazelcast.spi.BackupOperation;
-
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.Map;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryOperation.java
@@ -28,7 +28,6 @@ import com.hazelcast.query.Predicate;
 import com.hazelcast.query.impl.QueryEntry;
 import com.hazelcast.spi.BackupAwareOperation;
 import com.hazelcast.spi.Operation;
-
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.Map;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryWithPredicateBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryWithPredicateBackupOperation.java
@@ -20,7 +20,6 @@ import com.hazelcast.map.EntryBackupProcessor;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.query.Predicate;
-
 import java.io.IOException;
 
 public class PartitionWideEntryWithPredicateBackupOperation extends PartitionWideEntryBackupOperation {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryWithPredicateOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryWithPredicateOperation.java
@@ -22,7 +22,6 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.spi.Operation;
-
 import java.io.IOException;
 
 public class PartitionWideEntryWithPredicateOperation extends PartitionWideEntryOperation {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PostJoinMapOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PostJoinMapOperation.java
@@ -16,8 +16,8 @@
 
 package com.hazelcast.map.impl.operation;
 
-import com.hazelcast.map.impl.MapContainer;
 import com.hazelcast.map.MapInterceptor;
+import com.hazelcast.map.impl.MapContainer;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.map.impl.MapServiceContext;
 import com.hazelcast.nio.ObjectDataInput;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutAllBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutAllBackupOperation.java
@@ -24,15 +24,16 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.BackupOperation;
+import com.hazelcast.spi.impl.MutatingOperation;
 import com.hazelcast.spi.PartitionAwareOperation;
-
 import java.io.IOException;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-public class PutAllBackupOperation extends AbstractMapOperation implements PartitionAwareOperation, BackupOperation {
+public class PutAllBackupOperation extends AbstractMapOperation implements PartitionAwareOperation, BackupOperation,
+        MutatingOperation {
 
     private List<Map.Entry<Data, Data>> entries;
     private List<RecordInfo> recordInfos;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutAllOperation.java
@@ -32,10 +32,10 @@ import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.partition.InternalPartitionService;
 import com.hazelcast.spi.BackupAwareOperation;
+import com.hazelcast.spi.impl.MutatingOperation;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.PartitionAwareOperation;
 import com.hazelcast.util.Clock;
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -43,7 +43,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-public class PutAllOperation extends AbstractMapOperation implements PartitionAwareOperation, BackupAwareOperation {
+public class PutAllOperation extends AbstractMapOperation implements PartitionAwareOperation,
+        BackupAwareOperation, MutatingOperation {
 
     private MapEntrySet entrySet;
     private boolean initialLoad;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutBackupOperation.java
@@ -25,10 +25,11 @@ import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.BackupOperation;
-
+import com.hazelcast.spi.impl.MutatingOperation;
 import java.io.IOException;
 
-public final class PutBackupOperation extends KeyBasedMapOperation implements BackupOperation, IdentifiedDataSerializable {
+public final class PutBackupOperation extends KeyBasedMapOperation implements BackupOperation,
+        IdentifiedDataSerializable, MutatingOperation {
 
     // todo unlockKey is a logic just used in transactional put operations.
     // todo It complicates here there should be another Operation for that logic. e.g. TxnSetBackup

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutFromLoadAllBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutFromLoadAllBackupOperation.java
@@ -24,7 +24,7 @@ import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.DataSerializable;
 import com.hazelcast.spi.BackupOperation;
-
+import com.hazelcast.spi.impl.MutatingOperation;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -35,7 +35,8 @@ import java.util.List;
  *
  * @see PutFromLoadAllOperation
  */
-public class PutFromLoadAllBackupOperation extends AbstractMapOperation implements BackupOperation, DataSerializable {
+public class PutFromLoadAllBackupOperation extends AbstractMapOperation implements BackupOperation, MutatingOperation,
+        DataSerializable {
 
     private List<Data> keyValueSequence;
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutFromLoadAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutFromLoadAllOperation.java
@@ -29,9 +29,9 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.BackupAwareOperation;
+import com.hazelcast.spi.impl.MutatingOperation;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.PartitionAwareOperation;
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -40,7 +40,8 @@ import java.util.List;
 /**
  * Puts records to map which are loaded from map store by {@link com.hazelcast.core.IMap#loadAll}
  */
-public class PutFromLoadAllOperation extends AbstractMapOperation implements PartitionAwareOperation, BackupAwareOperation {
+public class PutFromLoadAllOperation extends AbstractMapOperation implements PartitionAwareOperation, MutatingOperation,
+        BackupAwareOperation {
 
     private List<Data> keyValueSequence;
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/QueryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/QueryOperation.java
@@ -30,9 +30,9 @@ import com.hazelcast.query.impl.QueryableEntry;
 import com.hazelcast.spi.ExceptionAction;
 import com.hazelcast.spi.ExecutionService;
 import com.hazelcast.spi.NodeEngine;
+import com.hazelcast.spi.ReadonlyOperation;
 import com.hazelcast.spi.exception.TargetNotMemberException;
 import com.hazelcast.util.FutureUtil;
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -51,7 +51,7 @@ import static com.hazelcast.util.FutureUtil.returnWithDeadline;
 import static com.hazelcast.util.SortingUtil.newComparator;
 import static java.util.Collections.sort;
 
-public class QueryOperation extends AbstractMapOperation {
+public class QueryOperation extends AbstractMapOperation implements ReadonlyOperation {
 
     private static final long QUERY_EXECUTION_TIMEOUT_MINUTES = 5;
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/QueryPartitionOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/QueryPartitionOperation.java
@@ -24,13 +24,13 @@ import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.impl.QueryableEntry;
 import com.hazelcast.spi.PartitionAwareOperation;
-
+import com.hazelcast.spi.ReadonlyOperation;
 import java.io.IOException;
 import java.util.Collection;
 
 import static java.util.Collections.singletonList;
 
-public class QueryPartitionOperation extends AbstractMapOperation implements PartitionAwareOperation {
+public class QueryPartitionOperation extends AbstractMapOperation implements PartitionAwareOperation, ReadonlyOperation {
 
     private Predicate predicate;
     private QueryResult result;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/RemoveBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/RemoveBackupOperation.java
@@ -25,9 +25,11 @@ import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.BackupOperation;
+import com.hazelcast.spi.impl.MutatingOperation;
 import java.io.IOException;
 
-public final class RemoveBackupOperation extends KeyBasedMapOperation implements BackupOperation, IdentifiedDataSerializable {
+public final class RemoveBackupOperation extends KeyBasedMapOperation implements BackupOperation, MutatingOperation,
+        IdentifiedDataSerializable {
 
     private boolean unlockKey;
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/RemoveIfSameOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/RemoveIfSameOperation.java
@@ -19,7 +19,6 @@ package com.hazelcast.map.impl.operation;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
-
 import java.io.IOException;
 
 public class RemoveIfSameOperation extends BaseRemoveOperation {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/RemoveInterceptorOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/RemoveInterceptorOperation.java
@@ -22,9 +22,11 @@ import com.hazelcast.map.impl.MapServiceContext;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.spi.AbstractOperation;
+import com.hazelcast.spi.impl.MutatingOperation;
+import com.hazelcast.spi.NamedOperation;
 import java.io.IOException;
 
-public class RemoveInterceptorOperation extends AbstractOperation {
+public class RemoveInterceptorOperation extends AbstractOperation implements MutatingOperation, NamedOperation {
 
     private MapService mapService;
     private String mapName;
@@ -63,6 +65,11 @@ public class RemoveInterceptorOperation extends AbstractOperation {
         super.writeInternal(out);
         out.writeUTF(mapName);
         out.writeUTF(id);
+    }
+
+    @Override
+    public String getName() {
+        return mapName;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ReplaceIfSameOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ReplaceIfSameOperation.java
@@ -19,7 +19,6 @@ package com.hazelcast.map.impl.operation;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
-
 import java.io.IOException;
 
 public class ReplaceIfSameOperation extends BasePutOperation {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/TryRemoveOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/TryRemoveOperation.java
@@ -20,7 +20,6 @@ import com.hazelcast.map.impl.MapServiceContext;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
-
 import java.io.IOException;
 
 public class TryRemoveOperation extends BaseRemoveOperation {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
@@ -974,7 +974,7 @@ abstract class MapProxySupport extends AbstractDistributedObject<MapService> imp
             Object o = getService().getMapServiceContext().toObject(f.get());
             return (EntryView) o;
         } catch (Throwable t) {
-            throw new RuntimeException(t);
+            throw ExceptionUtil.rethrow(t);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TransactionalMapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TransactionalMapProxySupport.java
@@ -16,8 +16,6 @@
 
 package com.hazelcast.map.impl.tx;
 
-import static com.hazelcast.map.impl.MapService.SERVICE_NAME;
-
 import com.hazelcast.core.PartitioningStrategy;
 import com.hazelcast.instance.MemberImpl;
 import com.hazelcast.map.QueryResultSizeExceededException;
@@ -49,7 +47,6 @@ import com.hazelcast.util.ExceptionUtil;
 import com.hazelcast.util.IterationType;
 import com.hazelcast.util.QueryResultSet;
 import com.hazelcast.util.ThreadUtil;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -59,6 +56,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+
+import static com.hazelcast.map.impl.MapService.SERVICE_NAME;
 
 /**
  * Base class contains proxy helper methods for {@link com.hazelcast.map.impl.tx.TransactionalMapProxy}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnLockAndGetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnLockAndGetOperation.java
@@ -17,6 +17,7 @@
 package com.hazelcast.map.impl.tx;
 
 import com.hazelcast.map.impl.operation.LockAwareOperation;
+import com.hazelcast.spi.impl.MutatingOperation;
 import com.hazelcast.map.impl.record.Record;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
@@ -28,7 +29,7 @@ import java.io.IOException;
 /**
  * Transactional lock and get operation.
  */
-public class TxnLockAndGetOperation extends LockAwareOperation {
+public class TxnLockAndGetOperation extends LockAwareOperation implements MutatingOperation {
 
     private VersionedValue response;
     private String ownerUuid;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnPrepareBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnPrepareBackupOperation.java
@@ -17,6 +17,7 @@
 package com.hazelcast.map.impl.tx;
 
 import com.hazelcast.map.impl.operation.KeyBasedMapOperation;
+import com.hazelcast.spi.impl.MutatingOperation;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -27,7 +28,7 @@ import java.io.IOException;
 /**
  *  An operation to prepare transaction by locking the key on key backup owner.
  */
-public class TxnPrepareBackupOperation extends KeyBasedMapOperation implements BackupOperation {
+public class TxnPrepareBackupOperation extends KeyBasedMapOperation implements BackupOperation, MutatingOperation {
 
     private static final long LOCK_TTL_MILLIS = 10000L;
     private String lockOwner;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnPrepareOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnPrepareOperation.java
@@ -18,6 +18,7 @@ package com.hazelcast.map.impl.tx;
 
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.map.impl.operation.KeyBasedMapOperation;
+import com.hazelcast.spi.impl.MutatingOperation;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -29,7 +30,7 @@ import java.io.IOException;
 /**
  * An operation to prepare transaction by locking the key on the key owner.
  */
-public class TxnPrepareOperation extends KeyBasedMapOperation implements BackupAwareOperation {
+public class TxnPrepareOperation extends KeyBasedMapOperation implements BackupAwareOperation, MutatingOperation {
 
     private static final long LOCK_TTL_MILLIS = 10000L;
     String ownerUuid;

--- a/hazelcast/src/main/java/com/hazelcast/quorum/Quorum.java
+++ b/hazelcast/src/main/java/com/hazelcast/quorum/Quorum.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.quorum;
+
+/**
+ * {@link Quorum} provides access to the current status of a quorum.
+ */
+public interface Quorum {
+    /**
+     * Returns true if quorum is present, false if absent.
+     *
+     * @return boolean presence of the quorum
+     */
+    boolean isPresent();
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/quorum/QuorumEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/quorum/QuorumEvent.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.quorum;
+
+import com.hazelcast.core.Member;
+import java.util.Collection;
+import java.util.EventObject;
+
+/**
+ * An Event that is send when a {@link Quorum} changes.
+ * <p/>
+ * Hold member list, quorum threshold and the quorum result.
+ */
+public class QuorumEvent extends EventObject {
+
+    private final int threshold;
+    private final Collection<Member> currentMembers;
+    private final boolean presence;
+
+    public QuorumEvent(Object source, int threshold, Collection<Member> currentMembers, boolean presence) {
+        super(source);
+        this.threshold = threshold;
+        this.currentMembers = currentMembers;
+        this.presence = presence;
+    }
+
+    /**
+     * Returns the predefined quorum threshold
+     *
+     * @return int threshold
+     */
+    public int getThreshold() {
+        return threshold;
+    }
+
+    /**
+     * Returns the snapshot of member list at the time quorum happened
+     *
+     * @return Collection<Member> collection of members
+     */
+    public Collection<Member> getCurrentMembers() {
+        return currentMembers;
+    }
+
+    /**
+     * Returns the presence of the quorum
+     *
+     * @return boolean presence of the quorum
+     */
+    public boolean isPresent() {
+        return presence;
+    }
+
+    @Override
+    public String toString() {
+        return "QuorumEvent{"
+                + "threshold=" + threshold
+                + ", currentMembers=" + currentMembers
+                + ", presence=" + presence
+                + '}';
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/quorum/QuorumException.java
+++ b/hazelcast/src/main/java/com/hazelcast/quorum/QuorumException.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.quorum;
+
+import com.hazelcast.transaction.TransactionException;
+
+/**
+ * An exception thrown when the cluster size is below the defined threshold.
+ */
+public class QuorumException extends TransactionException {
+
+    public QuorumException(String message) {
+        super(message);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/quorum/QuorumFunction.java
+++ b/hazelcast/src/main/java/com/hazelcast/quorum/QuorumFunction.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.quorum;
+
+import com.hazelcast.core.Member;
+import java.util.Collection;
+
+/**
+ * A function that can be used for conclude absence/presence of quorum.
+ * This function is triggered when any change happens to member list.
+ */
+public interface QuorumFunction {
+
+    /**
+     * Determines if quorum is present based on the member-list.
+     *
+     * @param members snapshot of current member list
+     * @return boolean presence/absence of quorum
+     */
+    boolean apply(Collection<Member> members);
+}

--- a/hazelcast/src/main/java/com/hazelcast/quorum/QuorumListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/quorum/QuorumListener.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.quorum;
+
+import java.util.EventListener;
+
+/**
+ * Listener to get notified when a quorum state is changed
+ */
+public interface QuorumListener extends EventListener {
+
+    /**
+     * Called when quorum presence state is changed.
+     *
+     * @param quorumEvent provides information about quorum presence and current member list.
+     */
+    void onChange(QuorumEvent quorumEvent);
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/quorum/QuorumService.java
+++ b/hazelcast/src/main/java/com/hazelcast/quorum/QuorumService.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.quorum;
+
+/**
+ * Quorum service can be used to trigger cluster quorums at any time.
+ * Normally quorums are done when any change happens on the member list.
+ */
+public interface QuorumService {
+
+    /**
+     * Returns the {@link Quorum} instance for a given quorum name.
+     *
+     * @param quorumName name of the quorum
+     * @return {@link Quorum}
+     * @throws IllegalArgumentException if no quorum found for given name
+     * @throws NullPointerException     if quorumName is null
+     */
+    Quorum getQuorum(String quorumName) throws IllegalArgumentException;
+}

--- a/hazelcast/src/main/java/com/hazelcast/quorum/QuorumType.java
+++ b/hazelcast/src/main/java/com/hazelcast/quorum/QuorumType.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.quorum;
+
+/**
+ * Represents a cluster quorum type
+ */
+public enum QuorumType {
+
+    /**
+     * Only read operations will participate in a quorum.
+     */
+    READ,
+
+    /**
+     * Only write operations will participate in a quorum.
+     */
+    WRITE,
+
+    /**
+     * Both read and write operations will participate in a quorum.
+     */
+    READ_WRITE
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/quorum/impl/QuorumImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/quorum/impl/QuorumImpl.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.quorum.impl;
+
+import com.hazelcast.config.QuorumConfig;
+import com.hazelcast.core.Member;
+import com.hazelcast.nio.ClassLoaderUtil;
+import com.hazelcast.quorum.Quorum;
+import com.hazelcast.quorum.QuorumEvent;
+import com.hazelcast.quorum.QuorumException;
+import com.hazelcast.quorum.QuorumFunction;
+import com.hazelcast.quorum.QuorumType;
+import com.hazelcast.spi.impl.MutatingOperation;
+import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.ReadonlyOperation;
+import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.spi.impl.eventservice.InternalEventService;
+import com.hazelcast.util.ExceptionUtil;
+import java.util.Collection;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * {@link QuorumImpl} can be used to notify quorum service for a particular quorum result that originated externally.
+ */
+public class QuorumImpl implements Quorum {
+
+    private final AtomicBoolean isPresent = new AtomicBoolean(true);
+    private final AtomicBoolean lastPresence = new AtomicBoolean(true);
+
+    private final NodeEngineImpl nodeEngine;
+    private final String quorumName;
+    private final int size;
+    private final QuorumConfig config;
+    private final InternalEventService eventService;
+    private QuorumFunction quorumFunction;
+
+    private volatile boolean initialized;
+
+    public QuorumImpl(QuorumConfig config, NodeEngineImpl nodeEngine) {
+        this.nodeEngine = nodeEngine;
+        this.eventService = nodeEngine.getEventService();
+        this.config = config;
+        this.quorumName = config.getName();
+        this.size = config.getSize();
+        initializeQuorumFunction();
+    }
+
+    public void update(Collection<Member> members) {
+        setLocalResult(quorumFunction.apply(members));
+    }
+
+    public String getName() {
+        return quorumName;
+    }
+
+    public int getSize() {
+        return size;
+    }
+
+    public QuorumConfig getConfig() {
+        return config;
+    }
+
+    public boolean isInitialized() {
+        return initialized;
+    }
+
+    @Override
+    public boolean isPresent() {
+        return isPresent.get();
+    }
+
+    public void setLocalResult(boolean presence) {
+        setLocalResultInternal(presence);
+    }
+
+    private void setLocalResultInternal(boolean presence) {
+        this.initialized = true;
+        this.isPresent.set(presence);
+    }
+
+    private boolean isQuorumNeeded(Operation op) {
+        QuorumType type = config.getType();
+        switch (type) {
+            case WRITE:
+                return isWriteOperation(op);
+            case READ:
+                return isReadOperation(op);
+            case READ_WRITE:
+                return isReadOperation(op) || isWriteOperation(op);
+            default:
+                throw new IllegalStateException("Unhandled quorum type: " + type);
+        }
+    }
+
+    private static boolean isReadOperation(Operation op) {
+        return op instanceof ReadonlyOperation;
+    }
+
+    private static boolean isWriteOperation(Operation op) {
+        return op instanceof MutatingOperation;
+    }
+
+    public void ensureQuorumPresent(Operation op) {
+        if (!isQuorumNeeded(op)) {
+            return;
+        }
+        Collection<Member> memberList = nodeEngine.getClusterService().getMembers();
+        if (!isInitialized()) {
+            update(memberList);
+        }
+        if (!isPresent()) {
+            updateLastResultAndFireEvent(memberList, false);
+            throw newQuorumException(memberList);
+        }
+        updateLastResultAndFireEvent(memberList, true);
+    }
+
+    private QuorumException newQuorumException(Collection<Member> memberList) {
+        if (size == 0) {
+            throw new QuorumException("Cluster quorum failed");
+        }
+        throw new QuorumException("Cluster quorum failed, quorum minimum size: "
+                + size + ", current size: " + memberList.size());
+    }
+
+
+    private void updateLastResultAndFireEvent(Collection<Member> memberList, Boolean presence) {
+        for (; ; ) {
+            boolean currentPresence = lastPresence.get();
+            if (presence.equals(currentPresence)) {
+                return;
+            }
+            if (lastPresence.compareAndSet(currentPresence, presence)) {
+                createAndPublishEvent(memberList, presence);
+                return;
+            }
+        }
+    }
+
+    private void createAndPublishEvent(Collection<Member> memberList, boolean presence) {
+        QuorumEvent quorumEvent = new QuorumEvent(nodeEngine.getThisAddress(), size, memberList, presence);
+        eventService.publishEvent(QuorumServiceImpl.SERVICE_NAME, quorumName, quorumEvent, quorumEvent.hashCode());
+    }
+
+    private void initializeQuorumFunction() {
+        if (config.getQuorumFunctionImplementation() != null) {
+            quorumFunction = config.getQuorumFunctionImplementation();
+        } else if (config.getQuorumFunctionClassName() != null) {
+            try {
+                quorumFunction = ClassLoaderUtil
+                        .newInstance(nodeEngine.getConfigClassLoader(), config.getQuorumFunctionClassName());
+            } catch (Exception e) {
+                throw ExceptionUtil.rethrow(e);
+            }
+        }
+        if (quorumFunction == null) {
+            quorumFunction = new MemberCountQuorumFunction();
+        }
+    }
+
+    private class MemberCountQuorumFunction implements QuorumFunction {
+        @Override
+        public boolean apply(Collection<Member> members) {
+            return members.size() >= size;
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "QuorumImpl{"
+                + "quorumName='" + quorumName + '\''
+                + ", isPresent=" + isPresent
+                + ", size=" + size
+                + ", config=" + config
+                + ", quorumFunction=" + quorumFunction
+                + ", initialized=" + initialized
+                + '}';
+    }
+
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/quorum/impl/QuorumServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/quorum/impl/QuorumServiceImpl.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.quorum.impl;
+
+import com.hazelcast.config.QuorumConfig;
+import com.hazelcast.config.QuorumListenerConfig;
+import com.hazelcast.core.Member;
+import com.hazelcast.core.MembershipEvent;
+import com.hazelcast.nio.ClassLoaderUtil;
+import com.hazelcast.quorum.Quorum;
+import com.hazelcast.quorum.QuorumEvent;
+import com.hazelcast.quorum.QuorumListener;
+import com.hazelcast.quorum.QuorumService;
+import com.hazelcast.spi.EventPublishingService;
+import com.hazelcast.spi.EventService;
+import com.hazelcast.spi.MemberAttributeServiceEvent;
+import com.hazelcast.spi.MembershipAwareService;
+import com.hazelcast.spi.MembershipServiceEvent;
+import com.hazelcast.spi.NamedOperation;
+import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.QuorumAwareService;
+import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.util.ExceptionUtil;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static com.hazelcast.util.Preconditions.checkNotNull;
+
+
+/**
+ * Service containing logic for cluster quorum.
+ */
+public class QuorumServiceImpl implements EventPublishingService<QuorumEvent, QuorumListener>, MembershipAwareService,
+        QuorumService {
+
+    /**
+     * Service name of map service used
+     * to register {@link com.hazelcast.spi.impl.ServiceManager#registerService}
+     */
+    public static final String SERVICE_NAME = "hz:impl:quorumService";
+
+    private final NodeEngineImpl nodeEngine;
+    private final EventService eventService;
+    private boolean inactive;
+    private final Map<String, QuorumImpl> quorums = new HashMap<String, QuorumImpl>();
+
+
+    public QuorumServiceImpl(NodeEngineImpl nodeEngine) {
+        this.nodeEngine = nodeEngine;
+        this.eventService = nodeEngine.getEventService();
+        initializeQuorums();
+        initializeListeners();
+        this.inactive = quorums.isEmpty();
+    }
+
+    private void initializeQuorums() {
+        for (QuorumConfig quorumConfig : nodeEngine.getConfig().getQuorumConfigs().values()) {
+            QuorumImpl quorum = new QuorumImpl(quorumConfig, nodeEngine);
+            quorums.put(quorumConfig.getName(), quorum);
+        }
+    }
+
+    private void initializeListeners() {
+        for (Map.Entry<String, QuorumConfig> configEntry : nodeEngine.getConfig().getQuorumConfigs().entrySet()) {
+            QuorumConfig config = configEntry.getValue();
+            String instanceName = configEntry.getKey();
+            for (QuorumListenerConfig listenerConfig : config.getListenerConfigs()) {
+                initializeListenerInternal(instanceName, listenerConfig);
+            }
+        }
+    }
+
+    private void initializeListenerInternal(String instanceName, QuorumListenerConfig listenerConfig) {
+        QuorumListener listener = null;
+        if (listenerConfig.getImplementation() != null) {
+            listener = listenerConfig.getImplementation();
+        } else if (listenerConfig.getClassName() != null) {
+            try {
+                listener = ClassLoaderUtil
+                        .newInstance(nodeEngine.getConfigClassLoader(), listenerConfig.getClassName());
+            } catch (Exception e) {
+                throw ExceptionUtil.rethrow(e);
+            }
+        }
+        if (listener != null) {
+            addQuorumListener(instanceName, listener);
+        }
+    }
+
+    public void addQuorumListener(String name, QuorumListener listener) {
+        eventService.registerLocalListener(SERVICE_NAME, name, listener);
+    }
+
+
+    public void ensureQuorumPresent(Operation op) {
+        if (inactive) {
+            return;
+        }
+
+        QuorumImpl quorum = findQuorum(op);
+        if (quorum == null) {
+            return;
+        }
+        quorum.ensureQuorumPresent(op);
+    }
+
+    private QuorumImpl findQuorum(Operation op) {
+        if (!isNamedOperation(op) || !isQuorumAware(op)) {
+            return null;
+        }
+        QuorumAwareService service = op.getService();
+        String name = ((NamedOperation) op).getName();
+        String quorumName = service.getQuorumName(name);
+        if (quorumName == null) {
+            return null;
+        }
+        return quorums.get(quorumName);
+    }
+
+    private boolean isQuorumAware(Operation op) {
+        return op.getService() instanceof QuorumAwareService;
+    }
+
+    private boolean isNamedOperation(Operation op) {
+        return op instanceof NamedOperation;
+    }
+
+    @Override
+    public void dispatchEvent(QuorumEvent event, QuorumListener listener) {
+        listener.onChange(event);
+    }
+
+    @Override
+    public void memberAdded(MembershipServiceEvent event) {
+        updateQuorums(event);
+    }
+
+    @Override
+    public void memberRemoved(MembershipServiceEvent event) {
+        updateQuorums(event);
+    }
+
+    @Override
+    public void memberAttributeChanged(MemberAttributeServiceEvent event) {
+        updateQuorums(event);
+    }
+
+    private void updateQuorums(MembershipEvent event) {
+        Set<Member> members = event.getMembers();
+        for (QuorumImpl quorum : quorums.values()) {
+            quorum.update(members);
+        }
+    }
+
+    @Override
+    public Quorum getQuorum(String quorumName) {
+        checkNotNull(quorumName, "quorumName cannot be null!");
+        Quorum quorum = quorums.get(quorumName);
+        if (quorum == null) {
+            throw new IllegalArgumentException("No quorum configuration named [ " + quorumName + " ] is found!");
+        }
+        return quorum;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/quorum/impl/operation/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/quorum/impl/operation/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Contains cluster quorum operation classes.
+ */
+package com.hazelcast.quorum.impl.operation;

--- a/hazelcast/src/main/java/com/hazelcast/quorum/impl/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/quorum/impl/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Contains cluster quorum implementation classes.
+ */
+package com.hazelcast.quorum.impl;

--- a/hazelcast/src/main/java/com/hazelcast/quorum/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/quorum/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Contains classes related to cluster quorum.
+ */
+package com.hazelcast.quorum;

--- a/hazelcast/src/main/java/com/hazelcast/spi/NamedOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/NamedOperation.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi;
+
+/**
+ *  Indicates that {@link Operation} carries the distributed data structure name that is going to work on.
+ */
+public interface NamedOperation {
+
+    /**
+     * Returns the name of the distributed data structure.
+     * @return String name of the distributed data structure.
+     */
+    String getName();
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/NodeEngine.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/NodeEngine.java
@@ -28,6 +28,7 @@ import com.hazelcast.nio.serialization.SerializationService;
 import com.hazelcast.partition.InternalPartitionService;
 import com.hazelcast.internal.storage.DataRef;
 import com.hazelcast.internal.storage.Storage;
+import com.hazelcast.quorum.impl.QuorumServiceImpl;
 import com.hazelcast.transaction.TransactionManagerService;
 import com.hazelcast.wan.WanReplicationService;
 
@@ -101,6 +102,8 @@ public interface NodeEngine {
      * @return the WanReplicationService.
      */
     WanReplicationService getWanReplicationService();
+
+    QuorumServiceImpl getQuorumService();
 
     /**
      * Gets the TransactionManagerService.

--- a/hazelcast/src/main/java/com/hazelcast/spi/Operation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/Operation.java
@@ -25,6 +25,7 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.DataSerializable;
 import com.hazelcast.partition.InternalPartition;
+import com.hazelcast.quorum.QuorumException;
 import com.hazelcast.spi.exception.RetryableException;
 import com.hazelcast.spi.exception.RetryableHazelcastException;
 import com.hazelcast.spi.impl.NodeEngineImpl;
@@ -357,6 +358,8 @@ public abstract class Operation implements DataSerializable {
             } catch (Throwable ignored) {
                 ignore(ignored);
             }
+        } else if (e instanceof QuorumException) {
+            logger.log(Level.WARNING, e.getMessage());
         } else {
             final Level level = nodeEngine != null && nodeEngine.isActive() ? Level.SEVERE : Level.FINEST;
             if (logger.isLoggable(level)) {

--- a/hazelcast/src/main/java/com/hazelcast/spi/QuorumAwareService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/QuorumAwareService.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi;
+
+/**
+ * Quorum service can ask for quorum information to the {@link QuorumAwareService}
+ * to decide whether operation participates into a quorum or not.
+ */
+public interface QuorumAwareService {
+
+    String getQuorumName(String operationName);
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/AbstractNamedOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/AbstractNamedOperation.java
@@ -20,9 +20,10 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.spi.AbstractOperation;
 
+import com.hazelcast.spi.NamedOperation;
 import java.io.IOException;
 
-public abstract class AbstractNamedOperation extends AbstractOperation {
+public abstract class AbstractNamedOperation extends AbstractOperation implements NamedOperation {
     protected String name;
 
     protected AbstractNamedOperation(String name) {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/MutatingOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/MutatingOperation.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi.impl;
+
+import com.hazelcast.spi.annotation.Beta;
+
+/**
+ * Marker interface for operations that changes map state/data.
+ * Used for quorum to reject operations if quorum size not satisfied
+ */
+@Beta
+public interface MutatingOperation {
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
@@ -29,6 +29,7 @@ import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.SerializationService;
 import com.hazelcast.partition.InternalPartitionService;
 import com.hazelcast.partition.MigrationInfo;
+import com.hazelcast.quorum.impl.QuorumServiceImpl;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.PostJoinAwareService;
@@ -77,6 +78,7 @@ public class NodeEngineImpl implements NodeEngine {
     private final ProxyServiceImpl proxyService;
     private final WanReplicationService wanReplicationService;
     private final PacketTransceiver packetTransceiver;
+    private final QuorumServiceImpl quorumService;
 
     public NodeEngineImpl(Node node) {
         this.node = node;
@@ -91,6 +93,7 @@ public class NodeEngineImpl implements NodeEngine {
         this.wanReplicationService = node.getNodeExtension().createService(WanReplicationService.class);
         this.packetTransceiver = new PacketTransceiverImpl(
                 node, logger, operationService, eventService, wanReplicationService, executionService);
+        quorumService = new QuorumServiceImpl(this);
     }
 
     public PacketTransceiver getPacketTransceiver() {
@@ -174,6 +177,11 @@ public class NodeEngineImpl implements NodeEngine {
     @Override
     public WanReplicationService getWanReplicationService() {
         return wanReplicationService;
+    }
+
+    @Override
+    public QuorumServiceImpl getQuorumService() {
+        return quorumService;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/ServiceManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/ServiceManager.java
@@ -41,6 +41,7 @@ import com.hazelcast.multimap.impl.MultiMapService;
 import com.hazelcast.nio.ClassLoaderUtil;
 import com.hazelcast.partition.InternalPartitionService;
 import com.hazelcast.collection.impl.queue.QueueService;
+import com.hazelcast.quorum.impl.QuorumServiceImpl;
 import com.hazelcast.replicatedmap.impl.ReplicatedMapService;
 import com.hazelcast.spi.ConfigurableService;
 import com.hazelcast.spi.ManagedService;
@@ -49,7 +50,6 @@ import com.hazelcast.spi.ServiceInfo;
 import com.hazelcast.spi.impl.proxyservice.impl.ProxyServiceImpl;
 import com.hazelcast.topic.impl.TopicService;
 import com.hazelcast.transaction.impl.TransactionManagerServiceImpl;
-
 import java.lang.reflect.Constructor;
 import java.util.Collection;
 import java.util.Collections;
@@ -102,6 +102,7 @@ final class ServiceManager {
         registerService(ProxyServiceImpl.SERVICE_NAME, nodeEngine.getProxyService());
         registerService(TransactionManagerServiceImpl.SERVICE_NAME, nodeEngine.getTransactionManagerService());
         registerService(ClientEngineImpl.SERVICE_NAME, node.clientEngine);
+        registerService(QuorumServiceImpl.SERVICE_NAME, nodeEngine.getQuorumService());
     }
 
     private void registerDefaultServices(ServicesConfig servicesConfig) {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImpl.java
@@ -27,6 +27,7 @@ import com.hazelcast.nio.IOUtil;
 import com.hazelcast.nio.Packet;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.partition.InternalPartition;
+import com.hazelcast.quorum.impl.QuorumServiceImpl;
 import com.hazelcast.spi.BackupAwareOperation;
 import com.hazelcast.spi.Notifier;
 import com.hazelcast.spi.Operation;
@@ -125,6 +126,8 @@ class OperationRunnerImpl extends OperationRunner {
 
             ensureNoPartitionProblems(op);
 
+            ensureQuorumPresent(op);
+
             op.beforeRun();
 
             if (waitingNeeded(op)) {
@@ -142,6 +145,12 @@ class OperationRunnerImpl extends OperationRunner {
             }
         }
     }
+
+    private void ensureQuorumPresent(Operation op) {
+        QuorumServiceImpl quorumService = operationService.nodeEngine.getQuorumService();
+        quorumService.ensureQuorumPresent(op);
+    }
+
 
     private boolean waitingNeeded(Operation op) {
         if (!(op instanceof WaitSupport)) {

--- a/hazelcast/src/main/java/com/hazelcast/transaction/TransactionOptions.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/TransactionOptions.java
@@ -177,7 +177,7 @@ public final class TransactionOptions implements DataSerializable {
         sb.append("TransactionOptions");
         sb.append("{timeoutMillis=").append(timeoutMillis);
         sb.append(", durability=").append(durability);
-        sb.append(", txType=").append(transactionType.value);
+        sb.append(", txType=").append(transactionType);
         sb.append('}');
         return sb.toString();
     }

--- a/hazelcast/src/main/resources/hazelcast-config-3.5.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-3.5.xsd
@@ -49,6 +49,7 @@
                 <xs:element name="services" type="services" minOccurs="0" maxOccurs="1"/>
                 <xs:element name="security" type="security" minOccurs="0" maxOccurs="1"/>
                 <xs:element ref="member-attributes" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="quorum" type="quorum" minOccurs="0" maxOccurs="1"/>
             </xs:choice>
             <xs:attribute name="id" type="xs:string" use="optional" default="default"/>
         </xs:complexType>
@@ -194,6 +195,7 @@
             <xs:element name="entry-listeners" type="entry-listeners" minOccurs="0" maxOccurs="1"/>
             <xs:element name="partition-lost-listeners" type="partition-lost-listeners" minOccurs="0" maxOccurs="1"/>
             <xs:element name="partition-strategy" type="xs:string" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="quorum-ref" minOccurs="0" maxOccurs="1"/>
         </xs:all>
         <xs:attribute name="name" use="required">
             <xs:simpleType>
@@ -880,12 +882,13 @@
     </xs:complexType>
     <xs:complexType name="partition-lost-listeners">
         <xs:sequence>
-            <xs:element name="partition-lost-listener" type="partition-lost-listener" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="partition-lost-listener" type="partition-lost-listener" minOccurs="0"
+                        maxOccurs="unbounded"/>
         </xs:sequence>
     </xs:complexType>
     <xs:complexType name="partition-lost-listener">
         <xs:simpleContent>
-            <xs:extension base="listener-base" />
+            <xs:extension base="listener-base"/>
         </xs:simpleContent>
     </xs:complexType>
     <xs:complexType name="index">
@@ -1101,7 +1104,8 @@
 
     <xs:complexType name="listener-base">
         <xs:annotation>
-            <xs:documentation>One of membership-listener, instance-listener, migration-listener or partition-lost-listener
+            <xs:documentation>One of membership-listener, instance-listener, migration-listener or
+                partition-lost-listener
             </xs:documentation>
         </xs:annotation>
         <xs:simpleContent>
@@ -1332,4 +1336,45 @@
         <xs:attribute name="name" type="xs:string" use="required"/>
     </xs:complexType>
 
+    <xs:complexType name="quorum">
+        <xs:all>
+            <xs:element name="quorum-size" type="quorum-size" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="quorum-type" type="quorum-type" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="quorum-function-class-name" type="xs:string" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="quorum-listeners" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="quorum-listener" type="quorum-listener" maxOccurs="unbounded"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+        </xs:all>
+        <xs:attribute name="enabled" type="xs:boolean" use="required"/>
+        <xs:attribute name="name" use="required">
+            <xs:simpleType>
+                <xs:restriction base="xs:string"/>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:simpleType name="quorum-type">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="READ"/>
+            <xs:enumeration value="WRITE"/>
+            <xs:enumeration value="READ_WRITE"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="quorum-size">
+        <xs:restriction base="xs:int">
+            <xs:minInclusive value="0"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="quorum-listener">
+        <xs:simpleContent>
+            <xs:extension base="listener-base">
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
 </xs:schema>

--- a/hazelcast/src/test/java/com/hazelcast/cluster/SplitBrainHandlerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/SplitBrainHandlerTest.java
@@ -62,6 +62,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.hazelcast.instance.HazelcastInstanceFactory.newHazelcastInstance;
+import static com.hazelcast.test.HazelcastTestSupport.closeConnectionBetween;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -271,14 +272,6 @@ public class SplitBrainHandlerTest extends HazelcastTestSupport {
         assertEquals(3, h1.getCluster().getMembers().size());
         assertEquals(3, h2.getCluster().getMembers().size());
         assertEquals(3, h3.getCluster().getMembers().size());
-    }
-
-    private void closeConnectionBetween(HazelcastInstance h1, HazelcastInstance h2) {
-        if (h1 == null || h2 == null) return;
-        final Node n1 = TestUtil.getNode(h1);
-        final Node n2 = TestUtil.getNode(h2);
-        n1.clusterService.removeAddress(n2.address);
-        n2.clusterService.removeAddress(n1.address);
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/list/ListSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/list/ListSplitBrainTest.java
@@ -13,20 +13,17 @@ import com.hazelcast.core.MembershipEvent;
 import com.hazelcast.core.MembershipListener;
 import com.hazelcast.instance.GroupProperties;
 import com.hazelcast.instance.HazelcastInstanceFactory;
-import com.hazelcast.instance.Node;
-import com.hazelcast.instance.TestUtil;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.NightlyTest;
+import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
-
-import java.io.IOException;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -106,13 +103,6 @@ public class ListSplitBrainTest extends HazelcastTestSupport {
         assertTrue(testList.contains("item45"));
     }
 
-    private void closeConnectionBetween(HazelcastInstance h1, HazelcastInstance h2) {
-        if (h1 == null || h2 == null) return;
-        final Node n1 = TestUtil.getNode(h1);
-        final Node n2 = TestUtil.getNode(h2);
-        n1.clusterService.removeAddress(n2.address);
-        n2.clusterService.removeAddress(n1.address);
-    }
 
     private Config getConfig(boolean multicast) {
         Config config = new Config();

--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/QueueSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/QueueSplitBrainTest.java
@@ -91,14 +91,6 @@ public class QueueSplitBrainTest extends HazelcastTestSupport {
         assertTrue(testQueue.contains("item45"));
     }
 
-    private void closeConnectionBetween(HazelcastInstance h1, HazelcastInstance h2) {
-        if (h1 == null || h2 == null) return;
-        final Node n1 = TestUtil.getNode(h1);
-        final Node n2 = TestUtil.getNode(h2);
-        n1.clusterService.removeAddress(n2.address);
-        n2.clusterService.removeAddress(n1.address);
-    }
-
     private Config newConfig() {
         Config config = new Config();
         config.setProperty(GroupProperties.PROP_MERGE_FIRST_RUN_DELAY_SECONDS, "30");

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/countdownlatch/CountDownLatchSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/countdownlatch/CountDownLatchSplitBrainTest.java
@@ -12,19 +12,14 @@ import com.hazelcast.core.MembershipEvent;
 import com.hazelcast.core.MembershipListener;
 import com.hazelcast.instance.GroupProperties;
 import com.hazelcast.instance.HazelcastInstanceFactory;
-import com.hazelcast.instance.Node;
-import com.hazelcast.instance.TestUtil;
 import com.hazelcast.test.HazelcastTestSupport;
+import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.io.IOException;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 public class CountDownLatchSplitBrainTest extends HazelcastTestSupport {
 
@@ -73,14 +68,6 @@ public class CountDownLatchSplitBrainTest extends HazelcastTestSupport {
 
         ICountDownLatch countDownLatchTest = h3.getCountDownLatch(name);
         assertEquals(3, countDownLatchTest.getCount());
-    }
-
-    private void closeConnectionBetween(HazelcastInstance h1, HazelcastInstance h2) {
-        if (h1 == null || h2 == null) return;
-        final Node n1 = TestUtil.getNode(h1);
-        final Node n2 = TestUtil.getNode(h2);
-        n1.clusterService.removeAddress(n2.address);
-        n2.clusterService.removeAddress(n1.address);
     }
 
     private Config newConfig() {

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/lock/LockSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/lock/LockSplitBrainTest.java
@@ -85,13 +85,6 @@ public class LockSplitBrainTest extends HazelcastTestSupport {
         assertTrue(testLock.isLocked());
     }
 
-    private void closeConnectionBetween(HazelcastInstance h1, HazelcastInstance h2) {
-        if (h1 == null || h2 == null) return;
-        final Node n1 = TestUtil.getNode(h1);
-        final Node n2 = TestUtil.getNode(h2);
-        n1.clusterService.removeAddress(n2.address);
-        n2.clusterService.removeAddress(n1.address);
-    }
 
     private Config newConfig() {
         Config config = new Config();

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/semaphore/SemaphoreSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/semaphore/SemaphoreSplitBrainTest.java
@@ -12,21 +12,17 @@ import com.hazelcast.core.MembershipEvent;
 import com.hazelcast.core.MembershipListener;
 import com.hazelcast.instance.GroupProperties;
 import com.hazelcast.instance.HazelcastInstanceFactory;
-import com.hazelcast.instance.Node;
-import com.hazelcast.instance.TestUtil;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.QuickTest;
-import com.hazelcast.test.annotation.Repeat;
+import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
-
-import java.io.IOException;
-import java.util.concurrent.CountDownLatch;
 
 import static junit.framework.TestCase.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -93,13 +89,6 @@ public class SemaphoreSplitBrainTest extends HazelcastTestSupport {
         assertEquals(1, testSemaphore.availablePermits());
     }
 
-    private void closeConnectionBetween(HazelcastInstance h1, HazelcastInstance h2) {
-        if (h1 == null || h2 == null) return;
-        final Node n1 = TestUtil.getNode(h1);
-        final Node n2 = TestUtil.getNode(h2);
-        n1.clusterService.removeAddress(n2.address);
-        n2.clusterService.removeAddress(n1.address);
-    }
 
     private Config newConfig() {
         Config config = new Config();

--- a/hazelcast/src/test/java/com/hazelcast/map/InterceptorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/InterceptorTest.java
@@ -86,7 +86,7 @@ public class InterceptorTest extends HazelcastTestSupport {
 
     }
 
-    static class SimpleInterceptor implements MapInterceptor, Serializable {
+    public static class SimpleInterceptor implements MapInterceptor, Serializable {
 
         @Override
         public Object interceptGet(Object value) {

--- a/hazelcast/src/test/java/com/hazelcast/map/MergePolicyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MergePolicyTest.java
@@ -13,8 +13,6 @@ import com.hazelcast.core.MembershipEvent;
 import com.hazelcast.core.MembershipListener;
 import com.hazelcast.instance.GroupProperties;
 import com.hazelcast.instance.HazelcastInstanceFactory;
-import com.hazelcast.instance.Node;
-import com.hazelcast.instance.TestUtil;
 import com.hazelcast.map.merge.HigherHitsMapMergePolicy;
 import com.hazelcast.map.merge.LatestUpdateMapMergePolicy;
 import com.hazelcast.map.merge.PassThroughMergePolicy;
@@ -22,13 +20,13 @@ import com.hazelcast.map.merge.PutIfAbsentMapMergePolicy;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.NightlyTest;
+import java.util.concurrent.CountDownLatch;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import java.util.concurrent.CountDownLatch;
 
 import static junit.framework.Assert.assertNotNull;
 import static junit.framework.Assert.assertTrue;
@@ -232,14 +230,6 @@ public class MergePolicyTest extends HazelcastTestSupport {
         MapConfig mapConfig = config.getMapConfig(mapName);
         mapConfig.setMergePolicy(mergePolicy);
         return config;
-    }
-
-    private void closeConnectionBetween(HazelcastInstance h1, HazelcastInstance h2) {
-        if (h1 == null || h2 == null) return;
-        final Node n1 = TestUtil.getNode(h1);
-        final Node n2 = TestUtil.getNode(h2);
-        n1.clusterService.removeAddress(n2.address);
-        n2.clusterService.removeAddress(n1.address);
     }
 
     private class TestLifeCycleListener implements LifecycleListener {

--- a/hazelcast/src/test/java/com/hazelcast/quorum/MapReadQuorumTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/MapReadQuorumTest.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.hazelcast.quorum;
+
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.core.IMap;
+import com.hazelcast.instance.HazelcastInstanceFactory;
+import com.hazelcast.config.QuorumConfig;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static com.hazelcast.test.HazelcastTestSupport.randomMapName;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class MapReadQuorumTest {
+
+    static PartitionedCluster cluster;
+    static IMap<Object, Object> map1;
+    static IMap<Object, Object> map2;
+    static IMap<Object, Object> map3;
+    static IMap<Object, Object> map4;
+    static IMap<Object, Object> map5;
+
+    private static final String MAP_NAME_PREFIX = "quorum";
+    private static final String QUORUM_ID = "threeNodeQuorumRule";
+
+    @BeforeClass
+    public static void initialize() throws InterruptedException {
+        QuorumConfig quorumConfig = new QuorumConfig();
+        quorumConfig.setName(QUORUM_ID);
+        quorumConfig.setType(QuorumType.READ_WRITE);
+        quorumConfig.setEnabled(true);
+        quorumConfig.setSize(3);
+        MapConfig mapConfig = new MapConfig(MAP_NAME_PREFIX + "*");
+        mapConfig.setQuorumName(QUORUM_ID);
+        cluster = new PartitionedCluster().partitionFiveMembersThreeAndTwo(mapConfig, quorumConfig);
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        String mapName = randomMapName(MAP_NAME_PREFIX);
+        map1 = cluster.h1.getMap(mapName);
+        map2 = cluster.h2.getMap(mapName);
+        map3 = cluster.h3.getMap(mapName);
+        map4 = cluster.h4.getMap(mapName);
+        map5 = cluster.h5.getMap(mapName);
+    }
+
+    @AfterClass
+    public static void killAllHazelcastInstances() throws IOException {
+        HazelcastInstanceFactory.terminateAll();
+    }
+
+
+    @Test
+    public void testGetOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.get("foo");
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testGetOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.get("foo");
+    }
+
+    @Test
+    public void testGetAsyncOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        Future<Object> foo = map1.getAsync("foo");
+        foo.get();
+    }
+
+    @Test(expected = ExecutionException.class)
+    public void testGetAsyncOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        Future<Object> foo = map4.getAsync("foo");
+        foo.get();
+    }
+
+    @Test
+    public void testGetAllOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        HashSet<Object> keys = new HashSet<Object>();
+        keys.add("foo");
+        map1.getAll(keys);
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testGetAllOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        HashSet<Object> keys = new HashSet<Object>();
+        keys.add("foo");
+        map4.getAll(keys);
+    }
+
+    @Test
+    public void testGetEntryViewOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.getEntryView("foo");
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testGetEntryViewOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.getEntryView("foo");
+    }
+
+
+    @Test
+    public void testContainsKeyOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.containsKey("foo");
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testContainsKeyOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.containsKey("foo");
+    }
+
+    @Test
+    public void testContainsValueOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.containsValue("foo");
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testContainsValueOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.containsValue("foo");
+    }
+
+    @Test
+    public void testKeySetOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.keySet();
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testKeySetOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.keySet();
+    }
+
+    @Test
+    public void testLocalKeySetOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.localKeySet();
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testLocalKeySetOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.localKeySet();
+    }
+
+    @Test
+    public void testValuesOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.values();
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testValuesOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.values();
+    }
+
+    @Test
+    public void testEntrySetOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.entrySet();
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testEntrySetOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.entrySet();
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/quorum/MapReadWriteQuorumTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/MapReadWriteQuorumTest.java
@@ -1,0 +1,485 @@
+/*
+ * Copyright (c) 2008-2014, Hazelcast, Inc. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.hazelcast.quorum;
+
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.core.IMap;
+import com.hazelcast.instance.HazelcastInstanceFactory;
+import com.hazelcast.config.QuorumConfig;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static com.hazelcast.map.InterceptorTest.SimpleInterceptor;
+import static com.hazelcast.map.TempData.LoggingEntryProcessor;
+import static com.hazelcast.test.HazelcastTestSupport.randomMapName;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class MapReadWriteQuorumTest {
+
+    static PartitionedCluster cluster;
+    static IMap<Object, Object> map1;
+    static IMap<Object, Object> map2;
+    static IMap<Object, Object> map3;
+    static IMap<Object, Object> map4;
+    static IMap<Object, Object> map5;
+
+    private static final String MAP_NAME_PREFIX = "quorum";
+    private static final String QUORUM_ID = "threeNodeQuorumRule";
+
+    @BeforeClass
+    public static void initialize() throws InterruptedException {
+        QuorumConfig quorumConfig = new QuorumConfig();
+        quorumConfig.setName(QUORUM_ID);
+        quorumConfig.setEnabled(true);
+        quorumConfig.setSize(3);
+        MapConfig mapConfig = new MapConfig(MAP_NAME_PREFIX + "*");
+        mapConfig.setQuorumName(QUORUM_ID);
+        cluster = new PartitionedCluster().partitionFiveMembersThreeAndTwo(mapConfig, quorumConfig);
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        String mapName = randomMapName(MAP_NAME_PREFIX);
+        map1 = cluster.h1.getMap(mapName);
+        map2 = cluster.h2.getMap(mapName);
+        map3 = cluster.h3.getMap(mapName);
+        map4 = cluster.h4.getMap(mapName);
+        map5 = cluster.h5.getMap(mapName);
+    }
+
+    @AfterClass
+    public static void killAllHazelcastInstances() throws IOException {
+        HazelcastInstanceFactory.terminateAll();
+    }
+
+    @Test
+    public void testPutOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.put("foo", "bar");
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testPutOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.put("foo", "bar");
+    }
+
+
+    @Test
+    public void testTryPutOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.tryPut("foo", "bar", 5, TimeUnit.SECONDS);
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testTryPutOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.tryPut("foo", "bar", 5, TimeUnit.SECONDS);
+    }
+
+    @Test
+    public void testPutTransientOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.putTransient("foo", "bar", 5, TimeUnit.SECONDS);
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testPutTransientOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.putTransient("foo", "bar", 5, TimeUnit.SECONDS);
+    }
+
+    @Test
+    public void testPutIfAbsentOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.putIfAbsent("foo", "bar");
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testPutIfAbsentOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.putIfAbsent("foo", "bar");
+    }
+
+    @Test
+    public void testPutAsyncOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        Future<Object> foo = map1.putAsync("foo", "bar");
+        foo.get();
+    }
+
+    @Test(expected = ExecutionException.class)
+    public void testPutAsyncOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        Future<Object> foo = map4.putAsync("foo", "bar");
+        foo.get();
+    }
+
+    @Test
+    public void testPutAllOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        HashMap<Object, Object> map = new HashMap<Object, Object>();
+        map.put("foo", "bar");
+        map1.putAll(map);
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testPutAllOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        HashMap<Object, Object> map = new HashMap<Object, Object>();
+        map.put("foo", "bar");
+        map4.putAll(map);
+    }
+
+    @Test
+    public void testGetOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.get("foo");
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testGetOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.get("foo");
+    }
+
+    @Test
+    public void testGetAsyncOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        Future<Object> foo = map1.getAsync("foo");
+        foo.get();
+    }
+
+    @Test(expected = ExecutionException.class)
+    public void testGetAsyncOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        Future<Object> foo = map4.getAsync("foo");
+        foo.get();
+    }
+
+    @Test
+    public void testGetAllOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        HashSet<Object> keys = new HashSet<Object>();
+        keys.add("foo");
+        map1.getAll(keys);
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testGetAllOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        HashSet<Object> keys = new HashSet<Object>();
+        keys.add("foo");
+        map4.getAll(keys);
+    }
+
+    @Test
+    public void testGetEntryViewOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.getEntryView("foo");
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testGetEntryViewOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.getEntryView("foo");
+    }
+
+    @Test
+    public void testRemoveOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.remove("foo");
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testRemoveOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.remove("foo");
+    }
+
+    @Test
+    public void testRemoveIfHasValueOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.remove("foo", "bar");
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testRemoveIfHasValueOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.remove("foo", "bar");
+    }
+
+    @Test
+    public void testRemoveAsyncOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        Future<Object> foo = map1.removeAsync("foo");
+        foo.get();
+    }
+
+    @Test(expected = ExecutionException.class)
+    public void testRemoveAsyncOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        Future<Object> foo = map4.removeAsync("foo");
+        foo.get();
+    }
+
+    @Test
+    public void testDeleteOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.delete("foo");
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testDeleteOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.delete("foo");
+    }
+
+    @Test
+    public void testClearOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.clear();
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testClearOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.clear();
+    }
+
+    @Test
+    public void testSetOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.set("foo", "bar");
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testSetOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.set("foo", "bar");
+    }
+
+    @Test
+    public void testReplaceOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.replace("foo", "bar");
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testReplaceOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.replace("foo", "bar");
+    }
+
+    @Test
+    public void testReplaceIfOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.replace("foo", "bar", "baz");
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testReplaceIfOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.replace("foo", "bar", "baz");
+    }
+
+    @Test
+    public void testTryRemoveOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.tryRemove("foo", 5, TimeUnit.SECONDS);
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testTryRemoveOperationThrowsExceptionWhenQuorumSizeNotMet() {
+        map4.tryRemove("foo", 5, TimeUnit.SECONDS);
+    }
+
+    @Test
+    public void testFlushOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.flush();
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testFlushOperationThrowsExceptionWhenQuorumSizeNotMet() {
+        map4.flush();
+    }
+
+    @Test
+    public void testEvictAllOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.evictAll();
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testEvictAllOperationThrowsExceptionWhenQuorumSizeNotMet() {
+        map4.evictAll();
+    }
+
+    @Test
+    public void testEvictOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.evict("foo");
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testEvictOperationThrowsExceptionWhenQuorumSizeNotMet() {
+        map4.evict("foo");
+    }
+
+    @Test
+    public void testContainsKeyOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.containsKey("foo");
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testContainsKeyOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.containsKey("foo");
+    }
+
+    @Test
+    public void testContainsValueOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.containsValue("foo");
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testContainsValueOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.containsValue("foo");
+    }
+
+    @Test
+    public void testKeySetOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.keySet();
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testKeySetOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.keySet();
+    }
+
+    @Test
+    public void testLocalKeySetOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.localKeySet();
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testLocalKeySetOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.localKeySet();
+    }
+
+    @Test
+    public void testValuesOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.values();
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testValuesOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.values();
+    }
+
+    @Test
+    public void testEntrySetOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.entrySet();
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testEntrySetOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.entrySet();
+    }
+
+    @Test
+    public void testAddIndexOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.addIndex("foo", false);
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testAddIndexOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.addIndex("foo", false);
+    }
+
+    @Test
+    public void testAddInterceptorOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.addInterceptor(new SimpleInterceptor());
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testAddInterceptorOperationThrowsExceptionWhenQuorumSizeNotMet() {
+        map4.addInterceptor(new SimpleInterceptor());
+    }
+
+    @Test
+    public void testRemoveInterceptorOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.removeInterceptor("foo");
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testRemoveInterceptorOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.removeInterceptor("foo");
+    }
+
+    @Test
+    public void testExecuteOnKeyOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.executeOnKey("foo", new LoggingEntryProcessor());
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testExecuteOnKeyOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.executeOnKey("foo", new LoggingEntryProcessor());
+    }
+
+    @Test
+    public void testExecuteOnKeysOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        HashSet<Object> keys = new HashSet<Object>();
+        keys.add("foo");
+        map1.executeOnKey(keys, new LoggingEntryProcessor());
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testExecuteOnKeysOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        HashSet<Object> keys = new HashSet<Object>();
+        keys.add("foo");
+        map4.executeOnKey(keys, new LoggingEntryProcessor());
+    }
+
+    @Test
+    public void testExecuteOnEntriesOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.executeOnEntries(new LoggingEntryProcessor());
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testExecuteOnEntriesOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.executeOnEntries(new LoggingEntryProcessor());
+    }
+
+    @Test
+    public void testSubmmitToKeyOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        Future foo = map1.submitToKey("foo", new LoggingEntryProcessor());
+        foo.get();
+    }
+
+    @Test(expected = ExecutionException.class)
+    public void testSubmmitToKeyOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        Future foo = map4.submitToKey("foo", new LoggingEntryProcessor());
+        foo.get();
+    }
+
+    @Ignore
+    @Test(expected = QuorumException.class)
+    public void testLockOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.lock("foo");
+    }
+
+    @Ignore
+    @Test(expected = QuorumException.class)
+    public void testTryLockOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.tryLock("foo");
+    }
+
+    @Ignore
+    @Test(expected = QuorumException.class)
+    public void testUnlockOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.unlock("foo");
+    }
+
+    @Ignore
+    @Test(expected = QuorumException.class)
+    public void testIsLockedOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.isLocked("foo");
+    }
+
+    @Ignore
+    @Test(expected = QuorumException.class)
+    public void testForceUnlockOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.forceUnlock("foo");
+    }
+
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/quorum/MapWriteQuorumTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/MapWriteQuorumTest.java
@@ -1,0 +1,380 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.hazelcast.quorum;
+
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.core.IMap;
+import com.hazelcast.instance.HazelcastInstanceFactory;
+import com.hazelcast.config.QuorumConfig;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static com.hazelcast.map.InterceptorTest.SimpleInterceptor;
+import static com.hazelcast.map.TempData.LoggingEntryProcessor;
+import static com.hazelcast.test.HazelcastTestSupport.randomMapName;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class MapWriteQuorumTest {
+
+    static PartitionedCluster cluster;
+    static IMap<Object, Object> map1;
+    static IMap<Object, Object> map2;
+    static IMap<Object, Object> map3;
+    static IMap<Object, Object> map4;
+    static IMap<Object, Object> map5;
+
+    private static final String MAP_NAME_PREFIX = "quorum";
+    private static final String QUORUM_ID = "threeNodeQuorumRule";
+
+    @BeforeClass
+    public static void initialize() throws InterruptedException {
+        QuorumConfig quorumConfig = new QuorumConfig();
+        quorumConfig.setName(QUORUM_ID);
+        quorumConfig.setEnabled(true);
+        quorumConfig.setType(QuorumType.WRITE);
+        quorumConfig.setSize(3);
+        MapConfig mapConfig = new MapConfig(MAP_NAME_PREFIX + "*");
+        mapConfig.setQuorumName(QUORUM_ID);
+        cluster = new PartitionedCluster().partitionFiveMembersThreeAndTwo(mapConfig, quorumConfig);
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        String mapName = randomMapName(MAP_NAME_PREFIX);
+        map1 = cluster.h1.getMap(mapName);
+        map2 = cluster.h2.getMap(mapName);
+        map3 = cluster.h3.getMap(mapName);
+        map4 = cluster.h4.getMap(mapName);
+        map5 = cluster.h5.getMap(mapName);
+    }
+
+    @AfterClass
+    public static void killAllHazelcastInstances() throws IOException {
+        HazelcastInstanceFactory.terminateAll();
+    }
+
+    @Test
+    public void testPutOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.put("foo", "bar");
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testPutOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.put("foo", "bar");
+    }
+
+
+    @Test
+    public void testTryPutOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.tryPut("foo", "bar", 5, TimeUnit.SECONDS);
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testTryPutOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.tryPut("foo", "bar", 5, TimeUnit.SECONDS);
+    }
+
+    @Test
+    public void testPutTransientOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.putTransient("foo", "bar", 5, TimeUnit.SECONDS);
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testPutTransientOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.putTransient("foo", "bar", 5, TimeUnit.SECONDS);
+    }
+
+    @Test
+    public void testPutIfAbsentOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.putIfAbsent("foo", "bar");
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testPutIfAbsentOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.putIfAbsent("foo", "bar");
+    }
+
+    @Test
+    public void testPutAsyncOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        Future<Object> foo = map1.putAsync("foo", "bar");
+        foo.get();
+    }
+
+    @Test(expected = ExecutionException.class)
+    public void testPutAsyncOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        Future<Object> foo = map4.putAsync("foo", "bar");
+        foo.get();
+    }
+
+    @Test
+    public void testPutAllOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        HashMap<Object, Object> map = new HashMap<Object, Object>();
+        map.put("foo", "bar");
+        map1.putAll(map);
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testPutAllOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        HashMap<Object, Object> map = new HashMap<Object, Object>();
+        map.put("foo", "bar");
+        map4.putAll(map);
+    }
+
+    @Test
+    public void testRemoveOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.remove("foo");
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testRemoveOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.remove("foo");
+    }
+
+    @Test
+    public void testRemoveIfHasValueOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.remove("foo", "bar");
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testRemoveIfHasValueOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.remove("foo", "bar");
+    }
+
+    @Test
+    public void testRemoveAsyncOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        Future<Object> foo = map1.removeAsync("foo");
+        foo.get();
+    }
+
+    @Test(expected = ExecutionException.class)
+    public void testRemoveAsyncOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        Future<Object> foo = map4.removeAsync("foo");
+        foo.get();
+    }
+
+    @Test
+    public void testDeleteOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.delete("foo");
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testDeleteOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.delete("foo");
+    }
+
+    @Test
+    public void testClearOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.clear();
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testClearOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.clear();
+    }
+
+    @Test
+    public void testSetOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.set("foo", "bar");
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testSetOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.set("foo", "bar");
+    }
+
+    @Test
+    public void testReplaceOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.replace("foo", "bar");
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testReplaceOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.replace("foo", "bar");
+    }
+
+    @Test
+    public void testReplaceIfOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.replace("foo", "bar", "baz");
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testReplaceIfOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.replace("foo", "bar", "baz");
+    }
+
+    @Test
+    public void testTryRemoveOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.tryRemove("foo", 5, TimeUnit.SECONDS);
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testTryRemoveOperationThrowsExceptionWhenQuorumSizeNotMet() {
+        map4.tryRemove("foo", 5, TimeUnit.SECONDS);
+    }
+
+    @Test
+    public void testFlushOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.flush();
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testFlushOperationThrowsExceptionWhenQuorumSizeNotMet() {
+        map4.flush();
+    }
+
+    @Test
+    public void testEvictAllOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.evictAll();
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testEvictAllOperationThrowsExceptionWhenQuorumSizeNotMet() {
+        map4.evictAll();
+    }
+
+    @Test
+    public void testEvictOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.evict("foo");
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testEvictOperationThrowsExceptionWhenQuorumSizeNotMet() {
+        map4.evict("foo");
+    }
+
+    @Test
+    public void testAddIndexOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.addIndex("foo", false);
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testAddIndexOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.addIndex("foo", false);
+    }
+
+    @Test
+    public void testAddInterceptorOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.addInterceptor(new SimpleInterceptor());
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testAddInterceptorOperationThrowsExceptionWhenQuorumSizeNotMet() {
+        map4.addInterceptor(new SimpleInterceptor());
+    }
+
+    @Test
+    public void testRemoveInterceptorOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.removeInterceptor("foo");
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testRemoveInterceptorOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.removeInterceptor("foo");
+    }
+
+    @Test
+    public void testExecuteOnKeyOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.executeOnKey("foo", new LoggingEntryProcessor());
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testExecuteOnKeyOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.executeOnKey("foo", new LoggingEntryProcessor());
+    }
+
+    @Test
+    public void testExecuteOnKeysOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        HashSet<Object> keys = new HashSet<Object>();
+        keys.add("foo");
+        map1.executeOnKey(keys, new LoggingEntryProcessor());
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testExecuteOnKeysOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        HashSet<Object> keys = new HashSet<Object>();
+        keys.add("foo");
+        map4.executeOnKey(keys, new LoggingEntryProcessor());
+    }
+
+    @Test
+    public void testExecuteOnEntriesOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        map1.executeOnEntries(new LoggingEntryProcessor());
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testExecuteOnEntriesOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.executeOnEntries(new LoggingEntryProcessor());
+    }
+
+    @Test
+    public void testSubmmitToKeyOperationSuccessfulWhenQuorumSizeMet() throws Exception {
+        Future foo = map1.submitToKey("foo", new LoggingEntryProcessor());
+        foo.get();
+    }
+
+    @Test(expected = ExecutionException.class)
+    public void testSubmmitToKeyOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        Future foo = map4.submitToKey("foo", new LoggingEntryProcessor());
+        foo.get();
+    }
+
+    @Ignore
+    @Test(expected = QuorumException.class)
+    public void testLockOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.lock("foo");
+    }
+
+    @Ignore
+    @Test(expected = QuorumException.class)
+    public void testTryLockOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.tryLock("foo");
+    }
+
+    @Ignore
+    @Test(expected = QuorumException.class)
+    public void testUnlockOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.unlock("foo");
+    }
+
+    @Ignore
+    @Test(expected = QuorumException.class)
+    public void testIsLockedOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.isLocked("foo");
+    }
+
+    @Ignore
+    @Test(expected = QuorumException.class)
+    public void testForceUnlockOperationThrowsExceptionWhenQuorumSizeNotMet() throws Exception {
+        map4.forceUnlock("foo");
+    }
+
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/quorum/PartitionedCluster.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/PartitionedCluster.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2008-2014, Hazelcast, Inc. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.hazelcast.quorum;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.MembershipAdapter;
+import com.hazelcast.core.MembershipEvent;
+import com.hazelcast.instance.DefaultNodeContext;
+import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.instance.HazelcastInstanceFactory;
+import com.hazelcast.instance.Node;
+import com.hazelcast.nio.ConnectionManager;
+import com.hazelcast.nio.NodeIOService;
+import com.hazelcast.nio.tcp.FirewallingTcpIpConnectionManager;
+import com.hazelcast.config.QuorumConfig;
+import java.nio.channels.ServerSocketChannel;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static com.hazelcast.test.HazelcastTestSupport.generateRandomString;
+import static com.hazelcast.test.HazelcastTestSupport.getNode;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class PartitionedCluster {
+    public HazelcastInstance h1;
+    public HazelcastInstance h2;
+    public HazelcastInstance h3;
+    public HazelcastInstance h4;
+    public HazelcastInstance h5;
+
+
+    public PartitionedCluster partitionFiveMembersThreeAndTwo(MapConfig mapConfig, QuorumConfig quorumConfig) throws InterruptedException {
+        Config config = new Config();
+        config.setProperty(GroupProperties.PROP_MERGE_FIRST_RUN_DELAY_SECONDS, "9999");
+        config.setProperty(GroupProperties.PROP_MERGE_NEXT_RUN_DELAY_SECONDS, "9999");
+        config.getGroupConfig().setName(generateRandomString(10));
+        config.addMapConfig(mapConfig);
+        config.addQuorumConfig(quorumConfig);
+        createInstances(config);
+
+        final CountDownLatch splitLatch = new CountDownLatch(6);
+        h4.getCluster().addMembershipListener(new MembershipAdapter() {
+            @Override
+            public void memberRemoved(MembershipEvent membershipEvent) {
+                splitLatch.countDown();
+            }
+        });
+        h5.getCluster().addMembershipListener(new MembershipAdapter() {
+            @Override
+            public void memberRemoved(MembershipEvent membershipEvent) {
+                splitLatch.countDown();
+            }
+        });
+
+        splitCluster();
+
+        assertTrue(splitLatch.await(30, TimeUnit.SECONDS));
+        assertEquals(3, h1.getCluster().getMembers().size());
+        assertEquals(3, h2.getCluster().getMembers().size());
+        assertEquals(3, h3.getCluster().getMembers().size());
+        assertEquals(2, h4.getCluster().getMembers().size());
+        assertEquals(2, h5.getCluster().getMembers().size());
+        return this;
+    }
+
+    private void createInstances(Config config) {
+        h1 = HazelcastInstanceFactory.newHazelcastInstance(config, "node1", new FirewallingNodeContext());
+        h2 = HazelcastInstanceFactory.newHazelcastInstance(config, "node2", new FirewallingNodeContext());
+        h3 = HazelcastInstanceFactory.newHazelcastInstance(config, "node3", new FirewallingNodeContext());
+        h4 = HazelcastInstanceFactory.newHazelcastInstance(config, "node4", new FirewallingNodeContext());
+        h5 = HazelcastInstanceFactory.newHazelcastInstance(config, "node5", new FirewallingNodeContext());
+    }
+
+    private void splitCluster() {
+        Node n1 = getNode(h1);
+        Node n2 = getNode(h2);
+        Node n3 = getNode(h3);
+        Node n4 = getNode(h4);
+        Node n5 = getNode(h5);
+
+        FirewallingTcpIpConnectionManager cm1 = getConnectionManager(n1);
+        FirewallingTcpIpConnectionManager cm2 = getConnectionManager(n2);
+        FirewallingTcpIpConnectionManager cm3 = getConnectionManager(n3);
+        FirewallingTcpIpConnectionManager cm4 = getConnectionManager(n4);
+        FirewallingTcpIpConnectionManager cm5 = getConnectionManager(n5);
+
+        cm1.block(n4.address);
+        cm2.block(n4.address);
+        cm3.block(n4.address);
+
+        cm1.block(n5.address);
+        cm2.block(n5.address);
+        cm3.block(n5.address);
+
+        cm4.block(n1.address);
+        cm4.block(n2.address);
+        cm4.block(n3.address);
+
+        cm5.block(n1.address);
+        cm5.block(n2.address);
+        cm5.block(n3.address);
+
+        n4.clusterService.removeAddress(n1.address);
+        n4.clusterService.removeAddress(n2.address);
+        n4.clusterService.removeAddress(n3.address);
+
+        n5.clusterService.removeAddress(n1.address);
+        n5.clusterService.removeAddress(n2.address);
+        n5.clusterService.removeAddress(n3.address);
+
+        n1.clusterService.removeAddress(n4.address);
+        n2.clusterService.removeAddress(n4.address);
+        n3.clusterService.removeAddress(n4.address);
+
+        n1.clusterService.removeAddress(n5.address);
+        n2.clusterService.removeAddress(n5.address);
+        n3.clusterService.removeAddress(n5.address);
+    }
+
+    private static class FirewallingNodeContext extends DefaultNodeContext {
+        @Override
+        public ConnectionManager createConnectionManager(Node node, ServerSocketChannel serverSocketChannel) {
+            NodeIOService ioService = new NodeIOService(node);
+            return new FirewallingTcpIpConnectionManager(node.loggingService,
+                    node.getHazelcastThreadGroup(), ioService, serverSocketChannel);
+        }
+    }
+
+    private static FirewallingTcpIpConnectionManager getConnectionManager(Node node) {
+        return (FirewallingTcpIpConnectionManager) node.getConnectionManager();
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/quorum/QuorumListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/QuorumListenerTest.java
@@ -1,0 +1,232 @@
+/*
+* Copyright (c) 2008-2014, Hazelcast, Inc. All Rights Reserved.
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*  http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+*/
+
+package com.hazelcast.quorum;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.config.QuorumConfig;
+import com.hazelcast.config.QuorumListenerConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.core.Member;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.QuickTest;
+import java.util.Collection;
+import java.util.concurrent.CountDownLatch;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class QuorumListenerTest extends HazelcastTestSupport {
+
+    @Test
+    public void testQuorumFailureEventFiredWhenNodeCountBelowThreshold() throws Exception {
+        final CountDownLatch countDownLatch = new CountDownLatch(1);
+        Config config = new Config();
+        QuorumListenerConfig listenerConfig = new QuorumListenerConfig();
+        listenerConfig.setImplementation(new QuorumListener() {
+            public void onChange(QuorumEvent quorumEvent) {
+                if (!quorumEvent.isPresent()) {
+                    countDownLatch.countDown();
+                }
+            }
+        });
+        String mapName = randomMapName();
+        String quorumName = randomString();
+        QuorumConfig quorumConfig = new QuorumConfig(quorumName, true, 3);
+        quorumConfig.addListenerConfig(listenerConfig);
+        config.getMapConfig(mapName).setQuorumName(quorumName);
+        config.addQuorumConfig(quorumConfig);
+        HazelcastInstance instance = createHazelcastInstance(config);
+        IMap<Object, Object> map = instance.getMap(mapName);
+        try {
+            map.put(generateKeyOwnedBy(instance), 1);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        assertOpenEventually(countDownLatch, 15);
+    }
+
+    @Test
+    public void testQuorumEventsFiredWhenNodeCountBelowThenAboveThreshold() throws Exception {
+        final CountDownLatch belowLatch = new CountDownLatch(1);
+        final CountDownLatch aboveLatch = new CountDownLatch(1);
+        Config config = new Config();
+        QuorumListenerConfig listenerConfig = new QuorumListenerConfig();
+        listenerConfig.setImplementation(new QuorumListener() {
+            public void onChange(QuorumEvent quorumEvent) {
+                if (quorumEvent.isPresent()) {
+                    aboveLatch.countDown();
+                } else {
+                    belowLatch.countDown();
+                }
+            }
+        });
+        String mapName = randomMapName();
+        String quorumName = randomString();
+        QuorumConfig quorumConfig = new QuorumConfig(quorumName, true, 3);
+        quorumConfig.addListenerConfig(listenerConfig);
+        config.getMapConfig(mapName).setQuorumName(quorumName);
+        config.addQuorumConfig(quorumConfig);
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(3);
+        HazelcastInstance instance1 = factory.newHazelcastInstance(config);
+        IMap<Object, Object> map = instance1.getMap(mapName);
+        try {
+            map.put(generateKeyOwnedBy(instance1), 1);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        assertOpenEventually(belowLatch, 15);
+        HazelcastInstance instance2 = factory.newHazelcastInstance(config);
+        HazelcastInstance instance3 = factory.newHazelcastInstance(config);
+        map.put(generateKeyOwnedBy(instance1), 1);
+        assertOpenEventually(aboveLatch);
+    }
+
+    @Test
+    public void testDifferentQuorumsGetCorrectEvents() throws Exception {
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(3);
+        final CountDownLatch quorumFailureLatch = new CountDownLatch(2);
+        String fourNodeQuorumName = "fourNode";
+        QuorumConfig fourNodeQuorumConfig = new QuorumConfig(fourNodeQuorumName, true, 4);
+        fourNodeQuorumConfig.addListenerConfig(new QuorumListenerConfig(new QuorumListener() {
+            public void onChange(QuorumEvent quorumEvent) {
+                if (!quorumEvent.isPresent()) {
+                    quorumFailureLatch.countDown();
+                }
+            }
+        }));
+        String threeNodeQuorumName = "threeNode";
+        QuorumConfig threeNodeQuorumConfig = new QuorumConfig(threeNodeQuorumName, true, 3);
+        threeNodeQuorumConfig.addListenerConfig(new QuorumListenerConfig(new QuorumListener() {
+            public void onChange(QuorumEvent quorumEvent) {
+                if (!quorumEvent.isPresent()) {
+                    quorumFailureLatch.countDown();
+                }
+            }
+        }));
+        MapConfig fourNodeMapConfig = new MapConfig("fourNode");
+        fourNodeMapConfig.setQuorumName(fourNodeQuorumName);
+
+        MapConfig threeNodeMapConfig = new MapConfig("threeNode");
+        threeNodeMapConfig.setQuorumName(threeNodeQuorumName);
+
+        Config config = new Config();
+        config.addMapConfig(fourNodeMapConfig);
+        config.addQuorumConfig(fourNodeQuorumConfig);
+        config.addMapConfig(threeNodeMapConfig);
+        config.addQuorumConfig(threeNodeQuorumConfig);
+
+        HazelcastInstance h1 = factory.newHazelcastInstance(config);
+        HazelcastInstance h2 = factory.newHazelcastInstance(config);
+
+        IMap<Object, Object> fourNode = h1.getMap("fourNode");
+        IMap<Object, Object> threeNode = h1.getMap("threeNode");
+        try {
+            threeNode.put(generateKeyOwnedBy(h1), "bar");
+            fail();
+        } catch (Exception e) {
+        }
+        try {
+            fourNode.put(generateKeyOwnedBy(h1), "bar");
+            fail();
+        } catch (Exception e) {
+        }
+        assertOpenEventually(quorumFailureLatch);
+
+    }
+
+    @Test
+    public void testCustomResolverFiresQuorumFailureEvent() throws Exception {
+        final CountDownLatch countDownLatch = new CountDownLatch(1);
+        Config config = new Config();
+        QuorumListenerConfig listenerConfig = new QuorumListenerConfig();
+        listenerConfig.setImplementation(new QuorumListener() {
+            @Override
+            public void onChange(QuorumEvent quorumEvent) {
+                if (!quorumEvent.isPresent()) {
+                    countDownLatch.countDown();
+                }
+            }
+        });
+        String mapName = randomMapName();
+        String quorumName = randomString();
+        QuorumConfig quorumConfig = new QuorumConfig();
+        quorumConfig.setName(quorumName);
+        quorumConfig.setEnabled(true);
+        quorumConfig.addListenerConfig(listenerConfig);
+        quorumConfig.setQuorumFunctionImplementation(new QuorumFunction() {
+            @Override
+            public boolean apply(Collection<Member> members) {
+                return false;
+            }
+        });
+        config.getMapConfig(mapName).setQuorumName(quorumName);
+        config.addQuorumConfig(quorumConfig);
+        HazelcastInstance instance = createHazelcastInstance(config);
+        QuorumService quorumService = instance.getQuorumService();
+        Quorum quorum = quorumService.getQuorum(quorumName);
+        IMap<Object, Object> map = instance.getMap(mapName);
+        try {
+            map.put(generateKeyOwnedBy(instance), 1);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        assertOpenEventually(countDownLatch, 15);
+
+    }
+
+    @Test
+    public void testQuorumEventProvidesCorrectMemberListSize() throws Exception {
+        final CountDownLatch belowLatch = new CountDownLatch(1);
+        Config config = new Config();
+        QuorumListenerConfig listenerConfig = new QuorumListenerConfig();
+        listenerConfig.setImplementation(new QuorumListener() {
+            public void onChange(QuorumEvent quorumEvent) {
+                if (!quorumEvent.isPresent()) {
+                    Collection<Member> currentMembers = quorumEvent.getCurrentMembers();
+                    assertEquals(2, currentMembers.size());
+                    assertEquals(3, quorumEvent.getThreshold());
+                    belowLatch.countDown();
+                }
+            }
+        });
+        String mapName = randomMapName();
+        String quorumName = randomString();
+        QuorumConfig quorumConfig = new QuorumConfig(quorumName, true, 3);
+        quorumConfig.addListenerConfig(listenerConfig);
+        config.getMapConfig(mapName).setQuorumName(quorumName);
+        config.addQuorumConfig(quorumConfig);
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(3);
+        HazelcastInstance instance1 = factory.newHazelcastInstance(config);
+        HazelcastInstance instance2 = factory.newHazelcastInstance(config);
+        IMap<Object, Object> map = instance1.getMap(mapName);
+        try {
+            map.put(generateKeyOwnedBy(instance1), 1);
+        } catch (Exception e) {
+
+        }
+        assertOpenEventually(belowLatch);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/quorum/QuorumTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/QuorumTest.java
@@ -1,0 +1,207 @@
+/*
+* Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*  http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+*/
+
+package com.hazelcast.quorum;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.config.QuorumConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.core.Member;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.QuickTest;
+import java.util.Collection;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.fail;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class QuorumTest extends HazelcastTestSupport {
+
+
+    @Test(expected = QuorumException.class)
+    public void testCustomQuorumFunctionFails() throws Exception {
+        Config config = new Config();
+        QuorumConfig quorumConfig = new QuorumConfig();
+        String quorumName = randomString();
+        quorumConfig.setName(quorumName);
+        quorumConfig.setEnabled(true);
+        quorumConfig.setQuorumFunctionImplementation(new QuorumFunction() {
+            @Override
+            public boolean apply(Collection<Member> members) {
+                return false;
+            }
+        });
+        config.addQuorumConfig(quorumConfig);
+        String mapName = randomMapName();
+        MapConfig mapConfig = new MapConfig(mapName);
+        mapConfig.setQuorumName(quorumName);
+        config.addMapConfig(mapConfig);
+        HazelcastInstance hazelcastInstance = createHazelcastInstance(config);
+        IMap<Object, Object> map = hazelcastInstance.getMap(mapName);
+        map.put("1", "1");
+    }
+
+    @Test
+    public void testCustomQuorumFunctionIsPresent() throws Exception {
+        Config config = new Config();
+        QuorumConfig quorumConfig = new QuorumConfig();
+        String quorumName = randomString();
+        quorumConfig.setName(quorumName);
+        quorumConfig.setEnabled(true);
+        quorumConfig.setQuorumFunctionImplementation(new QuorumFunction() {
+            @Override
+            public boolean apply(Collection<Member> members) {
+                return false;
+            }
+        });
+        config.addQuorumConfig(quorumConfig);
+        String mapName = randomMapName();
+        MapConfig mapConfig = new MapConfig(mapName);
+        mapConfig.setQuorumName(quorumName);
+        config.addMapConfig(mapConfig);
+        HazelcastInstance hazelcastInstance = createHazelcastInstance(config);
+        IMap<Object, Object> map = hazelcastInstance.getMap(mapName);
+        try {
+            map.put("1", "1");
+            fail();
+        } catch (Exception e) {
+        }
+        Quorum quorum = hazelcastInstance.getQuorumService().getQuorum(quorumName);
+        assertFalse(quorum.isPresent());
+    }
+
+
+    @Test(expected = QuorumException.class)
+    public void testCustomQuorumFunctionFailsForAllNodes() throws Exception {
+        Config config = new Config();
+        QuorumConfig quorumConfig = new QuorumConfig();
+        String quorumName = randomString();
+        quorumConfig.setName(quorumName);
+        quorumConfig.setEnabled(true);
+        quorumConfig.setQuorumFunctionImplementation(new QuorumFunction() {
+            @Override
+            public boolean apply(Collection<Member> members) {
+                return false;
+            }
+        });
+        config.addQuorumConfig(quorumConfig);
+        String mapName = randomMapName();
+        MapConfig mapConfig = new MapConfig(mapName);
+        mapConfig.setQuorumName(quorumName);
+        config.addMapConfig(mapConfig);
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(2);
+        HazelcastInstance h1 = factory.newHazelcastInstance(config);
+        HazelcastInstance h2 = factory.newHazelcastInstance(config);
+        IMap<Object, Object> map2 = h2.getMap(mapName);
+        map2.put("1", "1");
+    }
+
+    @Test
+    public void testCustomQuorumFunctionFailsThenSuccess() throws Exception {
+        Config config = new Config();
+        QuorumConfig quorumConfig = new QuorumConfig();
+        String quorumName = randomString();
+        quorumConfig.setName(quorumName);
+        quorumConfig.setEnabled(true);
+        final AtomicInteger count = new AtomicInteger(1);
+        quorumConfig.setQuorumFunctionImplementation(new QuorumFunction() {
+            @Override
+            public boolean apply(Collection<Member> members) {
+                if (count.get() == 1) {
+                    count.incrementAndGet();
+                    return false;
+                } else {
+                    return true;
+                }
+            }
+        });
+        config.addQuorumConfig(quorumConfig);
+        String mapName = randomMapName();
+        MapConfig mapConfig = new MapConfig(mapName);
+        mapConfig.setQuorumName(quorumName);
+        config.addMapConfig(mapConfig);
+        TestHazelcastInstanceFactory f = new TestHazelcastInstanceFactory(2);
+        HazelcastInstance hazelcastInstance = f.newHazelcastInstance(config);
+        IMap<Object, Object> map = hazelcastInstance.getMap(mapName);
+        try {
+            map.put("1", "1");
+            fail();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        HazelcastInstance hazelcastInstance2 = f.newHazelcastInstance(config);
+        map.put("1", "1");
+        f.shutdownAll();
+    }
+
+
+    @Test
+    public void testOneQuorumsFailsOneQuorumSuccessForDifferentMaps() throws Exception {
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(3);
+        String fourNodeQuorum = randomString();
+        QuorumConfig fourNodeQuorumConfig = new QuorumConfig(fourNodeQuorum, true);
+        fourNodeQuorumConfig.setQuorumFunctionImplementation(new QuorumFunction() {
+            @Override
+            public boolean apply(Collection<Member> members) {
+                return members.size() == 4;
+            }
+        });
+
+        String threeNodeQuorum = randomString();
+        QuorumConfig threeNodeQuorumConfig = new QuorumConfig(threeNodeQuorum, true);
+        threeNodeQuorumConfig.setQuorumFunctionImplementation(new QuorumFunction() {
+            @Override
+            public boolean apply(Collection<Member> members) {
+                return members.size() == 3;
+            }
+        });
+
+        MapConfig fourNodeMapConfig = new MapConfig("fourNode");
+        fourNodeMapConfig.setQuorumName(fourNodeQuorum);
+
+        MapConfig threeNodeMapConfig = new MapConfig("threeNode");
+        threeNodeMapConfig.setQuorumName(threeNodeQuorum);
+
+        Config config = new Config();
+        config.addQuorumConfig(threeNodeQuorumConfig);
+        config.addQuorumConfig(fourNodeQuorumConfig);
+        config.addMapConfig(fourNodeMapConfig);
+        config.addMapConfig(threeNodeMapConfig);
+
+        HazelcastInstance h1 = factory.newHazelcastInstance(config);
+        HazelcastInstance h2 = factory.newHazelcastInstance(config);
+        HazelcastInstance h3 = factory.newHazelcastInstance(config);
+
+        IMap<Object, Object> fourNode = h1.getMap("fourNode");
+        IMap<Object, Object> threeNode = h1.getMap("threeNode");
+        threeNode.put(generateKeyOwnedBy(h1), "bar");
+        try {
+            fourNode.put(generateKeyOwnedBy(h1), "bar");
+            fail();
+        } catch (Exception e) {
+        }
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/quorum/TransactionalMapReadQuorumTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/TransactionalMapReadQuorumTest.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.hazelcast.quorum;
+
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.core.TransactionalMap;
+import com.hazelcast.instance.HazelcastInstanceFactory;
+import com.hazelcast.query.TruePredicate;
+import com.hazelcast.config.QuorumConfig;
+import com.hazelcast.test.HazelcastTestRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.test.annotation.RunParallel;
+import com.hazelcast.transaction.TransactionContext;
+import com.hazelcast.transaction.TransactionException;
+import com.hazelcast.transaction.TransactionOptions;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import static com.hazelcast.test.HazelcastTestSupport.randomMapName;
+import static com.hazelcast.transaction.TransactionOptions.TransactionType.LOCAL;
+import static com.hazelcast.transaction.TransactionOptions.TransactionType.TWO_PHASE;
+
+@RunParallel
+@RunWith(HazelcastTestRunner.class)
+@Category(QuickTest.class)
+public class TransactionalMapReadQuorumTest {
+
+    static PartitionedCluster cluster;
+    private static final String MAP_NAME_PREFIX = "quorum";
+    private static final String QUORUM_ID = "threeNodeQuorumRule";
+
+    @Parameterized.Parameter(0)
+    public TransactionOptions options;
+
+
+    @Parameterized.Parameters(name = "Executing: {0}")
+    public static Collection<Object[]> parameters() {
+
+        TransactionOptions localOption = TransactionOptions.getDefault();
+        localOption.setTransactionType(LOCAL);
+
+        TransactionOptions twoPhaseOption = TransactionOptions.getDefault();
+        twoPhaseOption.setTransactionType(TWO_PHASE);
+
+        return Arrays.asList(
+                new Object[]{twoPhaseOption}, //
+                new Object[]{localOption} //
+        );
+    }
+
+    @BeforeClass
+    public static void initialize() throws InterruptedException {
+        QuorumConfig quorumConfig = new QuorumConfig();
+        quorumConfig.setEnabled(true);
+        quorumConfig.setSize(3);
+        quorumConfig.setName(QUORUM_ID);
+        quorumConfig.setType(QuorumType.READ);
+
+        MapConfig mapConfig = new MapConfig(MAP_NAME_PREFIX + "*");
+        mapConfig.setQuorumName(QUORUM_ID);
+        cluster = new PartitionedCluster().partitionFiveMembersThreeAndTwo(mapConfig, quorumConfig);
+    }
+
+    @AfterClass
+    public static void killAllHazelcastInstances() throws IOException {
+        HazelcastInstanceFactory.terminateAll();
+    }
+
+
+    @Test(expected = TransactionException.class)
+    public void testTxGetThrowsExceptionWhenQuorumSizeNotMet() {
+        TransactionContext transactionContext = cluster.h4.newTransactionContext(options);
+        transactionContext.beginTransaction();
+        TransactionalMap<Object, Object> map = transactionContext.getMap(randomMapName(MAP_NAME_PREFIX));
+        map.get("foo");
+        transactionContext.commitTransaction();
+    }
+
+
+    @Test(expected = TransactionException.class)
+    public void testTxSizeThrowsExceptionWhenQuorumSizeNotMet() {
+        TransactionContext transactionContext = cluster.h4.newTransactionContext(options);
+        transactionContext.beginTransaction();
+        TransactionalMap<Object, Object> map = transactionContext.getMap(randomMapName(MAP_NAME_PREFIX));
+        map.size();
+        transactionContext.commitTransaction();
+    }
+
+    @Test(expected = TransactionException.class)
+    public void testTxContainsKeyThrowsExceptionWhenQuorumSizeNotMet() {
+        TransactionContext transactionContext = cluster.h4.newTransactionContext(options);
+        transactionContext.beginTransaction();
+        TransactionalMap<Object, Object> map = transactionContext.getMap(randomMapName(MAP_NAME_PREFIX));
+        map.containsKey("foo");
+        transactionContext.commitTransaction();
+    }
+
+
+    @Test(expected = TransactionException.class)
+    public void testTxIsEmptyThrowsExceptionWhenQuorumSizeNotMet() {
+        TransactionContext transactionContext = cluster.h4.newTransactionContext(options);
+        transactionContext.beginTransaction();
+        TransactionalMap<Object, Object> map = transactionContext.getMap(randomMapName(MAP_NAME_PREFIX));
+        map.isEmpty();
+        transactionContext.commitTransaction();
+    }
+
+    @Test(expected = TransactionException.class)
+    public void testTxKeySetThrowsExceptionWhenQuorumSizeNotMet() {
+        TransactionContext transactionContext = cluster.h4.newTransactionContext(options);
+        transactionContext.beginTransaction();
+        TransactionalMap<Object, Object> map = transactionContext.getMap(randomMapName(MAP_NAME_PREFIX));
+        map.keySet();
+        transactionContext.commitTransaction();
+    }
+
+    @Test(expected = TransactionException.class)
+    public void testTxKeySetWithPredicateThrowsExceptionWhenQuorumSizeNotMet() {
+        TransactionContext transactionContext = cluster.h4.newTransactionContext(options);
+        transactionContext.beginTransaction();
+        TransactionalMap<Object, Object> map = transactionContext.getMap(randomMapName(MAP_NAME_PREFIX));
+        map.keySet(TruePredicate.INSTANCE);
+        transactionContext.commitTransaction();
+    }
+
+    @Test(expected = TransactionException.class)
+    public void testTxValuesThrowsExceptionWhenQuorumSizeNotMet() {
+        TransactionContext transactionContext = cluster.h4.newTransactionContext(options);
+        transactionContext.beginTransaction();
+        TransactionalMap<Object, Object> map = transactionContext.getMap(randomMapName(MAP_NAME_PREFIX));
+        map.values();
+        transactionContext.commitTransaction();
+    }
+
+    @Test(expected = TransactionException.class)
+    public void testTxValuesWithPredicateThrowsExceptionWhenQuorumSizeNotMet() {
+        TransactionContext transactionContext = cluster.h4.newTransactionContext(options);
+        transactionContext.beginTransaction();
+        TransactionalMap<Object, Object> map = transactionContext.getMap(randomMapName(MAP_NAME_PREFIX));
+        map.values(TruePredicate.INSTANCE);
+        transactionContext.commitTransaction();
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/quorum/TransactionalMapReadWriteQuorumTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/TransactionalMapReadWriteQuorumTest.java
@@ -1,0 +1,257 @@
+/*
+* Copyright (c) 2008-2014, Hazelcast, Inc. All Rights Reserved.
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*  http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+*/
+
+package com.hazelcast.quorum;
+
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.core.TransactionalMap;
+import com.hazelcast.instance.HazelcastInstanceFactory;
+import com.hazelcast.query.TruePredicate;
+import com.hazelcast.config.QuorumConfig;
+import com.hazelcast.test.HazelcastTestRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.test.annotation.RunParallel;
+import com.hazelcast.transaction.TransactionContext;
+import com.hazelcast.transaction.TransactionException;
+import com.hazelcast.transaction.TransactionOptions;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.concurrent.TimeUnit;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import static com.hazelcast.test.HazelcastTestSupport.randomMapName;
+import static com.hazelcast.transaction.TransactionOptions.TransactionType.LOCAL;
+import static com.hazelcast.transaction.TransactionOptions.TransactionType.TWO_PHASE;
+
+@RunParallel
+@RunWith(HazelcastTestRunner.class)
+@Category(QuickTest.class)
+public class TransactionalMapReadWriteQuorumTest {
+
+    static PartitionedCluster cluster;
+    private static final String MAP_NAME_PREFIX = "quorum";
+    private static final String QUORUM_ID = "threeNodeQuorumRule";
+
+    @Parameterized.Parameter(0)
+    public TransactionOptions options;
+
+
+    @Parameterized.Parameters(name = "Executing: {0}")
+    public static Collection<Object[]> parameters() {
+
+        TransactionOptions localOption = TransactionOptions.getDefault();
+        localOption.setTransactionType(LOCAL);
+
+        TransactionOptions twoPhaseOption = TransactionOptions.getDefault();
+        twoPhaseOption.setTransactionType(TWO_PHASE);
+
+        return Arrays.asList(
+                new Object[]{twoPhaseOption}, //
+                new Object[]{localOption} //
+        );
+    }
+
+    @BeforeClass
+    public static void initialize() throws InterruptedException {
+        QuorumConfig quorumConfig = new QuorumConfig();
+        quorumConfig.setEnabled(true);
+        quorumConfig.setSize(3);
+        quorumConfig.setName(QUORUM_ID);
+        quorumConfig.setType(QuorumType.READ_WRITE);
+
+        MapConfig mapConfig = new MapConfig(MAP_NAME_PREFIX + "*");
+        mapConfig.setQuorumName(QUORUM_ID);
+        cluster = new PartitionedCluster().partitionFiveMembersThreeAndTwo(mapConfig, quorumConfig);
+    }
+
+    @AfterClass
+    public static void killAllHazelcastInstances() throws IOException {
+        HazelcastInstanceFactory.terminateAll();
+    }
+
+
+    @Test(expected = TransactionException.class)
+    public void testTxPutThrowsExceptionWhenQuorumSizeNotMet() {
+        TransactionContext transactionContext = cluster.h4.newTransactionContext(options);
+        transactionContext.beginTransaction();
+        TransactionalMap<Object, Object> map = transactionContext.getMap(randomMapName(MAP_NAME_PREFIX));
+        map.put("foo", "bar");
+        transactionContext.commitTransaction();
+    }
+
+    @Test(expected = TransactionException.class)
+    public void testTxGetThrowsExceptionWhenQuorumSizeNotMet() {
+        TransactionContext transactionContext = cluster.h4.newTransactionContext(options);
+        transactionContext.beginTransaction();
+        TransactionalMap<Object, Object> map = transactionContext.getMap(randomMapName(MAP_NAME_PREFIX));
+        map.get("foo");
+        transactionContext.commitTransaction();
+    }
+
+
+    @Test(expected = TransactionException.class)
+    public void testTxGetForUpdateThrowsExceptionWhenQuorumSizeNotMet() {
+        TransactionContext transactionContext = cluster.h4.newTransactionContext(options);
+        transactionContext.beginTransaction();
+        TransactionalMap<Object, Object> map = transactionContext.getMap(randomMapName(MAP_NAME_PREFIX));
+        map.getForUpdate("foo");
+        transactionContext.commitTransaction();
+    }
+
+    @Test(expected = TransactionException.class)
+    public void testTxRemoveThrowsExceptionWhenQuorumSizeNotMet() {
+        TransactionContext transactionContext = cluster.h4.newTransactionContext(options);
+        transactionContext.beginTransaction();
+        TransactionalMap<Object, Object> map = transactionContext.getMap(randomMapName(MAP_NAME_PREFIX));
+        map.remove("foo");
+        transactionContext.commitTransaction();
+    }
+
+
+    @Test(expected = TransactionException.class)
+    public void testTxRemoveValueThrowsExceptionWhenQuorumSizeNotMet() {
+        TransactionContext transactionContext = cluster.h4.newTransactionContext(options);
+        transactionContext.beginTransaction();
+        TransactionalMap<Object, Object> map = transactionContext.getMap(randomMapName(MAP_NAME_PREFIX));
+        map.remove("foo", "bar");
+        transactionContext.commitTransaction();
+    }
+
+    @Test(expected = TransactionException.class)
+    public void testTxDeleteThrowsExceptionWhenQuorumSizeNotMet() {
+        TransactionContext transactionContext = cluster.h4.newTransactionContext(options);
+        transactionContext.beginTransaction();
+        TransactionalMap<Object, Object> map = transactionContext.getMap(randomMapName(MAP_NAME_PREFIX));
+        map.delete("foo");
+        transactionContext.commitTransaction();
+    }
+
+    @Test(expected = TransactionException.class)
+    public void testTxSetThrowsExceptionWhenQuorumSizeNotMet() {
+        TransactionContext transactionContext = cluster.h4.newTransactionContext(options);
+        transactionContext.beginTransaction();
+        TransactionalMap<Object, Object> map = transactionContext.getMap(randomMapName(MAP_NAME_PREFIX));
+        map.set("foo", "bar");
+        transactionContext.commitTransaction();
+    }
+
+    @Test(expected = TransactionException.class)
+    public void testTxPutWithTTLThrowsExceptionWhenQuorumSizeNotMet() {
+        TransactionContext transactionContext = cluster.h4.newTransactionContext(options);
+        transactionContext.beginTransaction();
+        TransactionalMap<Object, Object> map = transactionContext.getMap(randomMapName(MAP_NAME_PREFIX));
+        map.put("foo", "bar", 10, TimeUnit.SECONDS);
+        transactionContext.commitTransaction();
+    }
+
+    @Test(expected = TransactionException.class)
+    public void testTxPutIfAbsentThrowsExceptionWhenQuorumSizeNotMet() {
+        TransactionContext transactionContext = cluster.h4.newTransactionContext(options);
+        transactionContext.beginTransaction();
+        TransactionalMap<Object, Object> map = transactionContext.getMap(randomMapName(MAP_NAME_PREFIX));
+        map.putIfAbsent("foo", "bar");
+        transactionContext.commitTransaction();
+    }
+
+    @Test(expected = TransactionException.class)
+    public void testTxReplaceThrowsExceptionWhenQuorumSizeNotMet() {
+        TransactionContext transactionContext = cluster.h4.newTransactionContext(options);
+        transactionContext.beginTransaction();
+        TransactionalMap<Object, Object> map = transactionContext.getMap(randomMapName(MAP_NAME_PREFIX));
+        map.replace("foo", "bar");
+        transactionContext.commitTransaction();
+    }
+
+    @Test(expected = TransactionException.class)
+    public void testTxReplaceExpectedValueThrowsExceptionWhenQuorumSizeNotMet() {
+        TransactionContext transactionContext = cluster.h4.newTransactionContext(options);
+        transactionContext.beginTransaction();
+        TransactionalMap<Object, Object> map = transactionContext.getMap(randomMapName(MAP_NAME_PREFIX));
+        map.replace("foo", "bar", "baz");
+        transactionContext.commitTransaction();
+    }
+
+    @Test(expected = TransactionException.class)
+    public void testTxSizeThrowsExceptionWhenQuorumSizeNotMet() {
+        TransactionContext transactionContext = cluster.h4.newTransactionContext(options);
+        transactionContext.beginTransaction();
+        TransactionalMap<Object, Object> map = transactionContext.getMap(randomMapName(MAP_NAME_PREFIX));
+        map.size();
+        transactionContext.commitTransaction();
+    }
+
+    @Test(expected = TransactionException.class)
+    public void testTxContainsKeyThrowsExceptionWhenQuorumSizeNotMet() {
+        TransactionContext transactionContext = cluster.h4.newTransactionContext(options);
+        transactionContext.beginTransaction();
+        TransactionalMap<Object, Object> map = transactionContext.getMap(randomMapName(MAP_NAME_PREFIX));
+        map.containsKey("foo");
+        transactionContext.commitTransaction();
+    }
+
+
+    @Test(expected = TransactionException.class)
+    public void testTxIsEmptyThrowsExceptionWhenQuorumSizeNotMet() {
+        TransactionContext transactionContext = cluster.h4.newTransactionContext(options);
+        transactionContext.beginTransaction();
+        TransactionalMap<Object, Object> map = transactionContext.getMap(randomMapName(MAP_NAME_PREFIX));
+        map.isEmpty();
+        transactionContext.commitTransaction();
+    }
+
+    @Test(expected = TransactionException.class)
+    public void testTxKeySetThrowsExceptionWhenQuorumSizeNotMet() {
+        TransactionContext transactionContext = cluster.h4.newTransactionContext(options);
+        transactionContext.beginTransaction();
+        TransactionalMap<Object, Object> map = transactionContext.getMap(randomMapName(MAP_NAME_PREFIX));
+        map.keySet();
+        transactionContext.commitTransaction();
+    }
+
+    @Test(expected = TransactionException.class)
+    public void testTxKeySetWithPredicateThrowsExceptionWhenQuorumSizeNotMet() {
+        TransactionContext transactionContext = cluster.h4.newTransactionContext(options);
+        transactionContext.beginTransaction();
+        TransactionalMap<Object, Object> map = transactionContext.getMap(randomMapName(MAP_NAME_PREFIX));
+        map.keySet(TruePredicate.INSTANCE);
+        transactionContext.commitTransaction();
+    }
+
+    @Test(expected = TransactionException.class)
+    public void testTxValuesThrowsExceptionWhenQuorumSizeNotMet() {
+        TransactionContext transactionContext = cluster.h4.newTransactionContext(options);
+        transactionContext.beginTransaction();
+        TransactionalMap<Object, Object> map = transactionContext.getMap(randomMapName(MAP_NAME_PREFIX));
+        map.values();
+        transactionContext.commitTransaction();
+    }
+
+    @Test(expected = TransactionException.class)
+    public void testTxValuesWithPredicateThrowsExceptionWhenQuorumSizeNotMet() {
+        TransactionContext transactionContext = cluster.h4.newTransactionContext(options);
+        transactionContext.beginTransaction();
+        TransactionalMap<Object, Object> map = transactionContext.getMap(randomMapName(MAP_NAME_PREFIX));
+        map.values(TruePredicate.INSTANCE);
+        transactionContext.commitTransaction();
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/quorum/TransactionalMapWriteQuorumTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/TransactionalMapWriteQuorumTest.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.hazelcast.quorum;
+
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.core.TransactionalMap;
+import com.hazelcast.instance.HazelcastInstanceFactory;
+import com.hazelcast.config.QuorumConfig;
+import com.hazelcast.test.HazelcastTestRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.test.annotation.RunParallel;
+import com.hazelcast.transaction.TransactionContext;
+import com.hazelcast.transaction.TransactionException;
+import com.hazelcast.transaction.TransactionOptions;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.concurrent.TimeUnit;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import static com.hazelcast.test.HazelcastTestSupport.randomMapName;
+import static com.hazelcast.transaction.TransactionOptions.TransactionType.LOCAL;
+import static com.hazelcast.transaction.TransactionOptions.TransactionType.TWO_PHASE;
+
+@RunParallel
+@RunWith(HazelcastTestRunner.class)
+@Category(QuickTest.class)
+public class TransactionalMapWriteQuorumTest {
+
+    static PartitionedCluster cluster;
+    private static final String MAP_NAME_PREFIX = "quorum";
+    private static final String QUORUM_ID = "threeNodeQuorumRule";
+
+    @Parameterized.Parameter(0)
+    public TransactionOptions options;
+
+
+    @Parameterized.Parameters(name = "Executing: {0}")
+    public static Collection<Object[]> parameters() {
+
+        TransactionOptions localOption = TransactionOptions.getDefault();
+        localOption.setTransactionType(LOCAL);
+
+        TransactionOptions twoPhaseOption = TransactionOptions.getDefault();
+        twoPhaseOption.setTransactionType(TWO_PHASE);
+
+        return Arrays.asList(
+                new Object[]{twoPhaseOption}, //
+                new Object[]{localOption} //
+        );
+    }
+
+    @BeforeClass
+    public static void initialize() throws InterruptedException {
+        QuorumConfig quorumConfig = new QuorumConfig();
+        quorumConfig.setEnabled(true);
+        quorumConfig.setSize(3);
+        quorumConfig.setName(QUORUM_ID);
+        quorumConfig.setType(QuorumType.WRITE);
+
+        MapConfig mapConfig = new MapConfig(MAP_NAME_PREFIX + "*");
+        mapConfig.setQuorumName(QUORUM_ID);
+        cluster = new PartitionedCluster().partitionFiveMembersThreeAndTwo(mapConfig, quorumConfig);
+    }
+
+    @AfterClass
+    public static void killAllHazelcastInstances() throws IOException {
+        HazelcastInstanceFactory.terminateAll();
+    }
+
+
+    @Test(expected = TransactionException.class)
+    public void testTxPutThrowsExceptionWhenQuorumSizeNotMet() {
+        TransactionContext transactionContext = cluster.h4.newTransactionContext(options);
+        transactionContext.beginTransaction();
+        TransactionalMap<Object, Object> map = transactionContext.getMap(randomMapName(MAP_NAME_PREFIX));
+        map.put("foo", "bar");
+        transactionContext.commitTransaction();
+    }
+
+    @Test(expected = TransactionException.class)
+    public void testTxGetForUpdateThrowsExceptionWhenQuorumSizeNotMet() {
+        TransactionContext transactionContext = cluster.h4.newTransactionContext(options);
+        transactionContext.beginTransaction();
+        TransactionalMap<Object, Object> map = transactionContext.getMap(randomMapName(MAP_NAME_PREFIX));
+        map.getForUpdate("foo");
+        transactionContext.commitTransaction();
+    }
+
+    @Test(expected = TransactionException.class)
+    public void testTxRemoveThrowsExceptionWhenQuorumSizeNotMet() {
+        TransactionContext transactionContext = cluster.h4.newTransactionContext(options);
+        transactionContext.beginTransaction();
+        TransactionalMap<Object, Object> map = transactionContext.getMap(randomMapName(MAP_NAME_PREFIX));
+        map.remove("foo");
+        transactionContext.commitTransaction();
+    }
+
+
+    @Test(expected = TransactionException.class)
+    public void testTxRemoveValueThrowsExceptionWhenQuorumSizeNotMet() {
+        TransactionContext transactionContext = cluster.h4.newTransactionContext(options);
+        transactionContext.beginTransaction();
+        TransactionalMap<Object, Object> map = transactionContext.getMap(randomMapName(MAP_NAME_PREFIX));
+        map.remove("foo", "bar");
+        transactionContext.commitTransaction();
+    }
+
+    @Test(expected = TransactionException.class)
+    public void testTxDeleteThrowsExceptionWhenQuorumSizeNotMet() {
+        TransactionContext transactionContext = cluster.h4.newTransactionContext(options);
+        transactionContext.beginTransaction();
+        TransactionalMap<Object, Object> map = transactionContext.getMap(randomMapName(MAP_NAME_PREFIX));
+        map.delete("foo");
+        transactionContext.commitTransaction();
+    }
+
+    @Test(expected = TransactionException.class)
+    public void testTxSetThrowsExceptionWhenQuorumSizeNotMet() {
+        TransactionContext transactionContext = cluster.h4.newTransactionContext(options);
+        transactionContext.beginTransaction();
+        TransactionalMap<Object, Object> map = transactionContext.getMap(randomMapName(MAP_NAME_PREFIX));
+        map.set("foo", "bar");
+        transactionContext.commitTransaction();
+    }
+
+    @Test(expected = TransactionException.class)
+    public void testTxPutWithTTLThrowsExceptionWhenQuorumSizeNotMet() {
+        TransactionContext transactionContext = cluster.h4.newTransactionContext(options);
+        transactionContext.beginTransaction();
+        TransactionalMap<Object, Object> map = transactionContext.getMap(randomMapName(MAP_NAME_PREFIX));
+        map.put("foo", "bar", 10, TimeUnit.SECONDS);
+        transactionContext.commitTransaction();
+    }
+
+    @Test(expected = TransactionException.class)
+    public void testTxPutIfAbsentThrowsExceptionWhenQuorumSizeNotMet() {
+        TransactionContext transactionContext = cluster.h4.newTransactionContext(options);
+        transactionContext.beginTransaction();
+        TransactionalMap<Object, Object> map = transactionContext.getMap(randomMapName(MAP_NAME_PREFIX));
+        map.putIfAbsent("foo", "bar");
+        transactionContext.commitTransaction();
+    }
+
+    @Test(expected = TransactionException.class)
+    public void testTxReplaceThrowsExceptionWhenQuorumSizeNotMet() {
+        TransactionContext transactionContext = cluster.h4.newTransactionContext(options);
+        transactionContext.beginTransaction();
+        TransactionalMap<Object, Object> map = transactionContext.getMap(randomMapName(MAP_NAME_PREFIX));
+        map.replace("foo", "bar");
+        transactionContext.commitTransaction();
+    }
+
+    @Test(expected = TransactionException.class)
+    public void testTxReplaceExpectedValueThrowsExceptionWhenQuorumSizeNotMet() {
+        TransactionContext transactionContext = cluster.h4.newTransactionContext(options);
+        transactionContext.beginTransaction();
+        TransactionalMap<Object, Object> map = transactionContext.getMap(randomMapName(MAP_NAME_PREFIX));
+        map.replace("foo", "bar", "baz");
+        transactionContext.commitTransaction();
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/AbstractHazelcastClassRunner.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/AbstractHazelcastClassRunner.java
@@ -19,14 +19,6 @@ package com.hazelcast.test;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.test.annotation.Repeat;
-import org.junit.After;
-import org.junit.internal.runners.statements.RunAfters;
-import org.junit.runners.BlockJUnit4ClassRunner;
-import org.junit.runners.model.FrameworkMethod;
-import org.junit.runners.model.InitializationError;
-import org.junit.runners.model.MultipleFailureException;
-import org.junit.runners.model.Statement;
-
 import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadInfo;
 import java.lang.management.ThreadMXBean;
@@ -36,8 +28,17 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Random;
 import java.util.Set;
+import org.junit.After;
+import org.junit.internal.runners.statements.RunAfters;
+import org.junit.runners.model.FrameworkMethod;
+import org.junit.runners.model.InitializationError;
+import org.junit.runners.model.MultipleFailureException;
+import org.junit.runners.model.Statement;
 
-public abstract class AbstractHazelcastClassRunner extends BlockJUnit4ClassRunner {
+/**
+ * Base test runner which has base system properties and test repetition logic. The tests are run in random order.
+ */
+public abstract class AbstractHazelcastClassRunner extends AbstractParameterizedHazelcastClassRunner {
 
     protected static final boolean DISABLE_THREAD_DUMP_ON_FAILURE =
             Boolean.getBoolean("hazelcast.test.disableThreadDumpOnFailure");
@@ -66,7 +67,7 @@ public abstract class AbstractHazelcastClassRunner extends BlockJUnit4ClassRunne
 
     protected static final ThreadLocal<FrameworkMethod> FRAMEWORK_METHOD_THREAD_LOCAL = new ThreadLocal<FrameworkMethod>();
 
-    public static FrameworkMethod getThreadLocalFrameworkMethod(){
+    public static FrameworkMethod getThreadLocalFrameworkMethod() {
         return FRAMEWORK_METHOD_THREAD_LOCAL.get();
     }
 
@@ -79,6 +80,11 @@ public abstract class AbstractHazelcastClassRunner extends BlockJUnit4ClassRunne
         super(klass);
     }
 
+    public AbstractHazelcastClassRunner(Class<?> klass, Object[] parameters,
+                                        String name) throws InitializationError {
+        super(klass, parameters, name);
+    }
+
     @Override
     protected List<FrameworkMethod> getChildren() {
         List<FrameworkMethod> children = super.getChildren();
@@ -86,6 +92,7 @@ public abstract class AbstractHazelcastClassRunner extends BlockJUnit4ClassRunne
         Collections.shuffle(modifiableList);
         return modifiableList;
     }
+
 
     @Override
     protected Statement withAfters(FrameworkMethod method, Object target,
@@ -123,8 +130,8 @@ public abstract class AbstractHazelcastClassRunner extends BlockJUnit4ClassRunne
                 next.evaluate();
             } catch (Throwable e) {
                 System.err.println("THREAD DUMP FOR TEST FAILURE: " +
-                                   "\"" + e.getMessage() + "\" at " +
-                                   "\"" + method.getName() + "\"" + "\n");
+                        "\"" + e.getMessage() + "\" at " +
+                        "\"" + method.getName() + "\"" + "\n");
                 System.err.println(generateThreadDump());
                 errors.add(e);
             } finally {
@@ -172,7 +179,7 @@ public abstract class AbstractHazelcastClassRunner extends BlockJUnit4ClassRunne
                 originalStatement.evaluate();
 
                 Set<HazelcastInstance> instances = Hazelcast.getAllHazelcastInstances();
-                if(!instances.isEmpty()) {
+                if (!instances.isEmpty()) {
                     String message = "Instances haven't been shut down: " + instances;
                     Hazelcast.shutdownAll();
                     throw new IllegalStateException(message);
@@ -181,7 +188,7 @@ public abstract class AbstractHazelcastClassRunner extends BlockJUnit4ClassRunne
         };
     }
 
-    protected class TestRepeater extends Statement {
+    private class TestRepeater extends Statement {
 
         private final Statement statement;
         private final Method testMethod;

--- a/hazelcast/src/test/java/com/hazelcast/test/AbstractParameterizedHazelcastClassRunner.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/AbstractParameterizedHazelcastClassRunner.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.hazelcast.test;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+import java.util.List;
+import org.junit.runner.notification.RunNotifier;
+import org.junit.runners.BlockJUnit4ClassRunner;
+import org.junit.runners.Parameterized;
+import org.junit.runners.model.FrameworkField;
+import org.junit.runners.model.FrameworkMethod;
+import org.junit.runners.model.InitializationError;
+import org.junit.runners.model.Statement;
+
+/**
+ * A base test runner which has an ability to run parameterized tests.
+ */
+public abstract class AbstractParameterizedHazelcastClassRunner extends BlockJUnit4ClassRunner {
+
+    protected boolean isParameterized;
+    protected Object[] fParameters;
+    protected String fName;
+
+    /**
+     * Creates a BlockJUnit4ClassRunner to run {@code klass}
+     *
+     * @param klass
+     * @throws org.junit.runners.model.InitializationError if the test class is malformed.
+     */
+    public AbstractParameterizedHazelcastClassRunner(Class<?> klass) throws InitializationError {
+        super(klass);
+    }
+
+    public AbstractParameterizedHazelcastClassRunner(Class<?> klass, Object[] parameters,
+                                                     String name) throws InitializationError {
+        super(klass);
+        fParameters = parameters;
+        fName = name;
+    }
+
+    @Override
+    protected String getName() {
+        if (isParameterized) {
+            return fName;
+        } else {
+            return super.getName();
+        }
+    }
+
+    @Override
+    protected String testName(FrameworkMethod method) {
+        if (isParameterized) {
+            return method.getName() + getName();
+        } else {
+            return method.getName();
+        }
+    }
+
+    public void setParameterized(boolean isParameterized) {
+        this.isParameterized = isParameterized;
+    }
+
+    @Override
+    public Object createTest() throws Exception {
+        if (isParameterized) {
+            if (fieldsAreAnnotated()) {
+                return createTestUsingFieldInjection();
+            } else {
+                return createTestUsingConstructorInjection();
+            }
+        }
+        return super.createTest();
+    }
+
+    private Object createTestUsingConstructorInjection() throws Exception {
+        return getTestClass().getOnlyConstructor().newInstance(fParameters);
+    }
+
+    private Object createTestUsingFieldInjection() throws Exception {
+        List<FrameworkField> annotatedFieldsByParameter = getAnnotatedFieldsByParameter();
+        if (annotatedFieldsByParameter.size() != fParameters.length) {
+            throw new Exception("Wrong number of parameters and @Parameter fields." +
+                    " @Parameter fields counted: " + annotatedFieldsByParameter.size() + ", available parameters: " + fParameters.length + ".");
+        }
+        Object testClassInstance = getTestClass().getJavaClass().newInstance();
+        for (FrameworkField each : annotatedFieldsByParameter) {
+            Field field = each.getField();
+            Parameterized.Parameter annotation = field.getAnnotation(Parameterized.Parameter.class);
+            int index = annotation.value();
+            try {
+                field.set(testClassInstance, fParameters[index]);
+            } catch (IllegalArgumentException iare) {
+                throw new Exception(getTestClass().getName() + ": Trying to set " + field.getName() +
+                        " with the value " + fParameters[index] +
+                        " that is not the right type (" + fParameters[index].getClass().getSimpleName() + " instead of " +
+                        field.getType().getSimpleName() + ").", iare);
+            }
+        }
+        return testClassInstance;
+    }
+
+    private boolean fieldsAreAnnotated() {
+        return !getAnnotatedFieldsByParameter().isEmpty();
+    }
+
+    private List<FrameworkField> getAnnotatedFieldsByParameter() {
+        return getTestClass().getAnnotatedFields(Parameterized.Parameter.class);
+    }
+
+    @Override
+    protected Statement classBlock(RunNotifier notifier) {
+        if (isParameterized) {
+            return childrenInvoker(notifier);
+        } else {
+            return super.classBlock(notifier);
+        }
+    }
+
+    @Override
+    protected Annotation[] getRunnerAnnotations() {
+        return new Annotation[0];
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastParallelClassRunner.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastParallelClassRunner.java
@@ -23,6 +23,9 @@ import org.junit.runners.model.Statement;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
+/**
+ * Runs the tests in parallel with multiple threads.
+ */
 public class HazelcastParallelClassRunner extends AbstractHazelcastClassRunner {
 
     private static final int MAX_THREADS = !TestEnvironment.isMockNetwork() ? 1
@@ -32,6 +35,11 @@ public class HazelcastParallelClassRunner extends AbstractHazelcastClassRunner {
 
     public HazelcastParallelClassRunner(Class<?> klass) throws InitializationError {
         super(klass);
+    }
+
+    public HazelcastParallelClassRunner(Class<?> klass, Object[] parameters,
+                                        String name) throws InitializationError {
+        super(klass, parameters, name);
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastSerialClassRunner.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastSerialClassRunner.java
@@ -21,12 +21,17 @@ import org.junit.runners.model.FrameworkMethod;
 import org.junit.runners.model.InitializationError;
 
 /**
- * Run the tests randomly and log the running test.
+ * Run the tests in series and log the running test.
  */
 public class HazelcastSerialClassRunner extends AbstractHazelcastClassRunner {
 
     public HazelcastSerialClassRunner(Class<?> klass) throws InitializationError {
         super(klass);
+    }
+
+    public HazelcastSerialClassRunner(Class<?> klass, Object[] parameters,
+                                      String name) throws InitializationError {
+        super(klass, parameters, name);
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestRunner.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestRunner.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.hazelcast.test;
+
+import com.hazelcast.test.annotation.RunParallel;
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.junit.runner.Runner;
+import org.junit.runners.Suite;
+import org.junit.runners.model.FrameworkMethod;
+
+import static org.junit.runners.Parameterized.Parameters;
+
+
+/**
+ * A test suite with an ability to run parameterized tests.
+ * This suite runs the tests with either {@link com.hazelcast.test.HazelcastSerialClassRunner}
+ * or {@link com.hazelcast.test.HazelcastParallelClassRunner}
+ */
+public class HazelcastTestRunner extends Suite {
+
+    private static final List<Runner> NO_RUNNERS = Collections.<Runner>emptyList();
+
+    private final ArrayList<Runner> runners = new ArrayList<Runner>();
+
+    private boolean isParallel;
+
+    public HazelcastTestRunner(Class<?> klass) throws Throwable {
+        super(klass, NO_RUNNERS);
+
+        RunParallel parallel = getTestClass().getJavaClass().getAnnotation(RunParallel.class);
+        if (parallel != null) {
+            isParallel = true;
+        }
+        Parameters parameters = getParametersMethod().getAnnotation(Parameters.class);
+        createRunnersForParameters(allParameters(), parameters.name());
+    }
+
+
+    @Override
+    protected List<Runner> getChildren() {
+        return runners;
+    }
+
+
+    @SuppressWarnings("unchecked")
+    private Iterable<Object[]> allParameters() throws Throwable {
+        Object parameters = getParametersMethod().invokeExplosively(null);
+        if (parameters instanceof Iterable) {
+            return (Iterable<Object[]>) parameters;
+        } else {
+            throw parametersMethodReturnedWrongType();
+        }
+    }
+
+    private FrameworkMethod getParametersMethod() throws Exception {
+        List<FrameworkMethod> methods = getTestClass().getAnnotatedMethods(
+                Parameters.class);
+        for (FrameworkMethod each : methods) {
+            if (each.isStatic() && each.isPublic()) {
+                return each;
+            }
+        }
+
+        throw new Exception("No public static parameters method on class "
+                + getTestClass().getName());
+    }
+
+    private void createRunnersForParameters(Iterable<Object[]> allParameters,
+                                            String namePattern) throws Exception {
+        try {
+            int i = 0;
+            for (Object[] parametersOfSingleTest : allParameters) {
+                String name = nameFor(namePattern, i, parametersOfSingleTest);
+                AbstractHazelcastClassRunner runner;
+                if (isParallel) {
+                    runner = new HazelcastParallelClassRunner(
+                            getTestClass().getJavaClass(), parametersOfSingleTest,
+                            name);
+                } else {
+                    runner = new HazelcastSerialClassRunner(
+                            getTestClass().getJavaClass(), parametersOfSingleTest,
+                            name);
+                }
+                runner.setParameterized(true);
+                runners.add(runner);
+                ++i;
+            }
+        } catch (ClassCastException e) {
+            throw parametersMethodReturnedWrongType();
+        }
+    }
+
+    private String nameFor(String namePattern, int index, Object[] parameters) {
+        String finalPattern = namePattern.replaceAll("\\{index\\}",
+                Integer.toString(index));
+        String name = MessageFormat.format(finalPattern, parameters);
+        return "[" + name + "]";
+    }
+
+    private Exception parametersMethodReturnedWrongType() throws Exception {
+        String className = getTestClass().getName();
+        String methodName = getParametersMethod().getName();
+        String message = MessageFormat.format(
+                "{0}.{1}() must return an Iterable of arrays.",
+                className, methodName);
+        return new Exception(message);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
@@ -672,7 +672,14 @@ public abstract class HazelcastTestSupport {
         assertEquals(String.format(message, expected, actual), expected, actual);
     }
 
-    public static final class DummyUncheckedHazelcastTestException extends RuntimeException {
+    public static void closeConnectionBetween(HazelcastInstance h1, HazelcastInstance h2) {
+        if (h1 == null || h2 == null) return;
+        final Node n1 = TestUtil.getNode(h1);
+        final Node n2 = TestUtil.getNode(h2);
+        n1.clusterService.removeAddress(n2.address);
+        n2.clusterService.removeAddress(n1.address);
+    }
+    public final class DummyUncheckedHazelcastTestException extends RuntimeException {
     }
 
     public static void assertExactlyOneSuccessfulRun(AssertTask task) {

--- a/hazelcast/src/test/java/com/hazelcast/test/annotation/RunParallel.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/annotation/RunParallel.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.hazelcast.test.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+
+/**
+ *  Annotation to mark tests to be run in parallel. Used with {@link com.hazelcast.test.HazelcastTestRunner}
+ */
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface RunParallel {
+}


### PR DESCRIPTION
Cluster Quorum enables users to define the minimum number of nodes required in a cluster for the cluster to remain in an operational state. If the number of machines is below the defined minimum at any time, the operations are rejected and the rejected operations return a `QuorumException` to their callers.
