### PR TITLE
[DON'T MERGE] Use separate objects for instant stats and on-demand calculated stats

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapEventPublishingService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapEventPublishingService.java
@@ -42,7 +42,7 @@ class MapEventPublishingService implements EventPublishingService<EventData, Lis
         MapContainer mapContainer = mapServiceContext.getMapContainer(mapName);
         if (mapContainer.getMapConfig().isStatisticsEnabled()) {
             mapServiceContext.getLocalMapStatsProvider()
-                    .getLocalMapStatsImpl(mapName).incrementReceivedEvents();
+                    .getInstantLocalMapStats(mapName).incrementReceivedEvents();
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/client/MapGetRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/client/MapGetRequest.java
@@ -78,7 +78,7 @@ public class MapGetRequest extends KeyBasedClientRequest implements Portable, Re
         final MapService mapService = getService();
         MapContainer mapContainer = mapService.getMapServiceContext().getMapContainer(name);
         if (mapContainer.getMapConfig().isStatisticsEnabled()) {
-            mapService.getMapServiceContext().getLocalMapStatsProvider().getLocalMapStatsImpl(name)
+            mapService.getMapServiceContext().getLocalMapStatsProvider().getInstantLocalMapStats(name)
                     .incrementGets(latency);
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/client/MapPutRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/client/MapPutRequest.java
@@ -87,7 +87,7 @@ public class MapPutRequest extends KeyBasedClientRequest implements Portable, Se
         final MapService mapService = getService();
         MapContainer mapContainer = mapService.getMapServiceContext().getMapContainer(name);
         if (mapContainer.getMapConfig().isStatisticsEnabled()) {
-            mapService.getMapServiceContext().getLocalMapStatsProvider().getLocalMapStatsImpl(name)
+            mapService.getMapServiceContext().getLocalMapStatsProvider().getInstantLocalMapStats(name)
                     .incrementPuts(latency);
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/client/MapRemoveRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/client/MapRemoveRequest.java
@@ -74,7 +74,7 @@ public class MapRemoveRequest extends KeyBasedClientRequest implements Portable,
         final MapService mapService = getService();
         MapContainer mapContainer = mapService.getMapServiceContext().getMapContainer(name);
         if (mapContainer.getMapConfig().isStatisticsEnabled()) {
-            mapService.getMapServiceContext().getLocalMapStatsProvider().getLocalMapStatsImpl(name)
+            mapService.getMapServiceContext().getLocalMapStatsProvider().getInstantLocalMapStats(name)
                     .incrementRemoves(latency);
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/AbstractMultipleEntryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/AbstractMultipleEntryOperation.java
@@ -32,7 +32,7 @@ import com.hazelcast.map.impl.MapServiceContext;
 import com.hazelcast.map.impl.NearCacheProvider;
 import com.hazelcast.map.impl.RecordStore;
 import com.hazelcast.map.impl.record.Record;
-import com.hazelcast.monitor.impl.LocalMapStatsImpl;
+import com.hazelcast.monitor.impl.InstantLocalMapStats;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.partition.InternalPartitionService;
 import com.hazelcast.spi.EventService;
@@ -106,10 +106,10 @@ abstract class AbstractMultipleEntryOperation extends AbstractMapOperation {
         return mapServiceContext.getMapEventPublisher();
     }
 
-    protected LocalMapStatsImpl getLocalMapStats() {
+    protected InstantLocalMapStats getLocalMapStats() {
         final MapServiceContext mapServiceContext = mapService.getMapServiceContext();
         final LocalMapStatsProvider localMapStatsProvider = mapServiceContext.getLocalMapStatsProvider();
-        return localMapStatsProvider.getLocalMapStatsImpl(name);
+        return localMapStatsProvider.getInstantLocalMapStats(name);
     }
 
     private EntryEventType pickEventTypeOrNull(Map.Entry entry, Object oldValue) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ContainsValueOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ContainsValueOperation.java
@@ -44,7 +44,7 @@ public class ContainsValueOperation extends AbstractMapOperation implements Part
         contains = recordStore.containsValue(testValue);
         if (mapContainer.getMapConfig().isStatisticsEnabled()) {
             ((MapService) getService()).getMapServiceContext().getLocalMapStatsProvider()
-                    .getLocalMapStatsImpl(name).incrementOtherOperations();
+                    .getInstantLocalMapStats(name).incrementOtherOperations();
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOperation.java
@@ -29,7 +29,7 @@ import com.hazelcast.map.impl.MapEntrySimple;
 import com.hazelcast.map.impl.MapEventPublisher;
 import com.hazelcast.map.impl.MapServiceContext;
 import com.hazelcast.map.impl.record.Record;
-import com.hazelcast.monitor.impl.LocalMapStatsImpl;
+import com.hazelcast.monitor.impl.InstantLocalMapStats;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -243,10 +243,10 @@ public class EntryOperation extends LockAwareOperation implements BackupAwareOpe
         return new MapEntrySimple(key, value);
     }
 
-    private LocalMapStatsImpl getLocalMapStats() {
+    private InstantLocalMapStats getLocalMapStats() {
         final MapServiceContext mapServiceContext = mapService.getMapServiceContext();
         final LocalMapStatsProvider localMapStatsProvider = mapServiceContext.getLocalMapStatsProvider();
-        return localMapStatsProvider.getLocalMapStatsImpl(name);
+        return localMapStatsProvider.getInstantLocalMapStats(name);
     }
 
     private boolean hasRegisteredListenerForThisMap() {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapEntrySetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapEntrySetOperation.java
@@ -39,7 +39,7 @@ public class MapEntrySetOperation extends AbstractMapOperation implements Partit
         entrySet = recordStore.entrySetData();
         if (mapContainer.getMapConfig().isStatisticsEnabled()) {
             ((MapService) getService()).getMapServiceContext()
-                    .getLocalMapStatsProvider().getLocalMapStatsImpl(name).incrementOtherOperations();
+                    .getLocalMapStatsProvider().getInstantLocalMapStats(name).incrementOtherOperations();
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapIsEmptyOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapIsEmptyOperation.java
@@ -37,7 +37,7 @@ public class MapIsEmptyOperation extends AbstractMapOperation implements Partiti
         empty = recordStore.isEmpty();
         if (mapContainer.getMapConfig().isStatisticsEnabled()) {
             mapServiceContext.getLocalMapStatsProvider()
-                    .getLocalMapStatsImpl(name).incrementOtherOperations();
+                    .getInstantLocalMapStats(name).incrementOtherOperations();
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapKeySetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapKeySetOperation.java
@@ -39,7 +39,7 @@ public class MapKeySetOperation extends AbstractMapOperation implements Partitio
         keySet = recordStore.keySet();
         if (mapContainer.getMapConfig().isStatisticsEnabled()) {
             ((MapService) getService()).getMapServiceContext()
-                    .getLocalMapStatsProvider().getLocalMapStatsImpl(name).incrementOtherOperations();
+                    .getLocalMapStatsProvider().getInstantLocalMapStats(name).incrementOtherOperations();
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapSizeOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapSizeOperation.java
@@ -37,7 +37,7 @@ public class MapSizeOperation extends AbstractMapOperation implements PartitionA
         size = recordStore.size();
         if (mapContainer.getMapConfig().isStatisticsEnabled()) {
             ((MapService) getService()).getMapServiceContext()
-                    .getLocalMapStatsProvider().getLocalMapStatsImpl(name).incrementOtherOperations();
+                    .getLocalMapStatsProvider().getInstantLocalMapStats(name).incrementOtherOperations();
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapValuesOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapValuesOperation.java
@@ -40,7 +40,7 @@ public class MapValuesOperation extends AbstractMapOperation implements Partitio
         final RecordStore recordStore = mapServiceContext.getRecordStore(getPartitionId(), name);
         values = recordStore.valuesData();
         if (mapContainer.getMapConfig().isStatisticsEnabled()) {
-            mapServiceContext.getLocalMapStatsProvider().getLocalMapStatsImpl(name).incrementOtherOperations();
+            mapServiceContext.getLocalMapStatsProvider().getInstantLocalMapStats(name).incrementOtherOperations();
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/QueryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/QueryOperation.java
@@ -104,7 +104,7 @@ public class QueryOperation extends AbstractMapOperation {
         if (mapContainer.getMapConfig().isStatisticsEnabled()) {
             final MapServiceContext mapServiceContext = ((MapService) getService()).getMapServiceContext();
             mapServiceContext
-                    .getLocalMapStatsProvider().getLocalMapStatsImpl(name).incrementOtherOperations();
+                    .getLocalMapStatsProvider().getInstantLocalMapStats(name).incrementOtherOperations();
         }
 
         checkPartitionStateChanges(partitionService, partitionStateVersion);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
@@ -83,7 +83,7 @@ import com.hazelcast.map.impl.operation.TryPutOperation;
 import com.hazelcast.map.impl.operation.TryRemoveOperation;
 import com.hazelcast.map.listener.MapListener;
 import com.hazelcast.monitor.LocalMapStats;
-import com.hazelcast.monitor.impl.LocalMapStatsImpl;
+import com.hazelcast.monitor.impl.InstantLocalMapStats;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ClassLoaderUtil;
 import com.hazelcast.nio.serialization.Data;
@@ -134,7 +134,7 @@ abstract class MapProxySupport extends AbstractDistributedObject<MapService> imp
     protected static final String NULL_VALUE_IS_NOT_ALLOWED = "Null value is not allowed!";
 
     protected final String name;
-    protected final LocalMapStatsImpl localMapStats;
+    protected final InstantLocalMapStats localMapStats;
     protected final LockProxySupport lockSupport;
     protected final PartitioningStrategy partitionStrategy;
 
@@ -142,7 +142,7 @@ abstract class MapProxySupport extends AbstractDistributedObject<MapService> imp
         super(nodeEngine, service);
         this.name = name;
         partitionStrategy = service.getMapServiceContext().getMapContainer(name).getPartitioningStrategy();
-        localMapStats = service.getMapServiceContext().getLocalMapStatsProvider().getLocalMapStatsImpl(name);
+        localMapStats = service.getMapServiceContext().getLocalMapStatsProvider().getInstantLocalMapStats(name);
         lockSupport = new LockProxySupport(new DefaultObjectNamespace(MapService.SERVICE_NAME, name));
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/InstantLocalMapStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/InstantLocalMapStats.java
@@ -27,9 +27,7 @@ import static com.hazelcast.util.JsonUtil.getLong;
 /**
  * Internal API
  */
-public class InstantLocalMapStats
-        implements JsonSerializable
-     {
+public class InstantLocalMapStats implements JsonSerializable {
 
     private static final AtomicLongFieldUpdater<InstantLocalMapStats> LAST_ACCESS_TIME_UPDATER = AtomicLongFieldUpdater
             .newUpdater(InstantLocalMapStats.class, "lastAccessTime");

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/InstantLocalMapStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/InstantLocalMapStats.java
@@ -1,0 +1,232 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.monitor.impl;
+
+import com.eclipsesource.json.JsonObject;
+import com.hazelcast.management.JsonSerializable;
+import com.hazelcast.util.Clock;
+
+import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
+import static com.hazelcast.util.JsonUtil.getLong;
+
+/**
+ * Internal API
+ */
+public class InstantLocalMapStats
+        implements JsonSerializable
+     {
+
+    private static final AtomicLongFieldUpdater<InstantLocalMapStats> LAST_ACCESS_TIME_UPDATER = AtomicLongFieldUpdater
+            .newUpdater(InstantLocalMapStats.class, "lastAccessTime");
+    private static final AtomicLongFieldUpdater<InstantLocalMapStats> LAST_UPDATE_TIME_UPDATER = AtomicLongFieldUpdater
+            .newUpdater(InstantLocalMapStats.class, "lastUpdateTime");
+    private static final AtomicLongFieldUpdater<InstantLocalMapStats> NUMBER_OF_OTHER_OPERATIONS_UPDATER = AtomicLongFieldUpdater
+            .newUpdater(InstantLocalMapStats.class, "numberOfOtherOperations");
+    private static final AtomicLongFieldUpdater<InstantLocalMapStats> NUMBER_OF_EVENTS_UPDATER = AtomicLongFieldUpdater
+            .newUpdater(InstantLocalMapStats.class, "numberOfEvents");
+    private static final AtomicLongFieldUpdater<InstantLocalMapStats> GET_COUNT_UPDATER = AtomicLongFieldUpdater
+            .newUpdater(InstantLocalMapStats.class, "getCount");
+    private static final AtomicLongFieldUpdater<InstantLocalMapStats> PUT_COUNT_UPDATER = AtomicLongFieldUpdater
+            .newUpdater(InstantLocalMapStats.class, "putCount");
+    private static final AtomicLongFieldUpdater<InstantLocalMapStats> REMOVE_COUNT_UPDATER = AtomicLongFieldUpdater
+            .newUpdater(InstantLocalMapStats.class, "removeCount");
+    private static final AtomicLongFieldUpdater<InstantLocalMapStats> TOTAL_GET_LATENCIES_UPDATER = AtomicLongFieldUpdater
+            .newUpdater(InstantLocalMapStats.class, "totalGetLatencies");
+    private static final AtomicLongFieldUpdater<InstantLocalMapStats> TOTAL_PUT_LATENCIES_UPDATER = AtomicLongFieldUpdater
+            .newUpdater(InstantLocalMapStats.class, "totalPutLatencies");
+    private static final AtomicLongFieldUpdater<InstantLocalMapStats> TOTAL_REMOVE_LATENCIES_UPDATER = AtomicLongFieldUpdater
+            .newUpdater(InstantLocalMapStats.class, "totalRemoveLatencies");
+    private static final AtomicLongFieldUpdater<InstantLocalMapStats> MAX_GET_LATENCY_UPDATER = AtomicLongFieldUpdater
+            .newUpdater(InstantLocalMapStats.class, "maxGetLatency");
+    private static final AtomicLongFieldUpdater<InstantLocalMapStats> MAX_PUT_LATENCY_UPDATER = AtomicLongFieldUpdater
+            .newUpdater(InstantLocalMapStats.class, "maxPutLatency");
+    private static final AtomicLongFieldUpdater<InstantLocalMapStats> MAX_REMOVE_LATENCY_UPDATER = AtomicLongFieldUpdater
+            .newUpdater(InstantLocalMapStats.class, "maxRemoveLatency");
+
+    // These fields are only accessed through the updaters
+    private volatile long lastAccessTime;
+    private volatile long lastUpdateTime;
+    private volatile long numberOfOtherOperations;
+    private volatile long numberOfEvents;
+    private volatile long getCount;
+    private volatile long putCount;
+    private volatile long removeCount;
+    private volatile long totalGetLatencies;
+    private volatile long totalPutLatencies;
+    private volatile long totalRemoveLatencies;
+    private volatile long maxGetLatency;
+    private volatile long maxPutLatency;
+    private volatile long maxRemoveLatency;
+
+    private volatile long creationTime;
+
+    public InstantLocalMapStats() {
+        creationTime = Clock.currentTimeMillis();
+    }
+
+    public long getCreationTime() {
+        return creationTime;
+    }
+
+    public long getLastAccessTime() {
+        return lastAccessTime;
+    }
+
+    public void setLastAccessTime(long lastAccessTime) {
+        LAST_ACCESS_TIME_UPDATER.set(this, Math.max(this.lastAccessTime, lastAccessTime));
+    }
+
+    public long getLastUpdateTime() {
+        return lastUpdateTime;
+    }
+
+    public void setLastUpdateTime(long lastUpdateTime) {
+        LAST_UPDATE_TIME_UPDATER.set(this, Math.max(this.lastUpdateTime, lastUpdateTime));
+    }
+
+    public long total() {
+        return putCount + getCount + removeCount + numberOfOtherOperations;
+    }
+
+    public long getPutOperationCount() {
+        return putCount;
+    }
+
+    public void incrementPuts(long latency) {
+        PUT_COUNT_UPDATER.incrementAndGet(this);
+        TOTAL_PUT_LATENCIES_UPDATER.addAndGet(this, latency);
+        MAX_PUT_LATENCY_UPDATER.set(this, Math.max(maxPutLatency, latency));
+    }
+
+    public long getGetOperationCount() {
+        return getCount;
+    }
+
+    public void incrementGets(long latency) {
+        GET_COUNT_UPDATER.incrementAndGet(this);
+        TOTAL_GET_LATENCIES_UPDATER.addAndGet(this, latency);
+        MAX_GET_LATENCY_UPDATER.set(this, Math.max(maxGetLatency, latency));
+    }
+
+    public long getRemoveOperationCount() {
+        return removeCount;
+    }
+
+    public void incrementRemoves(long latency) {
+        REMOVE_COUNT_UPDATER.incrementAndGet(this);
+        TOTAL_REMOVE_LATENCIES_UPDATER.addAndGet(this, latency);
+        MAX_REMOVE_LATENCY_UPDATER.set(this, Math.max(maxRemoveLatency, latency));
+    }
+
+    public long getTotalPutLatency() {
+        return totalPutLatencies;
+    }
+
+    public long getTotalGetLatency() {
+        return totalGetLatencies;
+    }
+
+    public long getTotalRemoveLatency() {
+        return totalRemoveLatencies;
+    }
+
+    public long getMaxPutLatency() {
+        return maxPutLatency;
+    }
+
+    public long getMaxGetLatency() {
+        return maxGetLatency;
+    }
+
+    public long getMaxRemoveLatency() {
+        return maxRemoveLatency;
+    }
+
+    public long getOtherOperationCount() {
+        return numberOfOtherOperations;
+    }
+
+    public void incrementOtherOperations() {
+        NUMBER_OF_OTHER_OPERATIONS_UPDATER.incrementAndGet(this);
+    }
+
+    public long getEventOperationCount() {
+        return numberOfEvents;
+    }
+
+    public void incrementReceivedEvents() {
+        NUMBER_OF_EVENTS_UPDATER.incrementAndGet(this);
+    }
+
+    @Override
+    public JsonObject toJson() {
+        final JsonObject root = new JsonObject();
+
+        root.add("creationTime", creationTime);
+        root.add("getCount", getCount);
+        root.add("putCount", putCount);
+        root.add("removeCount", removeCount);
+        root.add("numberOfOtherOperations", numberOfOtherOperations);
+        root.add("numberOfEvents", numberOfEvents);
+        root.add("lastAccessTime", lastAccessTime);
+        root.add("lastUpdateTime", lastUpdateTime);
+        root.add("totalGetLatencies", totalGetLatencies);
+        root.add("totalPutLatencies", totalPutLatencies);
+        root.add("totalRemoveLatencies", totalRemoveLatencies);
+        root.add("maxGetLatency", maxGetLatency);
+        root.add("maxPutLatency", maxPutLatency);
+        root.add("maxRemoveLatency", maxRemoveLatency);
+
+        return root;
+    }
+
+    @Override
+    public void fromJson(JsonObject json) {
+        this.creationTime = getLong(json, "creationTime", -1L);
+        GET_COUNT_UPDATER.set(this, getLong(json, "getCount", -1L));
+        PUT_COUNT_UPDATER.set(this, getLong(json, "putCount", -1L));
+        REMOVE_COUNT_UPDATER.set(this, getLong(json, "removeCount", -1L));
+        NUMBER_OF_OTHER_OPERATIONS_UPDATER.set(this, getLong(json, "numberOfOtherOperations", -1L));
+        NUMBER_OF_EVENTS_UPDATER.set(this, getLong(json, "numberOfEvents", -1L));
+        LAST_ACCESS_TIME_UPDATER.set(this, getLong(json, "lastAccessTime", -1L));
+        LAST_UPDATE_TIME_UPDATER.set(this, getLong(json, "lastUpdateTime", -1L));
+        TOTAL_GET_LATENCIES_UPDATER.set(this, getLong(json, "totalGetLatencies", -1L));
+        TOTAL_PUT_LATENCIES_UPDATER.set(this, getLong(json, "totalPutLatencies", -1L));
+        TOTAL_REMOVE_LATENCIES_UPDATER.set(this, getLong(json, "totalRemoveLatencies", -1L));
+        MAX_GET_LATENCY_UPDATER.set(this, getLong(json, "maxGetLatency", -1L));
+        MAX_PUT_LATENCY_UPDATER.set(this, getLong(json, "maxPutLatency", -1L));
+        MAX_REMOVE_LATENCY_UPDATER.set(this, getLong(json, "maxRemoveLatency", -1L));
+    }
+
+    @Override
+    public String toString() {
+        return "LocalMapStatsImpl{"
+                + "lastAccessTime=" + lastAccessTime
+                + ", lastUpdateTime=" + lastUpdateTime
+                + ", numberOfOtherOperations=" + numberOfOtherOperations
+                + ", numberOfEvents=" + numberOfEvents
+                + ", getCount=" + getCount
+                + ", putCount=" + putCount
+                + ", removeCount=" + removeCount
+                + ", totalGetLatencies=" + totalGetLatencies
+                + ", totalPutLatencies=" + totalPutLatencies
+                + ", totalRemoveLatencies=" + totalRemoveLatencies
+                + ", creationTime=" + creationTime
+                + '}';
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/InstantNearCacheStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/InstantNearCacheStats.java
@@ -1,0 +1,86 @@
+package com.hazelcast.monitor.impl;
+
+import com.eclipsesource.json.JsonObject;
+import com.hazelcast.management.JsonSerializable;
+import com.hazelcast.util.Clock;
+
+import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
+import static com.hazelcast.util.JsonUtil.getLong;
+
+/**
+ * Internal API
+ */
+public class InstantNearCacheStats
+        implements JsonSerializable {
+
+    private static final AtomicLongFieldUpdater<InstantNearCacheStats> HITS_UPDATER = AtomicLongFieldUpdater
+            .newUpdater(InstantNearCacheStats.class, "hits");
+    private static final AtomicLongFieldUpdater<InstantNearCacheStats> MISSES_UPDATER = AtomicLongFieldUpdater
+            .newUpdater(InstantNearCacheStats.class, "misses");
+
+    private volatile long creationTime;
+
+    // These fields are only accessed through the updaters
+    private volatile long hits;
+    private volatile long misses;
+
+    public InstantNearCacheStats() {
+        this.creationTime = Clock.currentTimeMillis();
+    }
+
+    public long getCreationTime() {
+        return creationTime;
+    }
+
+    public long getHits() {
+        return hits;
+    }
+
+    public long getMisses() {
+        return misses;
+    }
+
+    public void setHits(long hits) {
+        HITS_UPDATER.set(this, hits);
+    }
+
+    public double getRatio() {
+        return (double) hits / misses;
+    }
+
+    public void incrementMisses() {
+        MISSES_UPDATER.incrementAndGet(this);
+    }
+
+    public void incrementHits() {
+        HITS_UPDATER.incrementAndGet(this);
+    }
+
+    @Override
+    public JsonObject toJson() {
+        JsonObject root = new JsonObject();
+        root.add("creationTime", creationTime);
+        root.add("hits", hits);
+        root.add("misses", misses);
+        return root;
+    }
+
+    @Override
+    public void fromJson(JsonObject json) {
+        creationTime = getLong(json, "creationTime", -1L);
+        HITS_UPDATER.set(this, getLong(json, "hits", -1L));
+        MISSES_UPDATER.set(this, getLong(json, "misses", -1L));
+    }
+
+    @Override
+    public String toString() {
+        return "NearCacheStatsImpl{"
+                + "creationTime=" + creationTime
+                + ", hits=" + hits
+                + ", misses=" + misses
+                + ", ratio=" + getRatio()
+                + '}';
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalMultiMapStatsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalMultiMapStatsImpl.java
@@ -18,5 +18,6 @@ package com.hazelcast.monitor.impl;
 
 import com.hazelcast.monitor.LocalMultiMapStats;
 
-public class LocalMultiMapStatsImpl extends LocalMapStatsImpl implements LocalMultiMapStats {
+public class LocalMultiMapStatsImpl extends LocalMapStatsImpl
+        implements LocalMultiMapStats {
 }

--- a/hazelcast/src/test/java/com/hazelcast/map/LocalMapStatsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/LocalMapStatsTest.java
@@ -1,5 +1,6 @@
 package com.hazelcast.map;
 
+import com.eclipsesource.json.JsonObject;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.MemberGroupConfig;
 import com.hazelcast.config.PartitionGroupConfig;
@@ -7,6 +8,9 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.core.MultiMap;
 import com.hazelcast.monitor.LocalMapStats;
+import com.hazelcast.monitor.NearCacheStats;
+import com.hazelcast.monitor.impl.LocalMapStatsImpl;
+import com.hazelcast.monitor.impl.NearCacheStatsImpl;
 import com.hazelcast.nio.Address;
 import com.hazelcast.partition.InternalPartitionService;
 import com.hazelcast.test.AssertTask;
@@ -14,6 +18,7 @@ import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.util.JsonUtil;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -21,6 +26,7 @@ import org.junit.runner.RunWith;
 import java.util.Collection;
 import java.util.concurrent.TimeUnit;
 
+import static com.hazelcast.util.JsonUtil.getLong;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -105,6 +111,142 @@ public class LocalMapStatsTest extends HazelcastTestSupport {
         assertEquals(inFirstInstance ? 0 : 3, multiMap1.getLocalMultiMapStats().getHits());
     }
 
+    @Test
+    public void test_localMapStatsToJson() {
+        final LocalMapStatsImpl localMapStats = new LocalMapStatsImpl();
+
+        localMapStats.setLastAccessTime(1);
+        localMapStats.setLastUpdateTime(2);
+        localMapStats.incrementReceivedEvents();
+        localMapStats.incrementOtherOperations();
+        localMapStats.incrementGets(3);
+        localMapStats.incrementPuts(4);
+        localMapStats.incrementRemoves(5);
+
+        localMapStats.setOwnedEntryCount(6);
+        localMapStats.setBackupEntryCount(7);
+        localMapStats.incrementOwnedEntryMemoryCost(8);
+        localMapStats.incrementBackupEntryMemoryCost(9);
+        localMapStats.incrementHeapCost(10);
+        localMapStats.setLockedEntryCount(11);
+        localMapStats.setDirtyEntryCount(12);
+        localMapStats.setBackupCount(13);
+        localMapStats.setHits(14);
+
+        final NearCacheStatsImpl nearCacheStats = new NearCacheStatsImpl();
+        nearCacheStats.setOwnedEntryCount(15);
+        nearCacheStats.setOwnedEntryMemoryCost(16);
+        nearCacheStats.incrementHits();
+        nearCacheStats.incrementMisses();
+        localMapStats.setNearCacheStats(nearCacheStats);
+
+        final JsonObject json = localMapStats.toJson();
+
+        assertEquals(getLong(json, "creationTime"), localMapStats.getCreationTime());
+        assertEquals(getLong(json, "lastAccessTime"), localMapStats.getLastAccessTime());
+        assertEquals(getLong(json, "lastUpdateTime"), localMapStats.getLastUpdateTime());
+        assertEquals(getLong(json, "numberOfEvents"), localMapStats.getEventOperationCount());
+        assertEquals(getLong(json, "numberOfOtherOperations"), localMapStats.getOtherOperationCount());
+        assertEquals(getLong(json, "getCount"), localMapStats.getGetOperationCount());
+        assertEquals(getLong(json, "putCount"), localMapStats.getPutOperationCount());
+        assertEquals(getLong(json, "removeCount"), localMapStats.getRemoveOperationCount());
+        assertEquals(getLong(json, "totalGetLatencies"), localMapStats.getTotalGetLatency());
+        assertEquals(getLong(json, "totalPutLatencies"), localMapStats.getTotalPutLatency());
+        assertEquals(getLong(json, "totalRemoveLatencies"), localMapStats.getTotalRemoveLatency());
+        assertEquals(getLong(json, "maxGetLatency"), localMapStats.getMaxGetLatency());
+        assertEquals(getLong(json, "maxPutLatency"), localMapStats.getMaxPutLatency());
+        assertEquals(getLong(json, "maxRemoveLatency"), localMapStats.getMaxRemoveLatency());
+
+        assertEquals(getLong(json, "ownedEntryCount"), localMapStats.getOwnedEntryCount());
+        assertEquals(getLong(json, "backupEntryCount"), localMapStats.getBackupEntryCount());
+        assertEquals(getLong(json, "ownedEntryMemoryCost"), localMapStats.getOwnedEntryMemoryCost());
+        assertEquals(getLong(json, "backupEntryMemoryCost"), localMapStats.getBackupEntryMemoryCost());
+        assertEquals(getLong(json, "heapCost"), localMapStats.getHeapCost());
+        assertEquals(getLong(json, "lockedEntryCount"), localMapStats.getLockedEntryCount());
+        assertEquals(getLong(json, "dirtyEntryCount"), localMapStats.getDirtyEntryCount());
+        assertEquals(getLong(json, "backupCount"), localMapStats.getBackupCount());
+        assertEquals(getLong(json, "hits"), localMapStats.getHits());
+
+        final JsonObject nearCacheStatsJson = JsonUtil.getObject(json, "nearCacheStats");
+        assertEquals(getLong(nearCacheStatsJson, "ownedEntryCount"), nearCacheStats.getOwnedEntryCount());
+        assertEquals(getLong(nearCacheStatsJson, "ownedEntryMemoryCost"), nearCacheStats.getOwnedEntryMemoryCost());
+        assertEquals(getLong(nearCacheStatsJson, "creationTime"), nearCacheStats.getCreationTime());
+        assertEquals(getLong(nearCacheStatsJson, "hits"), nearCacheStats.getHits());
+        assertEquals(getLong(nearCacheStatsJson, "misses"), nearCacheStats.getMisses());
+    }
+
+    @Test
+    public void test_jsonToLocalMapStats() {
+        final JsonObject json = new JsonObject();
+        json.add("creationTime", 1L);
+        json.add("lastAccessTime", 2L);
+        json.add("lastUpdateTime", 3L);
+        json.add("numberOfEvents", 4L);
+        json.add("numberOfOtherOperations", 5L);
+        json.add("getCount", 6L);
+        json.add("putCount", 7L);
+        json.add("removeCount", 8L);
+        json.add("totalGetLatencies", 9L);
+        json.add("totalPutLatencies", 10L);
+        json.add("totalRemoveLatencies", 11L);
+        json.add("maxGetLatency", 12L);
+        json.add("maxPutLatency", 13L);
+        json.add("maxRemoveLatency", 14L);
+
+        json.add("ownedEntryCount", 15L);
+        json.add("backupEntryCount", 16L);
+        json.add("ownedEntryMemoryCost", 17L);
+        json.add("backupEntryMemoryCost", 18L);
+        json.add("heapCost", 19L);
+        json.add("lockedEntryCount", 20L);
+        json.add("dirtyEntryCount", 21L);
+        json.add("backupCount", 22L);
+        json.add("hits", 23L);
+
+        final JsonObject nearCacheStatsJson = new JsonObject();
+        nearCacheStatsJson.add("ownedEntryCount", 24L);
+        nearCacheStatsJson.add("ownedEntryMemoryCost", 25L);
+        nearCacheStatsJson.add("creationTime", 26L);
+        nearCacheStatsJson.add("hits", 27L);
+        nearCacheStatsJson.add("misses", 28L);
+        json.add("nearCacheStats", nearCacheStatsJson);
+
+        final LocalMapStatsImpl localMapStats = new LocalMapStatsImpl();
+        localMapStats.fromJson(json);
+
+        assertEquals(localMapStats.getCreationTime(), 1L);
+        assertEquals(localMapStats.getLastAccessTime(), 2L);
+        assertEquals(localMapStats.getLastUpdateTime(), 3L);
+        assertEquals(localMapStats.getEventOperationCount(), 4L);
+        assertEquals(localMapStats.getOtherOperationCount(), 5L);
+        assertEquals(localMapStats.getGetOperationCount(), 6L);
+        assertEquals(localMapStats.getPutOperationCount(), 7L);
+        assertEquals(localMapStats.getRemoveOperationCount(), 8L);
+        assertEquals(localMapStats.getTotalGetLatency(), 9L);
+        assertEquals(localMapStats.getTotalPutLatency(), 10L);
+        assertEquals(localMapStats.getTotalRemoveLatency(), 11L);
+        assertEquals(localMapStats.getMaxGetLatency(), 12L);
+        assertEquals(localMapStats.getMaxPutLatency(), 13L);
+        assertEquals(localMapStats.getMaxRemoveLatency(), 14L);
+
+        assertEquals(localMapStats.getOwnedEntryCount(), 15L);
+        assertEquals(localMapStats.getBackupEntryCount(), 16L);
+        assertEquals(localMapStats.getOwnedEntryMemoryCost(), 17L);
+        assertEquals(localMapStats.getBackupEntryMemoryCost(), 18L);
+        assertEquals(localMapStats.getHeapCost(), 19L);
+        assertEquals(localMapStats.getLockedEntryCount(), 20L);
+        assertEquals(localMapStats.getDirtyEntryCount(), 21L);
+        assertEquals(localMapStats.getBackupCount(), 22L);
+        assertEquals(localMapStats.getHits(), 23L);
+
+        final NearCacheStats nearCacheStats = localMapStats.getNearCacheStats();
+        assertEquals(nearCacheStats.getOwnedEntryCount(), 24L);
+        assertEquals(nearCacheStats.getOwnedEntryMemoryCost(), 25L);
+        assertEquals(nearCacheStats.getCreationTime(), 26L);
+        assertEquals(nearCacheStats.getHits(), 27L);
+        assertEquals(nearCacheStats.getMisses(), 28L);
+
+    }
 
     @Test
     public void testLocalMapStats_withMemberGroups() throws Exception {


### PR DESCRIPTION
Use separate objects for instant stats and on-demand calculated stats for local map stats

Fixes #4497