### PR TITLE
Deprecated some OperationService methods.

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/OperationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/OperationService.java
@@ -33,26 +33,80 @@ import java.util.Map;
  */
 public interface OperationService {
 
+    /**
+     * This methods is deprecated since 3.5
+     *
+     * @return
+     */
+    @Deprecated
     int getResponseQueueSize();
 
+    /**
+     * This methods is deprecated since 3.5
+     *
+     * @return
+     */
+    @Deprecated
     int getOperationExecutorQueueSize();
 
+    /**
+     * This methods is deprecated since 3.5
+     *
+     * @return
+     */
+    @Deprecated
     int getPriorityOperationExecutorQueueSize();
 
+    /**
+     * This methods is deprecated since 3.5
+     *
+     * @return
+     */
+    @Deprecated
     int getRunningOperationsCount();
 
+    /**
+     * This methods is deprecated since 3.5
+     *
+     * @return
+     */
+    @Deprecated
     int getRemoteOperationsCount();
 
+    /**
+     * This methods is deprecated since 3.5
+     *
+     * @return
+     */
+    @Deprecated
     int getPartitionOperationThreadCount();
 
+    /**
+     * This methods is deprecated since 3.5
+     *
+     * @return
+     */
+    @Deprecated
     int getGenericOperationThreadCount();
 
+    /**
+     * This methods is deprecated since 3.5
+     *
+     * @return
+     */
+    @Deprecated
     long getExecutedOperationCount();
 
     /**
      * Dumps all kinds of metrics: for example, performance. This can be used for performance analysis. In the future we'll have a
      * more formal (such as map with key/value pairs) information.
      */
+    /**
+     * This methods is deprecated since 3.5
+     *
+     * @return
+     */
+    @Deprecated
     void dumpPerformanceMetrics(StringBuffer sb);
 
     /**
@@ -128,9 +182,13 @@ public interface OperationService {
     /**
      * Sends a response to a remote machine.
      *
+     * This methods is deprecated since 3.5. It is an implementation detail, so it is moved to the
+     * {@link com.hazelcast.spi.impl.InternalOperationService}.
+     *
      * @param response the response to send.
      * @param target   the address of the target machine
      * @return true if send is successful, false otherwise.
      */
+    @Deprecated
     boolean send(Response response, Address target);
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/OperationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/OperationService.java
@@ -29,70 +29,61 @@ import java.util.Map;
  * and {@link #executeOperation(Operation)}. Or it can executed remotely using one of the send methods.
  * <p/>
  * It also is possible to execute multiple operation on multiple partitions using one of the invoke methods.
- *
  */
 public interface OperationService {
 
     /**
-     * This methods is deprecated since 3.5
-     *
-     * @return
+     * This methods is deprecated since 3.5. This feature will be dropped since it is an internal implementation
+     * detail and should not directly be exposed the the SPI user.
      */
     @Deprecated
     int getResponseQueueSize();
 
     /**
-     * This methods is deprecated since 3.5
-     *
-     * @return
+     * This methods is deprecated since 3.5. This feature will be dropped since it is an internal implementation
+     * detail and should not directly be exposed the the SPI user.
      */
     @Deprecated
     int getOperationExecutorQueueSize();
 
     /**
-     * This methods is deprecated since 3.5
-     *
-     * @return
+     * This methods is deprecated since 3.5. This feature will be dropped since it is an internal implementation
+     * detail and should not directly be exposed the the SPI user.
      */
     @Deprecated
     int getPriorityOperationExecutorQueueSize();
 
     /**
-     * This methods is deprecated since 3.5
-     *
-     * @return
+     * This methods is deprecated since 3.5. This feature will be dropped since it is an internal implementation
+     * detail and should not directly be exposed the the SPI user.
      */
     @Deprecated
     int getRunningOperationsCount();
 
     /**
-     * This methods is deprecated since 3.5
-     *
-     * @return
+     * This methods is deprecated since 3.5. This feature will be dropped since it is an internal implementation
+     * detail and should not directly be exposed the the SPI user.
      */
     @Deprecated
     int getRemoteOperationsCount();
 
     /**
-     * This methods is deprecated since 3.5
-     *
-     * @return
+     * This methods is deprecated since 3.5. This feature will be dropped since it is an internal implementation
+     * detail and should not directly be exposed the the SPI user.
      */
     @Deprecated
     int getPartitionOperationThreadCount();
 
     /**
-     * This methods is deprecated since 3.5
-     *
-     * @return
+     * This methods is deprecated since 3.5. This feature will be dropped since it is an internal implementation
+     * detail and should not directly be exposed the the SPI user.
      */
     @Deprecated
     int getGenericOperationThreadCount();
 
     /**
-     * This methods is deprecated since 3.5
-     *
-     * @return
+     * This methods is deprecated since 3.5. This feature will be dropped since it is an internal implementation
+     * detail and should not directly be exposed the the SPI user.
      */
     @Deprecated
     long getExecutedOperationCount();
@@ -100,11 +91,9 @@ public interface OperationService {
     /**
      * Dumps all kinds of metrics: for example, performance. This can be used for performance analysis. In the future we'll have a
      * more formal (such as map with key/value pairs) information.
-     */
-    /**
-     * This methods is deprecated since 3.5
-     *
-     * @return
+     * <p/>
+     * This methods is deprecated since 3.5. This feature will be dropped since it is an internal implementation
+     * detail and should not directly be exposed the the SPI user.
      */
     @Deprecated
     void dumpPerformanceMetrics(StringBuffer sb);
@@ -130,7 +119,10 @@ public interface OperationService {
      *
      * @param op the operation to check.
      * @return true if the operation is allowed to run on the calling thread, false otherwise.
+     *
+     * @deprecated since 3.5 since not needed anymore.
      */
+    @Deprecated
     boolean isAllowedToRunOnCallingThread(Operation op);
 
     <E> InternalCompletableFuture<E> invokeOnPartition(String serviceName, Operation op, int partitionId);
@@ -181,7 +173,7 @@ public interface OperationService {
 
     /**
      * Sends a response to a remote machine.
-     *
+     * <p/>
      * This methods is deprecated since 3.5. It is an implementation detail, so it is moved to the
      * {@link com.hazelcast.spi.impl.InternalOperationService}.
      *

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/InternalOperationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/InternalOperationService.java
@@ -17,6 +17,7 @@
 package com.hazelcast.spi.impl;
 
 import com.hazelcast.instance.MemberImpl;
+import com.hazelcast.nio.Address;
 import com.hazelcast.nio.Packet;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.OperationService;
@@ -62,4 +63,16 @@ public interface InternalOperationService extends OperationService {
      * Shuts down this InternalOperationService.
      */
     void shutdown();
+
+    /**
+     * Sends a response to a remote machine.
+     *
+     * This methods is deprecated since 3.5. It is an implementation detaul
+     *
+     * @param response the response to send.
+     * @param target   the address of the target machine
+     * @return true if send is successful, false otherwise.
+     */
+    @Deprecated
+    boolean send(Response response, Address target);
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/ResponseHandlerFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/ResponseHandlerFactory.java
@@ -119,7 +119,7 @@ public final class ResponseHandlerFactory {
                 response = (Response) obj;
             }
 
-            OperationService operationService = nodeEngine.getOperationService();
+            InternalOperationService operationService = (InternalOperationService) nodeEngine.getOperationService();
             if (!operationService.send(response, operation.getCallerAddress())) {
                 throw new HazelcastException("Cannot send response: " + obj + " to " + conn.getEndPoint());
             }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/ResponseHandlerFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/ResponseHandlerFactory.java
@@ -21,7 +21,6 @@ import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.Operation;
-import com.hazelcast.spi.OperationService;
 import com.hazelcast.spi.ResponseHandler;
 import com.hazelcast.spi.exception.ResponseAlreadySentException;
 


### PR DESCRIPTION
Too many methods are exposed in the OperationService which makes us less flexible. By deprecating it now, we can get rid of it earlier because people have the ability to deal with it ASAP.

Some of the things are going to be dropped completely like getting all kinds of statistics, this will be replaced by the blackbox.

Other things are moved to the InternalOperationService because they are internal implementation details not needed to expose to the SPI user. For example sending back a response.