### PR TITLE
Iterator of MapLoader.loadAllKeys is now closed if it implements the Closeable interface

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/core/MapLoader.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/MapLoader.java
@@ -16,7 +16,9 @@
 
 package com.hazelcast.core;
 
+import java.io.Closeable;
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.Map;
 
 /**
@@ -53,7 +55,10 @@ public interface MapLoader<K, V> {
     Map<K, V> loadAll(Collection<K> keys);
 
     /**
-     * Loads all of the keys from the store.
+     * Loads all of the keys from the store. The returned {@link Iterable} may return the keys lazily
+     * by loading them in batches. The {@link Iterator} of this {@link Iterable} may implement the
+     * {@link Closeable} interface in which case it will be closed once iteration is over.
+     * This is intended for releasing resources such as closing a JDBC result set.
      *
      * @return all the keys
      */

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/BasicMapStoreContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/BasicMapStoreContext.java
@@ -28,11 +28,14 @@ import com.hazelcast.logging.ILogger;
 import com.hazelcast.map.impl.MapContainer;
 import com.hazelcast.map.impl.MapServiceContext;
 import com.hazelcast.map.impl.MapStoreWrapper;
+import com.hazelcast.nio.IOUtil;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.SerializationService;
 import com.hazelcast.spi.ExecutionService;
 import com.hazelcast.spi.NodeEngine;
 
+import java.io.Closeable;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.Callable;
@@ -249,16 +252,25 @@ final class BasicMapStoreContext implements MapStoreContext {
         initialKeys.clear();
         int maxSizePerNode = getApproximateMaxSize(maxSizeConfig, PER_NODE) - 1;
 
-        for (Object key : loadedKeys) {
-            Data dataKey = mapServiceContext.toData(key, partitioningStrategy);
-            // this node will load only owned keys
-            if (mapServiceContext.isOwnedKey(dataKey)) {
+        Iterator keyIterator = loadedKeys.iterator();
 
-                initialKeys.put(dataKey, key);
+        try {
+            while (keyIterator.hasNext()) {
+                Object key = keyIterator.next();
+                Data dataKey = mapServiceContext.toData(key, partitioningStrategy);
+                // this node will load only owned keys
+                if (mapServiceContext.isOwnedKey(dataKey)) {
 
-                if (initialKeys.size() == maxSizePerNode) {
-                    break;
+                    initialKeys.put(dataKey, key);
+
+                    if (initialKeys.size() == maxSizePerNode) {
+                        break;
+                    }
                 }
+            }
+        } finally {
+            if (keyIterator instanceof Closeable) {
+                IOUtil.closeResource((Closeable) keyIterator);
             }
         }
     }

--- a/hazelcast/src/test/java/com/hazelcast/map/mapstore/CountingMapLoader.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/mapstore/CountingMapLoader.java
@@ -1,0 +1,78 @@
+package com.hazelcast.map.mapstore;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class CountingMapLoader extends SimpleMapLoader {
+
+    private AtomicInteger loadedValueCount = new AtomicInteger();
+    private AtomicBoolean loadAllKeysClosed = new AtomicBoolean();
+
+    CountingMapLoader(int size) {
+        super(size, false);
+    }
+
+    @Override
+    public Map<Integer, Integer> loadAll(Collection<Integer> keys) {
+        loadedValueCount.addAndGet(keys.size());
+        return super.loadAll(keys);
+    }
+
+    public int getLoadedValueCount() {
+        return loadedValueCount.get();
+    }
+
+    public void reset() {
+        loadedValueCount.set(0);
+        loadAllKeysClosed.set(false);
+    }
+
+    public boolean isLoadAllKeysClosed() {
+        return loadAllKeysClosed.get();
+    }
+
+    @Override
+    public Iterable<Integer> loadAllKeys() {
+        final Iterable<Integer> allKeys = super.loadAllKeys();
+        return new Iterable<Integer>() {
+            @Override
+            public Iterator<Integer> iterator() {
+                return new CloseableIterator<Integer>(allKeys.iterator());
+            }
+        };
+    }
+
+    private class CloseableIterator<T> implements Iterator<T>, Closeable {
+
+        private Iterator<T> iterator;
+
+        public CloseableIterator(Iterator<T> iterator) {
+            this.iterator = iterator;
+        }
+
+        @Override
+        public boolean hasNext() {
+            return iterator.hasNext();
+        }
+
+        @Override
+        public T next() {
+            return iterator.next();
+        }
+
+        @Override
+        public void remove() {
+        }
+
+        @Override
+        public void close() throws IOException {
+            loadAllKeysClosed.set(true);
+        }
+
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/map/mapstore/SimpleMapLoader.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/mapstore/SimpleMapLoader.java
@@ -1,6 +1,5 @@
 package com.hazelcast.map.mapstore;
 
-import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.MapLoader;
 
 import java.util.Collection;
@@ -9,11 +8,10 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-public class SimpleMapLoader implements MapLoader {
+public class SimpleMapLoader implements MapLoader<Integer, Integer> {
 
     final int size;
     final boolean slow;
-    private HazelcastInstance hz;
 
     SimpleMapLoader(int size, boolean slow) {
         this.size = size;
@@ -21,12 +19,12 @@ public class SimpleMapLoader implements MapLoader {
     }
 
     @Override
-    public Object load(Object key) {
+    public Integer load(Integer key) {
         return null;
     }
 
     @Override
-    public Map loadAll(Collection keys) {
+    public Map<Integer, Integer> loadAll(Collection<Integer> keys) {
 
         if (slow) {
             try {
@@ -35,17 +33,17 @@ public class SimpleMapLoader implements MapLoader {
                 e.printStackTrace();
             }
         }
-        Map result = new HashMap();
-        for (Object key : keys) {
+        Map<Integer, Integer> result = new HashMap<Integer, Integer>();
+        for (Integer key : keys) {
             result.put(key, key);
         }
         return result;
     }
 
     @Override
-    public Iterable loadAllKeys() {
+    public Iterable<Integer> loadAllKeys() {
 
-        Set keys = new HashSet();
+        Set<Integer> keys = new HashSet<Integer>();
         for (int i = 0; i < size; i++) {
             keys.add(i);
         }


### PR DESCRIPTION
So that the implementation can free resources such as close a JDBC result set. 
Example usage is available in code samples: https://github.com/hazelcast/hazelcast-code-samples/tree/master/distributed-map/mapstore/src/main/java
