### PR TITLE
Pulled out HazelcastThreadGroup

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientExecutionServiceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientExecutionServiceImpl.java
@@ -43,7 +43,6 @@ public final class ClientExecutionServiceImpl implements ClientExecutionService 
     private final ExecutorService internalExecutor;
     private final ScheduledExecutorService scheduledExecutor;
 
-
     public ClientExecutionServiceImpl(String name, ThreadGroup threadGroup, ClassLoader classLoader, int poolSize) {
         int executorPoolSize = poolSize;
         if (executorPoolSize <= 0) {

--- a/hazelcast/src/main/java/com/hazelcast/ascii/TextCommandServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/ascii/TextCommandServiceImpl.java
@@ -32,6 +32,7 @@ import com.hazelcast.ascii.rest.HttpPostCommandProcessor;
 import com.hazelcast.ascii.rest.RestValue;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
+import com.hazelcast.instance.HazelcastThreadGroup;
 import com.hazelcast.instance.Node;
 import com.hazelcast.instance.OutOfMemoryErrorDispatcher;
 import com.hazelcast.logging.ILogger;
@@ -209,8 +210,10 @@ public class TextCommandServiceImpl implements TextCommandService {
             synchronized (this) {
                 if (responseThreadRunnable == null) {
                     responseThreadRunnable = new ResponseThreadRunnable();
-                    String threadNamePrefix = node.getThreadNamePrefix("ascii.service.response");
-                    Thread thread = new Thread(node.threadGroup, responseThreadRunnable, threadNamePrefix);
+                    HazelcastThreadGroup hazelcastThreadGroup = node.getHazelcastThreadGroup();
+                    String threadNamePrefix = hazelcastThreadGroup.getThreadNamePrefix("ascii.service.response");
+                    Thread thread = new Thread(
+                            hazelcastThreadGroup.getInternalThreadGroup(), responseThreadRunnable, threadNamePrefix);
                     thread.start();
                 }
             }

--- a/hazelcast/src/main/java/com/hazelcast/instance/HazelcastInstanceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/HazelcastInstanceImpl.java
@@ -98,14 +98,11 @@ public class HazelcastInstanceImpl implements HazelcastInstance {
 
     final ManagedContext managedContext;
 
-    final ThreadGroup threadGroup;
-
     final ConcurrentMap<String, Object> userContext = new ConcurrentHashMap<String, Object>();
 
     HazelcastInstanceImpl(String name, Config config, NodeContext nodeContext)
             throws Exception {
         this.name = name;
-        this.threadGroup = new ThreadGroup(name);
         lifecycleService = new LifecycleServiceImpl(this);
         ManagedContext configuredManagedContext = config.getManagedContext();
         managedContext = new HazelcastManagedContext(this, configuredManagedContext);
@@ -413,10 +410,6 @@ public class HazelcastInstanceImpl implements HazelcastInstance {
     public boolean removeDistributedObjectListener(String registrationId) {
         final ProxyService proxyService = node.nodeEngine.getProxyService();
         return proxyService.removeProxyListener(registrationId);
-    }
-
-    public ThreadGroup getThreadGroup() {
-        return threadGroup;
     }
 
     public SerializationService getSerializationService() {

--- a/hazelcast/src/main/java/com/hazelcast/instance/HazelcastThreadGroup.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/HazelcastThreadGroup.java
@@ -64,17 +64,7 @@ public final class HazelcastThreadGroup {
     }
 
     /**
-     * Interrupts all threads of this ThreadGroup. It does this by interrupting the {@link #internalThreadGroup}.
-     */
-    public void interrupt() {
-        internalThreadGroup.interrupt();
-    }
-
-    /**
-     * Destroys all threads in this ThreadGroup. The main difference between {@link #interrupt()} and this method is that
-     * this method add some logging.
-     * <p/>
-     * todo: probably get rid of {@link #interrupt()}.
+     * Destroys all threads in this ThreadGroup.
      */
     public void destroy() {
         int numThreads = internalThreadGroup.activeCount();

--- a/hazelcast/src/main/java/com/hazelcast/instance/HazelcastThreadGroup.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/HazelcastThreadGroup.java
@@ -1,0 +1,94 @@
+package com.hazelcast.instance;
+
+import com.hazelcast.logging.ILogger;
+
+/**
+ * A wrapper around the {@link java.lang.ThreadGroup} that provides some additional capabilities. It is a grouping of
+ * all thread creational logic throughout the system. To access the actual ThreadGroup, call {@link #getInternalThreadGroup()}.
+ */
+public final class HazelcastThreadGroup {
+
+    private final ILogger logger;
+    private final ThreadGroup internalThreadGroup;
+    private final ClassLoader classLoader;
+    private final String hzName;
+
+    public HazelcastThreadGroup(String name, ILogger logger, ClassLoader classLoader) {
+        this.hzName = name;
+        this.internalThreadGroup = new ThreadGroup(name);
+        this.logger = logger;
+        this.classLoader = classLoader;
+    }
+
+    /**
+     * Gets the threadname prefix.
+     *
+     * @param name the basic name of the thread.
+     * @return the created threadname prefix.
+     * @throws java.lang.NullPointerException if name is null.
+     */
+    public String getThreadNamePrefix(String name) {
+        if (name == null) {
+            throw new NullPointerException("name cant be null");
+        }
+        return "hz." + hzName + "." + name;
+    }
+
+    /**
+     * Gets the threadpool prefix for a given poolname.
+     *
+     * @param poolName the name of the pool.
+     * @return the threadpool prefix.
+     * @throws java.lang.NullPointerException if poolname is null.
+     */
+    public String getThreadPoolNamePrefix(String poolName) {
+        return getThreadNamePrefix(poolName) + ".thread-";
+    }
+
+    /**
+     * Returns the ClassLoader used by threads of this HazelcastThreadGroup.
+     *
+     * @return the ClassLoader.
+     */
+    public ClassLoader getClassLoader() {
+        return classLoader;
+    }
+
+    /**
+     * Gets the internal ThreadGroup; so the actual ThreadGroup object.
+     *
+     * @return the internal ThreadGroup.
+     */
+    public ThreadGroup getInternalThreadGroup() {
+        return internalThreadGroup;
+    }
+
+    /**
+     * Interrupts all threads of this ThreadGroup. It does this by interrupting the {@link #internalThreadGroup}.
+     */
+    public void interrupt() {
+        internalThreadGroup.interrupt();
+    }
+
+    /**
+     * Destroys all threads in this ThreadGroup. The main difference between {@link #interrupt()} and this method is that
+     * this method add some logging.
+     * <p/>
+     * todo: probably get rid of {@link #interrupt()}.
+     */
+    public void destroy() {
+        int numThreads = internalThreadGroup.activeCount();
+        Thread[] threads = new Thread[numThreads * 2];
+        numThreads = internalThreadGroup.enumerate(threads, false);
+        for (int i = 0; i < numThreads; i++) {
+            Thread thread = threads[i];
+            if (!thread.isAlive()) {
+                continue;
+            }
+            if (logger.isFinestEnabled()) {
+                logger.finest("Shutting down thread " + thread.getName());
+            }
+            thread.interrupt();
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/instance/OutOfMemoryHandlerHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/OutOfMemoryHandlerHelper.java
@@ -77,7 +77,7 @@ public final class OutOfMemoryHandlerHelper {
 
         HazelcastInstanceImpl factory = (HazelcastInstanceImpl) hazelcastInstance;
         try {
-            factory.node.threadGroup.interrupt();
+            factory.node.getHazelcastThreadGroup().interrupt();
         } catch (Throwable ignored) {
             EmptyStatement.ignore(ignored);
         }

--- a/hazelcast/src/main/java/com/hazelcast/instance/OutOfMemoryHandlerHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/OutOfMemoryHandlerHelper.java
@@ -77,7 +77,7 @@ public final class OutOfMemoryHandlerHelper {
 
         HazelcastInstanceImpl factory = (HazelcastInstanceImpl) hazelcastInstance;
         try {
-            factory.node.getHazelcastThreadGroup().interrupt();
+            factory.node.getHazelcastThreadGroup().destroy();
         } catch (Throwable ignored) {
             EmptyStatement.ignore(ignored);
         }

--- a/hazelcast/src/main/java/com/hazelcast/nio/NodeIOService.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/NodeIOService.java
@@ -21,6 +21,7 @@ import com.hazelcast.config.NetworkConfig;
 import com.hazelcast.config.SSLConfig;
 import com.hazelcast.config.SocketInterceptorConfig;
 import com.hazelcast.config.SymmetricEncryptionConfig;
+import com.hazelcast.instance.HazelcastThreadGroup;
 import com.hazelcast.instance.MemberImpl;
 import com.hazelcast.instance.Node;
 import com.hazelcast.instance.OutOfMemoryErrorDispatcher;
@@ -76,7 +77,8 @@ public class NodeIOService implements IOService {
 
     @Override
     public void onFatalError(Exception e) {
-        new Thread(node.threadGroup, node.getThreadNamePrefix("io.error.shutdown")) {
+        HazelcastThreadGroup threadGroup = node.getHazelcastThreadGroup();
+        new Thread(threadGroup.getInternalThreadGroup(), threadGroup.getThreadNamePrefix("io.error.shutdown")) {
             public void run() {
                 node.shutdown(false);
             }
@@ -142,12 +144,14 @@ public class NodeIOService implements IOService {
 
     @Override
     public String getThreadPrefix() {
-        return node.getThreadPoolNamePrefix("IO");
+        HazelcastThreadGroup threadGroup = node.getHazelcastThreadGroup();
+        return threadGroup.getThreadPoolNamePrefix("IO");
     }
 
     @Override
     public ThreadGroup getThreadGroup() {
-        return node.threadGroup;
+        HazelcastThreadGroup threadGroup = node.getHazelcastThreadGroup();
+        return threadGroup.getInternalThreadGroup();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/partition/impl/InternalPartitionServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/impl/InternalPartitionServiceImpl.java
@@ -1744,7 +1744,8 @@ public class InternalPartitionServiceImpl implements InternalPartitionService, M
         private volatile boolean migrating;
 
         MigrationThread(Node node) {
-            super(node.threadGroup, node.getThreadNamePrefix("migration"));
+            super(node.getHazelcastThreadGroup().getInternalThreadGroup(),
+                    node.getHazelcastThreadGroup().getThreadNamePrefix("migration"));
         }
 
         @Override

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/BasicOperationScheduler.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/BasicOperationScheduler.java
@@ -16,12 +16,14 @@
 
 package com.hazelcast.spi.impl;
 
-import com.hazelcast.instance.Node;
+import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.instance.HazelcastThreadGroup;
+import com.hazelcast.instance.NodeExtension;
 import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.LoggingService;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.NIOThread;
 import com.hazelcast.nio.Packet;
-import com.hazelcast.spi.ExecutionService;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.annotation.PrivateApi;
 import com.hazelcast.util.executor.HazelcastManagedThread;
@@ -30,7 +32,6 @@ import java.util.Queue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 
@@ -68,8 +69,6 @@ public final class BasicOperationScheduler {
     //all operations that are not specific for a partition will be executed here, e.g heartbeat or map.size
     final OperationThread[] genericOperationThreads;
     private final ILogger logger;
-    private final Node node;
-    private final ExecutionService executionService;
     private final BasicOperationHandler operationHandler;
 
     //the generic workqueues are shared between all generic operation threads, so that work can be stolen
@@ -79,6 +78,9 @@ public final class BasicOperationScheduler {
 
     private final ResponseThread responseThread;
     private final BasicResponsePacketHandler responsePacketHandler;
+    private final Address thisAddress;
+    private final NodeExtension nodeExtension;
+    private final HazelcastThreadGroup threadGroup;
 
     private volatile boolean shutdown;
 
@@ -96,21 +98,22 @@ public final class BasicOperationScheduler {
         }
     };
 
-    public BasicOperationScheduler(Node node,
-                                   ExecutionService executionService,
-                                   BasicOperationHandler operationHandler, BasicResponsePacketHandler responsePacketHandler) {
-        this.executionService = executionService;
-        this.logger = node.getLogger(BasicOperationScheduler.class);
-        this.node = node;
+    public BasicOperationScheduler(GroupProperties groupProperties,
+                                   LoggingService loggerService,
+                                   Address thisAddress,
+                                   BasicOperationHandler operationHandler,
+                                   NodeExtension nodeExtension,
+                                   BasicResponsePacketHandler responsePacketHandler,
+                                   HazelcastThreadGroup hazelcastThreadGroup) {
+        this.thisAddress = thisAddress;
+        this.logger = loggerService.getLogger(BasicOperationScheduler.class);
         this.operationHandler = operationHandler;
         this.responsePacketHandler = responsePacketHandler;
+        this.nodeExtension = nodeExtension;
+        this.threadGroup = hazelcastThreadGroup;
 
-        this.genericOperationThreads = new OperationThread[getGenericOperationThreadCount()];
-        initOperationThreads(genericOperationThreads, new GenericOperationThreadFactory());
-
-        this.partitionOperationThreads = new OperationThread[getPartitionOperationThreadCount()];
-        initOperationThreads(partitionOperationThreads, new PartitionOperationThreadFactory());
-
+        this.genericOperationThreads = initGenericThreads(groupProperties);
+        this.partitionOperationThreads = initPartitionThreads(groupProperties);
         this.responseThread = new ResponseThread();
         responseThread.start();
 
@@ -118,35 +121,44 @@ public final class BasicOperationScheduler {
                 + partitionOperationThreads.length + " partition operation threads.");
     }
 
-    @edu.umd.cs.findbugs.annotations.SuppressWarnings({"NP_NONNULL_PARAM_VIOLATION" })
-    private static void initOperationThreads(OperationThread[] operationThreads, ThreadFactory threadFactory) {
-        for (int threadId = 0; threadId < operationThreads.length; threadId++) {
-            OperationThread operationThread = (OperationThread) threadFactory.newThread(null);
-            operationThreads[threadId] = operationThread;
-            operationThread.start();
-        }
-    }
-
-    private int getGenericOperationThreadCount() {
-        int threadCount = node.getGroupProperties().GENERIC_OPERATION_THREAD_COUNT.getInteger();
-        if (threadCount <= 0) {
-            // default generic operation thread count
-            int coreSize = Runtime.getRuntime().availableProcessors();
-            threadCount = Math.max(2, coreSize / 2);
-        }
-        return threadCount;
-    }
-
-    private int getPartitionOperationThreadCount() {
-        int threadCount = node.getGroupProperties().PARTITION_OPERATION_THREAD_COUNT.getInteger();
+    private OperationThread[] initPartitionThreads(GroupProperties groupProperties) {
+        int threadCount = groupProperties.PARTITION_OPERATION_THREAD_COUNT.getInteger();
         if (threadCount <= 0) {
             // default partition operation thread count
             int coreSize = Runtime.getRuntime().availableProcessors();
             threadCount = Math.max(2, coreSize);
         }
-        return threadCount;
+
+        PartitionOperationThreadFactory threadFactory = new PartitionOperationThreadFactory();
+        OperationThread[] threads = new OperationThread[threadCount];
+        for (int threadId = 0; threadId < threads.length; threadId++) {
+
+            OperationThread operationThread = threadFactory.newThread(null);
+            threads[threadId] = operationThread;
+            operationThread.start();
+        }
+
+        return threads;
     }
 
+    private OperationThread[] initGenericThreads(GroupProperties groupProperties) {
+        int threadCount = groupProperties.GENERIC_OPERATION_THREAD_COUNT.getInteger();
+        if (threadCount <= 0) {
+            // default generic operation thread count
+            int coreSize = Runtime.getRuntime().availableProcessors();
+            threadCount = Math.max(2, coreSize / 2);
+        }
+
+        GenericOperationThreadFactory threadFactory = new GenericOperationThreadFactory();
+
+        OperationThread[] threads = new OperationThread[threadCount];
+        for (int threadId = 0; threadId < threads.length; threadId++) {
+            OperationThread operationThread = threadFactory.newThread(null);
+            threads[threadId] = operationThread;
+            operationThread.start();
+        }
+        return threads;
+    }
     @PrivateApi
     /**
      * Checks if an operation is still running.
@@ -302,20 +314,14 @@ public final class BasicOperationScheduler {
     }
 
     public void execute(Packet packet) {
-        try {
-            if (packet.isHeaderSet(Packet.HEADER_RESPONSE)) {
-                //it is an response packet.
-                responseThread.workQueue.add(packet);
-            } else {
-                //it is an must be an operation packet
-                int partitionId = packet.getPartitionId();
-                boolean hasPriority = packet.isUrgent();
-                execute(packet, partitionId, hasPriority);
-            }
-        } catch (RejectedExecutionException e) {
-            if (node.nodeEngine.isActive()) {
-                throw e;
-            }
+        if (packet.isHeaderSet(Packet.HEADER_RESPONSE)) {
+            //it is an response packet.
+            responseThread.workQueue.add(packet);
+        } else {
+            //it is an must be an operation packet
+            int partitionId = packet.getPartitionId();
+            boolean hasPriority = packet.isUrgent();
+            execute(packet, partitionId, hasPriority);
         }
     }
 
@@ -404,7 +410,7 @@ public final class BasicOperationScheduler {
     @Override
     public String toString() {
         return "BasicOperationScheduler{"
-                + "node=" + node.getThisAddress()
+                + "node=" + thisAddress
                 + '}';
     }
 
@@ -413,7 +419,7 @@ public final class BasicOperationScheduler {
 
         @Override
         public OperationThread newThread(Runnable ignore) {
-            String threadName = node.getThreadPoolNamePrefix("generic-operation") + threadId;
+            String threadName = threadGroup.getThreadPoolNamePrefix("generic-operation") + threadId;
             OperationThread thread = new OperationThread(threadName, false, threadId, genericWorkQueue,
                     genericPriorityWorkQueue);
             threadId++;
@@ -425,8 +431,8 @@ public final class BasicOperationScheduler {
         private int threadId;
 
         @Override
-        public Thread newThread(Runnable ignore) {
-            String threadName = node.getThreadPoolNamePrefix("partition-operation") + threadId;
+        public OperationThread newThread(Runnable ignore) {
+            String threadName = threadGroup.getThreadPoolNamePrefix("partition-operation") + threadId;
             //each partition operation thread, has its own workqueues because operations are partition specific and can't
             //be executed by other threads.
             LinkedBlockingQueue workQueue = new LinkedBlockingQueue();
@@ -452,8 +458,8 @@ public final class BasicOperationScheduler {
 
         public OperationThread(String name, boolean isPartitionSpecific,
                                int threadId, BlockingQueue workQueue, Queue priorityWorkQueue) {
-            super(node.threadGroup, name);
-            setContextClassLoader(node.getConfigClassLoader());
+            super(threadGroup.getInternalThreadGroup(), name);
+            setContextClassLoader(threadGroup.getClassLoader());
             this.isPartitionSpecific = isPartitionSpecific;
             this.workQueue = workQueue;
             this.priorityWorkQueue = priorityWorkQueue;
@@ -462,14 +468,14 @@ public final class BasicOperationScheduler {
 
         @Override
         public void run() {
-            node.getNodeExtension().onThreadStart(this);
+            nodeExtension.onThreadStart(this);
             try {
                 doRun();
             } catch (Throwable t) {
                 inspectOutputMemoryError(t);
                 logger.severe(t);
             } finally {
-                node.getNodeExtension().onThreadStop(this);
+                nodeExtension.onThreadStop(this);
             }
         }
 
@@ -561,8 +567,8 @@ public final class BasicOperationScheduler {
         private volatile long processedResponses;
 
         public ResponseThread() {
-            super(node.threadGroup, node.getThreadNamePrefix("response"));
-            setContextClassLoader(node.getConfigClassLoader());
+            super(threadGroup.getInternalThreadGroup(), threadGroup.getThreadNamePrefix("response"));
+            setContextClassLoader(threadGroup.getClassLoader());
         }
 
         public void run() {
@@ -604,22 +610,6 @@ public final class BasicOperationScheduler {
                 inspectOutputMemoryError(e);
                 logger.severe("Failed to process response: " + responsePacket + " on response thread:" + getName());
             }
-        }
-    }
-
-    /**
-     * Process the operation that has been send locally to this OperationService.
-     */
-    private final class LocalOperationProcessor implements Runnable {
-        private final Operation op;
-
-        private LocalOperationProcessor(Operation op) {
-            this.op = op;
-        }
-
-        @Override
-        public void run() {
-            operationHandler.process(op);
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/EventServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/EventServiceImpl.java
@@ -19,6 +19,7 @@ package com.hazelcast.spi.impl;
 import com.hazelcast.core.HazelcastException;
 import com.hazelcast.core.MemberLeftException;
 import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.instance.HazelcastThreadGroup;
 import com.hazelcast.instance.MemberImpl;
 import com.hazelcast.instance.Node;
 import com.hazelcast.logging.ILogger;
@@ -99,10 +100,11 @@ public class EventServiceImpl implements EventService {
         this.eventThreadCount = groupProperties.EVENT_THREAD_COUNT.getInteger();
         this.eventQueueCapacity = groupProperties.EVENT_QUEUE_CAPACITY.getInteger();
         this.eventQueueTimeoutMs = groupProperties.EVENT_QUEUE_TIMEOUT_MILLIS.getInteger();
+        HazelcastThreadGroup threadGroup = node.getHazelcastThreadGroup();
         this.eventExecutor = new StripedExecutor(
                 node.getLogger(EventServiceImpl.class),
-                node.getThreadNamePrefix("event"),
-                node.threadGroup,
+                threadGroup.getThreadNamePrefix("event"),
+                threadGroup.getInternalThreadGroup(),
                 eventThreadCount,
                 eventQueueCapacity);
         this.segments = new ConcurrentHashMap<String, EventServiceSegment>();

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/WaitNotifyServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/WaitNotifyServiceImpl.java
@@ -17,6 +17,7 @@
 package com.hazelcast.spi.impl;
 
 import com.hazelcast.core.HazelcastInstanceNotActiveException;
+import com.hazelcast.instance.HazelcastThreadGroup;
 import com.hazelcast.instance.MemberImpl;
 import com.hazelcast.instance.Node;
 import com.hazelcast.logging.ILogger;
@@ -77,9 +78,11 @@ class WaitNotifyServiceImpl implements WaitNotifyService {
         final Node node = nodeEngine.getNode();
         logger = node.getLogger(WaitNotifyService.class.getName());
 
-        String threadNamePrefix = node.getThreadNamePrefix("wait-notify");
+        HazelcastThreadGroup threadGroup = node.getHazelcastThreadGroup();
         expirationService = Executors.newSingleThreadExecutor(
-                new SingleExecutorThreadFactory(node.threadGroup, node.getConfigClassLoader(), threadNamePrefix));
+                new SingleExecutorThreadFactory(threadGroup.getInternalThreadGroup(),
+                        threadGroup.getClassLoader(),
+                        threadGroup.getThreadNamePrefix("wait-notify")));
 
         expirationTask = expirationService.submit(new ExpirationTask());
     }

--- a/hazelcast/src/main/java/com/hazelcast/util/HealthMonitor.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/HealthMonitor.java
@@ -82,7 +82,8 @@ public class HealthMonitor extends Thread {
     private final ThreadMXBean threadMxBean;
 
     public HealthMonitor(HazelcastInstanceImpl hazelcastInstance, HealthMonitorLevel logLevel, int delaySeconds) {
-        super(hazelcastInstance.node.threadGroup, hazelcastInstance.node.getThreadNamePrefix("HealthMonitor"));
+        super(hazelcastInstance.node.getHazelcastThreadGroup().getInternalThreadGroup(),
+                hazelcastInstance.node.getHazelcastThreadGroup().getThreadNamePrefix("HealthMonitor"));
         setDaemon(true);
 
         this.node = hazelcastInstance.node;

--- a/hazelcast/src/main/java/com/hazelcast/util/PerformanceMonitor.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/PerformanceMonitor.java
@@ -4,7 +4,7 @@ import com.hazelcast.instance.HazelcastInstanceImpl;
 import com.hazelcast.instance.Node;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.ConnectionManager;
-import com.hazelcast.spi.OperationService;
+import com.hazelcast.spi.impl.InternalOperationService;
 
 import java.util.concurrent.TimeUnit;
 
@@ -22,17 +22,18 @@ public class PerformanceMonitor extends Thread {
     private final ILogger logger;
     private final Node node;
     private final int delaySeconds;
-    private final OperationService operationService;
+    private final InternalOperationService operationService;
     private final ConnectionManager connectionManager;
 
     public PerformanceMonitor(HazelcastInstanceImpl hazelcastInstance, int delaySeconds) {
-        super(hazelcastInstance.node.threadGroup, hazelcastInstance.node.getThreadNamePrefix("PerformanceMonitor"));
+        super(hazelcastInstance.node.getHazelcastThreadGroup().getInternalThreadGroup(),
+                hazelcastInstance.node.getHazelcastThreadGroup().getThreadNamePrefix("PerformanceMonitor"));
         setDaemon(true);
 
         this.delaySeconds = delaySeconds;
         this.node = hazelcastInstance.node;
         this.logger = node.getLogger(PerformanceMonitor.class.getName());
-        this.operationService = node.nodeEngine.getOperationService();
+        this.operationService = (InternalOperationService) node.nodeEngine.getOperationService();
         this.connectionManager = node.connectionManager;
     }
 
@@ -57,5 +58,4 @@ public class PerformanceMonitor extends Thread {
             }
         }
     }
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/util/executor/PoolExecutorThreadFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/executor/PoolExecutorThreadFactory.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.util.executor;
 
+import com.hazelcast.instance.HazelcastThreadGroup;
 import com.hazelcast.util.EmptyStatement;
 
 import java.util.Queue;
@@ -31,6 +32,11 @@ public final class PoolExecutorThreadFactory extends AbstractExecutorThreadFacto
 
     public PoolExecutorThreadFactory(ThreadGroup threadGroup, String threadNamePrefix, ClassLoader classLoader) {
         super(threadGroup, classLoader);
+        this.threadNamePrefix = threadNamePrefix;
+    }
+
+    public PoolExecutorThreadFactory(HazelcastThreadGroup threadGroup, String threadNamePrefix) {
+        super(threadGroup.getInternalThreadGroup(), threadGroup.getClassLoader());
         this.threadNamePrefix = threadNamePrefix;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/util/executor/SingleExecutorThreadFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/executor/SingleExecutorThreadFactory.java
@@ -16,12 +16,19 @@
 
 package com.hazelcast.util.executor;
 
+import com.hazelcast.instance.HazelcastThreadGroup;
+
 public final class SingleExecutorThreadFactory extends AbstractExecutorThreadFactory {
 
     private final String threadName;
 
     public SingleExecutorThreadFactory(ThreadGroup threadGroup, ClassLoader classLoader, String threadName) {
         super(threadGroup, classLoader);
+        this.threadName = threadName;
+    }
+
+    public SingleExecutorThreadFactory(HazelcastThreadGroup threadGroup, String threadName) {
+        super(threadGroup.getInternalThreadGroup(), threadGroup.getClassLoader());
         this.threadName = threadName;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/wan/impl/WanReplicationServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/wan/impl/WanReplicationServiceImpl.java
@@ -19,6 +19,7 @@ package com.hazelcast.wan.impl;
 import com.hazelcast.config.ExecutorConfig;
 import com.hazelcast.config.WanReplicationConfig;
 import com.hazelcast.config.WanTargetClusterConfig;
+import com.hazelcast.instance.HazelcastThreadGroup;
 import com.hazelcast.instance.Node;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.ClassLoaderUtil;
@@ -127,9 +128,12 @@ public class WanReplicationServiceImpl implements WanReplicationService {
         if (ex == null) {
             synchronized (mutex) {
                 if (executor == null) {
+                    HazelcastThreadGroup threadGroup = node.getHazelcastThreadGroup();
                     executor = new StripedExecutor(node.getLogger(WanReplicationServiceImpl.class),
-                            node.getThreadNamePrefix("wan"),
-                            node.threadGroup, ExecutorConfig.DEFAULT_POOL_SIZE, ExecutorConfig.DEFAULT_QUEUE_CAPACITY);
+                            threadGroup.getThreadNamePrefix("wan"),
+                            threadGroup.getInternalThreadGroup(),
+                            ExecutorConfig.DEFAULT_POOL_SIZE,
+                            ExecutorConfig.DEFAULT_QUEUE_CAPACITY);
                 }
                 ex = executor;
             }


### PR DESCRIPTION
Introduced the HazelcastThreadGroup and pulled out that functionality from Node/NodeEngine. 

Also cleaned up the dependencies of the BasicOperationScheduler so it doesn't rely anymore on Node/NodeEngine. This was the intent of this PR so I can start to test it without having a HazelcastInstance up and running. 

This is going to be the first PR of many where I'm going to remove the need of Node/NodeEngine inside components to improve testability and reduce tight coupling.

This PR relies on the following PR to be merged first:
https://github.com/hazelcast/hazelcast/pull/4526