### PR TITLE
Introduced ClusterClock

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cluster/ClusterClock.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/ClusterClock.java
@@ -1,0 +1,15 @@
+package com.hazelcast.cluster;
+
+public interface ClusterClock {
+
+    /**
+     * Returns the cluster-time.
+     * <p/>
+     * TODO: We need to document what cluster time really means and what is can be used for.
+     *
+     * @return the cluster-time.
+     */
+    long getClusterTime();
+
+    long getClusterTimeDiff();
+}

--- a/hazelcast/src/main/java/com/hazelcast/cluster/ClusterService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/ClusterService.java
@@ -92,12 +92,5 @@ public interface ClusterService extends CoreService {
      */
     int getSize();
 
-    /**
-     * Returns the cluster-time.
-     * <p/>
-     * TODO: We need to document what cluster time really means and what is can be used for.
-     *
-     * @return the cluster-time.
-     */
-    long getClusterTime();
+    ClusterClock getClusterClock();
 }

--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/ClusterClockImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/ClusterClockImpl.java
@@ -1,0 +1,33 @@
+package com.hazelcast.cluster.impl;
+
+import com.hazelcast.cluster.ClusterClock;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.util.Clock;
+
+public class ClusterClockImpl implements ClusterClock {
+
+    private final ILogger logger;
+    private volatile long clusterTimeDiff = Long.MAX_VALUE;
+
+    public ClusterClockImpl(ILogger logger) {
+        this.logger = logger;
+    }
+
+    @Override
+    public long getClusterTime() {
+        return Clock.currentTimeMillis() + ((clusterTimeDiff == Long.MAX_VALUE) ? 0 : clusterTimeDiff);
+    }
+
+    public void setMasterTime(long masterTime) {
+        long diff = masterTime - Clock.currentTimeMillis();
+        if (logger.isFinestEnabled()) {
+            logger.finest("Setting cluster time diff to " + diff + "ms.");
+        }
+        this.clusterTimeDiff = diff;
+    }
+
+    @Override
+    public long getClusterTimeDiff() {
+        return (clusterTimeDiff == Long.MAX_VALUE) ? 0 : clusterTimeDiff;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/ClusterProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/ClusterProxy.java
@@ -42,7 +42,7 @@ public class ClusterProxy implements Cluster {
 
     @Override
     public long getClusterTime() {
-        return clusterService.getClusterTime();
+        return clusterService.getClusterClock().getClusterTime();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/operations/MemberInfoUpdateOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/operations/MemberInfoUpdateOperation.java
@@ -52,7 +52,7 @@ public class MemberInfoUpdateOperation extends AbstractClusterOperation implemen
     protected final void processMemberUpdate() {
         if (isValid()) {
             final ClusterServiceImpl clusterService = getService();
-            clusterService.setMasterTime(masterTime);
+            clusterService.getClusterClock().setMasterTime(masterTime);
             clusterService.updateMembers(memberInfos);
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/BasicInvocation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/BasicInvocation.java
@@ -250,7 +250,7 @@ abstract class BasicInvocation implements ResponseHandler, Runnable {
             return;
         }
 
-        setInvocationTime(op, nodeEngine.getClusterTime());
+        setInvocationTime(op, nodeEngine.getClusterService().getClusterClock().getClusterTime());
 
         if (remote) {
             doInvokeRemote();

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/BasicOperationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/BasicOperationService.java
@@ -296,7 +296,7 @@ final class BasicOperationService implements InternalOperationService {
             final long invocationTime = op.getInvocationTime();
             final long expireTime = invocationTime + callTimeout;
             if (expireTime > 0 && expireTime < Long.MAX_VALUE) {
-                final long now = nodeEngine.getClusterTime();
+                final long now = nodeEngine.getClusterService().getClusterClock().getClusterTime();
                 if (expireTime < now) {
                     return true;
                 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
@@ -371,7 +371,7 @@ public class NodeEngineImpl implements NodeEngine {
     }
 
     public long getClusterTime() {
-        return node.getClusterService().getClusterTime();
+        return node.getClusterService().getClusterClock().getClusterTime();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
@@ -370,10 +370,6 @@ public class NodeEngineImpl implements NodeEngine {
         return postJoinOps.isEmpty() ? null : postJoinOps.toArray(new Operation[postJoinOps.size()]);
     }
 
-    public long getClusterTime() {
-        return node.getClusterService().getClusterClock().getClusterTime();
-    }
-
     @Override
     public Storage<DataRef> getOffHeapStorage() {
         return node.getNodeExtension().getNativeDataStorage();

--- a/hazelcast/src/main/java/com/hazelcast/util/HealthMonitor.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/HealthMonitor.java
@@ -183,7 +183,7 @@ public class HealthMonitor extends Thread {
             systemCpuLoad = readLongAttribute("SystemCpuLoad", -1L);
             threadCount = threadMxBean.getThreadCount();
             peakThreadCount = threadMxBean.getPeakThreadCount();
-            clusterTimeDiff = clusterService.getClusterTimeDiff();
+            clusterTimeDiff = clusterService.getClusterClock().getClusterTimeDiff();
             asyncExecutorQueueSize = executionService.getExecutor(ExecutionService.ASYNC_EXECUTOR).getQueueSize();
             clientExecutorQueueSize = executionService.getExecutor(ExecutionService.CLIENT_EXECUTOR).getQueueSize();
             queryExecutorQueueSize = executionService.getExecutor(ExecutionService.QUERY_EXECUTOR).getQueueSize();


### PR DESCRIPTION
Pulled out the logic from ClusterService. 

This PR is a cleanup; extracting out a concept in its own structure.

It also is a step towards reducing the need for NodeEngine in OperationService. This is going to reduce tight coupling and make it easier to test.