### PR TITLE
Fix for #3373 Changed next time stamp implementation.

### DIFF
--- a/hazelcast-hibernate/hazelcast-hibernate3/src/main/java/com/hazelcast/hibernate/HazelcastTimestamper.java
+++ b/hazelcast-hibernate/hazelcast-hibernate3/src/main/java/com/hazelcast/hibernate/HazelcastTimestamper.java
@@ -59,8 +59,9 @@ public final class HazelcastTimestamper {
             for (long current = VALUE.get(), update = Math.max(base, current + 1); update < maxValue;
                  current = VALUE.get(), update = Math.max(base, current + 1)) {
                 if (VALUE.compareAndSet(current, update)) {
-                    if(runs > 1) {
-                        Logger.getLogger(HazelcastTimestamper.class).finest(String.format("Waiting for time to pass. Looped %d times",runs));
+                    if (runs > 1) {
+                        Logger.getLogger(HazelcastTimestamper.class)
+                                .finest(String.format("Waiting for time to pass. Looped %d times" , runs));
                     }
                     return update;
                 }

--- a/hazelcast-hibernate/hazelcast-hibernate3/src/test/java/com/hazelcast/hibernate/HibernateStatisticsTestSupport.java
+++ b/hazelcast-hibernate/hazelcast-hibernate3/src/test/java/com/hazelcast/hibernate/HibernateStatisticsTestSupport.java
@@ -182,6 +182,7 @@ public abstract class HibernateStatisticsTestSupport extends HibernateTestSuppor
         }
 
         Statistics stats = sf.getStatistics();
+        stats.setStatisticsEnabled(true);
         assertEquals(1, stats.getQueryCachePutCount());
         assertEquals(1, stats.getQueryCacheMissCount());
         assertEquals(queryCount - 1, stats.getQueryCacheHitCount());

--- a/hazelcast-hibernate/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/HazelcastTimestamper.java
+++ b/hazelcast-hibernate/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/HazelcastTimestamper.java
@@ -59,8 +59,9 @@ public final class HazelcastTimestamper {
             for (long current = VALUE.get(), update = Math.max(base, current + 1); update < maxValue;
                  current = VALUE.get(), update = Math.max(base, current + 1)) {
                 if (VALUE.compareAndSet(current, update)) {
-                    if(runs > 1) {
-                        Logger.getLogger(HazelcastTimestamper.class).finest(String.format("Waiting for time to pass. Looped %d times",runs));
+                    if (runs > 1) {
+                        Logger.getLogger(HazelcastTimestamper.class)
+                                .finest(String.format("Waiting for time to pass. Looped %d times" , runs));
                     }
                     return update;
                 }

--- a/hazelcast-hibernate/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/HazelcastTimestamper.java
+++ b/hazelcast-hibernate/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/HazelcastTimestamper.java
@@ -22,6 +22,8 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.instance.GroupProperties;
 import com.hazelcast.logging.Logger;
 
+import java.util.concurrent.atomic.AtomicLong;
+
 /**
  * Helper class to create timestamps and calculate timeouts based on either Hazelcast
  * configuration of by requesting values on the cluster.
@@ -29,20 +31,34 @@ import com.hazelcast.logging.Logger;
 public final class HazelcastTimestamper {
 
     private static final int SEC_TO_MS = 1000;
+    private static final int BIN_DIGITS = 12;
+    private static final int ONE_MS = 1 << BIN_DIGITS;
+    private static final AtomicLong VALUE  = new AtomicLong();
 
     private HazelcastTimestamper() {
     }
 
     public static long nextTimestamp(HazelcastInstance instance) {
-        // System time in ms.
-        return instance.getCluster().getClusterTime();
+        int runs = 0;
+        while (true) {
+            long base = instance.getCluster().getClusterTime() << BIN_DIGITS;
+            long maxValue = base + ONE_MS - 1;
+
+            for (long current = VALUE.get(), update = Math.max(base, current + 1); update < maxValue;
+                 current = VALUE.get(), update = Math.max(base, current + 1)) {
+                if (VALUE.compareAndSet(current, update)) {
+                    return update;
+                }
+            }
+            ++runs;
+        }
     }
 
     public static int getTimeout(HazelcastInstance instance, String regionName) {
         try {
             final MapConfig cfg = instance.getConfig().findMapConfig(regionName);
             if (cfg.getTimeToLiveSeconds() > 0) {
-                // TTL in ms
+                // TTL in ms.
                 return cfg.getTimeToLiveSeconds() * SEC_TO_MS;
             }
         } catch (UnsupportedOperationException e) {


### PR DESCRIPTION
As discussed in https://github.com/hazelcast/hazelcast/issues/3068 before, our time stamp implementation used by hibernate query cache is millisecond based which is taken with instance.getCluster().getClusterTime(). It causes test failures in fast machines form time to time. I have modified nextTimestamp(HazelcastInstance instance) so that it waits until a different new timestamp value is generated. This implementation is similar to ehcache implementation which is considered as reference implementation for hibernate second level cache.
