### PR TITLE
	Retry uses -execute- rather than -schedule- to be able to catch RejectedExecutionException ...

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocation.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocation.java
@@ -15,6 +15,7 @@ import com.hazelcast.executor.impl.client.RefreshableRequest;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.spi.exception.RetryableHazelcastException;
+import com.hazelcast.util.EmptyStatement;
 
 import java.io.IOException;
 import java.util.concurrent.RejectedExecutionException;
@@ -214,11 +215,20 @@ public class ClientInvocation implements Runnable {
         }
 
         try {
-            executionService.schedule(this, RETRY_WAIT_TIME_IN_SECONDS, TimeUnit.SECONDS);
+            sleep();
+            executionService.execute(this);
         } catch (RejectedExecutionException e) {
             return false;
         }
         return true;
+    }
+
+    private void sleep() {
+        try {
+            Thread.sleep(TimeUnit.SECONDS.toMillis(RETRY_WAIT_TIME_IN_SECONDS));
+        } catch (InterruptedException ignored) {
+            EmptyStatement.ignore(ignored);
+        }
     }
 
     private boolean isBindToSingleConnection() {

--- a/hazelcast-client/src/test/java/com/hazelcast/client/ClientRegressionTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ClientRegressionTest.java
@@ -17,6 +17,7 @@
 package com.hazelcast.client;
 
 import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.config.ClientProperties;
 import com.hazelcast.client.config.ClientSecurityConfig;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.ListenerConfig;
@@ -731,5 +732,96 @@ public class ClientRegressionTest
         map.get(1);
         //test should finish without throwing any exception.
         client.shutdown();
+    }
+
+    @Test
+    public void testClientReconnect_thenCheckRequestsAreRetriedWithoutException() throws Exception {
+        final HazelcastInstance hazelcastInstance = Hazelcast.newHazelcastInstance();
+
+        final CountDownLatch clientStartedDoingRequests = new CountDownLatch(1);
+        new Thread(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    clientStartedDoingRequests.await();
+                } catch (InterruptedException ignored) {
+                }
+
+                hazelcastInstance.shutdown();
+
+                Hazelcast.newHazelcastInstance();
+
+            }
+        }).start();
+
+
+        ClientConfig clientConfig = new ClientConfig();
+        //Retry all requests
+        clientConfig.getNetworkConfig().setRedoOperation(true);
+        //retry to connect to cluster forever(never shutdown the client)
+        clientConfig.getNetworkConfig().setConnectionAttemptLimit(Integer.MAX_VALUE);
+        //Retry all requests forever(until client is shutdown)
+        clientConfig.setProperty(ClientProperties.PROP_INVOCATION_TIMEOUT_SECONDS, String.valueOf(Integer.MAX_VALUE));
+        HazelcastInstance client = HazelcastClient.newHazelcastClient(clientConfig);
+
+        IMap<Object, Object> map = client.getMap(randomMapName());
+
+        int mapSize = 1000;
+        for (int i = 0; i < mapSize; i++) {
+            if (i == mapSize / 4) {
+                clientStartedDoingRequests.countDown();
+            }
+            try {
+                map.put(i, i);
+            } catch (Exception e) {
+                assertTrue("Requests should not throw exception with this configuration", false);
+            }
+        }
+    }
+
+    @Test
+    public void testClusterShutdown_thenCheckOperationsNotHanging() throws Exception {
+        final HazelcastInstance hazelcastInstance = Hazelcast.newHazelcastInstance();
+
+        ClientConfig clientConfig = new ClientConfig();
+        //Retry all requests
+        clientConfig.getNetworkConfig().setRedoOperation(true);
+        //Retry all requests forever(until client is shutdown)
+        clientConfig.setProperty(ClientProperties.PROP_INVOCATION_TIMEOUT_SECONDS, String.valueOf(Integer.MAX_VALUE));
+        HazelcastInstance client = HazelcastClient.newHazelcastClient(clientConfig);
+
+        final IMap<Object, Object> map = client.getMap(randomMapName());
+        final int mapSize = 1000;
+
+        final CountDownLatch clientStartedDoingRequests = new CountDownLatch(1);
+        final CountDownLatch testFinishedLatch = new CountDownLatch(1);
+        new Thread(new Runnable() {
+            @Override
+            public void run() {
+
+                for (int i = 0; i < mapSize; i++) {
+                    if (i == mapSize / 4) {
+                        clientStartedDoingRequests.countDown();
+                    }
+                    try {
+                        map.put(i, i);
+                    } catch (Exception ignored) {
+                    }
+                }
+                testFinishedLatch.countDown();
+
+            }
+        }).start();
+
+
+        try {
+            clientStartedDoingRequests.await();
+        } catch (InterruptedException ignored) {
+        }
+
+        hazelcastInstance.shutdown();
+
+        assertOpenEventually("Put operations should not hang", testFinishedLatch);
+
     }
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/io/ClientExecutionPoolSizeLowTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/io/ClientExecutionPoolSizeLowTest.java
@@ -24,7 +24,7 @@ import static org.junit.Assert.assertEquals;
 @Category(SlowTest.class)
 public class ClientExecutionPoolSizeLowTest {
 
-    static final int COUNT = 30000;
+    static final int COUNT = 1000;
     static HazelcastInstance server1;
     static HazelcastInstance server2;
     static HazelcastInstance client;


### PR DESCRIPTION
...ExecutionException which is thrown when client shutdown. related to #4592