### PR TITLE
Exceptional behavior + Operation.returnsResponse changed

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/ExpectedException.java
+++ b/hazelcast/src/test/java/com/hazelcast/ExpectedException.java
@@ -1,0 +1,9 @@
+package com.hazelcast;
+
+/**
+ * The ExpectedException is an Exception that is useful if you want to check for a
+ * certain exception to happen.
+ */
+public class ExpectedException extends RuntimeException {
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/atomicreference/AtomicReferenceBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/atomicreference/AtomicReferenceBasicTest.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.concurrent.atomicreference;
 
+import com.hazelcast.ExpectedException;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IAtomicReference;
 import com.hazelcast.core.IFunction;
@@ -175,7 +176,7 @@ public abstract class AtomicReferenceBasicTest extends HazelcastTestSupport {
         try {
             ref.apply(new FailingFunction());
             fail();
-        } catch (WoohaaException expected) {
+        } catch (ExpectedException expected) {
         }
 
         assertEquals("foo", ref.get());
@@ -193,7 +194,7 @@ public abstract class AtomicReferenceBasicTest extends HazelcastTestSupport {
         try {
             ref.alter(new FailingFunction());
             fail();
-        } catch (WoohaaException expected) {
+        } catch (ExpectedException expected) {
         }
 
         assertEquals("foo", ref.get());
@@ -224,7 +225,7 @@ public abstract class AtomicReferenceBasicTest extends HazelcastTestSupport {
         try {
             ref.alterAndGet(new FailingFunction());
             fail();
-        } catch (WoohaaException expected) {
+        } catch (ExpectedException expected) {
         }
 
         assertEquals("foo", ref.get());
@@ -255,7 +256,7 @@ public abstract class AtomicReferenceBasicTest extends HazelcastTestSupport {
         try {
             ref.getAndAlter(new FailingFunction());
             fail();
-        } catch (WoohaaException expected) {
+        } catch (ExpectedException expected) {
         }
 
         assertEquals("foo", ref.get());
@@ -297,12 +298,8 @@ public abstract class AtomicReferenceBasicTest extends HazelcastTestSupport {
     private static class FailingFunction implements IFunction<String, String> {
         @Override
         public String apply(String input) {
-            throw new WoohaaException();
+            throw new ExpectedException();
         }
-    }
-
-    private static class WoohaaException extends RuntimeException {
-
     }
 
     @Test


### PR DESCRIPTION
When an operation.returnsResponse returns false, it doesn't always mean that is doesn't return a response.. Only that it doesn't want a response when executing from an operation-thread. For example the IExecutor BaseCallableTaskOperation will not immediately return a response, only when the task that is executed is completed so the future.get can complete. This could be minutes after the BaseCallableTaskOperation completed (the only thing it did is to move to task into the TPE).

But.. if an exception is thrown:
- perhaps in the run methods when moving the task to the TPE
- verification errors: perhaps the partition has moved to a different machine

Then the exceptions are not send to the Invocation and therefore the Invocation can't handle it; e.g. resend the operation to the correct partition or propagate the exception to the user.

This pr changes the behaviour that a response is always send to the response handler no matter if operation.returnsResponse returns false. There is no change for operations that don't have an invocation, have callid==0 and therefor will have a empty-responsehandler; so the response is send to the empty response-handler.

What also is changed is that when a response is received and no invocation is found, no exception is thrown but just a log under warn is made. The thread dealing with this exception is the response handler and he can't do anything about the exception anyway.

I also added a test to verify the behaviour +  did some testing cleanup.