### PR TITLE
Fixed memory leak caused by empty await queues in WaitNotifyService. Awa...

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/WaitNotifyService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/WaitNotifyService.java
@@ -22,8 +22,35 @@ package com.hazelcast.spi;
  */
 public interface WaitNotifyService {
 
+    /**
+     * Causes the current operation to wait in WaitNotifyService until it is notified
+     * by a {@link com.hazelcast.spi.Notifier} operation or timeout specified by
+     * {@link WaitSupport#getWaitTimeout()} passes.
+     * <p/>
+     * {@link com.hazelcast.spi.WaitSupport} operation will be registered using {@link com.hazelcast.spi.WaitNotifyKey}
+     * returned from method {@link WaitSupport#getWaitKey()}.
+     * <p/>
+     * When operation is notified, it's re-executed by related scheduled mechanism.
+     * <p/>
+     * If wait time-outs, {@link WaitSupport#onWaitExpire()} method is called.
+     * <p/>
+     * This method should be called in the thread executes the actual {@link com.hazelcast.spi.WaitSupport} operation.
+     *
+     * @param waitSupport operation which will wait for notification
+     */
     void await(WaitSupport waitSupport);
 
+    /**
+     * Notifies the waiting {@link com.hazelcast.spi.WaitSupport} operation to wake-up and continue executing.
+     * <p/>
+     * A waiting operation registered with the {@link Notifier#getNotifiedKey()} will be notified and deregistered.
+     * This method has no effect if there isn't any operation registered
+     * for related {@link com.hazelcast.spi.WaitNotifyKey}.
+     * <p/>
+     * This method should be called in the thread executes the actual {@link com.hazelcast.spi.Notifier} operation.
+     *
+     * @param notifier operation which will notify a corresponding waiting operation
+     */
     void notify(Notifier notifier);
 
 }

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/WaitNotifyServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/WaitNotifyServiceTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2008-2014, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi.impl;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.HazelcastInstanceNotActiveException;
+import com.hazelcast.core.ILock;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.locks.LockSupport;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category(QuickTest.class)
+public class WaitNotifyServiceTest extends HazelcastTestSupport {
+
+    @Test
+    public void testAwaitQueueCount_shouldNotExceedBlockedThreadCount() {
+        final HazelcastInstance hz = createHazelcastInstance();
+        NodeEngineImpl nodeEngine = getNode(hz).nodeEngine;
+        WaitNotifyServiceImpl waitNotifyService = (WaitNotifyServiceImpl) nodeEngine.getWaitNotifyService();
+
+        final int keyCount = 1000;
+        int nThreads = 4;
+        CountDownLatch latch = new CountDownLatch(nThreads);
+
+        for (int i = 0; i < nThreads; i++) {
+            new Thread(new LockWaitAndUnlockTask(hz, keyCount, latch)).start();
+        }
+
+        while (latch.getCount() > 0) {
+            LockSupport.parkNanos(1);
+            int awaitQueueCount = waitNotifyService.getAwaitQueueCount();
+            Assert.assertTrue(
+                    "Await queue count should be smaller than total number of threads: " + awaitQueueCount + " VS "
+                            + nThreads, awaitQueueCount < nThreads);
+        }
+    }
+
+    private static class LockWaitAndUnlockTask implements Runnable {
+        private final HazelcastInstance hz;
+        private final int keyCount;
+        private final CountDownLatch latch;
+
+        public LockWaitAndUnlockTask(HazelcastInstance hz, int keyCount, CountDownLatch latch) {
+            this.hz = hz;
+            this.keyCount = keyCount;
+            this.latch = latch;
+        }
+
+        @Override
+        public void run() {
+            for (int i = 0; i < keyCount; i++) {
+                try {
+                    ILock lock = hz.getLock("key" + i);
+                    lock.lock();
+                    LockSupport.parkNanos(1);
+                    lock.unlock();
+                } catch (HazelcastInstanceNotActiveException ignored) {
+                }
+            }
+            latch.countDown();
+        }
+    }
+}


### PR DESCRIPTION
...it queues becoming empty should be removed from registration map. Fixes #4432.