### PR TITLE
Relaxed Checkstyle constraints for(;;)

### DIFF
--- a/checkstyle/checkstyle.xml
+++ b/checkstyle/checkstyle.xml
@@ -183,11 +183,11 @@
 
         <!-- Checks for whitespace                               -->
         <!-- See http://checkstyle.sf.net/config_whitespace.html -->
-        <module name="EmptyForIteratorPad"/>
+        <!-- module name="EmptyForIteratorPad"/ -->
         <module name="GenericWhitespace"/>
         <module name="MethodParamPad"/>
-        <module name="NoWhitespaceAfter"/>
-        <module name="NoWhitespaceBefore"/>
+        <!-- module name="NoWhitespaceAfter"/ -->
+        <!-- module name="NoWhitespaceBefore"/ -->
         <module name="OperatorWrap"/>
         <module name="ParenPad"/>
         <module name="TypecastParenPad"/>


### PR DESCRIPTION
Checkstyle doesn't want to have

```
for(;_;_) ....
```

But wants to have without spaces; and this is not what Intellij autoformatting respects. So this pr relaxes checkstyle checks. I think it is better to fix checkstyle because it causes the least amount of changes to people their environments and personally I don't care if a for loop with or without spaces is used.