### PR TITLE
Performance: Remove servicename from operation-serialization

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheProxy.java
@@ -178,7 +178,7 @@ abstract class AbstractCacheProxy<K, V>
         try {
             OperationFactory factory = operationProvider.createGetAllOperationFactory(ks, expiryPolicy);
             OperationService operationService = getNodeEngine().getOperationService();
-            Map<Integer, Object> responses = operationService.invokeOnPartitions(getServiceName(), factory, partitions);
+            Map<Integer, Object> responses = operationService.invokeOnPartitions(factory, partitions);
             for (Object response : responses.values()) {
                 final Object responseObject = serializationService.toObject(response);
                 final Set<Map.Entry<Data, Data>> entries = ((MapEntrySet) responseObject).getEntrySet();
@@ -270,8 +270,8 @@ abstract class AbstractCacheProxy<K, V>
         try {
             final SerializationService serializationService = getNodeEngine().getSerializationService();
             OperationFactory operationFactory = operationProvider.createSizeOperationFactory();
-            final Map<Integer, Object> results = getNodeEngine().getOperationService()
-                    .invokeOnAllPartitions(getServiceName(), operationFactory);
+            OperationService operationService = getNodeEngine().getOperationService();
+            final Map<Integer, Object> results = operationService.invokeOnAllPartitions(operationFactory);
             int total = 0;
             for (Object result : results.values()) {
                 total += (Integer) serializationService.toObject(result);

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheProxyBase.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheProxyBase.java
@@ -128,7 +128,7 @@ abstract class AbstractCacheProxyBase<K, V> {
         Operation operation = new CacheDestroyOperation(cacheConfig.getNameWithPrefix());
         int partitionId = getNodeEngine().getPartitionService().getPartitionId(getDistributedObjectName());
         OperationService operationService = getNodeEngine().getOperationService();
-        InternalCompletableFuture f = operationService.invokeOnPartition(CacheService.SERVICE_NAME, operation, partitionId);
+        InternalCompletableFuture f = operationService.invokeOnPartition(operation, partitionId);
         //todo What happens in exception case? Cache doesn't get destroyed
         f.getSafely();
 
@@ -212,8 +212,8 @@ abstract class AbstractCacheProxyBase<K, V> {
         @Override
         public void run() {
             try {
-                final Map<Integer, Object> results = getNodeEngine().getOperationService()
-                        .invokeOnAllPartitions(getServiceName(), operationFactory);
+                OperationService operationService = getNodeEngine().getOperationService();
+                final Map<Integer, Object> results = operationService.invokeOnAllPartitions(operationFactory);
                 validateResults(results);
                 if (completionListener != null) {
                     completionListener.onCompletion();

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheService.java
@@ -144,7 +144,7 @@ public abstract class AbstractCacheService implements ICacheService {
         for (MemberImpl member : members) {
             if (!member.localMember() && !member.getUuid().equals(callerUuid)) {
                 final CacheDestroyOperation op = new CacheDestroyOperation(objectName, true);
-                operationService.invokeOnTarget(AbstractCacheService.SERVICE_NAME, op, member.getAddress());
+                operationService.invokeOnTarget(op, member.getAddress());
             }
         }
     }
@@ -172,7 +172,7 @@ public abstract class AbstractCacheService implements ICacheService {
         for (MemberImpl member : members) {
             if (!member.localMember()) {
                 final CacheCreateConfigOperation op = new CacheCreateConfigOperation(cacheConfig, true);
-                operationService.invokeOnTarget(AbstractCacheService.SERVICE_NAME, op, member.getAddress());
+                operationService.invokeOnTarget(op, member.getAddress());
             }
         }
     }
@@ -326,8 +326,8 @@ public abstract class AbstractCacheService implements ICacheService {
     @Override
     public String registerListener(String distributedObjectName, CacheEventListener listener) {
         final EventService eventService = getNodeEngine().getEventService();
-        final EventRegistration registration = eventService
-                .registerListener(AbstractCacheService.SERVICE_NAME, distributedObjectName, listener);
+        final EventRegistration registration = eventService.registerListener(
+                CacheService.SERVICE_NAME, distributedObjectName, listener);
         return registration.getId();
     }
 
@@ -339,7 +339,7 @@ public abstract class AbstractCacheService implements ICacheService {
 
     @Override
     public void deregisterAllListener(String name) {
-        nodeEngine.getEventService().deregisterAllListeners(AbstractCacheService.SERVICE_NAME, name);
+        nodeEngine.getEventService().deregisterAllListeners(CacheService.SERVICE_NAME, name);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractInternalCacheProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractInternalCacheProxy.java
@@ -90,7 +90,7 @@ abstract class AbstractInternalCacheProxy<K, V>
         try {
             final int partitionId = getPartitionId(getNodeEngine(), keyData);
             final InternalCompletableFuture<T> f = getNodeEngine().getOperationService()
-                    .invokeOnPartition(getServiceName(), op, partitionId);
+                    .invokeOnPartition(op, partitionId);
             if (completionOperation) {
                 waitCompletionLatch(completionId);
             }
@@ -180,7 +180,7 @@ abstract class AbstractInternalCacheProxy<K, V>
         final OperationService operationService = getNodeEngine().getOperationService();
         OperationFactory operationFactory = operationProvider.createClearOperationFactory();
         try {
-            final Map<Integer, Object> results = operationService.invokeOnAllPartitions(getServiceName(), operationFactory);
+            final Map<Integer, Object> results = operationService.invokeOnAllPartitions(operationFactory);
             for (Object result : results.values()) {
                 if (result != null && result instanceof CacheClearResponse) {
                     final Object response = ((CacheClearResponse) result).getResponse();
@@ -209,7 +209,7 @@ abstract class AbstractInternalCacheProxy<K, V>
         final OperationService operationService = getNodeEngine().getOperationService();
         OperationFactory operationFactory = operationProvider.createRemoveAllOperationFactory(keysData, completionId);
         try {
-            final Map<Integer, Object> results = operationService.invokeOnAllPartitions(getServiceName(), operationFactory);
+            final Map<Integer, Object> results = operationService.invokeOnAllPartitions(operationFactory);
             int completionCount = 0;
             for (Object result : results.values()) {
                 if (result != null && result instanceof CacheClearResponse) {

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheProxy.java
@@ -100,7 +100,7 @@ public class CacheProxy<K, V>
         Operation operation = operationProvider.createContainsKeyOperation(k);
         OperationService operationService = getNodeEngine().getOperationService();
         int partitionId = getPartitionId(getNodeEngine(), k);
-        InternalCompletableFuture<Boolean> f = operationService.invokeOnPartition(getServiceName(), operation, partitionId);
+        InternalCompletableFuture<Boolean> f = operationService.invokeOnPartition(operation, partitionId);
         return f.getSafely();
     }
 
@@ -234,7 +234,7 @@ public class CacheProxy<K, V>
         try {
             OperationService operationService = getNodeEngine().getOperationService();
             int partitionId = getPartitionId(getNodeEngine(), keyData);
-            final InternalCompletableFuture<T> f = operationService.invokeOnPartition(getServiceName(), op, partitionId);
+            final InternalCompletableFuture<T> f = operationService.invokeOnPartition(op, partitionId);
             final T safely = f.getSafely();
             waitCompletionLatch(completionId);
             return safely;
@@ -336,7 +336,7 @@ public class CacheProxy<K, V>
                 final Operation op = new CacheListenerRegistrationOperation(getDistributedObjectName(),
                         cacheEntryListenerConfiguration, isRegister);
                 final InternalCompletableFuture<Object> future = operationService
-                        .invokeOnTarget(CacheService.SERVICE_NAME, op, member.getAddress());
+                        .invokeOnTarget(op, member.getAddress());
                 futures.add(future);
             }
         }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/ClusterWideIterator.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/ClusterWideIterator.java
@@ -55,7 +55,7 @@ public class ClusterWideIterator<K, V>
         Operation operation = cacheProxy.operationProvider.createKeyIteratorOperation(lastTableIndex, fetchSize);
         final OperationService operationService = cacheProxy.getNodeEngine().getOperationService();
         final InternalCompletableFuture<CacheKeyIteratorResult> f = operationService
-                .invokeOnPartition(CacheService.SERVICE_NAME, operation, partitionIndex);
+                .invokeOnPartition(operation, partitionIndex);
         return f.getSafely();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/HazelcastServerCacheManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/HazelcastServerCacheManager.java
@@ -90,17 +90,15 @@ public class HazelcastServerCacheManager
         final String cacheNameWithPrefix = getCacheNameWithPrefix(cacheName);
         final Collection<MemberImpl> members = nodeEngine.getClusterService().getMemberList();
         final Collection<Future> futures = new ArrayList<Future>();
+        OperationService operationService = nodeEngine.getOperationService();
         for (MemberImpl member : members) {
             if (!member.localMember()) {
-                final CacheManagementConfigOperation op = new CacheManagementConfigOperation(cacheNameWithPrefix, statOrMan,
-                        enabled);
-                final Future future = nodeEngine.getOperationService()
-                                                .invokeOnTarget(CacheService.SERVICE_NAME, op, member.getAddress());
+                CacheManagementConfigOperation op = new CacheManagementConfigOperation(cacheNameWithPrefix, statOrMan, enabled);
+                Future future = operationService.invokeOnTarget(op, member.getAddress());
                 futures.add(future);
             }
         }
         waitWithDeadline(futures, CacheProxyUtil.AWAIT_COMPLETION_TIMEOUT_SECONDS, TimeUnit.SECONDS);
-
     }
 
     @Override
@@ -116,7 +114,7 @@ public class HazelcastServerCacheManager
 
         int partitionId = nodeEngine.getPartitionService().getPartitionId(cacheConfig.getNameWithPrefix());
         final InternalCompletableFuture<CacheConfig<K, V>> f = operationService
-                .invokeOnPartition(CacheService.SERVICE_NAME, cacheCreateConfigOperation, partitionId);
+                .invokeOnPartition(cacheCreateConfigOperation, partitionId);
         return f.getSafely();
     }
 
@@ -136,7 +134,7 @@ public class HazelcastServerCacheManager
         final CacheGetConfigOperation op = new CacheGetConfigOperation(cacheNameWithPrefix, cacheName);
         int partitionId = nodeEngine.getPartitionService().getPartitionId(cacheNameWithPrefix);
         final InternalCompletableFuture<CacheConfig> f = nodeEngine.getOperationService()
-                                                                   .invokeOnPartition(CacheService.SERVICE_NAME, op, partitionId);
+                                                                   .invokeOnPartition(op, partitionId);
         return f.getSafely();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/client/CacheCreateConfigRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/client/CacheCreateConfigRequest.java
@@ -62,7 +62,7 @@ public class CacheCreateConfigRequest
         final ClientEndpoint endpoint = getEndpoint();
         final Operation op = prepareOperation();
         op.setCallerUuid(endpoint.getUuid());
-        final InvocationBuilder builder = operationService.createInvocationBuilder(getServiceName(), op, partitionId);
+        final InvocationBuilder builder = operationService.createInvocationBuilder(op, partitionId);
         builder.setTryCount(TRY_COUNT).setResultDeserialized(false).setCallback(new Callback<Object>() {
             public void notify(Object object) {
                 endpoint.sendResponse(object, getCallId());

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/client/CacheDestroyRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/client/CacheDestroyRequest.java
@@ -57,7 +57,7 @@ public class CacheDestroyRequest
         final ClientEndpoint endpoint = getEndpoint();
         final Operation op = prepareOperation();
         op.setCallerUuid(endpoint.getUuid());
-        final InvocationBuilder builder = operationService.createInvocationBuilder(getServiceName(), op, partitionId);
+        final InvocationBuilder builder = operationService.createInvocationBuilder(op, partitionId);
         builder.setTryCount(TRY_COUNT).setResultDeserialized(false).setCallback(new Callback<Object>() {
             public void notify(Object object) {
                 endpoint.sendResponse(object, getCallId());

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/AbstractCacheOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/AbstractCacheOperation.java
@@ -19,6 +19,7 @@ package com.hazelcast.cache.impl.operation;
 import com.hazelcast.cache.CacheNotExistsException;
 import com.hazelcast.cache.impl.AbstractCacheService;
 import com.hazelcast.cache.impl.CacheDataSerializerHook;
+import com.hazelcast.cache.impl.CacheService;
 import com.hazelcast.cache.impl.ICacheRecordStore;
 import com.hazelcast.cache.impl.ICacheService;
 import com.hazelcast.cache.impl.record.CacheRecord;
@@ -53,6 +54,11 @@ abstract class AbstractCacheOperation
     protected AbstractCacheOperation(String name, Data key) {
         super(name);
         this.key = key;
+    }
+
+    @Override
+    public String getServiceName() {
+        return CacheService.SERVICE_NAME;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheClearBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheClearBackupOperation.java
@@ -31,6 +31,11 @@ public class CacheClearBackupOperation extends AbstractNamedOperation
     }
 
     @Override
+    public String getServiceName() {
+        return CacheService.SERVICE_NAME;
+    }
+
+    @Override
     public void run() throws Exception {
         cache.clear();
     }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheCreateConfigOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheCreateConfigOperation.java
@@ -18,6 +18,7 @@ package com.hazelcast.cache.impl.operation;
 
 import com.hazelcast.cache.impl.AbstractCacheService;
 import com.hazelcast.cache.impl.CacheDataSerializerHook;
+import com.hazelcast.cache.impl.CacheService;
 import com.hazelcast.config.CacheConfig;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
@@ -58,6 +59,11 @@ public class CacheCreateConfigOperation
         super(config.getNameWithPrefix());
         this.config = config;
         this.isLocal = isLocal;
+    }
+
+    @Override
+    public String getServiceName() {
+        return CacheService.SERVICE_NAME;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheDestroyOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheDestroyOperation.java
@@ -50,6 +50,11 @@ public class CacheDestroyOperation
     }
 
     @Override
+    public String getServiceName() {
+        return CacheService.SERVICE_NAME;
+    }
+
+    @Override
     public void run()
             throws Exception {
         final CacheService service = getService();

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheGetAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheGetAllOperation.java
@@ -51,6 +51,12 @@ public class CacheGetAllOperation
     public CacheGetAllOperation() {
     }
 
+    @Override
+    public String getServiceName() {
+        return CacheService.SERVICE_NAME;
+    }
+
+    @Override
     public void run() {
         CacheService service = getService();
         ICacheRecordStore cache = service.getOrCreateCache(name, getPartitionId());

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheListenerRegistrationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheListenerRegistrationOperation.java
@@ -49,6 +49,11 @@ public class CacheListenerRegistrationOperation
     }
 
     @Override
+    public String getServiceName() {
+        return CacheService.SERVICE_NAME;
+    }
+
+    @Override
     public void run()
             throws Exception {
         final CacheService service = getService();

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheLoadAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheLoadAllOperation.java
@@ -65,6 +65,11 @@ public class CacheLoadAllOperation
     }
 
     @Override
+    public String getServiceName() {
+        return CacheService.SERVICE_NAME;
+    }
+
+    @Override
     public void run()
             throws Exception {
         final int partitionId = getPartitionId();

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheManagementConfigOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheManagementConfigOperation.java
@@ -50,6 +50,11 @@ public class CacheManagementConfigOperation
     }
 
     @Override
+    public String getServiceName() {
+        return CacheService.SERVICE_NAME;
+    }
+
+    @Override
     public void run()
             throws Exception {
         final CacheService service = getService();

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CachePutAllBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CachePutAllBackupOperation.java
@@ -52,6 +52,11 @@ public class CachePutAllBackupOperation
     }
 
     @Override
+    public String getServiceName() {
+        return CacheService.SERVICE_NAME;
+    }
+
+    @Override
     public void beforeRun()
             throws Exception {
         CacheService service = getService();

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheRemoveAllBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheRemoveAllBackupOperation.java
@@ -51,6 +51,11 @@ public class CacheRemoveAllBackupOperation
     }
 
     @Override
+    public String getServiceName() {
+        return CacheService.SERVICE_NAME;
+    }
+
+    @Override
     public int getFactoryId() {
         return CacheDataSerializerHook.F_ID;
     }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheSizeOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheSizeOperation.java
@@ -37,6 +37,11 @@ public class CacheSizeOperation
     }
 
     @Override
+    public String getServiceName() {
+        return CacheService.SERVICE_NAME;
+    }
+
+    @Override
     public void run()
             throws Exception {
         CacheService service = getService();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngineImpl.java
@@ -538,7 +538,6 @@ public class ClientEngineImpl implements ClientEngine, CoreService, PostJoinAwar
     private ClientDisconnectionOperation createClientDisconnectionOperation(String clientUuid) {
         ClientDisconnectionOperation op = new ClientDisconnectionOperation(clientUuid);
         op.setNodeEngine(nodeEngine)
-                .setServiceName(SERVICE_NAME)
                 .setService(this)
                 .setResponseHandler(createEmptyResponseHandler());
         return op;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/client/AllPartitionsClientRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/client/AllPartitionsClientRequest.java
@@ -31,7 +31,7 @@ public abstract class AllPartitionsClientRequest extends ClientRequest {
     public final void process() throws Exception {
         ClientEndpoint endpoint = getEndpoint();
         OperationFactory operationFactory = new OperationFactoryWrapper(createOperationFactory(), endpoint.getUuid());
-        Map<Integer, Object> map = operationService.invokeOnAllPartitions(getServiceName(), operationFactory);
+        Map<Integer, Object> map = operationService.invokeOnAllPartitions(operationFactory);
         Object result = reduce(map);
         endpoint.sendResponse(result, getCallId());
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/client/InvocationClientRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/client/InvocationClientRequest.java
@@ -29,11 +29,11 @@ public abstract class InvocationClientRequest extends ClientRequest {
 
     protected abstract void invoke();
 
-    protected final InvocationBuilder createInvocationBuilder(String serviceName, Operation op, int partitionId) {
-        return operationService.createInvocationBuilder(serviceName, op, partitionId);
+    protected final InvocationBuilder createInvocationBuilder(Operation op, int partitionId) {
+        return operationService.createInvocationBuilder(op, partitionId);
     }
 
-    protected final InvocationBuilder createInvocationBuilder(String serviceName, Operation op, Address target) {
-        return operationService.createInvocationBuilder(serviceName, op, target);
+    protected final InvocationBuilder createInvocationBuilder(Operation op, Address target) {
+        return operationService.createInvocationBuilder(op, target);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/client/MultiPartitionClientRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/client/MultiPartitionClientRequest.java
@@ -29,7 +29,7 @@ public abstract class MultiPartitionClientRequest extends ClientRequest {
     public final void process() throws Exception {
         ClientEndpoint endpoint = getEndpoint();
         OperationFactory operationFactory = new OperationFactoryWrapper(createOperationFactory(), endpoint.getUuid());
-        Map<Integer, Object> map = operationService.invokeOnPartitions(getServiceName(), operationFactory, getPartitions());
+        Map<Integer, Object> map = operationService.invokeOnPartitions(operationFactory, getPartitions());
         Object result = reduce(map);
         endpoint.sendResponse(result, getCallId());
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/client/MultiTargetClientRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/client/MultiTargetClientRequest.java
@@ -53,7 +53,7 @@ public abstract class MultiTargetClientRequest extends ClientRequest {
         for (Address target : targets) {
             Operation op = operationFactory.createOperation();
             op.setCallerUuid(endpoint.getUuid());
-            InvocationBuilder builder = operationService.createInvocationBuilder(getServiceName(), op, target)
+            InvocationBuilder builder = operationService.createInvocationBuilder(op, target)
                     .setTryCount(TRY_COUNT)
                     .setResultDeserialized(false)
                     .setCallback(new SingleTargetCallback(target, callback));

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/client/PartitionClientRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/client/PartitionClientRequest.java
@@ -52,7 +52,7 @@ public abstract class PartitionClientRequest extends ClientRequest {
         ClientEndpoint endpoint = getEndpoint();
         Operation op = prepareOperation();
         op.setCallerUuid(endpoint.getUuid());
-        InvocationBuilder builder = operationService.createInvocationBuilder(getServiceName(), op, getPartition())
+        InvocationBuilder builder = operationService.createInvocationBuilder(op, getPartition())
                 .setReplicaIndex(getReplicaIndex())
                 .setTryCount(TRY_COUNT)
                 .setResultDeserialized(false)

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/client/TargetClientRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/client/TargetClientRequest.java
@@ -43,7 +43,7 @@ public abstract class TargetClientRequest extends ClientRequest {
     }
 
     protected InvocationBuilder getInvocationBuilder(Operation op) {
-        return operationService.createInvocationBuilder(getServiceName(), op, getTarget());
+        return operationService.createInvocationBuilder(op, getTarget());
     }
 
     protected abstract Operation prepareOperation();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/operations/ClientDisconnectionOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/operations/ClientDisconnectionOperation.java
@@ -42,6 +42,11 @@ public class ClientDisconnectionOperation extends AbstractOperation implements U
     }
 
     @Override
+    public String getServiceName() {
+        return ClientEngineImpl.SERVICE_NAME;
+    }
+
+    @Override
     public void run() throws Exception {
         ClientEngineImpl engine = getService();
         final ClientEndpointManager endpointManager = engine.getEndpointManager();

--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/AbstractJoiner.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/AbstractJoiner.java
@@ -229,7 +229,7 @@ public abstract class AbstractJoiner implements Joiner {
         for (MemberImpl member : memberList) {
             if (!member.localMember()) {
                 Operation operation = new PrepareMergeOperation(targetAddress);
-                Future f = operationService.createInvocationBuilder(ClusterServiceImpl.SERVICE_NAME,
+                Future f = operationService.createInvocationBuilder(
                         operation, member.getAddress()).setTryCount(3).invoke();
                 calls.add(f);
             }
@@ -245,9 +245,8 @@ public abstract class AbstractJoiner implements Joiner {
 
         for (MemberImpl member : memberList) {
             if (!member.localMember()) {
-                operationService.createInvocationBuilder(ClusterServiceImpl.SERVICE_NAME,
-                        new MergeClustersOperation(targetAddress), member.getAddress())
-                        .setTryCount(1).invoke();
+                MergeClustersOperation op = new MergeClustersOperation(targetAddress);
+                operationService.createInvocationBuilder(op, member.getAddress()).setTryCount(1).invoke();
             }
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/ClusterServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/ClusterServiceImpl.java
@@ -242,9 +242,9 @@ public final class ClusterServiceImpl implements ClusterService, ConnectionListe
     }
 
     public JoinRequest checkJoinInfo(Address target) {
-        Future f = nodeEngine.getOperationService().createInvocationBuilder(SERVICE_NAME,
-                new JoinCheckOperation(node.createJoinRequest()), target)
-                .setTryCount(1).invoke();
+        JoinCheckOperation op = new JoinCheckOperation(node.createJoinRequest());
+        OperationService operationService = nodeEngine.getOperationService();
+        Future f = operationService.createInvocationBuilder(op, target).setTryCount(1).invoke();
         try {
             return (JoinRequest) nodeEngine.toObject(f.get());
         } catch (Exception e) {
@@ -1079,8 +1079,8 @@ public final class ClusterServiceImpl implements ClusterService, ConnectionListe
     }
 
     private Future invokeClusterOperation(Operation op, Address target) {
-        return nodeEngine.getOperationService().createInvocationBuilder(SERVICE_NAME, op, target)
-                .setTryCount(100).invoke();
+        OperationService operationService = nodeEngine.getOperationService();
+        return operationService.createInvocationBuilder(op, target).setTryCount(100).invoke();
     }
 
     public NodeEngineImpl getNodeEngine() {

--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/TcpIpJoiner.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/TcpIpJoiner.java
@@ -26,6 +26,7 @@ import com.hazelcast.instance.MemberImpl;
 import com.hazelcast.instance.Node;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.Connection;
+import com.hazelcast.spi.OperationService;
 import com.hazelcast.util.AddressUtil;
 import com.hazelcast.util.AddressUtil.AddressMatcher;
 import com.hazelcast.util.AddressUtil.InvalidAddressException;
@@ -178,14 +179,14 @@ public class TcpIpJoiner extends AbstractJoiner {
         }
         claimingMaster = true;
         Collection<Future<Boolean>> responses = new LinkedList<Future<Boolean>>();
+        OperationService operationService = node.nodeEngine.getOperationService();
         for (Address address : possibleAddresses) {
             if (isBlacklisted(address)) {
                 continue;
             }
             if (node.getConnectionManager().getConnection(address) != null) {
-                Future future = node.nodeEngine.getOperationService()
-                        .createInvocationBuilder(ClusterServiceImpl.SERVICE_NAME,
-                                new MasterClaimOperation(), address).setTryCount(1).invoke();
+                MasterClaimOperation op = new MasterClaimOperation();
+                Future future = operationService.createInvocationBuilder(op, address).setTryCount(1).invoke();
                 responses.add(future);
             }
         }

--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/operations/AuthorizationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/operations/AuthorizationOperation.java
@@ -38,6 +38,11 @@ public class AuthorizationOperation extends AbstractOperation implements JoinOpe
     }
 
     @Override
+    public String getServiceName() {
+        return null;
+    }
+
+    @Override
     public void run() {
         GroupConfig groupConfig = getNodeEngine().getConfig().getGroupConfig();
         if (!groupName.equals(groupConfig.getName())) {

--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/operations/FinalizeJoinOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/operations/FinalizeJoinOperation.java
@@ -72,8 +72,7 @@ public class FinalizeJoinOperation extends MemberInfoUpdateOperation implements 
             for (MemberImpl member : members) {
                 if (!member.localMember()) {
                     PostJoinOperation operation = new PostJoinOperation(postJoinOperations);
-                    operationService.createInvocationBuilder(ClusterServiceImpl.SERVICE_NAME,
-                            operation, member.getAddress()).setTryCount(100).invoke();
+                    operationService.createInvocationBuilder(operation, member.getAddress()).setTryCount(100).invoke();
                 }
             }
         }

--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/operations/JoinCheckOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/operations/JoinCheckOperation.java
@@ -22,6 +22,7 @@ import com.hazelcast.instance.Node;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.spi.AbstractOperation;
+import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 
 import java.io.IOException;
@@ -36,6 +37,11 @@ public class JoinCheckOperation extends AbstractOperation implements JoinOperati
 
     public JoinCheckOperation(final JoinRequest joinRequest) {
         this.joinRequest = joinRequest;
+    }
+
+    @Override
+    public String getServiceName() {
+        return ClusterServiceImpl.SERVICE_NAME;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/operations/MasterClaimOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/operations/MasterClaimOperation.java
@@ -29,6 +29,11 @@ public class MasterClaimOperation extends AbstractOperation implements JoinOpera
     private transient boolean approvedAsMaster;
 
     @Override
+    public String getServiceName() {
+        return null;
+    }
+
+    @Override
     public void run() {
         final NodeEngineImpl nodeEngine = (NodeEngineImpl) getNodeEngine();
         Node node = nodeEngine.getNode();

--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/operations/PostJoinOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/operations/PostJoinOperation.java
@@ -52,6 +52,11 @@ public class PostJoinOperation extends AbstractOperation implements UrgentSystem
     }
 
     @Override
+    public String getServiceName() {
+        return null;
+    }
+
+    @Override
     public void beforeRun() throws Exception {
         if (operations != null && operations.length > 0) {
             final NodeEngine nodeEngine = getNodeEngine();

--- a/hazelcast/src/main/java/com/hazelcast/collection/CollectionAddAllBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/CollectionAddAllBackupOperation.java
@@ -20,6 +20,7 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.BackupOperation;
+
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
@@ -31,8 +32,8 @@ public class CollectionAddAllBackupOperation extends CollectionOperation impleme
     public CollectionAddAllBackupOperation() {
     }
 
-    public CollectionAddAllBackupOperation(String name, Map<Long, Data> valueMap) {
-        super(name);
+    public CollectionAddAllBackupOperation(CollectionType collectionType, String name, Map<Long, Data> valueMap) {
+        super(collectionType, name);
         this.valueMap = valueMap;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/collection/CollectionAddAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/CollectionAddAllOperation.java
@@ -35,8 +35,8 @@ public class CollectionAddAllOperation extends CollectionBackupAwareOperation {
     public CollectionAddAllOperation() {
     }
 
-    public CollectionAddAllOperation(String name, List<Data> valueList) {
-        super(name);
+    public CollectionAddAllOperation(CollectionType collectionType, String name, List<Data> valueList) {
+        super(collectionType, name);
         this.valueList = valueList;
     }
 
@@ -47,7 +47,7 @@ public class CollectionAddAllOperation extends CollectionBackupAwareOperation {
 
     @Override
     public Operation getBackupOperation() {
-        return new CollectionAddAllBackupOperation(name, valueMap);
+        return new CollectionAddAllBackupOperation(getCollectionType(), name, valueMap);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/collection/CollectionAddBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/CollectionAddBackupOperation.java
@@ -31,8 +31,8 @@ public class CollectionAddBackupOperation extends CollectionOperation implements
     public CollectionAddBackupOperation() {
     }
 
-    public CollectionAddBackupOperation(String name, long itemId, Data value) {
-        super(name);
+    public CollectionAddBackupOperation(CollectionType collectionType, String name, long itemId, Data value) {
+        super(collectionType, name);
         this.itemId = itemId;
         this.value = value;
     }

--- a/hazelcast/src/main/java/com/hazelcast/collection/CollectionAddOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/CollectionAddOperation.java
@@ -31,8 +31,8 @@ public class CollectionAddOperation extends CollectionBackupAwareOperation {
     public CollectionAddOperation() {
     }
 
-    public CollectionAddOperation(String name, Data value) {
-        super(name);
+    public CollectionAddOperation(CollectionType collectionType, String name, Data value) {
+        super(collectionType, name);
         this.value = value;
     }
 
@@ -43,7 +43,7 @@ public class CollectionAddOperation extends CollectionBackupAwareOperation {
 
     @Override
     public Operation getBackupOperation() {
-        return new CollectionAddBackupOperation(name, itemId, value);
+        return new CollectionAddBackupOperation(getCollectionType(), name, itemId, value);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/collection/CollectionBackupAwareOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/CollectionBackupAwareOperation.java
@@ -23,8 +23,8 @@ public abstract class CollectionBackupAwareOperation extends CollectionOperation
     protected CollectionBackupAwareOperation() {
     }
 
-    protected CollectionBackupAwareOperation(String name) {
-        super(name);
+    protected CollectionBackupAwareOperation(CollectionType collectionType, String name) {
+        super(collectionType, name);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/collection/CollectionClearBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/CollectionClearBackupOperation.java
@@ -25,13 +25,13 @@ import java.util.Set;
 
 public class CollectionClearBackupOperation extends CollectionOperation implements BackupOperation {
 
-    Set<Long> itemIdSet;
+    private  Set<Long> itemIdSet;
 
     public CollectionClearBackupOperation() {
     }
 
-    public CollectionClearBackupOperation(String name, Set<Long> itemIdSet) {
-        super(name);
+    public CollectionClearBackupOperation(CollectionType collectionType, String name, Set<Long> itemIdSet) {
+        super(collectionType, name);
         this.itemIdSet = itemIdSet;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/collection/CollectionClearOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/CollectionClearOperation.java
@@ -19,6 +19,7 @@ package com.hazelcast.collection;
 import com.hazelcast.core.ItemEventType;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.Operation;
+
 import java.util.Map;
 
 public class CollectionClearOperation extends CollectionBackupAwareOperation {
@@ -28,8 +29,8 @@ public class CollectionClearOperation extends CollectionBackupAwareOperation {
     public CollectionClearOperation() {
     }
 
-    public CollectionClearOperation(String name) {
-        super(name);
+    public CollectionClearOperation(CollectionType collectionType, String name) {
+        super(collectionType, name);
     }
 
     @Override
@@ -39,7 +40,7 @@ public class CollectionClearOperation extends CollectionBackupAwareOperation {
 
     @Override
     public Operation getBackupOperation() {
-        return new CollectionClearBackupOperation(name, itemIdMap.keySet());
+        return new CollectionClearBackupOperation(getCollectionType(), name, itemIdMap.keySet());
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/collection/CollectionCompareAndRemoveOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/CollectionCompareAndRemoveOperation.java
@@ -35,8 +35,8 @@ public class CollectionCompareAndRemoveOperation extends CollectionBackupAwareOp
     public CollectionCompareAndRemoveOperation() {
     }
 
-    public CollectionCompareAndRemoveOperation(String name, boolean retain, Set<Data> valueSet) {
-        super(name);
+    public CollectionCompareAndRemoveOperation(CollectionType collectionType, String name, boolean retain, Set<Data> valueSet) {
+        super(collectionType, name);
         this.retain = retain;
         this.valueSet = valueSet;
     }
@@ -48,7 +48,7 @@ public class CollectionCompareAndRemoveOperation extends CollectionBackupAwareOp
 
     @Override
     public Operation getBackupOperation() {
-        return new CollectionClearBackupOperation(name, itemIdMap.keySet());
+        return new CollectionClearBackupOperation(getCollectionType(), name, itemIdMap.keySet());
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/collection/CollectionContainsOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/CollectionContainsOperation.java
@@ -30,8 +30,8 @@ public class CollectionContainsOperation extends CollectionOperation {
     public CollectionContainsOperation() {
     }
 
-    public CollectionContainsOperation(String name, Set<Data> valueSet) {
-        super(name);
+    public CollectionContainsOperation(CollectionType collectionType, String name, Set<Data> valueSet) {
+        super(collectionType, name);
         this.valueSet = valueSet;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/collection/CollectionGetAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/CollectionGetAllOperation.java
@@ -25,8 +25,8 @@ public class CollectionGetAllOperation extends CollectionOperation {
     public CollectionGetAllOperation() {
     }
 
-    public CollectionGetAllOperation(String name) {
-        super(name);
+    public CollectionGetAllOperation(CollectionType collectionType, String name) {
+        super(collectionType, name);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/collection/CollectionIsEmptyOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/CollectionIsEmptyOperation.java
@@ -21,8 +21,8 @@ public class CollectionIsEmptyOperation extends CollectionOperation {
     public CollectionIsEmptyOperation() {
     }
 
-    public CollectionIsEmptyOperation(String name) {
-        super(name);
+    public CollectionIsEmptyOperation(CollectionType collectionType, String name) {
+        super(collectionType, name);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/collection/CollectionRemoveBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/CollectionRemoveBackupOperation.java
@@ -28,8 +28,8 @@ public class CollectionRemoveBackupOperation extends CollectionOperation impleme
     public CollectionRemoveBackupOperation() {
     }
 
-    public CollectionRemoveBackupOperation(String name, long itemId) {
-        super(name);
+    public CollectionRemoveBackupOperation(CollectionType collectionType, String name, long itemId) {
+        super(collectionType, name);
         this.itemId = itemId;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/collection/CollectionRemoveOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/CollectionRemoveOperation.java
@@ -31,8 +31,8 @@ public class CollectionRemoveOperation extends CollectionBackupAwareOperation {
     public CollectionRemoveOperation() {
     }
 
-    public CollectionRemoveOperation(String name, Data value) {
-        super(name);
+    public CollectionRemoveOperation(CollectionType collectionType, String name, Data value) {
+        super(collectionType, name);
         this.value = value;
     }
 
@@ -64,7 +64,7 @@ public class CollectionRemoveOperation extends CollectionBackupAwareOperation {
 
     @Override
     public Operation getBackupOperation() {
-        return new CollectionRemoveBackupOperation(name, itemId);
+        return new CollectionRemoveBackupOperation(getCollectionType(), name, itemId);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/collection/CollectionService.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/CollectionService.java
@@ -48,10 +48,12 @@ public abstract class CollectionService implements ManagedService, RemoteService
     protected final NodeEngine nodeEngine;
 
     private final ILogger logger;
+    private final CollectionType collectionType;
 
-    protected CollectionService(NodeEngine nodeEngine) {
+    protected CollectionService(NodeEngine nodeEngine, CollectionType collectionType) {
         this.nodeEngine = nodeEngine;
         this.logger = nodeEngine.getLogger(getClass());
+        this.collectionType = collectionType;
     }
 
     @Override
@@ -105,7 +107,7 @@ public abstract class CollectionService implements ManagedService, RemoteService
         OperationService operationService = nodeEngine.getOperationService();
         for (String name : collectionNames) {
             int partitionId = partitionService.getPartitionId(StringPartitioningStrategy.getPartitionKey(name));
-            Operation operation = new CollectionTransactionRollbackOperation(name, transactionId)
+            Operation operation = new CollectionTransactionRollbackOperation(collectionType, name, transactionId)
                     .setPartitionId(partitionId)
                     .setService(this)
                     .setNodeEngine(nodeEngine);

--- a/hazelcast/src/main/java/com/hazelcast/collection/CollectionSizeOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/CollectionSizeOperation.java
@@ -21,8 +21,8 @@ public class CollectionSizeOperation extends CollectionOperation {
     public CollectionSizeOperation() {
     }
 
-    public CollectionSizeOperation(String name) {
-        super(name);
+    public CollectionSizeOperation(CollectionType collectionType, String name) {
+        super(collectionType, name);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/collection/CollectionTransactionRollbackOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/CollectionTransactionRollbackOperation.java
@@ -22,13 +22,13 @@ import java.io.IOException;
 
 public class CollectionTransactionRollbackOperation extends CollectionOperation {
 
-    String transactionId;
+    private String transactionId;
 
     public CollectionTransactionRollbackOperation() {
     }
 
-    public CollectionTransactionRollbackOperation(String name, String transactionId) {
-        super(name);
+    public CollectionTransactionRollbackOperation(CollectionType collectionType, String name, String transactionId) {
+        super(collectionType, name);
         this.transactionId = transactionId;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/collection/CollectionType.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/CollectionType.java
@@ -1,0 +1,51 @@
+package com.hazelcast.collection;
+
+import com.hazelcast.collection.list.ListService;
+import com.hazelcast.collection.set.SetService;
+
+public enum CollectionType {
+
+    List(ListService.SERVICE_NAME, (byte) 0),
+    Set(SetService.SERVICE_NAME, (byte) 1);
+
+    private final String serviceName;
+    private final byte type;
+
+    private CollectionType(String serviceName, byte type) {
+        this.serviceName = serviceName;
+        this.type = type;
+    }
+
+    public String getServiceName() {
+        return serviceName;
+    }
+
+    public byte asByte() {
+        return type;
+    }
+
+    public static CollectionType fromServiceName(String serviceName) {
+        if (serviceName == null) {
+            throw new NullPointerException("serviceName can't be null");
+        }
+
+        if (SetService.SERVICE_NAME.equals(serviceName)) {
+            return Set;
+        } else if (ListService.SERVICE_NAME.equals(serviceName)) {
+            return List;
+        } else {
+            throw new IllegalArgumentException("Unrecognized collection service-name: " + serviceName);
+        }
+    }
+
+    public static CollectionType fromByte(byte type) {
+        switch (type) {
+            case 0:
+                return List;
+            case 1:
+                return Set;
+            default:
+                throw new IllegalArgumentException("Unregonized CollectionType:" + type);
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/collection/client/CollectionAddAllRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/client/CollectionAddAllRequest.java
@@ -44,7 +44,7 @@ public class CollectionAddAllRequest extends CollectionRequest {
 
     @Override
     protected Operation prepareOperation() {
-        return new CollectionAddAllOperation(name, valueList);
+        return new CollectionAddAllOperation(getCollectionType(), name, valueList);
     }
 
     @Override
@@ -52,6 +52,7 @@ public class CollectionAddAllRequest extends CollectionRequest {
         return CollectionPortableHook.COLLECTION_ADD_ALL;
     }
 
+    @Override
     public void write(PortableWriter writer) throws IOException {
         super.write(writer);
         final ObjectDataOutput out = writer.getRawDataOutput();
@@ -61,6 +62,7 @@ public class CollectionAddAllRequest extends CollectionRequest {
         }
     }
 
+    @Override
     public void read(PortableReader reader) throws IOException {
         super.read(reader);
         final ObjectDataInput in = reader.getRawDataInput();

--- a/hazelcast/src/main/java/com/hazelcast/collection/client/CollectionAddListenerRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/client/CollectionAddListenerRequest.java
@@ -122,12 +122,14 @@ public class CollectionAddListenerRequest extends CallableClientRequest implemen
         return CollectionPortableHook.COLLECTION_ADD_LISTENER;
     }
 
+    @Override
     public void write(PortableWriter writer) throws IOException {
         writer.writeUTF("n", name);
         writer.writeBoolean("i", includeValue);
         writer.writeUTF("s", serviceName);
     }
 
+    @Override
     public void read(PortableReader reader) throws IOException {
         name = reader.readUTF("n");
         includeValue = reader.readBoolean("i");

--- a/hazelcast/src/main/java/com/hazelcast/collection/client/CollectionAddRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/client/CollectionAddRequest.java
@@ -40,7 +40,7 @@ public class CollectionAddRequest extends CollectionRequest {
 
     @Override
     protected Operation prepareOperation() {
-        return new CollectionAddOperation(name, value);
+        return new CollectionAddOperation(getCollectionType(), name, value);
     }
 
     @Override
@@ -48,11 +48,13 @@ public class CollectionAddRequest extends CollectionRequest {
         return CollectionPortableHook.COLLECTION_ADD;
     }
 
+    @Override
     public void write(PortableWriter writer) throws IOException {
         super.write(writer);
         writer.getRawDataOutput().writeData(value);
     }
 
+    @Override
     public void read(PortableReader reader) throws IOException {
         super.read(reader);
         value = reader.getRawDataInput().readData();

--- a/hazelcast/src/main/java/com/hazelcast/collection/client/CollectionClearRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/client/CollectionClearRequest.java
@@ -32,7 +32,7 @@ public class CollectionClearRequest extends CollectionRequest {
 
     @Override
     protected Operation prepareOperation() {
-        return new CollectionClearOperation(name);
+        return new CollectionClearOperation(getCollectionType(), name);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/collection/client/CollectionCompareAndRemoveRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/client/CollectionCompareAndRemoveRequest.java
@@ -47,7 +47,7 @@ public class CollectionCompareAndRemoveRequest extends CollectionRequest {
 
     @Override
     protected Operation prepareOperation() {
-        return new CollectionCompareAndRemoveOperation(name, retain, valueSet);
+        return new CollectionCompareAndRemoveOperation(getCollectionType(), name, retain, valueSet);
     }
 
     @Override
@@ -55,6 +55,7 @@ public class CollectionCompareAndRemoveRequest extends CollectionRequest {
         return CollectionPortableHook.COLLECTION_COMPARE_AND_REMOVE;
     }
 
+    @Override
     public void write(PortableWriter writer) throws IOException {
         super.write(writer);
         writer.writeBoolean("r", retain);
@@ -65,6 +66,7 @@ public class CollectionCompareAndRemoveRequest extends CollectionRequest {
         }
     }
 
+    @Override
     public void read(PortableReader reader) throws IOException {
         super.read(reader);
         retain = reader.readBoolean("r");

--- a/hazelcast/src/main/java/com/hazelcast/collection/client/CollectionContainsRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/client/CollectionContainsRequest.java
@@ -50,7 +50,7 @@ public class CollectionContainsRequest extends CollectionRequest {
 
     @Override
     protected Operation prepareOperation() {
-        return new CollectionContainsOperation(name, valueSet);
+        return new CollectionContainsOperation(getCollectionType(), name, valueSet);
     }
 
     @Override
@@ -58,6 +58,7 @@ public class CollectionContainsRequest extends CollectionRequest {
         return CollectionPortableHook.COLLECTION_CONTAINS;
     }
 
+    @Override
     public void write(PortableWriter writer) throws IOException {
         super.write(writer);
         final ObjectDataOutput out = writer.getRawDataOutput();
@@ -67,6 +68,7 @@ public class CollectionContainsRequest extends CollectionRequest {
         }
     }
 
+    @Override
     public void read(PortableReader reader) throws IOException {
         super.read(reader);
         final ObjectDataInput in = reader.getRawDataInput();

--- a/hazelcast/src/main/java/com/hazelcast/collection/client/CollectionGetAllRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/client/CollectionGetAllRequest.java
@@ -32,7 +32,7 @@ public class CollectionGetAllRequest extends CollectionRequest {
 
     @Override
     protected Operation prepareOperation() {
-        return new CollectionGetAllOperation(name);
+        return new CollectionGetAllOperation(getCollectionType(), name);
     }
 
     @Override
@@ -49,5 +49,4 @@ public class CollectionGetAllRequest extends CollectionRequest {
     public String getMethodName() {
         return "iterator";
     }
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/collection/client/CollectionIsEmptyRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/client/CollectionIsEmptyRequest.java
@@ -32,7 +32,7 @@ public class CollectionIsEmptyRequest extends CollectionRequest {
 
     @Override
     protected Operation prepareOperation() {
-        return new CollectionIsEmptyOperation(name);
+        return new CollectionIsEmptyOperation(getCollectionType(), name);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/collection/client/CollectionRemoveListenerRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/client/CollectionRemoveListenerRequest.java
@@ -39,29 +39,35 @@ public class CollectionRemoveListenerRequest extends BaseClientRemoveListenerReq
         this.serviceName = serviceName;
     }
 
+    @Override
     public Object call() throws Exception {
         final ClientEngine clientEngine = getClientEngine();
         final EventService eventService = clientEngine.getEventService();
         return eventService.deregisterListener(serviceName, name, registrationId);
     }
 
+    @Override
     public String getServiceName() {
         return serviceName;
     }
 
+    @Override
     public int getFactoryId() {
         return CollectionPortableHook.F_ID;
     }
 
+    @Override
     public int getClassId() {
         return CollectionPortableHook.COLLECTION_REMOVE_LISTENER;
     }
 
+    @Override
     public void write(PortableWriter writer) throws IOException {
         super.write(writer);
         writer.writeUTF("s", serviceName);
     }
 
+    @Override
     public void read(PortableReader reader) throws IOException {
         super.read(reader);
         serviceName = reader.readUTF("s");

--- a/hazelcast/src/main/java/com/hazelcast/collection/client/CollectionRemoveRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/client/CollectionRemoveRequest.java
@@ -40,7 +40,7 @@ public class CollectionRemoveRequest extends CollectionRequest {
 
     @Override
     protected Operation prepareOperation() {
-        return new CollectionRemoveOperation(name, value);
+        return new CollectionRemoveOperation(getCollectionType(), name, value);
     }
 
     @Override
@@ -48,11 +48,13 @@ public class CollectionRemoveRequest extends CollectionRequest {
         return CollectionPortableHook.COLLECTION_REMOVE;
     }
 
+    @Override
     public void write(PortableWriter writer) throws IOException {
         super.write(writer);
         writer.getRawDataOutput().writeData(value);
     }
 
+    @Override
     public void read(PortableReader reader) throws IOException {
         super.read(reader);
         value = reader.getRawDataInput().readData();

--- a/hazelcast/src/main/java/com/hazelcast/collection/client/CollectionRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/client/CollectionRequest.java
@@ -19,11 +19,13 @@ package com.hazelcast.collection.client;
 import com.hazelcast.client.impl.client.PartitionClientRequest;
 import com.hazelcast.client.impl.client.SecureRequest;
 import com.hazelcast.collection.CollectionPortableHook;
+import com.hazelcast.collection.CollectionType;
 import com.hazelcast.collection.list.ListService;
 import com.hazelcast.collection.set.SetService;
 import com.hazelcast.nio.serialization.Portable;
 import com.hazelcast.nio.serialization.PortableReader;
 import com.hazelcast.nio.serialization.PortableWriter;
+import com.hazelcast.partition.InternalPartitionService;
 import com.hazelcast.partition.strategy.StringPartitioningStrategy;
 import com.hazelcast.security.permission.ListPermission;
 import com.hazelcast.security.permission.SetPermission;
@@ -44,9 +46,14 @@ public abstract class CollectionRequest extends PartitionClientRequest implement
         this.name = name;
     }
 
+    public CollectionType getCollectionType() {
+        return CollectionType.fromServiceName(serviceName);
+    }
+
     @Override
     protected int getPartition() {
-        return getClientEngine().getPartitionService().getPartitionId(StringPartitioningStrategy.getPartitionKey(name));
+        InternalPartitionService partitionService = getClientEngine().getPartitionService();
+        return partitionService.getPartitionId(StringPartitioningStrategy.getPartitionKey(name));
     }
 
     @Override
@@ -63,11 +70,13 @@ public abstract class CollectionRequest extends PartitionClientRequest implement
         return CollectionPortableHook.F_ID;
     }
 
+    @Override
     public void write(PortableWriter writer) throws IOException {
         writer.writeUTF("s", serviceName);
         writer.writeUTF("n", name);
     }
 
+    @Override
     public void read(PortableReader reader) throws IOException {
         serviceName = reader.readUTF("s");
         name = reader.readUTF("n");

--- a/hazelcast/src/main/java/com/hazelcast/collection/client/CollectionSizeRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/client/CollectionSizeRequest.java
@@ -32,7 +32,7 @@ public class CollectionSizeRequest extends CollectionRequest {
 
     @Override
     protected Operation prepareOperation() {
-        return new CollectionSizeOperation(name);
+        return new CollectionSizeOperation(getCollectionType(), name);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/collection/client/ListAddAllRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/client/ListAddAllRequest.java
@@ -48,11 +48,13 @@ public class ListAddAllRequest extends CollectionAddAllRequest {
         return CollectionPortableHook.LIST_ADD_ALL;
     }
 
+    @Override
     public void write(PortableWriter writer) throws IOException {
         writer.writeInt("i", index);
         super.write(writer);
     }
 
+    @Override
     public void read(PortableReader reader) throws IOException {
         index = reader.readInt("i");
         super.read(reader);

--- a/hazelcast/src/main/java/com/hazelcast/collection/client/ListAddRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/client/ListAddRequest.java
@@ -47,11 +47,13 @@ public class ListAddRequest extends CollectionAddRequest {
         return CollectionPortableHook.LIST_ADD;
     }
 
+    @Override
     public void write(PortableWriter writer) throws IOException {
         writer.writeInt("i", index);
         super.write(writer);
     }
 
+    @Override
     public void read(PortableReader reader) throws IOException {
         index = reader.readInt("i");
         super.read(reader);

--- a/hazelcast/src/main/java/com/hazelcast/collection/client/ListGetRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/client/ListGetRequest.java
@@ -47,11 +47,13 @@ public class ListGetRequest extends CollectionRequest {
         return CollectionPortableHook.LIST_GET;
     }
 
+    @Override
     public void write(PortableWriter writer) throws IOException {
         super.write(writer);
         writer.writeInt("i", index);
     }
 
+    @Override
     public void read(PortableReader reader) throws IOException {
         super.read(reader);
         index = reader.readInt("i");

--- a/hazelcast/src/main/java/com/hazelcast/collection/client/ListIndexOfRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/client/ListIndexOfRequest.java
@@ -29,7 +29,6 @@ import java.io.IOException;
 public class ListIndexOfRequest extends CollectionRequest {
 
     Data value;
-
     boolean last;
 
     public ListIndexOfRequest() {
@@ -51,12 +50,14 @@ public class ListIndexOfRequest extends CollectionRequest {
         return CollectionPortableHook.LIST_INDEX_OF;
     }
 
+    @Override
     public void write(PortableWriter writer) throws IOException {
         super.write(writer);
         writer.writeBoolean("l", last);
         writer.getRawDataOutput().writeData(value);
     }
 
+    @Override
     public void read(PortableReader reader) throws IOException {
         super.read(reader);
         last = reader.readBoolean("l");

--- a/hazelcast/src/main/java/com/hazelcast/collection/client/ListRemoveRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/client/ListRemoveRequest.java
@@ -47,11 +47,13 @@ public class ListRemoveRequest extends CollectionRequest {
         return CollectionPortableHook.LIST_REMOVE;
     }
 
+    @Override
     public void write(PortableWriter writer) throws IOException {
         super.write(writer);
         writer.writeInt("i", index);
     }
 
+    @Override
     public void read(PortableReader reader) throws IOException {
         super.read(reader);
         index = reader.readInt("i");

--- a/hazelcast/src/main/java/com/hazelcast/collection/client/ListSetRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/client/ListSetRequest.java
@@ -51,12 +51,14 @@ public class ListSetRequest extends CollectionRequest {
         return CollectionPortableHook.LIST_SET;
     }
 
+    @Override
     public void write(PortableWriter writer) throws IOException {
         super.write(writer);
         writer.writeInt("i", index);
         writer.getRawDataOutput().writeData(value);
     }
 
+    @Override
     public void read(PortableReader reader) throws IOException {
         super.read(reader);
         index = reader.readInt("i");

--- a/hazelcast/src/main/java/com/hazelcast/collection/client/ListSubRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/client/ListSubRequest.java
@@ -49,12 +49,14 @@ public class ListSubRequest extends CollectionRequest {
         return CollectionPortableHook.LIST_SUB;
     }
 
+    @Override
     public void write(PortableWriter writer) throws IOException {
         super.write(writer);
         writer.writeInt("f", from);
         writer.writeInt("t", to);
     }
 
+    @Override
     public void read(PortableReader reader) throws IOException {
         super.read(reader);
         from = reader.readInt("f");

--- a/hazelcast/src/main/java/com/hazelcast/collection/client/TxnCollectionRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/client/TxnCollectionRequest.java
@@ -48,12 +48,14 @@ public abstract class TxnCollectionRequest extends BaseTransactionRequest implem
         return CollectionPortableHook.F_ID;
     }
 
+    @Override
     public void write(PortableWriter writer) throws IOException {
         super.write(writer);
         writer.writeUTF("n", name);
         writer.getRawDataOutput().writeData(value);
     }
 
+    @Override
     public void read(PortableReader reader) throws IOException {
         super.read(reader);
         name = reader.readUTF("n");

--- a/hazelcast/src/main/java/com/hazelcast/collection/client/TxnListRemoveRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/client/TxnListRemoveRequest.java
@@ -16,11 +16,14 @@
 
 package com.hazelcast.collection.client;
 
+import com.hazelcast.client.ClientEndpoint;
 import com.hazelcast.collection.CollectionPortableHook;
 import com.hazelcast.collection.list.ListService;
+import com.hazelcast.core.TransactionalList;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.security.permission.ActionConstants;
 import com.hazelcast.security.permission.ListPermission;
+import com.hazelcast.transaction.TransactionContext;
 
 import java.security.Permission;
 
@@ -35,7 +38,10 @@ public class TxnListRemoveRequest extends TxnCollectionRequest {
 
     @Override
     public Object innerCall() throws Exception {
-        return getEndpoint().getTransactionContext(txnId).getList(name).remove(value);
+        ClientEndpoint endpoint = getEndpoint();
+        TransactionContext transactionContext = endpoint.getTransactionContext(txnId);
+        TransactionalList<Object> list = transactionContext.getList(name);
+        return list.remove(value);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/collection/client/TxnListSizeRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/client/TxnListSizeRequest.java
@@ -16,10 +16,13 @@
 
 package com.hazelcast.collection.client;
 
+import com.hazelcast.client.ClientEndpoint;
 import com.hazelcast.collection.CollectionPortableHook;
 import com.hazelcast.collection.list.ListService;
+import com.hazelcast.core.TransactionalList;
 import com.hazelcast.security.permission.ActionConstants;
 import com.hazelcast.security.permission.ListPermission;
+import com.hazelcast.transaction.TransactionContext;
 
 import java.security.Permission;
 
@@ -34,7 +37,10 @@ public class TxnListSizeRequest extends TxnCollectionRequest {
 
     @Override
     public Object innerCall() throws Exception {
-        return getEndpoint().getTransactionContext(txnId).getList(name).size();
+        ClientEndpoint endpoint = getEndpoint();
+        TransactionContext transactionContext = endpoint.getTransactionContext(txnId);
+        TransactionalList<Object> list = transactionContext.getList(name);
+        return list.size();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/collection/client/TxnSetAddRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/client/TxnSetAddRequest.java
@@ -16,11 +16,14 @@
 
 package com.hazelcast.collection.client;
 
+import com.hazelcast.client.ClientEndpoint;
 import com.hazelcast.collection.CollectionPortableHook;
 import com.hazelcast.collection.set.SetService;
+import com.hazelcast.core.TransactionalSet;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.security.permission.ActionConstants;
 import com.hazelcast.security.permission.SetPermission;
+import com.hazelcast.transaction.TransactionContext;
 
 import java.security.Permission;
 
@@ -35,7 +38,10 @@ public class TxnSetAddRequest extends TxnCollectionRequest {
 
     @Override
     public Object innerCall() throws Exception {
-        return getEndpoint().getTransactionContext(txnId).getSet(name).add(value);
+        ClientEndpoint endpoint = getEndpoint();
+        TransactionContext transactionContext = endpoint.getTransactionContext(txnId);
+        TransactionalSet<Object> set = transactionContext.getSet(name);
+        return set.add(value);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/collection/client/TxnSetRemoveRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/client/TxnSetRemoveRequest.java
@@ -16,11 +16,14 @@
 
 package com.hazelcast.collection.client;
 
+import com.hazelcast.client.ClientEndpoint;
 import com.hazelcast.collection.CollectionPortableHook;
 import com.hazelcast.collection.set.SetService;
+import com.hazelcast.core.TransactionalSet;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.security.permission.ActionConstants;
 import com.hazelcast.security.permission.SetPermission;
+import com.hazelcast.transaction.TransactionContext;
 
 import java.security.Permission;
 
@@ -35,7 +38,10 @@ public class TxnSetRemoveRequest extends TxnCollectionRequest {
 
     @Override
     public Object innerCall() throws Exception {
-        return getEndpoint().getTransactionContext(txnId).getSet(name).remove(value);
+        ClientEndpoint endpoint = getEndpoint();
+        TransactionContext transactionContext = endpoint.getTransactionContext(txnId);
+        TransactionalSet<Object> set = transactionContext.getSet(name);
+        return set.remove(value);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/collection/client/TxnSetSizeRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/client/TxnSetSizeRequest.java
@@ -16,10 +16,13 @@
 
 package com.hazelcast.collection.client;
 
+import com.hazelcast.client.ClientEndpoint;
 import com.hazelcast.collection.CollectionPortableHook;
 import com.hazelcast.collection.set.SetService;
+import com.hazelcast.core.TransactionalSet;
 import com.hazelcast.security.permission.ActionConstants;
 import com.hazelcast.security.permission.SetPermission;
+import com.hazelcast.transaction.TransactionContext;
 
 import java.security.Permission;
 
@@ -34,7 +37,10 @@ public class TxnSetSizeRequest extends TxnCollectionRequest {
 
     @Override
     public Object innerCall() throws Exception {
-        return getEndpoint().getTransactionContext(txnId).getSet(name).size();
+        ClientEndpoint endpoint = getEndpoint();
+        TransactionContext transactionContext = endpoint.getTransactionContext(txnId);
+        TransactionalSet<Object> set = transactionContext.getSet(name);
+        return set.size();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/collection/list/ListAddAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/list/ListAddAllOperation.java
@@ -18,6 +18,7 @@ package com.hazelcast.collection.list;
 
 import com.hazelcast.collection.CollectionAddAllOperation;
 import com.hazelcast.collection.CollectionDataSerializerHook;
+import com.hazelcast.collection.CollectionType;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -32,7 +33,7 @@ public class ListAddAllOperation extends CollectionAddAllOperation {
     }
 
     public ListAddAllOperation(String name, int index, List<Data> valueList) {
-        super(name, valueList);
+        super(CollectionType.List, name, valueList);
         this.index = index;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/collection/list/ListAddOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/list/ListAddOperation.java
@@ -20,6 +20,7 @@ import com.hazelcast.collection.CollectionAddBackupOperation;
 import com.hazelcast.collection.CollectionAddOperation;
 import com.hazelcast.collection.CollectionDataSerializerHook;
 import com.hazelcast.collection.CollectionItem;
+import com.hazelcast.collection.CollectionType;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -34,7 +35,7 @@ public class ListAddOperation extends CollectionAddOperation {
     }
 
     public ListAddOperation(String name, int index, Data value) {
-        super(name, value);
+        super(CollectionType.List, name, value);
         this.index = index;
     }
 
@@ -54,7 +55,7 @@ public class ListAddOperation extends CollectionAddOperation {
 
     @Override
     public Operation getBackupOperation() {
-        return new CollectionAddBackupOperation(name, itemId, value);
+        return new CollectionAddBackupOperation(CollectionType.List, name, itemId, value);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/collection/list/ListGetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/list/ListGetOperation.java
@@ -19,6 +19,7 @@ package com.hazelcast.collection.list;
 import com.hazelcast.collection.CollectionDataSerializerHook;
 import com.hazelcast.collection.CollectionItem;
 import com.hazelcast.collection.CollectionOperation;
+import com.hazelcast.collection.CollectionType;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import java.io.IOException;
@@ -31,8 +32,13 @@ public class ListGetOperation extends CollectionOperation {
     }
 
     public ListGetOperation(String name, int index) {
-        super(name);
+        super(CollectionType.List, name);
         this.index = index;
+    }
+
+    @Override
+    public String getServiceName() {
+        return ListService.SERVICE_NAME;
     }
 
     @Override
@@ -41,7 +47,7 @@ public class ListGetOperation extends CollectionOperation {
 
     @Override
     public void run() throws Exception {
-        final CollectionItem item = getOrCreateListContainer().get(index);
+        CollectionItem item = getOrCreateListContainer().get(index);
         response = item.getValue();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/collection/list/ListIndexOfOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/list/ListIndexOfOperation.java
@@ -18,6 +18,7 @@ package com.hazelcast.collection.list;
 
 import com.hazelcast.collection.CollectionDataSerializerHook;
 import com.hazelcast.collection.CollectionOperation;
+import com.hazelcast.collection.CollectionType;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -26,16 +27,20 @@ import java.io.IOException;
 public class ListIndexOfOperation extends CollectionOperation {
 
     private boolean last;
-
     private Data value;
 
     public ListIndexOfOperation() {
     }
 
     public ListIndexOfOperation(String name, boolean last, Data value) {
-        super(name);
+        super(CollectionType.List, name);
         this.last = last;
         this.value = value;
+    }
+
+    @Override
+    public String getServiceName() {
+        return ListService.SERVICE_NAME;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/collection/list/ListProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/list/ListProxyImpl.java
@@ -17,6 +17,7 @@
 package com.hazelcast.collection.list;
 
 import com.hazelcast.collection.AbstractCollectionProxyImpl;
+import com.hazelcast.collection.CollectionType;
 import com.hazelcast.config.CollectionConfig;
 import com.hazelcast.core.IList;
 import com.hazelcast.nio.serialization.Data;
@@ -31,7 +32,7 @@ import java.util.ListIterator;
 public class ListProxyImpl<E> extends AbstractCollectionProxyImpl<ListService, E> implements IList<E> {
 
     protected ListProxyImpl(String name, NodeEngine nodeEngine, ListService service) {
-        super(name, nodeEngine, service);
+        super(CollectionType.List, name, nodeEngine, service);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/collection/list/ListRemoveOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/list/ListRemoveOperation.java
@@ -20,6 +20,7 @@ import com.hazelcast.collection.CollectionBackupAwareOperation;
 import com.hazelcast.collection.CollectionDataSerializerHook;
 import com.hazelcast.collection.CollectionItem;
 import com.hazelcast.collection.CollectionRemoveBackupOperation;
+import com.hazelcast.collection.CollectionType;
 import com.hazelcast.core.ItemEventType;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
@@ -36,7 +37,7 @@ public class ListRemoveOperation extends CollectionBackupAwareOperation {
     }
 
     public ListRemoveOperation(String name, int index) {
-        super(name);
+        super(CollectionType.List, name);
         this.index = index;
     }
 
@@ -47,7 +48,7 @@ public class ListRemoveOperation extends CollectionBackupAwareOperation {
 
     @Override
     public Operation getBackupOperation() {
-        return new CollectionRemoveBackupOperation(name, itemId);
+        return new CollectionRemoveBackupOperation(CollectionType.List, name, itemId);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/collection/list/ListReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/list/ListReplicationOperation.java
@@ -46,6 +46,11 @@ public class ListReplicationOperation extends CollectionReplicationOperation {
     }
 
     @Override
+    public String getServiceName() {
+        return ListService.SERVICE_NAME;
+    }
+
+    @Override
     public int getId() {
         return CollectionDataSerializerHook.LIST_REPLICATION;
     }

--- a/hazelcast/src/main/java/com/hazelcast/collection/list/ListService.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/list/ListService.java
@@ -18,6 +18,7 @@ package com.hazelcast.collection.list;
 
 import com.hazelcast.collection.CollectionContainer;
 import com.hazelcast.collection.CollectionService;
+import com.hazelcast.collection.CollectionType;
 import com.hazelcast.collection.txn.TransactionalListProxy;
 import com.hazelcast.core.DistributedObject;
 import com.hazelcast.spi.NodeEngine;
@@ -35,7 +36,7 @@ public class ListService extends CollectionService {
     private final ConcurrentMap<String, ListContainer> containerMap = new ConcurrentHashMap<String, ListContainer>();
 
     public ListService(NodeEngine nodeEngine) {
-        super(nodeEngine);
+        super(nodeEngine, CollectionType.List);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/collection/list/ListSetBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/list/ListSetBackupOperation.java
@@ -18,6 +18,7 @@ package com.hazelcast.collection.list;
 
 import com.hazelcast.collection.CollectionDataSerializerHook;
 import com.hazelcast.collection.CollectionOperation;
+import com.hazelcast.collection.CollectionType;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -34,7 +35,7 @@ public class ListSetBackupOperation extends CollectionOperation implements Backu
     }
 
     public ListSetBackupOperation(String name, long oldItemId, long itemId, Data value) {
-        super(name);
+        super(CollectionType.List, name);
         this.oldItemId = oldItemId;
         this.itemId = itemId;
         this.value = value;
@@ -43,6 +44,11 @@ public class ListSetBackupOperation extends CollectionOperation implements Backu
     @Override
     public int getId() {
         return CollectionDataSerializerHook.LIST_SET_BACKUP;
+    }
+
+    @Override
+    public String getServiceName() {
+        return ListService.SERVICE_NAME;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/collection/list/ListSetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/list/ListSetOperation.java
@@ -19,6 +19,7 @@ package com.hazelcast.collection.list;
 import com.hazelcast.collection.CollectionBackupAwareOperation;
 import com.hazelcast.collection.CollectionDataSerializerHook;
 import com.hazelcast.collection.CollectionItem;
+import com.hazelcast.collection.CollectionType;
 import com.hazelcast.core.ItemEventType;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
@@ -37,7 +38,7 @@ public class ListSetOperation extends CollectionBackupAwareOperation {
     }
 
     public ListSetOperation(String name, int index, Data value) {
-        super(name);
+        super(CollectionType.List, name);
         this.index = index;
         this.value = value;
     }

--- a/hazelcast/src/main/java/com/hazelcast/collection/list/ListSubOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/list/ListSubOperation.java
@@ -18,6 +18,7 @@ package com.hazelcast.collection.list;
 
 import com.hazelcast.collection.CollectionDataSerializerHook;
 import com.hazelcast.collection.CollectionOperation;
+import com.hazelcast.collection.CollectionType;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -34,7 +35,7 @@ public class ListSubOperation extends CollectionOperation {
     }
 
     public ListSubOperation(String name, int from, int to) {
-        super(name);
+        super(CollectionType.List, name);
         this.from = from;
         this.to = to;
     }

--- a/hazelcast/src/main/java/com/hazelcast/collection/set/SetProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/set/SetProxyImpl.java
@@ -17,6 +17,7 @@
 package com.hazelcast.collection.set;
 
 import com.hazelcast.collection.AbstractCollectionProxyImpl;
+import com.hazelcast.collection.CollectionType;
 import com.hazelcast.config.CollectionConfig;
 import com.hazelcast.core.ISet;
 import com.hazelcast.spi.NodeEngine;
@@ -24,7 +25,7 @@ import com.hazelcast.spi.NodeEngine;
 public class SetProxyImpl<E> extends AbstractCollectionProxyImpl<SetService, E> implements ISet<E> {
 
     public SetProxyImpl(String name, NodeEngine nodeEngine, SetService service) {
-        super(name, nodeEngine, service);
+        super(CollectionType.Set, name, nodeEngine, service);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/collection/set/SetReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/set/SetReplicationOperation.java
@@ -34,6 +34,11 @@ public class SetReplicationOperation extends CollectionReplicationOperation {
     }
 
     @Override
+    public String getServiceName() {
+        return SetService.SERVICE_NAME;
+    }
+
+    @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         int mapSize = in.readInt();
         migrationData = new HashMap<String, CollectionContainer>(mapSize);

--- a/hazelcast/src/main/java/com/hazelcast/collection/set/SetService.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/set/SetService.java
@@ -18,6 +18,7 @@ package com.hazelcast.collection.set;
 
 import com.hazelcast.collection.CollectionContainer;
 import com.hazelcast.collection.CollectionService;
+import com.hazelcast.collection.CollectionType;
 import com.hazelcast.collection.txn.TransactionalSetProxy;
 import com.hazelcast.core.DistributedObject;
 import com.hazelcast.spi.NodeEngine;
@@ -35,7 +36,7 @@ public class SetService extends CollectionService {
     private final ConcurrentMap<String, SetContainer> containerMap = new ConcurrentHashMap<String, SetContainer>();
 
     public SetService(NodeEngine nodeEngine) {
-        super(nodeEngine);
+        super(nodeEngine, CollectionType.Set);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/collection/txn/CollectionPrepareBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/txn/CollectionPrepareBackupOperation.java
@@ -16,8 +16,10 @@
 
 package com.hazelcast.collection.txn;
 
+import com.hazelcast.collection.CollectionContainer;
 import com.hazelcast.collection.CollectionDataSerializerHook;
 import com.hazelcast.collection.CollectionOperation;
+import com.hazelcast.collection.CollectionType;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.spi.BackupOperation;
@@ -25,17 +27,16 @@ import java.io.IOException;
 
 public class CollectionPrepareBackupOperation extends CollectionOperation implements BackupOperation {
 
-    long itemId;
-
-    boolean removeOperation;
-
-    String transactionId;
+    private long itemId;
+    private boolean removeOperation;
+    private String transactionId;
 
     public CollectionPrepareBackupOperation() {
     }
 
-    public CollectionPrepareBackupOperation(String name, long itemId, String transactionId, boolean removeOperation) {
-        super(name);
+    public CollectionPrepareBackupOperation(CollectionType collectionType, String name, long itemId,
+                                            String transactionId, boolean removeOperation) {
+        super(collectionType, name);
         this.itemId = itemId;
         this.removeOperation = removeOperation;
         this.transactionId = transactionId;
@@ -52,10 +53,11 @@ public class CollectionPrepareBackupOperation extends CollectionOperation implem
 
     @Override
     public void run() throws Exception {
+        CollectionContainer container = getOrCreateContainer();
         if (removeOperation) {
-            getOrCreateContainer().reserveRemoveBackup(itemId, transactionId);
+            container.reserveRemoveBackup(itemId, transactionId);
         } else {
-            getOrCreateContainer().reserveAddBackup(itemId, transactionId);
+            container.reserveAddBackup(itemId, transactionId);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/collection/txn/CollectionPrepareOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/txn/CollectionPrepareOperation.java
@@ -18,6 +18,7 @@ package com.hazelcast.collection.txn;
 
 import com.hazelcast.collection.CollectionBackupAwareOperation;
 import com.hazelcast.collection.CollectionDataSerializerHook;
+import com.hazelcast.collection.CollectionType;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.spi.Operation;
@@ -25,16 +26,16 @@ import java.io.IOException;
 
 public class CollectionPrepareOperation extends CollectionBackupAwareOperation {
 
-    boolean removeOperation;
-    String transactionId;
-
+    private boolean removeOperation;
+    private String transactionId;
     private long itemId = -1;
 
     public CollectionPrepareOperation() {
     }
 
-    public CollectionPrepareOperation(String name, long itemId, String transactionId, boolean removeOperation) {
-        super(name);
+    public CollectionPrepareOperation(CollectionType collectionType, String name, long itemId,
+                                      String transactionId, boolean removeOperation) {
+        super(collectionType, name);
         this.itemId = itemId;
         this.removeOperation = removeOperation;
         this.transactionId = transactionId;
@@ -47,7 +48,7 @@ public class CollectionPrepareOperation extends CollectionBackupAwareOperation {
 
     @Override
     public Operation getBackupOperation() {
-        return new CollectionPrepareBackupOperation(name, itemId, transactionId, removeOperation);
+        return new CollectionPrepareBackupOperation(getCollectionType(), name, itemId, transactionId, removeOperation);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/collection/txn/CollectionReserveAddOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/txn/CollectionReserveAddOperation.java
@@ -18,6 +18,7 @@ package com.hazelcast.collection.txn;
 
 import com.hazelcast.collection.CollectionDataSerializerHook;
 import com.hazelcast.collection.CollectionOperation;
+import com.hazelcast.collection.CollectionType;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -25,14 +26,14 @@ import java.io.IOException;
 
 public class CollectionReserveAddOperation extends CollectionOperation {
 
-    String transactionId;
-    Data value;
+    private String transactionId;
+    private Data value;
 
     public CollectionReserveAddOperation() {
     }
 
-    public CollectionReserveAddOperation(String name, String transactionId, Data value) {
-        super(name);
+    public CollectionReserveAddOperation(CollectionType collectionType, String name, String transactionId, Data value) {
+        super(collectionType, name);
         this.transactionId = transactionId;
         this.value = value;
     }

--- a/hazelcast/src/main/java/com/hazelcast/collection/txn/CollectionReserveRemoveOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/txn/CollectionReserveRemoveOperation.java
@@ -18,6 +18,7 @@ package com.hazelcast.collection.txn;
 
 import com.hazelcast.collection.CollectionDataSerializerHook;
 import com.hazelcast.collection.CollectionOperation;
+import com.hazelcast.collection.CollectionType;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -25,15 +26,16 @@ import java.io.IOException;
 
 public class CollectionReserveRemoveOperation extends CollectionOperation {
 
-    String transactionId;
+    private String transactionId;
     private Data value;
     private long reservedItemId = -1;
 
     public CollectionReserveRemoveOperation() {
     }
 
-    public CollectionReserveRemoveOperation(String name, long reservedItemId, Data value, String transactionId) {
-        super(name);
+    public CollectionReserveRemoveOperation(CollectionType collectionType, String name, long reservedItemId,
+                                            Data value, String transactionId) {
+        super(collectionType, name);
         this.reservedItemId = reservedItemId;
         this.value = value;
         this.transactionId = transactionId;

--- a/hazelcast/src/main/java/com/hazelcast/collection/txn/CollectionRollbackBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/txn/CollectionRollbackBackupOperation.java
@@ -16,8 +16,10 @@
 
 package com.hazelcast.collection.txn;
 
+import com.hazelcast.collection.CollectionContainer;
 import com.hazelcast.collection.CollectionDataSerializerHook;
 import com.hazelcast.collection.CollectionOperation;
+import com.hazelcast.collection.CollectionType;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.spi.BackupOperation;
@@ -26,14 +28,13 @@ import java.io.IOException;
 public class CollectionRollbackBackupOperation extends CollectionOperation implements BackupOperation {
 
     private long itemId;
-
     private boolean removeOperation;
 
     public CollectionRollbackBackupOperation() {
     }
 
-    public CollectionRollbackBackupOperation(String name, long itemId, boolean removeOperation) {
-        super(name);
+    public CollectionRollbackBackupOperation(CollectionType collectionType, String name, long itemId, boolean removeOperation) {
+        super(collectionType, name);
         this.itemId = itemId;
         this.removeOperation = removeOperation;
     }
@@ -49,10 +50,11 @@ public class CollectionRollbackBackupOperation extends CollectionOperation imple
 
     @Override
     public void run() throws Exception {
+        CollectionContainer container = getOrCreateContainer();
         if (removeOperation) {
-            getOrCreateContainer().rollbackRemoveBackup(itemId);
+            container.rollbackRemoveBackup(itemId);
         } else {
-            getOrCreateContainer().rollbackAddBackup(itemId);
+            container.rollbackAddBackup(itemId);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/collection/txn/CollectionRollbackOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/txn/CollectionRollbackOperation.java
@@ -18,6 +18,7 @@ package com.hazelcast.collection.txn;
 
 import com.hazelcast.collection.CollectionBackupAwareOperation;
 import com.hazelcast.collection.CollectionDataSerializerHook;
+import com.hazelcast.collection.CollectionType;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.spi.Operation;
@@ -32,8 +33,8 @@ public class CollectionRollbackOperation extends CollectionBackupAwareOperation 
     public CollectionRollbackOperation() {
     }
 
-    public CollectionRollbackOperation(String name, long itemId, boolean removeOperation) {
-        super(name);
+    public CollectionRollbackOperation(CollectionType collectionType, String name, long itemId, boolean removeOperation) {
+        super(collectionType, name);
         this.itemId = itemId;
         this.removeOperation = removeOperation;
     }
@@ -45,7 +46,7 @@ public class CollectionRollbackOperation extends CollectionBackupAwareOperation 
 
     @Override
     public Operation getBackupOperation() {
-        return new CollectionRollbackBackupOperation(name, itemId, removeOperation);
+        return new CollectionRollbackBackupOperation(getCollectionType(), name, itemId, removeOperation);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/collection/txn/CollectionTxnAddBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/txn/CollectionTxnAddBackupOperation.java
@@ -16,8 +16,10 @@
 
 package com.hazelcast.collection.txn;
 
+import com.hazelcast.collection.CollectionContainer;
 import com.hazelcast.collection.CollectionDataSerializerHook;
 import com.hazelcast.collection.CollectionOperation;
+import com.hazelcast.collection.CollectionType;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -27,14 +29,13 @@ import java.io.IOException;
 public class CollectionTxnAddBackupOperation extends CollectionOperation implements BackupOperation {
 
     private long itemId;
-
     private Data value;
 
     public CollectionTxnAddBackupOperation() {
     }
 
-    public CollectionTxnAddBackupOperation(String name, long itemId, Data value) {
-        super(name);
+    public CollectionTxnAddBackupOperation(CollectionType collectionType, String name, long itemId, Data value) {
+        super(collectionType, name);
         this.itemId = itemId;
         this.value = value;
     }
@@ -50,7 +51,8 @@ public class CollectionTxnAddBackupOperation extends CollectionOperation impleme
 
     @Override
     public void run() throws Exception {
-        getOrCreateContainer().commitAddBackup(itemId, value);
+        CollectionContainer container = getOrCreateContainer();
+        container.commitAddBackup(itemId, value);
         response = true;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/collection/txn/CollectionTxnAddOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/txn/CollectionTxnAddOperation.java
@@ -18,6 +18,7 @@ package com.hazelcast.collection.txn;
 
 import com.hazelcast.collection.CollectionBackupAwareOperation;
 import com.hazelcast.collection.CollectionDataSerializerHook;
+import com.hazelcast.collection.CollectionType;
 import com.hazelcast.core.ItemEventType;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
@@ -34,8 +35,8 @@ public class CollectionTxnAddOperation extends CollectionBackupAwareOperation {
     public CollectionTxnAddOperation() {
     }
 
-    public CollectionTxnAddOperation(String name, long itemId, Data value) {
-        super(name);
+    public CollectionTxnAddOperation(CollectionType collectionType, String name, long itemId, Data value) {
+        super(collectionType, name);
         this.itemId = itemId;
         this.value = value;
     }
@@ -47,7 +48,7 @@ public class CollectionTxnAddOperation extends CollectionBackupAwareOperation {
 
     @Override
     public Operation getBackupOperation() {
-        return new CollectionTxnAddBackupOperation(name, itemId, value);
+        return new CollectionTxnAddBackupOperation(getCollectionType(), name, itemId, value);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/collection/txn/CollectionTxnRemoveBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/txn/CollectionTxnRemoveBackupOperation.java
@@ -16,8 +16,10 @@
 
 package com.hazelcast.collection.txn;
 
+import com.hazelcast.collection.CollectionContainer;
 import com.hazelcast.collection.CollectionDataSerializerHook;
 import com.hazelcast.collection.CollectionOperation;
+import com.hazelcast.collection.CollectionType;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.spi.BackupOperation;
@@ -30,8 +32,8 @@ public class CollectionTxnRemoveBackupOperation extends CollectionOperation impl
     public CollectionTxnRemoveBackupOperation() {
     }
 
-    public CollectionTxnRemoveBackupOperation(String name, long itemId) {
-        super(name);
+    public CollectionTxnRemoveBackupOperation(CollectionType collectionType, String name, long itemId) {
+        super(collectionType, name);
         this.itemId = itemId;
     }
 
@@ -46,7 +48,8 @@ public class CollectionTxnRemoveBackupOperation extends CollectionOperation impl
 
     @Override
     public void run() throws Exception {
-        getOrCreateContainer().commitRemoveBackup(itemId);
+        CollectionContainer container = getOrCreateContainer();
+        container.commitRemoveBackup(itemId);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/collection/txn/CollectionTxnRemoveOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/txn/CollectionTxnRemoveOperation.java
@@ -17,26 +17,26 @@
 package com.hazelcast.collection.txn;
 
 import com.hazelcast.collection.CollectionBackupAwareOperation;
+import com.hazelcast.collection.CollectionContainer;
 import com.hazelcast.collection.CollectionDataSerializerHook;
 import com.hazelcast.collection.CollectionItem;
+import com.hazelcast.collection.CollectionType;
 import com.hazelcast.core.ItemEventType;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.Operation;
 import java.io.IOException;
 
 public class CollectionTxnRemoveOperation extends CollectionBackupAwareOperation {
 
     private long itemId;
-
     private transient CollectionItem item;
 
     public CollectionTxnRemoveOperation() {
     }
 
-    public CollectionTxnRemoveOperation(String name, long itemId) {
-        super(name);
+    public CollectionTxnRemoveOperation(CollectionType collectionType, String name, long itemId) {
+        super(collectionType, name);
         this.itemId = itemId;
     }
 
@@ -47,7 +47,7 @@ public class CollectionTxnRemoveOperation extends CollectionBackupAwareOperation
 
     @Override
     public Operation getBackupOperation() {
-        return new CollectionTxnRemoveBackupOperation(name, itemId);
+        return new CollectionTxnRemoveBackupOperation(getCollectionType(), name, itemId);
     }
 
     @Override
@@ -61,13 +61,14 @@ public class CollectionTxnRemoveOperation extends CollectionBackupAwareOperation
 
     @Override
     public void run() throws Exception {
-        item = getOrCreateContainer().commitRemove(itemId);
+        CollectionContainer container = getOrCreateContainer();
+        item = container.commitRemove(itemId);
     }
 
     @Override
     public void afterRun() throws Exception {
         if (item != null) {
-            publishEvent(ItemEventType.REMOVED, (Data) item.getValue());
+            publishEvent(ItemEventType.REMOVED, item.getValue());
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/collection/txn/TransactionalListProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/txn/TransactionalListProxy.java
@@ -17,6 +17,7 @@
 package com.hazelcast.collection.txn;
 
 import com.hazelcast.collection.CollectionItem;
+import com.hazelcast.collection.CollectionType;
 import com.hazelcast.collection.list.ListService;
 import com.hazelcast.core.TransactionalList;
 import com.hazelcast.spi.NodeEngine;
@@ -30,7 +31,7 @@ public class TransactionalListProxy<E> extends AbstractTransactionalCollectionPr
     private final LinkedList<CollectionItem> list = new LinkedList<CollectionItem>();
 
     public TransactionalListProxy(String name, TransactionSupport tx, NodeEngine nodeEngine, ListService service) {
-        super(name, tx, nodeEngine, service);
+        super(CollectionType.List, name, tx, nodeEngine, service);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/AtomicLongProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/AtomicLongProxy.java
@@ -52,8 +52,7 @@ public class AtomicLongProxy extends AbstractDistributedObject<AtomicLongService
         try {
             OperationService operationService = getNodeEngine().getOperationService();
             //noinspection unchecked
-            return (InternalCompletableFuture<E>) operationService.invokeOnPartition(
-                    AtomicLongService.SERVICE_NAME, operation, partitionId);
+            return (InternalCompletableFuture<E>) operationService.invokeOnPartition(operation, partitionId);
         } catch (Throwable throwable) {
             throw ExceptionUtil.rethrow(throwable);
         }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/AtomicLongBaseOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/AtomicLongBaseOperation.java
@@ -39,6 +39,11 @@ public abstract class AtomicLongBaseOperation extends Operation
         this.name = name;
     }
 
+    @Override
+    public String getServiceName() {
+        return AtomicLongService.SERVICE_NAME;
+    }
+
     public LongWrapper getNumber() {
         AtomicLongService service = getService();
         return service.getNumber(name);

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/AtomicReferenceProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/AtomicReferenceProxy.java
@@ -53,7 +53,7 @@ public class AtomicReferenceProxy<E> extends AbstractDistributedObject<AtomicRef
     private <E> InternalCompletableFuture<E> asyncInvoke(Operation operation, NodeEngine nodeEngine) {
         try {
             OperationService operationService = nodeEngine.getOperationService();
-            return operationService.invokeOnPartition(AtomicReferenceService.SERVICE_NAME, operation, partitionId);
+            return operationService.invokeOnPartition(operation, partitionId);
         } catch (Throwable throwable) {
             throw rethrow(throwable);
         }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/AtomicReferenceBackupAwareOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/AtomicReferenceBackupAwareOperation.java
@@ -35,7 +35,6 @@ public abstract class AtomicReferenceBackupAwareOperation extends AtomicReferenc
         return shouldBackup;
     }
 
-
     @Override
     public int getSyncBackupCount() {
         return 1;

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/AtomicReferenceBaseOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/AtomicReferenceBaseOperation.java
@@ -33,11 +33,15 @@ public abstract class AtomicReferenceBaseOperation extends Operation
     protected String name;
 
     public AtomicReferenceBaseOperation() {
-        super();
     }
 
     public AtomicReferenceBaseOperation(String name) {
         this.name = name;
+    }
+
+    @Override
+    public String getServiceName() {
+        return AtomicReferenceService.SERVICE_NAME;
     }
 
     public ReferenceWrapper getReference() {

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/countdownlatch/CountDownLatchProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/countdownlatch/CountDownLatchProxy.java
@@ -93,7 +93,7 @@ public class CountDownLatchProxy extends AbstractDistributedObject<CountDownLatc
     private InternalCompletableFuture invoke(Operation op) {
         NodeEngine nodeEngine = getNodeEngine();
         OperationService operationService = nodeEngine.getOperationService();
-        return operationService.invokeOnPartition(CountDownLatchService.SERVICE_NAME, op, partitionId);
+        return operationService.invokeOnPartition(op, partitionId);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/countdownlatch/operations/CountDownLatchReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/countdownlatch/operations/CountDownLatchReplicationOperation.java
@@ -40,6 +40,11 @@ public class CountDownLatchReplicationOperation extends AbstractOperation implem
     }
 
     @Override
+    public String getServiceName() {
+        return CountDownLatchService.SERVICE_NAME;
+    }
+
+    @Override
     public void run() throws Exception {
         if (data != null) {
             CountDownLatchService service = getService();

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/ConditionImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/ConditionImpl.java
@@ -33,7 +33,6 @@ import java.util.Date;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
-import static com.hazelcast.concurrent.lock.LockService.SERVICE_NAME;
 import static com.hazelcast.util.ExceptionUtil.rethrowAllowInterrupted;
 
 final class ConditionImpl implements ICondition {
@@ -101,7 +100,7 @@ final class ConditionImpl implements ICondition {
 
     private InternalCompletableFuture invoke(Operation op) {
         NodeEngine nodeEngine = lockProxy.getNodeEngine();
-        return nodeEngine.getOperationService().invokeOnPartition(SERVICE_NAME, op, partitionId);
+        return nodeEngine.getOperationService().invokeOnPartition(op, partitionId);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockEvictionProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockEvictionProcessor.java
@@ -32,8 +32,6 @@ import com.hazelcast.util.scheduler.ScheduledEntryProcessor;
 
 import java.util.Collection;
 
-import static com.hazelcast.concurrent.lock.LockServiceImpl.SERVICE_NAME;
-
 public final class LockEvictionProcessor implements ScheduledEntryProcessor<Data, Integer> {
 
     private final NodeEngine nodeEngine;
@@ -44,8 +42,8 @@ public final class LockEvictionProcessor implements ScheduledEntryProcessor<Data
     public LockEvictionProcessor(NodeEngine nodeEngine, ObjectNamespace namespace) {
         this.nodeEngine = nodeEngine;
         this.namespace = namespace;
-        logger = nodeEngine.getLogger(getClass());
-        unlockResponseHandler = new UnlockResponseHandler();
+        this.logger = nodeEngine.getLogger(getClass());
+        this.unlockResponseHandler = new UnlockResponseHandler();
     }
 
     @Override
@@ -71,7 +69,6 @@ public final class LockEvictionProcessor implements ScheduledEntryProcessor<Data
         int partitionId = nodeEngine.getPartitionService().getPartitionId(key);
         OperationService operationService = nodeEngine.getOperationService();
         operation.setNodeEngine(nodeEngine);
-        operation.setServiceName(SERVICE_NAME);
         operation.setPartitionId(partitionId);
         OperationAccessor.setCallerAddress(operation, nodeEngine.getThisAddress());
         operation.setCallerUuid(nodeEngine.getLocalMember().getUuid());

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockProxySupport.java
@@ -28,7 +28,6 @@ import com.hazelcast.spi.ObjectNamespace;
 import com.hazelcast.spi.Operation;
 import java.util.concurrent.TimeUnit;
 
-import static com.hazelcast.concurrent.lock.LockServiceImpl.SERVICE_NAME;
 import static com.hazelcast.util.ExceptionUtil.rethrowAllowInterrupted;
 import static com.hazelcast.util.ThreadUtil.getThreadId;
 
@@ -48,7 +47,7 @@ public final class LockProxySupport {
 
     private InternalCompletableFuture invoke(NodeEngine nodeEngine, Operation operation, Data key) {
         int partitionId = nodeEngine.getPartitionService().getPartitionId(key);
-        return nodeEngine.getOperationService().invokeOnPartition(SERVICE_NAME, operation, partitionId);
+        return nodeEngine.getOperationService().invokeOnPartition(operation, partitionId);
     }
 
     public boolean isLockedByCurrentThread(NodeEngine nodeEngine, Data key) {

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockServiceImpl.java
@@ -205,7 +205,6 @@ public final class LockServiceImpl implements LockService, ManagedService, Remot
         UnlockOperation op = new LocalLockCleanupOperation(lockStore.getNamespace(), key, -1);
         op.setAsyncBackup(true);
         op.setNodeEngine(nodeEngine);
-        op.setServiceName(SERVICE_NAME);
         op.setService(LockServiceImpl.this);
         op.setResponseHandler(ResponseHandlerFactory.createEmptyResponseHandler());
         op.setPartitionId(container.getPartitionId());

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/SemaphoreProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/SemaphoreProxy.java
@@ -150,8 +150,7 @@ public class SemaphoreProxy extends AbstractDistributedObject<SemaphoreService> 
         NodeEngine nodeEngine = getNodeEngine();
         OperationService operationService = nodeEngine.getOperationService();
         //noinspection unchecked
-        return (InternalCompletableFuture) operationService.invokeOnPartition(
-                SemaphoreService.SERVICE_NAME, operation, partitionId);
+        return (InternalCompletableFuture) operationService.invokeOnPartition(operation, partitionId);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/SemaphoreService.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/SemaphoreService.java
@@ -120,8 +120,7 @@ public class SemaphoreService implements ManagedService, MigrationAwareService, 
                         .setPartitionId(partitionId)
                         .setResponseHandler(createEmptyResponseHandler())
                         .setService(this)
-                        .setNodeEngine(nodeEngine)
-                        .setServiceName(SERVICE_NAME);
+                        .setNodeEngine(nodeEngine);
                 operationService.executeOperation(op);
             }
         }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/SemaphoreOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/SemaphoreOperation.java
@@ -40,6 +40,11 @@ public abstract class SemaphoreOperation extends AbstractNamedOperation
     }
 
     @Override
+    public String getServiceName() {
+        return SemaphoreService.SERVICE_NAME;
+    }
+
+    @Override
     public Object getResponse() {
         return response;
     }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/SemaphoreReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/SemaphoreReplicationOperation.java
@@ -40,6 +40,11 @@ public class SemaphoreReplicationOperation extends AbstractOperation implements 
     }
 
     @Override
+    public String getServiceName() {
+        return SemaphoreService.SERVICE_NAME;
+    }
+
+    @Override
     public void run() throws Exception {
         SemaphoreService service = getService();
         for (Permit permit : migrationData.values()) {

--- a/hazelcast/src/main/java/com/hazelcast/executor/impl/CancellableDelegatingFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/executor/impl/CancellableDelegatingFuture.java
@@ -92,9 +92,9 @@ final class CancellableDelegatingFuture<V> extends DelegatingFuture<V> {
         OperationService opService = nodeEngine.getOperationService();
         InvocationBuilder builder;
         if (partitionId > -1) {
-            builder = opService.createInvocationBuilder(DistributedExecutorService.SERVICE_NAME, op, partitionId);
+            builder = opService.createInvocationBuilder(op, partitionId);
         } else {
-            builder = opService.createInvocationBuilder(DistributedExecutorService.SERVICE_NAME, op, target);
+            builder = opService.createInvocationBuilder(op, target);
         }
         builder.setTryCount(CANCEL_TRY_COUNT).setTryPauseMillis(CANCEL_TRY_PAUSE_MILLIS);
         return builder.invoke();

--- a/hazelcast/src/main/java/com/hazelcast/executor/impl/ExecutorServiceProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/executor/impl/ExecutorServiceProxy.java
@@ -220,7 +220,7 @@ public class ExecutorServiceProxy
     private InternalCompletableFuture invoke(int partitionId, CallableTaskOperation op) {
         NodeEngine nodeEngine = getNodeEngine();
         OperationService operationService = nodeEngine.getOperationService();
-        return operationService.invokeOnPartition(DistributedExecutorService.SERVICE_NAME, op, partitionId);
+        return operationService.invokeOnPartition(op, partitionId);
     }
 
     @Override
@@ -304,8 +304,8 @@ public class ExecutorServiceProxy
 
         boolean sync = checkSync();
         MemberCallableTaskOperation op = new MemberCallableTaskOperation(name, uuid, taskData);
-        InternalCompletableFuture future = nodeEngine.getOperationService()
-                .invokeOnTarget(DistributedExecutorService.SERVICE_NAME, op, target);
+        OperationService operationService = nodeEngine.getOperationService();
+        InternalCompletableFuture future = operationService.invokeOnTarget(op, target);
         if (sync) {
             Object response;
             try {
@@ -371,7 +371,7 @@ public class ExecutorServiceProxy
         Data taskData = nodeEngine.toData(task);
         CallableTaskOperation op = new CallableTaskOperation(name, null, taskData);
         OperationService operationService = nodeEngine.getOperationService();
-        operationService.createInvocationBuilder(DistributedExecutorService.SERVICE_NAME, op, partitionId)
+        operationService.createInvocationBuilder(op, partitionId)
                 .setCallback(new ExecutionCallbackAdapter(callback)).invoke();
     }
 
@@ -396,7 +396,7 @@ public class ExecutorServiceProxy
         MemberCallableTaskOperation op = new MemberCallableTaskOperation(name, null, taskData);
         OperationService operationService = nodeEngine.getOperationService();
         Address address = ((MemberImpl) member).getAddress();
-        operationService.createInvocationBuilder(DistributedExecutorService.SERVICE_NAME, op, address)
+        operationService.createInvocationBuilder(op, address)
                 .setCallback(new ExecutionCallbackAdapter(callback)).invoke();
     }
 
@@ -580,7 +580,7 @@ public class ExecutorServiceProxy
 
     private InternalCompletableFuture submitShutdownOperation(OperationService operationService, MemberImpl member) {
         ShutdownOperation op = new ShutdownOperation(name);
-        return operationService.invokeOnTarget(getServiceName(), op, member.getAddress());
+        return operationService.invokeOnTarget(op, member.getAddress());
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/executor/impl/client/AbstractTargetCallableRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/executor/impl/client/AbstractTargetCallableRequest.java
@@ -72,7 +72,7 @@ abstract class AbstractTargetCallableRequest extends TargetClientRequest {
     protected InvocationBuilder getInvocationBuilder(Operation op) {
         final Address target = getTarget();
         if (target != null) {
-            return operationService.createInvocationBuilder(getServiceName(), op, target);
+            return operationService.createInvocationBuilder(op, target);
         }
 
         final int partitionId = getPartitionId();
@@ -80,7 +80,7 @@ abstract class AbstractTargetCallableRequest extends TargetClientRequest {
             throw new IllegalArgumentException("Partition id is -1");
         }
 
-        return operationService.createInvocationBuilder(getServiceName(), op, partitionId);
+        return operationService.createInvocationBuilder(op, partitionId);
     }
 
     @SuppressWarnings("unchecked")

--- a/hazelcast/src/main/java/com/hazelcast/executor/impl/client/CancellationRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/executor/impl/client/CancellationRequest.java
@@ -63,9 +63,9 @@ public class CancellationRequest extends InvocationClientRequest {
         CancellationOperation op = new CancellationOperation(uuid, interrupt);
         InvocationBuilder builder;
         if (target == null) {
-            builder = createInvocationBuilder(getServiceName(), op, partitionId);
+            builder = createInvocationBuilder(op, partitionId);
         } else {
-            builder = createInvocationBuilder(getServiceName(), op, target);
+            builder = createInvocationBuilder(op, target);
         }
 
         builder.setTryCount(CANCEL_TRY_COUNT).setTryPauseMillis(CANCEL_TRY_PAUSE_MILLIS);

--- a/hazelcast/src/main/java/com/hazelcast/executor/impl/operations/BaseCallableTaskOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/executor/impl/operations/BaseCallableTaskOperation.java
@@ -49,6 +49,11 @@ abstract class BaseCallableTaskOperation extends Operation implements TraceableO
     }
 
     @Override
+    public String getServiceName() {
+        return DistributedExecutorService.SERVICE_NAME;
+    }
+
+    @Override
     public final void beforeRun() throws Exception {
         callable = getCallable();
         ManagedContext managedContext = getManagedContext();

--- a/hazelcast/src/main/java/com/hazelcast/executor/impl/operations/CancellationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/executor/impl/operations/CancellationOperation.java
@@ -38,6 +38,11 @@ public final class CancellationOperation extends Operation {
     }
 
     @Override
+    public String getServiceName() {
+        return DistributedExecutorService.SERVICE_NAME;
+    }
+
+    @Override
     public void beforeRun() throws Exception {
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/executor/impl/operations/ShutdownOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/executor/impl/operations/ShutdownOperation.java
@@ -29,6 +29,11 @@ public final class ShutdownOperation extends AbstractNamedOperation {
     }
 
     @Override
+    public String getServiceName() {
+        return DistributedExecutorService.SERVICE_NAME;
+    }
+
+    @Override
     public void run() throws Exception {
         DistributedExecutorService service = getService();
         service.shutdownExecutor(getName());

--- a/hazelcast/src/main/java/com/hazelcast/management/ManagementCenterService.java
+++ b/hazelcast/src/main/java/com/hazelcast/management/ManagementCenterService.java
@@ -45,7 +45,6 @@ import com.hazelcast.management.request.MemberConfigRequest;
 import com.hazelcast.management.request.RunGcRequest;
 import com.hazelcast.management.request.ShutdownMemberRequest;
 import com.hazelcast.management.request.ThreadDumpRequest;
-import com.hazelcast.map.impl.MapService;
 import com.hazelcast.monitor.TimedMemberState;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.IOUtil;
@@ -227,7 +226,7 @@ public class ManagementCenterService {
     public Object callOnAddress(Address address, Operation operation) {
         //todo: why are we always executing on the mapservice??
         OperationService operationService = instance.node.nodeEngine.getOperationService();
-        Future future = operationService.invokeOnTarget(MapService.SERVICE_NAME, operation, address);
+        Future future = operationService.invokeOnTarget(operation, address);
         try {
             return future.get();
         } catch (Throwable t) {
@@ -248,7 +247,7 @@ public class ManagementCenterService {
 
     public void send(Address address, Operation operation) {
         OperationService operationService = instance.node.nodeEngine.getOperationService();
-        operationService.createInvocationBuilder(MapService.SERVICE_NAME, operation, address).invoke();
+        operationService.createInvocationBuilder(operation, address).invoke();
     }
 
     public HazelcastInstanceImpl getHazelcastInstance() {

--- a/hazelcast/src/main/java/com/hazelcast/management/operation/GetMapConfigOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/management/operation/GetMapConfigOperation.java
@@ -17,7 +17,9 @@
 package com.hazelcast.management.operation;
 
 import com.hazelcast.config.MapConfig;
+import com.hazelcast.map.impl.MapContainer;
 import com.hazelcast.map.impl.MapService;
+import com.hazelcast.map.impl.MapServiceContext;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.spi.Operation;
@@ -39,13 +41,20 @@ public class GetMapConfigOperation extends Operation {
     }
 
     @Override
+    public String getServiceName() {
+        return MapService.SERVICE_NAME;
+    }
+
+    @Override
     public void beforeRun() throws Exception {
     }
 
     @Override
     public void run() throws Exception {
         MapService service = getService();
-        mapConfig = service.getMapServiceContext().getMapContainer(mapName).getMapConfig();
+        MapServiceContext mapServiceContext = service.getMapServiceContext();
+        MapContainer mapContainer = mapServiceContext.getMapContainer(mapName);
+        mapConfig = mapContainer.getMapConfig();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/management/operation/ScriptExecutorOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/management/operation/ScriptExecutorOperation.java
@@ -48,6 +48,11 @@ public class ScriptExecutorOperation extends Operation {
     }
 
     @Override
+    public String getServiceName() {
+        return null;
+    }
+
+    @Override
     public void beforeRun() throws Exception {
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/management/operation/ThreadDumpOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/management/operation/ThreadDumpOperation.java
@@ -38,28 +38,40 @@ public class ThreadDumpOperation extends Operation {
         this.dumpDeadlocks = dumpDeadlocks;
     }
 
+    @Override
+    public String getServiceName() {
+        return null;
+    }
+
+    @Override
     public void beforeRun() throws Exception {
     }
 
+    @Override
     public void run() throws Exception {
         result = dumpDeadlocks ? ThreadDumpGenerator.dumpDeadlocks() : ThreadDumpGenerator.dumpAllThreads();
     }
 
+    @Override
     public void afterRun() throws Exception {
     }
 
+    @Override
     public boolean returnsResponse() {
         return true;
     }
 
+    @Override
     public Object getResponse() {
         return result;
     }
 
+    @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         out.writeBoolean(dumpDeadlocks);
     }
 
+    @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         dumpDeadlocks = in.readBoolean();
     }

--- a/hazelcast/src/main/java/com/hazelcast/management/operation/UpdateManagementCenterUrlOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/management/operation/UpdateManagementCenterUrlOperation.java
@@ -40,6 +40,11 @@ public class UpdateManagementCenterUrlOperation extends Operation {
     }
 
     @Override
+    public String getServiceName() {
+        return null;
+    }
+
+    @Override
     public void beforeRun() throws Exception {
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/management/operation/UpdateMapConfigOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/management/operation/UpdateMapConfigOperation.java
@@ -41,6 +41,11 @@ public class UpdateMapConfigOperation extends Operation {
     }
 
     @Override
+    public String getServiceName() {
+        return MapService.SERVICE_NAME;
+    }
+
+    @Override
     public void beforeRun() throws Exception {
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/AbstractMapServiceContextSupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/AbstractMapServiceContextSupport.java
@@ -182,7 +182,7 @@ abstract class AbstractMapServiceContextSupport implements MapServiceContextSupp
     public String addLocalEventListener(MapListener mapListener, String mapName) {
         ListenerAdapter listenerAdaptor = createMapListenerAdaptor(mapListener);
         EventRegistration registration = nodeEngine.getEventService().
-                registerLocalListener(mapServiceContext.serviceName(), mapName, listenerAdaptor);
+                registerLocalListener(MapService.SERVICE_NAME, mapName, listenerAdaptor);
         return registration.getId();
     }
 
@@ -190,29 +190,30 @@ abstract class AbstractMapServiceContextSupport implements MapServiceContextSupp
     public String addLocalEventListener(MapListener mapListener, EventFilter eventFilter, String mapName) {
         ListenerAdapter listenerAdaptor = createMapListenerAdaptor(mapListener);
         EventRegistration registration = nodeEngine.getEventService().
-                registerLocalListener(mapServiceContext.serviceName(), mapName, eventFilter, listenerAdaptor);
+                registerLocalListener(MapService.SERVICE_NAME, mapName, eventFilter, listenerAdaptor);
         return registration.getId();
     }
 
     @Override
     public String addEventListener(MapListener mapListener, EventFilter eventFilter, String mapName) {
         ListenerAdapter listenerAdaptor = createMapListenerAdaptor(mapListener);
-        EventRegistration registration = nodeEngine.getEventService().
-                registerListener(mapServiceContext.serviceName(), mapName, eventFilter, listenerAdaptor);
+        EventService eventService = nodeEngine.getEventService();
+        EventRegistration registration = eventService.registerListener(
+                MapService.SERVICE_NAME, mapName, eventFilter, listenerAdaptor);
         return registration.getId();
     }
 
     @Override
     public boolean removeEventListener(String mapName, String registrationId) {
-        return nodeEngine.getEventService().deregisterListener(mapServiceContext.serviceName(), mapName, registrationId);
+        EventService eventService = nodeEngine.getEventService();
+        return eventService.deregisterListener(MapService.SERVICE_NAME, mapName, registrationId);
     }
 
     @Override
     public boolean hasRegisteredListener(String name) {
         final MapServiceContext mapServiceContext = this.mapServiceContext;
         final EventService eventService = mapServiceContext.getNodeEngine().getEventService();
-        final String serviceName = mapServiceContext.serviceName();
-        return eventService.hasEventRegistration(serviceName, name);
+        return eventService.hasEventRegistration(MapService.SERVICE_NAME, name);
     }
 }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/BasicMapContextQuerySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/BasicMapContextQuerySupport.java
@@ -249,9 +249,9 @@ class BasicMapContextQuerySupport implements MapContextQuerySupport {
     }
 
     private Future queryOnLocalMember(String mapName, Predicate predicate, NodeEngine nodeEngine) {
-        return nodeEngine
-                .getOperationService()
-                .invokeOnTarget(MapService.SERVICE_NAME, new QueryOperation(mapName, predicate), nodeEngine.getThisAddress());
+        OperationService operationService = nodeEngine.getOperationService();
+        QueryOperation op = new QueryOperation(mapName, predicate);
+        return operationService.invokeOnTarget(op, nodeEngine.getThisAddress());
     }
 
     private List<Future> queryOnMembers(String mapName, Predicate predicate, NodeEngine nodeEngine) {
@@ -259,8 +259,8 @@ class BasicMapContextQuerySupport implements MapContextQuerySupport {
         Collection<MemberImpl> members = nodeEngine.getClusterService().getMemberList();
         List<Future> futures = new ArrayList<Future>(members.size());
         for (MemberImpl member : members) {
-            Future future = operationService
-                    .invokeOnTarget(MapService.SERVICE_NAME, new QueryOperation(mapName, predicate), member.getAddress());
+            QueryOperation op = new QueryOperation(mapName, predicate);
+            Future future = operationService.invokeOnTarget(op, member.getAddress());
             futures.add(future);
         }
         return futures;
@@ -278,7 +278,7 @@ class BasicMapContextQuerySupport implements MapContextQuerySupport {
             QueryPartitionOperation queryPartitionOperation = new QueryPartitionOperation(mapName, predicate);
             queryPartitionOperation.setPartitionId(partitionId);
             try {
-                Future future = operationService.invokeOnPartition(MapService.SERVICE_NAME, queryPartitionOperation, partitionId);
+                Future future = operationService.invokeOnPartition(queryPartitionOperation, partitionId);
                 futures.add(future);
             } catch (Throwable t) {
                 throw ExceptionUtil.rethrow(t);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/BasicRecordStoreLoader.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/BasicRecordStoreLoader.java
@@ -291,7 +291,6 @@ class BasicRecordStoreLoader implements RecordStoreLoader {
         operation.setPartitionId(partitionId);
         OperationAccessor.setCallerAddress(operation, nodeEngine.getThisAddress());
         operation.setCallerUuid(nodeEngine.getLocalMember().getUuid());
-        operation.setServiceName(MapService.SERVICE_NAME);
         return operation;
     }
 
@@ -433,7 +432,7 @@ class BasicRecordStoreLoader implements RecordStoreLoader {
 
                 PutAllOperation operation = new PutAllOperation(name, entrySet, true);
                 final OperationService operationService = nodeEngine.getOperationService();
-                operationService.createInvocationBuilder(MapService.SERVICE_NAME, operation, partitionId)
+                operationService.createInvocationBuilder(operation, partitionId)
                         .setCallback(new Callback<Object>() {
                             @Override
                             public void notify(Object obj) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/DefaultMapServiceContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/DefaultMapServiceContext.java
@@ -107,11 +107,6 @@ public class DefaultMapServiceContext extends AbstractMapServiceContextSupport i
     }
 
     @Override
-    public String serviceName() {
-        return MapService.SERVICE_NAME;
-    }
-
-    @Override
     public MapService getService() {
         return mapService;
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapEventPublisherSupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapEventPublisherSupport.java
@@ -33,7 +33,7 @@ class MapEventPublisherSupport implements MapEventPublisher {
         MapContainer mapContainer = mapServiceContext.getMapContainer(mapName);
         MapReplicationUpdate replicationEvent = new MapReplicationUpdate(mapName, mapContainer.getWanMergePolicy(),
                 entryView);
-        mapContainer.getWanReplicationPublisher().publishReplicationEvent(mapServiceContext.serviceName(), replicationEvent);
+        mapContainer.getWanReplicationPublisher().publishReplicationEvent(MapService.SERVICE_NAME, replicationEvent);
     }
 
     @Override
@@ -165,12 +165,9 @@ class MapEventPublisherSupport implements MapEventPublisher {
     }
 
     private Collection<EventRegistration> getRegistrations(String mapName) {
-        final MapServiceContext mapServiceContext = this.mapServiceContext;
         final NodeEngine nodeEngine = mapServiceContext.getNodeEngine();
         final EventService eventService = nodeEngine.getEventService();
-        final String serviceName = mapServiceContext.serviceName();
-
-        return eventService.getRegistrations(serviceName, mapName);
+        return eventService.getRegistrations(MapService.SERVICE_NAME, mapName);
     }
 
     private int pickOrderKey(Data key) {
@@ -195,12 +192,9 @@ class MapEventPublisherSupport implements MapEventPublisher {
     }
 
     private void publishEventInternal(Collection<EventRegistration> registrations, Object eventData, int orderKey) {
-        final MapServiceContext mapServiceContext = this.mapServiceContext;
         final NodeEngine nodeEngine = mapServiceContext.getNodeEngine();
         final EventService eventService = nodeEngine.getEventService();
-        final String serviceName = mapServiceContext.serviceName();
-
-        eventService.publishEvent(serviceName, registrations, eventData, orderKey);
+        eventService.publishEvent(MapService.SERVICE_NAME, registrations, eventData, orderKey);
     }
 
     private String getThisNodesAddress() {
@@ -245,9 +239,8 @@ class MapEventPublisherSupport implements MapEventPublisher {
     private void publishWanReplicationEventInternal(String mapName, ReplicationEventObject event) {
         final MapServiceContext mapServiceContext = this.mapServiceContext;
         final MapContainer mapContainer = mapServiceContext.getMapContainer(mapName);
-        final String serviceName = mapServiceContext.serviceName();
         final WanReplicationPublisher wanReplicationPublisher = mapContainer.getWanReplicationPublisher();
-        wanReplicationPublisher.publishReplicationEvent(serviceName, event);
+        wanReplicationPublisher.publishReplicationEvent(MapService.SERVICE_NAME, event);
     }
 
     private EntryEventData createEntryEventData(String mapName, Address caller,

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapManagedService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapManagedService.java
@@ -27,7 +27,7 @@ class MapManagedService implements ManagedService {
         mapServiceContext.initPartitionsContainers();
         final LockService lockService = nodeEngine.getSharedService(LockService.SERVICE_NAME);
         if (lockService != null) {
-            lockService.registerLockStoreConstructor(mapServiceContext.serviceName(),
+            lockService.registerLockStoreConstructor(MapService.SERVICE_NAME,
                     new ConstructorFunction<ObjectNamespace, LockStoreInfo>() {
                         public LockStoreInfo createNew(final ObjectNamespace key) {
                             final MapContainer mapContainer = mapServiceContext.getMapContainer(key.getObjectName());

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapRemoteService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapRemoteService.java
@@ -37,7 +37,7 @@ class MapRemoteService implements RemoteService {
             mapContainer.getMapStoreContext().stop();
         }
         mapServiceContext.destroyMap(name);
-        nodeEngine.getEventService().deregisterAllListeners(mapServiceContext.serviceName(), name);
+        nodeEngine.getEventService().deregisterAllListeners(MapService.SERVICE_NAME, name);
     }
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapReplicationSupportingService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapReplicationSupportingService.java
@@ -37,7 +37,7 @@ class MapReplicationSupportingService implements ReplicationSupportingService {
             try {
                 int partitionId = nodeEngine.getPartitionService().getPartitionId(entryView.getKey());
                 Future f = nodeEngine.getOperationService()
-                        .invokeOnPartition(mapServiceContext.serviceName(), operation, partitionId);
+                        .invokeOnPartition(operation, partitionId);
                 f.get();
             } catch (Throwable t) {
                 throw ExceptionUtil.rethrow(t);
@@ -49,7 +49,7 @@ class MapReplicationSupportingService implements ReplicationSupportingService {
             try {
                 int partitionId = nodeEngine.getPartitionService().getPartitionId(replicationRemove.getKey());
                 Future f = nodeEngine.getOperationService()
-                        .invokeOnPartition(mapServiceContext.serviceName(), operation, partitionId);
+                        .invokeOnPartition(operation, partitionId);
                 f.get();
             } catch (Throwable t) {
                 throw ExceptionUtil.rethrow(t);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContext.java
@@ -38,8 +38,6 @@ public interface MapServiceContext extends MapServiceContextSupport,
 
     void clearPartitionData(int partitionId);
 
-    String serviceName();
-
     MapService getService();
 
     void clearPartitions();

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapSplitBrainHandlerService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapSplitBrainHandlerService.java
@@ -113,7 +113,7 @@ class MapSplitBrainHandlerService implements SplitBrainHandlerService {
                     try {
                         int partitionId = nodeEngine.getPartitionService().getPartitionId(record.getKey());
                         ICompletableFuture f = nodeEngine.getOperationService()
-                                .invokeOnPartition(mapServiceContext.serviceName(), operation, partitionId);
+                                .invokeOnPartition(operation, partitionId);
 
                         f.andThen(mergeCallback);
                     } catch (Throwable t) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/NearCacheProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/NearCacheProvider.java
@@ -105,7 +105,7 @@ public class NearCacheProvider {
                 if (member.localMember()) {
                     continue;
                 }
-                Operation operation = new InvalidateNearCacheOperation(mapName, key).setServiceName(MapService.SERVICE_NAME);
+                Operation operation = new InvalidateNearCacheOperation(mapName, key);
                 nodeEngine.getOperationService().send(operation, member.getAddress());
             } catch (Throwable throwable) {
                 throw new HazelcastException(throwable);
@@ -135,8 +135,7 @@ public class NearCacheProvider {
             return;
         }
         //send operation.
-        Operation operation = new NearCacheKeySetInvalidationOperation(mapName, keys)
-                .setServiceName(MapService.SERVICE_NAME);
+        Operation operation = new NearCacheKeySetInvalidationOperation(mapName, keys);
         Collection<MemberImpl> members = nodeEngine.getClusterService().getMemberList();
         for (MemberImpl member : members) {
             try {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/client/AbstractMapQueryRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/client/AbstractMapQueryRequest.java
@@ -16,8 +16,6 @@
 
 package com.hazelcast.map.impl.client;
 
-import static com.hazelcast.map.impl.MapService.SERVICE_NAME;
-
 import com.hazelcast.client.impl.client.InvocationClientRequest;
 import com.hazelcast.client.impl.client.RetryableRequest;
 import com.hazelcast.client.impl.client.SecureRequest;
@@ -88,7 +86,7 @@ abstract class AbstractMapQueryRequest extends InvocationClientRequest implement
 
     private void createInvocations(Collection<MemberImpl> members, List<Future> futures, Predicate predicate) {
         for (MemberImpl member : members) {
-            Future future = createInvocationBuilder(SERVICE_NAME, new QueryOperation(name, predicate),
+            Future future = createInvocationBuilder(new QueryOperation(name, predicate),
                     member.getAddress()).invoke();
             futures.add(future);
         }
@@ -129,7 +127,7 @@ abstract class AbstractMapQueryRequest extends InvocationClientRequest implement
             QueryPartitionOperation queryPartitionOperation = new QueryPartitionOperation(name, predicate);
             queryPartitionOperation.setPartitionId(partitionId);
             try {
-                Future future = createInvocationBuilder(SERVICE_NAME, queryPartitionOperation, partitionId).invoke();
+                Future future = createInvocationBuilder(queryPartitionOperation, partitionId).invoke();
                 futures.add(future);
             } catch (Throwable t) {
                 throw ExceptionUtil.rethrow(t);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/eviction/EvictionOperator.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/eviction/EvictionOperator.java
@@ -21,6 +21,7 @@ import com.hazelcast.config.MapConfig;
 import com.hazelcast.config.MaxSizeConfig;
 import com.hazelcast.core.EntryEventType;
 import com.hazelcast.map.impl.MapEventPublisher;
+import com.hazelcast.map.impl.MapService;
 import com.hazelcast.map.impl.MapServiceContext;
 import com.hazelcast.map.impl.RecordStore;
 import com.hazelcast.map.impl.record.Record;
@@ -165,9 +166,8 @@ public final class EvictionOperator {
     }
 
     private boolean hasListener(String mapName) {
-        final String serviceName = mapServiceContext.serviceName();
         final EventService eventService = mapServiceContext.getNodeEngine().getEventService();
-        return eventService.hasEventRegistration(serviceName, mapName);
+        return eventService.hasEventRegistration(MapService.SERVICE_NAME, mapName);
     }
 
     private boolean evictIfNotLocked(Data key, RecordStore recordStore, boolean backup) {
@@ -177,7 +177,6 @@ public final class EvictionOperator {
         recordStore.evict(key, backup);
         return true;
     }
-
 
     public int evictableSize(int currentPartitionSize, MapConfig mapConfig) {
         final int maxSize = mapConfig.getMaxSizeConfig().getSize();

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/AbstractMapOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/AbstractMapOperation.java
@@ -29,8 +29,12 @@ public abstract class AbstractMapOperation extends AbstractNamedOperation {
     }
 
     public AbstractMapOperation(String name) {
-        super();
         this.name = name;
+    }
+
+    @Override
+    public String getServiceName() {
+        return MapService.SERVICE_NAME;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/AbstractMultipleEntryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/AbstractMultipleEntryOperation.java
@@ -81,9 +81,8 @@ abstract class AbstractMultipleEntryOperation extends AbstractMapOperation {
     }
 
     protected boolean hasRegisteredListenerForThisMap() {
-        final String serviceName = mapService.getMapServiceContext().serviceName();
         final EventService eventService = getNodeEngine().getEventService();
-        return eventService.hasEventRegistration(serviceName, name);
+        return eventService.hasEventRegistration(MapService.SERVICE_NAME, name);
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/AddIndexOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/AddIndexOperation.java
@@ -67,6 +67,11 @@ public class AddIndexOperation extends AbstractNamedOperation implements Partiti
         }
     }
 
+    @Override
+    public String getServiceName() {
+        return MapService.SERVICE_NAME;
+    }
+
     private long getNow() {
         return Clock.currentTimeMillis();
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/AddInterceptorOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/AddInterceptorOperation.java
@@ -40,6 +40,12 @@ public class AddInterceptorOperation extends AbstractOperation {
     public AddInterceptorOperation() {
     }
 
+    @Override
+    public String getServiceName() {
+        return MapService.SERVICE_NAME;
+    }
+
+    @Override
     public void run() {
         mapService = getService();
         mapService.getMapServiceContext().getMapContainer(mapName).addInterceptor(id, mapInterceptor);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/BasePutOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/BasePutOperation.java
@@ -47,6 +47,7 @@ public abstract class BasePutOperation extends LockAwareOperation implements Bac
     public BasePutOperation() {
     }
 
+    @Override
     public void afterRun() {
         final MapServiceContext mapServiceContext = mapService.getMapServiceContext();
         final MapEventPublisher mapEventPublisher = mapServiceContext.getMapEventPublisher();

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ClearBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ClearBackupOperation.java
@@ -35,6 +35,11 @@ public class ClearBackupOperation extends AbstractNamedOperation implements Back
     }
 
     @Override
+    public String getServiceName() {
+        return MapService.SERVICE_NAME;
+    }
+
+    @Override
     public void beforeRun() throws Exception {
         mapService = getService();
         recordStore = mapService.getMapServiceContext().getRecordStore(getPartitionId(), name);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ClearExpiredOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ClearExpiredOperation.java
@@ -54,6 +54,11 @@ public class ClearExpiredOperation extends AbstractOperation implements Partitio
         }
     }
 
+    @Override
+    public String getServiceName() {
+        return MapService.SERVICE_NAME;
+    }
+
     private boolean isOwner() {
         final NodeEngine nodeEngine = getNodeEngine();
         final Address owner = nodeEngine.getPartitionService().getPartitionOwner(getPartitionId());
@@ -66,11 +71,6 @@ public class ClearExpiredOperation extends AbstractOperation implements Partitio
         final PartitionContainer partitionContainer = mapService.getMapServiceContext().getPartitionContainer(getPartitionId());
         partitionContainer.setHasRunningCleanup(false);
         partitionContainer.setLastCleanupTime(Clock.currentTimeMillis());
-    }
-
-    @Override
-    public boolean returnsResponse() {
-        return false;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ClearOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ClearOperation.java
@@ -21,8 +21,6 @@ import com.hazelcast.spi.BackupAwareOperation;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.PartitionAwareOperation;
 
-import static com.hazelcast.map.impl.MapService.SERVICE_NAME;
-
 public class ClearOperation extends AbstractMapOperation implements BackupAwareOperation, PartitionAwareOperation {
 
     boolean shouldBackup = true;
@@ -69,9 +67,7 @@ public class ClearOperation extends AbstractMapOperation implements BackupAwareO
     }
 
     public Operation getBackupOperation() {
-        ClearBackupOperation clearBackupOperation = new ClearBackupOperation(name);
-        clearBackupOperation.setServiceName(SERVICE_NAME);
-        return clearBackupOperation;
+        return new ClearBackupOperation(name);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOperation.java
@@ -27,6 +27,7 @@ import com.hazelcast.map.impl.LocalMapStatsProvider;
 import com.hazelcast.map.impl.MapContainer;
 import com.hazelcast.map.impl.MapEntrySimple;
 import com.hazelcast.map.impl.MapEventPublisher;
+import com.hazelcast.map.impl.MapService;
 import com.hazelcast.map.impl.MapServiceContext;
 import com.hazelcast.map.impl.record.Record;
 import com.hazelcast.monitor.impl.LocalMapStatsImpl;
@@ -250,9 +251,8 @@ public class EntryOperation extends LockAwareOperation implements BackupAwareOpe
     }
 
     private boolean hasRegisteredListenerForThisMap() {
-        final String serviceName = mapService.getMapServiceContext().serviceName();
         final EventService eventService = getNodeEngine().getEventService();
-        return eventService.hasEventRegistration(serviceName, name);
+        return eventService.hasEventRegistration(MapService.SERVICE_NAME, name);
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/InvalidateNearCacheOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/InvalidateNearCacheOperation.java
@@ -47,6 +47,11 @@ public class InvalidateNearCacheOperation extends AbstractOperation {
     }
 
     @Override
+    public String getServiceName() {
+        return MapService.SERVICE_NAME;
+    }
+
+    @Override
     public boolean returnsResponse() {
         return false;
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/KeyBasedMapOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/KeyBasedMapOperation.java
@@ -71,6 +71,11 @@ public abstract class KeyBasedMapOperation extends Operation implements Partitio
         this.ttl = ttl;
     }
 
+    @Override
+    public String getServiceName() {
+        return MapService.SERVICE_NAME;
+    }
+
     public final String getName() {
         return name;
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapPutAllOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapPutAllOperationFactory.java
@@ -17,7 +17,6 @@
 package com.hazelcast.map.impl.operation;
 
 import com.hazelcast.map.impl.MapEntrySet;
-import com.hazelcast.map.impl.MapService;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.spi.Operation;
@@ -29,7 +28,6 @@ public class MapPutAllOperationFactory implements OperationFactory {
     String name;
     MapEntrySet entrySet = new MapEntrySet();
 
-
     public MapPutAllOperationFactory() {
     }
 
@@ -40,9 +38,7 @@ public class MapPutAllOperationFactory implements OperationFactory {
 
     @Override
     public Operation createOperation() {
-        PutAllOperation putAllOperation = new PutAllOperation(name, entrySet);
-        putAllOperation.setServiceName(MapService.SERVICE_NAME);
-        return putAllOperation;
+        return new PutAllOperation(name, entrySet);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/NearCacheKeySetInvalidationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/NearCacheKeySetInvalidationOperation.java
@@ -25,10 +25,6 @@ import com.hazelcast.spi.AbstractOperation;
 import java.io.IOException;
 import java.util.Set;
 
-/**
- * User: ahmetmircik
- * Date: 10/31/13
- */
 public class NearCacheKeySetInvalidationOperation extends AbstractOperation {
     MapService mapService;
     MapKeySet mapKeySet;
@@ -50,6 +46,11 @@ public class NearCacheKeySetInvalidationOperation extends AbstractOperation {
             getLogger().warning("Cache clear operation has been accepted while near cache is not enabled for "
                     + mapName + " map. Possible configuration conflict among nodes.");
         }
+    }
+
+    @Override
+    public String getServiceName() {
+        return MapService.SERVICE_NAME;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/RemoveInterceptorOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/RemoveInterceptorOperation.java
@@ -43,6 +43,11 @@ public class RemoveInterceptorOperation extends AbstractOperation {
     }
 
     @Override
+    public String getServiceName() {
+        return MapService.SERVICE_NAME;
+    }
+
+    @Override
     public Object getResponse() {
         return true;
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
@@ -56,7 +56,6 @@ import java.util.Set;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
-import static com.hazelcast.map.impl.MapService.SERVICE_NAME;
 import static com.hazelcast.util.ValidationUtil.checkNotNull;
 import static com.hazelcast.util.ValidationUtil.shouldBePositive;
 
@@ -671,7 +670,7 @@ public class MapProxyImpl<K, V> extends MapProxySupport implements IMap<K, V>, I
 
     protected Object invoke(Operation operation, int partitionId) throws Throwable {
         NodeEngine nodeEngine = getNodeEngine();
-        Future f = nodeEngine.getOperationService().invokeOnPartition(SERVICE_NAME, operation, partitionId);
+        Future f = nodeEngine.getOperationService().invokeOnPartition(operation, partitionId);
         Object response = f.get();
         Object returnObj = toObject(response);
         if (returnObj instanceof Throwable) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/MapTransactionLog.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/MapTransactionLog.java
@@ -17,7 +17,6 @@
 package com.hazelcast.map.impl.tx;
 
 import com.hazelcast.map.impl.MapRecordKey;
-import com.hazelcast.map.impl.MapService;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -61,7 +60,7 @@ public class MapTransactionLog implements KeyAwareTransactionLog {
         operation.setThreadId(threadId);
         try {
             int partitionId = nodeEngine.getPartitionService().getPartitionId(key);
-            return nodeEngine.getOperationService().invokeOnPartition(MapService.SERVICE_NAME, operation, partitionId);
+            return nodeEngine.getOperationService().invokeOnPartition(operation, partitionId);
         } catch (Throwable t) {
             throw ExceptionUtil.rethrow(t);
         }
@@ -74,7 +73,7 @@ public class MapTransactionLog implements KeyAwareTransactionLog {
         txnOp.setOwnerUuid(ownerUuid);
         try {
             int partitionId = nodeEngine.getPartitionService().getPartitionId(key);
-            return nodeEngine.getOperationService().invokeOnPartition(MapService.SERVICE_NAME, op, partitionId);
+            return nodeEngine.getOperationService().invokeOnPartition(op, partitionId);
         } catch (Throwable t) {
             throw ExceptionUtil.rethrow(t);
         }
@@ -85,7 +84,7 @@ public class MapTransactionLog implements KeyAwareTransactionLog {
         TxnRollbackOperation operation = new TxnRollbackOperation(name, key, ownerUuid);
         operation.setThreadId(threadId);
         try {
-            return nodeEngine.getOperationService().invokeOnPartition(MapService.SERVICE_NAME, operation, partitionId);
+            return nodeEngine.getOperationService().invokeOnPartition(operation, partitionId);
         } catch (Throwable t) {
             throw ExceptionUtil.rethrow(t);
         }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TransactionalMapProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TransactionalMapProxy.java
@@ -104,12 +104,14 @@ public class TransactionalMapProxy extends TransactionalMapProxySupport implemen
         return wrapper == null || wrapper.type == TxnValueWrapper.Type.REMOVED ? null : wrapper.value;
     }
 
+    @Override
     public Object put(Object key, Object value) {
         checkTransactionState();
         MapService service = getService();
-        final MapServiceContext mapServiceContext = service.getMapServiceContext();
-        final Object valueBeforeTxn = mapServiceContext.toObject(putInternal(mapServiceContext.toData(key, partitionStrategy),
-                mapServiceContext.toData(value)));
+        MapServiceContext mapServiceContext = service.getMapServiceContext();
+        Data valueData = mapServiceContext.toData(value);
+        Data keyData = mapServiceContext.toData(key, partitionStrategy);
+        Object valueBeforeTxn = mapServiceContext.toObject(putInternal(keyData, valueData));
         TxnValueWrapper currentValue = txMap.get(key);
         if (value != null) {
             TxnValueWrapper wrapper = valueBeforeTxn == null
@@ -121,6 +123,7 @@ public class TransactionalMapProxy extends TransactionalMapProxySupport implemen
         return currentValue == null ? valueBeforeTxn : checkIfRemoved(currentValue);
     }
 
+    @Override
     public Object put(Object key, Object value, long ttl, TimeUnit timeUnit) {
         checkTransactionState();
         MapService service = getService();

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/MapReduceService.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/MapReduceService.java
@@ -35,6 +35,7 @@ import com.hazelcast.partition.InternalPartitionService;
 import com.hazelcast.spi.InvocationBuilder;
 import com.hazelcast.spi.ManagedService;
 import com.hazelcast.spi.NodeEngine;
+import com.hazelcast.spi.OperationService;
 import com.hazelcast.spi.RemoteService;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.util.ConcurrencyUtil;
@@ -216,9 +217,8 @@ public class MapReduceService
     public <R> R processRequest(Address address, ProcessingOperation processingOperation)
             throws ExecutionException, InterruptedException {
 
-        InvocationBuilder invocation = nodeEngine.getOperationService()
-                                                 .createInvocationBuilder(SERVICE_NAME, processingOperation, address);
-
+        OperationService operationService = nodeEngine.getOperationService();
+        InvocationBuilder invocation = operationService.createInvocationBuilder(processingOperation, address);
         Future<R> future = invocation.invoke();
         return future.get();
     }

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/MapReduceUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/MapReduceUtil.java
@@ -261,7 +261,7 @@ public final class MapReduceUtil {
                     }
                 } else {
                     if (returnsResponse) {
-                        InvocationBuilder ib = os.createInvocationBuilder(SERVICE_NAME, operation, member.getAddress());
+                        InvocationBuilder ib = os.createInvocationBuilder(operation, member.getAddress());
 
                         V response = (V) ib.invoke().getSafely();
                         if (response != null) {
@@ -302,7 +302,7 @@ public final class MapReduceUtil {
                 }
             } else {
                 if (returnsResponse) {
-                    InvocationBuilder ib = os.createInvocationBuilder(SERVICE_NAME, operation, address);
+                    InvocationBuilder ib = os.createInvocationBuilder(operation, address);
                     return (V) ib.invoke().get();
                 } else {
                     os.send(operation, address);

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapProxySupport.java
@@ -32,6 +32,7 @@ import com.hazelcast.spi.AbstractDistributedObject;
 import com.hazelcast.spi.DefaultObjectNamespace;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.OperationService;
 import com.hazelcast.util.ExceptionUtil;
 import com.hazelcast.util.ThreadUtil;
 import java.util.HashSet;
@@ -95,13 +96,10 @@ public abstract class MultiMapProxySupport extends AbstractDistributedObject<Mul
 
     protected Set<Data> keySetInternal() {
         final NodeEngine nodeEngine = getNodeEngine();
+        OperationService operationService = nodeEngine.getOperationService();
         try {
-
-            Map<Integer, Object> results = nodeEngine.getOperationService()
-                    .invokeOnAllPartitions(
-                            MultiMapService.SERVICE_NAME,
-                            new MultiMapOperationFactory(name, OperationFactoryType.KEY_SET)
-                    );
+            MultiMapOperationFactory operationFactory = new MultiMapOperationFactory(name, OperationFactoryType.KEY_SET);
+            Map<Integer, Object> results = operationService.invokeOnAllPartitions(operationFactory);
             Set<Data> keySet = new HashSet<Data>();
             for (Object result : results.values()) {
                 if (result == null) {
@@ -120,12 +118,10 @@ public abstract class MultiMapProxySupport extends AbstractDistributedObject<Mul
 
     protected Map valuesInternal() {
         final NodeEngine nodeEngine = getNodeEngine();
+        OperationService operationService = nodeEngine.getOperationService();
         try {
-            Map<Integer, Object> results = nodeEngine.getOperationService()
-                    .invokeOnAllPartitions(
-                            MultiMapService.SERVICE_NAME,
-                            new MultiMapOperationFactory(name, OperationFactoryType.VALUES)
-                    );
+            MultiMapOperationFactory operationFactory = new MultiMapOperationFactory(name, OperationFactoryType.VALUES);
+            Map<Integer, Object> results = operationService.invokeOnAllPartitions(operationFactory);
             return results;
         } catch (Throwable throwable) {
             throw ExceptionUtil.rethrow(throwable);
@@ -134,12 +130,10 @@ public abstract class MultiMapProxySupport extends AbstractDistributedObject<Mul
 
     protected Map entrySetInternal() {
         final NodeEngine nodeEngine = getNodeEngine();
+        OperationService operationService = nodeEngine.getOperationService();
         try {
-            Map<Integer, Object> results = nodeEngine.getOperationService()
-                    .invokeOnAllPartitions(
-                            MultiMapService.SERVICE_NAME,
-                            new MultiMapOperationFactory(name, OperationFactoryType.ENTRY_SET)
-                    );
+            MultiMapOperationFactory operationFactory = new MultiMapOperationFactory(name, OperationFactoryType.ENTRY_SET);
+            Map<Integer, Object> results = operationService.invokeOnAllPartitions(operationFactory);
             return results;
         } catch (Throwable throwable) {
             throw ExceptionUtil.rethrow(throwable);
@@ -148,13 +142,11 @@ public abstract class MultiMapProxySupport extends AbstractDistributedObject<Mul
 
     protected boolean containsInternal(Data key, Data value) {
         final NodeEngine nodeEngine = getNodeEngine();
+        OperationService operationService = nodeEngine.getOperationService();
         try {
-            Map<Integer, Object> results = nodeEngine.getOperationService()
-                    .invokeOnAllPartitions(
-                            MultiMapService.SERVICE_NAME,
-                            new MultiMapOperationFactory(name, OperationFactoryType.CONTAINS,
-                                    key, value, ThreadUtil.getThreadId())
-                    );
+            MultiMapOperationFactory operationFactory = new MultiMapOperationFactory(name, OperationFactoryType.CONTAINS,
+                    key, value, ThreadUtil.getThreadId());
+            Map<Integer, Object> results = operationService.invokeOnAllPartitions(operationFactory);
             for (Object obj : results.values()) {
                 if (obj == null) {
                     continue;
@@ -172,12 +164,10 @@ public abstract class MultiMapProxySupport extends AbstractDistributedObject<Mul
 
     public int size() {
         final NodeEngine nodeEngine = getNodeEngine();
+        OperationService operationService = nodeEngine.getOperationService();
         try {
-            Map<Integer, Object> results = nodeEngine.getOperationService()
-                    .invokeOnAllPartitions(
-                            MultiMapService.SERVICE_NAME,
-                            new MultiMapOperationFactory(name, OperationFactoryType.SIZE)
-                    );
+            MultiMapOperationFactory operationFactory = new MultiMapOperationFactory(name, OperationFactoryType.SIZE);
+            Map<Integer, Object> results = operationService.invokeOnAllPartitions(operationFactory);
             int size = 0;
             for (Object obj : results.values()) {
                 if (obj == null) {
@@ -194,12 +184,10 @@ public abstract class MultiMapProxySupport extends AbstractDistributedObject<Mul
 
     public void clear() {
         final NodeEngine nodeEngine = getNodeEngine();
+        OperationService operationService = nodeEngine.getOperationService();
         try {
-            final Map<Integer, Object> resultMap
-                    = nodeEngine.getOperationService().invokeOnAllPartitions(
-                    MultiMapService.SERVICE_NAME,
-                    new MultiMapOperationFactory(name, OperationFactoryType.CLEAR)
-            );
+            MultiMapOperationFactory operationFactory = new MultiMapOperationFactory(name, OperationFactoryType.CLEAR);
+            Map<Integer, Object> resultMap = operationService.invokeOnAllPartitions(operationFactory);
 
             int numberOfAffectedEntries = 0;
             for (Object o : resultMap.values()) {
@@ -238,8 +226,7 @@ public abstract class MultiMapProxySupport extends AbstractDistributedObject<Mul
             Object o;
             if (config.isStatisticsEnabled()) {
                 long time = System.currentTimeMillis();
-                f = nodeEngine.getOperationService()
-                        .invokeOnPartition(MultiMapService.SERVICE_NAME, operation, partitionId);
+                f = nodeEngine.getOperationService().invokeOnPartition(operation, partitionId);
                 o = f.get();
                 if (operation instanceof PutOperation) {
                     //TODO @ali should we remove statics from operations ?
@@ -250,8 +237,7 @@ public abstract class MultiMapProxySupport extends AbstractDistributedObject<Mul
                     getService().getLocalMultiMapStatsImpl(name).incrementGets(System.currentTimeMillis() - time);
                 }
             } else {
-                f = nodeEngine.getOperationService()
-                        .invokeOnPartition(MultiMapService.SERVICE_NAME, operation, partitionId);
+                f = nodeEngine.getOperationService().invokeOnPartition(operation, partitionId);
                 o = f.get();
             }
             return nodeEngine.toObject(o);

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/MultiMapMigrationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/MultiMapMigrationOperation.java
@@ -43,11 +43,18 @@ public class MultiMapMigrationOperation extends AbstractOperation {
         this.map = map;
     }
 
+    @Override
+    public String getServiceName() {
+        return MultiMapService.SERVICE_NAME;
+    }
+
+    @Override
     public void run() throws Exception {
         MultiMapService service = getService();
         service.insertMigratedData(getPartitionId(), map);
     }
 
+    @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         out.writeInt(map.size());
         for (Map.Entry<String, Map> entry : map.entrySet()) {
@@ -74,6 +81,7 @@ public class MultiMapMigrationOperation extends AbstractOperation {
         }
     }
 
+    @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         int mapSize = in.readInt();
         map = new HashMap<String, Map>(mapSize);

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/MultiMapTransactionLog.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/MultiMapTransactionLog.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.multimap.impl.txn;
 
-import com.hazelcast.multimap.impl.MultiMapService;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -55,7 +54,7 @@ public class MultiMapTransactionLog implements KeyAwareTransactionLog {
         try {
             int partitionId = nodeEngine.getPartitionService().getPartitionId(key);
             final OperationService operationService = nodeEngine.getOperationService();
-            return operationService.invokeOnPartition(MultiMapService.SERVICE_NAME, operation, partitionId);
+            return operationService.invokeOnPartition(operation, partitionId);
         } catch (Throwable t) {
             throw ExceptionUtil.rethrow(t);
         }
@@ -66,7 +65,7 @@ public class MultiMapTransactionLog implements KeyAwareTransactionLog {
         try {
             int partitionId = nodeEngine.getPartitionService().getPartitionId(key);
             final OperationService operationService = nodeEngine.getOperationService();
-            return operationService.invokeOnPartition(MultiMapService.SERVICE_NAME, operation, partitionId);
+            return operationService.invokeOnPartition(operation, partitionId);
         } catch (Throwable t) {
             throw ExceptionUtil.rethrow(t);
         }
@@ -77,7 +76,7 @@ public class MultiMapTransactionLog implements KeyAwareTransactionLog {
         try {
             int partitionId = nodeEngine.getPartitionService().getPartitionId(key);
             final OperationService operationService = nodeEngine.getOperationService();
-            return operationService.invokeOnPartition(MultiMapService.SERVICE_NAME, operation, partitionId);
+            return operationService.invokeOnPartition(operation, partitionId);
         } catch (Throwable t) {
             throw ExceptionUtil.rethrow(t);
         }

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TransactionalMultiMapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TransactionalMultiMapProxySupport.java
@@ -172,11 +172,7 @@ public abstract class TransactionalMultiMapProxySupport extends AbstractDistribu
             try {
                 int partitionId = getNodeEngine().getPartitionService().getPartitionId(key);
                 final OperationService operationService = getNodeEngine().getOperationService();
-                Future<MultiMapResponse> f = operationService.invokeOnPartition(
-                        MultiMapService.SERVICE_NAME,
-                        operation,
-                        partitionId
-                );
+                Future<MultiMapResponse> f = operationService.invokeOnPartition(operation, partitionId);
                 MultiMapResponse response = f.get();
                 coll = response.getRecordCollection(getNodeEngine());
             } catch (Throwable t) {
@@ -197,7 +193,7 @@ public abstract class TransactionalMultiMapProxySupport extends AbstractDistribu
                 int partitionId = getNodeEngine().getPartitionService().getPartitionId(key);
                 final OperationService operationService = getNodeEngine().getOperationService();
                 Future<Integer> f = operationService
-                        .invokeOnPartition(MultiMapService.SERVICE_NAME, operation, partitionId);
+                        .invokeOnPartition(operation, partitionId);
                 return f.get();
             } catch (Throwable t) {
                 throw ExceptionUtil.rethrow(t);
@@ -210,8 +206,9 @@ public abstract class TransactionalMultiMapProxySupport extends AbstractDistribu
         checkTransactionState();
         try {
             final OperationService operationService = getNodeEngine().getOperationService();
-            final Map<Integer, Object> results = operationService.invokeOnAllPartitions(MultiMapService.SERVICE_NAME,
-                    new MultiMapOperationFactory(name, MultiMapOperationFactory.OperationFactoryType.SIZE));
+            MultiMapOperationFactory operationFactory
+                    = new MultiMapOperationFactory(name, MultiMapOperationFactory.OperationFactoryType.SIZE);
+            final Map<Integer, Object> results = operationService.invokeOnAllPartitions(operationFactory);
             int size = 0;
             for (Object obj : results.values()) {
                 if (obj == null) {
@@ -257,8 +254,7 @@ public abstract class TransactionalMultiMapProxySupport extends AbstractDistribu
         try {
             int partitionId = nodeEngine.getPartitionService().getPartitionId(key);
             final OperationService operationService = nodeEngine.getOperationService();
-            Future<MultiMapResponse> f = operationService.
-                    invokeOnPartition(MultiMapService.SERVICE_NAME, operation, partitionId);
+            Future<MultiMapResponse> f = operationService.invokeOnPartition(operation, partitionId);
             return f.get();
         } catch (Throwable t) {
             throw ExceptionUtil.rethrow(t);
@@ -271,7 +267,7 @@ public abstract class TransactionalMultiMapProxySupport extends AbstractDistribu
         try {
             int partitionId = nodeEngine.getPartitionService().getPartitionId(key);
             final OperationService operationService = nodeEngine.getOperationService();
-            Future<Long> f = operationService.invokeOnPartition(MultiMapService.SERVICE_NAME, operation, partitionId);
+            Future<Long> f = operationService.invokeOnPartition(operation, partitionId);
             return f.get();
         } catch (Throwable t) {
             throw ExceptionUtil.rethrow(t);

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnCommitOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnCommitOperation.java
@@ -22,6 +22,7 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.BackupAwareOperation;
+import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.Notifier;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.WaitNotifyKey;
@@ -43,8 +44,10 @@ public class TxnCommitOperation extends MultiMapBackupAwareOperation implements 
     }
 
     public void run() throws Exception {
+        NodeEngine nodeEngine = getNodeEngine();
+        int partitionId = getPartitionId();
         for (Operation op : opList) {
-            op.setNodeEngine(getNodeEngine()).setServiceName(getServiceName()).setPartitionId(getPartitionId());
+            op.setNodeEngine(nodeEngine).setPartitionId(partitionId);
             op.beforeRun();
             op.run();
             op.afterRun();

--- a/hazelcast/src/main/java/com/hazelcast/partition/PartitionServiceProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/PartitionServiceProxy.java
@@ -27,6 +27,7 @@ import com.hazelcast.partition.impl.InternalPartitionServiceImpl;
 import com.hazelcast.partition.impl.SafeStateCheckOperation;
 import com.hazelcast.spi.InternalCompletableFuture;
 import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.OperationService;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -91,11 +92,11 @@ public class PartitionServiceProxy implements com.hazelcast.core.PartitionServic
             return true;
         }
         final Collection<Future> futures = new ArrayList<Future>(memberList.size());
+        OperationService operationService = node.getNodeEngine().getOperationService();
         for (MemberImpl member : memberList) {
             final Address target = member.getAddress();
             final Operation operation = new SafeStateCheckOperation();
-            final InternalCompletableFuture future = node.getNodeEngine().getOperationService()
-                    .invokeOnTarget(InternalPartitionService.SERVICE_NAME, operation, target);
+            final InternalCompletableFuture future = operationService.invokeOnTarget(operation, target);
             futures.add(future);
         }
         // todo this max wait is appropriate?
@@ -126,8 +127,8 @@ public class PartitionServiceProxy implements com.hazelcast.core.PartitionServic
         }
         final Address target = ((MemberImpl) member).getAddress();
         final Operation operation = new SafeStateCheckOperation();
-        final InternalCompletableFuture future = getNode().getNodeEngine().getOperationService()
-                .invokeOnTarget(InternalPartitionService.SERVICE_NAME, operation, target);
+        OperationService operationService = getNode().getNodeEngine().getOperationService();
+        final InternalCompletableFuture future = operationService.invokeOnTarget(operation, target);
         boolean safe;
         try {
             final Object result = future.get(10, TimeUnit.SECONDS);

--- a/hazelcast/src/main/java/com/hazelcast/partition/impl/AssignPartitions.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/impl/AssignPartitions.java
@@ -1,5 +1,6 @@
 package com.hazelcast.partition.impl;
 
+import com.hazelcast.partition.InternalPartitionService;
 import com.hazelcast.spi.AbstractOperation;
 
 public class AssignPartitions extends AbstractOperation {
@@ -8,6 +9,11 @@ public class AssignPartitions extends AbstractOperation {
     public void run() {
         InternalPartitionServiceImpl service = getService();
         service.firstArrangement();
+    }
+
+    @Override
+    public String getServiceName() {
+        return InternalPartitionService.SERVICE_NAME;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/partition/impl/BaseMigrationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/impl/BaseMigrationOperation.java
@@ -19,6 +19,7 @@ package com.hazelcast.partition.impl;
 import com.hazelcast.core.MemberLeftException;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.partition.InternalPartitionService;
 import com.hazelcast.partition.MigrationCycleOperation;
 import com.hazelcast.partition.MigrationInfo;
 import com.hazelcast.spi.AbstractOperation;
@@ -39,6 +40,11 @@ public abstract class BaseMigrationOperation extends AbstractOperation
     public BaseMigrationOperation(MigrationInfo migrationInfo) {
         this.migrationInfo = migrationInfo;
         setPartitionId(migrationInfo.getPartitionId());
+    }
+
+    @Override
+    public String getServiceName() {
+        return InternalPartitionService.SERVICE_NAME;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/partition/impl/ClearReplicaOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/impl/ClearReplicaOperation.java
@@ -55,6 +55,11 @@ final class ClearReplicaOperation extends AbstractOperation
     }
 
     @Override
+    public String getServiceName() {
+        return InternalPartitionService.SERVICE_NAME;
+    }
+
+    @Override
     public boolean returnsResponse() {
         return false;
     }

--- a/hazelcast/src/main/java/com/hazelcast/partition/impl/FinalizeMigrationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/impl/FinalizeMigrationOperation.java
@@ -18,6 +18,7 @@ package com.hazelcast.partition.impl;
 
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.partition.InternalPartitionService;
 import com.hazelcast.partition.MigrationCycleOperation;
 import com.hazelcast.partition.MigrationEndpoint;
 import com.hazelcast.partition.MigrationInfo;
@@ -39,6 +40,12 @@ final class FinalizeMigrationOperation extends AbstractOperation
     public FinalizeMigrationOperation(MigrationEndpoint endpoint, boolean success) {
         this.endpoint = endpoint;
         this.success = success;
+    }
+
+
+    @Override
+    public String getServiceName() {
+        return InternalPartitionService.SERVICE_NAME;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/partition/impl/InternalPartitionServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/impl/InternalPartitionServiceImpl.java
@@ -254,7 +254,7 @@ public class InternalPartitionServiceImpl implements InternalPartitionService, M
         if (lock.tryLock()) {
             try {
                 if (!initialized && !node.isMaster() && node.getMasterAddress() != null && node.joined()) {
-                    Future f = nodeEngine.getOperationService().createInvocationBuilder(SERVICE_NAME, new AssignPartitions(),
+                    Future f = nodeEngine.getOperationService().createInvocationBuilder(new AssignPartitions(),
                             node.getMasterAddress()).setTryCount(1).invoke();
                     f.get(1, TimeUnit.SECONDS);
                 }
@@ -541,7 +541,7 @@ public class InternalPartitionServiceImpl implements InternalPartitionService, M
                 try {
                     Address address = member.getAddress();
                     PartitionStateOperation operation = new PartitionStateOperation(partitionState, true);
-                    Future<Object> f = operationService.invokeOnTarget(SERVICE_NAME, operation, address);
+                    Future<Object> f = operationService.invokeOnTarget(operation, address);
                     calls.add(f);
                 } catch (Exception e) {
                     logger.finest(e);
@@ -1032,8 +1032,7 @@ public class InternalPartitionServiceImpl implements InternalPartitionService, M
         }
         Operation operation = new HasOngoingMigration();
         OperationService operationService = nodeEngine.getOperationService();
-        InvocationBuilder invocationBuilder = operationService.createInvocationBuilder(SERVICE_NAME, operation,
-                masterAddress);
+        InvocationBuilder invocationBuilder = operationService.createInvocationBuilder(operation, masterAddress);
         Future future = invocationBuilder.setTryCount(100).setTryPauseMillis(100).invoke();
         try {
             return (Boolean) future.get(1, TimeUnit.MINUTES);
@@ -1102,7 +1101,7 @@ public class InternalPartitionServiceImpl implements InternalPartitionService, M
 
     private Future invoke(Operation operation, int replicaIndex, int partitionId) {
         final OperationService operationService = nodeEngine.getOperationService();
-        return operationService.createInvocationBuilder(InternalPartitionService.SERVICE_NAME, operation, partitionId)
+        return operationService.createInvocationBuilder(operation, partitionId)
                 .setTryCount(3)
                 .setTryPauseMillis(250)
                 .setReplicaIndex(replicaIndex)
@@ -1685,7 +1684,7 @@ public class InternalPartitionServiceImpl implements InternalPartitionService, M
         }
 
         private Boolean executeMigrateOperation(MigrationRequestOperation migrationRequestOp, MemberImpl fromMember) {
-            Future future = nodeEngine.getOperationService().createInvocationBuilder(SERVICE_NAME, migrationRequestOp,
+            Future future = nodeEngine.getOperationService().createInvocationBuilder(migrationRequestOp,
                     migrationInfo.getSource())
                     .setCallTimeout(partitionMigrationTimeout)
                     .setTryPauseMillis(DEFAULT_PAUSE_MILLIS).invoke();

--- a/hazelcast/src/main/java/com/hazelcast/partition/impl/IsReplicaVersionSync.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/impl/IsReplicaVersionSync.java
@@ -2,6 +2,7 @@ package com.hazelcast.partition.impl;
 
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.partition.InternalPartitionService;
 import com.hazelcast.partition.MigrationCycleOperation;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.PartitionAwareOperation;
@@ -16,12 +17,16 @@ public class IsReplicaVersionSync extends Operation implements PartitionAwareOpe
     private long version;
     private transient boolean result;
 
-
     public IsReplicaVersionSync() {
     }
 
     public IsReplicaVersionSync(long version) {
         this.version = version;
+    }
+
+    @Override
+    public String getServiceName() {
+        return InternalPartitionService.SERVICE_NAME;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/partition/impl/MigrationRequestOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/impl/MigrationRequestOperation.java
@@ -21,7 +21,6 @@ import com.hazelcast.core.Member;
 import com.hazelcast.core.MemberLeftException;
 import com.hazelcast.nio.Address;
 import com.hazelcast.partition.InternalPartition;
-import com.hazelcast.partition.InternalPartitionService;
 import com.hazelcast.partition.MigrationEndpoint;
 import com.hazelcast.partition.MigrationInfo;
 import com.hazelcast.spi.Callback;
@@ -56,6 +55,7 @@ public final class MigrationRequestOperation extends BaseMigrationOperation {
         super(migrationInfo);
     }
 
+    @Override
     public void run() {
         NodeEngine nodeEngine = getNodeEngine();
         verifyGoodMaster(nodeEngine);
@@ -145,7 +145,7 @@ public final class MigrationRequestOperation extends BaseMigrationOperation {
         InternalPartitionServiceImpl partitionService = getService();
 
         nodeEngine.getOperationService()
-                .createInvocationBuilder(InternalPartitionService.SERVICE_NAME, operation, destination)
+                .createInvocationBuilder(operation, destination)
                 .setCallback(new MigrationCallback(migrationInfo, getResponseHandler()))
                 .setResultDeserialized(true)
                 .setCallTimeout(partitionService.getPartitionMigrationTimeout())
@@ -201,7 +201,8 @@ public final class MigrationRequestOperation extends BaseMigrationOperation {
             service.beforeMigration(migrationEvent);
             Operation op = service.prepareReplicationOperation(replicationEvent);
             if (op != null) {
-                op.setServiceName(serviceInfo.getName());
+                //todo:
+                //op.setServiceName(serviceInfo.getName());
                 tasks.add(op);
             }
         }

--- a/hazelcast/src/main/java/com/hazelcast/partition/impl/PromoteFromBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/impl/PromoteFromBackupOperation.java
@@ -22,6 +22,7 @@ import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.partition.InternalPartitionService;
 import com.hazelcast.partition.MigrationCycleOperation;
 import com.hazelcast.partition.MigrationEndpoint;
 import com.hazelcast.spi.AbstractOperation;
@@ -46,6 +47,11 @@ final class PromoteFromBackupOperation extends AbstractOperation
 
     public PromoteFromBackupOperation(Address deadAddress) {
         this.deadAddress = deadAddress;
+    }
+
+    @Override
+    public String getServiceName() {
+        return InternalPartitionService.SERVICE_NAME;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/partition/impl/ReplicaSyncRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/impl/ReplicaSyncRequest.java
@@ -49,6 +49,11 @@ public final class ReplicaSyncRequest extends Operation implements PartitionAwar
     }
 
     @Override
+    public String getServiceName() {
+        return InternalPartitionService.SERVICE_NAME;
+    }
+
+    @Override
     public void beforeRun() throws Exception {
         int syncReplicaIndex = getReplicaIndex();
         if (syncReplicaIndex < 1 || syncReplicaIndex > InternalPartition.MAX_BACKUP_COUNT) {
@@ -143,7 +148,8 @@ public final class ReplicaSyncRequest extends Operation implements PartitionAwar
             MigrationAwareService service = (MigrationAwareService) serviceInfo.getService();
             Operation op = service.prepareReplicationOperation(event);
             if (op != null) {
-                op.setServiceName(serviceInfo.getName());
+                //todo:
+                //op.setServiceName(serviceInfo.getName());
                 tasks.add(op);
             }
         }

--- a/hazelcast/src/main/java/com/hazelcast/partition/impl/ReplicaSyncRetryResponse.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/impl/ReplicaSyncRetryResponse.java
@@ -34,9 +34,11 @@ public class ReplicaSyncRetryResponse extends Operation
     public ReplicaSyncRetryResponse() {
     }
 
+    @Override
     public void beforeRun() throws Exception {
     }
 
+    @Override
     public void run() throws Exception {
         final InternalPartitionServiceImpl partitionService = getService();
         final int partitionId = getPartitionId();
@@ -52,17 +54,21 @@ public class ReplicaSyncRetryResponse extends Operation
         }
     }
 
+    @Override
     public void afterRun() throws Exception {
     }
 
+    @Override
     public boolean returnsResponse() {
         return false;
     }
 
+    @Override
     public Object getResponse() {
         return null;
     }
 
+    @Override
     public boolean validatesTarget() {
         return false;
     }
@@ -72,13 +78,16 @@ public class ReplicaSyncRetryResponse extends Operation
         return InternalPartitionService.SERVICE_NAME;
     }
 
+    @Override
     public void logError(Throwable e) {
         ReplicaErrorLogger.log(e, getLogger());
     }
 
+    @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
     }
 
+    @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/partition/impl/ResetReplicaVersionOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/impl/ResetReplicaVersionOperation.java
@@ -30,6 +30,11 @@ final class ResetReplicaVersionOperation extends AbstractOperation
         implements PartitionAwareOperation, MigrationCycleOperation {
 
     @Override
+    public String getServiceName() {
+        return InternalPartitionService.SERVICE_NAME;
+    }
+
+    @Override
     public void run() throws Exception {
         int partitionId = getPartitionId();
         InternalPartitionService partitionService = getService();

--- a/hazelcast/src/main/java/com/hazelcast/partition/impl/SafeStateCheckOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/impl/SafeStateCheckOperation.java
@@ -1,5 +1,6 @@
 package com.hazelcast.partition.impl;
 
+import com.hazelcast.partition.InternalPartitionService;
 import com.hazelcast.spi.AbstractOperation;
 
 /**
@@ -17,6 +18,11 @@ public class SafeStateCheckOperation extends AbstractOperation {
     public void run() throws Exception {
         final InternalPartitionServiceImpl service = getService();
         safe = service.getNode().getPartitionService().isMemberStateSafe();
+    }
+
+    @Override
+    public String getServiceName() {
+        return InternalPartitionService.SERVICE_NAME;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/partition/impl/SyncReplicaVersion.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/impl/SyncReplicaVersion.java
@@ -80,7 +80,7 @@ final class SyncReplicaVersion extends Operation implements PartitionAwareOperat
             NodeEngine nodeEngine = getNodeEngine();
             OperationService operationService = nodeEngine.getOperationService();
             if (sync) {
-                operationService.createInvocationBuilder(InternalPartitionService.SERVICE_NAME, op, target)
+                operationService.createInvocationBuilder(op, target)
                         .setCallback(callback)
                         .setTryCount(OPERATION_TRY_COUNT)
                         .setTryPauseMillis(OPERATION_TRY_PAUSE_MILLIS)
@@ -101,7 +101,8 @@ final class SyncReplicaVersion extends Operation implements PartitionAwareOperat
 
     private CheckReplicaVersion createCheckReplicaVersion(int partitionId, int replicaIndex, long currentVersion) {
         CheckReplicaVersion op = new CheckReplicaVersion(currentVersion, sync);
-        op.setPartitionId(partitionId).setReplicaIndex(replicaIndex).setServiceName(InternalPartitionService.SERVICE_NAME);
+        op.setPartitionId(partitionId)
+                .setReplicaIndex(replicaIndex);
         return op;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/queue/impl/QueueEvictionProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/queue/impl/QueueEvictionProcessor.java
@@ -52,7 +52,7 @@ public class QueueEvictionProcessor implements ScheduledEntryProcessor<String, V
             String name = entry.getKey();
             int partitionId = partitionService.getPartitionId(nodeEngine.toData(name));
             CheckAndEvictOperation op = new CheckAndEvictOperation(entry.getKey());
-            operationService.invokeOnPartition(QueueService.SERVICE_NAME, op, partitionId).getSafely();
+            operationService.invokeOnPartition(op, partitionId).getSafely();
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/queue/impl/proxy/QueueProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/queue/impl/proxy/QueueProxySupport.java
@@ -185,14 +185,14 @@ abstract class QueueProxySupport extends AbstractDistributedObject<QueueService>
     private InternalCompletableFuture invoke(Operation operation) {
         final NodeEngine nodeEngine = getNodeEngine();
         OperationService operationService = nodeEngine.getOperationService();
-        return operationService.invokeOnPartition(QueueService.SERVICE_NAME, operation, getPartitionId());
+        return operationService.invokeOnPartition(operation, getPartitionId());
     }
 
     private Object invokeAndGetData(QueueOperation operation) {
         final NodeEngine nodeEngine = getNodeEngine();
         try {
             OperationService operationService = nodeEngine.getOperationService();
-            Future f = operationService.invokeOnPartition(QueueService.SERVICE_NAME, operation, partitionId);
+            Future f = operationService.invokeOnPartition(operation, partitionId);
             return f.get();
         } catch (Throwable throwable) {
             throw ExceptionUtil.rethrow(throwable);

--- a/hazelcast/src/main/java/com/hazelcast/queue/impl/tx/QueueTransactionLog.java
+++ b/hazelcast/src/main/java/com/hazelcast/queue/impl/tx/QueueTransactionLog.java
@@ -18,7 +18,6 @@ package com.hazelcast.queue.impl.tx;
 
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.queue.impl.QueueService;
 import com.hazelcast.spi.InternalCompletableFuture;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.Operation;
@@ -64,14 +63,14 @@ public class QueueTransactionLog implements KeyAwareTransactionLog {
 
     private InternalCompletableFuture invoke(NodeEngine nodeEngine, Operation operation) {
         OperationService operationService = nodeEngine.getOperationService();
-        return operationService.invokeOnPartition(QueueService.SERVICE_NAME, operation, partitionId);
+        return operationService.invokeOnPartition(operation, partitionId);
     }
 
     @Override
     public Future commit(NodeEngine nodeEngine) {
         try {
             OperationService operationService = nodeEngine.getOperationService();
-            return operationService.invokeOnPartition(QueueService.SERVICE_NAME, op, partitionId);
+            return operationService.invokeOnPartition(op, partitionId);
         } catch (Throwable t) {
             throw ExceptionUtil.rethrow(t);
         }

--- a/hazelcast/src/main/java/com/hazelcast/queue/impl/tx/TransactionalQueueProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/queue/impl/tx/TransactionalQueueProxySupport.java
@@ -152,7 +152,7 @@ public abstract class TransactionalQueueProxySupport extends AbstractDistributed
 
     private <E> InternalCompletableFuture<E> invoke(Operation operation) {
         OperationService operationService = getNodeEngine().getOperationService();
-        return operationService.invokeOnPartition(QueueService.SERVICE_NAME, operation, partitionId);
+        return operationService.invokeOnPartition(operation, partitionId);
     }
 
     public String getName() {

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/ReplicationPublisher.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/ReplicationPublisher.java
@@ -292,7 +292,7 @@ public class ReplicationPublisher<K, V>
             Address address = member.getAddress();
             if (!thisAddress.equals(address)) {
                 Operation operation = new ReplicatedMapClearOperation(name, emptyReplicationQueue);
-                InvocationBuilder ib = operationService.createInvocationBuilder(SERVICE_NAME, operation, address);
+                InvocationBuilder ib = operationService.createInvocationBuilder(operation, address);
                 futures.put(member, ib.invoke());
             }
         }

--- a/hazelcast/src/main/java/com/hazelcast/spi/InvocationBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/InvocationBuilder.java
@@ -54,7 +54,6 @@ public abstract class InvocationBuilder {
     public static final boolean DEFAULT_DESERIALIZE_RESULT = true;
 
     protected final NodeEngineImpl nodeEngine;
-    protected final String serviceName;
     protected final Operation op;
     protected final int partitionId;
     protected final Address target;
@@ -71,15 +70,13 @@ public abstract class InvocationBuilder {
      * Creates an InvocationBuilder
      *
      * @param nodeEngine  the nodeEngine
-     * @param serviceName the name of the service
      * @param op          the operation to execute
      * @param partitionId the id of the partition upon which to execute the operation
      * @param target      the target machine. Either the partitionId or the target needs to be set.
      */
-    public InvocationBuilder(NodeEngineImpl nodeEngine, String serviceName, Operation op,
+    public InvocationBuilder(NodeEngineImpl nodeEngine, Operation op,
                              int partitionId, Address target) {
         this.nodeEngine = nodeEngine;
-        this.serviceName = serviceName;
         this.op = op;
         this.partitionId = partitionId;
         this.target = target;
@@ -182,7 +179,7 @@ public abstract class InvocationBuilder {
      * @return the name of the service
      */
     public String getServiceName() {
-        return serviceName;
+        return op.getServiceName();
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/spi/Operation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/Operation.java
@@ -94,6 +94,13 @@ public abstract class Operation implements DataSerializable, RemotePropagatable<
         return serviceName;
     }
 
+    /**
+     * Don't use this method. If your operation needs a service name, implement {@link #getServiceName()}.
+     *
+     * @param serviceName
+     * @return this operation.
+     */
+    @Deprecated
     public final Operation setServiceName(String serviceName) {
         this.serviceName = serviceName;
         setFlag(serviceName != null, BITMASK_SERVICE_NAME_SET);
@@ -395,8 +402,8 @@ public abstract class Operation implements DataSerializable, RemotePropagatable<
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder("Operation{");
-        sb.append("serviceName='").append(serviceName).append('\'');
+        final StringBuilder sb = new StringBuilder(getClass().getName()).append("+{");
+        sb.append("serviceName='").append(getServiceName()).append('\'');
         sb.append(", callId=").append(callId);
         sb.append(", invocationTime=").append(invocationTime);
         sb.append(", waitTimeout=").append(waitTimeout);
@@ -404,5 +411,4 @@ public abstract class Operation implements DataSerializable, RemotePropagatable<
         sb.append('}');
         return sb.toString();
     }
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/OperationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/OperationService.java
@@ -79,25 +79,40 @@ public interface OperationService {
      */
     boolean isAllowedToRunOnCallingThread(Operation op);
 
+    @Deprecated
     <E> InternalCompletableFuture<E> invokeOnPartition(String serviceName, Operation op, int partitionId);
 
+    <E> InternalCompletableFuture<E> invokeOnPartition(Operation op, int partitionId);
+
+    @Deprecated
     <E> InternalCompletableFuture<E> invokeOnTarget(String serviceName, Operation op, Address target);
 
+    <E> InternalCompletableFuture<E> invokeOnTarget(Operation op, Address target);
+
+    @Deprecated
     InvocationBuilder createInvocationBuilder(String serviceName, Operation op, int partitionId);
 
+    InvocationBuilder createInvocationBuilder(Operation op, int partitionId);
+
+    @Deprecated
     InvocationBuilder createInvocationBuilder(String serviceName, Operation op, Address target);
+
+    InvocationBuilder createInvocationBuilder(Operation op, Address target);
+
+    @Deprecated
+    Map<Integer, Object> invokeOnAllPartitions(String serviceName, OperationFactory operationFactory)
+            throws Exception;
 
     /**
      * Invokes a set of operation on each partition.
      * <p/>
      * This method blocks until the operation completes.
      *
-     * @param serviceName      the name of the service.
      * @param operationFactory the factory responsible for creating operations
      * @return a Map with partitionId as key and the outcome of the operation as value.
      * @throws Exception
      */
-    Map<Integer, Object> invokeOnAllPartitions(String serviceName, OperationFactory operationFactory)
+    Map<Integer, Object> invokeOnAllPartitions(OperationFactory operationFactory)
             throws Exception;
 
     /**
@@ -105,12 +120,15 @@ public interface OperationService {
      * * <p/>
      * This method blocks until all operations complete.
      *
-     * @param serviceName      the name of the service
      * @param operationFactory the factory responsible for creating operations
      * @param partitions       the partitions the operation should be executed on.
      * @return a Map with partitionId as key and the outcome of the operation as value.
      * @throws Exception
      */
+    Map<Integer, Object> invokeOnPartitions(OperationFactory operationFactory,
+                                            Collection<Integer> partitions) throws Exception;
+
+    @Deprecated
     Map<Integer, Object> invokeOnPartitions(String serviceName, OperationFactory operationFactory,
                                             Collection<Integer> partitions) throws Exception;
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/Backup.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/Backup.java
@@ -58,6 +58,11 @@ final class Backup extends Operation implements BackupOperation, IdentifiedDataS
     }
 
     @Override
+    public String getServiceName() {
+        return null;
+    }
+
+    @Override
     public void beforeRun() throws Exception {
         NodeEngine nodeEngine = getNodeEngine();
         int partitionId = getPartitionId();

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/BasicInvocationBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/BasicInvocationBuilder.java
@@ -26,26 +26,25 @@ import com.hazelcast.spi.Operation;
  */
 public class BasicInvocationBuilder extends InvocationBuilder {
 
-    public BasicInvocationBuilder(NodeEngineImpl nodeEngine, String serviceName, Operation op, int partitionId) {
-        this(nodeEngine, serviceName, op, partitionId, null);
+    public BasicInvocationBuilder(NodeEngineImpl nodeEngine, Operation op, int partitionId) {
+        this(nodeEngine, op, partitionId, null);
     }
 
-    public BasicInvocationBuilder(NodeEngineImpl nodeEngine, String serviceName, Operation op, Address target) {
-        this(nodeEngine, serviceName, op, -1, target);
+    public BasicInvocationBuilder(NodeEngineImpl nodeEngine, Operation op, Address target) {
+        this(nodeEngine, op, -1, target);
     }
 
-    private BasicInvocationBuilder(NodeEngineImpl nodeEngine, String serviceName, Operation op,
-                                   int partitionId, Address target) {
-        super(nodeEngine, serviceName, op, partitionId, target);
+    private BasicInvocationBuilder(NodeEngineImpl nodeEngine, Operation op, int partitionId, Address target) {
+        super(nodeEngine, op, partitionId, target);
     }
 
     @Override
     public InternalCompletableFuture invoke() {
         if (target == null) {
-            return new BasicPartitionInvocation(nodeEngine, serviceName, op, partitionId, replicaIndex,
-                    tryCount, tryPauseMillis, callTimeout, callback, executorName, resultDeserialized).invoke();
+            return new BasicPartitionInvocation(nodeEngine, op, partitionId, replicaIndex, tryCount,
+                    tryPauseMillis, callTimeout, callback, executorName, resultDeserialized).invoke();
         } else {
-            return new BasicTargetInvocation(nodeEngine, serviceName, op, target, tryCount, tryPauseMillis,
+            return new BasicTargetInvocation(nodeEngine, op, target, tryCount, tryPauseMillis,
                     callTimeout, callback, executorName, resultDeserialized).invoke();
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/BasicInvocationFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/BasicInvocationFuture.java
@@ -417,8 +417,7 @@ final class BasicInvocationFuture<E> implements InternalCompletableFuture<E> {
         try {
             Operation isStillExecuting = createCheckOperation();
 
-            BasicInvocation inv = new BasicTargetInvocation(
-                    invocation.nodeEngine, invocation.serviceName, isStillExecuting,
+            BasicInvocation inv = new BasicTargetInvocation(invocation.nodeEngine, isStillExecuting,
                     target, 0, 0, IS_EXECUTING_CALL_TIMEOUT, null, null, true);
             Future f = inv.invoke();
             invocation.logger.warning("Asking if operation execution has been started: " + toString());
@@ -434,7 +433,7 @@ final class BasicInvocationFuture<E> implements InternalCompletableFuture<E> {
         Operation op = invocation.op;
         if (op instanceof TraceableOperation) {
             TraceableOperation traceable = (TraceableOperation) op;
-            return new TraceableIsStillExecutingOperation(invocation.serviceName, traceable.getTraceIdentifier());
+            return new TraceableIsStillExecutingOperation(invocation.op.getServiceName(), traceable.getTraceIdentifier());
         } else {
             return new IsStillExecutingOperation(op.getCallId(), op.getPartitionId());
         }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/BasicPartitionInvocation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/BasicPartitionInvocation.java
@@ -27,17 +27,19 @@ import com.hazelcast.spi.Operation;
  */
 public final class BasicPartitionInvocation extends BasicInvocation {
 
-    public BasicPartitionInvocation(NodeEngineImpl nodeEngine, String serviceName, Operation op, int partitionId,
+    public BasicPartitionInvocation(NodeEngineImpl nodeEngine, Operation op, int partitionId,
                                     int replicaIndex, int tryCount, long tryPauseMillis, long callTimeout,
                                     Callback<Object> callback, String executorName, boolean resultDeserialized) {
-        super(nodeEngine, serviceName, op, partitionId, replicaIndex, tryCount, tryPauseMillis,
+        super(nodeEngine, op, partitionId, replicaIndex, tryCount, tryPauseMillis,
                 callTimeout, callback, executorName, resultDeserialized);
     }
 
+    @Override
     public Address getTarget() {
         return getPartition().getReplicaAddress(getReplicaIndex());
     }
 
+    @Override
     ExceptionAction onException(Throwable t) {
         final ExceptionAction action = op.onException(t);
         return action != null ? action : ExceptionAction.THROW_EXCEPTION;

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/BasicTargetInvocation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/BasicTargetInvocation.java
@@ -30,10 +30,10 @@ public final class BasicTargetInvocation extends BasicInvocation {
 
     private final Address target;
 
-    public BasicTargetInvocation(NodeEngineImpl nodeEngine, String serviceName, Operation op,
+    public BasicTargetInvocation(NodeEngineImpl nodeEngine, Operation op,
                                  Address target, int tryCount, long tryPauseMillis, long callTimeout,
                                  Callback<Object> callback, String executorName, boolean resultDeserialized) {
-        super(nodeEngine, serviceName, op, op.getPartitionId(), op.getReplicaIndex(),
+        super(nodeEngine, op, op.getPartitionId(), op.getReplicaIndex(),
                 tryCount, tryPauseMillis, callTimeout, callback, executorName, resultDeserialized);
         this.target = target;
     }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/IsStillExecutingOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/IsStillExecutingOperation.java
@@ -23,6 +23,11 @@ public class IsStillExecutingOperation extends AbstractOperation implements Urge
     }
 
     @Override
+    public String getServiceName() {
+        return null;
+    }
+
+    @Override
     public void run() throws Exception {
         NodeEngineImpl nodeEngine = (NodeEngineImpl) getNodeEngine();
         BasicOperationService operationService = (BasicOperationService) nodeEngine.operationService;

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/PartitionIteratingOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/PartitionIteratingOperation.java
@@ -51,6 +51,12 @@ public final class PartitionIteratingOperation extends AbstractOperation impleme
     public PartitionIteratingOperation() {
     }
 
+    @Override
+    public String getServiceName() {
+        return null;
+    }
+
+    @Override
     public void run() throws Exception {
         final NodeEngine nodeEngine = getNodeEngine();
         results = new HashMap<Integer, Object>(partitions.size());
@@ -59,12 +65,12 @@ public final class PartitionIteratingOperation extends AbstractOperation impleme
             for (final int partitionId : partitions) {
                 ResponseQueue responseQueue = new ResponseQueue();
                 final Operation op = operationFactory.createOperation();
+                Object service = ((NodeEngineImpl) nodeEngine).getService(op.getServiceName());
                 op.setNodeEngine(nodeEngine)
                         .setPartitionId(partitionId)
                         .setReplicaIndex(getReplicaIndex())
                         .setResponseHandler(responseQueue)
-                        .setServiceName(getServiceName())
-                        .setService(getService())
+                        .setService(service)
                         .setCallerUuid(getCallerUuid());
                 OperationAccessor.setCallerAddress(op, getCallerAddress());
                 responses.put(partitionId, responseQueue);

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/ProxyServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/ProxyServiceImpl.java
@@ -148,7 +148,7 @@ public class ProxyServiceImpl
             }
 
             DistributedObjectDestroyOperation operation = new DistributedObjectDestroyOperation(serviceName, name);
-            Future f = operationService.createInvocationBuilder(SERVICE_NAME, operation, member.getAddress())
+            Future f = operationService.createInvocationBuilder(operation, member.getAddress())
                                                           .setTryCount(TRY_COUNT).invoke();
             calls.add(f);
         }
@@ -512,6 +512,11 @@ public class ProxyServiceImpl
         public DistributedObjectDestroyOperation(String serviceName, String name) {
             this.serviceName = serviceName;
             this.name = name;
+        }
+
+        @Override
+        public String getServiceName() {
+            return ProxyServiceImpl.SERVICE_NAME;
         }
 
         @Override

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/TraceableIsStillExecutingOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/TraceableIsStillExecutingOperation.java
@@ -21,6 +21,11 @@ public class TraceableIsStillExecutingOperation extends AbstractOperation implem
     }
 
     @Override
+    public String getServiceName() {
+        return null;
+    }
+
+    @Override
     public void run() throws Exception {
         NodeEngineImpl nodeEngine = (NodeEngineImpl) getNodeEngine();
         BasicOperationService operationService = (BasicOperationService) nodeEngine.operationService;

--- a/hazelcast/src/main/java/com/hazelcast/topic/impl/PublishOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/impl/PublishOperation.java
@@ -42,6 +42,11 @@ public class PublishOperation extends AbstractNamedOperation
     }
 
     @Override
+    public String getServiceName() {
+        return TopicService.SERVICE_NAME;
+    }
+
+    @Override
     public void beforeRun() throws Exception {
         TopicService service = getService();
         service.incrementPublishes(name);

--- a/hazelcast/src/main/java/com/hazelcast/topic/impl/TotalOrderedTopicProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/impl/TotalOrderedTopicProxy.java
@@ -35,7 +35,7 @@ public class TotalOrderedTopicProxy extends TopicProxy {
     public void publish(Object message) {
         NodeEngine nodeEngine = getNodeEngine();
         PublishOperation operation = new PublishOperation(getName(), nodeEngine.toData(message));
-        InternalCompletableFuture f = operationService.invokeOnPartition(TopicService.SERVICE_NAME, operation, partitionId);
+        InternalCompletableFuture f = operationService.invokeOnPartition(operation, partitionId);
         f.getSafely();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/transaction/client/RecoverAllTransactionsRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/client/RecoverAllTransactionsRequest.java
@@ -81,8 +81,7 @@ public class RecoverAllTransactionsRequest extends InvocationClientRequest {
         List<Future<SerializableCollection>> futures = new ArrayList<Future<SerializableCollection>>(memberList.size());
         for (MemberImpl member : memberList) {
             RecoverTxnOperation op = new RecoverTxnOperation();
-            Future<SerializableCollection> f = createInvocationBuilder(TransactionManagerServiceImpl.SERVICE_NAME,
-                    op, member.getAddress()).invoke();
+            Future<SerializableCollection> f = createInvocationBuilder(op, member.getAddress()).invoke();
             futures.add(f);
         }
         return futures;

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/BeginTxBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/BeginTxBackupOperation.java
@@ -41,6 +41,11 @@ public final class BeginTxBackupOperation extends Operation {
     }
 
     @Override
+    public String getServiceName() {
+       return TransactionManagerServiceImpl.SERVICE_NAME;
+    }
+
+    @Override
     public void beforeRun() throws Exception {
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/BroadcastTxRollbackOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/BroadcastTxRollbackOperation.java
@@ -39,6 +39,11 @@ public final class BroadcastTxRollbackOperation extends Operation {
     }
 
     @Override
+    public String getServiceName() {
+        return TransactionManagerServiceImpl.SERVICE_NAME;
+    }
+
+    @Override
     public void beforeRun() throws Exception {
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/PurgeTxBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/PurgeTxBackupOperation.java
@@ -37,6 +37,11 @@ public final class PurgeTxBackupOperation extends Operation {
     }
 
     @Override
+    public String getServiceName() {
+        return TransactionManagerServiceImpl.SERVICE_NAME;
+    }
+
+    @Override
     public void beforeRun() throws Exception {
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/RecoverTxnOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/RecoverTxnOperation.java
@@ -35,6 +35,11 @@ public class RecoverTxnOperation extends Operation {
     }
 
     @Override
+    public String getServiceName() {
+        return TransactionManagerServiceImpl.SERVICE_NAME;
+    }
+
+    @Override
     public void beforeRun() throws Exception {
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/ReplicateTxOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/ReplicateTxOperation.java
@@ -48,6 +48,11 @@ public final class ReplicateTxOperation extends Operation {
     }
 
     @Override
+    public String getServiceName() {
+        return TransactionManagerServiceImpl.SERVICE_NAME;
+    }
+
+    @Override
     public void beforeRun() throws Exception {
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/RollbackTxBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/RollbackTxBackupOperation.java
@@ -37,6 +37,11 @@ public final class RollbackTxBackupOperation extends Operation {
     }
 
     @Override
+    public String getServiceName() {
+        return TransactionManagerServiceImpl.SERVICE_NAME;
+    }
+
+    @Override
     public void beforeRun() throws Exception {
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionImpl.java
@@ -228,8 +228,8 @@ final class TransactionImpl implements Transaction, TransactionSupport {
         List<Future> futures = new ArrayList<Future>(backupAddresses.length);
         for (Address backupAddress : backupAddresses) {
             if (nodeEngine.getClusterService().getMember(backupAddress) != null) {
-                final Future f = operationService.invokeOnTarget(TransactionManagerServiceImpl.SERVICE_NAME,
-                        new BeginTxBackupOperation(txOwnerUuid, txnId, xid), backupAddress);
+                BeginTxBackupOperation op = new BeginTxBackupOperation(txOwnerUuid, txnId, xid);
+                Future f = operationService.invokeOnTarget(op, backupAddress);
                 futures.add(f);
             }
         }
@@ -270,9 +270,8 @@ final class TransactionImpl implements Transaction, TransactionSupport {
         final OperationService operationService = nodeEngine.getOperationService();
         for (Address backupAddress : backupAddresses) {
             if (nodeEngine.getClusterService().getMember(backupAddress) != null) {
-                final Future f = operationService.invokeOnTarget(TransactionManagerServiceImpl.SERVICE_NAME,
-                        new ReplicateTxOperation(txLogs, txOwnerUuid, txnId, timeoutMillis, startTime),
-                        backupAddress);
+                ReplicateTxOperation op = new ReplicateTxOperation(txLogs, txOwnerUuid, txnId, timeoutMillis, startTime);
+                Future f = operationService.invokeOnTarget(op, backupAddress);
                 futures.add(f);
             }
         }
@@ -359,8 +358,7 @@ final class TransactionImpl implements Transaction, TransactionSupport {
         if (durability > 0 && transactionType.equals(TransactionType.TWO_PHASE)) {
             for (Address backupAddress : backupAddresses) {
                 if (nodeEngine.getClusterService().getMember(backupAddress) != null) {
-                    final Future f = operationService.invokeOnTarget(TransactionManagerServiceImpl.SERVICE_NAME,
-                            new RollbackTxBackupOperation(txnId), backupAddress);
+                    Future f = operationService.invokeOnTarget(new RollbackTxBackupOperation(txnId), backupAddress);
                     futures.add(f);
                 }
             }
@@ -380,8 +378,8 @@ final class TransactionImpl implements Transaction, TransactionSupport {
             for (Address backupAddress : backupAddresses) {
                 if (nodeEngine.getClusterService().getMember(backupAddress) != null) {
                     try {
-                        operationService.invokeOnTarget(TransactionManagerServiceImpl.SERVICE_NAME,
-                                new PurgeTxBackupOperation(txnId), backupAddress);
+                        PurgeTxBackupOperation op = new PurgeTxBackupOperation(txnId);
+                        operationService.invokeOnTarget(op, backupAddress);
                     } catch (Throwable e) {
                         nodeEngine.getLogger(getClass()).warning("Error during purging backups!", e);
                     }

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionManagerServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionManagerServiceImpl.java
@@ -65,9 +65,8 @@ import static com.hazelcast.util.FutureUtil.waitWithDeadline;
 public class TransactionManagerServiceImpl implements TransactionManagerService, ManagedService,
         MembershipAwareService, ClientAwareService {
 
-    public static final String SERVICE_NAME = "hz:core:txManagerService";
-
     public static final int RECOVER_TIMEOUT = 5000;
+    public static final String SERVICE_NAME = "hz:core:txManagerService";
 
     private final ExceptionHandler finalizeExceptionHandler;
 
@@ -219,7 +218,7 @@ public class TransactionManagerServiceImpl implements TransactionManagerService,
             Collection<Future> futures = new ArrayList<Future>(memberList.size());
             for (MemberImpl member : memberList) {
                 Operation op = new BroadcastTxRollbackOperation(txnId);
-                Future f = operationService.invokeOnTarget(SERVICE_NAME, op, member.getAddress());
+                Future f = operationService.invokeOnTarget(op, member.getAddress());
                 futures.add(f);
             }
 
@@ -366,8 +365,7 @@ public class TransactionManagerServiceImpl implements TransactionManagerService,
             if (member.localMember()) {
                 continue;
             }
-            final Future f = operationService.createInvocationBuilder(TransactionManagerServiceImpl.SERVICE_NAME,
-                    new RecoverTxnOperation(), member.getAddress()).invoke();
+            final Future f = operationService.createInvocationBuilder(new RecoverTxnOperation(), member.getAddress()).invoke();
             futures.add(f);
         }
         return futures;

--- a/hazelcast/src/main/java/com/hazelcast/wan/impl/WanNoDelayReplication.java
+++ b/hazelcast/src/main/java/com/hazelcast/wan/impl/WanNoDelayReplication.java
@@ -32,7 +32,6 @@ import com.hazelcast.util.AddressUtil.AddressHolder;
 import com.hazelcast.wan.ReplicationEventObject;
 import com.hazelcast.wan.WanReplicationEndpoint;
 import com.hazelcast.wan.WanReplicationEvent;
-import com.hazelcast.wan.WanReplicationService;
 
 import java.util.Arrays;
 import java.util.LinkedList;
@@ -153,8 +152,7 @@ public class WanNoDelayReplication
     public boolean checkAuthorization(String groupName, String groupPassword, Address target) {
         Operation authorizationCall = new AuthorizationOperation(groupName, groupPassword);
         OperationService operationService = node.nodeEngine.getOperationService();
-        String serviceName = WanReplicationService.SERVICE_NAME;
-        InvocationBuilder invocationBuilder = operationService.createInvocationBuilder(serviceName, authorizationCall, target);
+        InvocationBuilder invocationBuilder = operationService.createInvocationBuilder(authorizationCall, target);
         Future<Boolean> future = invocationBuilder.setTryCount(1).invoke();
         try {
             return future.get();

--- a/hazelcast/src/test/java/com/hazelcast/map/ListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/ListenerTest.java
@@ -123,9 +123,8 @@ public class ListenerTest extends HazelcastTestSupport {
     @Test
     public void globalListenerRemoveTest() throws InterruptedException {
         TestHazelcastInstanceFactory nodeFactory = createHazelcastInstanceFactory(2);
-        Config cfg = new Config();
-        HazelcastInstance h1 = nodeFactory.newHazelcastInstance(cfg);
-        HazelcastInstance h2 = nodeFactory.newHazelcastInstance(cfg);
+        HazelcastInstance h1 = nodeFactory.newHazelcastInstance();
+        HazelcastInstance h2 = nodeFactory.newHazelcastInstance();
         IMap<String, String> map1 = h1.getMap(name);
         IMap<String, String> map2 = h2.getMap(name);
 
@@ -133,9 +132,9 @@ public class ListenerTest extends HazelcastTestSupport {
         String id2 = map1.addEntryListener(createEntryListener(false), true);
         String id3 = map2.addEntryListener(createEntryListener(false), true);
         int k = 3;
-        map1.removeEntryListener(id1);
-        map1.removeEntryListener(id2);
-        map1.removeEntryListener(id3);
+        assertTrue(map1.removeEntryListener(id1));
+        assertTrue(map1.removeEntryListener(id2));
+        assertTrue(map1.removeEntryListener(id3));
         putDummyData(map2, k);
         checkCountWithExpected(0, 0, 0);
     }
@@ -211,9 +210,9 @@ public class ListenerTest extends HazelcastTestSupport {
         assertTrueEventually(new AssertTask() {
             @Override
             public void run() {
-                assertEquals(expectedLocal, localCount.get());
-                assertEquals(expectedGlobal, globalCount.get());
-                assertEquals(expectedValue, valueCount.get());
+                assertEquals("local count does not match", expectedLocal, localCount.get());
+                assertEquals("global count does not match",expectedGlobal, globalCount.get());
+                assertEquals("value does not match", expectedValue, valueCount.get());
             }
         });
     }

--- a/hazelcast/src/test/java/com/hazelcast/map/MapRemoveFailingBackupTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapRemoveFailingBackupTest.java
@@ -77,7 +77,7 @@ public class MapRemoveFailingBackupTest extends HazelcastTestSupport {
                 int partitionId = nodeEngine.getPartitionService().getPartitionId(key);
                 operation.setThreadId(ThreadUtil.getThreadId());
                 OperationService operationService = nodeEngine.getOperationService();
-                InternalCompletableFuture<Data> f = operationService.createInvocationBuilder(SERVICE_NAME, operation, partitionId)
+                InternalCompletableFuture<Data> f = operationService.createInvocationBuilder(operation, partitionId)
                         .setResultDeserialized(false).invoke();
                 Data result = f.get();
                 return nodeEngine.toObject(result);

--- a/hazelcast/src/test/java/com/hazelcast/map/MapTransactionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapTransactionTest.java
@@ -52,6 +52,7 @@ import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -219,11 +220,10 @@ public class MapTransactionTest extends HazelcastTestSupport {
 
     @Test
     public void testTxnOwnerDies() throws TransactionException, InterruptedException {
-        Config config = new Config();
         final TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(3);
-        final HazelcastInstance h1 = factory.newHazelcastInstance(config);
-        final HazelcastInstance h2 = factory.newHazelcastInstance(config);
-        final HazelcastInstance h3 = factory.newHazelcastInstance(config);
+        final HazelcastInstance h1 = factory.newHazelcastInstance();
+        final HazelcastInstance h2 = factory.newHazelcastInstance();
+        final HazelcastInstance h3 = factory.newHazelcastInstance();
         final IMap map1 = h1.getMap("default");
         final int size = 50;
         final AtomicBoolean result = new AtomicBoolean(false);

--- a/hazelcast/src/test/java/com/hazelcast/partition/InternalPartitionServiceStackOverflowTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/partition/InternalPartitionServiceStackOverflowTest.java
@@ -78,6 +78,11 @@ public class InternalPartitionServiceStackOverflowTest extends HazelcastTestSupp
             Thread.sleep(10);
             latch.countDown();
         }
+
+        @Override
+        public String getServiceName() {
+            return null;
+        }
     }
 
     public static class SlowPartitionUnawareSystemOperation extends AbstractOperation
@@ -93,6 +98,11 @@ public class InternalPartitionServiceStackOverflowTest extends HazelcastTestSupp
         public void run() throws Exception {
             Thread.sleep(10);
             latch.countDown();
+        }
+
+        @Override
+        public String getServiceName() {
+            return null;
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/partition/SystemOperationPrecedenseTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/partition/SystemOperationPrecedenseTest.java
@@ -90,6 +90,11 @@ public class SystemOperationPrecedenseTest extends HazelcastTestSupport {
         public void run() throws Exception {
             latch.countDown();
         }
+
+        @Override
+        public String getServiceName() {
+            return null;
+        }
     }
 
     public static class NormalPartitionAwareOperation extends AbstractOperation
@@ -97,6 +102,11 @@ public class SystemOperationPrecedenseTest extends HazelcastTestSupport {
 
         public NormalPartitionAwareOperation(int partitionId) {
             setPartitionId(partitionId);
+        }
+
+        @Override
+        public String getServiceName() {
+            return null;
         }
 
         @Override
@@ -115,6 +125,11 @@ public class SystemOperationPrecedenseTest extends HazelcastTestSupport {
         }
 
         @Override
+        public String getServiceName() {
+            return null;
+        }
+
+        @Override
         public void run() throws Exception {
             latch.countDown();
         }
@@ -124,6 +139,11 @@ public class SystemOperationPrecedenseTest extends HazelcastTestSupport {
         @Override
         public void run() throws Exception {
             Thread.sleep(1000);
+        }
+
+        @Override
+        public String getServiceName() {
+            return null;
         }
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/spi/InvocationFutureGetNewInstanceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/InvocationFutureGetNewInstanceTest.java
@@ -53,7 +53,7 @@ public class InvocationFutureGetNewInstanceTest extends HazelcastTestSupport {
         Operation op = new OperationWithResponse(response);
 
         OperationService service = localNode.nodeEngine.getOperationService();
-        Future f = service.createInvocationBuilder(null, op, localNode.address).invoke();
+        Future f = service.createInvocationBuilder(op, localNode.address).invoke();
         Object instance1 = f.get();
         Object instance2 = f.get();
 
@@ -76,7 +76,7 @@ public class InvocationFutureGetNewInstanceTest extends HazelcastTestSupport {
         Address remoteAddress = getNode(remote).address;
 
         OperationService operationService = localNode.nodeEngine.getOperationService();
-        Future f = operationService.createInvocationBuilder(null, op, remoteAddress).invoke();
+        Future f = operationService.createInvocationBuilder(op, remoteAddress).invoke();
         Object instance1 = f.get();
         Object instance2 = f.get();
 
@@ -100,6 +100,11 @@ public class InvocationFutureGetNewInstanceTest extends HazelcastTestSupport {
 
         public OperationWithResponse(Data response) {
             this.response = response;
+        }
+
+        @Override
+        public String getServiceName() {
+            return null;
         }
 
         @Override

--- a/hazelcast/src/test/java/com/hazelcast/spi/InvocationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/InvocationTest.java
@@ -64,7 +64,7 @@ public class InvocationTest extends HazelcastTestSupport {
         Operation op = new PartitionTargetOperation();
         String partitionKey = generateKeyOwnedBy(remote);
         int partitionId = localNode.nodeEngine.getPartitionService().getPartitionId(partitionKey);
-        Future f = service.createInvocationBuilder(null, op, partitionId).setCallTimeout(30000).invoke();
+        Future f = service.createInvocationBuilder(op, partitionId).setCallTimeout(30000).invoke();
         sleepSeconds(1);
 
         remote.shutdown();
@@ -84,7 +84,7 @@ public class InvocationTest extends HazelcastTestSupport {
         OperationService service = getNode(local).nodeEngine.getOperationService();
         Operation op = new TargetOperation();
         Address address = new Address(remote.getCluster().getLocalMember().getSocketAddress());
-        Future f = service.createInvocationBuilder(null, op, address).invoke();
+        Future f = service.createInvocationBuilder(op, address).invoke();
         sleepSeconds(1);
 
         remote.getLifecycleService().terminate();
@@ -101,8 +101,14 @@ public class InvocationTest extends HazelcastTestSupport {
      * Operation send to a specific member.
      */
     private static class TargetOperation extends AbstractOperation {
+        @Override
         public void run() throws InterruptedException {
             Thread.sleep(10000);
+        }
+
+        @Override
+        public String getServiceName() {
+            return null;
         }
     }
 
@@ -111,8 +117,14 @@ public class InvocationTest extends HazelcastTestSupport {
      */
     private static class PartitionTargetOperation extends AbstractOperation implements PartitionAwareOperation {
 
+        @Override
         public void run() throws InterruptedException {
             Thread.sleep(5000);
+        }
+
+        @Override
+        public String getServiceName() {
+            return null;
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/BasicBackPressureServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/BasicBackPressureServiceTest.java
@@ -177,6 +177,11 @@ public class BasicBackPressureServiceTest {
         @Override
         public void run() throws Exception {
         }
+
+        @Override
+        public String getServiceName() {
+            return null;
+        }
     }
 
     private class PartitionSpecificOperation extends AbstractOperation implements PartitionAwareOperation {
@@ -184,12 +189,22 @@ public class BasicBackPressureServiceTest {
         @Override
         public void run() throws Exception {
         }
+
+        @Override
+        public String getServiceName() {
+            return null;
+        }
     }
 
     private class GenericOperation extends AbstractOperation {
 
         @Override
         public void run() throws Exception {
+        }
+
+        @Override
+        public String getServiceName() {
+            return null;
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/BasicOperationServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/BasicOperationServiceTest.java
@@ -175,8 +175,8 @@ public class BasicOperationServiceTest extends HazelcastTestSupport {
         OperationService operationService = nodeEngine.getOperationService();
         int partitionId = (int) (Math.random() * node.getPartitionService().getPartitionCount());
 
-        InternalCompletableFuture<Object> future = operationService
-                .invokeOnPartition(null, new TimedOutBackupAwareOperation(), partitionId);
+        InternalCompletableFuture<Object> future = operationService.invokeOnPartition(
+                new TimedOutBackupAwareOperation(), partitionId);
 
         final CountDownLatch latch = new CountDownLatch(1);
         if (async) {
@@ -213,6 +213,11 @@ public class BasicOperationServiceTest extends HazelcastTestSupport {
         @Override
         public void run() throws Exception {
             LockSupport.parkNanos((long) (Math.random() * 1000 + 10));
+        }
+
+        @Override
+        public String getServiceName() {
+            return null;
         }
 
         @Override
@@ -259,8 +264,7 @@ public class BasicOperationServiceTest extends HazelcastTestSupport {
         Address address = ((MemberImpl) hz2.getCluster().getLocalMember()).getAddress();
 
         Operation operation = new GithubIssue2559Operation();
-        String serviceName = DistributedExecutorService.SERVICE_NAME;
-        InvocationBuilder invocationBuilder = operationService.createInvocationBuilder(serviceName, operation, address);
+        InvocationBuilder invocationBuilder = operationService.createInvocationBuilder(operation, address);
         invocationBuilder.invoke().get();
     }
 
@@ -272,6 +276,11 @@ public class BasicOperationServiceTest extends HazelcastTestSupport {
         @Override
         public void beforeRun()
                 throws Exception {
+        }
+
+        @Override
+        public String getServiceName() {
+            return null;
         }
 
         @Override


### PR DESCRIPTION
Servicename is not passed anymore through the serialization of an operation. Each subclass needs to provide its own by implementing the getServiceName method. 

This has the following benefits for every operation invocation:
- reduction in the amount of data to send. So less pressure on the network. It might even help IO batching since more operations can be 'read' or 'written' in one batch because they are smaller. 
- less object litter (no need to create strings/byte-arrays) so less pressure on gc
- less work to do since there is less serialization/deserialization so less pressure on the cpu's.

This pr is big because even though the serviceName is just just for an implementation detail (get the actual service) this detail has leaked into the system at almost every interaction with the operation service. The old methods are still available on the operation-service for compatibility reasons (e.g. stabilizer). But the passed in servicename is ignored.

A closely related PR:
https://github.com/hazelcast/hazelcast/pull/4469