### PR TITLE
membership registration made over connection to prevent re registration ...

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
@@ -223,9 +223,9 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance {
         connectionManager.start();
         try {
             clusterService.start();
-        } catch (IllegalStateException e) {
+        } catch (Exception e) {
             lifecycleService.shutdown();
-            throw e;
+            throw ExceptionUtil.rethrow(e);
         }
         loadBalancer.init(getCluster(), config);
         partitionService.start();

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapReduceProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapReduceProxy.java
@@ -150,7 +150,7 @@ public class ClientMapReduceProxy
                     }
                 });
 
-                Address runningMember = clientInvocation.getConnection().getRemoteEndpoint();
+                Address runningMember = clientInvocation.getSendConnection().getRemoteEndpoint();
                 trackableJobs.putIfAbsent(jobId, new ClientTrackableJob<T>(jobId, runningMember, completableFuture));
                 return completableFuture;
             } catch (Exception e) {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientClusterServiceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientClusterServiceImpl.java
@@ -209,7 +209,7 @@ public class ClientClusterServiceImpl implements ClientClusterService {
         return listeners.remove(registrationId) != null;
     }
 
-    public void start() {
+    public void start() throws Exception {
         clusterListenerSupport.init(client);
         clusterListenerSupport.connectToCluster();
         initMembershipListener();

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocationServiceSupport.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocationServiceSupport.java
@@ -84,7 +84,7 @@ abstract class ClientInvocationServiceSupport implements ClientInvocationService
             throw new HazelcastClientNotActiveException("Client is shut down");
         }
         registerInvocation(invocation);
-        invocation.setConnection(connection);
+        invocation.setSendConnection(connection);
         final SerializationService ss = client.getSerializationService();
         final Data data = ss.toData(invocation.getRequest());
         Packet packet = new Packet(data, invocation.getPartitionId(), ss.getPortableContext());
@@ -152,7 +152,7 @@ abstract class ClientInvocationServiceSupport implements ClientInvocationService
         while (iter.hasNext()) {
             final Map.Entry<Integer, ClientInvocation> entry = iter.next();
             final ClientInvocation invocation = entry.getValue();
-            if (invocation.getConnection().equals(connection)) {
+            if (invocation.getSendConnection().equals(connection)) {
                 iter.remove();
                 invocation.notify(responseCtor.createNew(null));
                 eventHandlerMap.remove(entry.getKey());
@@ -161,7 +161,7 @@ abstract class ClientInvocationServiceSupport implements ClientInvocationService
         final Iterator<ClientInvocation> iterator = eventHandlerMap.values().iterator();
         while (iterator.hasNext()) {
             final ClientInvocation invocation = iterator.next();
-            if (invocation.getConnection().equals(connection)) {
+            if (invocation.getSendConnection().equals(connection)) {
                 iterator.remove();
                 invocation.notify(responseCtor.createNew(null));
             }
@@ -185,7 +185,7 @@ abstract class ClientInvocationServiceSupport implements ClientInvocationService
 
         while (iterator.hasNext()) {
             final ClientInvocation clientInvocation = iterator.next();
-            if (clientInvocation.getConnection().equals(connection)) {
+            if (clientInvocation.getSendConnection().equals(connection)) {
                 iterator.remove();
                 clientInvocation.notify(response);
             }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientMembershipEventHandler.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientMembershipEventHandler.java
@@ -1,0 +1,173 @@
+package com.hazelcast.client.spi.impl;
+
+import com.hazelcast.client.connection.nio.ClientConnectionManagerImpl;
+import com.hazelcast.client.impl.HazelcastClientInstanceImpl;
+import com.hazelcast.client.spi.EventHandler;
+import com.hazelcast.cluster.MemberAttributeOperationType;
+import com.hazelcast.cluster.client.ClientInitialMembershipEvent;
+import com.hazelcast.cluster.client.MemberAttributeChange;
+import com.hazelcast.core.Member;
+import com.hazelcast.core.MemberAttributeEvent;
+import com.hazelcast.core.MembershipEvent;
+import com.hazelcast.instance.MemberImpl;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.nio.Address;
+import com.hazelcast.nio.Connection;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+class ClientMembershipEventHandler implements EventHandler<ClientInitialMembershipEvent> {
+
+    private static final ILogger LOGGER = com.hazelcast.logging.Logger.getLogger(ClientMembershipEventHandler.class);
+    private final List<MemberImpl> members = new LinkedList<MemberImpl>();
+    private final HazelcastClientInstanceImpl client;
+    private final ClientClusterServiceImpl clusterService;
+    private final ClientPartitionServiceImpl partitionService;
+    private final ClientConnectionManagerImpl connectionManager;
+
+    public ClientMembershipEventHandler(HazelcastClientInstanceImpl client) {
+        this.client = client;
+        connectionManager = (ClientConnectionManagerImpl) client.getConnectionManager();
+        partitionService = (ClientPartitionServiceImpl) client.getClientPartitionService();
+        clusterService = (ClientClusterServiceImpl) client.getClientClusterService();
+    }
+
+    @Override
+    public void handle(ClientInitialMembershipEvent event) {
+        final MemberImpl member = (MemberImpl) event.getMember();
+        if (event.getEventType() == ClientInitialMembershipEvent.INITIAL_MEMBERS) {
+            initialMembers(event);
+        } else if (event.getEventType() == ClientInitialMembershipEvent.MEMBER_ADDED) {
+            memberAdded(member);
+            partitionService.refreshPartitions();
+        } else if (event.getEventType() == ClientInitialMembershipEvent.MEMBER_REMOVED) {
+            memberRemoved(member);
+            partitionService.refreshPartitions();
+        } else if (event.getEventType() == ClientInitialMembershipEvent.MEMBER_ATTRIBUTE_CHANGED) {
+            memberAttributeChanged(event);
+        }
+    }
+
+    @Override
+    public void beforeListenerRegister() {
+
+    }
+
+    @Override
+    public void onListenerRegister() {
+
+    }
+
+    void initialMembers(ClientInitialMembershipEvent event) {
+
+        Map<String, MemberImpl> prevMembers = Collections.emptyMap();
+        if (!members.isEmpty()) {
+            prevMembers = new HashMap<String, MemberImpl>(members.size());
+            for (MemberImpl member : members) {
+                prevMembers.put(member.getUuid(), member);
+            }
+            members.clear();
+        }
+        members.addAll(event.getMembers());
+
+
+        final List<MembershipEvent> events = detectMembershipEvents(prevMembers);
+        if (events.size() != 0) {
+            applyMemberListChanges();
+        }
+        fireMembershipEvent(events);
+    }
+
+
+    private void memberRemoved(MemberImpl member) {
+        members.remove(member);
+        final Connection connection = connectionManager.getConnection(member.getAddress());
+        if (connection != null) {
+            connectionManager.destroyConnection(connection);
+        }
+        applyMemberListChanges();
+        MembershipEvent event = new MembershipEvent(client.getCluster(), member,
+                ClientInitialMembershipEvent.MEMBER_REMOVED,
+                Collections.unmodifiableSet(new LinkedHashSet<Member>(members)));
+        clusterService.fireMembershipEvent(event);
+    }
+
+    private void memberAttributeChanged(ClientInitialMembershipEvent event) {
+        MemberAttributeChange memberAttributeChange = event.getMemberAttributeChange();
+        Map<Address, MemberImpl> memberMap = clusterService.getMembersRef();
+        if (memberMap == null) {
+            return;
+        }
+        for (MemberImpl target : memberMap.values()) {
+            if (target.getUuid().equals(memberAttributeChange.getUuid())) {
+                final MemberAttributeOperationType operationType = memberAttributeChange.getOperationType();
+                final String key = memberAttributeChange.getKey();
+                final Object value = memberAttributeChange.getValue();
+                target.updateAttribute(operationType, key, value);
+                MemberAttributeEvent memberAttributeEvent = new MemberAttributeEvent(
+                        client.getCluster(), target, operationType, key, value);
+                clusterService.fireMemberAttributeEvent(memberAttributeEvent);
+                break;
+            }
+        }
+    }
+
+    private void applyMemberListChanges() {
+        updateMembersRef();
+        LOGGER.info(clusterService.membersString());
+    }
+
+    private void fireMembershipEvent(List<MembershipEvent> events) {
+
+        for (MembershipEvent event : events) {
+            clusterService.fireMembershipEvent(event);
+        }
+    }
+
+    private List<MembershipEvent> detectMembershipEvents(Map<String, MemberImpl> prevMembers) {
+        final List<MembershipEvent> events = new LinkedList<MembershipEvent>();
+        final Set<Member> eventMembers = Collections.unmodifiableSet(new LinkedHashSet<Member>(members));
+        for (MemberImpl member : members) {
+            final MemberImpl former = prevMembers.remove(member.getUuid());
+            if (former == null) {
+                events.add(new MembershipEvent(client.getCluster(), member, MembershipEvent.MEMBER_ADDED, eventMembers));
+            }
+        }
+        for (MemberImpl member : prevMembers.values()) {
+            events.add(new MembershipEvent(client.getCluster(), member, MembershipEvent.MEMBER_REMOVED, eventMembers));
+            if (clusterService.getMember(member.getAddress()) == null) {
+                final Connection connection = connectionManager.getConnection(member.getAddress());
+                if (connection != null) {
+                    connectionManager.destroyConnection(connection);
+                }
+            }
+        }
+        return events;
+    }
+
+    private void memberAdded(MemberImpl member) {
+        members.add(member);
+        applyMemberListChanges();
+        MembershipEvent event = new MembershipEvent(client.getCluster(), member,
+                ClientInitialMembershipEvent.MEMBER_ADDED,
+                Collections.unmodifiableSet(new LinkedHashSet<Member>(members)));
+        clusterService.fireMembershipEvent(event);
+    }
+
+    private void updateMembersRef() {
+        final Map<Address, MemberImpl> map = new LinkedHashMap<Address, MemberImpl>(members.size());
+        for (MemberImpl member : members) {
+            map.put(member.getAddress(), member);
+        }
+        clusterService.setMembersRef(Collections.unmodifiableMap(map));
+    }
+
+
+}

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClusterListenerSupport.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClusterListenerSupport.java
@@ -24,16 +24,8 @@ import com.hazelcast.client.connection.nio.ClientConnection;
 import com.hazelcast.client.impl.HazelcastClientInstanceImpl;
 import com.hazelcast.client.impl.client.AuthenticationRequest;
 import com.hazelcast.client.impl.client.ClientPrincipal;
-import com.hazelcast.client.impl.client.GetMemberListRequest;
-import com.hazelcast.client.spi.EventHandler;
-import com.hazelcast.cluster.MemberAttributeOperationType;
-import com.hazelcast.cluster.client.ClientMembershipEvent;
-import com.hazelcast.cluster.client.MemberAttributeChange;
 import com.hazelcast.cluster.client.RegisterMembershipListenerRequest;
 import com.hazelcast.core.LifecycleEvent;
-import com.hazelcast.core.Member;
-import com.hazelcast.core.MemberAttributeEvent;
-import com.hazelcast.core.MembershipEvent;
 import com.hazelcast.instance.MemberImpl;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
@@ -51,14 +43,10 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Future;
 import java.util.logging.Level;
@@ -67,17 +55,17 @@ public class ClusterListenerSupport implements ConnectionListener, ConnectionHea
 
     private static final ILogger LOGGER = Logger.getLogger(ClusterListenerSupport.class);
 
-    protected final List<MemberImpl> members = new LinkedList<MemberImpl>();
     protected ClientClusterServiceImpl clusterService;
 
     private final Collection<AddressProvider> addressProviders;
     private final ManagerAuthenticator managerAuthenticator = new ManagerAuthenticator();
     private final boolean shuffleMemberList;
-
     private Credentials credentials;
+
     private HazelcastClientInstanceImpl client;
     private ClientConnectionManager connectionManager;
     private ClientListenerServiceImpl clientListenerService;
+    private ClientMembershipEventHandler clientMembershipEventHandler;
     private volatile Address ownerConnectionAddress;
     private volatile ClientPrincipal principal;
 
@@ -91,6 +79,7 @@ public class ClusterListenerSupport implements ConnectionListener, ConnectionHea
         this.connectionManager = client.getConnectionManager();
         this.clusterService = (ClientClusterServiceImpl) client.getClientClusterService();
         this.clientListenerService = (ClientListenerServiceImpl) client.getListenerService();
+        this.clientMembershipEventHandler = new ClientMembershipEventHandler(client);
         connectionManager.addConnectionListener(this);
         connectionManager.addConnectionHeartbeatListener(this);
         credentials = client.getCredentials();
@@ -126,18 +115,25 @@ public class ClusterListenerSupport implements ConnectionListener, ConnectionHea
         }
     }
 
-    public void connectToCluster() {
-        try {
-            connectToOne();
-        } catch (Exception e) {
-            client.getLifecycleService().shutdown();
-            throw ExceptionUtil.rethrow(e);
-        }
+    void connectToCluster() throws Exception {
+        connectToOne();
+        listenMembershipEvents();
+        clientListenerService.triggerFailedListeners();
+    }
 
+    private void listenMembershipEvents() {
         try {
-            clientListenerService.triggerFailedListeners();
-            loadInitialMemberList();
-            listenMembershipEvents();
+            RegisterMembershipListenerRequest request = new RegisterMembershipListenerRequest();
+
+            Connection connection = connectionManager.getConnection(ownerConnectionAddress);
+            if (connection == null) {
+                System.out.println("FATAL connection null " + ownerConnectionAddress);
+                throw new IllegalStateException("Can not load initial members list because owner connection is null. "
+                        + "Address " + ownerConnectionAddress);
+            }
+            ClientInvocation invocation =
+                    new ClientInvocation(client, clientMembershipEventHandler, request, connection);
+            invocation.invoke().get();
         } catch (Exception e) {
             if (client.getLifecycleService().isRunning()) {
                 if (LOGGER.isFinestEnabled()) {
@@ -152,10 +148,10 @@ public class ClusterListenerSupport implements ConnectionListener, ConnectionHea
 
     private Collection<InetSocketAddress> getSocketAddresses() {
         final List<InetSocketAddress> socketAddresses = new LinkedList<InetSocketAddress>();
-        if (!members.isEmpty()) {
-            for (MemberImpl member : members) {
-                socketAddresses.add(member.getInetSocketAddress());
-            }
+
+        Collection<MemberImpl> memberList = clusterService.getMemberList();
+        for (MemberImpl member : memberList) {
+            socketAddresses.add(member.getInetSocketAddress());
         }
 
         for (AddressProvider addressProvider : addressProviders) {
@@ -169,80 +165,6 @@ public class ClusterListenerSupport implements ConnectionListener, ConnectionHea
         return socketAddresses;
     }
 
-    private void loadInitialMemberList() throws Exception {
-        final SerializationService serializationService = clusterService.getSerializationService();
-        final GetMemberListRequest request = new GetMemberListRequest();
-        final Connection connection = connectionManager.getConnection(ownerConnectionAddress);
-        if (connection == null) {
-            throw new IllegalStateException("Can not load initial members list because owner connection is null. "
-                    + "Address " + ownerConnectionAddress);
-        }
-        final ClientInvocation clientInvocation = new ClientInvocation(client, request, connection);
-        final Future<SerializableCollection> future = clientInvocation.invoke();
-        final SerializableCollection coll = serializationService.toObject(future.get());
-
-        Map<String, MemberImpl> prevMembers = Collections.emptyMap();
-        if (!members.isEmpty()) {
-            prevMembers = new HashMap<String, MemberImpl>(members.size());
-            for (MemberImpl member : members) {
-                prevMembers.put(member.getUuid(), member);
-            }
-            members.clear();
-        }
-        for (Data data : coll) {
-            members.add((MemberImpl) serializationService.toObject(data));
-        }
-        updateMembersRef();
-        LOGGER.info(clusterService.membersString());
-        fireMembershipEvent(prevMembers);
-    }
-
-    private void fireMembershipEvent(Map<String, MemberImpl> prevMembers) {
-        final List<MembershipEvent> events = new LinkedList<MembershipEvent>();
-        final Set<Member> eventMembers = Collections.unmodifiableSet(new LinkedHashSet<Member>(members));
-        for (MemberImpl member : members) {
-            final MemberImpl former = prevMembers.remove(member.getUuid());
-            if (former == null) {
-                events.add(new MembershipEvent(client.getCluster(), member, MembershipEvent.MEMBER_ADDED, eventMembers));
-            }
-        }
-        for (MemberImpl member : prevMembers.values()) {
-            events.add(new MembershipEvent(client.getCluster(), member, MembershipEvent.MEMBER_REMOVED, eventMembers));
-            if (clusterService.getMember(member.getAddress()) == null) {
-                final Connection connection = connectionManager.getConnection(member.getAddress());
-                if (connection != null) {
-                    connectionManager.destroyConnection(connection);
-                }
-            }
-        }
-        for (MembershipEvent event : events) {
-            clusterService.fireMembershipEvent(event);
-        }
-    }
-
-    private void listenMembershipEvents() throws Exception {
-        final RegisterMembershipListenerRequest request = new RegisterMembershipListenerRequest();
-        final EventHandler<ClientMembershipEvent> handler = createEventHandler();
-        final ClientInvocation invocation = new ClientInvocation(client, handler, request, ownerConnectionAddress);
-        final Future<SerializableCollection> future = invocation.invoke();
-        final SerializationService serializationService = clusterService.getSerializationService();
-        final Object response = serializationService.toObject(future.get());
-        if (response instanceof Exception) {
-            throw (Exception) response;
-        }
-    }
-
-    private EventHandler<ClientMembershipEvent> createEventHandler() {
-        return new ClientMembershipEventEventHandler();
-    }
-
-    protected void updateMembersRef() {
-        final Map<Address, MemberImpl> map = new LinkedHashMap<Address, MemberImpl>(members.size());
-        for (MemberImpl member : members) {
-            map.put(member.getAddress(), member);
-        }
-        clusterService.setMembersRef(Collections.unmodifiableMap(map));
-    }
 
     public ClientPrincipal getPrincipal() {
         return principal;
@@ -256,24 +178,26 @@ public class ClusterListenerSupport implements ConnectionListener, ConnectionHea
         final int connectionAttemptLimit = connAttemptLimit == 0 ? Integer.MAX_VALUE : connAttemptLimit;
 
         int attempt = 0;
-        Throwable lastError = null;
         Set<InetSocketAddress> triedAddresses = new HashSet<InetSocketAddress>();
         while (attempt < connectionAttemptLimit) {
+            if (!client.getLifecycleService().isRunning()) {
+                if (LOGGER.isFinestEnabled()) {
+                    LOGGER.finest("Giving up on retrying to connect to cluster since client is shutdown");
+                }
+                break;
+            }
             attempt++;
             final long nextTry = Clock.currentTimeMillis() + connectionAttemptPeriod;
 
-            final Throwable throwable = connect(triedAddresses);
+            boolean isConnected = connect(triedAddresses);
 
-            if (throwable == null) {
+            if (isConnected) {
                 return;
             }
 
-            lastError = throwable;
-
             final long remainingTime = nextTry - Clock.currentTimeMillis();
             LOGGER.warning(
-                    String.format("Unable to get alive cluster connection,"
-                                    + " try in %d ms later, attempt %d of %d.",
+                    String.format("Unable to get alive cluster connection, try in %d ms later, attempt %d of %d.",
                             Math.max(0, remainingTime), attempt, connectionAttemptLimit));
 
             if (remainingTime > 0) {
@@ -285,12 +209,11 @@ public class ClusterListenerSupport implements ConnectionListener, ConnectionHea
             }
         }
         throw new IllegalStateException("Unable to connect to any address in the config! "
-                + "The following addresses were tried:" + triedAddresses, lastError);
+                + "The following addresses were tried:" + triedAddresses);
     }
 
-    private Throwable connect(Set<InetSocketAddress> triedAddresses) {
+    private boolean connect(Set<InetSocketAddress> triedAddresses) throws Exception {
         final Collection<InetSocketAddress> socketAddresses = getSocketAddresses();
-        Throwable lastError = null;
         for (InetSocketAddress inetSocketAddress : socketAddresses) {
             try {
                 triedAddresses.add(inetSocketAddress);
@@ -301,14 +224,13 @@ public class ClusterListenerSupport implements ConnectionListener, ConnectionHea
                 final Connection connection = connectionManager.getOrConnect(address, managerAuthenticator);
                 clusterService.fireConnectionEvent(LifecycleEvent.LifecycleState.CLIENT_CONNECTED);
                 ownerConnectionAddress = connection.getEndPoint();
-                return null;
+                return true;
             } catch (Exception e) {
-                lastError = e;
                 Level level = e instanceof AuthenticationException ? Level.WARNING : Level.FINEST;
                 LOGGER.log(level, "Exception during initial connection to " + inetSocketAddress, e);
             }
         }
-        return lastError;
+        return false;
     }
 
     @Override
@@ -327,7 +249,8 @@ public class ClusterListenerSupport implements ConnectionListener, ConnectionHea
                             clusterService.fireConnectionEvent(LifecycleEvent.LifecycleState.CLIENT_DISCONNECTED);
                             clusterService.getClusterListenerSupport().connectToCluster();
                         } catch (Exception e) {
-                            LOGGER.warning("Could not re-connect to cluster", e);
+                            LOGGER.warning("Could not re-connect to cluster shutting down the client", e);
+                            client.getLifecycleService().shutdown();
                         }
                     }
                 });
@@ -344,60 +267,6 @@ public class ClusterListenerSupport implements ConnectionListener, ConnectionHea
     public void heartBeatStopped(Connection connection) {
         if (connection.getEndPoint().equals(ownerConnectionAddress)) {
             connectionManager.destroyConnection(connection);
-        }
-    }
-
-    private class ClientMembershipEventEventHandler implements EventHandler<ClientMembershipEvent> {
-        @Override
-        public void handle(ClientMembershipEvent event) {
-            final MemberImpl member = (MemberImpl) event.getMember();
-            boolean membersUpdated = false;
-            if (event.getEventType() == MembershipEvent.MEMBER_ADDED) {
-                members.add(member);
-                membersUpdated = true;
-            } else if (event.getEventType() == ClientMembershipEvent.MEMBER_REMOVED) {
-                members.remove(member);
-                membersUpdated = true;
-                final Connection connection = connectionManager.getConnection(member.getAddress());
-                if (connection != null) {
-                    connectionManager.destroyConnection(connection);
-                }
-            } else if (event.getEventType() == ClientMembershipEvent.MEMBER_ATTRIBUTE_CHANGED) {
-                MemberAttributeChange memberAttributeChange = event.getMemberAttributeChange();
-                Map<Address, MemberImpl> memberMap = clusterService.getMembersRef();
-                if (memberMap != null) {
-                    for (MemberImpl target : memberMap.values()) {
-                        if (target.getUuid().equals(memberAttributeChange.getUuid())) {
-                            final MemberAttributeOperationType operationType = memberAttributeChange.getOperationType();
-                            final String key = memberAttributeChange.getKey();
-                            final Object value = memberAttributeChange.getValue();
-                            target.updateAttribute(operationType, key, value);
-                            MemberAttributeEvent memberAttributeEvent = new MemberAttributeEvent(
-                                    client.getCluster(), target, operationType, key, value);
-                            clusterService.fireMemberAttributeEvent(memberAttributeEvent);
-                            break;
-                        }
-                    }
-                }
-            }
-
-            if (membersUpdated) {
-                ((ClientPartitionServiceImpl) client.getClientPartitionService()).refreshPartitions();
-                updateMembersRef();
-                LOGGER.info(clusterService.membersString());
-                clusterService.fireMembershipEvent(new MembershipEvent(client.getCluster(), member, event.getEventType(),
-                        Collections.unmodifiableSet(new LinkedHashSet<Member>(members))));
-            }
-        }
-
-        @Override
-        public void beforeListenerRegister() {
-
-        }
-
-        @Override
-        public void onListenerRegister() {
-
         }
     }
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/ClientRegressionTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ClientRegressionTest.java
@@ -47,6 +47,7 @@ import com.hazelcast.nio.serialization.PortableFactory;
 import com.hazelcast.nio.serialization.PortableReader;
 import com.hazelcast.nio.serialization.PortableWriter;
 import com.hazelcast.security.UsernamePasswordCredentials;
+import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.QuickTest;
@@ -568,6 +569,7 @@ public class ClientRegressionTest
         final HazelcastInstance instance = Hazelcast.newHazelcastInstance();
 
         final ClientConfig clientConfig = new ClientConfig();
+        clientConfig.getNetworkConfig().setConnectionAttemptLimit(Integer.MAX_VALUE);
         final String mapName = randomMapName();
 
         NearCacheConfig nearCacheConfig = new NearCacheConfig();
@@ -586,7 +588,13 @@ public class ClientRegressionTest
         instance.shutdown();
         Hazelcast.newHazelcastInstance();
 
-        assertEquals(null, map.get("a"));
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertEquals(null, map.get("a"));
+            }
+        });
+
     }
 
     @Test
@@ -610,7 +618,6 @@ public class ClientRegressionTest
         for (int i = 0; i < tryCount; i++) {
             final HazelcastInstance instance = Hazelcast.newHazelcastInstance();
             final HazelcastInstance client = HazelcastClient.newHazelcastClient(clientConfig);
-
             final ILock lock = client.getLock("lock");
             assertTrue(lock.tryLock(1, TimeUnit.MINUTES));
             client.getLifecycleService().terminate(); //with client is dead, lock should be released.

--- a/hazelcast/src/main/java/com/hazelcast/cluster/client/ClientInitialMembershipEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/client/ClientInitialMembershipEvent.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.cluster.client;
+
+import com.hazelcast.cluster.impl.ClusterDataSerializerHook;
+import com.hazelcast.core.Member;
+import com.hazelcast.core.MembershipEvent;
+import com.hazelcast.instance.MemberImpl;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.LinkedList;
+
+public final class ClientInitialMembershipEvent implements IdentifiedDataSerializable {
+
+    public static final int MEMBER_ADDED = MembershipEvent.MEMBER_ADDED;
+
+    public static final int MEMBER_REMOVED = MembershipEvent.MEMBER_REMOVED;
+
+    public static final int INITIAL_MEMBERS = 3;
+
+    public static final int MEMBER_ATTRIBUTE_CHANGED = MembershipEvent.MEMBER_ATTRIBUTE_CHANGED;
+
+    private Member member;
+
+    private MemberAttributeChange memberAttributeChange;
+
+    private int eventType;
+
+    private Collection<MemberImpl> memberList;
+
+    public ClientInitialMembershipEvent() {
+    }
+
+    public ClientInitialMembershipEvent(Member member, int eventType) {
+        this.member = member;
+        this.eventType = eventType;
+    }
+
+    public ClientInitialMembershipEvent(Member member, MemberAttributeChange memberAttributeChange) {
+        this.member = member;
+        this.eventType = MEMBER_ATTRIBUTE_CHANGED;
+        this.memberAttributeChange = memberAttributeChange;
+    }
+
+    public ClientInitialMembershipEvent(Collection<MemberImpl> members) {
+        this.eventType = INITIAL_MEMBERS;
+        memberList = members;
+    }
+
+
+    /**
+     * Returns the membership event type; #MEMBER_ADDED or #MEMBER_REMOVED
+     *
+     * @return the membership event type
+     */
+    public int getEventType() {
+        return eventType;
+    }
+
+    /**
+     * Returns the removed or added member.
+     *
+     * @return member which is removed/added
+     */
+    public Member getMember() {
+        return member;
+    }
+
+    /**
+     * Returns the member attribute chance operation to execute
+     * if event type is {@link #MEMBER_ATTRIBUTE_CHANGED}.
+     *
+     * @return MemberAttributeChange to execute
+     */
+    public MemberAttributeChange getMemberAttributeChange() {
+        return memberAttributeChange;
+    }
+
+    /**
+     * Returns member list after initial registration. Note this method returns null if event type is not INITIAL_MEMBERS
+     *
+     * @return set of members at the moment of registration
+     */
+    public Collection<MemberImpl> getMembers() {
+        if (eventType != INITIAL_MEMBERS) {
+            return null;
+        }
+
+        return memberList;
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
+        out.writeInt(eventType);
+        if (eventType == INITIAL_MEMBERS) {
+
+            out.writeInt(memberList.size());
+            for (MemberImpl member : memberList) {
+                member.writeData(out);
+            }
+
+            return;
+        }
+        member.writeData(out);
+        if (eventType == MEMBER_ATTRIBUTE_CHANGED) {
+            memberAttributeChange.writeData(out);
+        }
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) throws IOException {
+        eventType = in.readInt();
+        if (eventType == INITIAL_MEMBERS) {
+            int memberListSize = in.readInt();
+            memberList = new LinkedList<MemberImpl>();
+            for (int i = 0; i < memberListSize; i++) {
+                MemberImpl m = new MemberImpl();
+                m.readData(in);
+                memberList.add(m);
+            }
+            return;
+        }
+
+        member = new MemberImpl();
+        member.readData(in);
+
+        if (eventType == MEMBER_ATTRIBUTE_CHANGED) {
+            memberAttributeChange = new MemberAttributeChange();
+            memberAttributeChange.readData(in);
+        }
+    }
+
+    @Override
+    public int getFactoryId() {
+        return ClusterDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return ClusterDataSerializerHook.INITIAL_MEMBERSHIP_EVENT;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/ClusterDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/ClusterDataSerializerHook.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.cluster.impl;
 
+import com.hazelcast.cluster.client.ClientInitialMembershipEvent;
 import com.hazelcast.cluster.client.ClientMembershipEvent;
 import com.hazelcast.cluster.impl.operations.HeartbeatOperation;
 import com.hazelcast.instance.MemberImpl;
@@ -36,6 +37,7 @@ public final class ClusterDataSerializerHook implements DataSerializerHook {
 
     // client
     public static final int MEMBERSHIP_EVENT = 8;
+    public static final int INITIAL_MEMBERSHIP_EVENT = 9;
 
     @Override
     public int getFactoryId() {
@@ -60,6 +62,8 @@ public final class ClusterDataSerializerHook implements DataSerializerHook {
                         return new BindMessage();
                     case MEMBERSHIP_EVENT:
                         return new ClientMembershipEvent();
+                    case INITIAL_MEMBERSHIP_EVENT:
+                        return new ClientInitialMembershipEvent();
                     default:
                         return null;
                 }

--- a/hazelcast/src/main/java/com/hazelcast/partition/client/GetPartitionsRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/client/GetPartitionsRequest.java
@@ -53,13 +53,15 @@ public final class GetPartitionsRequest extends CallableClientRequest implements
         for (int i = 0; i < indexes.length; i++) {
             Address owner = partitions[i].getOwnerOrNull();
             int index = -1;
-            if (owner != null) {
-                final Integer idx = addressMap.get(owner);
-                if (idx != null) {
-                    index = idx;
-                }
-
+            if (owner == null) {
+                return null;
             }
+
+            final Integer idx = addressMap.get(owner);
+            if (idx != null) {
+                index = idx;
+            }
+
             indexes[i] = index;
         }
         return new PartitionsResponse(addresses, indexes);

--- a/hazelcast/src/main/java/com/hazelcast/partition/impl/InternalPartitionServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/impl/InternalPartitionServiceImpl.java
@@ -251,6 +251,9 @@ public class InternalPartitionServiceImpl implements InternalPartitionService, M
     }
 
     private void notifyMasterToAssignPartitions() {
+        if (initialized) {
+            return;
+        }
         if (lock.tryLock()) {
             try {
                 if (!initialized && !node.isMaster() && node.getMasterAddress() != null && node.joined()) {
@@ -269,6 +272,7 @@ public class InternalPartitionServiceImpl implements InternalPartitionService, M
     @Override
     public void firstArrangement() {
         if (!node.isMaster() || !node.isActive()) {
+            notifyMasterToAssignPartitions();
             return;
         }
         if (!initialized) {
@@ -1765,7 +1769,7 @@ public class InternalPartitionServiceImpl implements InternalPartitionService, M
         }
 
         private void doRun() throws InterruptedException {
-            for (;;) {
+            for (; ; ) {
                 if (!isMigrationActive()) {
                     break;
                 }


### PR DESCRIPTION
membership registration made over connection to prevent re registration when connection is removed. 
Partition trigger mechanism is changed from client. 
Membershiplistener is converted to initial membership listener to get member list without loss of event. ClientMembershipEvent handler is refactored out from ClientInvocationServiceSupport to make it more understandable.