### PR TITLE
Introduces new MapListener interface and sub-interfaces

### DIFF
--- a/hazelcast-documentation/src/Map-MapListener.md
+++ b/hazelcast-documentation/src/Map-MapListener.md
@@ -1,11 +1,21 @@
 
 
 
-### Entry Listener
+### Map Listener
 
-You can listen to map entry events. Hazelcast distributed map offers the method `addEntryListener` to add an entry listener to the map. 
+You can listen to map-wide or entry-based events by implementing a `MapListener` sub-interface. 
+A map-wide event is fired as a result of a map-wide operation e.g. `IMap#clear` or `IMap#evictAll`.
+An entry-based event is fired after the operations that affects a specific entry e.g.`IMap#remove` or `IMap#evict`.
 
+<<<<<<< Updated upstream:hazelcast-documentation/src/Map-EntryListener.md
 Let's take a look at the following example code.
+=======
+Hazelcast distributed map offers the method `addEntryListener` to add a map listener to the map. 
+
+Let's take a look at the below sample code. As you will see, to catch an event you should explicitly implement a corresponding sub-interface of a `MapListener` e.g. `EntryAddedListener` or `MapClearedListener`.
+
+![image](images/NoteSmall.jpg) ***NOTE:*** * `EntryListener` interface still can be implemented, we kept it as is due to the backward compatibility reasons but if you need to listen a different event which is not available in the `EntryListener` interface you should also implement a relevant `MapListener` sub-interface. 
+>>>>>>> Stashed changes:hazelcast-documentation/src/Map-MapListener.md
 
 ```java
 public class Listen {
@@ -17,7 +27,7 @@ public class Listen {
      System.out.println( "EntryListener registered" );
   }
 
-  static class MyEntryListener implements EntryListener<String, String> {
+  static class MyEntryListener implements EntryAddedListener<String, String>, EntryRemovedListener<String, String>, EntryUpdatedListener<String, String>, EntryEvictedListener<String, String> , MapEvictedListener, MapClearedListener   {
     @Override
     public void entryAdded( EntryEvent<String, String> event ) {
       System.out.println( "Entry Added:" + event );
@@ -82,6 +92,7 @@ entryRemoved:EntryEvent {Address[192.168.1.100]:5702} key=251359212222282,
     oldValue=2, value=2, event=REMOVED, by Member [192.168.1.100]:5702
 ```
 
+<<<<<<< Updated upstream:hazelcast-documentation/src/Map-EntryListener.md
 Entry Listener runs on event threads which are also used by other listeners (e.g. collection listeners, pub/sub message listeners, etc.). This means entry listeners can access to other partitions. Consider this when you run long tasks, since listening to those tasks may cause other event listeners to starve. In these cases, you might consider executing these reactionary tasks inside an Executor. The following shows an example usage.
 
 ```java
@@ -96,3 +107,6 @@ public class MyEntryListener implements EntryListener{
 ...
 ```
 
+=======
+A map listener runs on event threads which are also used by other listeners (e.g. collection listeners, pub/sub message listeners, etc.). This means entry listeners can access other partitions. Consider this when you run long tasks, since listening to those tasks may cause other map/event listeners to starve.
+>>>>>>> Stashed changes:hazelcast-documentation/src/Map-MapListener.md

--- a/hazelcast/src/main/java/com/hazelcast/core/EntryAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/EntryAdapter.java
@@ -17,10 +17,11 @@
 package com.hazelcast.core;
 
 /**
- * Adapter for EntryListener.
+ * Adapter for {@link com.hazelcast.map.listener.MapListener}.
  *
  * @param <K> key of the map entry
  * @param <V> value of the map entry.
+ * @see com.hazelcast.map.listener.MapListener
  * @see com.hazelcast.core.EntryListener
  */
 public class EntryAdapter<K, V> implements EntryListener<K, V> {

--- a/hazelcast/src/main/java/com/hazelcast/core/EntryEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/EntryEvent.java
@@ -22,7 +22,8 @@ package com.hazelcast.core;
  * @param <K> key of the map entry
  * @param <V> value of the map entry
  * @see com.hazelcast.core.EntryListener
- * @see com.hazelcast.core.IMap#addEntryListener(EntryListener, boolean)
+ * @see com.hazelcast.map.listener.MapListener
+ * @see com.hazelcast.core.IMap#addEntryListener(com.hazelcast.map.listener.MapListener, boolean)
  */
 @edu.umd.cs.findbugs.annotations.SuppressWarnings("SE_BAD_FIELD")
 public class EntryEvent<K, V> extends AbstractIMapEvent {

--- a/hazelcast/src/main/java/com/hazelcast/core/EntryListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/EntryListener.java
@@ -16,60 +16,29 @@
 
 package com.hazelcast.core;
 
-import java.util.EventListener;
+import com.hazelcast.map.listener.EntryAddedListener;
+import com.hazelcast.map.listener.EntryEvictedListener;
+import com.hazelcast.map.listener.EntryRemovedListener;
+import com.hazelcast.map.listener.EntryUpdatedListener;
+import com.hazelcast.map.listener.MapClearedListener;
+import com.hazelcast.map.listener.MapEvictedListener;
 
 /**
  * Map Entry listener to get notified when a map entry
  * is added, removed, updated or evicted.  Events will fire as a result
  * of operations carried out via the {@link com.hazelcast.core.IMap} interface.  Events will not fire, for example,
  * for an entry that comes into the Map via the {@link MapLoader} lifecycle.
+ * <p/>
+ * This interface is here for backward compatibility reasons. For a most appropriate alternative
+ * please use/check {@link com.hazelcast.map.listener.MapListener} interface.
  *
- * @param <K> key of the map entry
- * @param <V> value of the map entry.
- * @see com.hazelcast.core.IMap#addEntryListener(EntryListener, boolean)
+ * @param <K> the type of key.
+ * @param <V> the type of value.
+ * @see com.hazelcast.core.IMap#addEntryListener
+ * @see com.hazelcast.map.listener.MapListener
  */
-public interface EntryListener<K, V> extends EventListener {
+public interface EntryListener<K, V>
+        extends EntryAddedListener<K, V>, EntryUpdatedListener<K, V>, EntryRemovedListener<K, V>,
+        EntryEvictedListener<K, V>, MapClearedListener, MapEvictedListener {
 
-    /**
-     * Invoked when an entry is added.
-     *
-     * @param event the event invoked when an entry is added
-     */
-    void entryAdded(EntryEvent<K, V> event);
-
-    /**
-     * Invoked when an entry is removed.
-     *
-     * @param event the event invoked when an entry is removed
-     */
-    void entryRemoved(EntryEvent<K, V> event);
-
-    /**
-     * Invoked when an entry is updated.
-     *
-     * @param event the event invoked when an entry is updated
-     */
-    void entryUpdated(EntryEvent<K, V> event);
-
-    /**
-     * Invoked when an entry is evicted.
-     *
-     * @param event the event invoked when an entry is evicted
-     */
-    void entryEvicted(EntryEvent<K, V> event);
-
-    /**
-     * Invoked when all entries are evicted by {@link IMap#evictAll()}.
-     *
-     * @param event the map event invoked when all entries are evicted by {@link IMap#evictAll()}
-     */
-    void mapEvicted(MapEvent event);
-
-    /**
-     * Invoked when all entries are removed by {@link IMap#clear()}.
-     *
-     * @param event the map event invoked when all entries are removed by {@link IMap#clear()}
-
-     */
-    void mapCleared(MapEvent event);
 }

--- a/hazelcast/src/main/java/com/hazelcast/core/IMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/IMap.java
@@ -18,6 +18,7 @@ package com.hazelcast.core;
 
 import com.hazelcast.map.EntryProcessor;
 import com.hazelcast.map.MapInterceptor;
+import com.hazelcast.map.listener.MapListener;
 import com.hazelcast.mapreduce.JobTracker;
 import com.hazelcast.mapreduce.aggregation.Aggregation;
 import com.hazelcast.mapreduce.aggregation.Supplier;
@@ -763,7 +764,7 @@ public interface IMap<K, V>
      * @return A UUID.randomUUID().toString() which is used as a key to remove the listener.
      * @see #localKeySet()
      */
-    String addLocalEntryListener(EntryListener<K, V> listener);
+    String addLocalEntryListener(MapListener listener);
 
     /**
      * Adds a local entry listener for this map. The added listener will be only
@@ -776,7 +777,7 @@ public interface IMap<K, V>
      *                     contain the value.
      * @return A UUID.randomUUID().toString() which is used as a key to remove the listener.
      */
-    String addLocalEntryListener(EntryListener<K, V> listener, Predicate<K, V> predicate, boolean includeValue);
+    String addLocalEntryListener(MapListener listener, Predicate<K, V> predicate, boolean includeValue);
 
     /**
      * Adds a local entry listener for this map. The added listener will be only
@@ -790,7 +791,7 @@ public interface IMap<K, V>
      *                     contain the value.
      * @return A UUID.randomUUID().toString() which is used as a key to remove the listener.
      */
-    String addLocalEntryListener(EntryListener<K, V> listener, Predicate<K, V> predicate, K key, boolean includeValue);
+    String addLocalEntryListener(MapListener listener, Predicate<K, V> predicate, K key, boolean includeValue);
 
     /**
      * Adds an interceptor for this map. Added interceptor will intercept operations
@@ -819,7 +820,7 @@ public interface IMap<K, V>
      *                     contain the value.
      * @return A UUID.randomUUID().toString() which is used as a key to remove the listener.
      */
-    String addEntryListener(EntryListener<K, V> listener, boolean includeValue);
+    String addEntryListener(MapListener listener, boolean includeValue);
 
     /**
      * Removes the specified entry listener
@@ -847,7 +848,7 @@ public interface IMap<K, V>
      * @return A UUID.randomUUID().toString() which is used as a key to remove the listener.
      * @throws NullPointerException if the specified key is null
      */
-    String addEntryListener(EntryListener<K, V> listener, K key, boolean includeValue);
+    String addEntryListener(MapListener listener, K key, boolean includeValue);
 
     /**
      * Adds an continuous entry listener for this map. Listener will get notified
@@ -859,7 +860,7 @@ public interface IMap<K, V>
      *                     contain the value.
      * @return A UUID.randomUUID().toString() which is used as a key to remove the listener.
      */
-    String addEntryListener(EntryListener<K, V> listener, Predicate<K, V> predicate, boolean includeValue);
+    String addEntryListener(MapListener listener, Predicate<K, V> predicate, boolean includeValue);
 
     /**
      * Adds an continuous entry listener for this map. Listener will get notified
@@ -872,7 +873,7 @@ public interface IMap<K, V>
      *                     contain the value.
      * @return A UUID.randomUUID().toString() which is used as a key to remove the listener.
      */
-    String addEntryListener(EntryListener<K, V> listener, Predicate<K, V> predicate, K key, boolean includeValue);
+    String addEntryListener(MapListener listener, Predicate<K, V> predicate, K key, boolean includeValue);
 
     /**
      * Returns the <tt>EntryView</tt> for the specified key.

--- a/hazelcast/src/main/java/com/hazelcast/core/MapEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/MapEvent.java
@@ -3,6 +3,9 @@ package com.hazelcast.core;
 /**
  * Used for map-wide events like {@link com.hazelcast.core.EntryEventType#EVICT_ALL}
  * and {@link  com.hazelcast.core.EntryEventType#CLEAR_ALL}.
+ *
+ * @see com.hazelcast.map.listener.MapListener
+ * @see com.hazelcast.core.EntryListener
  */
 public class MapEvent extends AbstractIMapEvent {
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/AbstractMapServiceContextSupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/AbstractMapServiceContextSupport.java
@@ -1,8 +1,8 @@
 package com.hazelcast.map.impl;
 
-import com.hazelcast.core.EntryListener;
 import com.hazelcast.core.PartitioningStrategy;
 import com.hazelcast.map.MapInterceptor;
+import com.hazelcast.map.listener.MapListener;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.EventFilter;
 import com.hazelcast.spi.EventRegistration;
@@ -12,6 +12,7 @@ import com.hazelcast.util.Clock;
 
 import java.util.List;
 
+import static com.hazelcast.map.impl.MapListenerAdaptors.createMapListenerAdaptor;
 
 abstract class AbstractMapServiceContextSupport implements MapServiceContextSupport,
         MapServiceContextInterceptorSupport, MapServiceContextEventListenerSupport {
@@ -178,23 +179,26 @@ abstract class AbstractMapServiceContextSupport implements MapServiceContextSupp
     }
 
     @Override
-    public String addLocalEventListener(EntryListener entryListener, String mapName) {
+    public String addLocalEventListener(MapListener mapListener, String mapName) {
+        ListenerAdapter listenerAdaptor = createMapListenerAdaptor(mapListener);
         EventRegistration registration = nodeEngine.getEventService().
-                registerLocalListener(mapServiceContext.serviceName(), mapName, entryListener);
+                registerLocalListener(mapServiceContext.serviceName(), mapName, listenerAdaptor);
         return registration.getId();
     }
 
     @Override
-    public String addLocalEventListener(EntryListener entryListener, EventFilter eventFilter, String mapName) {
+    public String addLocalEventListener(MapListener mapListener, EventFilter eventFilter, String mapName) {
+        ListenerAdapter listenerAdaptor = createMapListenerAdaptor(mapListener);
         EventRegistration registration = nodeEngine.getEventService().
-                registerLocalListener(mapServiceContext.serviceName(), mapName, eventFilter, entryListener);
+                registerLocalListener(mapServiceContext.serviceName(), mapName, eventFilter, listenerAdaptor);
         return registration.getId();
     }
 
     @Override
-    public String addEventListener(EntryListener entryListener, EventFilter eventFilter, String mapName) {
+    public String addEventListener(MapListener mapListener, EventFilter eventFilter, String mapName) {
+        ListenerAdapter listenerAdaptor = createMapListenerAdaptor(mapListener);
         EventRegistration registration = nodeEngine.getEventService().
-                registerListener(mapServiceContext.serviceName(), mapName, eventFilter, entryListener);
+                registerListener(mapServiceContext.serviceName(), mapName, eventFilter, listenerAdaptor);
         return registration.getId();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/InternalMapListenerAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/InternalMapListenerAdapter.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2008-2014, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl;
+
+import com.hazelcast.core.EntryEventType;
+import com.hazelcast.core.IMapEvent;
+import com.hazelcast.map.listener.MapListener;
+
+import static com.hazelcast.map.impl.MapListenerAdaptors.createListenerAdapters;
+import static com.hazelcast.util.ValidationUtil.isNotNull;
+
+/**
+ * Internal-usage-only adapter which wraps all {@link MapListener} sub-interfaces into a {@link ListenerAdapter}.
+ * <p/>
+ * Main purpose of this adapter is to avoid lots of instanceOf checks when firing events to check whether or not
+ * a corresponding {@link MapListener} sub-interface for a specific {@link com.hazelcast.core.EntryEventType} is extended.
+ * And also to provide an abstraction over all {@link MapListener} sub-interfaces to make a smooth usage when passing
+ * fired events to listeners e.g. only calling {@link ListenerAdapter#onEvent} is sufficient to fire any event.
+ */
+class InternalMapListenerAdapter implements ListenerAdapter {
+
+    private final ListenerAdapter[] listenerAdapters;
+
+    InternalMapListenerAdapter(MapListener mapListener) {
+        isNotNull(mapListener, "mapListener");
+
+        this.listenerAdapters = createListenerAdapters(mapListener);
+    }
+
+    @Override
+    public void onEvent(IMapEvent event) {
+        final EntryEventType eventType = event.getEventType();
+        final ListenerAdapter listenerAdapter = listenerAdapters[eventType.ordinal()];
+        if (listenerAdapter == null) {
+            return;
+        }
+        listenerAdapter.onEvent(event);
+    }
+}
+

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/ListenerAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/ListenerAdapter.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2008-2014, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl;
+
+import com.hazelcast.core.IMapEvent;
+
+/**
+ * Adapter for all {@link com.hazelcast.core.IMap} listeners. This interface is considered to be used only
+ * by {@link com.hazelcast.core.IMap} internals.
+ * <p/>
+ * Also every {@link com.hazelcast.map.listener.MapListener} should be wrapped
+ * in a {@link com.hazelcast.map.impl.ListenerAdapter} before {@link com.hazelcast.spi.EventService} registration.
+ */
+public interface ListenerAdapter {
+
+    /**
+     * Handle event.
+     *
+     * @param event type of event.
+     */
+    void onEvent(IMapEvent event);
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapListenerAdaptors.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapListenerAdaptors.java
@@ -1,0 +1,232 @@
+/*
+ * Copyright (c) 2008-2014, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl;
+
+import com.hazelcast.core.EntryEvent;
+import com.hazelcast.core.EntryEventType;
+import com.hazelcast.core.IMapEvent;
+import com.hazelcast.core.MapEvent;
+import com.hazelcast.map.listener.EntryAddedListener;
+import com.hazelcast.map.listener.EntryEvictedListener;
+import com.hazelcast.map.listener.EntryRemovedListener;
+import com.hazelcast.map.listener.EntryUpdatedListener;
+import com.hazelcast.map.listener.MapClearedListener;
+import com.hazelcast.map.listener.MapEvictedListener;
+import com.hazelcast.map.listener.MapListener;
+import com.hazelcast.util.ConstructorFunction;
+
+import java.util.EnumMap;
+import java.util.Map;
+
+/**
+ * A static factory class which creates various
+ * {@link com.hazelcast.map.impl.ListenerAdapter} implementations.
+ */
+public final class MapListenerAdaptors {
+
+    /**
+     * Registry for all {@link com.hazelcast.map.listener.MapListener} to {@link com.hazelcast.map.impl.ListenerAdapter}
+     * constructors according to {@link com.hazelcast.core.EntryEventType}s.
+     */
+    private static final Map<EntryEventType, ConstructorFunction<MapListener, ListenerAdapter>> CONSTRUCTORS
+            = new EnumMap<EntryEventType, ConstructorFunction<MapListener, ListenerAdapter>>(EntryEventType.class);
+
+    /**
+     * Converts an {@link com.hazelcast.map.listener.EntryAddedListener} to a {@link com.hazelcast.map.impl.ListenerAdapter}.
+     */
+    private static final ConstructorFunction<MapListener, ListenerAdapter> ENTRY_ADDED_LISTENER_ADAPTER_CONSTRUCTOR =
+            new ConstructorFunction<MapListener, ListenerAdapter>() {
+                @Override
+                public ListenerAdapter createNew(MapListener mapListener) {
+                    if (!(mapListener instanceof EntryAddedListener)) {
+                        return null;
+                    }
+                    final EntryAddedListener listener = (EntryAddedListener) mapListener;
+                    return new ListenerAdapter() {
+                        @Override
+                        public void onEvent(IMapEvent event) {
+                            listener.entryAdded((EntryEvent) event);
+                        }
+                    };
+                }
+            };
+
+    /**
+     * Converts an {@link com.hazelcast.map.listener.EntryRemovedListener} to a {@link com.hazelcast.map.impl.ListenerAdapter}.
+     */
+    private static final ConstructorFunction<MapListener, ListenerAdapter> ENTRY_REMOVED_LISTENER_ADAPTER_CONSTRUCTOR =
+            new ConstructorFunction<MapListener, ListenerAdapter>() {
+                @Override
+                public ListenerAdapter createNew(MapListener mapListener) {
+                    if (!(mapListener instanceof EntryRemovedListener)) {
+                        return null;
+                    }
+                    final EntryRemovedListener listener = (EntryRemovedListener) mapListener;
+                    return new ListenerAdapter() {
+                        @Override
+                        public void onEvent(IMapEvent event) {
+                            listener.entryRemoved((EntryEvent) event);
+                        }
+                    };
+                }
+            };
+
+
+    /**
+     * Converts an {@link com.hazelcast.map.listener.EntryEvictedListener} to a {@link com.hazelcast.map.impl.ListenerAdapter}.
+     */
+    private static final ConstructorFunction<MapListener, ListenerAdapter> ENTRY_EVICTED_LISTENER_ADAPTER_CONSTRUCTOR =
+            new ConstructorFunction<MapListener, ListenerAdapter>() {
+                @Override
+                public ListenerAdapter createNew(MapListener mapListener) {
+                    if (!(mapListener instanceof EntryEvictedListener)) {
+                        return null;
+                    }
+                    final EntryEvictedListener listener = (EntryEvictedListener) mapListener;
+                    return new ListenerAdapter() {
+                        @Override
+                        public void onEvent(IMapEvent event) {
+                            listener.entryEvicted((EntryEvent) event);
+                        }
+                    };
+                }
+            };
+
+
+    /**
+     * Converts an {@link com.hazelcast.map.listener.EntryUpdatedListener} to a {@link com.hazelcast.map.impl.ListenerAdapter}.
+     */
+    private static final ConstructorFunction<MapListener, ListenerAdapter> ENTRY_UPDATED_LISTENER_ADAPTER_CONSTRUCTOR =
+            new ConstructorFunction<MapListener, ListenerAdapter>() {
+                @Override
+                public ListenerAdapter createNew(MapListener mapListener) {
+                    if (!(mapListener instanceof EntryUpdatedListener)) {
+                        return null;
+                    }
+                    final EntryUpdatedListener listener = (EntryUpdatedListener) mapListener;
+                    return new ListenerAdapter() {
+                        @Override
+                        public void onEvent(IMapEvent event) {
+                            listener.entryUpdated((EntryEvent) event);
+                        }
+                    };
+                }
+            };
+
+
+    /**
+     * Converts an {@link com.hazelcast.map.listener.MapEvictedListener} to a {@link com.hazelcast.map.impl.ListenerAdapter}.
+     */
+    private static final ConstructorFunction<MapListener, ListenerAdapter> MAP_EVICTED_LISTENER_ADAPTER_CONSTRUCTOR =
+            new ConstructorFunction<MapListener, ListenerAdapter>() {
+                @Override
+                public ListenerAdapter createNew(MapListener mapListener) {
+                    if (!(mapListener instanceof MapEvictedListener)) {
+                        return null;
+                    }
+                    final MapEvictedListener listener = (MapEvictedListener) mapListener;
+                    return new ListenerAdapter() {
+                        @Override
+                        public void onEvent(IMapEvent event) {
+                            listener.mapEvicted((MapEvent) event);
+                        }
+                    };
+                }
+            };
+
+
+    /**
+     * Converts an {@link com.hazelcast.map.listener.MapClearedListener} to a {@link com.hazelcast.map.impl.ListenerAdapter}.
+     */
+    private static final ConstructorFunction<MapListener, ListenerAdapter> MAP_CLEARED_LISTENER_ADAPTER_CONSTRUCTOR =
+            new ConstructorFunction<MapListener, ListenerAdapter>() {
+                @Override
+                public ListenerAdapter createNew(MapListener mapListener) {
+                    if (!(mapListener instanceof MapClearedListener)) {
+                        return null;
+                    }
+                    final MapClearedListener listener = (MapClearedListener) mapListener;
+                    return new ListenerAdapter() {
+                        @Override
+                        public void onEvent(IMapEvent event) {
+                            listener.mapCleared((MapEvent) event);
+                        }
+                    };
+                }
+            };
+
+    /**
+     * Register all {@link com.hazelcast.map.impl.ListenerAdapter} constructors
+     * according to {@link com.hazelcast.core.EntryEventType}s.
+     */
+    static {
+        CONSTRUCTORS.put(EntryEventType.ADDED, ENTRY_ADDED_LISTENER_ADAPTER_CONSTRUCTOR);
+        CONSTRUCTORS.put(EntryEventType.REMOVED, ENTRY_REMOVED_LISTENER_ADAPTER_CONSTRUCTOR);
+        CONSTRUCTORS.put(EntryEventType.EVICTED, ENTRY_EVICTED_LISTENER_ADAPTER_CONSTRUCTOR);
+        CONSTRUCTORS.put(EntryEventType.UPDATED, ENTRY_UPDATED_LISTENER_ADAPTER_CONSTRUCTOR);
+        CONSTRUCTORS.put(EntryEventType.EVICT_ALL, MAP_EVICTED_LISTENER_ADAPTER_CONSTRUCTOR);
+        CONSTRUCTORS.put(EntryEventType.CLEAR_ALL, MAP_CLEARED_LISTENER_ADAPTER_CONSTRUCTOR);
+    }
+
+    private MapListenerAdaptors() {
+    }
+
+    /**
+     * Creates a {@link com.hazelcast.map.impl.ListenerAdapter} array
+     * for all event types of {@link com.hazelcast.core.EntryEventType}.
+     *
+     * @param mapListener a {@link com.hazelcast.map.listener.MapListener} instance.
+     * @return an array of {@link com.hazelcast.map.impl.ListenerAdapter}
+     */
+    public static ListenerAdapter[] createListenerAdapters(MapListener mapListener) {
+        EntryEventType[] values = EntryEventType.values();
+        ListenerAdapter[] listenerAdapters = new ListenerAdapter[values.length];
+        for (EntryEventType eventType : values) {
+            listenerAdapters[eventType.ordinal()] = createListenerAdapter(eventType, mapListener);
+        }
+        return listenerAdapters;
+    }
+
+    /**
+     * Creates a {@link ListenerAdapter} for a specific {@link com.hazelcast.core.EntryEventType}.
+     *
+     * @param eventType   an {@link com.hazelcast.core.EntryEventType}.
+     * @param mapListener a {@link com.hazelcast.map.listener.MapListener} instance.
+     * @return {@link com.hazelcast.map.impl.ListenerAdapter} for a specific {@link com.hazelcast.core.EntryEventType}
+     */
+    private static ListenerAdapter createListenerAdapter(EntryEventType eventType, MapListener mapListener) {
+        final ConstructorFunction<MapListener, ListenerAdapter> constructorFunction = CONSTRUCTORS.get(eventType);
+        if (constructorFunction == null) {
+            throw new IllegalArgumentException("First, define a ListenerAdapter for the event EntryEventType." + eventType);
+        }
+        return constructorFunction.createNew(mapListener);
+    }
+
+
+    /**
+     * Wraps a user defined {@link com.hazelcast.map.listener.MapListener}
+     * into a {@link com.hazelcast.map.impl.ListenerAdapter}.
+     *
+     * @param mapListener a {@link com.hazelcast.map.listener.MapListener} instance.
+     * @return {@link com.hazelcast.map.impl.ListenerAdapter} for the user-defined
+     * {@link com.hazelcast.map.listener.MapListener}
+     */
+    public static ListenerAdapter createMapListenerAdaptor(MapListener mapListener) {
+        return new InternalMapListenerAdapter(mapListener);
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapService.java
@@ -17,7 +17,6 @@
 package com.hazelcast.map.impl;
 
 import com.hazelcast.core.DistributedObject;
-import com.hazelcast.core.EntryListener;
 import com.hazelcast.spi.EventPublishingService;
 import com.hazelcast.spi.ManagedService;
 import com.hazelcast.spi.MigrationAwareService;
@@ -49,7 +48,7 @@ import java.util.Properties;
  * @see MapReplicationSupportingService
  */
 public final class MapService implements ManagedService, MigrationAwareService,
-        TransactionalService, RemoteService, EventPublishingService<EventData, EntryListener>,
+        TransactionalService, RemoteService, EventPublishingService<EventData, ListenerAdapter>,
         PostJoinAwareService, SplitBrainHandlerService, ReplicationSupportingService {
 
     /**
@@ -72,7 +71,7 @@ public final class MapService implements ManagedService, MigrationAwareService,
     }
 
     @Override
-    public void dispatchEvent(EventData event, EntryListener listener) {
+    public void dispatchEvent(EventData event, ListenerAdapter listener) {
         eventPublishingService.dispatchEvent(event, listener);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextEventListenerSupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextEventListenerSupport.java
@@ -1,6 +1,6 @@
 package com.hazelcast.map.impl;
 
-import com.hazelcast.core.EntryListener;
+import com.hazelcast.map.listener.MapListener;
 import com.hazelcast.spi.EventFilter;
 
 /**
@@ -8,11 +8,11 @@ import com.hazelcast.spi.EventFilter;
  */
 public interface MapServiceContextEventListenerSupport {
 
-    String addLocalEventListener(EntryListener entryListener, String mapName);
+    String addLocalEventListener(MapListener mapListener, String mapName);
 
-    String addLocalEventListener(EntryListener entryListener, EventFilter eventFilter, String mapName);
+    String addLocalEventListener(MapListener mapListener, EventFilter eventFilter, String mapName);
 
-    String addEventListener(EntryListener entryListener, EventFilter eventFilter, String mapName);
+    String addEventListener(MapListener mapListener, EventFilter eventFilter, String mapName);
 
     boolean removeEventListener(String mapName, String registrationId);
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/client/AbstractMapAddEntryListenerRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/client/AbstractMapAddEntryListenerRequest.java
@@ -22,7 +22,6 @@ import com.hazelcast.client.impl.client.RetryableRequest;
 import com.hazelcast.core.EntryAdapter;
 import com.hazelcast.core.EntryEvent;
 import com.hazelcast.core.EntryEventType;
-import com.hazelcast.core.EntryListener;
 import com.hazelcast.core.MapEvent;
 import com.hazelcast.map.impl.DataAwareEntryEvent;
 import com.hazelcast.map.impl.EntryEventFilter;
@@ -67,7 +66,7 @@ public abstract class AbstractMapAddEntryListenerRequest extends CallableClientR
         final ClientEndpoint endpoint = getEndpoint();
         final MapService mapService = getService();
 
-        EntryListener<Object, Object> listener = new EntryAdapter<Object, Object>() {
+        EntryAdapter<Object, Object> listener = new EntryAdapter<Object, Object>() {
 
             @Override
             public void onEntryEvent(EntryEvent<Object, Object> event) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
@@ -17,7 +17,6 @@
 
 package com.hazelcast.map.impl.proxy;
 
-import com.hazelcast.core.EntryListener;
 import com.hazelcast.core.EntryView;
 import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.core.HazelcastException;
@@ -29,6 +28,7 @@ import com.hazelcast.map.EntryProcessor;
 import com.hazelcast.map.MapInterceptor;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.map.impl.SimpleEntryView;
+import com.hazelcast.map.listener.MapListener;
 import com.hazelcast.mapreduce.Collator;
 import com.hazelcast.mapreduce.CombinerFactory;
 import com.hazelcast.mapreduce.Job;
@@ -398,7 +398,7 @@ public class MapProxyImpl<K, V> extends MapProxySupport implements IMap<K, V>, I
     }
 
     @Override
-    public String addLocalEntryListener(EntryListener<K, V> listener, Predicate<K, V> predicate, boolean includeValue) {
+    public String addLocalEntryListener(MapListener listener, Predicate<K, V> predicate, boolean includeValue) {
         if (listener == null) {
             throw new NullPointerException("Listener should not be null!");
         }
@@ -409,7 +409,7 @@ public class MapProxyImpl<K, V> extends MapProxySupport implements IMap<K, V>, I
     }
 
     @Override
-    public String addLocalEntryListener(EntryListener<K, V> listener, Predicate<K, V> predicate, K key,
+    public String addLocalEntryListener(MapListener listener, Predicate<K, V> predicate, K key,
                                         boolean includeValue) {
         if (listener == null) {
             throw new NullPointerException("Listener should not be null!");
@@ -422,7 +422,7 @@ public class MapProxyImpl<K, V> extends MapProxySupport implements IMap<K, V>, I
     }
 
     @Override
-    public String addEntryListener(final EntryListener listener, final boolean includeValue) {
+    public String addEntryListener(final MapListener listener, final boolean includeValue) {
         if (listener == null) {
             throw new NullPointerException("Listener should not be null!");
         }
@@ -430,7 +430,7 @@ public class MapProxyImpl<K, V> extends MapProxySupport implements IMap<K, V>, I
     }
 
     @Override
-    public String addEntryListener(final EntryListener<K, V> listener, final K key, final boolean includeValue) {
+    public String addEntryListener(final MapListener listener, final K key, final boolean includeValue) {
         if (listener == null) {
             throw new NullPointerException("Listener should not be null!");
         }
@@ -439,7 +439,7 @@ public class MapProxyImpl<K, V> extends MapProxySupport implements IMap<K, V>, I
 
     @Override
     public String addEntryListener(
-            EntryListener<K, V> listener, Predicate<K, V> predicate, K key, boolean includeValue) {
+            MapListener listener, Predicate<K, V> predicate, K key, boolean includeValue) {
         if (listener == null) {
             throw new NullPointerException("Listener should not be null!");
         }
@@ -450,7 +450,7 @@ public class MapProxyImpl<K, V> extends MapProxySupport implements IMap<K, V>, I
     }
 
     @Override
-    public String addEntryListener(EntryListener<K, V> listener, Predicate<K, V> predicate, boolean includeValue) {
+    public String addEntryListener(MapListener listener, Predicate<K, V> predicate, boolean includeValue) {
         if (listener == null) {
             throw new NullPointerException("Listener should not be null!");
         }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
@@ -22,7 +22,6 @@ import com.hazelcast.config.MapConfig;
 import com.hazelcast.config.MapIndexConfig;
 import com.hazelcast.config.MapStoreConfig;
 import com.hazelcast.core.EntryEventType;
-import com.hazelcast.core.EntryListener;
 import com.hazelcast.core.EntryView;
 import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.core.HazelcastInstanceAware;
@@ -81,6 +80,7 @@ import com.hazelcast.map.impl.operation.SetOperation;
 import com.hazelcast.map.impl.operation.SizeOperationFactory;
 import com.hazelcast.map.impl.operation.TryPutOperation;
 import com.hazelcast.map.impl.operation.TryRemoveOperation;
+import com.hazelcast.map.listener.MapListener;
 import com.hazelcast.monitor.LocalMapStats;
 import com.hazelcast.monitor.impl.LocalMapStatsImpl;
 import com.hazelcast.nio.Address;
@@ -174,7 +174,7 @@ abstract class MapProxySupport extends AbstractDistributedObject<MapService> imp
         final NodeEngine nodeEngine = getNodeEngine();
         List<EntryListenerConfig> listenerConfigs = getMapConfig().getEntryListenerConfigs();
         for (EntryListenerConfig listenerConfig : listenerConfigs) {
-            EntryListener listener = null;
+            MapListener listener = null;
             if (listenerConfig.getImplementation() != null) {
                 listener = listenerConfig.getImplementation();
             } else if (listenerConfig.getClassName() != null) {
@@ -895,12 +895,12 @@ abstract class MapProxySupport extends AbstractDistributedObject<MapService> imp
         }
     }
 
-    public String addLocalEntryListener(final EntryListener listener) {
+    public String addLocalEntryListener(final MapListener listener) {
         final MapService mapService = getService();
         return mapService.getMapServiceContext().addLocalEventListener(listener, name);
     }
 
-    public String addLocalEntryListenerInternal(EntryListener listener, Predicate predicate,
+    public String addLocalEntryListenerInternal(MapListener listener, Predicate predicate,
                                                 final Data key, boolean includeValue) {
 
         final MapService mapService = getService();
@@ -909,14 +909,14 @@ abstract class MapProxySupport extends AbstractDistributedObject<MapService> imp
     }
 
     protected String addEntryListenerInternal(
-            final EntryListener listener, final Data key, final boolean includeValue) {
+            final MapListener listener, final Data key, final boolean includeValue) {
         EventFilter eventFilter = new EntryEventFilter(includeValue, key);
         final MapService mapService = getService();
         return mapService.getMapServiceContext().addEventListener(listener, eventFilter, name);
     }
 
     protected String addEntryListenerInternal(
-            EntryListener listener, Predicate predicate, final Data key, final boolean includeValue) {
+            MapListener listener, Predicate predicate, final Data key, final boolean includeValue) {
         EventFilter eventFilter = new QueryEventFilter(includeValue, key, predicate);
         final MapService mapService = getService();
         return mapService.getMapServiceContext().addEventListener(listener, eventFilter, name);

--- a/hazelcast/src/main/java/com/hazelcast/map/listener/EntryAddedListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/listener/EntryAddedListener.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2008-2014, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.listener;
+
+import com.hazelcast.core.EntryEvent;
+
+/**
+ * Invoked upon addition of an entry.
+ *
+ * @param <K> the type of key.
+ * @param <V> the type of value.
+ * @since 3.5
+ */
+public interface EntryAddedListener<K, V> extends MapListener {
+
+    /**
+     * Invoked upon addition of an entry.
+     *
+     * @param event the event invoked when an entry is added
+     */
+    void entryAdded(EntryEvent<K, V> event);
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/listener/EntryEvictedListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/listener/EntryEvictedListener.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2008-2014, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.listener;
+
+import com.hazelcast.core.EntryEvent;
+
+/**
+ * Invoked upon eviction of an entry.
+ *
+ * @param <K> the type of key.
+ * @param <V> the type of value.
+ * @since 3.5
+ */
+public interface EntryEvictedListener<K, V> extends MapListener {
+
+    /**
+     * Invoked upon eviction of an entry.
+     *
+     * @param event the event invoked when an entry is evicted
+     */
+    void entryEvicted(EntryEvent<K, V> event);
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/listener/EntryRemovedListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/listener/EntryRemovedListener.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2008-2014, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hazelcast.map.listener;
+
+import com.hazelcast.core.EntryEvent;
+
+/**
+ * Invoked upon removal of an entry.
+ *
+ * @param <K> the type of key.
+ * @param <V> the type of value.
+ * @since 3.5
+ */
+public interface EntryRemovedListener<K, V> extends MapListener {
+
+    /**
+     * Invoked upon removal of an entry.
+     *
+     * @param event the event invoked when an entry is removed
+     */
+    void entryRemoved(EntryEvent<K, V> event);
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/listener/EntryUpdatedListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/listener/EntryUpdatedListener.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2008-2014, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.listener;
+
+import com.hazelcast.core.EntryEvent;
+
+/**
+ * Invoked upon update of an entry.
+ *
+ * @param <K> the type of key.
+ * @param <V> the type of value.
+ * @since 3.5
+ */
+public interface EntryUpdatedListener<K, V> extends MapListener {
+
+    /**
+     * Invoked upon update of an entry.
+     *
+     * @param event the event invoked when an entry is updated
+     */
+    void entryUpdated(EntryEvent<K, V> event);
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/listener/MapClearedListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/listener/MapClearedListener.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2008-2014, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.listener;
+
+import com.hazelcast.core.MapEvent;
+
+/**
+ * Invoked after all entries are removed by {@link com.hazelcast.core.IMap#clear()}.
+ *
+ * @since 3.5
+ */
+public interface MapClearedListener extends MapListener {
+    /**
+     * Invoked when all entries are removed by {@link com.hazelcast.core.IMap#clear()}.
+     *
+     * @param event the map event invoked when all entries are removed by {@link com.hazelcast.core.IMap#clear()}
+     */
+    void mapCleared(MapEvent event);
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/listener/MapEvictedListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/listener/MapEvictedListener.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2008-2014, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.listener;
+
+import com.hazelcast.core.MapEvent;
+
+/**
+ * Invoked after all entries are evicted by {@link com.hazelcast.core.IMap#evictAll()}.
+ *
+ * @since 3.5
+ */
+public interface MapEvictedListener extends MapListener {
+
+    /**
+     * Invoked when all entries are evicted by {@link com.hazelcast.core.IMap#evictAll()}.
+     *
+     * @param event the map event invoked when all entries are evicted by {@link com.hazelcast.core.IMap#evictAll()}
+     */
+    void mapEvicted(MapEvent event);
+}
+

--- a/hazelcast/src/main/java/com/hazelcast/map/listener/MapListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/listener/MapListener.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2008-2014, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.listener;
+
+import java.util.EventListener;
+
+/**
+ * A marker interface which is used to get notified upon a map or an entry event.
+ * <p/>
+ * Specifically:
+ * <ul>
+ * <li>
+ * A map event is fired as a result of a map-wide operations like e.g. {@link com.hazelcast.core.EntryEventType#CLEAR_ALL}.
+ * {@link com.hazelcast.core.EntryEventType#EVICT_ALL}.
+ * </li>
+ * <li>
+ * An entry event is fired after the changes that affects a specific entry e.g. {@link com.hazelcast.core.EntryEventType#ADDED},
+ * {@link com.hazelcast.core.EntryEventType#UPDATED}
+ * </li>
+ * </ul>
+ * <p/>
+ * An implementer of this interface should extend one of the sub-interfaces of it
+ * to receive a corresponding event.
+ *
+ * @see MapClearedListener
+ * @see MapEvictedListener
+ * @see EntryAddedListener
+ * @see EntryEvictedListener
+ * @see EntryRemovedListener
+ * @see EntryUpdatedListener
+ * @since 3.5
+ */
+public interface MapListener extends EventListener {
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/listener/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/listener/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2008-2014, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Contains various {@link com.hazelcast.map.listener.MapListener} interfaces.
+ * @since 3.5
+ */
+package com.hazelcast.map.listener;

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/client/AddEntryListenerRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/client/AddEntryListenerRequest.java
@@ -22,7 +22,6 @@ import com.hazelcast.client.impl.client.RetryableRequest;
 import com.hazelcast.core.EntryAdapter;
 import com.hazelcast.core.EntryEvent;
 import com.hazelcast.core.EntryEventType;
-import com.hazelcast.core.EntryListener;
 import com.hazelcast.core.MapEvent;
 import com.hazelcast.map.impl.DataAwareEntryEvent;
 import com.hazelcast.multimap.impl.MultiMapPortableHook;
@@ -57,7 +56,7 @@ public class AddEntryListenerRequest extends CallableClientRequest implements Re
     public Object call() throws Exception {
         final ClientEndpoint endpoint = getEndpoint();
         final MultiMapService service = getService();
-        EntryListener listener = new EntryAdapter() {
+        EntryAdapter listener = new EntryAdapter() {
             @Override
             public void onEntryEvent(EntryEvent event) {
                 if (endpoint.isAlive()) {

--- a/hazelcast/src/test/java/com/hazelcast/map/IssuesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/IssuesTest.java
@@ -19,7 +19,10 @@ package com.hazelcast.map;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.GlobalSerializerConfig;
 import com.hazelcast.config.NearCacheConfig;
-import com.hazelcast.core.*;
+import com.hazelcast.core.EntryAdapter;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.HazelcastInstanceAware;
+import com.hazelcast.core.IMap;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.StreamSerializer;
@@ -37,7 +40,11 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 
 @RunWith(HazelcastParallelClassRunner.class)
@@ -50,23 +57,23 @@ public class IssuesTest extends HazelcastTestSupport {
         TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(n);
 
         final IMap<Integer, Integer> imap = factory.newHazelcastInstance(null).getMap("testIssue321_1");
-        final BlockingQueue<EntryEvent<Integer, Integer>> events1 = new LinkedBlockingQueue<EntryEvent<Integer, Integer>>();
-        final BlockingQueue<EntryEvent<Integer, Integer>> events2 = new LinkedBlockingQueue<EntryEvent<Integer, Integer>>();
+        final BlockingQueue<com.hazelcast.core.EntryEvent<Integer, Integer>> events1 = new LinkedBlockingQueue<com.hazelcast.core.EntryEvent<Integer, Integer>>();
+        final BlockingQueue<com.hazelcast.core.EntryEvent<Integer, Integer>> events2 = new LinkedBlockingQueue<com.hazelcast.core.EntryEvent<Integer, Integer>>();
         imap.addEntryListener(new EntryAdapter<Integer, Integer>() {
             @Override
-            public void entryAdded(EntryEvent<Integer, Integer> event) {
+            public void entryAdded(com.hazelcast.core.EntryEvent<Integer, Integer> event) {
                 events2.add(event);
             }
         }, false);
         imap.addEntryListener(new EntryAdapter<Integer, Integer>() {
             @Override
-            public void entryAdded(EntryEvent<Integer, Integer> event) {
+            public void entryAdded(com.hazelcast.core.EntryEvent<Integer, Integer> event) {
                 events1.add(event);
             }
         }, true);
         imap.put(1, 1);
-        final EntryEvent<Integer, Integer> event1 = events1.poll(10, TimeUnit.SECONDS);
-        final EntryEvent<Integer, Integer> event2 = events2.poll(10, TimeUnit.SECONDS);
+        final com.hazelcast.core.EntryEvent<Integer, Integer> event1 = events1.poll(10, TimeUnit.SECONDS);
+        final com.hazelcast.core.EntryEvent<Integer, Integer> event2 = events2.poll(10, TimeUnit.SECONDS);
         assertNotNull(event1);
         assertNotNull(event2);
         assertNotNull(event1.getValue());
@@ -79,24 +86,24 @@ public class IssuesTest extends HazelcastTestSupport {
         TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(n);
 
         final IMap<Integer, Integer> imap = factory.newHazelcastInstance(null).getMap("testIssue321_2");
-        final BlockingQueue<EntryEvent<Integer, Integer>> events1 = new LinkedBlockingQueue<EntryEvent<Integer, Integer>>();
-        final BlockingQueue<EntryEvent<Integer, Integer>> events2 = new LinkedBlockingQueue<EntryEvent<Integer, Integer>>();
+        final BlockingQueue<com.hazelcast.core.EntryEvent<Integer, Integer>> events1 = new LinkedBlockingQueue<com.hazelcast.core.EntryEvent<Integer, Integer>>();
+        final BlockingQueue<com.hazelcast.core.EntryEvent<Integer, Integer>> events2 = new LinkedBlockingQueue<com.hazelcast.core.EntryEvent<Integer, Integer>>();
         imap.addEntryListener(new EntryAdapter<Integer, Integer>() {
             @Override
-            public void entryAdded(EntryEvent<Integer, Integer> event) {
+            public void entryAdded(com.hazelcast.core.EntryEvent<Integer, Integer> event) {
                 events1.add(event);
             }
         }, true);
         Thread.sleep(50L);
         imap.addEntryListener(new EntryAdapter<Integer, Integer>() {
             @Override
-            public void entryAdded(EntryEvent<Integer, Integer> event) {
+            public void entryAdded(com.hazelcast.core.EntryEvent<Integer, Integer> event) {
                 events2.add(event);
             }
         }, false);
         imap.put(1, 1);
-        final EntryEvent<Integer, Integer> event1 = events1.poll(10, TimeUnit.SECONDS);
-        final EntryEvent<Integer, Integer> event2 = events2.poll(10, TimeUnit.SECONDS);
+        final com.hazelcast.core.EntryEvent<Integer, Integer> event1 = events1.poll(10, TimeUnit.SECONDS);
+        final com.hazelcast.core.EntryEvent<Integer, Integer> event2 = events2.poll(10, TimeUnit.SECONDS);
         assertNotNull(event1);
         assertNotNull(event2);
         assertNotNull(event1.getValue());
@@ -109,10 +116,10 @@ public class IssuesTest extends HazelcastTestSupport {
         TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(n);
 
         final IMap<Integer, Integer> imap = factory.newHazelcastInstance(null).getMap("testIssue321_3");
-        final BlockingQueue<EntryEvent<Integer, Integer>> events = new LinkedBlockingQueue<EntryEvent<Integer, Integer>>();
+        final BlockingQueue<com.hazelcast.core.EntryEvent<Integer, Integer>> events = new LinkedBlockingQueue<com.hazelcast.core.EntryEvent<Integer, Integer>>();
         final EntryAdapter<Integer, Integer> listener = new EntryAdapter<Integer, Integer>() {
             @Override
-            public void entryAdded(EntryEvent<Integer, Integer> event) {
+            public void entryAdded(com.hazelcast.core.EntryEvent<Integer, Integer> event) {
                 events.add(event);
             }
         };
@@ -120,8 +127,8 @@ public class IssuesTest extends HazelcastTestSupport {
         Thread.sleep(50L);
         imap.addEntryListener(listener, false);
         imap.put(1, 1);
-        final EntryEvent<Integer, Integer> event1 = events.poll(10, TimeUnit.SECONDS);
-        final EntryEvent<Integer, Integer> event2 = events.poll(10, TimeUnit.SECONDS);
+        final com.hazelcast.core.EntryEvent<Integer, Integer> event1 = events.poll(10, TimeUnit.SECONDS);
+        final com.hazelcast.core.EntryEvent<Integer, Integer> event2 = events.poll(10, TimeUnit.SECONDS);
         assertNotNull(event1);
         assertNotNull(event2);
         assertNotNull(event1.getValue());
@@ -286,8 +293,7 @@ public class IssuesTest extends HazelcastTestSupport {
         assertFalse("equals method should not have been called on key during clear", CompositeKey.equalsCalled);
     }
 
-    public static class CompositeKey implements Serializable
-    {
+    public static class CompositeKey implements Serializable {
         static boolean hashCodeCalled = false;
         static boolean equalsCalled = false;
 


### PR DESCRIPTION
Introduced sub-interfaces of `MapListener`:
- `MapClearedListener`
- `MapEvictedListener`
- `EntryAddedListener`
- `EntryEvictedListener`
- `EntryRemovedListener`
- `EntryUpdatedListener`