### PR TITLE
When near cache configured to store OBJECT then more efficient to nearca...

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
@@ -215,23 +215,25 @@ abstract class MapProxySupport extends AbstractDistributedObject<MapService> imp
                 return fromNearCache;
             }
         }
+
+        Data result = null;
         // todo action for read-backup true is not well tested.
         if (mapConfig.isReadBackupData()) {
-            final Object fromBackup = readBackupDataOrNull(key);
-            if (fromBackup != null) {
-                return fromBackup;
-            }
+            result = readBackupDataOrNull(key);
         }
-        final GetOperation operation = new GetOperation(name, key);
-        operation.setThreadId(ThreadUtil.getThreadId());
-        final Data value = (Data) invokeOperation(key, operation);
+
+        if (result == null) {
+            final GetOperation operation = new GetOperation(name, key);
+            operation.setThreadId(ThreadUtil.getThreadId());
+            result = (Data) invokeOperation(key, operation);
+        }
 
         if (nearCacheEnabled) {
             if (notOwnerPartitionForKey(key) || cacheKeyAnyway()) {
-                return putNearCache(key, value);
+                return putNearCache(key, result);
             }
         }
-        return value;
+        return result;
     }
 
     private boolean notOwnerPartitionForKey(Data key) {

--- a/hazelcast/src/test/java/com/hazelcast/map/nearcache/NearCacheTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/nearcache/NearCacheTest.java
@@ -17,6 +17,7 @@
 package com.hazelcast.map.nearcache;
 
 import com.hazelcast.config.Config;
+import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.config.NearCacheConfig;
 import com.hazelcast.core.EntryAdapter;
@@ -519,6 +520,28 @@ public class NearCacheTest extends HazelcastTestSupport {
 
         waitUntilEvictionEventsReceived(latch);
         assertNearCacheSize(mapSize, mapName, map);
+    }
+
+    @Test
+    public void testNearCacheBackups() throws Exception {
+        final String mapName = randomMapName();
+        final Config config = createNearCachedMapConfig(mapName);
+
+        //Set up backup
+        final MapConfig mapConfig = config.getMapConfig(mapName).setReadBackupData(true);
+        mapConfig.setBackupCount(1);
+        mapConfig.getNearCacheConfig().setInMemoryFormat(InMemoryFormat.BINARY.OBJECT);
+
+        final HazelcastInstance instance = createHazelcastInstance(config);
+        final IMap<Integer, Object> map = instance.getMap(mapName);
+        HashMap<String, String> value = new HashMap<String, String>();
+        value.put("a","b");
+        map.put(1, value);
+
+        Object o1 = map.get(1);
+        Object o2 = map.get(1);
+
+        Assert.assertTrue(o1 == o2);
     }
 
     private void waitUntilEvictionEventsReceived(CountDownLatch latch) {


### PR DESCRIPTION
When ```readBackupData``` is true and near caching is configured then the value is not placed in the near cache when it is read from backup. On high frequency reads the value will be read from the backup and de-serialised on every request, but if the near cache is configured with ```InMemoryFormat.OBJECT``` then storing it in the near cache is much more efficient. 

It has the downside of using more memory, but that can be controlled by the near cache TTL  and max size settings.

The included test does not test the performance improvement - just that the same object is returned, but local tests showed a 5 times improvement for high frequency gets of the same value when the near cache is configured with ```InMemoryFormat.OBJECT```.