### PR TITLE
Cleanup: skipping deregistration when callid 0

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/BasicOperationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/BasicOperationService.java
@@ -372,7 +372,14 @@ final class BasicOperationService implements InternalOperationService {
     }
 
     public void deregisterInvocation(BasicInvocation invocation) {
-        invocations.remove(invocation.op.getCallId());
+        long callId = invocation.op.getCallId();
+        // locally executed non backup-aware operations (e.g. a map.get on a local member) doesn't have a call id.
+        // so in that case we can skip the deregistration since it isn't registered in the first place.
+        if (callId == 0) {
+            return;
+        }
+
+        invocations.remove(callId);
     }
 
     @PrivateApi


### PR DESCRIPTION
Local calls like Map.get are currently deregistered from the OperationService, even if they are not registered. 

This PR fixes that; so when an operation has call id 0, it isn't registered and therefore doesn't need to be deregistered.

I have no clue of this is going to make any improvement in performance, but I think the logic is a bit cleaner since it doesn't make a lot of sense to do a deregister if there was no register.