### PR TITLE
Introduction of StatisticsService

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -410,6 +410,7 @@
     <suppress checks="ReturnCount" files="com.hazelcast.multimap.impl.operations.MultiMapOperationFactory"/>
     <!-- todo: needs to be fixed -->
     <suppress checks="CyclomaticComplexity" files="com.hazelcast.multimap.impl.MultiMapService"/>
+    <suppress checks="MethodCount" files="com.hazelcast.multimap.impl.MultiMapService"/>
 
     <!-- Util -->
     <!-- /*

--- a/hazelcast/src/main/java/com/hazelcast/executor/impl/DistributedExecutorService.java
+++ b/hazelcast/src/main/java/com/hazelcast/executor/impl/DistributedExecutorService.java
@@ -26,7 +26,7 @@ import com.hazelcast.spi.ManagedService;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.RemoteService;
 import com.hazelcast.spi.ResponseHandler;
-import com.hazelcast.spi.StatisticsService;
+import com.hazelcast.spi.StatisticsAwareService;
 import com.hazelcast.util.Clock;
 import com.hazelcast.util.ConcurrencyUtil;
 import com.hazelcast.util.ConstructorFunction;
@@ -44,7 +44,8 @@ import java.util.concurrent.FutureTask;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 
-public class DistributedExecutorService implements ManagedService, RemoteService, ExecutionTracingService, StatisticsService {
+public class DistributedExecutorService implements ManagedService, RemoteService, ExecutionTracingService,
+        StatisticsAwareService {
 
     public static final String SERVICE_NAME = "hz:impl:executorService";
 

--- a/hazelcast/src/main/java/com/hazelcast/executor/impl/DistributedExecutorService.java
+++ b/hazelcast/src/main/java/com/hazelcast/executor/impl/DistributedExecutorService.java
@@ -17,6 +17,7 @@
 package com.hazelcast.executor.impl;
 
 import com.hazelcast.logging.ILogger;
+import com.hazelcast.monitor.LocalExecutorStats;
 import com.hazelcast.monitor.impl.LocalExecutorStatsImpl;
 import com.hazelcast.nio.Address;
 import com.hazelcast.spi.ExecutionService;
@@ -25,11 +26,14 @@ import com.hazelcast.spi.ManagedService;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.RemoteService;
 import com.hazelcast.spi.ResponseHandler;
+import com.hazelcast.spi.StatisticsService;
 import com.hazelcast.util.Clock;
 import com.hazelcast.util.ConcurrencyUtil;
 import com.hazelcast.util.ConstructorFunction;
 
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.Callable;
@@ -40,7 +44,7 @@ import java.util.concurrent.FutureTask;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 
-public class DistributedExecutorService implements ManagedService, RemoteService, ExecutionTracingService {
+public class DistributedExecutorService implements ManagedService, RemoteService, ExecutionTracingService, StatisticsService {
 
     public static final String SERVICE_NAME = "hz:impl:executorService";
 
@@ -157,6 +161,15 @@ public class DistributedExecutorService implements ManagedService, RemoteService
     public boolean isOperationExecuting(Address callerAddress, String callerUuid, Object identifier) {
         String uuid = String.valueOf(identifier);
         return submittedTasks.containsKey(uuid);
+    }
+
+    @Override
+    public Map<String, LocalExecutorStats> getStats() {
+        Map<String, LocalExecutorStats> executorStats = new HashMap<String, LocalExecutorStats>();
+        for (Map.Entry<String, LocalExecutorStatsImpl> queueStat : statsMap.entrySet()) {
+            executorStats.put(queueStat.getKey(), queueStat.getValue());
+        }
+        return executorStats;
     }
 
     private final class CallableProcessor extends FutureTask implements Runnable {

--- a/hazelcast/src/main/java/com/hazelcast/executor/impl/DistributedExecutorService.java
+++ b/hazelcast/src/main/java/com/hazelcast/executor/impl/DistributedExecutorService.java
@@ -30,9 +30,9 @@ import com.hazelcast.spi.StatisticsService;
 import com.hazelcast.util.Clock;
 import com.hazelcast.util.ConcurrencyUtil;
 import com.hazelcast.util.ConstructorFunction;
+import com.hazelcast.util.MapUtil;
 
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
@@ -165,7 +165,7 @@ public class DistributedExecutorService implements ManagedService, RemoteService
 
     @Override
     public Map<String, LocalExecutorStats> getStats() {
-        Map<String, LocalExecutorStats> executorStats = new HashMap<String, LocalExecutorStats>();
+        Map<String, LocalExecutorStats> executorStats = MapUtil.createHashMap(statsMap.size());
         for (Map.Entry<String, LocalExecutorStatsImpl> queueStat : statsMap.entrySet()) {
             executorStats.put(queueStat.getKey(), queueStat.getValue());
         }

--- a/hazelcast/src/main/java/com/hazelcast/executor/impl/ExecutorServiceProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/executor/impl/ExecutorServiceProxy.java
@@ -91,6 +91,7 @@ public class ExecutorServiceProxy
         this.name = name;
         this.partitionCount = nodeEngine.getPartitionService().getPartitionCount();
         this.logger = nodeEngine.getLogger(ExecutorServiceProxy.class);
+        getLocalExecutorStats();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapService.java
@@ -17,6 +17,7 @@
 package com.hazelcast.map.impl;
 
 import com.hazelcast.core.DistributedObject;
+import com.hazelcast.monitor.LocalMapStats;
 import com.hazelcast.spi.EventPublishingService;
 import com.hazelcast.spi.ManagedService;
 import com.hazelcast.spi.MigrationAwareService;
@@ -28,11 +29,14 @@ import com.hazelcast.spi.PostJoinAwareService;
 import com.hazelcast.spi.RemoteService;
 import com.hazelcast.spi.ReplicationSupportingService;
 import com.hazelcast.spi.SplitBrainHandlerService;
+import com.hazelcast.spi.StatisticsService;
 import com.hazelcast.spi.TransactionalService;
 import com.hazelcast.transaction.TransactionalObject;
 import com.hazelcast.transaction.impl.TransactionSupport;
 import com.hazelcast.wan.WanReplicationEvent;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Properties;
 
 /**
@@ -48,8 +52,10 @@ import java.util.Properties;
  * @see MapReplicationSupportingService
  */
 public final class MapService implements ManagedService, MigrationAwareService,
+
         TransactionalService, RemoteService, EventPublishingService<EventData, ListenerAdapter>,
-        PostJoinAwareService, SplitBrainHandlerService, ReplicationSupportingService {
+        PostJoinAwareService, SplitBrainHandlerService, ReplicationSupportingService, StatisticsService {
+
 
     /**
      * Service name of map service used
@@ -224,4 +230,13 @@ public final class MapService implements ManagedService, MigrationAwareService,
         this.replicationSupportingService = replicationSupportingService;
     }
 
+    @Override
+    public Map<String, LocalMapStats> getStats() {
+        Map<String, LocalMapStats> mapStats = new HashMap<String, LocalMapStats>();
+        Map<String, MapContainer> mapContainers = mapServiceContext.getMapContainers();
+        for (String mapName : mapContainers.keySet()) {
+            mapStats.put(mapName, mapServiceContext.getLocalMapStatsProvider().createLocalMapStats(mapName));
+        }
+        return mapStats;
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapService.java
@@ -29,7 +29,7 @@ import com.hazelcast.spi.PostJoinAwareService;
 import com.hazelcast.spi.RemoteService;
 import com.hazelcast.spi.ReplicationSupportingService;
 import com.hazelcast.spi.SplitBrainHandlerService;
-import com.hazelcast.spi.StatisticsService;
+import com.hazelcast.spi.StatisticsAwareService;
 import com.hazelcast.spi.TransactionalService;
 import com.hazelcast.transaction.TransactionalObject;
 import com.hazelcast.transaction.impl.TransactionSupport;
@@ -54,7 +54,7 @@ import java.util.Properties;
 public final class MapService implements ManagedService, MigrationAwareService,
 
         TransactionalService, RemoteService, EventPublishingService<EventData, ListenerAdapter>,
-        PostJoinAwareService, SplitBrainHandlerService, ReplicationSupportingService, StatisticsService {
+        PostJoinAwareService, SplitBrainHandlerService, ReplicationSupportingService, StatisticsAwareService {
 
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapService.java
@@ -232,8 +232,8 @@ public final class MapService implements ManagedService, MigrationAwareService,
 
     @Override
     public Map<String, LocalMapStats> getStats() {
-        Map<String, LocalMapStats> mapStats = new HashMap<String, LocalMapStats>();
         Map<String, MapContainer> mapContainers = mapServiceContext.getMapContainers();
+        Map<String, LocalMapStats> mapStats = new HashMap<String, LocalMapStats>(mapContainers.size());
         for (String mapName : mapContainers.keySet()) {
             mapStats.put(mapName, mapServiceContext.getLocalMapStatsProvider().createLocalMapStats(mapName));
         }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapService.java
@@ -33,9 +33,9 @@ import com.hazelcast.spi.StatisticsService;
 import com.hazelcast.spi.TransactionalService;
 import com.hazelcast.transaction.TransactionalObject;
 import com.hazelcast.transaction.impl.TransactionSupport;
+import com.hazelcast.util.MapUtil;
 import com.hazelcast.wan.WanReplicationEvent;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 
@@ -233,7 +233,7 @@ public final class MapService implements ManagedService, MigrationAwareService,
     @Override
     public Map<String, LocalMapStats> getStats() {
         Map<String, MapContainer> mapContainers = mapServiceContext.getMapContainers();
-        Map<String, LocalMapStats> mapStats = new HashMap<String, LocalMapStats>(mapContainers.size());
+        Map<String, LocalMapStats> mapStats = MapUtil.createHashMap(mapContainers.size());
         for (String mapName : mapContainers.keySet()) {
             mapStats.put(mapName, mapServiceContext.getLocalMapStatsProvider().createLocalMapStats(mapName));
         }

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/MemberStateImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/MemberStateImpl.java
@@ -44,11 +44,11 @@ public class MemberStateImpl implements MemberState {
 
     private String address;
     private Map<String, Long> runtimeProps = new HashMap<String, Long>();
-    private Map<String, LocalMapStatsImpl> mapStats = new HashMap<String, LocalMapStatsImpl>();
-    private Map<String, LocalMultiMapStatsImpl> multiMapStats = new HashMap<String, LocalMultiMapStatsImpl>();
-    private Map<String, LocalQueueStatsImpl> queueStats = new HashMap<String, LocalQueueStatsImpl>();
-    private Map<String, LocalTopicStatsImpl> topicStats = new HashMap<String, LocalTopicStatsImpl>();
-    private Map<String, LocalExecutorStatsImpl> executorStats = new HashMap<String, LocalExecutorStatsImpl>();
+    private Map<String, LocalMapStats> mapStats = new HashMap<String, LocalMapStats>();
+    private Map<String, LocalMultiMapStats> multiMapStats = new HashMap<String, LocalMultiMapStats>();
+    private Map<String, LocalQueueStats> queueStats = new HashMap<String, LocalQueueStats>();
+    private Map<String, LocalTopicStats> topicStats = new HashMap<String, LocalTopicStats>();
+    private Map<String, LocalExecutorStats> executorStats = new HashMap<String, LocalExecutorStats>();
     private Map<String, LocalCacheStats> cacheStats = new HashMap<String, LocalCacheStats>();
     private Collection<SerializableClientEndPoint> clients = new HashSet<SerializableClientEndPoint>();
     private SerializableMXBeans beans = new SerializableMXBeans();
@@ -63,27 +63,27 @@ public class MemberStateImpl implements MemberState {
         JsonObject root = new JsonObject();
         root.add("address", address);
         JsonObject mapStatsObject = new JsonObject();
-        for (Map.Entry<String, LocalMapStatsImpl> entry : mapStats.entrySet()) {
+        for (Map.Entry<String, LocalMapStats> entry : mapStats.entrySet()) {
             mapStatsObject.add(entry.getKey(), entry.getValue().toJson());
         }
         root.add("mapStats", mapStatsObject);
         JsonObject multimapStatsObject = new JsonObject();
-        for (Map.Entry<String, LocalMultiMapStatsImpl> entry : multiMapStats.entrySet()) {
+        for (Map.Entry<String, LocalMultiMapStats> entry : multiMapStats.entrySet()) {
             multimapStatsObject.add(entry.getKey(), entry.getValue().toJson());
         }
         root.add("multiMapStats", multimapStatsObject);
         JsonObject queueStatsObject = new JsonObject();
-        for (Map.Entry<String, LocalQueueStatsImpl> entry : queueStats.entrySet()) {
+        for (Map.Entry<String, LocalQueueStats> entry : queueStats.entrySet()) {
             queueStatsObject.add(entry.getKey(), entry.getValue().toJson());
         }
         root.add("queueStats", queueStatsObject);
         JsonObject topicStatsObject = new JsonObject();
-        for (Map.Entry<String, LocalTopicStatsImpl> entry : topicStats.entrySet()) {
+        for (Map.Entry<String, LocalTopicStats> entry : topicStats.entrySet()) {
             topicStatsObject.add(entry.getKey(), entry.getValue().toJson());
         }
         root.add("topicStats", topicStatsObject);
         JsonObject executorStatsObject = new JsonObject();
-        for (Map.Entry<String, LocalExecutorStatsImpl> entry : executorStats.entrySet()) {
+        for (Map.Entry<String, LocalExecutorStats> entry : executorStats.entrySet()) {
             executorStatsObject.add(entry.getKey(), entry.getValue().toJson());
         }
         root.add("executorStats", executorStatsObject);
@@ -211,23 +211,23 @@ public class MemberStateImpl implements MemberState {
         this.address = address;
     }
 
-    public void putLocalMapStats(String name, LocalMapStatsImpl localMapStats) {
+    public void putLocalMapStats(String name, LocalMapStats localMapStats) {
         mapStats.put(name, localMapStats);
     }
 
-    public void putLocalMultiMapStats(String name, LocalMultiMapStatsImpl localMultiMapStats) {
+    public void putLocalMultiMapStats(String name, LocalMultiMapStats localMultiMapStats) {
         multiMapStats.put(name, localMultiMapStats);
     }
 
-    public void putLocalQueueStats(String name, LocalQueueStatsImpl localQueueStats) {
+    public void putLocalQueueStats(String name, LocalQueueStats localQueueStats) {
         queueStats.put(name, localQueueStats);
     }
 
-    public void putLocalTopicStats(String name, LocalTopicStatsImpl localTopicStats) {
+    public void putLocalTopicStats(String name, LocalTopicStats localTopicStats) {
         topicStats.put(name, localTopicStats);
     }
 
-    public void putLocalExecutorStats(String name, LocalExecutorStatsImpl localExecutorStats) {
+    public void putLocalExecutorStats(String name, LocalExecutorStats localExecutorStats) {
         executorStats.put(name, localExecutorStats);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapService.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapService.java
@@ -45,7 +45,7 @@ import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.PartitionMigrationEvent;
 import com.hazelcast.spi.PartitionReplicationEvent;
 import com.hazelcast.spi.RemoteService;
-import com.hazelcast.spi.StatisticsService;
+import com.hazelcast.spi.StatisticsAwareService;
 import com.hazelcast.spi.TransactionalService;
 import com.hazelcast.transaction.TransactionalObject;
 import com.hazelcast.transaction.impl.TransactionSupport;
@@ -63,7 +63,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
 public class MultiMapService implements ManagedService, RemoteService, MigrationAwareService,
-        EventPublishingService<EventData, EntryListener>, TransactionalService, StatisticsService {
+        EventPublishingService<EventData, EntryListener>, TransactionalService, StatisticsAwareService {
 
     public static final String SERVICE_NAME = "hz:impl:multiMapService";
     private static final int STATS_MAP_INITIAL_CAPACITY = 1000;
@@ -343,9 +343,8 @@ public class MultiMapService implements ManagedService, RemoteService, Migration
     @Override
     public Map<String, LocalMultiMapStats> getStats() {
         Map<String, LocalMultiMapStats> multiMapStats = new HashMap<String, LocalMultiMapStats>();
-        for (int i = 0; i < nodeEngine.getPartitionService().getPartitionCount(); i++) {
-            MultiMapPartitionContainer partitionContainer = getPartitionContainer(i);
-            for (String name : partitionContainer.containerMap.keySet()) {
+        for (int i = 0; i < partitionContainers.length; i++) {
+            for (String name : partitionContainers[i].containerMap.keySet()) {
                 if (!multiMapStats.containsKey(name)) {
                     multiMapStats.put(name, createStats(name));
                 }

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapService.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapService.java
@@ -342,13 +342,15 @@ public class MultiMapService implements ManagedService, RemoteService, Migration
 
     @Override
     public Map<String, LocalMultiMapStats> getStats() {
-        Map<String, LocalMultiMapStats> mapStats = new HashMap<String, LocalMultiMapStats>();
+        Map<String, LocalMultiMapStats> multiMapStats = new HashMap<String, LocalMultiMapStats>();
         for (int i = 0; i < nodeEngine.getPartitionService().getPartitionCount(); i++) {
             MultiMapPartitionContainer partitionContainer = getPartitionContainer(i);
             for (String name : partitionContainer.containerMap.keySet()) {
-                mapStats.put(name, createStats(name));
+                if (!multiMapStats.containsKey(name)) {
+                    multiMapStats.put(name, createStats(name));
+                }
             }
         }
-        return mapStats;
+        return multiMapStats;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapService.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapService.java
@@ -25,7 +25,7 @@ import com.hazelcast.core.EntryEventType;
 import com.hazelcast.core.EntryListener;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.map.impl.EventData;
-import com.hazelcast.monitor.LocalMapStats;
+import com.hazelcast.monitor.LocalMultiMapStats;
 import com.hazelcast.monitor.impl.LocalMultiMapStatsImpl;
 import com.hazelcast.multimap.impl.operations.MultiMapMigrationOperation;
 import com.hazelcast.multimap.impl.txn.TransactionalMultiMapProxy;
@@ -45,6 +45,7 @@ import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.PartitionMigrationEvent;
 import com.hazelcast.spi.PartitionReplicationEvent;
 import com.hazelcast.spi.RemoteService;
+import com.hazelcast.spi.StatisticsService;
 import com.hazelcast.spi.TransactionalService;
 import com.hazelcast.transaction.TransactionalObject;
 import com.hazelcast.transaction.impl.TransactionSupport;
@@ -62,7 +63,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
 public class MultiMapService implements ManagedService, RemoteService, MigrationAwareService,
-        EventPublishingService<EventData, EntryListener>, TransactionalService {
+        EventPublishingService<EventData, EntryListener>, TransactionalService, StatisticsService {
 
     public static final String SERVICE_NAME = "hz:impl:multiMapService";
     private static final int STATS_MAP_INITIAL_CAPACITY = 1000;
@@ -265,7 +266,7 @@ public class MultiMapService implements ManagedService, RemoteService, Migration
         clearMigrationData(partitionId);
     }
 
-    public LocalMapStats createStats(String name) {
+    public LocalMultiMapStats createStats(String name) {
         LocalMultiMapStatsImpl stats = getLocalMultiMapStatsImpl(name);
         long ownedEntryCount = 0;
         long backupEntryCount = 0;
@@ -337,5 +338,17 @@ public class MultiMapService implements ManagedService, RemoteService, Migration
     @Override
     public void dispatchEvent(EventData event, EntryListener listener) {
         dispatcher.dispatchEvent(event, listener);
+    }
+
+    @Override
+    public Map<String, LocalMultiMapStats> getStats() {
+        Map<String, LocalMultiMapStats> mapStats = new HashMap<String, LocalMultiMapStats>();
+        for (int i = 0; i < nodeEngine.getPartitionService().getPartitionCount(); i++) {
+            MultiMapPartitionContainer partitionContainer = getPartitionContainer(i);
+            for (String name : partitionContainer.containerMap.keySet()) {
+                mapStats.put(name, createStats(name));
+            }
+        }
+        return mapStats;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/queue/impl/QueueService.java
+++ b/hazelcast/src/main/java/com/hazelcast/queue/impl/QueueService.java
@@ -49,6 +49,7 @@ import com.hazelcast.spi.TransactionalService;
 import com.hazelcast.transaction.impl.TransactionSupport;
 import com.hazelcast.util.ConcurrencyUtil;
 import com.hazelcast.util.ConstructorFunction;
+import com.hazelcast.util.MapUtil;
 import com.hazelcast.util.scheduler.EntryTaskScheduler;
 import com.hazelcast.util.scheduler.EntryTaskSchedulerFactory;
 import com.hazelcast.util.scheduler.ScheduleType;
@@ -303,7 +304,7 @@ public class QueueService implements ManagedService, MigrationAwareService, Tran
 
     @Override
     public Map<String, LocalQueueStats> getStats() {
-        Map<String, LocalQueueStats> queueStats = new HashMap<String, LocalQueueStats>();
+        Map<String, LocalQueueStats> queueStats = MapUtil.createHashMap(containerMap.size());
         for (Entry<String, QueueContainer> queueStat : containerMap.entrySet()) {
             queueStats.put(queueStat.getKey(), createLocalQueueStats(queueStat.getKey(),
                     nodeEngine.getPartitionService().getPartitionId(nodeEngine.getSerializationService().toData(

--- a/hazelcast/src/main/java/com/hazelcast/queue/impl/QueueService.java
+++ b/hazelcast/src/main/java/com/hazelcast/queue/impl/QueueService.java
@@ -44,6 +44,7 @@ import com.hazelcast.spi.OperationService;
 import com.hazelcast.spi.PartitionMigrationEvent;
 import com.hazelcast.spi.PartitionReplicationEvent;
 import com.hazelcast.spi.RemoteService;
+import com.hazelcast.spi.StatisticsService;
 import com.hazelcast.spi.TransactionalService;
 import com.hazelcast.transaction.impl.TransactionSupport;
 import com.hazelcast.util.ConcurrencyUtil;
@@ -68,7 +69,7 @@ import java.util.logging.Level;
  * such as {@link com.hazelcast.queue.impl.QueueEvictionProcessor }
  */
 public class QueueService implements ManagedService, MigrationAwareService, TransactionalService,
-        RemoteService, EventPublishingService<QueueEvent, ItemListener> {
+        RemoteService, EventPublishingService<QueueEvent, ItemListener>, StatisticsService {
     /**
      * Service name.
      */
@@ -298,5 +299,16 @@ public class QueueService implements ManagedService, MigrationAwareService, Tran
                     .setNodeEngine(nodeEngine);
             operationService.executeOperation(operation);
         }
+    }
+
+    @Override
+    public Map<String, LocalQueueStats> getStats() {
+        Map<String, LocalQueueStats> queueStats = new HashMap<String, LocalQueueStats>();
+        for (Entry<String, QueueContainer> queueStat : containerMap.entrySet()) {
+            queueStats.put(queueStat.getKey(), createLocalQueueStats(queueStat.getKey(),
+                    nodeEngine.getPartitionService().getPartitionId(nodeEngine.getSerializationService().toData(
+                            queueStat.getKey(), StringPartitioningStrategy.INSTANCE))));
+        }
+        return queueStats;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/StatisticsAwareService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/StatisticsAwareService.java
@@ -5,9 +5,11 @@ import com.hazelcast.monitor.LocalInstanceStats;
 import java.util.Map;
 
 /**
- * An interface to give SPI services ability to publish their statistics.
+ *
+ * This interface is in BETA stage and is subject to change in upcoming releases.
+ *
  */
-public interface StatisticsService {
+public interface StatisticsAwareService {
 
     <T extends LocalInstanceStats> Map<String, T> getStats();
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/StatisticsService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/StatisticsService.java
@@ -1,0 +1,14 @@
+package com.hazelcast.spi;
+
+import com.hazelcast.monitor.LocalInstanceStats;
+
+import java.util.Map;
+
+/**
+ * An interface to give SPI services ability to publish their statistics.
+ */
+public interface StatisticsService {
+
+    <T extends LocalInstanceStats> Map<String, T> getStats();
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/topic/impl/TopicService.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/impl/TopicService.java
@@ -32,9 +32,9 @@ import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.RemoteService;
 import com.hazelcast.spi.StatisticsService;
 import com.hazelcast.util.ConstructorFunction;
+import com.hazelcast.util.MapUtil;
 
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
@@ -168,7 +168,7 @@ public class TopicService implements ManagedService, RemoteService, EventPublish
 
     @Override
     public Map<String, LocalTopicStats> getStats() {
-        Map<String, LocalTopicStats> topicStats = new HashMap<String, LocalTopicStats>();
+        Map<String, LocalTopicStats> topicStats = MapUtil.createHashMap(statsMap.size());
         for (Map.Entry<String, LocalTopicStatsImpl> queueStat : statsMap.entrySet()) {
             topicStats.put(queueStat.getKey(), queueStat.getValue());
         }

--- a/hazelcast/src/main/java/com/hazelcast/topic/impl/TopicService.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/impl/TopicService.java
@@ -30,7 +30,7 @@ import com.hazelcast.spi.EventService;
 import com.hazelcast.spi.ManagedService;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.RemoteService;
-import com.hazelcast.spi.StatisticsService;
+import com.hazelcast.spi.StatisticsAwareService;
 import com.hazelcast.util.ConstructorFunction;
 import com.hazelcast.util.MapUtil;
 
@@ -45,7 +45,7 @@ import java.util.logging.Level;
 
 import static com.hazelcast.util.ConcurrencyUtil.getOrPutSynchronized;
 
-public class TopicService implements ManagedService, RemoteService, EventPublishingService, StatisticsService {
+public class TopicService implements ManagedService, RemoteService, EventPublishingService, StatisticsAwareService {
 
     public static final String SERVICE_NAME = "hz:impl:topicService";
     public static final int ORDERING_LOCKS_LENGTH = 1000;

--- a/hazelcast/src/main/java/com/hazelcast/topic/impl/TopicService.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/impl/TopicService.java
@@ -22,6 +22,7 @@ import com.hazelcast.core.Message;
 import com.hazelcast.core.MessageListener;
 import com.hazelcast.instance.MemberImpl;
 import com.hazelcast.logging.ILogger;
+import com.hazelcast.monitor.LocalTopicStats;
 import com.hazelcast.monitor.impl.LocalTopicStatsImpl;
 import com.hazelcast.spi.EventPublishingService;
 import com.hazelcast.spi.EventRegistration;
@@ -29,9 +30,12 @@ import com.hazelcast.spi.EventService;
 import com.hazelcast.spi.ManagedService;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.RemoteService;
+import com.hazelcast.spi.StatisticsService;
 import com.hazelcast.util.ConstructorFunction;
 
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -41,7 +45,7 @@ import java.util.logging.Level;
 
 import static com.hazelcast.util.ConcurrencyUtil.getOrPutSynchronized;
 
-public class TopicService implements ManagedService, RemoteService, EventPublishingService {
+public class TopicService implements ManagedService, RemoteService, EventPublishingService, StatisticsService {
 
     public static final String SERVICE_NAME = "hz:impl:topicService";
     public static final int ORDERING_LOCKS_LENGTH = 1000;
@@ -160,5 +164,14 @@ public class TopicService implements ManagedService, RemoteService, EventPublish
 
     public boolean removeMessageListener(String name, String registrationId) {
         return eventService.deregisterListener(TopicService.SERVICE_NAME, name, registrationId);
+    }
+
+    @Override
+    public Map<String, LocalTopicStats> getStats() {
+        Map<String, LocalTopicStats> topicStats = new HashMap<String, LocalTopicStats>();
+        for (Map.Entry<String, LocalTopicStatsImpl> queueStat : statsMap.entrySet()) {
+            topicStats.put(queueStat.getKey(), queueStat.getValue());
+        }
+        return topicStats;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/util/MapUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/MapUtil.java
@@ -17,7 +17,7 @@ public final class MapUtil {
      * to minimize rehash operations
      */
     public static <K, V> Map<K, V> createHashMap(int expectedMapSize) {
-        int initialCapacity = (int) (expectedMapSize * HASHMAP_DEFAULT_LOAD_FACTOR) + 1;
+        int initialCapacity = (int) (expectedMapSize / HASHMAP_DEFAULT_LOAD_FACTOR) + 1;
         return new HashMap<K, V>(initialCapacity);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/util/MapUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/MapUtil.java
@@ -1,0 +1,24 @@
+package com.hazelcast.util;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Utility class for Maps
+ */
+public final class MapUtil {
+
+    private static final double HASHMAP_DEFAULT_LOAD_FACTOR = 0.75;
+
+    private MapUtil() { }
+
+    /**
+     * Utility method that creates an {@link java.util.HashMap} with its initialCapacity calculated
+     * to minimize rehash operations
+     */
+    public static <K, V> Map<K, V> createHashMap(int expectedMapSize) {
+        int initialCapacity = (int) (expectedMapSize * HASHMAP_DEFAULT_LOAD_FACTOR) + 1;
+        return new HashMap<K, V>(initialCapacity);
+    }
+
+}


### PR DESCRIPTION
`StatisticsService` interface is introduced and implemented by related services.
This is for https://github.com/hazelcast/management-center/issues/153 essentially. 
We're used to collect statistics from proxy objects for management center but there are cases when a proxy object is not created. (Like the above issue or [this google group question](https://groups.google.com/forum/#!topic/hazelcast/VG6xle_SxyY)). To prevent this behaviour, services will provide their statistics instead of proxy objects.