### PR TITLE
fixes #4516. Unhandled socket exception causes one of the ioselectors to...

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/AbstractIOSelector.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/AbstractIOSelector.java
@@ -163,7 +163,7 @@ public abstract class AbstractIOSelector extends Thread implements IOSelector {
         }
     }
 
-    private void handleSelectionKeyFailure(final Throwable e) {
+    public void handleSelectionKeyFailure(final Throwable e) {
         String msg = "Selector exception at  " + getName() + ", cause= " + e.toString();
         logger.warning(msg, e);
         if (e instanceof OutOfMemoryError) {

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/IOSelector.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/IOSelector.java
@@ -34,4 +34,5 @@ public interface IOSelector extends NIOThread {
 
     void awaitShutdown();
 
+    void handleSelectionKeyFailure(Throwable e);
 }

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/WriteHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/WriteHandler.java
@@ -149,7 +149,7 @@ public final class WriteHandler extends AbstractSelectionHandler implements Runn
      * if there is more space in the socket output buffer.
      * If the outputBuffer is not dirty, then it will unregister itself from an OP_WRITE since it isn't interested
      * in space in the socket outputBuffer.
-     *
+     * <p/>
      * This call is only made by the IO thread.
      */
     private void unschedule() {
@@ -285,7 +285,11 @@ public final class WriteHandler extends AbstractSelectionHandler implements Runn
 
     @Override
     public void run() {
-        handle();
+        try {
+            handle();
+        } catch (Throwable e) {
+            ioSelector.handleSelectionKeyFailure(e);
+        }
     }
 
     public void shutdown() {


### PR DESCRIPTION
Unhandled socket exception causes one of the ioselectors to be closed eventough node is still running. Fixed with catching and logging the exception in WriteHandler.