### PR TITLE
made runnable partition-aware

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/executor/impl/ExecutorServiceProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/executor/impl/ExecutorServiceProxy.java
@@ -274,14 +274,13 @@ public class ExecutorServiceProxy
     }
 
     private <T> int getTaskPartitionId(Callable<T> task) {
-        int partitionId;
         if (task instanceof PartitionAware) {
-            final Object partitionKey = ((PartitionAware) task).getPartitionKey();
-            partitionId = getNodeEngine().getPartitionService().getPartitionId(partitionKey);
-        } else {
-            partitionId = random.nextInt(partitionCount);
+            Object partitionKey = ((PartitionAware) task).getPartitionKey();
+            if (partitionKey != null) {
+                return getNodeEngine().getPartitionService().getPartitionId(partitionKey);
+            }
         }
-        return partitionId;
+        return random.nextInt(partitionCount);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/executor/impl/RunnableAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/executor/impl/RunnableAdapter.java
@@ -18,6 +18,7 @@ package com.hazelcast.executor.impl;
 
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.HazelcastInstanceAware;
+import com.hazelcast.core.PartitionAware;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
@@ -29,7 +30,7 @@ import java.util.concurrent.Callable;
  * An adapter that adapts a {@link Runnable} to become a {@link Callable}.
  * @param <V>
  */
-public final class RunnableAdapter<V> implements IdentifiedDataSerializable, Callable<V>, HazelcastInstanceAware {
+public final class RunnableAdapter<V> implements IdentifiedDataSerializable, Callable<V>, HazelcastInstanceAware, PartitionAware {
 
     private Runnable task;
 
@@ -51,6 +52,14 @@ public final class RunnableAdapter<V> implements IdentifiedDataSerializable, Cal
     @Override
     public V call() throws Exception {
         task.run();
+        return null;
+    }
+
+    @Override
+    public Object getPartitionKey() {
+        if (task instanceof PartitionAware) {
+            return ((PartitionAware) task).getPartitionKey();
+        }
         return null;
     }
 


### PR DESCRIPTION
After we've removed PartitionAwareOperation marker, executor service operations are now running in partition-threads. The test was assuming the operations are running on caller threads, fixed it with adding `PartitionAware` interface to the runnables.

Also fixed that runnables which are implementing `PartitionAware` interface were ignored.