### PR TITLE
Interceptor id generation de-coupled from adding interceptor, this way w...

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/AbstractMapServiceContextSupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/AbstractMapServiceContextSupport.java
@@ -152,8 +152,15 @@ abstract class AbstractMapServiceContextSupport implements MapServiceContextSupp
     }
 
     @Override
-    public String addInterceptor(String mapName, MapInterceptor interceptor) {
-        return mapServiceContext.getMapContainer(mapName).addInterceptor(interceptor);
+    public void addInterceptor(String id, String mapName, MapInterceptor interceptor) {
+        MapContainer mapContainer = mapServiceContext.getMapContainer(mapName);
+        mapContainer.addInterceptor(id, interceptor);
+    }
+
+
+    @Override
+    public String generateInterceptorId(String mapName, MapInterceptor interceptor) {
+        return interceptor.getClass().getName() + interceptor.hashCode();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapContainer.java
@@ -150,14 +150,6 @@ public class MapContainer extends MapContainerSupport {
         return wanMergePolicy;
     }
 
-    public String addInterceptor(MapInterceptor interceptor) {
-        String id = interceptor.getClass().getName() + interceptor.hashCode();
-
-        addInterceptor(id, interceptor);
-
-        return id;
-    }
-
     public void addInterceptor(String id, MapInterceptor interceptor) {
 
         removeInterceptor(id);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextInterceptorSupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextInterceptorSupport.java
@@ -17,7 +17,9 @@ public interface MapServiceContextInterceptorSupport {
 
     void interceptAfterRemove(String mapName, Object value);
 
-    String addInterceptor(String mapName, MapInterceptor interceptor);
+    String generateInterceptorId(String mapName, MapInterceptor interceptor);
+
+    void addInterceptor(String id, String mapName, MapInterceptor interceptor);
 
     void removeInterceptor(String mapName, String id);
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/client/MapAddInterceptorRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/client/MapAddInterceptorRequest.java
@@ -22,6 +22,7 @@ import com.hazelcast.instance.MemberImpl;
 import com.hazelcast.map.MapInterceptor;
 import com.hazelcast.map.impl.MapPortableHook;
 import com.hazelcast.map.impl.MapService;
+import com.hazelcast.map.impl.MapServiceContext;
 import com.hazelcast.map.impl.operation.AddInterceptorOperationFactory;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
@@ -68,7 +69,8 @@ public class MapAddInterceptorRequest extends MultiTargetClientRequest implement
     @Override
     protected OperationFactory createOperationFactory() {
         final MapService mapService = getService();
-        id = mapService.getMapServiceContext().addInterceptor(name, mapInterceptor);
+        final MapServiceContext mapServiceContext = mapService.getMapServiceContext();
+        id = mapServiceContext.generateInterceptorId(name, mapInterceptor);
         return new AddInterceptorOperationFactory(id, name, mapInterceptor);
     }
 
@@ -82,9 +84,7 @@ public class MapAddInterceptorRequest extends MultiTargetClientRequest implement
         Collection<MemberImpl> memberList = getClientEngine().getClusterService().getMemberList();
         Collection<Address> addresses = new HashSet<Address>();
         for (MemberImpl member : memberList) {
-            if (!member.localMember()) {
-                addresses.add(member.getAddress());
-            }
+            addresses.add(member.getAddress());
         }
         return addresses;
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
@@ -867,16 +867,14 @@ abstract class MapProxySupport extends AbstractDistributedObject<MapService> imp
     public String addMapInterceptorInternal(MapInterceptor interceptor) {
         final NodeEngine nodeEngine = getNodeEngine();
         final MapService mapService = getService();
+        final MapServiceContext mapServiceContext = mapService.getMapServiceContext();
         if (interceptor instanceof HazelcastInstanceAware) {
             ((HazelcastInstanceAware) interceptor).setHazelcastInstance(nodeEngine.getHazelcastInstance());
         }
-        String id = mapService.getMapServiceContext().addInterceptor(name, interceptor);
+        String id = mapServiceContext.generateInterceptorId(name, interceptor);
         Collection<MemberImpl> members = nodeEngine.getClusterService().getMemberList();
         for (MemberImpl member : members) {
             try {
-                if (member.localMember()) {
-                    continue;
-                }
                 Future f = nodeEngine.getOperationService()
                         .invokeOnTarget(SERVICE_NAME, new AddInterceptorOperation(id, interceptor, name),
                                 member.getAddress());


### PR DESCRIPTION
...e are not adding map interceptors up-front. This enables features like quorum to prevent the operation. Operations should do their job inside their run method, not in the proxy etc.