### PR TITLE
Performance: removed executor from operation-serialization

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/InvocationBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/InvocationBuilder.java
@@ -64,7 +64,6 @@ public abstract class InvocationBuilder {
     protected int replicaIndex;
     protected int tryCount = DEFAULT_TRY_COUNT;
     protected long tryPauseMillis = DEFAULT_TRY_PAUSE_MILLIS;
-    protected String executorName;
     protected boolean resultDeserialized = DEFAULT_DESERIALIZE_RESULT;
 
     /**
@@ -83,29 +82,6 @@ public abstract class InvocationBuilder {
         this.op = op;
         this.partitionId = partitionId;
         this.target = target;
-    }
-
-    /**
-     * Gets the name of the Executor to use. This functionality is useful if you want to customize which
-     * executor is going to run an operation. By default, you don't need to configure anything. But in some
-     * cases, such as map reduce logic where you don't want to hog the partition threads, you could
-     * offload to another executor.
-     *
-     * @return the name of the executor. Returns null if no explicit executor has been configured.
-     */
-    public String getExecutorName() {
-        return executorName;
-    }
-
-    /**
-     * Sets the executor name. Value can be null, meaning that no custom executor will be used.
-     *
-     * @param executorName the name of the executor.
-     * @return the InvocationBuilder
-     */
-    public InvocationBuilder setExecutorName(String executorName) {
-        this.executorName = executorName;
-        return this;
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/spi/Operation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/Operation.java
@@ -46,8 +46,7 @@ public abstract class Operation implements DataSerializable {
     static final int BITMASK_WAIT_TIMEOUT_SET = 1 << 3;
     static final int BITMASK_PARTITION_ID_32_BIT = 1 << 4;
     static final int BITMASK_CALL_TIMEOUT_64_BIT = 1 << 5;
-    static final int BITMASK_EXECUTOR_NAME_SET = 1 << 6;
-    static final int BITMASK_SERVICE_NAME_SET = 1 << 7;
+    static final int BITMASK_SERVICE_NAME_SET = 1 << 6;
 
     // serialized
     private String serviceName;
@@ -59,7 +58,6 @@ public abstract class Operation implements DataSerializable {
     private long callTimeout = Long.MAX_VALUE;
     private long waitTimeout = -1;
     private String callerUuid;
-    private String executorName;
 
     // injected
     private transient NodeEngine nodeEngine;
@@ -145,15 +143,6 @@ public abstract class Operation implements DataSerializable {
         setFlag(replicaIndex != 0, BITMASK_REPLICA_INDEX_SET);
         this.replicaIndex = replicaIndex;
         return this;
-    }
-
-    public String getExecutorName() {
-        return executorName;
-    }
-
-    public void setExecutorName(String executorName) {
-        this.executorName = executorName;
-        setFlag(executorName != null, BITMASK_EXECUTOR_NAME_SET);
     }
 
     public final long getCallId() {
@@ -361,9 +350,6 @@ public abstract class Operation implements DataSerializable {
             out.writeUTF(callerUuid);
         }
 
-        if (isFlagSet(BITMASK_EXECUTOR_NAME_SET)) {
-            out.writeUTF(executorName);
-        }
         writeInternal(out);
     }
 
@@ -405,9 +391,9 @@ public abstract class Operation implements DataSerializable {
             callerUuid = in.readUTF();
         }
 
-        if (isFlagSet(BITMASK_EXECUTOR_NAME_SET)) {
-            executorName = in.readUTF();
-        }
+        callTimeout = in.readLong();
+        waitTimeout = in.readLong();
+        callerUuid = in.readUTF();
         readInternal(in);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/BasicInvocation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/BasicInvocation.java
@@ -138,14 +138,12 @@ abstract class BasicInvocation implements ResponseHandler, Runnable {
      //writes to that are normally handled through the INVOKE_COUNT_UPDATER to ensure atomic increments / decrements
     private volatile int invokeCount;
 
-    private final String executorName;
-
     private Address invTarget;
     private MemberImpl invTargetMember;
 
     BasicInvocation(NodeEngineImpl nodeEngine, String serviceName, Operation op, int partitionId,
                     int replicaIndex, int tryCount, long tryPauseMillis, long callTimeout, Callback<Object> callback,
-                    String executorName, boolean resultDeserialized) {
+                    boolean resultDeserialized) {
         this.operationService = (BasicOperationService) nodeEngine.operationService;
         this.logger = operationService.invocationLogger;
         this.nodeEngine = nodeEngine;
@@ -157,7 +155,6 @@ abstract class BasicInvocation implements ResponseHandler, Runnable {
         this.tryPauseMillis = tryPauseMillis;
         this.callTimeout = getCallTimeout(callTimeout);
         this.invocationFuture = new BasicInvocationFuture(operationService, this, callback);
-        this.executorName = executorName;
         this.resultDeserialized = resultDeserialized;
     }
 
@@ -220,8 +217,7 @@ abstract class BasicInvocation implements ResponseHandler, Runnable {
             op.setNodeEngine(nodeEngine)
                     .setServiceName(serviceName)
                     .setPartitionId(partitionId)
-                    .setReplicaIndex(replicaIndex)
-                    .setExecutorName(executorName);
+                    .setReplicaIndex(replicaIndex);
 
             if (!operationService.scheduler.isInvocationAllowedFromCurrentThread(op) && !isMigrationOperation(op)) {
                 throw new IllegalThreadStateException(Thread.currentThread() + " cannot make remote call: " + op);

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/BasicInvocationBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/BasicInvocationBuilder.java
@@ -43,10 +43,10 @@ public class BasicInvocationBuilder extends InvocationBuilder {
     public InternalCompletableFuture invoke() {
         if (target == null) {
             return new BasicPartitionInvocation(nodeEngine, serviceName, op, partitionId, replicaIndex,
-                    tryCount, tryPauseMillis, callTimeout, callback, executorName, resultDeserialized).invoke();
+                    tryCount, tryPauseMillis, callTimeout, callback, resultDeserialized).invoke();
         } else {
             return new BasicTargetInvocation(nodeEngine, serviceName, op, target, tryCount, tryPauseMillis,
-                    callTimeout, callback, executorName, resultDeserialized).invoke();
+                    callTimeout, callback, resultDeserialized).invoke();
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/BasicInvocationFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/BasicInvocationFuture.java
@@ -419,7 +419,7 @@ final class BasicInvocationFuture<E> implements InternalCompletableFuture<E> {
 
             BasicInvocation inv = new BasicTargetInvocation(
                     invocation.nodeEngine, invocation.serviceName, isStillExecuting,
-                    target, 0, 0, IS_EXECUTING_CALL_TIMEOUT, null, null, true);
+                    target, 0, 0, IS_EXECUTING_CALL_TIMEOUT, null, true);
             Future f = inv.invoke();
             invocation.logger.warning("Asking if operation execution has been started: " + toString());
             executing = (Boolean) invocation.nodeEngine.toObject(f.get(IS_EXECUTING_CALL_TIMEOUT, TimeUnit.MILLISECONDS));

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/BasicOperationScheduler.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/BasicOperationScheduler.java
@@ -606,20 +606,4 @@ public final class BasicOperationScheduler {
             }
         }
     }
-
-    /**
-     * Process the operation that has been send locally to this OperationService.
-     */
-    private final class LocalOperationProcessor implements Runnable {
-        private final Operation op;
-
-        private LocalOperationProcessor(Operation op) {
-            this.op = op;
-        }
-
-        @Override
-        public void run() {
-            operationHandler.process(op);
-        }
-    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/BasicOperationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/BasicOperationService.java
@@ -262,7 +262,7 @@ final class BasicOperationService implements InternalOperationService {
     public <E> InternalCompletableFuture<E> invokeOnPartition(String serviceName, Operation op, int partitionId) {
         return new BasicPartitionInvocation(nodeEngine, serviceName, op, partitionId, InvocationBuilder.DEFAULT_REPLICA_INDEX,
                 InvocationBuilder.DEFAULT_TRY_COUNT, InvocationBuilder.DEFAULT_TRY_PAUSE_MILLIS,
-                InvocationBuilder.DEFAULT_CALL_TIMEOUT, null, null, InvocationBuilder.DEFAULT_DESERIALIZE_RESULT).invoke();
+                InvocationBuilder.DEFAULT_CALL_TIMEOUT, null, InvocationBuilder.DEFAULT_DESERIALIZE_RESULT).invoke();
     }
 
     @Override
@@ -270,7 +270,7 @@ final class BasicOperationService implements InternalOperationService {
     public <E> InternalCompletableFuture<E> invokeOnTarget(String serviceName, Operation op, Address target) {
         return new BasicTargetInvocation(nodeEngine, serviceName, op, target, InvocationBuilder.DEFAULT_TRY_COUNT,
                 InvocationBuilder.DEFAULT_TRY_PAUSE_MILLIS,
-                InvocationBuilder.DEFAULT_CALL_TIMEOUT, null, null, InvocationBuilder.DEFAULT_DESERIALIZE_RESULT).invoke();
+                InvocationBuilder.DEFAULT_CALL_TIMEOUT, null, InvocationBuilder.DEFAULT_DESERIALIZE_RESULT).invoke();
     }
 
     // =============================== processing response  ===============================

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/BasicPartitionInvocation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/BasicPartitionInvocation.java
@@ -29,9 +29,9 @@ public final class BasicPartitionInvocation extends BasicInvocation {
 
     public BasicPartitionInvocation(NodeEngineImpl nodeEngine, String serviceName, Operation op, int partitionId,
                                     int replicaIndex, int tryCount, long tryPauseMillis, long callTimeout,
-                                    Callback<Object> callback, String executorName, boolean resultDeserialized) {
+                                    Callback<Object> callback, boolean resultDeserialized) {
         super(nodeEngine, serviceName, op, partitionId, replicaIndex, tryCount, tryPauseMillis,
-                callTimeout, callback, executorName, resultDeserialized);
+                callTimeout, callback, resultDeserialized);
     }
 
     public Address getTarget() {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/BasicTargetInvocation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/BasicTargetInvocation.java
@@ -32,9 +32,9 @@ public final class BasicTargetInvocation extends BasicInvocation {
 
     public BasicTargetInvocation(NodeEngineImpl nodeEngine, String serviceName, Operation op,
                                  Address target, int tryCount, long tryPauseMillis, long callTimeout,
-                                 Callback<Object> callback, String executorName, boolean resultDeserialized) {
+                                 Callback<Object> callback, boolean resultDeserialized) {
         super(nodeEngine, serviceName, op, op.getPartitionId(), op.getReplicaIndex(),
-                tryCount, tryPauseMillis, callTimeout, callback, executorName, resultDeserialized);
+                tryCount, tryPauseMillis, callTimeout, callback, resultDeserialized);
         this.target = target;
     }
 


### PR DESCRIPTION
This was introduced a long time ago for map reduce. But since it isn't used any more, it can go. 

Apart from reducing complexity (which is always good) it also should be a performance improvement since less work is done. For more information see:  https://github.com/hazelcast/hazelcast/pull/4468