### PR TITLE
added a check before running execution-callback

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/BasicInvocationFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/BasicInvocationFuture.java
@@ -70,7 +70,7 @@ final class BasicInvocationFuture<E> implements InternalCompletableFuture<E> {
         isNotNull(executor, "executor");
 
         synchronized (this) {
-            if (response != null) {
+            if (response != null && !(response instanceof BasicInvocation.InternalResponse)) {
                 runAsynchronous(callback, executor);
                 return;
             }


### PR DESCRIPTION
if and internal response has arrived before adding an execution callback, we pass that response to callback but end-up with a class-cast exception
fixes #4627 