### PR TITLE
Dangling connection removed.

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnectionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnectionManager.java
@@ -304,9 +304,9 @@ public class TcpIpConnectionManager implements ConnectionManager {
             if (existingConnection != connection) {
                 if (logger.isFinestEnabled()) {
                     log(Level.FINEST, existingConnection + " is already bound to " + remoteEndPoint
-                            + ", new one is " + connection);
+                            + ", destroying the new " + connection);
                 }
-                activeConnections.add(connection);
+                destroyConnection(connection);
             }
             return true;
         }

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnectionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnectionManager.java
@@ -252,7 +252,7 @@ public class TcpIpConnectionManager implements ConnectionManager {
         if (reply) {
             sendBindRequest(connection, remoteEndPoint, false);
         }
-        if (checkAlreadyConnected(connection, remoteEndPoint)) {
+        if (destroyIfAnotherConnectionIsAlreadyBound(connection, remoteEndPoint)) {
             return false;
         }
         if (!registerConnection(remoteEndPoint, connection)) {
@@ -298,7 +298,7 @@ public class TcpIpConnectionManager implements ConnectionManager {
         return true;
     }
 
-    private boolean checkAlreadyConnected(TcpIpConnection connection, Address remoteEndPoint) {
+    private boolean destroyIfAnotherConnectionIsAlreadyBound(TcpIpConnection connection, Address remoteEndPoint) {
         final Connection existingConnection = connectionsMap.get(remoteEndPoint);
         if (existingConnection != null && existingConnection.isAlive()) {
             if (existingConnection != connection) {
@@ -307,6 +307,7 @@ public class TcpIpConnectionManager implements ConnectionManager {
                             + ", destroying the new " + connection);
                 }
                 destroyConnection(connection);
+                sendBindRequest((TcpIpConnection) existingConnection, remoteEndPoint, false);
             }
             return true;
         }


### PR DESCRIPTION
When A connects to B and B connects to A at the same time we can close the second connection.

I'm not too sure about possible side-effects (could each member decides to close a different connection??), but it seems it's working - there are no longer unused "active" connections - and all tests are passing. 

@mdogan: Could you please have a look? Thanks!