### PR TITLE
Removed additional "No configuration found for ..., using default config!" warnings

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientConfig.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientConfig.java
@@ -630,7 +630,7 @@ public class ClientConfig {
         if (configPatternKey != null) {
             return configPatterns.get(configPatternKey);
         }
-        if (!"default".equals(itemName)) {
+        if (!"default".equals(itemName) && !itemName.startsWith("hz:")) {
             LOGGER.warning("No configuration found for " + itemName + ", using default config!");
         }
         return null;

--- a/hazelcast/src/main/java/com/hazelcast/config/Config.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/Config.java
@@ -907,7 +907,7 @@ public class Config {
         if (configPatternKey != null) {
             return configPatterns.get(configPatternKey);
         }
-        if (!"default".equals(itemName)) {
+        if (!"default".equals(itemName) && !itemName.startsWith("hz:")) {
             LOGGER.warning("No configuration found for " + itemName + ", using default config!");
         }
         return null;


### PR DESCRIPTION
Removed additional warnings when default configuration is chosen if itemName starts with "hz:" (internal data).