### PR TITLE
fix wrong class name, IList => ISet

### DIFF
--- a/hazelcast-documentation/src/MR-Introduction.md
+++ b/hazelcast-documentation/src/MR-Introduction.md
@@ -95,7 +95,7 @@ KeyValueSource<String, String> source = KeyValueSource.fromList( list );
 ```
 
 ```java
-// KeyValueSource from com.hazelcast.core.IList
+// KeyValueSource from com.hazelcast.core.ISet
 ISet<String> set = hazelcastInstance.getSet( "my-set" );
 KeyValueSource<String, String> source = KeyValueSource.fromSet( set );
 ```


### PR DESCRIPTION
In the example of KeyValueSource of MapReduce, where it should be ISet has become the IList.