### PR TITLE
Performance: replica-index smaller serialization

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/Operation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/Operation.java
@@ -271,7 +271,7 @@ public abstract class Operation implements DataSerializable, RemotePropagatable<
 
         out.writeUTF(serviceName);
         out.writeInt(partitionId);
-        out.writeInt(replicaIndex);
+        out.writeByte(replicaIndex);
         out.writeBoolean(validateTarget);
         out.writeLong(invocationTime);
         out.writeLong(callTimeout);
@@ -289,7 +289,7 @@ public abstract class Operation implements DataSerializable, RemotePropagatable<
 
         serviceName = in.readUTF();
         partitionId = in.readInt();
-        replicaIndex = in.readInt();
+        replicaIndex = in.readByte();
         validateTarget = in.readBoolean();
         invocationTime = in.readLong();
         callTimeout = in.readLong();


### PR DESCRIPTION
Operation replica-index now takes a byte instead of an int (4 bytes). So this cuts 3 bytes of every operation. 

The change is only visible in the actual serialization where we read/write a byte instead of an int. In the rest if the system the type remains 'int. 