### PR TITLE
Deprecated PartitionAwareOperation 

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/operations/PostJoinOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/operations/PostJoinOperation.java
@@ -24,7 +24,6 @@ import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.OperationAccessor;
 import com.hazelcast.spi.OperationService;
-import com.hazelcast.spi.PartitionAwareOperation;
 import com.hazelcast.spi.ResponseHandler;
 import com.hazelcast.spi.UrgentSystemOperation;
 

--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/operations/PostJoinOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/operations/PostJoinOperation.java
@@ -43,8 +43,8 @@ public class PostJoinOperation extends AbstractOperation implements UrgentSystem
             if (op == null) {
                 throw new NullPointerException();
             }
-            if (op instanceof PartitionAwareOperation) {
-                throw new IllegalArgumentException("Post join operation can not be a PartitionAwareOperation!");
+            if (op.getPartitionId() >= 0) {
+                throw new IllegalArgumentException("Post join operation can not have a partition-id!");
             }
         }
         // we may need to do array copy!

--- a/hazelcast/src/main/java/com/hazelcast/spi/PartitionAwareOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/PartitionAwareOperation.java
@@ -20,6 +20,12 @@ package com.hazelcast.spi;
  * An interface that can be implemented by an operation to indicate that is should
  * be invoked on a particular partition.
  *
+ * This interface only has means for documentation purposes. Because every operation has a {@link Operation#getPartitionId()}
+ * method, the system will use that to determine if an Operation is partition-aware. So the system is fine if you create
+ * an Operation that doesn't implements PartitionAwareOperation, but returns a partitionId equal or larger than 0 (and therefor is
+ * partition-specific). But it is also fine if you do implement this PartitionAwareOperation interface, and return -1 as
+ * partition-id (and therefor is not specific to a partition).
+ *
  * @author mdogan 12/3/12
  */
 public interface PartitionAwareOperation {
@@ -28,6 +34,7 @@ public interface PartitionAwareOperation {
      * Gets the partition id.
      *
      * @return the partition id
+     * @see Operation#getPartitionId()
      */
     int getPartitionId();
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/BasicOperationScheduler.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/BasicOperationScheduler.java
@@ -194,16 +194,12 @@ public final class BasicOperationScheduler {
         return true;
     }
 
-    int getPartitionIdForExecution(Operation op) {
-        return op instanceof PartitionAwareOperation ? op.getPartitionId() : -1;
-    }
-
     boolean isAllowedToRunInCurrentThread(Operation op) {
-        return isAllowedToRunInCurrentThread(getPartitionIdForExecution(op));
+        return isAllowedToRunInCurrentThread(op.getPartitionId());
     }
 
     boolean isInvocationAllowedFromCurrentThread(Operation op) {
-        return isInvocationAllowedFromCurrentThread(getPartitionIdForExecution(op));
+        return isInvocationAllowedFromCurrentThread(op.getPartitionId());
     }
 
     private boolean isAllowedToRunInCurrentThread(int partitionId) {
@@ -304,7 +300,7 @@ public final class BasicOperationScheduler {
     public void execute(Operation op) {
         String executorName = op.getExecutorName();
         if (executorName == null) {
-            int partitionId = getPartitionIdForExecution(op);
+            int partitionId = op.getPartitionId();
             boolean hasPriority = op.isUrgent();
             execute(op, partitionId, hasPriority);
         } else {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/BasicOperationScheduler.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/BasicOperationScheduler.java
@@ -24,7 +24,6 @@ import com.hazelcast.nio.NIOThread;
 import com.hazelcast.nio.Packet;
 import com.hazelcast.spi.ExecutionService;
 import com.hazelcast.spi.Operation;
-import com.hazelcast.spi.PartitionAwareOperation;
 import com.hazelcast.spi.UrgentSystemOperation;
 import com.hazelcast.spi.annotation.PrivateApi;
 import com.hazelcast.util.executor.HazelcastManagedThread;

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/BasicOperationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/BasicOperationService.java
@@ -338,7 +338,7 @@ final class BasicOperationService implements InternalOperationService {
             throw new IllegalArgumentException("Target is this node! -> " + target + ", op: " + op);
         }
         Data data = nodeEngine.toData(op);
-        int partitionId = scheduler.getPartitionIdForExecution(op);
+        int partitionId = op.getPartitionId();
         Packet packet = new Packet(data, partitionId, nodeEngine.getPortableContext());
         packet.setHeader(Packet.HEADER_OP);
         if (op instanceof UrgentSystemOperation) {
@@ -670,13 +670,9 @@ final class BasicOperationService implements InternalOperationService {
         }
 
         private void ensureNoPartitionProblems(Operation op) {
-            if (!(op instanceof PartitionAwareOperation)) {
-                return;
-            }
-
             int partitionId = op.getPartitionId();
             if (partitionId < 0) {
-                throw new IllegalArgumentException("Partition id cannot be negative! -> " + partitionId);
+                return;
             }
 
             InternalPartition internalPartition = nodeEngine.getPartitionService().getPartition(partitionId);

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/BasicOperationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/BasicOperationService.java
@@ -41,7 +41,6 @@ import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.OperationAccessor;
 import com.hazelcast.spi.OperationFactory;
 import com.hazelcast.spi.OperationService;
-import com.hazelcast.spi.PartitionAwareOperation;
 import com.hazelcast.spi.ReadonlyOperation;
 import com.hazelcast.spi.UrgentSystemOperation;
 import com.hazelcast.spi.WaitSupport;

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
@@ -38,7 +38,6 @@ import com.hazelcast.spi.ExecutionService;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.OperationService;
-import com.hazelcast.spi.PartitionAwareOperation;
 import com.hazelcast.spi.PostJoinAwareService;
 import com.hazelcast.spi.ProxyService;
 import com.hazelcast.spi.ServiceInfo;

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
@@ -357,15 +357,15 @@ public class NodeEngineImpl implements NodeEngine {
         }
         Collection<PostJoinAwareService> services = getServices(PostJoinAwareService.class);
         for (PostJoinAwareService service : services) {
-            final Operation pjOp = service.getPostJoinOperation();
-            if (pjOp != null) {
-                if (pjOp instanceof PartitionAwareOperation) {
+            final Operation postJoinOperation = service.getPostJoinOperation();
+            if (postJoinOperation != null) {
+                if (postJoinOperation.getPartitionId() >= 0) {
                     logger.severe(
                             "Post-join operations cannot implement PartitionAwareOperation! Service: " + service + ", Operation: "
-                                    + pjOp);
+                                    + postJoinOperation);
                     continue;
                 }
-                postJoinOps.add(pjOp);
+                postJoinOps.add(postJoinOperation);
             }
         }
         return postJoinOps.isEmpty() ? null : postJoinOps.toArray(new Operation[postJoinOps.size()]);


### PR DESCRIPTION
Since it already provided by the Operation.getPartitionId method which is always available.

So people can still use the interface, but it will just be ignored by the system. The only thing the system cares about is the value of the getPartitionid method. If >=0, then partition specific, if <0, then 'generic'.