### PR TITLE
Don't show "no configuration found, default is used" warning for default configuration.

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientConfig.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientConfig.java
@@ -630,7 +630,9 @@ public class ClientConfig {
         if (configPatternKey != null) {
             return configPatterns.get(configPatternKey);
         }
-        LOGGER.warning("No configuration found for " + itemName + ", using default config!");
+        if (!"default".equals(itemName)) {
+            LOGGER.warning("No configuration found for " + itemName + ", using default config!");
+        }
         return null;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/Config.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/Config.java
@@ -907,7 +907,9 @@ public class Config {
         if (configPatternKey != null) {
             return configPatterns.get(configPatternKey);
         }
-        LOGGER.warning("No configuration found for " + itemName + ", using default config!");
+        if (!"default".equals(itemName)) {
+            LOGGER.warning("No configuration found for " + itemName + ", using default config!");
+        }
         return null;
     }
 


### PR DESCRIPTION
Should fix minor issue in #4316 