### PR TITLE
Fixes duplicate store operation on a key upon map-store flush during eviction

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/MapDataStores.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/MapDataStores.java
@@ -46,7 +46,7 @@ public final class MapDataStores {
         final long writeDelayMillis = TimeUnit.SECONDS.toMillis(writeDelaySeconds);
         final boolean writeCoalescing = mapStoreConfig.isWriteCoalescing();
         final WriteBehindStore mapDataStore
-                = new WriteBehindStore(store, serializationService, writeDelayMillis, partitionId, writeCoalescing);
+                = new WriteBehindStore(store, serializationService, writeDelayMillis, partitionId);
         final WriteBehindQueue writeBehindQueue = newWriteBehindQueue(mapServiceContext, writeCoalescing);
         mapDataStore.setWriteBehindQueue(writeBehindQueue);
         mapDataStore.setWriteBehindProcessor(writeBehindProcessor);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/ArrayWriteBehindQueue.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/ArrayWriteBehindQueue.java
@@ -160,4 +160,29 @@ class ArrayWriteBehindQueue implements WriteBehindQueue<DelayedEntry> {
         return delayedEntries;
     }
 
+    /**
+     * Returns supplied number of entries from the start.
+     *
+     * @param count number of entries to return.
+     * @return list of entries
+     */
+    @Override
+    public List<DelayedEntry> get(int count) {
+        if (count <= 0) {
+            return Collections.emptyList();
+        }
+        Collection<DelayedEntry> values = this.list;
+        if (values.isEmpty()) {
+            return Collections.emptyList();
+        }
+        List<DelayedEntry> delayedEntries = new ArrayList<DelayedEntry>(count);
+        for (DelayedEntry e : values) {
+            if (delayedEntries.size() == count) {
+                break;
+            }
+            delayedEntries.add(e);
+        }
+        return delayedEntries;
+    }
+
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/CoalescedWriteBehindQueue.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/CoalescedWriteBehindQueue.java
@@ -167,4 +167,29 @@ class CoalescedWriteBehindQueue implements WriteBehindQueue<DelayedEntry> {
         }
         return delayedEntries;
     }
+
+    /**
+     * Returns supplied number of entries from the start.
+     *
+     * @param count number of entries to return.
+     * @return list of entries
+     */
+    @Override
+    public List<DelayedEntry> get(int count) {
+        if (count <= 0) {
+            return Collections.emptyList();
+        }
+        Collection<DelayedEntry> values = queue.values();
+        if (values.isEmpty()) {
+            return Collections.emptyList();
+        }
+        List<DelayedEntry> delayedEntries = new ArrayList<DelayedEntry>(count);
+        for (DelayedEntry e : values) {
+            if (delayedEntries.size() == count) {
+                break;
+            }
+            delayedEntries.add(e);
+        }
+        return delayedEntries;
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/SynchronizedWriteBehindQueue.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/SynchronizedWriteBehindQueue.java
@@ -145,4 +145,17 @@ class SynchronizedWriteBehindQueue<E> implements WriteBehindQueue<E> {
         }
     }
 
+    /**
+     * Returns supplied number of entries from the start.
+     *
+     * @param count number of entries to return.
+     * @return list of entries
+     */
+    @Override
+    public List<DelayedEntry> get(int count) {
+        synchronized (mutex) {
+            return queue.get(count);
+        }
+    }
+
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/WriteBehindQueue.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/WriteBehindQueue.java
@@ -114,5 +114,14 @@ public interface WriteBehindQueue<E> {
      */
     List<E> filterItems(long now);
 
+
+    /**
+     * Returns supplied number of entries from the start.
+     *
+     * @param count number of entries to return.
+     * @return list of entries
+     */
+    List<DelayedEntry> get(int count);
+
 }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/WriteBehindQueues.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/WriteBehindQueues.java
@@ -132,6 +132,17 @@ public final class WriteBehindQueues {
         public List filterItems(long now) {
             return Collections.emptyList();
         }
+
+        /**
+         * Returns supplied number of entries from the start.
+         *
+         * @param count number of entries to return.
+         * @return list of entries
+         */
+        @Override
+        public List<DelayedEntry> get(int count) {
+            return Collections.emptyList();
+        }
     }
 
 }

--- a/hazelcast/src/test/java/com/hazelcast/map/mapstore/writebehind/WriteBehindQueueTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/mapstore/writebehind/WriteBehindQueueTest.java
@@ -14,6 +14,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.hazelcast.map.impl.mapstore.writebehind.WriteBehindQueues.createDefaultWriteBehindQueue;
@@ -134,6 +135,51 @@ public class WriteBehindQueueTest extends HazelcastTestSupport {
         queue.removeAll();
 
         assertEquals(0, queue.size());
+    }
+
+
+    @Test
+    public void testGet_onCoalescedWBQ_whenCount_smallerThanQueueSize() throws Exception {
+        int queueSize = 100;
+        int fetchNumberOfEntries = 10;
+        WriteBehindQueue wbq = createWBQ();
+
+        testGetWithCount(wbq, queueSize, fetchNumberOfEntries);
+    }
+
+    @Test
+    public void testGet_onBoundedWBQ_whenCount_smallerThanQueueSize() throws Exception {
+        int queueSize = 100;
+        int fetchNumberOfEntries = 10;
+        WriteBehindQueue wbq = createBoundedWBQ();
+
+        testGetWithCount(wbq, queueSize, fetchNumberOfEntries);
+    }
+
+    @Test
+    public void testGet_onCoalescedWBQ_whenCount_higherThanQueueSize() throws Exception {
+        int queueSize = 100;
+        int fetchNumberOfEntries = 10000;
+        WriteBehindQueue wbq = createWBQ();
+
+        testGetWithCount(wbq, queueSize, fetchNumberOfEntries);
+    }
+
+    @Test
+    public void testGet_onBoundedWBQ_whenCount_higherThanQueueSize() throws Exception {
+        int queueSize = 100;
+        int fetchNumberOfEntries = 10000;
+        WriteBehindQueue wbq = createBoundedWBQ();
+
+        testGetWithCount(wbq, queueSize, fetchNumberOfEntries);
+    }
+
+    private void testGetWithCount(WriteBehindQueue<DelayedEntry> queue, int queueSize, int fetchNumberOfEntries) {
+        fillQueue(queue, queueSize);
+        List<DelayedEntry> entries = queue.get(fetchNumberOfEntries);
+
+        int expectedFetchedEntryCount = Math.min(queueSize, fetchNumberOfEntries);
+        assertEquals(expectedFetchedEntryCount, entries.size());
     }
 
     private void fillQueue(WriteBehindQueue queue, int numberOfItems) {


### PR DESCRIPTION
closes https://github.com/hazelcast/hazelcast/issues/4448 

Instead of flushing directly uses a flush counter and removes entries according to this counter from the start of write-behind queues.