### PR TITLE
PutBackupOperation should set TTL before adding enry to recordstore

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutBackupOperation.java
@@ -50,6 +50,7 @@ public final class PutBackupOperation extends KeyBasedMapOperation implements Ba
     }
 
     public void run() {
+        ttl = recordInfo != null ? recordInfo.getTtl() : ttl;
         final Record record = recordStore.putBackup(dataKey, dataValue, ttl);
         if (recordInfo != null) {
             Records.applyRecordInfo(record, recordInfo);


### PR DESCRIPTION
follow up the fix for https://github.com/hazelcast/hazelcast/issues/4144