### PR TITLE
Introduced the schedulequeue

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/classicscheduler/DefaultScheduleQueue.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/classicscheduler/DefaultScheduleQueue.java
@@ -1,0 +1,88 @@
+package com.hazelcast.spi.impl.classicscheduler;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+
+import static com.hazelcast.util.ValidationUtil.checkNotNull;
+
+public final class DefaultScheduleQueue implements ScheduleQueue {
+
+    static final Object TRIGGER_TASK = new Object() {
+        public String toString() {
+            return "triggerTask";
+        }
+    };
+
+    private final BlockingQueue normalQueue;
+    private final ConcurrentLinkedQueue priorityQueue;
+    private Object pendingNormalItem;
+
+    public DefaultScheduleQueue() {
+        this(new LinkedBlockingQueue(), new ConcurrentLinkedQueue());
+    }
+
+    public DefaultScheduleQueue(BlockingQueue normalQueue, ConcurrentLinkedQueue priorityQueue) {
+        this.normalQueue = checkNotNull(normalQueue, "normalQueue");
+        this.priorityQueue = checkNotNull(priorityQueue, "priorityQueue");
+    }
+
+    @Override
+    public void add(Object task, boolean priority) {
+        if (task == null) {
+            throw new NullPointerException("task can't be null");
+        }
+
+        if (priority) {
+            priorityQueue.add(task);
+            normalQueue.add(TRIGGER_TASK);
+        } else {
+            normalQueue.add(task);
+        }
+    }
+
+    @Override
+    public int normalSize() {
+        return normalQueue.size();
+    }
+
+    @Override
+    public int prioritySize() {
+        return priorityQueue.size();
+    }
+
+    @Override
+    public int size() {
+        return normalQueue.size() + priorityQueue.size();
+    }
+
+    @Override
+    public Object take() throws InterruptedException {
+        ConcurrentLinkedQueue priorityQueue = this.priorityQueue;
+        for (; ; ) {
+            Object priorityItem = priorityQueue.poll();
+            if (priorityItem != null) {
+                return priorityItem;
+            }
+
+            if (pendingNormalItem != null) {
+                Object tmp = pendingNormalItem;
+                pendingNormalItem = null;
+                return tmp;
+            }
+
+            Object normalItem = normalQueue.take();
+            if (normalItem == TRIGGER_TASK) {
+                continue;
+            }
+
+            priorityItem = priorityQueue.poll();
+            if (priorityItem != null) {
+                pendingNormalItem = normalItem;
+                return priorityItem;
+            }
+
+            return normalItem;
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/classicscheduler/GenericOperationThread.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/classicscheduler/GenericOperationThread.java
@@ -5,9 +5,6 @@ import com.hazelcast.instance.NodeExtension;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.spi.impl.OperationHandler;
 
-import java.util.Queue;
-import java.util.concurrent.BlockingQueue;
-
 /**
  * An {@link OperationThread} for non partition specific operations.
  */
@@ -15,10 +12,10 @@ public final class GenericOperationThread extends OperationThread {
 
     private final OperationHandler operationHandler;
 
-    public GenericOperationThread(String name, int threadId, BlockingQueue workQueue,
-                                  Queue priorityWorkQueue, ILogger logger, HazelcastThreadGroup threadGroup,
+    public GenericOperationThread(String name, int threadId, ScheduleQueue scheduleQueue,
+                                  ILogger logger, HazelcastThreadGroup threadGroup,
                                   NodeExtension nodeExtension,  OperationHandler operationHandler) {
-        super(name, threadId, workQueue, priorityWorkQueue, logger, threadGroup, nodeExtension);
+        super(name, threadId, scheduleQueue, logger, threadGroup, nodeExtension);
         this.operationHandler = operationHandler;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/classicscheduler/PartitionOperationThread.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/classicscheduler/PartitionOperationThread.java
@@ -5,9 +5,6 @@ import com.hazelcast.instance.NodeExtension;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.spi.impl.OperationHandler;
 
-import java.util.Queue;
-import java.util.concurrent.BlockingQueue;
-
 /**
  * An {@link OperationThread} that executes Operations for a particular partition, e.g. a map.get operation.
  */
@@ -15,11 +12,11 @@ public final class PartitionOperationThread extends OperationThread {
 
     private final OperationHandler[] partitionOperationHandlers;
 
-    public PartitionOperationThread(String name, int threadId, BlockingQueue workQueue,
-                                    Queue priorityWorkQueue, ILogger logger,
+    public PartitionOperationThread(String name, int threadId,
+                                    ScheduleQueue scheduleQueue, ILogger logger,
                                     HazelcastThreadGroup threadGroup, NodeExtension nodeExtension,
                                     OperationHandler[] partitionOperationHandlers) {
-        super(name, threadId, workQueue, priorityWorkQueue, logger, threadGroup, nodeExtension);
+        super(name, threadId, scheduleQueue, logger, threadGroup, nodeExtension);
         this.partitionOperationHandlers = partitionOperationHandlers;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/classicscheduler/ScheduleQueue.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/classicscheduler/ScheduleQueue.java
@@ -1,0 +1,69 @@
+package com.hazelcast.spi.impl.classicscheduler;
+
+/**
+ * The ScheduleQueue is a kind of priority queue where 'tasks' are queued for scheduling.
+ * <p/>
+ * ScheduleQueue support concurrent producers but only need to support single consumers.
+ * <p/>
+ * The ScheduledQueue also support priority tasks; so if a task with a priority comes in, than
+ * that one is taken before any other normal operation is taken.
+ * <p/>
+ * The ordering between normal tasks will always be FIFO. And the same goes for the ordering between
+ * priority tasks, but there is no ordering guarantee between priority and normal tasks.
+ */
+public interface ScheduleQueue {
+
+    /**
+     * Adds an task to this queue.
+     * <p/>
+     * This method is thread safe.
+     *
+     * @param task     the item to add
+     * @param priority if the item has a priority or not.
+     * @throws java.lang.NullPointerException if task is null
+     */
+    void add(Object task, boolean priority);
+
+    /**
+     * Takes an item from this queue. If no item is available, the call blocks.
+     * <p/>
+     * This method should always be called by the same thread.
+     *
+     * @return the taken item.
+     * @throws InterruptedException if the thread is interrupted while waiting.
+     */
+    Object take() throws InterruptedException;
+
+    /**
+     * returns the number of normal operations pending.
+     * <p/>
+     * This method is thread safe.
+     *
+     * This method returns a best effort value and should only be used for monitoring purposes.
+     *
+     * @return the number of normal pending operations.
+     */
+    int normalSize();
+
+    /**
+     * returns the number of priority operations pending.
+     * <p/>
+     * This method is thread safe.
+     *
+     * This method returns a best effort value and should only be used for monitoring purposes.
+     *
+     * @return the number of priority pending operations.
+     */
+    int prioritySize();
+
+    /**
+     * Returns the total number of pending operations.
+     * <p/>
+     * This method is thread safe.
+     *
+     * This method returns a best effort value and should only be used for monitoring purposes.
+     *
+     * @return the total number of pending operations.
+     */
+    int size();
+}

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/classicscheduler/DefaultScheduleQueueTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/classicscheduler/DefaultScheduleQueueTest.java
@@ -1,0 +1,109 @@
+package com.hazelcast.spi.impl.classicscheduler;
+
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class DefaultScheduleQueueTest extends HazelcastTestSupport {
+
+    private DefaultScheduleQueue queue;
+    private LinkedBlockingQueue normalQueue;
+    private ConcurrentLinkedQueue priorityQueue;
+
+    @Before
+    public void setup() {
+        normalQueue = new LinkedBlockingQueue();
+        priorityQueue = new ConcurrentLinkedQueue();
+        queue = new DefaultScheduleQueue(normalQueue, priorityQueue);
+    }
+
+    // ================== add =====================
+
+    @Test(expected = NullPointerException.class)
+    public void test_add_whenNull() {
+        queue.add(null, false);
+    }
+
+    @Test
+    public void test_add_whenPriority() {
+        Object task = new Object();
+        queue.add(task, true);
+
+        assertContent(priorityQueue, task);
+        assertContent(normalQueue, DefaultScheduleQueue.TRIGGER_TASK);
+        assertEquals(1, queue.prioritySize());
+        assertEquals(1, queue.normalSize());
+        assertEquals(2, queue.size());
+    }
+
+    @Test
+    public void test_add_whenNormal() {
+        Object task = new Object();
+        queue.add(task, false);
+
+        assertContent(normalQueue, task);
+        assertEmpty(priorityQueue);
+        assertEquals(0, queue.prioritySize());
+        assertEquals(1, queue.normalSize());
+        assertEquals(1, queue.size());
+    }
+
+    // ================== take =====================
+
+    @Test
+    public void test_take_priorityIsRetrievedFirst() throws InterruptedException {
+        Object priorityTask1 = "priority1";
+        Object priorityTask2 = "priority2";
+        Object priorityTask3 = "priority4";
+
+        Object normalTask1 = "normalTask1";
+        Object normalTask2 = "normalTask2";
+        Object normalTask3 = "normalTask3";
+
+        queue.add(priorityTask1, true);
+        queue.add(normalTask1, false);
+        queue.add(normalTask2, false);
+
+        queue.add(priorityTask2, true);
+        queue.add(normalTask3, false);
+        queue.add(priorityTask3, true);
+
+        assertSame(priorityTask1, queue.take());
+        assertSame(priorityTask2, queue.take());
+        assertSame(priorityTask3, queue.take());
+        assertSame(normalTask1, queue.take());
+        assertSame(normalTask2, queue.take());
+        assertSame(normalTask3, queue.take());
+
+        assertEmpty(priorityQueue);
+        assertContent(normalQueue, DefaultScheduleQueue.TRIGGER_TASK);
+    }
+
+
+    public void assertEmpty(Queue q) {
+        assertEquals("expecting an empty queue, but the queue is:"+q,0, q.size());
+    }
+
+    public void assertContent(Queue q, Object... expected) {
+        List actual = new LinkedList(q);
+        assertEquals(Arrays.asList(expected), actual);
+    }
+
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/classicscheduler/ExecutePartitionSpecificRunnableTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/classicscheduler/ExecutePartitionSpecificRunnableTest.java
@@ -1,8 +1,14 @@
 package com.hazelcast.spi.impl.classicscheduler;
 
 import com.hazelcast.spi.impl.PartitionSpecificRunnable;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
 public class ExecutePartitionSpecificRunnableTest extends AbstractClassicSchedulerTest {
 
     @Test(expected = NullPointerException.class)


### PR DESCRIPTION
I added the ScheduleQueue as an abstraction that merges the BlockingQueue/PriorityQueue thing we have currently in the OperationScheduler. Apart from cleaning up the code, it also makes it a lot easier to integrate the caller runs scheduler since it can reuse all the thread-classes from the classic scheduler.

I also add some tests for the default implementation of this queue.