### PR TITLE
MapMergePolicy mergingEntry.getValue() does not return Value Object

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/DefaultRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/DefaultRecordStore.java
@@ -778,6 +778,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore implements 
         final long now = getNow();
 
         Record record = getRecordOrNull(key, now, false);
+        mergingEntry = EntryViews.convertToLazyEntryView(mergingEntry, serializationService, mergePolicy);
         Object newValue;
         if (record == null) {
             final Object notExistingKey = mapServiceContext.toObject(key);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/EntryViews.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/EntryViews.java
@@ -68,4 +68,20 @@ public final class EntryViews {
         return lazyEntryView;
     }
 
+    public static <K, V> EntryView<K, V> convertToLazyEntryView(EntryView entryView,
+            SerializationService serializationService, MapMergePolicy mergePolicy) {
+        final LazyEntryView lazyEntryView = new LazyEntryView(entryView.getKey(), entryView.getValue(),
+                serializationService, mergePolicy);
+        lazyEntryView.setCost(entryView.getCost());
+        lazyEntryView.setVersion(entryView.getVersion());
+        lazyEntryView.setLastAccessTime(entryView.getLastAccessTime());
+        lazyEntryView.setLastUpdateTime(entryView.getLastUpdateTime());
+        lazyEntryView.setTtl(entryView.getTtl());
+        lazyEntryView.setCreationTime(entryView.getCreationTime());
+        lazyEntryView.setHits(entryView.getHits());
+        lazyEntryView.setExpirationTime(entryView.getExpirationTime());
+        lazyEntryView.setLastStoredTime(entryView.getLastStoredTime());
+        return lazyEntryView;
+    }
+
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/LazyEntryView.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/LazyEntryView.java
@@ -1,6 +1,8 @@
 package com.hazelcast.map.impl;
 
 import com.hazelcast.core.EntryView;
+import com.hazelcast.map.merge.HigherHitsMapMergePolicy;
+import com.hazelcast.map.merge.LatestUpdateMapMergePolicy;
 import com.hazelcast.map.merge.MapMergePolicy;
 import com.hazelcast.map.merge.PassThroughMergePolicy;
 import com.hazelcast.map.merge.PutIfAbsentMapMergePolicy;
@@ -51,16 +53,18 @@ class LazyEntryView<K, V> implements EntryView<K, V> {
     }
 
     public V getValue() {
-        if (validMergePolicyForValueNullCheck(mergePolicy)) {
+        if (returnRawData(mergePolicy)) {
             return value;
         }
         value = serializationService.toObject(value);
         return value;
     }
 
-    private boolean validMergePolicyForValueNullCheck(MapMergePolicy mergePolicy) {
+    private boolean returnRawData(MapMergePolicy mergePolicy) {
         return mergePolicy instanceof PutIfAbsentMapMergePolicy
-                || mergePolicy instanceof PassThroughMergePolicy;
+                || mergePolicy instanceof PassThroughMergePolicy
+                || mergePolicy instanceof HigherHitsMapMergePolicy
+                || mergePolicy instanceof LatestUpdateMapMergePolicy;
     }
 
     public void setValue(V value) {

--- a/hazelcast/src/test/java/com/hazelcast/map/CustomMergePolicy.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/CustomMergePolicy.java
@@ -1,0 +1,28 @@
+package com.hazelcast.map;
+
+import com.hazelcast.core.EntryView;
+import com.hazelcast.map.merge.MapMergePolicy;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+
+import java.io.IOException;
+
+public class CustomMergePolicy implements MapMergePolicy {
+    @Override
+    public Object merge(String mapName, EntryView mergingEntry, EntryView existingEntry) {
+        if (mergingEntry.getValue() instanceof Integer) {
+            return mergingEntry.getValue();
+        }
+        return null;
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
+
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) throws IOException {
+
+    }
+}


### PR DESCRIPTION

**mergingEntry.getValue()** argument is always in a type of SimpleEntryView which does not return real Value Object but **com.hazelcast.nio.serialization.Data**. This is a problem for Developers who want to create their own Custom Merge Policy by manipulating real Value Object... 

Following PR converts EntryView Object into LazyEntryView Object which returns Value Object for Custom Merge Policies when **mergingEntry.getValue()** called...