### PR TITLE
Using waitAllForSafeState in QueryIndexMigrationTest

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/map/query/QueryIndexMigrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/query/QueryIndexMigrationTest.java
@@ -225,7 +225,7 @@ public class QueryIndexMigrationTest extends HazelcastTestSupport {
         assertTrue(latch.await(1, MINUTES));
         Collection<HazelcastInstance> instances = nodeFactory.getAllHazelcastInstances();
         assertEquals(nodes, instances.size());
-        waitAllForSafeState();
+        waitAllForSafeState(instances);
 
         final int expected = entryPerNode / modulo * nodes;
 

--- a/hazelcast/src/test/java/com/hazelcast/map/query/QueryIndexMigrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/query/QueryIndexMigrationTest.java
@@ -46,7 +46,6 @@ import java.util.concurrent.Future;
 
 import static com.hazelcast.query.Predicates.equal;
 import static com.hazelcast.test.TimeConstants.MINUTE;
-import static com.hazelcast.util.IterableUtil.getFirst;
 import static java.lang.Thread.interrupted;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -55,6 +54,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.After;
+import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -64,9 +64,14 @@ import org.junit.runner.RunWith;
 @Category(QuickTest.class)
 public class QueryIndexMigrationTest extends HazelcastTestSupport {
 
-    private TestHazelcastInstanceFactory nodeFactory = createHazelcastInstanceFactory(6);
+    private TestHazelcastInstanceFactory nodeFactory;
     private ExecutorService executor;
     private Random rand = new Random();
+
+    @Before
+    public void createFactory() {
+        nodeFactory = createHazelcastInstanceFactory(6);
+    }
 
     @After
     public void shutdown() throws Exception {
@@ -217,10 +222,10 @@ public class QueryIndexMigrationTest extends HazelcastTestSupport {
             }).start();
         }
 
-        assertTrue(latch.await(5, MINUTES));
+        assertTrue(latch.await(1, MINUTES));
         Collection<HazelcastInstance> instances = nodeFactory.getAllHazelcastInstances();
         assertEquals(nodes, instances.size());
-        waitClusterForSafeState( getFirst(instances, null) );
+        waitAllForSafeState();
 
         final int expected = entryPerNode / modulo * nodes;
 

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
@@ -30,8 +30,6 @@ import com.hazelcast.nio.serialization.SerializationService;
 import com.hazelcast.partition.InternalPartition;
 import com.hazelcast.partition.InternalPartitionService;
 import com.hazelcast.spi.impl.InternalOperationService;
-import org.junit.After;
-import org.junit.ComparisonFailure;
 
 import java.util.Collection;
 import java.util.Map;
@@ -45,9 +43,14 @@ import java.util.concurrent.FutureTask;
 import java.util.concurrent.TimeUnit;
 
 import static java.lang.String.format;
+import static java.util.Arrays.asList;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+
+import org.junit.After;
+import org.junit.ComparisonFailure;
 
 @SuppressWarnings("unused")
 public abstract class HazelcastTestSupport {
@@ -348,11 +351,10 @@ public abstract class HazelcastTestSupport {
 
     public static boolean isAllInSafeState() {
         final Set<HazelcastInstance> nodeSet = HazelcastInstanceFactory.getAllHazelcastInstances();
-        final HazelcastInstance[] nodes = nodeSet.toArray(new HazelcastInstance[nodeSet.size()]);
-        return isAllInSafeState(nodes);
+        return isAllInSafeState(nodeSet);
     }
 
-    public static boolean isAllInSafeState(HazelcastInstance[] nodes) {
+    public static boolean isAllInSafeState(Collection<HazelcastInstance> nodes) {
         for (HazelcastInstance node : nodes) {
             if (!isInstanceInSafeState(node)) {
                 return false;
@@ -369,12 +371,16 @@ public abstract class HazelcastTestSupport {
         });
     }
 
-    public static void waitAllForSafeState(final HazelcastInstance... nodes) {
+    public static void waitAllForSafeState(final Collection<HazelcastInstance> nodes) {
         assertTrueEventually(new AssertTask() {
             public void run() {
                 assertTrue(isAllInSafeState(nodes));
             }
         });
+    }
+
+    public static void waitAllForSafeState(final HazelcastInstance... nodes) {
+        waitAllForSafeState(asList(nodes));
     }
 
     public static void assertStartsWith(String expected, String actual) {


### PR DESCRIPTION
#4517 
Not really a fix since I couldn't reproduce the test failure. This is just to see if it makes any difference.