### PR TITLE
Introducing the InternalNodeEngine

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngineImpl.java
@@ -60,6 +60,7 @@ import com.hazelcast.spi.PostJoinAwareService;
 import com.hazelcast.spi.ProxyService;
 import com.hazelcast.spi.impl.InternalOperationService;
 import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.spi.impl.ServiceManager;
 import com.hazelcast.transaction.TransactionManagerService;
 import com.hazelcast.util.executor.ExecutorType;
 
@@ -467,7 +468,8 @@ public class ClientEngineImpl implements ClientEngine, CoreService, PostJoinAwar
                 return;
             }
 
-            Object service = nodeEngine.getService(serviceName);
+            ServiceManager serviceManager = nodeEngine.getServiceManager();
+            Object service = serviceManager.getService(serviceName);
             if (service == null) {
                 if (nodeEngine.isActive()) {
                     throw new IllegalArgumentException("No service registered with name: " + serviceName);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/operations/ClientDisconnectionOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/operations/ClientDisconnectionOperation.java
@@ -25,6 +25,7 @@ import com.hazelcast.spi.AbstractOperation;
 import com.hazelcast.spi.ClientAwareService;
 import com.hazelcast.spi.UrgentSystemOperation;
 import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.spi.impl.ServiceManager;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -53,7 +54,8 @@ public class ClientDisconnectionOperation extends AbstractOperation implements U
 
         NodeEngineImpl nodeEngine = (NodeEngineImpl) getNodeEngine();
         nodeEngine.onClientDisconnected(clientUuid);
-        Collection<ClientAwareService> services = nodeEngine.getServices(ClientAwareService.class);
+        ServiceManager serviceManager = nodeEngine.getServiceManager();
+        Collection<ClientAwareService> services = serviceManager.getServices(ClientAwareService.class);
         for (ClientAwareService service : services) {
             service.clientDisconnected(clientUuid);
         }

--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/ClusterServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/ClusterServiceImpl.java
@@ -66,6 +66,7 @@ import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.OperationService;
 import com.hazelcast.spi.SplitBrainHandlerService;
 import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.spi.impl.ServiceManager;
 import com.hazelcast.util.Clock;
 import com.hazelcast.util.EmptyStatement;
 import com.hazelcast.util.ValidationUtil;
@@ -852,7 +853,8 @@ public final class ClusterServiceImpl implements ClusterService, ConnectionListe
                 public void run() {
                     lifecycleService.fireLifecycleEvent(MERGING);
                     final NodeEngineImpl nodeEngine = node.nodeEngine;
-                    final Collection<SplitBrainHandlerService> services = nodeEngine.getServices(SplitBrainHandlerService.class);
+                    ServiceManager serviceManager = nodeEngine.getServiceManager();
+                    final Collection<SplitBrainHandlerService> services = serviceManager.getServices(SplitBrainHandlerService.class);
                     final Collection<Runnable> tasks = new LinkedList<Runnable>();
                     for (SplitBrainHandlerService service : services) {
                         final Runnable runnable = service.prepareMergeRunnable();
@@ -860,7 +862,7 @@ public final class ClusterServiceImpl implements ClusterService, ConnectionListe
                             tasks.add(runnable);
                         }
                     }
-                    final Collection<ManagedService> managedServices = nodeEngine.getServices(ManagedService.class);
+                    final Collection<ManagedService> managedServices = serviceManager.getServices(ManagedService.class);
                     for (ManagedService service : managedServices) {
                         service.reset();
                     }
@@ -1177,7 +1179,8 @@ public final class ClusterServiceImpl implements ClusterService, ConnectionListe
     private void sendMembershipEventNotifications(final MemberImpl member, Set<Member> members, final boolean added) {
         final int eventType = added ? MembershipEvent.MEMBER_ADDED : MembershipEvent.MEMBER_REMOVED;
         final MembershipEvent membershipEvent = new MembershipEvent(getClusterProxy(), member, eventType, members);
-        final Collection<MembershipAwareService> membershipAwareServices = nodeEngine.getServices(MembershipAwareService.class);
+        ServiceManager serviceManager = nodeEngine.getServiceManager();
+        final Collection<MembershipAwareService> membershipAwareServices = serviceManager.getServices(MembershipAwareService.class);
         if (membershipAwareServices != null && !membershipAwareServices.isEmpty()) {
             final MembershipServiceEvent event = new MembershipServiceEvent(membershipEvent);
             for (final MembershipAwareService service : membershipAwareServices) {
@@ -1202,7 +1205,8 @@ public final class ClusterServiceImpl implements ClusterService, ConnectionListe
 
     private void sendMemberAttributeEvent(MemberImpl member, MemberAttributeOperationType operationType, String key, Object value) {
         final MemberAttributeEvent memberAttributeEvent = new MemberAttributeEvent(getClusterProxy(), member, operationType, key, value);
-        final Collection<MembershipAwareService> membershipAwareServices = nodeEngine.getServices(MembershipAwareService.class);
+        ServiceManager serviceManager = nodeEngine.getServiceManager();
+        final Collection<MembershipAwareService> membershipAwareServices = serviceManager.getServices(MembershipAwareService.class);
         final MemberAttributeServiceEvent event = new MemberAttributeServiceEvent(getClusterProxy(), member, operationType, key, value);
         if (membershipAwareServices != null && !membershipAwareServices.isEmpty()) {
             for (final MembershipAwareService service : membershipAwareServices) {

--- a/hazelcast/src/main/java/com/hazelcast/management/TimedMemberStateFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/management/TimedMemberStateFactory.java
@@ -48,6 +48,7 @@ import com.hazelcast.partition.InternalPartition;
 import com.hazelcast.partition.InternalPartitionService;
 import com.hazelcast.queue.impl.QueueService;
 import com.hazelcast.spi.StatisticsAwareService;
+import com.hazelcast.spi.impl.ServiceManager;
 import com.hazelcast.topic.impl.TopicService;
 
 import java.util.ArrayList;
@@ -75,7 +76,8 @@ public class TimedMemberStateFactory {
     public TimedMemberStateFactory(final HazelcastInstanceImpl instance) {
         this.instance = instance;
         maxVisibleInstanceCount = instance.node.groupProperties.MC_MAX_INSTANCE_COUNT.getInteger();
-        cacheServiceEnabled = instance.node.nodeEngine.getService(CacheService.SERVICE_NAME) != null;
+        ServiceManager serviceManager = instance.node.nodeEngine.getServiceManager();
+        cacheServiceEnabled = serviceManager.getService(CacheService.SERVICE_NAME) != null;
         logger = instance.node.getLogger(TimedMemberStateFactory.class);
     }
 
@@ -90,7 +92,8 @@ public class TimedMemberStateFactory {
 
     public TimedMemberState createTimedMemberState() {
         MemberStateImpl memberState = new MemberStateImpl();
-        Collection<StatisticsAwareService> services = instance.node.nodeEngine.getServices(StatisticsAwareService.class);
+        ServiceManager serviceManager = instance.node.nodeEngine.getServiceManager();
+        Collection<StatisticsAwareService> services = serviceManager.getServices(StatisticsAwareService.class);
         createMemberState(memberState, services);
         GroupConfig groupConfig = instance.getConfig().getGroupConfig();
         TimedMemberState timedMemberState = new TimedMemberState();

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/MapReduceService.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/MapReduceService.java
@@ -36,7 +36,7 @@ import com.hazelcast.spi.InvocationBuilder;
 import com.hazelcast.spi.ManagedService;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.RemoteService;
-import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.spi.impl.InternalNodeEngine;
 import com.hazelcast.util.ConcurrencyUtil;
 import com.hazelcast.util.ConstructorFunction;
 
@@ -81,12 +81,12 @@ public class MapReduceService
     private final InternalPartitionService partitionService;
     private final ClusterService clusterService;
 
-    private final NodeEngineImpl nodeEngine;
+    private final InternalNodeEngine nodeEngine;
     private final Config config;
 
     public MapReduceService(NodeEngine nodeEngine) {
         this.config = nodeEngine.getConfig();
-        this.nodeEngine = (NodeEngineImpl) nodeEngine;
+        this.nodeEngine = (InternalNodeEngine) nodeEngine;
         this.clusterService = nodeEngine.getClusterService();
         this.partitionService =  nodeEngine.getPartitionService();
 

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/TrackableJobFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/TrackableJobFuture.java
@@ -27,7 +27,8 @@ import com.hazelcast.mapreduce.impl.MapReduceService;
 import com.hazelcast.nio.Address;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.impl.AbstractCompletableFuture;
-import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.spi.impl.InternalNodeEngine;
+import com.hazelcast.spi.impl.ServiceManager;
 import com.hazelcast.util.ValidationUtil;
 
 import java.util.Arrays;
@@ -66,7 +67,8 @@ public class TrackableJobFuture<V>
         this.jobTracker = jobTracker;
         this.collator = collator;
         this.latch = new CountDownLatch(1);
-        this.mapReduceService = ((NodeEngineImpl) nodeEngine).getService(MapReduceService.SERVICE_NAME);
+        ServiceManager serviceManager = ((InternalNodeEngine) nodeEngine).getServiceManager();
+        this.mapReduceService = serviceManager.getService(MapReduceService.SERVICE_NAME);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/partition/impl/ClearReplicaOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/impl/ClearReplicaOperation.java
@@ -25,6 +25,7 @@ import com.hazelcast.spi.AbstractOperation;
 import com.hazelcast.spi.MigrationAwareService;
 import com.hazelcast.spi.PartitionAwareOperation;
 import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.spi.impl.ServiceManager;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -37,7 +38,8 @@ final class ClearReplicaOperation extends AbstractOperation
     public void run() throws Exception {
         int partitionId = getPartitionId();
         NodeEngineImpl nodeEngine = (NodeEngineImpl) getNodeEngine();
-        final Collection<MigrationAwareService> services = nodeEngine.getServices(MigrationAwareService.class);
+        ServiceManager serviceManager = nodeEngine.getServiceManager();
+        final Collection<MigrationAwareService> services = serviceManager.getServices(MigrationAwareService.class);
         for (MigrationAwareService service : services) {
             try {
                 service.clearPartitionReplica(partitionId);

--- a/hazelcast/src/main/java/com/hazelcast/partition/impl/FinalizeMigrationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/impl/FinalizeMigrationOperation.java
@@ -26,6 +26,7 @@ import com.hazelcast.spi.MigrationAwareService;
 import com.hazelcast.spi.PartitionAwareOperation;
 import com.hazelcast.spi.PartitionMigrationEvent;
 import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.spi.impl.ServiceManager;
 
 import java.io.IOException;
 
@@ -54,7 +55,8 @@ final class FinalizeMigrationOperation extends AbstractOperation
         NodeEngineImpl nodeEngine = (NodeEngineImpl) getNodeEngine();
 
         PartitionMigrationEvent event = new PartitionMigrationEvent(endpoint, partitionId);
-        for (MigrationAwareService service : nodeEngine.getServices(MigrationAwareService.class)) {
+        ServiceManager serviceManager = nodeEngine.getServiceManager();
+        for (MigrationAwareService service : serviceManager.getServices(MigrationAwareService.class)) {
             finishMigration(event, service);
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/partition/impl/MigrationRequestOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/impl/MigrationRequestOperation.java
@@ -36,6 +36,7 @@ import com.hazelcast.spi.ServiceInfo;
 import com.hazelcast.spi.exception.RetryableHazelcastException;
 import com.hazelcast.spi.exception.TargetNotMemberException;
 import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.spi.impl.ServiceManager;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -196,7 +197,8 @@ public final class MigrationRequestOperation extends BaseMigrationOperation {
                 = new PartitionMigrationEvent(MigrationEndpoint.SOURCE, migrationInfo.getPartitionId());
 
         Collection<Operation> tasks = new LinkedList<Operation>();
-        for (ServiceInfo serviceInfo : nodeEngine.getServiceInfos(MigrationAwareService.class)) {
+        ServiceManager serviceManager = nodeEngine.getServiceManager();
+        for (ServiceInfo serviceInfo : serviceManager.getServiceInfos(MigrationAwareService.class)) {
             MigrationAwareService service = (MigrationAwareService) serviceInfo.getService();
             service.beforeMigration(migrationEvent);
             Operation op = service.prepareReplicationOperation(replicationEvent);

--- a/hazelcast/src/main/java/com/hazelcast/partition/impl/PromoteFromBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/impl/PromoteFromBackupOperation.java
@@ -32,6 +32,7 @@ import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.PartitionAwareOperation;
 import com.hazelcast.spi.PartitionMigrationEvent;
 import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.spi.impl.ServiceManager;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -88,7 +89,8 @@ final class PromoteFromBackupOperation extends AbstractOperation
 
     private void sendToAllMigrationAwareServices(PartitionMigrationEvent event) {
         NodeEngineImpl nodeEngine = (NodeEngineImpl) getNodeEngine();
-        for (MigrationAwareService service : nodeEngine.getServices(MigrationAwareService.class)) {
+        ServiceManager serviceManager = nodeEngine.getServiceManager();
+        for (MigrationAwareService service : serviceManager.getServices(MigrationAwareService.class)) {
             try {
                 service.beforeMigration(event);
                 service.commitMigration(event);

--- a/hazelcast/src/main/java/com/hazelcast/partition/impl/ReplicaSyncRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/impl/ReplicaSyncRequest.java
@@ -32,6 +32,7 @@ import com.hazelcast.spi.PartitionAwareOperation;
 import com.hazelcast.spi.PartitionReplicationEvent;
 import com.hazelcast.spi.ServiceInfo;
 import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.spi.impl.ServiceManager;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -136,7 +137,8 @@ public final class ReplicaSyncRequest extends Operation implements PartitionAwar
 
     private List<Operation> createReplicationOperations() {
         NodeEngineImpl nodeEngine = (NodeEngineImpl) getNodeEngine();
-        Collection<ServiceInfo> services = nodeEngine.getServiceInfos(MigrationAwareService.class);
+        ServiceManager serviceManager = nodeEngine.getServiceManager();
+        Collection<ServiceInfo> services = serviceManager.getServiceInfos(MigrationAwareService.class);
         PartitionReplicationEvent event = new PartitionReplicationEvent(getPartitionId(), getReplicaIndex());
         List<Operation> tasks = new LinkedList<Operation>();
         for (ServiceInfo serviceInfo : services) {

--- a/hazelcast/src/main/java/com/hazelcast/spi/Operation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/Operation.java
@@ -28,6 +28,7 @@ import com.hazelcast.partition.InternalPartition;
 import com.hazelcast.spi.exception.RetryableException;
 import com.hazelcast.spi.exception.RetryableHazelcastException;
 import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.spi.impl.ServiceManager;
 
 import java.io.IOException;
 import java.util.logging.Level;
@@ -190,7 +191,8 @@ public abstract class Operation implements DataSerializable {
         if (service == null) {
             // one might have overridden getServiceName() method...
             final String name = serviceName != null ? serviceName : getServiceName();
-            service = ((NodeEngineImpl) nodeEngine).getService(name);
+            ServiceManager serviceManager = ((NodeEngineImpl) nodeEngine).getServiceManager();
+            service = serviceManager.getService(name);
             if (service == null) {
                 if (nodeEngine.isActive()) {
                     throw new HazelcastException("Service with name '" + name + "' not found!");

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/BasicOperationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/BasicOperationService.java
@@ -395,7 +395,8 @@ final class BasicOperationService implements InternalOperationService {
 
     @PrivateApi
     boolean isOperationExecuting(Address callerAddress, String callerUuid, String serviceName, Object identifier) {
-        Object service = nodeEngine.getService(serviceName);
+        ServiceManager serviceManager = nodeEngine.getServiceManager();
+        Object service = serviceManager.getService(serviceName);
         if (service == null) {
             logger.severe("Not able to find operation execution info. Invalid service: " + serviceName);
             return false;

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/EventServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/EventServiceImpl.java
@@ -552,7 +552,8 @@ public class EventServiceImpl implements EventService {
         }
 
         private EventPublishingService<Object, Object> getPublishingService(String serviceName) {
-            EventPublishingService<Object, Object> service = nodeEngine.getService(serviceName);
+            ServiceManager serviceManager = nodeEngine.getServiceManager();
+            EventPublishingService<Object, Object> service = serviceManager.getService(serviceName);
             if (service == null) {
                 if (nodeEngine.isActive()) {
                     logger.warning("There is no service named: " + serviceName);
@@ -663,7 +664,8 @@ public class EventServiceImpl implements EventService {
 
         @Override
         public void run() {
-            final EventPublishingService<Object, Object> service = nodeEngine.getService(serviceName);
+            ServiceManager serviceManager = nodeEngine.getServiceManager();
+            final EventPublishingService<Object, Object> service = serviceManager.getService(serviceName);
             if (service != null) {
                 service.dispatchEvent(event, listener);
             } else {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/InternalNodeEngine.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/InternalNodeEngine.java
@@ -1,0 +1,12 @@
+package com.hazelcast.spi.impl;
+
+import com.hazelcast.spi.NodeEngine;
+
+/**
+ * The InternalNodeEngine extends the NodeEngine and exposes all kinds of other internal services that
+ * are not exposed to the regular SPI user.
+ */
+public interface InternalNodeEngine extends NodeEngine{
+
+    ServiceManager getServiceManager();
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/InternalNodeEngine.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/InternalNodeEngine.java
@@ -6,7 +6,7 @@ import com.hazelcast.spi.NodeEngine;
  * The InternalNodeEngine extends the NodeEngine and exposes all kinds of other internal services that
  * are not exposed to the regular SPI user.
  */
-public interface InternalNodeEngine extends NodeEngine{
+public interface InternalNodeEngine extends NodeEngine {
 
     ServiceManager getServiceManager();
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/InternalNodeEngine.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/InternalNodeEngine.java
@@ -10,8 +10,7 @@ import com.hazelcast.spi.NodeEngine;
  * are not exposed to the regular SPI user.
  * <p/>
  * The InternalNodeEngine is purely an 'umbrella' to inject dependencies. It should not contain all kinds of convenience
- * methods because then it will become polluted + more difficult to test. So don't add methods like 'toObject' or 'toData';
- * let this be a concern of the appropriate dependency.
+ * methods because then it will become polluted + more difficult to test.
  */
 public interface InternalNodeEngine extends NodeEngine {
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/InternalNodeEngine.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/InternalNodeEngine.java
@@ -1,5 +1,6 @@
 package com.hazelcast.spi.impl;
 
+import com.hazelcast.config.Config;
 import com.hazelcast.instance.GroupProperties;
 import com.hazelcast.instance.HazelcastThreadGroup;
 import com.hazelcast.spi.NodeEngine;
@@ -7,12 +8,19 @@ import com.hazelcast.spi.NodeEngine;
 /**
  * The InternalNodeEngine extends the {@link NodeEngine} and exposes all kinds of other internal services that
  * are not exposed to the regular SPI user.
- *
+ * <p/>
  * The InternalNodeEngine is purely an 'umbrella' to inject dependencies. It should not contain all kinds of convenience
  * methods because then it will become polluted + more difficult to test. So don't add methods like 'toObject' or 'toData';
  * let this be a concern of the appropriate dependency.
  */
 public interface InternalNodeEngine extends NodeEngine {
+
+    /**
+     * Gets the Config.
+     *
+     * @return the config.
+     */
+    Config getConfig();
 
     InternalOperationService getOperationService();
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/InternalNodeEngine.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/InternalNodeEngine.java
@@ -14,6 +14,8 @@ import com.hazelcast.spi.NodeEngine;
  */
 public interface InternalNodeEngine extends NodeEngine {
 
+    InternalOperationService getOperationService();
+
     /**
      * Gets the ServiceManager.
      *

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/InternalNodeEngine.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/InternalNodeEngine.java
@@ -3,10 +3,15 @@ package com.hazelcast.spi.impl;
 import com.hazelcast.spi.NodeEngine;
 
 /**
- * The InternalNodeEngine extends the NodeEngine and exposes all kinds of other internal services that
+ * The InternalNodeEngine extends the {@link NodeEngine} and exposes all kinds of other internal services that
  * are not exposed to the regular SPI user.
  */
 public interface InternalNodeEngine extends NodeEngine {
 
+    /**
+     * Gets the ServiceManager
+     *
+     * @return the ServiceManager.
+     */
     ServiceManager getServiceManager();
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/InternalNodeEngine.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/InternalNodeEngine.java
@@ -1,17 +1,44 @@
 package com.hazelcast.spi.impl;
 
+import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.instance.HazelcastThreadGroup;
 import com.hazelcast.spi.NodeEngine;
 
 /**
  * The InternalNodeEngine extends the {@link NodeEngine} and exposes all kinds of other internal services that
  * are not exposed to the regular SPI user.
+ *
+ * The InternalNodeEngine is purely an 'umbrella' to inject dependencies. It should not contain all kinds of convenience
+ * methods because then it will become polluted + more difficult to test. So don't add methods like 'toObject' or 'toData';
+ * let this be a concern of the appropriate dependency.
  */
 public interface InternalNodeEngine extends NodeEngine {
 
     /**
-     * Gets the ServiceManager
+     * Gets the ServiceManager.
      *
      * @return the ServiceManager.
      */
     ServiceManager getServiceManager();
+
+    /**
+     * Returns the HazelcastThreadGroup.
+     *
+     * @return the HazelcastThreadGroup.
+     */
+    HazelcastThreadGroup getHazelcastThreadGroup();
+
+    /**
+     * Returns the GroupProperties.
+     *
+     * @return the groupProperties.
+     */
+    GroupProperties getGroupProperties();
+
+    /**
+     * Gets the PacketTransceiver.
+     *
+     * @return the PacketTransceiver.
+     */
+    PacketTransceiver getPacketTransceiver();
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
@@ -20,6 +20,7 @@ import com.hazelcast.cluster.ClusterService;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.instance.HazelcastThreadGroup;
 import com.hazelcast.instance.MemberImpl;
 import com.hazelcast.instance.Node;
 import com.hazelcast.logging.ILogger;
@@ -80,6 +81,12 @@ public class NodeEngineImpl implements InternalNodeEngine {
                 node, logger, operationService, eventService, wanReplicationService, executionService);
     }
 
+    @Override
+    public HazelcastThreadGroup getHazelcastThreadGroup() {
+        return node.getHazelcastThreadGroup();
+    }
+
+    @Override
     public PacketTransceiver getPacketTransceiver() {
         return packetTransceiver;
     }
@@ -220,7 +227,6 @@ public class NodeEngineImpl implements InternalNodeEngine {
     public GroupProperties getGroupProperties() {
         return node.getGroupProperties();
     }
-
 
     @PrivateApi
     public Node getNode() {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
@@ -35,7 +35,6 @@ import com.hazelcast.spi.EventService;
 import com.hazelcast.spi.ExecutionService;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.Operation;
-import com.hazelcast.spi.OperationService;
 import com.hazelcast.spi.PostJoinAwareService;
 import com.hazelcast.spi.ProxyService;
 import com.hazelcast.spi.SharedService;

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
@@ -37,7 +37,6 @@ import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.OperationService;
 import com.hazelcast.spi.PostJoinAwareService;
 import com.hazelcast.spi.ProxyService;
-import com.hazelcast.spi.ServiceInfo;
 import com.hazelcast.spi.SharedService;
 import com.hazelcast.spi.WaitNotifyService;
 import com.hazelcast.spi.annotation.PrivateApi;

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
@@ -147,7 +147,7 @@ public class NodeEngineImpl implements InternalNodeEngine {
     }
 
     @Override
-    public OperationService getOperationService() {
+    public InternalOperationService getOperationService() {
         return operationService;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/ProxyServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/ProxyServiceImpl.java
@@ -163,7 +163,8 @@ public class ProxyServiceImpl
         if (registry != null) {
             registry.destroyProxy(name, fireEvent);
         }
-        final RemoteService service = nodeEngine.getService(serviceName);
+        ServiceManager serviceManager = nodeEngine.getServiceManager();
+        final RemoteService service = serviceManager.getService(serviceName);
         if (service != null) {
             service.destroyDistributedObject(name);
         }
@@ -283,7 +284,8 @@ public class ProxyServiceImpl
 
         private ProxyRegistry(String serviceName) {
             this.serviceName = serviceName;
-            this.service = nodeEngine.getService(serviceName);
+            ServiceManager serviceManager = nodeEngine.getServiceManager();
+            this.service = serviceManager.getService(serviceName);
             if (service == null) {
                 if (nodeEngine.isActive()) {
                     throw new IllegalArgumentException("Unknown service: " + serviceName);

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/BroadcastTxRollbackOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/BroadcastTxRollbackOperation.java
@@ -23,6 +23,7 @@ import com.hazelcast.spi.ExceptionAction;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.TransactionalService;
 import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.spi.impl.ServiceManager;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -50,7 +51,8 @@ public final class BroadcastTxRollbackOperation extends Operation {
     @Override
     public void run() throws Exception {
         NodeEngineImpl nodeEngine = (NodeEngineImpl) getNodeEngine();
-        Collection<TransactionalService> services = nodeEngine.getServices(TransactionalService.class);
+        ServiceManager serviceManager = nodeEngine.getServiceManager();
+        Collection<TransactionalService> services = serviceManager.getServices(TransactionalService.class);
         for (TransactionalService service : services) {
             try {
                 service.rollbackTransaction(txnId);

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionContextImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionContextImpl.java
@@ -29,6 +29,7 @@ import com.hazelcast.multimap.impl.MultiMapService;
 import com.hazelcast.queue.impl.QueueService;
 import com.hazelcast.spi.TransactionalService;
 import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.spi.impl.ServiceManager;
 import com.hazelcast.transaction.TransactionContext;
 import com.hazelcast.transaction.TransactionException;
 import com.hazelcast.transaction.TransactionNotActiveException;
@@ -134,7 +135,8 @@ final class TransactionContextImpl implements TransactionContext {
             return obj;
         }
 
-        final Object service = nodeEngine.getService(serviceName);
+        ServiceManager serviceManager = nodeEngine.getServiceManager();
+        final Object service = serviceManager.getService(serviceName);
         if (service instanceof TransactionalService) {
             nodeEngine.getProxyService().initializeDistributedObject(serviceName, name);
             obj = ((TransactionalService) service).createTransactionalObject(name, transaction);

--- a/hazelcast/src/main/java/com/hazelcast/wan/impl/WanReplicationServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/wan/impl/WanReplicationServiceImpl.java
@@ -26,6 +26,7 @@ import com.hazelcast.nio.ClassLoaderUtil;
 import com.hazelcast.nio.Packet;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.ReplicationSupportingService;
+import com.hazelcast.spi.impl.ServiceManager;
 import com.hazelcast.util.ExceptionUtil;
 import com.hazelcast.util.executor.StripedExecutor;
 import com.hazelcast.util.executor.StripedRunnable;
@@ -109,7 +110,8 @@ public class WanReplicationServiceImpl implements WanReplicationService {
                 try {
                     WanReplicationEvent replicationEvent = (WanReplicationEvent) node.nodeEngine.toObject(data);
                     String serviceName = replicationEvent.getServiceName();
-                    ReplicationSupportingService service = node.nodeEngine.getService(serviceName);
+                    ServiceManager serviceManager = node.nodeEngine.getServiceManager();
+                    ReplicationSupportingService service = serviceManager.getService(serviceName);
                     service.onReplicationEvent(replicationEvent);
                 } catch (Exception e) {
                     logger.severe(e);

--- a/hazelcast/src/test/java/com/hazelcast/cache/CacheSerializationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CacheSerializationTest.java
@@ -98,7 +98,7 @@ public class CacheSerializationTest extends HazelcastTestSupport {
 
             HazelcastInstanceImpl impl = (HazelcastInstanceImpl) original.get(proxy);
             NodeEngineImpl nodeEngine = impl.node.nodeEngine;
-            CacheService cacheService = nodeEngine.getService(CacheService.SERVICE_NAME);
+            CacheService cacheService = getService(impl, CacheService.SERVICE_NAME);
 
             int partitionCount = nodeEngine.getPartitionService().getPartitionCount();
 

--- a/hazelcast/src/test/java/com/hazelcast/cache/entryprocessor/JCacheEntryProcessorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/entryprocessor/JCacheEntryProcessorTest.java
@@ -256,10 +256,9 @@ public class JCacheEntryProcessorTest extends HazelcastTestSupport {
         original.setAccessible(true);
 
         HazelcastInstanceImpl impl1 = (HazelcastInstanceImpl) original.get(node1);
-        HazelcastInstanceImpl impl2 = (HazelcastInstanceImpl) original.get(node2);
 
-        cacheServiceOnNode1 = impl1.node.getNodeEngine().getService(CacheService.SERVICE_NAME);
-        cacheServiceOnNode2 = impl2.node.getNodeEngine().getService(CacheService.SERVICE_NAME);
+        cacheServiceOnNode1 = getService(node1, CacheService.SERVICE_NAME);
+        cacheServiceOnNode2 = getService(node2, CacheService.SERVICE_NAME);
 
         serializationService = impl1.node.getNodeEngine().getSerializationService();
     }

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/countdownlatch/CountDownLatchTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/countdownlatch/CountDownLatchTest.java
@@ -111,7 +111,7 @@ public class CountDownLatchTest extends HazelcastTestSupport {
     public void testCountDown_whenReachZero_thenLatchRemoved() {
         HazelcastInstance instance = createHazelcastInstance();
         ICountDownLatch latch = instance.getCountDownLatch(randomString());
-        CountDownLatchService service = getNode(instance).getNodeEngine().getService(CountDownLatchService.SERVICE_NAME);
+        CountDownLatchService service = getNode(instance).getNodeEngine().getServiceManager().getService(CountDownLatchService.SERVICE_NAME);
 
         latch.trySetCount(1);
         assertTrue(service.containsLatch(latch.getName()));
@@ -136,8 +136,7 @@ public class CountDownLatchTest extends HazelcastTestSupport {
     public void testDestroy() {
         HazelcastInstance instance = createHazelcastInstance();
         ICountDownLatch latch = instance.getCountDownLatch(randomString());
-        NodeEngineImpl nodeEngine = getNode(instance).getNodeEngine();
-        CountDownLatchService service = nodeEngine.getService(CountDownLatchService.SERVICE_NAME);
+        CountDownLatchService service = getService(instance, CountDownLatchService.SERVICE_NAME);
 
         latch.destroy();
         assertFalse(service.containsLatch(latch.getName()));

--- a/hazelcast/src/test/java/com/hazelcast/map/MergePolicySerializationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MergePolicySerializationTest.java
@@ -42,7 +42,7 @@ public class MergePolicySerializationTest extends HazelcastTestSupport {
         map.put("key", myObjectExisting);
 
         NodeEngineImpl nodeEngine = HazelcastTestSupport.getNode(instance).getNodeEngine();
-        MapService mapService = nodeEngine.getService(serviceName);
+        MapService mapService = getService(instance, serviceName);
         MapServiceContext mapServiceContext = mapService.getMapServiceContext();
         int partitionId = nodeEngine.getPartitionService().getPartitionId("key");
         Data dataKey = mapServiceContext.toData("key");

--- a/hazelcast/src/test/java/com/hazelcast/map/mapstore/MapStoreTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/mapstore/MapStoreTest.java
@@ -528,7 +528,7 @@ public class MapStoreTest extends HazelcastTestSupport {
     private int writeBehindQueueSize(HazelcastInstance node, String mapName) {
         int size = 0;
         final NodeEngineImpl nodeEngine = getNode(node).getNodeEngine();
-        MapService mapService = nodeEngine.getService(MapService.SERVICE_NAME);
+        MapService mapService = nodeEngine.getServiceManager().getService(MapService.SERVICE_NAME);
         final MapServiceContext mapServiceContext = mapService.getMapServiceContext();
         final int partitionCount = nodeEngine.getPartitionService().getPartitionCount();
         for (int i = 0; i < partitionCount; i++) {
@@ -973,7 +973,7 @@ public class MapStoreTest extends HazelcastTestSupport {
     private boolean checkIfMapLoaded(String mapName, HazelcastInstance instance) throws InterruptedException {
         NodeEngineImpl nodeEngine = TestUtil.getNode(instance).nodeEngine;
         int partitionCount = nodeEngine.getPartitionService().getPartitionCount();
-        MapService service = nodeEngine.getService(MapService.SERVICE_NAME);
+        MapService service = getService(instance, MapService.SERVICE_NAME);
         boolean loaded = false;
 
         final long end = System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(1);

--- a/hazelcast/src/test/java/com/hazelcast/map/mapstore/writebehind/WriteBehindOnBackupsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/mapstore/writebehind/WriteBehindOnBackupsTest.java
@@ -25,6 +25,7 @@ import com.hazelcast.map.impl.mapstore.MapDataStore;
 import com.hazelcast.map.impl.mapstore.writebehind.WriteBehindStore;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.spi.impl.ServiceManager;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
@@ -95,7 +96,7 @@ public class WriteBehindOnBackupsTest extends HazelcastTestSupport {
     private int writeBehindQueueSize(HazelcastInstance node, String mapName) {
         int size = 0;
         final NodeEngineImpl nodeEngine = getNode(node).getNodeEngine();
-        MapService mapService = nodeEngine.getService(MapService.SERVICE_NAME);
+        MapService mapService = getService(node, MapService.SERVICE_NAME);
         final MapServiceContext mapServiceContext = mapService.getMapServiceContext();
         final int partitionCount = nodeEngine.getPartitionService().getPartitionCount();
         for (int i = 0; i < partitionCount; i++) {

--- a/hazelcast/src/test/java/com/hazelcast/map/nearcache/NearCacheTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/nearcache/NearCacheTest.java
@@ -31,6 +31,7 @@ import com.hazelcast.map.impl.NearCacheProvider;
 import com.hazelcast.map.impl.proxy.MapProxyImpl;
 import com.hazelcast.monitor.NearCacheStats;
 import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.spi.impl.ServiceManager;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
@@ -577,9 +578,7 @@ public class NearCacheTest extends HazelcastTestSupport {
     }
 
     private NearCache getNearCache(String mapName, HazelcastInstance instance) {
-        NodeEngineImpl nodeEngine = TestUtil.getNode(instance).nodeEngine;
-        MapService service = nodeEngine.getService(MapService.SERVICE_NAME);
-
+        MapService service = getService(instance, MapService.SERVICE_NAME);
         return service.getMapServiceContext().getNearCacheProvider().getNearCache(mapName);
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/partition/PartitionControlledIdTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/partition/PartitionControlledIdTest.java
@@ -47,6 +47,7 @@ import com.hazelcast.instance.TestUtil;
 import com.hazelcast.partition.strategy.StringAndPartitionAwarePartitioningStrategy;
 import com.hazelcast.queue.impl.QueueService;
 import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.spi.impl.ServiceManager;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
@@ -122,7 +123,8 @@ public class PartitionControlledIdTest extends HazelcastTestSupport {
         assertEquals(partitionKey, lock.getPartitionKey());
 
         Node node = getNode(hz);
-        LockServiceImpl lockService = node.nodeEngine.getService(LockServiceImpl.SERVICE_NAME);
+        ServiceManager serviceManager = node.nodeEngine.getServiceManager();
+        LockServiceImpl lockService = serviceManager.getService(LockServiceImpl.SERVICE_NAME);
 
         Partition partition = instances[0].getPartitionService().getPartition(partitionKey);
         LockStore lockStore = lockService.getLockStore(partition.getPartitionId(), new InternalLockNamespace(lock.getName()));
@@ -139,7 +141,7 @@ public class PartitionControlledIdTest extends HazelcastTestSupport {
         assertEquals("semaphore@" + partitionKey, semaphore.getName());
         assertEquals(partitionKey, semaphore.getPartitionKey());
 
-        SemaphoreService service = getNodeEngine(hz).getService(SemaphoreService.SERVICE_NAME);
+        SemaphoreService service = getNodeEngine(hz).getServiceManager().getService(SemaphoreService.SERVICE_NAME);
         assertTrue(service.containsSemaphore(semaphore.getName()));
     }
 
@@ -153,7 +155,7 @@ public class PartitionControlledIdTest extends HazelcastTestSupport {
         assertEquals("idgenerator@" + partitionKey, idGenerator.getName());
         assertEquals(partitionKey, idGenerator.getPartitionKey());
 
-        AtomicLongService service = getNodeEngine(hz).getService(AtomicLongService.SERVICE_NAME);
+        AtomicLongService service = getNodeEngine(hz).getServiceManager().getService(AtomicLongService.SERVICE_NAME);
         assertTrue(service.containsAtomicLong("hz:atomic:idGenerator:" + idGenerator.getName()));
     }
 
@@ -167,7 +169,7 @@ public class PartitionControlledIdTest extends HazelcastTestSupport {
         assertEquals("atomiclong@" + partitionKey, atomicLong.getName());
         assertEquals(partitionKey, atomicLong.getPartitionKey());
 
-        AtomicLongService service = getNodeEngine(hz).getService(AtomicLongService.SERVICE_NAME);
+        AtomicLongService service = getNodeEngine(hz).getServiceManager().getService(AtomicLongService.SERVICE_NAME);
         assertTrue(service.containsAtomicLong(atomicLong.getName()));
     }
 
@@ -181,7 +183,7 @@ public class PartitionControlledIdTest extends HazelcastTestSupport {
         assertEquals("queue@" + partitionKey, queue.getName());
         assertEquals(partitionKey, queue.getPartitionKey());
 
-        QueueService service = getNodeEngine(hz).getService(QueueService.SERVICE_NAME);
+        QueueService service = getNodeEngine(hz).getServiceManager().getService(QueueService.SERVICE_NAME);
         assertTrue(service.containsQueue(queue.getName()));
     }
 
@@ -195,7 +197,7 @@ public class PartitionControlledIdTest extends HazelcastTestSupport {
         assertEquals("list@" + partitionKey, list.getName());
         assertEquals(partitionKey, list.getPartitionKey());
 
-        ListService service = getNodeEngine(hz).getService(ListService.SERVICE_NAME);
+        ListService service = getNodeEngine(hz).getServiceManager().getService(ListService.SERVICE_NAME);
         assertTrue(service.getContainerMap().containsKey(list.getName()));
     }
 
@@ -209,7 +211,7 @@ public class PartitionControlledIdTest extends HazelcastTestSupport {
         assertEquals("set@" + partitionKey, set.getName());
         assertEquals(partitionKey, set.getPartitionKey());
 
-        SetService service = getNodeEngine(hz).getService(SetService.SERVICE_NAME);
+        SetService service = getNodeEngine(hz).getServiceManager().getService(SetService.SERVICE_NAME);
         assertTrue(service.getContainerMap().containsKey(set.getName()));
     }
 
@@ -223,7 +225,7 @@ public class PartitionControlledIdTest extends HazelcastTestSupport {
         assertEquals("countdownlatch@" + partitionKey, countDownLatch.getName());
         assertEquals(partitionKey, countDownLatch.getPartitionKey());
 
-        CountDownLatchService service = getNodeEngine(hz).getService(CountDownLatchService.SERVICE_NAME);
+        CountDownLatchService service = getNodeEngine(hz).getServiceManager().getService(CountDownLatchService.SERVICE_NAME);
         assertTrue(service.containsLatch(countDownLatch.getName()));
     }
 
@@ -255,7 +257,7 @@ public class PartitionControlledIdTest extends HazelcastTestSupport {
         @Override
         public Boolean call() {
             NodeEngineImpl nodeEngine = TestUtil.getNode(hz).nodeEngine;
-            SemaphoreService service = nodeEngine.getService(SemaphoreService.SERVICE_NAME);
+            SemaphoreService service = nodeEngine.getServiceManager().getService(SemaphoreService.SERVICE_NAME);
             return service.containsSemaphore(semaphoreName);
         }
     }
@@ -301,8 +303,7 @@ public class PartitionControlledIdTest extends HazelcastTestSupport {
 
         @Override
         public Boolean call() {
-            NodeEngineImpl nodeEngine = TestUtil.getNode(hz).nodeEngine;
-            SemaphoreService service = nodeEngine.getService(SemaphoreService.SERVICE_NAME);
+            SemaphoreService service = getService(hz, SemaphoreService.SERVICE_NAME);
 
             IMap map = hz.getMap("map");
             if (map.localKeySet().contains(mapKey)) {

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
@@ -26,6 +26,8 @@ import com.hazelcast.instance.HazelcastInstanceFactory;
 import com.hazelcast.instance.Node;
 import com.hazelcast.instance.TestUtil;
 import com.hazelcast.partition.InternalPartitionService;
+import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.spi.impl.ServiceManager;
 import com.hazelcast.util.StringUtil;
 import org.junit.After;
 import org.junit.ComparisonFailure;
@@ -203,6 +205,12 @@ public abstract class HazelcastTestSupport {
 
     public static Node getNode(HazelcastInstance hz) {
         return TestUtil.getNode(hz);
+    }
+
+    public static <T> T getService(HazelcastInstance hz, String name){
+        NodeEngineImpl nodeEngine = getNode(hz).getNodeEngine();
+        ServiceManager serviceManager = nodeEngine.getServiceManager();
+        return serviceManager.getService(name);
     }
 
     public static void warmUpPartitions(HazelcastInstance... instances) {

--- a/hazelcast/src/test/java/com/hazelcast/topic/TopicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/topic/TopicTest.java
@@ -28,6 +28,7 @@ import com.hazelcast.monitor.impl.LocalTopicStatsImpl;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.DataSerializable;
+import com.hazelcast.spi.impl.ServiceManager;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
@@ -71,7 +72,7 @@ public class TopicTest extends HazelcastTestSupport {
 
         topic.destroy();
 
-        final TopicService topicService = getNode(instance).nodeEngine.getService(TopicService.SERVICE_NAME);
+        final TopicService topicService = getService(instance, TopicService.SERVICE_NAME);
 
         assertTrueEventually(new AssertTask() {
             @Override


### PR DESCRIPTION
Currently a lot of services are directly tied to the NodeEngineImpl and therefore there is a dependency on Node and everything else. This makes it very difficult to test in isolation; you need to have a running cluster. It makes is almost impossible to mock things because we can't control dependencies.

The InternalNodeEngine interface protects us against this. A lot of services like OperationService, EventService etc, get an instance of the InternalNodeEngine injected. For testing we can mock it if needed.

I have currently fixed the map reduce package so it makes use of the InternalNodeEngine interface. Once this is merged, I'll take care of other services.

It follows the same naming/interface approach we use for other services. E.g
OperationService -> public interface
InternalOperationService ->private interface
BasicOperationService -> concrete implementation

The InternalNodeEngine has abilities that are only for internal use and we don't want to expose on the NodeEngine interface.