### PR TITLE
Responsehandler remoteinvocation singleton

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -278,7 +278,7 @@
     <suppress checks="JavadocType" files="com.hazelcast.spi[\\/]"/>
     <suppress checks="JavadocMethod" files="com.hazelcast.spi[\\/]"/>
     <suppress checks="JavadocVariable" files="com.hazelcast.spi[\\/]"/>
-    <suppress checks="MethodCount|NPathComplexity|MagicNumber" files="com.hazelcast.spi.Operation"/>
+    <suppress checks="MethodCount|NPathComplexity|MagicNumber|DeclarationOrder" files="com.hazelcast.spi.Operation"/>
     <suppress checks="MethodCount" files="com.hazelcast.spi.impl.NodeEngineImpl"/>
     <suppress checks="ClassFanOutComplexity" files="com.hazelcast.spi.impl.NodeEngineImpl"/>
     <suppress checks="ReturnCount" files="com.hazelcast.spi.impl.SpiDataSerializerHook"/>

--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/operations/PostJoinOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/operations/PostJoinOperation.java
@@ -60,7 +60,7 @@ public class PostJoinOperation extends AbstractOperation implements UrgentSystem
                 op.setNodeEngine(nodeEngine)
                         .setResponseHandler(new ResponseHandler() {
                             @Override
-                            public void sendResponse(Object obj) {
+                            public void sendResponse(Operation op, Object obj) {
                                 if (obj instanceof Throwable) {
                                     Throwable t = (Throwable) obj;
                                     ILogger logger = nodeEngine.getLogger(op.getClass());

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/countdownlatch/operations/AwaitOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/countdownlatch/operations/AwaitOperation.java
@@ -19,6 +19,7 @@ package com.hazelcast.concurrent.countdownlatch.operations;
 import com.hazelcast.concurrent.countdownlatch.CountDownLatchDataSerializerHook;
 import com.hazelcast.concurrent.countdownlatch.CountDownLatchService;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.spi.ResponseHandler;
 import com.hazelcast.spi.WaitNotifyKey;
 import com.hazelcast.spi.WaitSupport;
 
@@ -53,7 +54,8 @@ public class AwaitOperation extends BaseCountDownLatchOperation implements WaitS
 
     @Override
     public void onWaitExpire() {
-        getResponseHandler().sendResponse(false);
+        ResponseHandler responseHandler = getResponseHandler();
+        responseHandler.sendResponse(this, false);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockEvictionProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockEvictionProcessor.java
@@ -22,6 +22,7 @@ import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.ObjectNamespace;
+import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.OperationAccessor;
 import com.hazelcast.spi.OperationService;
 import com.hazelcast.spi.ResponseHandler;
@@ -83,7 +84,7 @@ public final class LockEvictionProcessor implements ScheduledEntryProcessor<Data
 
     private class UnlockResponseHandler implements ResponseHandler {
         @Override
-        public void sendResponse(Object obj) {
+        public void sendResponse(Operation op, Object obj) {
             if (obj instanceof Throwable) {
                 Throwable t = (Throwable) obj;
                 if (t instanceof RetryableException) {

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/AwaitOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/AwaitOperation.java
@@ -113,7 +113,7 @@ public class AwaitOperation extends BaseLockOperation
         if (locked) {
             ResponseHandler responseHandler = getResponseHandler();
             // expired & acquired lock, send FALSE
-            responseHandler.sendResponse(false);
+            responseHandler.sendResponse(this, false);
         } else {
             // expired but could not acquire lock, no response atm
             lockStore.registerExpiredAwaitOp(this);

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/LockOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/LockOperation.java
@@ -23,6 +23,7 @@ import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.BackupAwareOperation;
 import com.hazelcast.spi.ObjectNamespace;
 import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.ResponseHandler;
 import com.hazelcast.spi.WaitNotifyKey;
 import com.hazelcast.spi.WaitSupport;
 
@@ -78,6 +79,7 @@ public class LockOperation extends BaseLockOperation implements WaitSupport, Bac
         } else {
             response = Boolean.FALSE;
         }
-        getResponseHandler().sendResponse(response);
+        ResponseHandler responseHandler = getResponseHandler();
+        responseHandler.sendResponse(this, response);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/AcquireOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/AcquireOperation.java
@@ -56,7 +56,7 @@ public class AcquireOperation extends SemaphoreBackupAwareOperation
     @Override
     public void onWaitExpire() {
         ResponseHandler responseHandler = getResponseHandler();
-        responseHandler.sendResponse(false);
+        responseHandler.sendResponse(this, false);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/executor/impl/operations/BaseCallableTaskOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/executor/impl/operations/BaseCallableTaskOperation.java
@@ -26,6 +26,7 @@ import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.HazelcastSerializationException;
 import com.hazelcast.nio.serialization.SerializationServiceImpl;
 import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.ResponseHandler;
 import com.hazelcast.spi.TraceableOperation;
 import com.hazelcast.util.ExceptionUtil;
 
@@ -80,7 +81,8 @@ abstract class BaseCallableTaskOperation extends Operation implements TraceableO
         try {
             return getNodeEngine().toObject(callableData);
         } catch (HazelcastSerializationException e) {
-            getResponseHandler().sendResponse(e);
+            ResponseHandler responseHandler = getResponseHandler();
+            responseHandler.sendResponse(this, e);
             throw ExceptionUtil.rethrow(e);
         }
     }
@@ -95,7 +97,7 @@ abstract class BaseCallableTaskOperation extends Operation implements TraceableO
     @Override
     public final void run() throws Exception {
         DistributedExecutorService service = getService();
-        service.execute(name, uuid, callable, getResponseHandler());
+        service.execute(name, uuid, callable, this);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/BasicRecordStoreLoader.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/BasicRecordStoreLoader.java
@@ -277,7 +277,7 @@ class BasicRecordStoreLoader implements RecordStoreLoader {
         operation.setNodeEngine(nodeEngine);
         operation.setResponseHandler(new ResponseHandler() {
             @Override
-            public void sendResponse(Object obj) {
+            public void sendResponse(Operation op, Object obj) {
                 if (finishedBatchCounter.decrementAndGet() == 0) {
                     loaded.set(true);
                 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/BasePutOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/BasePutOperation.java
@@ -108,7 +108,7 @@ public abstract class BasePutOperation extends LockAwareOperation implements Bac
 
     public void onWaitExpire() {
         final ResponseHandler responseHandler = getResponseHandler();
-        responseHandler.sendResponse(null);
+        responseHandler.sendResponse(this, null);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/BaseRemoveOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/BaseRemoveOperation.java
@@ -22,6 +22,7 @@ import com.hazelcast.map.impl.MapServiceContext;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.BackupAwareOperation;
 import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.ResponseHandler;
 import com.hazelcast.util.Clock;
 
 public abstract class BaseRemoveOperation extends LockAwareOperation implements BackupAwareOperation {
@@ -71,7 +72,8 @@ public abstract class BaseRemoveOperation extends LockAwareOperation implements 
 
     @Override
     public void onWaitExpire() {
-        getResponseHandler().sendResponse(null);
+        ResponseHandler responseHandler = getResponseHandler();
+        responseHandler.sendResponse(this, null);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ContainsKeyOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ContainsKeyOperation.java
@@ -22,6 +22,7 @@ import com.hazelcast.map.impl.MapService;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.DefaultObjectNamespace;
 import com.hazelcast.spi.ReadonlyOperation;
+import com.hazelcast.spi.ResponseHandler;
 import com.hazelcast.spi.WaitNotifyKey;
 import com.hazelcast.spi.WaitSupport;
 
@@ -66,6 +67,7 @@ public class ContainsKeyOperation extends KeyBasedMapOperation implements Readon
 
     @Override
     public void onWaitExpire() {
-        getResponseHandler().sendResponse(new OperationTimeoutException("Cannot read transactionally locked entry!"));
+        ResponseHandler responseHandler = getResponseHandler();
+        responseHandler.sendResponse(this, new OperationTimeoutException("Cannot read transactionally locked entry!"));
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/DeleteOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/DeleteOperation.java
@@ -17,6 +17,7 @@
 package com.hazelcast.map.impl.operation;
 
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.spi.ResponseHandler;
 
 public class DeleteOperation extends BaseRemoveOperation {
     boolean success;
@@ -49,7 +50,8 @@ public class DeleteOperation extends BaseRemoveOperation {
 
     @Override
     public void onWaitExpire() {
-        getResponseHandler().sendResponse(false);
+        ResponseHandler responseHandler = getResponseHandler();
+        responseHandler.sendResponse(this, false);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOperation.java
@@ -37,6 +37,7 @@ import com.hazelcast.nio.serialization.SerializationService;
 import com.hazelcast.spi.BackupAwareOperation;
 import com.hazelcast.spi.EventService;
 import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.ResponseHandler;
 import com.hazelcast.util.Clock;
 
 import java.io.IOException;
@@ -107,7 +108,8 @@ public class EntryOperation extends LockAwareOperation implements BackupAwareOpe
 
     @Override
     public void onWaitExpire() {
-        getResponseHandler().sendResponse(null);
+        ResponseHandler responseHandler = getResponseHandler();
+        responseHandler.sendResponse(this, null);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EvictOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EvictOperation.java
@@ -22,6 +22,7 @@ import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.BackupAwareOperation;
 import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.ResponseHandler;
 
 import java.io.IOException;
 
@@ -50,7 +51,8 @@ public class EvictOperation extends LockAwareOperation implements BackupAwareOpe
 
     @Override
     public void onWaitExpire() {
-        getResponseHandler().sendResponse(false);
+        ResponseHandler responseHandler = getResponseHandler();
+        responseHandler.sendResponse(this, false);
     }
 
     public Operation getBackupOperation() {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/GetEntryViewOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/GetEntryViewOperation.java
@@ -25,6 +25,7 @@ import com.hazelcast.map.impl.RecordStore;
 import com.hazelcast.map.impl.record.Record;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.DefaultObjectNamespace;
+import com.hazelcast.spi.ResponseHandler;
 import com.hazelcast.spi.WaitNotifyKey;
 import com.hazelcast.spi.WaitSupport;
 
@@ -61,7 +62,8 @@ public class GetEntryViewOperation extends KeyBasedMapOperation implements WaitS
 
     @Override
     public void onWaitExpire() {
-        getResponseHandler().sendResponse(new OperationTimeoutException("Cannot read transactionally locked entry!"));
+        ResponseHandler responseHandler = getResponseHandler();
+        responseHandler.sendResponse(this, new OperationTimeoutException("Cannot read transactionally locked entry!"));
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/GetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/GetOperation.java
@@ -24,6 +24,7 @@ import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.DefaultObjectNamespace;
 import com.hazelcast.spi.ReadonlyOperation;
+import com.hazelcast.spi.ResponseHandler;
 import com.hazelcast.spi.WaitNotifyKey;
 import com.hazelcast.spi.WaitSupport;
 
@@ -61,7 +62,8 @@ public final class GetOperation extends KeyBasedMapOperation
 
     @Override
     public void onWaitExpire() {
-        getResponseHandler().sendResponse(new OperationTimeoutException("Cannot read transactionally locked entry!"));
+        ResponseHandler responseHandler = getResponseHandler();
+        responseHandler.sendResponse(this, new OperationTimeoutException("Cannot read transactionally locked entry!"));
     }
     @Override
     public Object getResponse() {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutTransientOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutTransientOperation.java
@@ -17,6 +17,7 @@
 package com.hazelcast.map.impl.operation;
 
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.spi.ResponseHandler;
 
 public class PutTransientOperation extends BasePutOperation {
 
@@ -38,7 +39,8 @@ public class PutTransientOperation extends BasePutOperation {
 
     @Override
     public void onWaitExpire() {
-        getResponseHandler().sendResponse(null);
+        ResponseHandler responseHandler = getResponseHandler();
+        responseHandler.sendResponse(this, null);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/RemoveIfSameOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/RemoveIfSameOperation.java
@@ -19,6 +19,7 @@ package com.hazelcast.map.impl.operation;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.spi.ResponseHandler;
 
 import java.io.IOException;
 
@@ -68,7 +69,8 @@ public class RemoveIfSameOperation extends BaseRemoveOperation {
 
     @Override
     public void onWaitExpire() {
-        getResponseHandler().sendResponse(null);
+        ResponseHandler responseHandler = getResponseHandler();
+        responseHandler.sendResponse(this, null);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ReplaceIfSameOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ReplaceIfSameOperation.java
@@ -19,6 +19,7 @@ package com.hazelcast.map.impl.operation;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.spi.ResponseHandler;
 
 import java.io.IOException;
 
@@ -58,7 +59,8 @@ public class ReplaceIfSameOperation extends BasePutOperation {
 
     @Override
     public void onWaitExpire() {
-        getResponseHandler().sendResponse(false);
+        ResponseHandler responseHandler = getResponseHandler();
+        responseHandler.sendResponse(this, false);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/TryPutOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/TryPutOperation.java
@@ -17,6 +17,7 @@
 package com.hazelcast.map.impl.operation;
 
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.spi.ResponseHandler;
 
 public class TryPutOperation extends BasePutOperation {
 
@@ -45,7 +46,8 @@ public class TryPutOperation extends BasePutOperation {
     }
 
     public void onWaitExpire() {
-        getResponseHandler().sendResponse(false);
+        ResponseHandler responseHandler = getResponseHandler();
+        responseHandler.sendResponse(this, false);
     }
 
     public Object getResponse() {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/TryRemoveOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/TryRemoveOperation.java
@@ -19,6 +19,7 @@ package com.hazelcast.map.impl.operation;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.spi.ResponseHandler;
 
 import java.io.IOException;
 
@@ -64,7 +65,8 @@ public class TryRemoveOperation extends BaseRemoveOperation {
     }
 
     public void onWaitExpire() {
-        getResponseHandler().sendResponse(false);
+        ResponseHandler responseHandler = getResponseHandler();
+        responseHandler.sendResponse(this, false);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/WanOriginatedDeleteOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/WanOriginatedDeleteOperation.java
@@ -18,6 +18,7 @@ package com.hazelcast.map.impl.operation;
 
 import com.hazelcast.core.EntryEventType;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.spi.ResponseHandler;
 
 public class WanOriginatedDeleteOperation extends BaseRemoveOperation {
 
@@ -56,7 +57,8 @@ public class WanOriginatedDeleteOperation extends BaseRemoveOperation {
 
     @Override
     public void onWaitExpire() {
-        getResponseHandler().sendResponse(false);
+        ResponseHandler responseHandler = getResponseHandler();
+        responseHandler.sendResponse(this, false);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnDeleteOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnDeleteOperation.java
@@ -77,7 +77,7 @@ public class TxnDeleteOperation extends BaseRemoveOperation implements MapTxnOpe
     @Override
     public void onWaitExpire() {
         final ResponseHandler responseHandler = getResponseHandler();
-        responseHandler.sendResponse(false);
+        responseHandler.sendResponse(this, false);
     }
 
     public long getVersion() {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnLockAndGetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnLockAndGetOperation.java
@@ -59,7 +59,7 @@ public class TxnLockAndGetOperation extends LockAwareOperation {
     @Override
     public void onWaitExpire() {
         final ResponseHandler responseHandler = getResponseHandler();
-        responseHandler.sendResponse(null);
+        responseHandler.sendResponse(this, null);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnSetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnSetOperation.java
@@ -117,7 +117,7 @@ public class TxnSetOperation extends BasePutOperation implements MapTxnOperation
 
     public void onWaitExpire() {
         final ResponseHandler responseHandler = getResponseHandler();
-        responseHandler.sendResponse(false);
+        responseHandler.sendResponse(this, false);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnUnlockOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnUnlockOperation.java
@@ -85,7 +85,7 @@ public class TxnUnlockOperation extends LockAwareOperation implements MapTxnOper
 
     public void onWaitExpire() {
         final ResponseHandler responseHandler = getResponseHandler();
-        responseHandler.sendResponse(false);
+        responseHandler.sendResponse(this, false);
     }
 
     public final int getAsyncBackupCount() {

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/ContainsEntryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/ContainsEntryOperation.java
@@ -25,6 +25,7 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.DefaultObjectNamespace;
+import com.hazelcast.spi.ResponseHandler;
 import com.hazelcast.spi.WaitNotifyKey;
 import com.hazelcast.spi.WaitSupport;
 import java.io.IOException;
@@ -110,6 +111,7 @@ public class ContainsEntryOperation extends MultiMapOperation implements WaitSup
 
     @Override
     public void onWaitExpire() {
-        getResponseHandler().sendResponse(new OperationTimeoutException("Cannot read transactionally locked entry!"));
+        ResponseHandler responseHandler = getResponseHandler();
+        responseHandler.sendResponse(this, new OperationTimeoutException("Cannot read transactionally locked entry!"));
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/CountOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/CountOperation.java
@@ -24,6 +24,7 @@ import com.hazelcast.multimap.impl.MultiMapService;
 import com.hazelcast.multimap.impl.MultiMapWrapper;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.DefaultObjectNamespace;
+import com.hazelcast.spi.ResponseHandler;
 import com.hazelcast.spi.WaitNotifyKey;
 import com.hazelcast.spi.WaitSupport;
 
@@ -63,7 +64,8 @@ public class CountOperation extends MultiMapKeyBasedOperation implements WaitSup
 
     @Override
     public void onWaitExpire() {
-        getResponseHandler().sendResponse(new OperationTimeoutException("Cannot read transactionally locked entry!"));
+        ResponseHandler responseHandler = getResponseHandler();
+        responseHandler.sendResponse(this, new OperationTimeoutException("Cannot read transactionally locked entry!"));
     }
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/GetAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/GetAllOperation.java
@@ -70,6 +70,7 @@ public class GetAllOperation extends MultiMapKeyBasedOperation implements WaitSu
 
     @Override
     public void onWaitExpire() {
-        getResponseHandler().sendResponse(new OperationTimeoutException("Cannot read transactionally locked entry!"));
+        ResponseHandler responseHandler = getResponseHandler();
+        responseHandler.sendResponse(this, new OperationTimeoutException("Cannot read transactionally locked entry!"));
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/MultiMapBackupAwareOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/MultiMapBackupAwareOperation.java
@@ -23,6 +23,7 @@ import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.BackupAwareOperation;
 import com.hazelcast.spi.DefaultObjectNamespace;
+import com.hazelcast.spi.ResponseHandler;
 import com.hazelcast.spi.WaitNotifyKey;
 import com.hazelcast.spi.WaitSupport;
 import java.io.IOException;
@@ -59,6 +60,7 @@ public abstract class MultiMapBackupAwareOperation extends MultiMapKeyBasedOpera
     }
 
     public void onWaitExpire() {
-        getResponseHandler().sendResponse(null);
+        ResponseHandler responseHandler = getResponseHandler();
+        responseHandler.sendResponse(this, null);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/PutOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/PutOperation.java
@@ -24,6 +24,8 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.ResponseHandler;
+
 import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
@@ -75,7 +77,8 @@ public class PutOperation extends MultiMapBackupAwareOperation {
     }
 
     public void onWaitExpire() {
-        getResponseHandler().sendResponse(false);
+        ResponseHandler responseHandler = getResponseHandler();
+        responseHandler.sendResponse(this, false);
     }
 
     protected void writeInternal(ObjectDataOutput out) throws IOException {

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/RemoveAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/RemoveAllOperation.java
@@ -23,6 +23,7 @@ import com.hazelcast.multimap.impl.MultiMapDataSerializerHook;
 import com.hazelcast.multimap.impl.MultiMapRecord;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.ResponseHandler;
 
 import java.util.Collection;
 
@@ -63,7 +64,8 @@ public class RemoveAllOperation extends MultiMapBackupAwareOperation {
     public void onWaitExpire() {
         MultiMapContainer container = getOrCreateContainer();
         MultiMapConfig.ValueCollectionType valueCollectionType = getValueCollectionType(container);
-        getResponseHandler().sendResponse(new MultiMapResponse(null, valueCollectionType));
+        ResponseHandler responseHandler = getResponseHandler();
+        responseHandler.sendResponse(this, new MultiMapResponse(null, valueCollectionType));
     }
 
     public int getId() {

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/RemoveOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/RemoveOperation.java
@@ -24,6 +24,8 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.ResponseHandler;
+
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Iterator;
@@ -80,7 +82,8 @@ public class RemoveOperation extends MultiMapBackupAwareOperation {
     }
 
     public void onWaitExpire() {
-        getResponseHandler().sendResponse(false);
+        ResponseHandler responseHandler = getResponseHandler();
+        responseHandler.sendResponse(this, false);
     }
 
     protected void writeInternal(ObjectDataOutput out) throws IOException {

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnLockAndGetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnLockAndGetOperation.java
@@ -28,6 +28,7 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.DefaultObjectNamespace;
+import com.hazelcast.spi.ResponseHandler;
 import com.hazelcast.spi.WaitNotifyKey;
 import com.hazelcast.spi.WaitSupport;
 import com.hazelcast.transaction.TransactionException;
@@ -70,7 +71,8 @@ public class TxnLockAndGetOperation extends MultiMapKeyBasedOperation implements
     }
 
     public void onWaitExpire() {
-        getResponseHandler().sendResponse(null);
+        ResponseHandler responseHandler = getResponseHandler();
+        responseHandler.sendResponse(this, null);
     }
 
     protected void writeInternal(ObjectDataOutput out) throws IOException {

--- a/hazelcast/src/main/java/com/hazelcast/partition/impl/MigrationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/impl/MigrationOperation.java
@@ -42,7 +42,7 @@ public final class MigrationOperation extends BaseMigrationOperation {
 
     private static final ResponseHandler ERROR_RESPONSE_HANDLER = new ResponseHandler() {
         @Override
-        public void sendResponse(Object obj) {
+        public void sendResponse(Operation op, Object obj) {
             throw new HazelcastException("Migration operations can not send response!");
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/partition/impl/MigrationRequestOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/impl/MigrationRequestOperation.java
@@ -146,7 +146,7 @@ public final class MigrationRequestOperation extends BaseMigrationOperation {
 
         nodeEngine.getOperationService()
                 .createInvocationBuilder(InternalPartitionService.SERVICE_NAME, operation, destination)
-                .setCallback(new MigrationCallback(migrationInfo, getResponseHandler()))
+                .setCallback(new MigrationCallback(migrationInfo, getResponseHandler(), this))
                 .setResultDeserialized(true)
                 .setCallTimeout(partitionService.getPartitionMigrationTimeout())
                 .setTryPauseMillis(TRY_PAUSE_MILLIS)
@@ -210,18 +210,20 @@ public final class MigrationRequestOperation extends BaseMigrationOperation {
 
     private static final class MigrationCallback implements Callback<Object> {
 
-        final MigrationInfo migrationInfo;
-        final ResponseHandler responseHandler;
+        private final MigrationInfo migrationInfo;
+        private final ResponseHandler responseHandler;
+        private final MigrationRequestOperation op;
 
-        private MigrationCallback(MigrationInfo migrationInfo, ResponseHandler responseHandler) {
+        private MigrationCallback(MigrationInfo migrationInfo, ResponseHandler responseHandler, MigrationRequestOperation op) {
             this.migrationInfo = migrationInfo;
             this.responseHandler = responseHandler;
+            this.op = op;
         }
 
         @Override
         public void notify(Object result) {
             migrationInfo.doneProcessing();
-            responseHandler.sendResponse(result);
+            responseHandler.sendResponse(op, result);
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/partition/impl/ReplicaSyncResponse.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/impl/ReplicaSyncResponse.java
@@ -200,7 +200,7 @@ public class ReplicaSyncResponse extends Operation
         }
 
         @Override
-        public void sendResponse(final Object obj) {
+        public void sendResponse(Operation op, Object obj) {
             if (obj instanceof Throwable) {
                 Throwable t = (Throwable) obj;
                 logger.severe(t);

--- a/hazelcast/src/main/java/com/hazelcast/queue/impl/operations/OfferOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/queue/impl/operations/OfferOperation.java
@@ -26,6 +26,7 @@ import com.hazelcast.queue.impl.QueueContainer;
 import com.hazelcast.queue.impl.QueueDataSerializerHook;
 import com.hazelcast.spi.Notifier;
 import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.ResponseHandler;
 import com.hazelcast.spi.WaitNotifyKey;
 import com.hazelcast.spi.WaitSupport;
 
@@ -103,7 +104,8 @@ public final class OfferOperation extends QueueBackupAwareOperation
 
     @Override
     public void onWaitExpire() {
-        getResponseHandler().sendResponse(Boolean.FALSE);
+        ResponseHandler responseHandler = getResponseHandler();
+        responseHandler.sendResponse(this, Boolean.FALSE);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/queue/impl/operations/PollOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/queue/impl/operations/PollOperation.java
@@ -23,6 +23,7 @@ import com.hazelcast.queue.impl.QueueDataSerializerHook;
 import com.hazelcast.queue.impl.QueueItem;
 import com.hazelcast.spi.Notifier;
 import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.ResponseHandler;
 import com.hazelcast.spi.WaitNotifyKey;
 import com.hazelcast.spi.WaitSupport;
 
@@ -92,7 +93,8 @@ public final class PollOperation extends QueueBackupAwareOperation
 
     @Override
     public void onWaitExpire() {
-        getResponseHandler().sendResponse(null);
+        ResponseHandler responseHandler = getResponseHandler();
+        responseHandler.sendResponse(this, null);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/queue/impl/tx/TxnReserveOfferOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/queue/impl/tx/TxnReserveOfferOperation.java
@@ -22,6 +22,7 @@ import com.hazelcast.queue.impl.operations.QueueBackupAwareOperation;
 import com.hazelcast.queue.impl.QueueContainer;
 import com.hazelcast.queue.impl.QueueDataSerializerHook;
 import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.ResponseHandler;
 import com.hazelcast.spi.WaitNotifyKey;
 import com.hazelcast.spi.WaitSupport;
 
@@ -67,7 +68,8 @@ public class TxnReserveOfferOperation extends QueueBackupAwareOperation implemen
 
     @Override
     public void onWaitExpire() {
-        getResponseHandler().sendResponse(null);
+        ResponseHandler responseHandler = getResponseHandler();
+        responseHandler.sendResponse(this, null);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/queue/impl/tx/TxnReservePollOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/queue/impl/tx/TxnReservePollOperation.java
@@ -23,6 +23,7 @@ import com.hazelcast.queue.impl.QueueContainer;
 import com.hazelcast.queue.impl.QueueDataSerializerHook;
 import com.hazelcast.queue.impl.QueueItem;
 import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.ResponseHandler;
 import com.hazelcast.spi.WaitNotifyKey;
 import com.hazelcast.spi.WaitSupport;
 
@@ -65,7 +66,8 @@ public class TxnReservePollOperation extends QueueBackupAwareOperation implement
 
     @Override
     public void onWaitExpire() {
-        getResponseHandler().sendResponse(null);
+        ResponseHandler responseHandler = getResponseHandler();
+        responseHandler.sendResponse(this, null);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/spi/OperationAccessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/OperationAccessor.java
@@ -33,6 +33,14 @@ public final class OperationAccessor {
     private OperationAccessor() {
     }
 
+    public static boolean setResponseSend(Operation op) {
+        return op.setResponseSend();
+    }
+
+    public static void resetResponseSend(Operation op) {
+        op.resetResponseSend();
+    }
+
     public static boolean isJoinOperation(Operation op) {
         return op instanceof JoinOperation
                 && op.getClass().getClassLoader() == THIS_CLASS_LOADER;

--- a/hazelcast/src/main/java/com/hazelcast/spi/ResponseHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/ResponseHandler.java
@@ -22,7 +22,7 @@ package com.hazelcast.spi;
  */
 public interface ResponseHandler {
 
-    void sendResponse(Object obj);
+    void sendResponse(Operation op, Object obj);
 
     boolean isLocal();
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/IsStillExecutingOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/IsStillExecutingOperation.java
@@ -3,6 +3,7 @@ package com.hazelcast.spi.impl;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.spi.AbstractOperation;
+import com.hazelcast.spi.ResponseHandler;
 import com.hazelcast.spi.UrgentSystemOperation;
 
 import java.io.IOException;
@@ -28,7 +29,8 @@ public class IsStillExecutingOperation extends AbstractOperation implements Urge
         BasicOperationService operationService = (BasicOperationService) nodeEngine.operationService;
         BasicOperationScheduler scheduler = operationService.scheduler;
         boolean executing = scheduler.isOperationExecuting(getCallerAddress(), getPartitionId(), operationCallId);
-        getResponseHandler().sendResponse(executing);
+        ResponseHandler responseHandler = getResponseHandler();
+        responseHandler.sendResponse(this, executing);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/PartitionIteratingOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/PartitionIteratingOperation.java
@@ -102,7 +102,7 @@ public final class PartitionIteratingOperation extends AbstractOperation impleme
         final BlockingQueue b = ResponseQueueFactory.newResponseQueue();
 
         @Override
-        public void sendResponse(Object obj) {
+        public void sendResponse(Operation op, Object obj) {
             if (!b.offer(obj)) {
                 throw new HazelcastException("Response could not be queued for transportation");
             }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/ResponseHandlerFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/ResponseHandlerFactory.java
@@ -22,7 +22,6 @@ import com.hazelcast.nio.Connection;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.OperationAccessor;
-import com.hazelcast.spi.OperationService;
 import com.hazelcast.spi.ResponseHandler;
 import com.hazelcast.spi.exception.ResponseAlreadySentException;
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/ResponseHandlerFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/ResponseHandlerFactory.java
@@ -21,32 +21,21 @@ import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.OperationAccessor;
+import com.hazelcast.spi.OperationService;
 import com.hazelcast.spi.ResponseHandler;
 import com.hazelcast.spi.exception.ResponseAlreadySentException;
-
-import java.util.concurrent.atomic.AtomicBoolean;
 
 public final class ResponseHandlerFactory {
 
     private static final NoResponseHandler NO_RESPONSE_HANDLER = new NoResponseHandler();
+    private static final RemoteInvocationResponseHandler REMOTE_RESPONSE_HANDLER = new RemoteInvocationResponseHandler();
 
     private ResponseHandlerFactory() {
     }
 
-    public static void setRemoteResponseHandler(NodeEngine nodeEngine, Operation operation) {
-        ResponseHandler responseHandler = createRemoteResponseHandler(nodeEngine, operation);
-        operation.setResponseHandler(responseHandler);
-    }
-
-    public static ResponseHandler createRemoteResponseHandler(NodeEngine nodeEngine, Operation operation) {
-        if (operation.getCallId() == 0) {
-            if (operation.returnsResponse()) {
-                throw new HazelcastException(
-                        "Op: " + operation.getClass().getName() + " can not return response without call-id!");
-            }
-            return NO_RESPONSE_HANDLER;
-        }
-        return new RemoteInvocationResponseHandler(nodeEngine, operation);
+    public static ResponseHandler createRemoteResponseHandler() {
+        return REMOTE_RESPONSE_HANDLER;
     }
 
     public static ResponseHandler createEmptyResponseHandler() {
@@ -57,7 +46,7 @@ public final class ResponseHandlerFactory {
             implements ResponseHandler {
 
         @Override
-        public void sendResponse(final Object obj) {
+        public void sendResponse(Operation op, Object obj) {
         }
 
         @Override
@@ -78,7 +67,7 @@ public final class ResponseHandlerFactory {
         }
 
         @Override
-        public void sendResponse(final Object obj) {
+        public void sendResponse(Operation op, Object obj) {
             if (obj instanceof Throwable) {
                 Throwable t = (Throwable) obj;
                 logger.severe(t);
@@ -91,33 +80,25 @@ public final class ResponseHandlerFactory {
         }
     }
 
-    private static final class RemoteInvocationResponseHandler implements ResponseHandler {
-
-        private final NodeEngine nodeEngine;
-        private final Operation operation;
-        private final AtomicBoolean sent = new AtomicBoolean(false);
-
-        private RemoteInvocationResponseHandler(NodeEngine nodeEngine, Operation operation) {
-            this.nodeEngine = nodeEngine;
-            this.operation = operation;
-        }
+    public static final class RemoteInvocationResponseHandler implements ResponseHandler {
 
         @Override
-        public void sendResponse(Object obj) {
+        public void sendResponse(Operation operation, Object obj) {
             long callId = operation.getCallId();
             Connection conn = operation.getConnection();
-            if (!sent.compareAndSet(false, true) && !(obj instanceof Throwable)) {
+            if (!OperationAccessor.setResponseSend(operation) && !(obj instanceof Throwable)) {
                 throw new ResponseAlreadySentException("NormalResponse already sent for call: " + callId
                         + " to " + conn.getEndPoint() + ", current-response: " + obj);
             }
 
             Response response;
             if (!(obj instanceof Response)) {
-                response = new NormalResponse(obj, operation.getCallId(), 0, operation.isUrgent());
+                response = new NormalResponse(obj, callId, 0, operation.isUrgent());
             } else {
                 response = (Response) obj;
             }
 
+            NodeEngine nodeEngine = operation.getNodeEngine();
             InternalOperationService operationService = (InternalOperationService) nodeEngine.getOperationService();
             if (!operationService.send(response, operation.getCallerAddress())) {
                 throw new HazelcastException("Cannot send response: " + obj + " to " + conn.getEndPoint());

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/TraceableIsStillExecutingOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/TraceableIsStillExecutingOperation.java
@@ -3,6 +3,7 @@ package com.hazelcast.spi.impl;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.spi.AbstractOperation;
+import com.hazelcast.spi.ResponseHandler;
 import com.hazelcast.spi.UrgentSystemOperation;
 
 import java.io.IOException;
@@ -26,7 +27,8 @@ public class TraceableIsStillExecutingOperation extends AbstractOperation implem
         BasicOperationService operationService = (BasicOperationService) nodeEngine.operationService;
         boolean executing = operationService.isOperationExecuting(getCallerAddress(), getCallerUuid(),
                 serviceName, identifier);
-        getResponseHandler().sendResponse(executing);
+        ResponseHandler responseHandler = getResponseHandler();
+        responseHandler.sendResponse(this, executing);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/WaitNotifyServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/WaitNotifyServiceImpl.java
@@ -26,6 +26,7 @@ import com.hazelcast.spi.AbstractOperation;
 import com.hazelcast.spi.Notifier;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.PartitionAwareOperation;
+import com.hazelcast.spi.ResponseHandler;
 import com.hazelcast.spi.WaitNotifyKey;
 import com.hazelcast.spi.WaitNotifyService;
 import com.hazelcast.spi.WaitSupport;
@@ -191,7 +192,8 @@ class WaitNotifyServiceImpl implements WaitNotifyService {
                             waitingOp.setValid(false);
                             PartitionMigratingException pme = new PartitionMigratingException(thisAddress,
                                     partitionId, op.getClass().getName(), op.getServiceName());
-                            op.getResponseHandler().sendResponse(pme);
+                            ResponseHandler responseHandler = op.getResponseHandler();
+                            responseHandler.sendResponse(op, pme);
                             it.remove();
                         }
                     }
@@ -227,7 +229,8 @@ class WaitNotifyServiceImpl implements WaitNotifyService {
                     // only for local invocations, remote ones will be expired via #onMemberLeft()
                     if (thisAddress.equals(op.getCallerAddress())) {
                         try {
-                            op.getResponseHandler().sendResponse(response);
+                            ResponseHandler responseHandler = op.getResponseHandler();
+                            responseHandler.sendResponse(op, response);
                         } catch (Exception e) {
                             logger.finest("While sending HazelcastInstanceNotActiveException response...", e);
                         }
@@ -340,7 +343,8 @@ class WaitNotifyServiceImpl implements WaitNotifyService {
             if (expired) {
                 waitSupport.onWaitExpire();
             } else {
-                op.getResponseHandler().sendResponse(cancelResponse);
+                ResponseHandler responseHandler = op.getResponseHandler();
+                responseHandler.sendResponse(op, cancelResponse);
             }
         }
 


### PR DESCRIPTION
The responsehandler provides a flexible design, but the current implementation causes quite some object litter (2 objects per remote invocation). This PR cleans up the API by making the RemoteResponseHandler a singleton. To provide access to the Operation-context, the operation is passed into the handleResponse method.

This pr depends on the following pr to get merged first:
https://github.com/hazelcast/hazelcast/pull/4485

This pr is the basis for some additional cleanup. One of the things that is the OperationService.sendResponse methods:
- get rid of the response; needed for removing the response-thread
- pass in connection to the sendResponse method so that you don't send in the address and then lookup the connection, if the connection already is at hand.

This is an API breaking method; but to get rid of the response-thread, modifications need to be done anyway to the response-handler. 