### PR TITLE
Review Request, Do Not Merge. First version of tracing for advanced troubleshooting.

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/ClusterServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/ClusterServiceImpl.java
@@ -47,6 +47,7 @@ import com.hazelcast.instance.LifecycleServiceImpl;
 import com.hazelcast.instance.MemberImpl;
 import com.hazelcast.instance.Node;
 import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Tracing;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.ConnectionListener;
@@ -1303,6 +1304,7 @@ public final class ClusterServiceImpl implements ClusterService, ConnectionListe
         if (logger.isFinestEnabled()) {
             logger.finest("Setting cluster time diff to " + diff + "ms.");
         }
+        traceSetMasterTime(diff);
         this.clusterTimeDiff = diff;
     }
 
@@ -1385,5 +1387,13 @@ public final class ClusterServiceImpl implements ClusterService, ConnectionListe
         sb.append("{address=").append(thisAddress);
         sb.append('}');
         return sb.toString();
+    }
+
+    private void traceSetMasterTime(long diff) {
+        if (Tracing.CLUSTER_TIME_ENABLED) {
+            if (diff > Tracing.CLUSTER_TIME_THRESHOLD_MS) {
+                logger.info(Tracing.CLUSTER_TIME_CODE + " Setting cluster time diff to " + diff + " ms.");
+            }
+        }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/logging/Tracing.java
+++ b/hazelcast/src/main/java/com/hazelcast/logging/Tracing.java
@@ -1,0 +1,36 @@
+package com.hazelcast.logging;
+
+/**
+ * Support class for advanced troubleshooting. It's not intended to be used under normal circumstances and
+ * it is disabled by default. Set a system property {@code hazelcast.troubleshooting.tracing.enabled}
+ * to {@code true} to enable tracing.
+ *
+ * Each probe must prefix its output to by a unique code for convenient filtering and searching.
+ *
+ */
+public final class Tracing {
+    public static final boolean ENABLED =
+            Boolean.getBoolean("hazelcast.troubleshooting.tracing.enabled");
+
+
+    public static final String DELAYED_INVOCATION_CODE = "TRC001";
+    public static final boolean DELAYED_INVOCATION_ENABLED = ENABLED
+            && !Boolean.getBoolean("hazelcast.troubleshooting.tracing.delayed.invocation.disabled");
+    public static final int DELAYED_INVOCATION_THRESHOLD_MS =
+            Integer.getInteger("hazelcast.troubleshooting.tracing.delayed.invocation.threshold.ms", 1000);
+
+    public static final String PACKET_THROUGHPUT_CODE = "TRC002";
+    public static final boolean PACKET_THROUGHPUT_ENABLED = ENABLED
+            && !Boolean.getBoolean("hazelcast.troubleshooting.tracing.packet.throughput.disabled");
+    public static final int PACKET_THROUGHPUT_SLEEP_MS =
+            Integer.getInteger("hazelcast.troubleshooting.tracing.packet.throughput.delay.ms", 10000);
+
+    public static final String CLUSTER_TIME_CODE = "TRC003";
+    public static final boolean CLUSTER_TIME_ENABLED = ENABLED
+            && !Boolean.getBoolean("hazelcast.troubleshooting.tracing.clustertime.disabled");
+    public static final int CLUSTER_TIME_THRESHOLD_MS =
+            Integer.getInteger("hazelcast.troubleshooting.tracing.clustertime.threshold.ms", 1000);
+
+    private Tracing() {
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/nio/IOService.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/IOService.java
@@ -121,4 +121,6 @@ public interface IOService {
     PacketReader createPacketReader(TcpIpConnection connection);
 
     PacketWriter createPacketWriter(TcpIpConnection connection);
+
+    void shutdown();
 }

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnectionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnectionManager.java
@@ -523,6 +523,7 @@ public class TcpIpConnectionManager implements ConnectionManager {
         closeServerSocket();
         stop();
         connectionListeners.clear();
+        ioService.shutdown();
     }
 
     private void closeServerSocket() {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/BasicOperationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/BasicOperationService.java
@@ -23,6 +23,7 @@ import com.hazelcast.instance.MemberImpl;
 import com.hazelcast.instance.Node;
 import com.hazelcast.instance.OutOfMemoryErrorDispatcher;
 import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Tracing;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.IOUtil;
@@ -585,6 +586,8 @@ final class BasicOperationService implements InternalOperationService {
             executedOperationsCount.incrementAndGet();
 
             try {
+                traceSlowInvocation(op);
+
                 if (timeout(op)) {
                     return;
                 }
@@ -602,6 +605,24 @@ final class BasicOperationService implements InternalOperationService {
                 afterRun(op);
             } catch (Throwable e) {
                 handleOperationError(op, e);
+            }
+        }
+
+        private void traceSlowInvocation(Operation op) {
+            if (Tracing.DELAYED_INVOCATION_ENABLED) {
+                long invocationTime = op.getInvocationTime();
+                if (invocationTime > 0) {
+                    long diff = nodeEngine.getClusterTime() - invocationTime;
+                    if (diff > Tracing.DELAYED_INVOCATION_THRESHOLD_MS) {
+                        StringBuilder sb = new StringBuilder(Tracing.DELAYED_INVOCATION_CODE)
+                                .append(" Operation ")
+                                .append(op)
+                                .append(" has been invoked ")
+                                .append(diff)
+                                .append(" ms ago.");
+                        logger.warning(sb.toString());
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
This is a foundation for "Tracing for advanced troubleshooting"
The idea is simple: Setting a single system property enables extra tracing useful for troubleshooting. Sometimes it's just logging to a different log level, but it can start new monitoring threads, collect extra informations, etc. 

Output of each probe/trace should be prefixed by an unique ID for easy searching. I used very similar system during 3.3.4 troubleshooting; It greatly increases visibility into cluster, allows to create charts such as this one:
![delayedinvocations6](https://cloud.githubusercontent.com/assets/158619/5682237/51507a86-9816-11e4-884a-4e0db26f3af1.png)


I appreciate there is a certain overlap with PerformanceMonitor and HealthMonitor or even logging. I'm not exactly sure where to draw a line between these facilitates. Perhaps it can be integrated together - eg. enabling tracing will automatically enable PerformanceMonitor and set HealthMonitor to NOISY. 