### PR TITLE
fix attempt for #4494. Client connection destroy was running twice if re...

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/ClientConnectionManager.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/ClientConnectionManager.java
@@ -64,6 +64,9 @@ public interface ClientConnectionManager {
     /**
      * Destroys the connection
      * Clears related resources of given connection.
+     * ConnectionListener.connectionRemoved is called on registered listeners.
+     * <p/>
+     * If connection is already destroyed before calling this then does nothing.
      *
      * @param connection to be closed
      */

--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
@@ -258,10 +258,13 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
     public void destroyConnection(Connection connection) {
         Address endpoint = connection.getEndPoint();
         if (endpoint != null) {
-            connections.remove(endpoint);
-            connection.close();
+            final ClientConnection conn = connections.remove(endpoint);
+            if (conn == null) {
+                return;
+            }
+            conn.close();
             for (ConnectionListener connectionListener : connectionListeners) {
-                connectionListener.connectionRemoved(connection);
+                connectionListener.connectionRemoved(conn);
             }
         }
     }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/ClientConnectionTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ClientConnectionTest.java
@@ -113,20 +113,9 @@ public class ClientConnectionTest extends HazelcastTestSupport {
         HazelcastClientInstanceImpl clientImpl = ClientTestUtil.getHazelcastClientInstanceImpl(client);
         ClientConnectionManager connectionManager = clientImpl.getConnectionManager();
 
+        final CountingConnectionRemoveListener listener = new CountingConnectionRemoveListener();
 
-        final AtomicInteger count = new AtomicInteger();
-
-        connectionManager.addConnectionListener(new ConnectionListener() {
-            @Override
-            public void connectionAdded(Connection connection) {
-
-            }
-
-            @Override
-            public void connectionRemoved(Connection connection) {
-                count.incrementAndGet();
-            }
-        });
+        connectionManager.addConnectionListener(listener);
 
         final Address serverAddress = new Address(server.getCluster().getLocalMember().getSocketAddress());
         final Connection connectionToServer = connectionManager.getConnection(serverAddress);
@@ -134,6 +123,22 @@ public class ClientConnectionTest extends HazelcastTestSupport {
         connectionManager.destroyConnection(connectionToServer);
         connectionManager.destroyConnection(connectionToServer);
 
-        assertEquals("connection removed should be called only once", 1, count.get());
+        assertEquals("connection removed should be called only once", 1, listener.count.get());
     }
+
+    private class CountingConnectionRemoveListener implements ConnectionListener {
+
+        final AtomicInteger count = new AtomicInteger();
+
+        @Override
+        public void connectionAdded(Connection connection) {
+
+        }
+
+        @Override
+        public void connectionRemoved(Connection connection) {
+            count.incrementAndGet();
+        }
+    }
+
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/ClientConnectionTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ClientConnectionTest.java
@@ -107,7 +107,7 @@ public class ClientConnectionTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void testConnectionRemovedOnce() {
+    public void destroyConnection_whenDestroyedMultipleTimes_thenListenerRemoveCalledOnce() {
         HazelcastInstance server = Hazelcast.newHazelcastInstance();
         HazelcastInstance client = HazelcastClient.newHazelcastClient();
         HazelcastClientInstanceImpl clientImpl = ClientTestUtil.getHazelcastClientInstanceImpl(client);

--- a/hazelcast-client/src/test/java/com/hazelcast/client/impl/ClientTestUtil.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/impl/ClientTestUtil.java
@@ -1,0 +1,19 @@
+package com.hazelcast.client.impl;
+
+import com.hazelcast.core.HazelcastInstance;
+import org.junit.Ignore;
+
+@Ignore("not a JUnit test")
+public final class ClientTestUtil {
+
+    public static HazelcastClientInstanceImpl getHazelcastClientInstanceImpl(HazelcastInstance hz) {
+        HazelcastClientInstanceImpl impl = null;
+        if (hz instanceof HazelcastClientProxy) {
+            impl = ((HazelcastClientProxy) hz).client;
+        } else if (hz instanceof HazelcastClientInstanceImpl) {
+            impl = (HazelcastClientInstanceImpl) hz;
+        }
+        return impl;
+    }
+
+}

--- a/hazelcast-client/src/test/java/com/hazelcast/client/impl/ClientTestUtil.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/impl/ClientTestUtil.java
@@ -3,7 +3,6 @@ package com.hazelcast.client.impl;
 import com.hazelcast.core.HazelcastInstance;
 import org.junit.Ignore;
 
-@Ignore("not a JUnit test")
 public final class ClientTestUtil {
 
     public static HazelcastClientInstanceImpl getHazelcastClientInstanceImpl(HazelcastInstance hz) {

--- a/hazelcast/src/test/java/com/hazelcast/instance/TestUtil.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/TestUtil.java
@@ -30,7 +30,6 @@ import java.net.ServerSocket;
 import java.util.ArrayList;
 import java.util.List;
 
-@Ignore("not a JUnit test")
 public final class TestUtil {
 
     static final private SerializationService serializationService = new DefaultSerializationServiceBuilder().build();


### PR DESCRIPTION
...ad and writehandler get socket exception at the same time. Changed the implementation to remove the connection once