### PR TITLE
Backport - Unnecessary de-serialization removed

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/standalone/model/MyPortableElement.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/standalone/model/MyPortableElement.java
@@ -1,0 +1,53 @@
+package com.hazelcast.client.standalone.model;
+
+import com.hazelcast.nio.serialization.Portable;
+import com.hazelcast.nio.serialization.PortableFactory;
+import com.hazelcast.nio.serialization.PortableReader;
+import com.hazelcast.nio.serialization.PortableWriter;
+
+import java.io.IOException;
+
+public class MyPortableElement implements Portable {
+    public static final int FACTORY_ID = 1;
+    public static final int CLASS_ID = 1;
+
+    private int id;
+
+    private MyPortableElement() {
+    }
+
+    public MyPortableElement(int id) {
+        this.id = id;
+    }
+
+    @Override
+    public int getFactoryId() {
+        return FACTORY_ID;
+    }
+
+    @Override
+    public int getClassId() {
+        return CLASS_ID;
+    }
+
+    @Override
+    public void writePortable(PortableWriter writer) throws IOException {
+        writer.writeInt("id", id);
+    }
+
+    @Override
+    public void readPortable(PortableReader reader) throws IOException {
+        id = reader.readInt("id");
+    }
+
+    public static class Factory implements PortableFactory {
+        @Override
+        public Portable create(int classId) {
+            if (classId == CLASS_ID) {
+                return new MyPortableElement();
+            } else {
+                throw new IllegalArgumentException("Unknown class ID " + classId);
+            }
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapEventPublisherSupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapEventPublisherSupport.java
@@ -227,15 +227,14 @@ class MapEventPublisherSupport implements MapEventPublisher {
                                            final Data dataKey, Data dataOldValue, Data dataValue) {
         final NodeEngine nodeEngine = mapServiceContext.getNodeEngine();
         final SerializationService serializationService = nodeEngine.getSerializationService();
-        Object testValue;
+        Data testValue;
         if (eventType == EntryEventType.REMOVED || eventType == EntryEventType.EVICTED) {
-            testValue = serializationService.toObject(dataOldValue);
+            testValue = dataOldValue;
         } else {
-            testValue = serializationService.toObject(dataValue);
+            testValue = dataValue;
         }
-        final Object key = serializationService.toObject(dataKey);
         final QueryEventFilter queryEventFilter = (QueryEventFilter) filter;
-        final QueryEntry entry = new QueryEntry(serializationService, dataKey, key, testValue);
+        final QueryEntry entry = new QueryEntry(serializationService, dataKey, dataKey, testValue);
         if (queryEventFilter.eval(entry)) {
             return queryEventFilter.isIncludeValue() ? Result.VALUE_INCLUDED : Result.NO_VALUE_INCLUDED;
         }


### PR DESCRIPTION
backport of #4457

Listeners with predicates now works even when a domain class is not on a member classpath when the domain class implements Portable
(cherry picked from commit 58af5a9)