### PR TITLE
added a check for already created distributed object

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/client/ClientCreateRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/client/ClientCreateRequest.java
@@ -24,6 +24,7 @@ import com.hazelcast.spi.ProxyService;
 
 import java.io.IOException;
 import java.security.Permission;
+import java.util.Collection;
 
 public class ClientCreateRequest extends CallableClientRequest implements Portable, RetryableRequest, SecureRequest {
 
@@ -75,6 +76,11 @@ public class ClientCreateRequest extends CallableClientRequest implements Portab
 
     @Override
     public Permission getRequiredPermission() {
+        ProxyService proxyService = clientEngine.getProxyService();
+        Collection<String> distributedObjectNames = proxyService.getDistributedObjectNames(serviceName);
+        if (distributedObjectNames.contains(name)) {
+            return null;
+        }
         return ActionConstants.getPermission(name, serviceName, ActionConstants.ACTION_CREATE);
     }
 }


### PR DESCRIPTION
fixes https://github.com/hazelcast/hazelcast-enterprise/issues/120
With this PR hazelcast does not ask create permission for an already created distributed object