### PR TITLE
Removed implementations of returnsResponse true

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/AbstractCacheOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/AbstractCacheOperation.java
@@ -63,11 +63,6 @@ abstract class AbstractCacheOperation
     }
 
     @Override
-    public boolean returnsResponse() {
-        return true;
-    }
-
-    @Override
     public final Object getResponse() {
         return response;
     }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheCreateConfigOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheCreateConfigOperation.java
@@ -68,11 +68,6 @@ public class CacheCreateConfigOperation
     }
 
     @Override
-    public boolean returnsResponse() {
-        return true;
-    }
-
-    @Override
     public Object getResponse() {
         return response;
     }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheListenerRegistrationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheListenerRegistrationOperation.java
@@ -66,11 +66,6 @@ public class CacheListenerRegistrationOperation
     }
 
     @Override
-    public boolean returnsResponse() {
-        return true;
-    }
-
-    @Override
     public Object getResponse() {
         return null;
     }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheManagementConfigOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheManagementConfigOperation.java
@@ -61,16 +61,6 @@ public class CacheManagementConfigOperation
     }
 
     @Override
-    public boolean returnsResponse() {
-        return true;
-    }
-
-    @Override
-    public Object getResponse() {
-        return null;
-    }
-
-    @Override
     protected void writeInternal(ObjectDataOutput out)
             throws IOException {
         super.writeInternal(out);

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/PartitionWideCacheOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/PartitionWideCacheOperation.java
@@ -43,11 +43,6 @@ abstract class PartitionWideCacheOperation
     }
 
     @Override
-    public boolean returnsResponse() {
-        return true;
-    }
-
-    @Override
     public Object getResponse() {
         return response;
     }

--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/operations/AuthorizationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/operations/AuthorizationOperation.java
@@ -53,11 +53,6 @@ public class AuthorizationOperation extends AbstractOperation implements JoinOpe
     }
 
     @Override
-    public boolean returnsResponse() {
-        return true;
-    }
-
-    @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         groupName = in.readUTF();
         groupPassword = in.readUTF();

--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/operations/JoinCheckOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/operations/JoinCheckOperation.java
@@ -56,11 +56,6 @@ public class JoinCheckOperation extends AbstractOperation implements JoinOperati
     }
 
     @Override
-    public boolean returnsResponse() {
-        return true;
-    }
-
-    @Override
     public Object getResponse() {
         return response;
     }

--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/operations/MasterClaimOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/operations/MasterClaimOperation.java
@@ -50,11 +50,6 @@ public class MasterClaimOperation extends AbstractOperation implements JoinOpera
     }
 
     @Override
-    public boolean returnsResponse() {
-        return true;
-    }
-
-    @Override
     public Object getResponse() {
         return approvedAsMaster;
     }

--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/operations/PostJoinOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/operations/PostJoinOperation.java
@@ -98,11 +98,6 @@ public class PostJoinOperation extends AbstractOperation implements UrgentSystem
     }
 
     @Override
-    public boolean returnsResponse() {
-        return true;
-    }
-
-    @Override
     public boolean validatesTarget() {
         return false;
     }

--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/operations/PrepareMergeOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/operations/PrepareMergeOperation.java
@@ -53,11 +53,6 @@ public class PrepareMergeOperation extends AbstractClusterOperation {
     }
 
     @Override
-    public boolean returnsResponse() {
-        return true;
-    }
-
-    @Override
     public Object getResponse() {
         return Boolean.TRUE;
     }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/countdownlatch/operations/BaseCountDownLatchOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/countdownlatch/operations/BaseCountDownLatchOperation.java
@@ -33,11 +33,6 @@ abstract class BaseCountDownLatchOperation extends AbstractNamedOperation
     }
 
     @Override
-    public boolean returnsResponse() {
-        return true;
-    }
-
-    @Override
     public final String getServiceName() {
         return CountDownLatchService.SERVICE_NAME;
     }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/countdownlatch/operations/CountDownLatchBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/countdownlatch/operations/CountDownLatchBackupOperation.java
@@ -49,11 +49,6 @@ public class CountDownLatchBackupOperation extends BaseCountDownLatchOperation
     }
 
     @Override
-    public boolean returnsResponse() {
-        return true;
-    }
-
-    @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
         out.writeInt(count);

--- a/hazelcast/src/main/java/com/hazelcast/executor/impl/operations/ShutdownOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/executor/impl/operations/ShutdownOperation.java
@@ -35,11 +35,6 @@ public final class ShutdownOperation extends AbstractNamedOperation {
     }
 
     @Override
-    public boolean returnsResponse() {
-        return true;
-    }
-
-    @Override
     public Object getResponse() {
         return Boolean.TRUE;
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/AbstractMapOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/AbstractMapOperation.java
@@ -46,10 +46,4 @@ public abstract class AbstractMapOperation extends AbstractNamedOperation {
     @Override
     public void afterRun() throws Exception {
     }
-
-    @Override
-    public boolean returnsResponse() {
-        return true;
-    }
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/AddInterceptorOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/AddInterceptorOperation.java
@@ -45,11 +45,6 @@ public class AddInterceptorOperation extends AbstractOperation {
         mapService.getMapServiceContext().getMapContainer(mapName).addInterceptor(id, mapInterceptor);
     }
 
-    @Override
-    public boolean returnsResponse() {
-        return true;
-    }
-
     public Object getResponse() {
         return true;
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ClearOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ClearOperation.java
@@ -64,11 +64,6 @@ public class ClearOperation extends AbstractMapOperation implements BackupAwareO
     }
 
     @Override
-    public boolean returnsResponse() {
-        return true;
-    }
-
-    @Override
     public Object getResponse() {
         return numberOfClearedEntries;
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EvictAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EvictAllOperation.java
@@ -49,11 +49,6 @@ public class EvictAllOperation extends AbstractMapOperation implements BackupAwa
     }
 
     @Override
-    public boolean returnsResponse() {
-        return true;
-    }
-
-    @Override
     public int getSyncBackupCount() {
         return mapService.getMapServiceContext().getMapContainer(name).getBackupCount();
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MultipleEntryBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MultipleEntryBackupOperation.java
@@ -54,11 +54,6 @@ public class MultipleEntryBackupOperation extends AbstractMultipleEntryOperation
     }
 
     @Override
-    public boolean returnsResponse() {
-        return true;
-    }
-
-    @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
         backupProcessor = in.readObject();

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MultipleEntryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MultipleEntryOperation.java
@@ -70,11 +70,6 @@ public class MultipleEntryOperation extends AbstractMultipleEntryOperation imple
     }
 
     @Override
-    public boolean returnsResponse() {
-        return true;
-    }
-
-    @Override
     public Object getResponse() {
         return responses;
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryBackupOperation.java
@@ -71,11 +71,6 @@ public class PartitionWideEntryBackupOperation extends AbstractMultipleEntryOper
         }
     }
 
-    @Override
-    public boolean returnsResponse() {
-        return true;
-    }
-
     protected Predicate getPredicate() {
         return null;
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryOperation.java
@@ -90,11 +90,6 @@ public class PartitionWideEntryOperation extends AbstractMultipleEntryOperation 
     }
 
     @Override
-    public boolean returnsResponse() {
-        return true;
-    }
-
-    @Override
     public Object getResponse() {
         return responses;
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutFromLoadAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutFromLoadAllOperation.java
@@ -96,11 +96,6 @@ public class PutFromLoadAllOperation extends AbstractMapOperation implements Par
     }
 
     @Override
-    public boolean returnsResponse() {
-        return true;
-    }
-
-    @Override
     public Object getResponse() {
         return true;
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/RemoveInterceptorOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/RemoveInterceptorOperation.java
@@ -36,15 +36,13 @@ public class RemoveInterceptorOperation extends AbstractOperation {
     public RemoveInterceptorOperation() {
     }
 
+    @Override
     public void run() {
         mapService = (MapService) getService();
         mapService.getMapServiceContext().getMapContainer(mapName).removeInterceptor(id);
     }
 
-    public boolean returnsResponse() {
-        return true;
-    }
-
+    @Override
     public Object getResponse() {
         return true;
     }
@@ -67,5 +65,4 @@ public class RemoveInterceptorOperation extends AbstractOperation {
     public String toString() {
         return "RemoveInterceptorOperation{}";
     }
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/operation/KeyValueJobOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/operation/KeyValueJobOperation.java
@@ -110,11 +110,6 @@ public class KeyValueJobOperation<K, V>
     }
 
     @Override
-    public boolean returnsResponse() {
-        return true;
-    }
-
-    @Override
     public Object getResponse() {
         return Boolean.TRUE;
     }

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/operation/ProcessingOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/operation/ProcessingOperation.java
@@ -44,11 +44,6 @@ public abstract class ProcessingOperation
     }
 
     @Override
-    public boolean returnsResponse() {
-        return true;
-    }
-
-    @Override
     public String getServiceName() {
         return MapReduceService.SERVICE_NAME;
     }

--- a/hazelcast/src/main/java/com/hazelcast/partition/impl/AssignPartitions.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/impl/AssignPartitions.java
@@ -11,11 +11,6 @@ public class AssignPartitions extends AbstractOperation {
     }
 
     @Override
-    public boolean returnsResponse() {
-        return true;
-    }
-
-    @Override
     public Object getResponse() {
         return Boolean.TRUE;
     }

--- a/hazelcast/src/main/java/com/hazelcast/partition/impl/BaseMigrationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/impl/BaseMigrationOperation.java
@@ -47,11 +47,6 @@ public abstract class BaseMigrationOperation extends AbstractOperation
     }
 
     @Override
-    public boolean returnsResponse() {
-        return true;
-    }
-
-    @Override
     public final boolean validatesTarget() {
         return false;
     }

--- a/hazelcast/src/main/java/com/hazelcast/partition/impl/HasOngoingMigration.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/impl/HasOngoingMigration.java
@@ -44,11 +44,6 @@ public final class HasOngoingMigration extends AbstractOperation {
     }
 
     @Override
-    public boolean returnsResponse() {
-        return true;
-    }
-
-    @Override
     public Object getResponse() {
         return response;
     }

--- a/hazelcast/src/main/java/com/hazelcast/partition/impl/SafeStateCheckOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/impl/SafeStateCheckOperation.java
@@ -20,13 +20,7 @@ public class SafeStateCheckOperation extends AbstractOperation {
     }
 
     @Override
-    public boolean returnsResponse() {
-        return true;
-    }
-
-    @Override
     public Object getResponse() {
         return safe;
     }
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/queue/impl/operations/QueueOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/queue/impl/operations/QueueOperation.java
@@ -75,6 +75,11 @@ public abstract class QueueOperation extends Operation
     }
 
     @Override
+    public boolean returnsResponse() {
+        return true;
+    }
+
+    @Override
     public final Object getResponse() {
         return response;
     }

--- a/hazelcast/src/main/java/com/hazelcast/queue/impl/operations/QueueOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/queue/impl/operations/QueueOperation.java
@@ -96,11 +96,6 @@ public abstract class QueueOperation extends Operation
     public void beforeRun() throws Exception {
     }
 
-    @Override
-    public boolean returnsResponse() {
-        return true;
-    }
-
     public boolean hasListener() {
         EventService eventService = getNodeEngine().getEventService();
         Collection<EventRegistration> registrations = eventService.getRegistrations(getServiceName(), name);

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/ReplicatedMapClearOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/ReplicatedMapClearOperation.java
@@ -61,11 +61,6 @@ public class ReplicatedMapClearOperation
     }
 
     @Override
-    public boolean returnsResponse() {
-        return true;
-    }
-
-    @Override
     public int getFactoryId() {
         return ReplicatedMapDataSerializerHook.F_ID;
     }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/EventServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/EventServiceImpl.java
@@ -905,11 +905,6 @@ public class EventServiceImpl implements EventService {
         }
 
         @Override
-        public boolean returnsResponse() {
-            return true;
-        }
-
-        @Override
         protected void writeInternal(ObjectDataOutput out) throws IOException {
             super.writeInternal(out);
             eventPacket.writeData(out);
@@ -949,11 +944,6 @@ public class EventServiceImpl implements EventService {
         }
 
         @Override
-        public boolean returnsResponse() {
-            return true;
-        }
-
-        @Override
         protected void writeInternal(ObjectDataOutput out) throws IOException {
             registration.writeData(out);
         }
@@ -989,11 +979,6 @@ public class EventServiceImpl implements EventService {
 
         @Override
         public Object getResponse() {
-            return true;
-        }
-
-        @Override
-        public boolean returnsResponse() {
             return true;
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/PartitionIteratingOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/PartitionIteratingOperation.java
@@ -98,11 +98,6 @@ public final class PartitionIteratingOperation extends AbstractOperation impleme
         return new PartitionResponse(results);
     }
 
-    @Override
-    public boolean returnsResponse() {
-        return true;
-    }
-
     private static class ResponseQueue implements ResponseHandler {
         final BlockingQueue b = ResponseQueueFactory.newResponseQueue();
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/ProxyServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/ProxyServiceImpl.java
@@ -522,11 +522,6 @@ public class ProxyServiceImpl
         }
 
         @Override
-        public boolean returnsResponse() {
-            return true;
-        }
-
-        @Override
         public Object getResponse() {
             return Boolean.TRUE;
         }

--- a/hazelcast/src/main/java/com/hazelcast/topic/impl/PublishOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/impl/PublishOperation.java
@@ -64,11 +64,6 @@ public class PublishOperation extends AbstractNamedOperation
     }
 
     @Override
-    public boolean returnsResponse() {
-        return true;
-    }
-
-    @Override
     public int getFactoryId() {
         return TopicDataSerializerHook.F_ID;
     }

--- a/hazelcast/src/test/java/com/hazelcast/spi/InvocationFutureGetNewInstanceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/InvocationFutureGetNewInstanceTest.java
@@ -108,11 +108,6 @@ public class InvocationFutureGetNewInstanceTest extends HazelcastTestSupport {
         }
 
         @Override
-        public boolean returnsResponse() {
-            return true;
-        }
-
-        @Override
         public Object getResponse() {
             return response;
         }


### PR DESCRIPTION
 When it is already implemented by the AbstractOperation. The AbstractOperation by contract returns true; so there is no need to override it. 