### PR TITLE
Performance: Smarter operation serialization

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -278,7 +278,7 @@
     <suppress checks="JavadocType" files="com.hazelcast.spi[\\/]"/>
     <suppress checks="JavadocMethod" files="com.hazelcast.spi[\\/]"/>
     <suppress checks="JavadocVariable" files="com.hazelcast.spi[\\/]"/>
-    <suppress checks="MethodCount" files="com.hazelcast.spi.Operation"/>
+    <suppress checks="MethodCount|NPathComplexity|MagicNumber" files="com.hazelcast.spi.Operation"/>
     <suppress checks="MethodCount" files="com.hazelcast.spi.impl.NodeEngineImpl"/>
     <suppress checks="ClassFanOutComplexity" files="com.hazelcast.spi.impl.NodeEngineImpl"/>
     <suppress checks="ReturnCount" files="com.hazelcast.spi.impl.SpiDataSerializerHook"/>

--- a/hazelcast/src/main/java/com/hazelcast/spi/Operation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/Operation.java
@@ -47,6 +47,8 @@ public abstract class Operation implements DataSerializable, RemotePropagatable<
     static final int BITMASK_WAIT_TIMEOUT_SET = 8;
     static final int BITMASK_PARTITION_ID_32_BIT = 16;
     static final int BITMASK_CALL_TIMEOUT_64_BIT = 32;
+    static final int BITMASK_EXECUTOR_NAME_SET = 64;
+    static final int BITMASK_SERVICE_NAME_SET = 128;
 
     // serialized
     private String serviceName;
@@ -94,6 +96,7 @@ public abstract class Operation implements DataSerializable, RemotePropagatable<
 
     public final Operation setServiceName(String serviceName) {
         this.serviceName = serviceName;
+        setFlag(serviceName!=null , BITMASK_SERVICE_NAME_SET);
         return this;
     }
 
@@ -128,6 +131,7 @@ public abstract class Operation implements DataSerializable, RemotePropagatable<
 
     public void setExecutorName(String executorName) {
         this.executorName = executorName;
+        setFlag(executorName!=null, BITMASK_EXECUTOR_NAME_SET);
     }
 
     public final long getCallId() {
@@ -305,7 +309,9 @@ public abstract class Operation implements DataSerializable, RemotePropagatable<
         // write state next, so that it is first available on reading.
         out.writeShort(flags);
 
-        out.writeUTF(serviceName);
+        if(isFlagSet(BITMASK_SERVICE_NAME_SET)) {
+            out.writeUTF(serviceName);
+        }
 
         if (isFlagSet(BITMASK_PARTITION_ID_32_BIT)) {
             out.writeInt(partitionId);
@@ -333,7 +339,9 @@ public abstract class Operation implements DataSerializable, RemotePropagatable<
             out.writeUTF(callerUuid);
         }
 
-        out.writeUTF(executorName);
+        if(isFlagSet(BITMASK_EXECUTOR_NAME_SET)) {
+            out.writeUTF(executorName);
+        }
         writeInternal(out);
     }
 
@@ -345,7 +353,9 @@ public abstract class Operation implements DataSerializable, RemotePropagatable<
 
         flags = in.readShort();
 
-        serviceName = in.readUTF();
+        if(isFlagSet(BITMASK_SERVICE_NAME_SET)) {
+            serviceName = in.readUTF();
+        }
 
         if (isFlagSet(BITMASK_PARTITION_ID_32_BIT)) {
             partitionId = in.readInt();
@@ -373,7 +383,9 @@ public abstract class Operation implements DataSerializable, RemotePropagatable<
             callerUuid = in.readUTF();
         }
 
-        executorName = in.readUTF();
+        if(isFlagSet(BITMASK_EXECUTOR_NAME_SET)) {
+            executorName = in.readUTF();
+        }
         readInternal(in);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/Operation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/Operation.java
@@ -53,7 +53,7 @@ public abstract class Operation implements DataSerializable, RemotePropagatable<
     private int partitionId = -1;
     private int replicaIndex;
     private long callId;
-    private byte flags;
+    private short flags;
     private long invocationTime = -1;
     private long callTimeout = Long.MAX_VALUE;
     private long waitTimeout = -1;
@@ -271,7 +271,7 @@ public abstract class Operation implements DataSerializable, RemotePropagatable<
         return (flags & bitmask) != 0;
     }
 
-    byte getFlags() {
+    short getFlags() {
         return flags;
     }
 
@@ -303,7 +303,7 @@ public abstract class Operation implements DataSerializable, RemotePropagatable<
         out.writeLong(callId);
 
         // write state next, so that it is first available on reading.
-        out.writeByte(flags);
+        out.writeShort(flags);
 
         out.writeUTF(serviceName);
 
@@ -343,7 +343,7 @@ public abstract class Operation implements DataSerializable, RemotePropagatable<
         // It is used to return deserialization exceptions to the caller
         callId = in.readLong();
 
-        flags = in.readByte();
+        flags = in.readShort();
 
         serviceName = in.readUTF();
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/Operation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/Operation.java
@@ -42,13 +42,13 @@ import static com.hazelcast.util.EmptyStatement.ignore;
 public abstract class Operation implements DataSerializable, RemotePropagatable<Operation> {
 
     static final int BITMASK_VALIDATE_TARGET = 1;
-    static final int BITMASK_CALLER_UUID_SET = 2;
-    static final int BITMASK_REPLICA_INDEX_SET = 4;
-    static final int BITMASK_WAIT_TIMEOUT_SET = 8;
-    static final int BITMASK_PARTITION_ID_32_BIT = 16;
-    static final int BITMASK_CALL_TIMEOUT_64_BIT = 32;
-    static final int BITMASK_EXECUTOR_NAME_SET = 64;
-    static final int BITMASK_SERVICE_NAME_SET = 128;
+    static final int BITMASK_CALLER_UUID_SET = 1 << 1;
+    static final int BITMASK_REPLICA_INDEX_SET = 1 << 2;
+    static final int BITMASK_WAIT_TIMEOUT_SET = 1 << 3;
+    static final int BITMASK_PARTITION_ID_32_BIT = 1 << 4;
+    static final int BITMASK_CALL_TIMEOUT_64_BIT = 1 << 5;
+    static final int BITMASK_EXECUTOR_NAME_SET = 1 << 6;
+    static final int BITMASK_SERVICE_NAME_SET = 1 << 7;
 
     // serialized
     private String serviceName;
@@ -96,7 +96,7 @@ public abstract class Operation implements DataSerializable, RemotePropagatable<
 
     public final Operation setServiceName(String serviceName) {
         this.serviceName = serviceName;
-        setFlag(serviceName!=null , BITMASK_SERVICE_NAME_SET);
+        setFlag(serviceName != null, BITMASK_SERVICE_NAME_SET);
         return this;
     }
 
@@ -131,7 +131,7 @@ public abstract class Operation implements DataSerializable, RemotePropagatable<
 
     public void setExecutorName(String executorName) {
         this.executorName = executorName;
-        setFlag(executorName!=null, BITMASK_EXECUTOR_NAME_SET);
+        setFlag(executorName != null, BITMASK_EXECUTOR_NAME_SET);
     }
 
     public final long getCallId() {
@@ -309,7 +309,7 @@ public abstract class Operation implements DataSerializable, RemotePropagatable<
         // write state next, so that it is first available on reading.
         out.writeShort(flags);
 
-        if(isFlagSet(BITMASK_SERVICE_NAME_SET)) {
+        if (isFlagSet(BITMASK_SERVICE_NAME_SET)) {
             out.writeUTF(serviceName);
         }
 
@@ -339,7 +339,7 @@ public abstract class Operation implements DataSerializable, RemotePropagatable<
             out.writeUTF(callerUuid);
         }
 
-        if(isFlagSet(BITMASK_EXECUTOR_NAME_SET)) {
+        if (isFlagSet(BITMASK_EXECUTOR_NAME_SET)) {
             out.writeUTF(executorName);
         }
         writeInternal(out);
@@ -353,7 +353,7 @@ public abstract class Operation implements DataSerializable, RemotePropagatable<
 
         flags = in.readShort();
 
-        if(isFlagSet(BITMASK_SERVICE_NAME_SET)) {
+        if (isFlagSet(BITMASK_SERVICE_NAME_SET)) {
             serviceName = in.readUTF();
         }
 
@@ -383,7 +383,7 @@ public abstract class Operation implements DataSerializable, RemotePropagatable<
             callerUuid = in.readUTF();
         }
 
-        if(isFlagSet(BITMASK_EXECUTOR_NAME_SET)) {
+        if (isFlagSet(BITMASK_EXECUTOR_NAME_SET)) {
             executorName = in.readUTF();
         }
         readInternal(in);

--- a/hazelcast/src/test/java/com/hazelcast/spi/OperationSerializationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/OperationSerializationTest.java
@@ -1,8 +1,8 @@
 package com.hazelcast.spi;
 
-import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.nio.BufferObjectDataInput;
 import com.hazelcast.nio.BufferObjectDataOutput;
+import com.hazelcast.nio.serialization.DefaultSerializationServiceBuilder;
 import com.hazelcast.nio.serialization.SerializationService;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
@@ -24,8 +24,7 @@ public class OperationSerializationTest extends HazelcastTestSupport {
 
     @Before
     public void setup() {
-        HazelcastInstance hz = createHazelcastInstance();
-        serializationService = getNode(hz).getSerializationService();
+        serializationService = new DefaultSerializationServiceBuilder().build();
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/spi/OperationSerializationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/OperationSerializationTest.java
@@ -1,0 +1,170 @@
+package com.hazelcast.spi;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.nio.BufferObjectDataInput;
+import com.hazelcast.nio.BufferObjectDataOutput;
+import com.hazelcast.nio.serialization.SerializationService;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class OperationSerializationTest extends HazelcastTestSupport {
+
+    private SerializationService serializationService;
+
+    @Before
+    public void setup() {
+        HazelcastInstance hz = createHazelcastInstance();
+        serializationService = getNode(hz).getSerializationService();
+    }
+
+    @Test
+    public void test_partitionId() throws IOException {
+        test_partitionId(0, false);
+        test_partitionId(100, false);
+        test_partitionId(-1, false);
+        test_partitionId(Short.MAX_VALUE, false);
+        test_partitionId(Short.MAX_VALUE + 1, true);
+        test_partitionId(Integer.MAX_VALUE, true);
+    }
+
+    public void test_partitionId(int partitionId, boolean is32bit) {
+        Operation op = new DummyOperation();
+        op.setPartitionId(partitionId);
+        assertEquals(partitionId, op.getPartitionId());
+
+        assertEquals("is partition 32 bits", is32bit, op.isFlagSet(Operation.BITMASK_PARTITION_ID_32_BIT));
+
+        assertSerializationCloneEquals(op);
+    }
+
+    @Test
+    public void test_replicaIndex() throws IOException {
+        test_replicaIndex(0, false);
+        test_replicaIndex(1, true);
+        test_replicaIndex(3, true);
+    }
+
+    public void test_replicaIndex(int replicaIndex, boolean isReplicaIndexSet) {
+        Operation op = new DummyOperation();
+        op.setReplicaIndex(replicaIndex);
+        assertEquals(replicaIndex, op.getReplicaIndex());
+
+        assertEquals("is replicaindex set", isReplicaIndexSet, op.isFlagSet(Operation.BITMASK_REPLICA_INDEX_SET));
+
+        assertSerializationCloneEquals(op);
+    }
+
+    @Test
+    public void test_callTimeout() throws IOException {
+        test_callTimeout(0, false);
+        test_callTimeout(100, false);
+        test_callTimeout(-1, false);
+        test_callTimeout(Integer.MAX_VALUE, false);
+        test_callTimeout(Integer.MAX_VALUE + 1l, true);
+        test_callTimeout(Long.MAX_VALUE, true);
+    }
+
+    public void test_callTimeout(long callTimeout, boolean callTimeout64Bits) {
+        Operation op = new DummyOperation();
+        op.setCallTimeout(callTimeout);
+        assertEquals(callTimeout, op.getCallTimeout());
+
+        assertEquals("is calltimeout 64 bits", callTimeout64Bits, op.isFlagSet(Operation.BITMASK_CALL_TIMEOUT_64_BIT));
+
+        assertSerializationCloneEquals(op);
+    }
+
+    @Test
+    public void test_callId() {
+        Operation op = new DummyOperation();
+        op.setCallId(10000);
+        assertEquals(10000, op.getCallId());
+        assertSerializationCloneEquals(op);
+    }
+
+    @Test
+    public void test_invocationTime() {
+        Operation op = new DummyOperation();
+        op.setInvocationTime(10000);
+        assertEquals(10000, op.getInvocationTime());
+        assertSerializationCloneEquals(op);
+    }
+
+    @Test
+    public void test_waitTimeout() {
+        test_waitTimeout(-1, false);
+        test_waitTimeout(0, true);
+        test_waitTimeout(1, true);
+    }
+
+    public void test_waitTimeout(long waitTimeout, boolean waitTimeoutSet) {
+        Operation op = new DummyOperation();
+        op.setWaitTimeout(waitTimeout);
+        assertEquals(waitTimeout, op.getWaitTimeout());
+
+        assertEquals("wait timeout set", waitTimeoutSet, op.isFlagSet(Operation.BITMASK_WAIT_TIMEOUT_SET));
+
+        assertSerializationCloneEquals(op);
+    }
+
+    @Test
+    public void test_callerUuid() {
+        test_callerUuid(null, false);
+        test_callerUuid("", true);
+        test_callerUuid("foofbar", true);
+    }
+
+    public void test_callerUuid(String callerUuid, boolean callerUuidSet) {
+        Operation op = new DummyOperation();
+        op.setCallerUuid(callerUuid);
+        assertEquals(callerUuid, op.getCallerUuid());
+
+        assertEquals("wait timeout set", callerUuidSet, op.isFlagSet(Operation.BITMASK_CALLER_UUID_SET));
+
+        assertSerializationCloneEquals(op);
+    }
+
+    public void assertSerializationCloneEquals(Operation expected) {
+        Operation actual = copy(expected);
+        assertEquals("caller uuid does not match", expected.getCallerUuid(), actual.getCallerUuid());
+        assertEquals("call timeout does not match", expected.getCallTimeout(), actual.getCallTimeout());
+        assertEquals("validates target does not match", expected.validatesTarget(), actual.validatesTarget());
+        assertEquals("callid does not match", expected.getCallId(), actual.getCallId());
+        assertEquals("invocation time does not match", expected.getInvocationTime(), actual.getInvocationTime());
+        assertEquals("partitionId does not match", expected.getPartitionId(), actual.getPartitionId());
+        assertEquals("replica index does not match", expected.getReplicaIndex(), actual.getReplicaIndex());
+        assertEquals("state does not match", expected.getFlags(), actual.getFlags());
+        assertEquals("wait timeout does not match", expected.getWaitTimeout(), actual.getWaitTimeout());
+    }
+
+    private Operation copy(Operation op) {
+        try {
+            BufferObjectDataOutput out = serializationService.createObjectDataOutput(1000);
+            op.writeData(out);
+
+            BufferObjectDataInput in = serializationService.createObjectDataInput(out.toByteArray());
+            Operation copiedOperation = new DummyOperation();
+            copiedOperation.readData(in);
+            return copiedOperation;
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static class DummyOperation extends AbstractOperation {
+        @Override
+        public void run() throws Exception {
+        }
+    }
+}


### PR DESCRIPTION
Operation serialization is now a bit smarter by minimizing amount of data send.
- either the data is not send at all if not set. For example calleruuid or waitTimeout.
- a smaller data type is selected, e.g. a byte/short instead of an int. Or an int instead of a long.

The maximum size will not be bigger than the original implementation. The technique applied is that there was a byte being used for 'validateTarget'. This byte is now the 'flags' byte and contains that field + all the other optimization techniques. So the size of an operation will be equal or smaller than the original implementation.

[edit]
The maximum size can now be 1 byte bigger than before this change since the state field has been upgraded from a byte to a short for future flags without breaking binary compatibility.