### PR TITLE
Fixes the logging issue for tests

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
@@ -26,7 +26,6 @@ import com.hazelcast.instance.HazelcastInstanceFactory;
 import com.hazelcast.instance.Node;
 import com.hazelcast.instance.TestUtil;
 import com.hazelcast.partition.InternalPartitionService;
-import com.hazelcast.util.StringUtil;
 import org.junit.After;
 import org.junit.ComparisonFailure;
 
@@ -65,56 +64,6 @@ public abstract class HazelcastTestSupport {
             testHazelcastInstanceFactory.terminateAll();
         }
     }
-
-    public static void setLoggingNone() {
-        System.setProperty("hazelcast.logging.type", "none");
-    }
-
-    public static void setLoggingLog4j() {
-        System.setProperty("hazelcast.logging.type", "log4j");
-    }
-
-    public static void setLogLevelDebug() {
-        if (isLog4jLoaded()) {
-            org.apache.log4j.Logger.getRootLogger().setLevel(org.apache.log4j.Level.DEBUG);
-        }
-    }
-
-    public static void setLogLevelInfo() {
-        if (isLog4jLoaded()) {
-            org.apache.log4j.Logger.getRootLogger().setLevel(org.apache.log4j.Level.INFO);
-        }
-    }
-
-    public static void setLogLevelWarn() {
-        if (isLog4jLoaded()) {
-            org.apache.log4j.Logger.getRootLogger().setLevel(org.apache.log4j.Level.WARN);
-        }
-    }
-
-    public static void setLogLevelError() {
-        if (isLog4jLoaded()) {
-            org.apache.log4j.Logger.getRootLogger().setLevel(org.apache.log4j.Level.ERROR);
-        }
-    }
-
-    public static void setLogLevelFatal() {
-        if (isLog4jLoaded()) {
-            org.apache.log4j.Logger.getRootLogger().setLevel(org.apache.log4j.Level.FATAL);
-        }
-    }
-
-    private static boolean isLog4jLoaded() {
-        setLoggingLog4j();
-        try {
-            Class.forName("org.apache.log4j.Logger");
-            Class.forName("org.apache.log4j.Level");
-            return true;
-        } catch (Throwable ignored) {
-        }
-        return false;
-    }
-
     public static void sleepMillis(int millis) {
         try {
             TimeUnit.MILLISECONDS.sleep(millis);

--- a/pom.xml
+++ b/pom.xml
@@ -233,7 +233,6 @@
                         -Xms128m -Xmx1G -XX:MaxPermSize=128M
                         -Dhazelcast.version.check.enabled=false
                         -Dhazelcast.mancenter.enabled=false
-                        -Dhazelcast.logging.type=none
                         -Dhazelcast.test.use.network=false
                     </argLine>
                     <includes>


### PR DESCRIPTION
Removed all the previously logging hacks + resolved the issue for unpredictable logging.

The cause of the problem that Intellij sometimes doesn't show logging is that sometimes it does and sometimes it doesn't picked up the hazelcast.logging.type=none from the pom.xml. On my machine it never picks it up, so the AbstractHazelcastClassRunner default to log4j. And therefore I always get logging.

On either people their machine the ...=none is (sometimes) picked up by IntelliJ and therefore the AbstractHazelcastClassRunner will not default to log4j, and uses no logging at all!

There is one concern:
Because we have removed the hazelcast.logging.type=none from the main execution, is this going to cause problems in Jenkins?