### PR TITLE
fixes #4662 testOpereationRedo. ...

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/AbstractClientSelectionHandler.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/AbstractClientSelectionHandler.java
@@ -28,15 +28,10 @@ import java.nio.channels.SelectionKey;
 public abstract class AbstractClientSelectionHandler implements SelectionHandler, Runnable {
 
     protected final ILogger logger;
-
     protected final SocketChannelWrapper socketChannel;
-
     protected final ClientConnection connection;
-
     protected final ClientConnectionManager connectionManager;
-
-    protected final IOSelector ioSelector;
-
+    private final IOSelector ioSelector;
     private SelectionKey sk;
 
     public AbstractClientSelectionHandler(final ClientConnection connection, IOSelector ioSelector) {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
@@ -43,7 +43,6 @@ import com.hazelcast.nio.SocketInterceptor;
 import com.hazelcast.nio.tcp.IOSelector;
 import com.hazelcast.nio.tcp.IOSelectorOutOfMemoryHandler;
 import com.hazelcast.nio.tcp.InSelectorImpl;
-import com.hazelcast.nio.tcp.OutSelectorImpl;
 import com.hazelcast.nio.tcp.SocketChannelWrapper;
 import com.hazelcast.nio.tcp.SocketChannelWrapperFactory;
 import com.hazelcast.util.Clock;
@@ -120,13 +119,13 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
 
         inSelector = new InSelectorImpl(
                 client.getThreadGroup(),
-                "InSelector",
+                "ClientInSelector",
                 Logger.getLogger(InSelectorImpl.class),
                 OUT_OF_MEMORY_HANDLER);
-        outSelector = new OutSelectorImpl(
+        outSelector = new ClientOutSelectorImpl(
                 client.getThreadGroup(),
-                "OutSelector",
-                Logger.getLogger(OutSelectorImpl.class),
+                "ClientOutSelector",
+                Logger.getLogger(ClientOutSelectorImpl.class),
                 OUT_OF_MEMORY_HANDLER);
 
         socketOptions = networkConfig.getSocketOptions();

--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientOutSelectorImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientOutSelectorImpl.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hazelcast.client.connection.nio;
+
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.nio.tcp.AbstractIOSelector;
+import com.hazelcast.nio.tcp.IOSelectorOutOfMemoryHandler;
+import com.hazelcast.nio.tcp.SelectionHandler;
+
+import java.nio.channels.SelectionKey;
+
+
+public final class ClientOutSelectorImpl extends AbstractIOSelector {
+
+    public ClientOutSelectorImpl(ThreadGroup threadGroup, String tname, ILogger logger,
+                                 IOSelectorOutOfMemoryHandler oomeHandler) {
+        super(threadGroup, tname, logger, oomeHandler);
+    }
+
+    @Override
+    protected void handleSelectionKey(SelectionKey sk) {
+        if (sk.isValid() && sk.isWritable()) {
+            sk.interestOps(sk.interestOps() & ~SelectionKey.OP_WRITE);
+            SelectionHandler handler = (SelectionHandler) sk.attachment();
+            handler.handle();
+        }
+    }
+}
+

--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientWriteHandler.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientWriteHandler.java
@@ -103,8 +103,7 @@ public class ClientWriteHandler extends AbstractClientSelectionHandler implement
             // already in the task queue.
             // we can have a counter to check this later on.
             // for now, wake up regardless.
-            ioSelector.addTask(this);
-            ioSelector.wakeup();
+            register();
         }
     }
 

--- a/hazelcast-client/src/test/java/com/hazelcast/client/ClientRegressionTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ClientRegressionTest.java
@@ -183,10 +183,10 @@ public class ClientRegressionTest
     @Test(timeout = 60000)
     public void testOperationRedo() throws Exception {
         final HazelcastInstance hz1 = Hazelcast.newHazelcastInstance();
-        final HazelcastInstance hz2 = Hazelcast.newHazelcastInstance();
+        Hazelcast.newHazelcastInstance();
 
         ClientConfig clientConfig = new ClientConfig();
-        clientConfig.setRedoOperation(true);
+        clientConfig.getNetworkConfig().setRedoOperation(true);
         HazelcastInstance client = HazelcastClient.newHazelcastClient(clientConfig);
 
         final Thread thread = new Thread() {


### PR DESCRIPTION
Our refactorings on OutSelected and WriteHandler in node side caused a nasty bug on client side. OutSelectorImpl class is duplicated to revert the behaviour for client side. 
