### PR TITLE
MapLoaderLifecycleSupport for MapLoader

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapStoreWrapper.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapStoreWrapper.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.map.impl;
 
+import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.MapLoader;
 import com.hazelcast.core.MapLoaderLifecycleSupport;
 import com.hazelcast.core.MapStore;
@@ -25,9 +26,10 @@ import com.hazelcast.query.impl.ReflectionHelper;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Properties;
 
 @SuppressWarnings("unchecked")
-public class MapStoreWrapper implements MapStore {
+public class MapStoreWrapper implements MapStore, MapLoaderLifecycleSupport {
 
     private final MapLoader mapLoader;
 
@@ -57,10 +59,17 @@ public class MapStoreWrapper implements MapStore {
         return mapStore;
     }
 
-
+    @Override
     public void destroy() {
         if (impl instanceof MapLoaderLifecycleSupport) {
             ((MapLoaderLifecycleSupport) impl).destroy();
+        }
+    }
+
+    @Override
+    public void init(HazelcastInstance hazelcastInstance, Properties properties, String mapName) {
+        if (impl instanceof MapLoaderLifecycleSupport) {
+            ((MapLoaderLifecycleSupport) impl).init(hazelcastInstance, properties, mapName);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/BasicMapStoreContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/BasicMapStoreContext.java
@@ -21,8 +21,6 @@ import com.hazelcast.config.MapConfig;
 import com.hazelcast.config.MapStoreConfig;
 import com.hazelcast.config.MaxSizeConfig;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.MapLoaderLifecycleSupport;
-import com.hazelcast.core.MapStore;
 import com.hazelcast.core.PartitioningStrategy;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.map.impl.MapContainer;
@@ -206,11 +204,6 @@ final class BasicMapStoreContext implements MapStoreContext {
 
     private static void callLifecycleSupportInit(MapStoreContext mapStoreContext) {
         final MapStoreWrapper mapStoreWrapper = mapStoreContext.getMapStoreWrapper();
-        final MapStore store = mapStoreWrapper.getMapStore();
-        if (!(store instanceof MapLoaderLifecycleSupport)) {
-            return;
-        }
-
         final MapServiceContext mapServiceContext = mapStoreContext.getMapServiceContext();
         final NodeEngine nodeEngine = mapServiceContext.getNodeEngine();
         final HazelcastInstance hazelcastInstance = nodeEngine.getHazelcastInstance();
@@ -218,8 +211,7 @@ final class BasicMapStoreContext implements MapStoreContext {
         final Properties properties = mapStoreConfig.getProperties();
         final String mapName = mapStoreContext.getMapName();
 
-        final MapLoaderLifecycleSupport mapLoaderLifecycleSupport = (MapLoaderLifecycleSupport) store;
-        mapLoaderLifecycleSupport.init(hazelcastInstance, properties, mapName);
+        mapStoreWrapper.init(hazelcastInstance, properties, mapName);
     }
 
     private void loadInitialKeys() {

--- a/hazelcast/src/test/java/com/hazelcast/map/mapstore/MapLoaderLifecycleTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/mapstore/MapLoaderLifecycleTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hazelcast.map.mapstore;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.MapStoreConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.MapLoader;
+import com.hazelcast.core.MapLoaderLifecycleSupport;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.QuickTest;
+
+import java.util.Properties;
+
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.withSettings;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category(QuickTest.class)
+public class MapLoaderLifecycleTest extends HazelcastTestSupport {
+
+    private MapLoaderLifecycleSupport loader = mockMapLoaderWithLifecycle();
+    private Config config = new Config();
+
+    @Before
+    public void configure() {
+        config.getMapConfig("map").setMapStoreConfig(new MapStoreConfig().setImplementation(loader));
+    }
+
+    @Test
+    public void testInitCalled_whenMapCreated() throws Exception {
+
+        HazelcastInstance hz = createHazelcastInstance(config);
+
+        hz.getMap("map");
+
+        verify(loader).init(eq(hz), eq(new Properties()), eq("map"));
+    }
+
+    @Test
+    public void testDestroyCalled_whenNodeShutdown() throws Exception {
+
+        HazelcastInstance hz = createHazelcastInstance(config);
+
+        hz.getMap("map");
+        hz.shutdown();
+
+        verify(loader).destroy();
+    }
+
+    private static MapLoaderLifecycleSupport mockMapLoaderWithLifecycle() {
+        return mock(MapLoaderLifecycleSupport.class, withSettings().extraInterfaces(MapLoader.class));
+    }
+}


### PR DESCRIPTION
With this change MapLoader.init is called if MapLoader implements MapLoaderLifecycleSupport
closes https://github.com/hazelcast/hazelcast/issues/4623