### PR TITLE
Use slf4j as default if found in classpath, fall back to default JDK logger otherwise

### DIFF
--- a/hazelcast-documentation/src/ConfigurationProperties.md
+++ b/hazelcast-documentation/src/ConfigurationProperties.md
@@ -79,7 +79,7 @@ Property Name | Default Value | Type | Description
 `hazelcast.initial.wait.seconds` | 0 | int  |   Initial time in seconds to wait before node to start completely.
 `hazelcast.map.replica.wait.seconds.for.scheduled.tasks`|10|int|Scheduler delay for the map tasks to be executed on backup members.
 `hazelcast.partition.count` | 271 | int  |   Total partition count.
-`hazelcast.logging.type` | jdk | enum |   Name of [logging](#logging-configuration) framework type to send logging events.
+`hazelcast.logging.type` | slf4j with fallback to jdk | enum |   Name of [logging](#logging-configuration) framework type to send logging events.
 `hazelcast.jmx` | false | bool  |   Enable [JMX](#monitoring-with-jmx) agent.
 `hazelcast.jmx.detailed` | false | bool  |   Enable detailed views on [JMX](#monitoring-with-jmx).
 `hazelcast.mc.max.visible.instance.count` | 100 | int  |   Management Center maximum visible instance count.

--- a/hazelcast-documentation/src/HazelcastConfiguration/AdvConfProperties.md
+++ b/hazelcast-documentation/src/HazelcastConfiguration/AdvConfProperties.md
@@ -68,7 +68,7 @@ Property Name | Default Value | Type | Description
 `hazelcast.jcache.provider.type`||string|Type of the JCache provider. Values can be `client` or `server`.
 `hazelcast.jmx` | false | bool  |   Enable [JMX](#monitoring-with-jmx) agent.
 `hazelcast.jmx.detailed` | false | bool  |   Enable detailed views on [JMX](#monitoring-with-jmx).
-`hazelcast.logging.type` | jdk | enum |   Name of [logging](#logging-configuration) framework type to send logging events.
+`hazelcast.logging.type` | slf4j with fallback to jdk | enum |   Name of [logging](#logging-configuration) framework type to send logging events.
 `hazelcast.map.load.chunk.size` | 1000 | int |   Chunk size for [MapLoader](#persistence) 's map initialization process (MapLoder.loadAllKeys()).
 `hazelcast.map.replica.wait.seconds.for.scheduled.tasks`|10|int|Scheduler delay for map tasks those will be executed on backup members.
 `hazelcast.master.confirmation.interval.seconds` | 30 | int  |   Interval at which nodes send master confirmation.

--- a/hazelcast-documentation/src/HazelcastConfiguration/LoggingConfiguration.md
+++ b/hazelcast-documentation/src/HazelcastConfiguration/LoggingConfiguration.md
@@ -5,11 +5,11 @@ Hazelcast has a flexible logging configuration and does not depend on any loggin
 
 To use built-in adaptors, you should set `hazelcast.logging.type` property to one of predefined types below.
 
--   **jdk**: JDK logging (default)
+-   **slf4j**: Slf4j (default if slf4j found in classpath)
+
+-   **jdk**: JDK logging (default if slf4j not found in classpath)
 
 -   **log4j**: Log4j
-
--   **slf4j**: Slf4j
 
 -   **none**: disable logging
 

--- a/hazelcast-documentation/src/Logging.md
+++ b/hazelcast-documentation/src/Logging.md
@@ -5,7 +5,9 @@ Hazelcast has a flexible logging configuration and does not depend on any loggin
 
 To use built-in adaptors, set the `hazelcast.logging.type` property to one of the predefined types below.
 
--   **jdk**: JDK logging (default)
+-   **slf4j**: Slf4j (default if slf4j found in classpath)
+
+-   **jdk**: JDK logging (default if slf4j not found in classpath)
 
 -   **log4j**: Log4j
 

--- a/hazelcast/src/main/java/com/hazelcast/instance/GroupProperties.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/GroupProperties.java
@@ -409,7 +409,7 @@ public class GroupProperties {
         MAP_REPLICA_SCHEDULED_TASK_DELAY_SECONDS
                 = new GroupProperty(config, PROP_MAP_REPLICA_SCHEDULED_TASK_DELAY_SECONDS, "10");
         PARTITION_COUNT = new GroupProperty(config, PROP_PARTITION_COUNT, "271");
-        LOGGING_TYPE = new GroupProperty(config, PROP_LOGGING_TYPE, "jdk");
+        LOGGING_TYPE = new GroupProperty(config, PROP_LOGGING_TYPE, (String)null); // use default logic in Logger class
         ENABLE_JMX = new GroupProperty(config, PROP_ENABLE_JMX, "false");
         ENABLE_JMX_DETAILED = new GroupProperty(config, PROP_ENABLE_JMX_DETAILED, "false");
         MC_MAX_INSTANCE_COUNT = new GroupProperty(config, PROP_MC_MAX_VISIBLE_INSTANCE_COUNT, "100");

--- a/hazelcast/src/main/java/com/hazelcast/logging/Logger.java
+++ b/hazelcast/src/main/java/com/hazelcast/logging/Logger.java
@@ -68,7 +68,17 @@ public final class Logger {
         }
 
         if (loggerFactory == null) {
-            loggerFactory = new StandardLoggerFactory();
+            if (loggerType == null) {
+                try {
+                    Class c = Class.forName("org.slf4j.LoggerFactory");
+                    loggerFactory = loadLoggerFactory("com.hazelcast.logging.Slf4jFactory");
+                } catch(ClassNotFoundException ex) {
+                    // slf4j API not on classpath, ignore
+                }
+            }
+            if(loggerFactory == null) {
+                loggerFactory = new StandardLoggerFactory();
+            }
         }
         return loggerFactory;
     }


### PR DESCRIPTION

Many people already have slf4j in their project classpath so it is a good idea to check for it and just use it if present.