### PR TITLE
fix JCache Documet example

### DIFF
--- a/hazelcast-documentation/src/JCache-Eviction-SPI.md
+++ b/hazelcast-documentation/src/JCache-Eviction-SPI.md
@@ -6,7 +6,7 @@
   <backup-count>1</backup-count>
   <async-backup-count>1</async-backup-count>
   <in-memory-format>BINARY</in-memory-format>
-  <eviction size="10000" size-policy="ENTRY-COUNT" eviction-policy="LRU">
+  <eviction size="10000" size-policy="ENTRY_COUNT" eviction-policy="LRU">
     <eviction-strategy-factory
         class-name="com.hazelcast.cache...sampling.SamplingBasedEvictionStrategyFactory"/>
     <eviction-policy-strategy-factory

--- a/hazelcast-documentation/src/JCache-Eviction.md
+++ b/hazelcast-documentation/src/JCache-Eviction.md
@@ -35,13 +35,13 @@ Eviction Policies are configured by providing the corresponding abbreviation to 
 To configure the use of the LRU (Less Recently Used) policy:
 
 ```xml
-<eviction size="10000" max-size-policy="ENTRY-COUNT" eviction-policy="LRU" />
+<eviction size="10000" max-size-policy="ENTRY_COUNT" eviction-policy="LRU" />
 ```
 
 And to configure the use of the LFU (Less Frequently Used) policy:
 
 ```xml
-<eviction size="10000" max-size-policy="ENTRY-COUNT" eviction-policy="LFU" />
+<eviction size="10000" max-size-policy="ENTRY_COUNT" eviction-policy="LFU" />
 ```
 
 The default eviction policy is LRU. Therefore, Hazelcast JCache does not offer the possibility to perform no eviction.


### PR DESCRIPTION
t is about the size-policy attributes that are written in XML example of JCache but, "ENTRY-COUNT" is wrong, it is "ENTRY_COUNT" as is correct.