### PR TITLE
Fixed leaking waiting ops and invocations after a partial network split

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/ClusterServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/ClusterServiceImpl.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.cluster.impl;
 
-import com.hazelcast.cluster.ClusterClock;
 import com.hazelcast.cluster.ClusterService;
 import com.hazelcast.cluster.MemberAttributeOperationType;
 import com.hazelcast.cluster.MemberInfo;
@@ -865,6 +864,7 @@ public final class ClusterServiceImpl implements ClusterService, ConnectionListe
                         service.reset();
                     }
                     node.onRestart();
+                    node.nodeEngine.reset();
                     node.connectionManager.restart();
                     node.rejoin();
                     final Collection<Future> futures = new LinkedList<Future>();

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/BasicOperationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/BasicOperationService.java
@@ -487,6 +487,18 @@ final class BasicOperationService implements InternalOperationService {
     }
 
     @Override
+    public void reset() {
+        for (BasicInvocation invocation : invocations.values()) {
+            try {
+                invocation.notify(new MemberLeftException());
+            } catch (Throwable e) {
+                logger.warning(invocation + " could not be notified with reset message -> " + e.getMessage());
+            }
+        }
+        invocations.clear();
+    }
+
+    @Override
     public void shutdown() {
         shutdown = true;
         logger.finest("Stopping operation threads...");

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/InternalOperationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/InternalOperationService.java
@@ -76,6 +76,12 @@ public interface InternalOperationService extends OperationService {
     Collection<SlowOperationLog> getSlowOperationLogs();
 
     /**
+     * Resets internal state of InternalOperationService.
+     * Notifies registered invocations with an error message.
+     */
+    void reset();
+
+    /**
      * Shuts down this InternalOperationService.
      */
     void shutdown();

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
@@ -303,6 +303,12 @@ public class NodeEngineImpl implements NodeEngine {
     }
 
     @PrivateApi
+    public void reset() {
+        waitNotifyService.reset();
+        operationService.reset();
+    }
+
+    @PrivateApi
     public void shutdown(final boolean terminate) {
         logger.finest("Shutting down services...");
         waitNotifyService.shutdown();

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/WaitNotifyServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/WaitNotifyServiceImpl.java
@@ -155,6 +155,15 @@ class WaitNotifyServiceImpl implements WaitNotifyService {
         return mapWaitingOps.size();
     }
 
+    // for testing purposes only
+    int getTotalWaitingOperationCount() {
+        int count = 0;
+        for (Queue<WaitingOp> queue : mapWaitingOps.values()) {
+            count += queue.size();
+        }
+        return count;
+    }
+
     // invalidated waiting ops will removed from queue eventually by notifiers.
     void onMemberLeft(MemberImpl leftMember) {
         invalidateWaitingOps(leftMember.getUuid());
@@ -215,6 +224,11 @@ class WaitNotifyServiceImpl implements WaitNotifyService {
                 }
             }
         }
+    }
+
+    void reset() {
+        delayQueue.clear();
+        mapWaitingOps.clear();
     }
 
     void shutdown() {

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/InvocationNetworkSplitTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/InvocationNetworkSplitTest.java
@@ -1,0 +1,262 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi.impl;
+
+import com.hazelcast.cluster.impl.ClusterServiceImpl;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.MemberLeftException;
+import com.hazelcast.instance.Node;
+import com.hazelcast.instance.TestUtil;
+import com.hazelcast.spi.AbstractOperation;
+import com.hazelcast.spi.AbstractWaitNotifyKey;
+import com.hazelcast.spi.ExceptionAction;
+import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.OperationService;
+import com.hazelcast.spi.WaitNotifyKey;
+import com.hazelcast.spi.WaitSupport;
+import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.util.EmptyStatement;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category(QuickTest.class)
+public class InvocationNetworkSplitTest extends HazelcastTestSupport {
+
+    @Test
+    public void testWaitingInvocations_whenNodeSplitFromCluster() throws Exception {
+        SplitAction action = new FullSplitAction();
+        testWaitingInvocations_whenNodeSplitFromCluster(action);
+    }
+
+    @Test
+    public void testWaitingInvocations_whenNodePartiallySplitFromCluster_scenario1() throws Exception {
+        SplitAction action = new PartialSplitAction();
+        testWaitingInvocations_whenNodeSplitFromCluster(action);
+    }
+
+    @Test
+    public void testWaitingInvocations_whenNodePartiallySplitFromCluster_scenario2() throws Exception {
+        SplitAction action = new HalfPartialSplitAction();
+        testWaitingInvocations_whenNodeSplitFromCluster(action);
+    }
+
+    private void testWaitingInvocations_whenNodeSplitFromCluster(SplitAction splitAction) throws Exception {
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(3);
+        HazelcastInstance hz1 = factory.newHazelcastInstance();
+        HazelcastInstance hz2 = factory.newHazelcastInstance();
+        HazelcastInstance hz3 = factory.newHazelcastInstance();
+
+        Node node1 = TestUtil.getNode(hz1);
+        Node node2 = TestUtil.getNode(hz2);
+        Node node3 = TestUtil.getNode(hz3);
+
+        warmUpPartitions(hz1, hz2, hz3);
+        int partitionId = getPartitionId(hz2);
+
+        NodeEngineImpl nodeEngine3 = node3.getNodeEngine();
+        OperationService operationService3 = nodeEngine3.getOperationService();
+        Operation op = new AlwaysBlockingOperation();
+        Future<Object> future = operationService3.invokeOnPartition("", op, partitionId);
+
+        // just wait a little to make sure
+        // operation is landed on wait-queue
+        sleepSeconds(1);
+
+        // execute the given split action
+        splitAction.run(node1, node2, node3);
+
+        // Let node3 detect the split and merge it back to other two.
+        ClusterServiceImpl clusterService3 = node3.getClusterService();
+        clusterService3.prepareToMerge(node1.address);
+        clusterService3.merge(node1.address);
+
+        assertEquals(3, node1.getClusterService().getSize());
+        assertEquals(3, node2.getClusterService().getSize());
+        assertEquals(3, node3.getClusterService().getSize());
+
+        try {
+            future.get(1, TimeUnit.MINUTES);
+            fail("Future.get() should fail with a MemberLeftException!");
+        } catch (MemberLeftException e) {
+            // expected
+            EmptyStatement.ignore(e);
+        } catch (Exception e) {
+            fail(e.getClass().getName() + ": " + e.getMessage());
+        }
+    }
+
+    @Test
+    public void testWaitNotifyService_whenNodeSplitFromCluster() throws Exception {
+        SplitAction action = new FullSplitAction();
+        testWaitNotifyService_whenNodeSplitFromCluster(action);
+    }
+
+    @Test
+    public void testWaitNotifyService_whenNodePartiallySplitFromCluster() throws Exception {
+        SplitAction action = new PartialSplitAction();
+        testWaitNotifyService_whenNodeSplitFromCluster(action);
+    }
+
+    private void testWaitNotifyService_whenNodeSplitFromCluster(SplitAction action) throws Exception {
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(5);
+        HazelcastInstance hz1 = factory.newHazelcastInstance();
+        HazelcastInstance hz2 = factory.newHazelcastInstance();
+        HazelcastInstance hz3 = factory.newHazelcastInstance();
+
+        final Node node1 = TestUtil.getNode(hz1);
+        Node node2 = TestUtil.getNode(hz2);
+        Node node3 = TestUtil.getNode(hz3);
+
+        warmUpPartitions(hz1, hz2, hz3);
+        int partitionId = getPartitionId(hz3);
+
+        NodeEngineImpl nodeEngine1 = node1.getNodeEngine();
+        OperationService operationService1 = nodeEngine1.getOperationService();
+        operationService1.invokeOnPartition("", new AlwaysBlockingOperation(), partitionId);
+
+        final WaitNotifyServiceImpl waitNotifyService3 = (WaitNotifyServiceImpl) node3.getNodeEngine().getWaitNotifyService();
+        assertEqualsEventually(new Callable<Integer>() {
+            @Override
+            public Integer call() throws Exception {
+                return waitNotifyService3.getTotalWaitingOperationCount();
+            }
+        }, 1);
+
+        action.run(node1, node2, node3);
+
+        // create a new node to prevent same partition assignments
+        // after node3 rejoins
+        factory.newHazelcastInstance();
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                Assert.assertEquals(0, node1.partitionService.getMigrationQueueSize());
+            }
+        });
+
+        // Let node3 detect the split and merge it back to other two.
+        ClusterServiceImpl clusterService3 = node3.getClusterService();
+        clusterService3.prepareToMerge(node1.address);
+        clusterService3.merge(node1.address);
+
+        assertEquals(4, node1.getClusterService().getSize());
+        assertEquals(4, node2.getClusterService().getSize());
+        assertEquals(4, node3.getClusterService().getSize());
+
+        assertEquals(0, waitNotifyService3.getTotalWaitingOperationCount());
+    }
+
+    private static class AlwaysBlockingOperation extends AbstractOperation implements WaitSupport {
+
+        @Override
+        public void run() throws Exception {
+        }
+
+        @Override
+        public WaitNotifyKey getWaitKey() {
+            return new AbstractWaitNotifyKey(getServiceName(), "test") {};
+        }
+
+        @Override
+        public boolean shouldWait() {
+            return true;
+        }
+
+        @Override
+        public void onWaitExpire() {
+            getResponseHandler().sendResponse(new TimeoutException());
+        }
+
+        @Override
+        public String getServiceName() {
+            return "AlwaysBlockingOperationService";
+        }
+
+        @Override
+        public ExceptionAction onException(Throwable throwable) {
+            return ExceptionAction.THROW_EXCEPTION;
+        }
+    }
+
+    private interface SplitAction {
+        void run(Node node1, Node node2, Node node3);
+    }
+
+    private static class FullSplitAction implements SplitAction {
+        @Override
+        public void run(Node node1, Node node2, Node node3) {
+            // Artificially create a network-split
+            node1.clusterService.removeAddress(node3.address);
+            node2.clusterService.removeAddress(node3.address);
+
+            node3.clusterService.removeAddress(node1.address);
+            node3.clusterService.removeAddress(node2.address);
+
+            assertEquals(2, node1.getClusterService().getSize());
+            assertEquals(2, node2.getClusterService().getSize());
+            assertEquals(1, node3.getClusterService().getSize());
+
+        }
+    }
+
+    private static class PartialSplitAction implements SplitAction {
+        @Override
+        public void run(Node node1, Node node2, Node node3) {
+            // Artificially create a partial network-split;
+            // node1 and node2 will be split from node3
+            // but node 3 will not be able to detect that.
+            node1.clusterService.removeAddress(node3.address);
+            node2.clusterService.removeAddress(node3.address);
+
+            assertEquals(2, node1.getClusterService().getSize());
+            assertEquals(2, node2.getClusterService().getSize());
+            assertEquals(3, node3.getClusterService().getSize());
+        }
+    }
+
+    private static class HalfPartialSplitAction implements SplitAction {
+        @Override
+        public void run(Node node1, Node node2, Node node3) {
+            // Artificially create a partial network-split;
+            // node1 and node2 will be split from node3
+            // but node 3 will not be able to detect that.
+            node1.clusterService.removeAddress(node3.address);
+            node2.clusterService.removeAddress(node3.address);
+            node3.clusterService.removeAddress(node1.address);
+
+            assertEquals(2, node1.getClusterService().getSize());
+            assertEquals(2, node2.getClusterService().getSize());
+            assertEquals(2, node3.getClusterService().getSize());
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
@@ -468,6 +468,15 @@ public abstract class HazelcastTestSupport {
         });
     }
 
+    public static <E> void assertEqualsEventually(final Callable<E> task, final E value) {
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertEquals(value, task.call());
+            }
+        });
+    }
+
     public static void assertClusterSize(int expectedSize, HazelcastInstance instance) {
         assertEquals("Cluster size is not correct", expectedSize, instance.getCluster().getMembers().size());
     }


### PR DESCRIPTION
Before merging to another cluster due to network split detection, registered invocations in operation-service should be notified to either retry or fail with an exception and also waiting operations in local wait-notifies queue should be removed, because they have no use anymore after merge.

Fixes #4676 

See [Zendesk Ticket](https://hazelcast.zendesk.com/agent/tickets/772)