### PR TITLE
if resend gets an exception, it will retry until retry count is reached....

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientExecutionServiceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientExecutionServiceImpl.java
@@ -38,11 +38,10 @@ import java.util.concurrent.TimeUnit;
 public final class ClientExecutionServiceImpl implements ClientExecutionService {
 
     private static final ILogger LOGGER = Logger.getLogger(ClientExecutionService.class);
-
+    private final long terminateTimeoutSeconds = 30;
     private final ExecutorService executor;
     private final ExecutorService internalExecutor;
     private final ScheduledExecutorService scheduledExecutor;
-
 
     public ClientExecutionServiceImpl(String name, ThreadGroup threadGroup, ClassLoader classLoader, int poolSize) {
         int executorPoolSize = poolSize;
@@ -77,7 +76,7 @@ public final class ClientExecutionServiceImpl implements ClientExecutionService 
     }
 
     public <T> ICompletableFuture<T> submitInternal(final Callable<T> command) {
-        CompletableFutureTask futureTask = new CompletableFutureTask(command, internalExecutor);
+        CompletableFutureTask futureTask = new CompletableFutureTask<T>(command, internalExecutor);
         internalExecutor.submit(futureTask);
         return futureTask;
     }
@@ -134,8 +133,25 @@ public final class ClientExecutionServiceImpl implements ClientExecutionService 
     }
 
     public void shutdown() {
-        internalExecutor.shutdownNow();
+        internalExecutor.shutdown();
+        try {
+            boolean success = internalExecutor.awaitTermination(terminateTimeoutSeconds, TimeUnit.SECONDS);
+            if (!success) {
+                LOGGER.warning("InternalExecutor awaitTermination could not completed in "
+                        + terminateTimeoutSeconds + " seconds");
+            }
+        } catch (InterruptedException e) {
+            LOGGER.warning("Internal Executor await termination is interrupted", e);
+        }
         scheduledExecutor.shutdownNow();
-        executor.shutdownNow();
+        executor.shutdown();
+        try {
+            boolean success = executor.awaitTermination(terminateTimeoutSeconds, TimeUnit.SECONDS);
+            if (!success) {
+                LOGGER.warning("Executor awaitTermination could not completed in " + terminateTimeoutSeconds + " seconds");
+            }
+        } catch (InterruptedException e) {
+            LOGGER.warning("Executor await termination is interrupted", e);
+        }
     }
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/ClientRegressionTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ClientRegressionTest.java
@@ -775,7 +775,7 @@ public class ClientRegressionTest
             try {
                 map.put(i, i);
             } catch (Exception e) {
-                assertTrue("Requests should not throw exception with this configuration", false);
+                assertTrue("Requests should not throw exception with this configuration. Last put key: " + i, false);
             }
         }
     }
@@ -795,34 +795,37 @@ public class ClientRegressionTest
         final int mapSize = 1000;
 
         final CountDownLatch clientStartedDoingRequests = new CountDownLatch(1);
-        final CountDownLatch testFinishedLatch = new CountDownLatch(1);
-        new Thread(new Runnable() {
-            @Override
-            public void run() {
+        int threadCount = 100;
 
-                for (int i = 0; i < mapSize; i++) {
-                    if (i == mapSize / 4) {
-                        clientStartedDoingRequests.countDown();
-                    }
+        final CountDownLatch testFinishedLatch = new CountDownLatch(threadCount);
+
+        for (int i = 0; i < threadCount; i++) {
+            Thread thread = new Thread(new Runnable() {
+                @Override
+                public void run() {
                     try {
-                        map.put(i, i);
-                    } catch (Exception ignored) {
+                        for (int i = 0; i < mapSize; i++) {
+                            if (i == mapSize / 4) {
+                                clientStartedDoingRequests.countDown();
+                            }
+
+                            map.put(i, i);
+
+                        }
+                    } catch (Throwable ignored) {
+                    } finally {
+                        testFinishedLatch.countDown();
                     }
                 }
-                testFinishedLatch.countDown();
-
-            }
-        }).start();
-
-
-        try {
-            clientStartedDoingRequests.await();
-        } catch (InterruptedException ignored) {
+            });
+            thread.start();
         }
+
+        assertTrue(clientStartedDoingRequests.await(30, TimeUnit.SECONDS));
 
         hazelcastInstance.shutdown();
 
-        assertOpenEventually("Put operations should not hang", testFinishedLatch);
+        assertOpenEventually("Put operations should not hang.", testFinishedLatch);
 
     }
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/io/ClientExecutionPoolSizeLowTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/io/ClientExecutionPoolSizeLowTest.java
@@ -2,15 +2,12 @@ package com.hazelcast.client.io;
 
 import com.hazelcast.client.HazelcastClient;
 import com.hazelcast.client.config.ClientConfig;
-import com.hazelcast.client.spi.impl.ClientCallFuture;
 import com.hazelcast.config.Config;
-import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.SlowTest;
-import com.hazelcast.util.executor.DelegatingFuture;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -18,7 +15,6 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
 
 import static com.hazelcast.test.HazelcastTestSupport.assertSizeEventually;
 import static com.hazelcast.test.HazelcastTestSupport.randomString;
@@ -28,7 +24,7 @@ import static org.junit.Assert.assertEquals;
 @Category(SlowTest.class)
 public class ClientExecutionPoolSizeLowTest {
 
-    static final int COUNT = 30000;
+    static final int COUNT = 1000;
     static HazelcastInstance server1;
     static HazelcastInstance server2;
     static HazelcastInstance client;


### PR DESCRIPTION
... Retry uses  rather than  to be able to catch RejectedExecutionException which is thrown, when client shutdown. fixes #4592