### PR TITLE
Backport WaitNotifyService issues to 3.3.6

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cluster/ClusterServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/ClusterServiceImpl.java
@@ -773,7 +773,7 @@ public final class ClusterServiceImpl implements ClusterService, ConnectionListe
         }
     }
 
-    void prepareToMerge(final Address newTargetAddress) {
+    public void prepareToMerge(final Address newTargetAddress) {
         preparingToMerge.set(true);
         node.getJoiner().setTargetAddress(newTargetAddress);
         nodeEngine.getExecutionService().schedule(new Runnable() {
@@ -783,7 +783,7 @@ public final class ClusterServiceImpl implements ClusterService, ConnectionListe
         }, 10, TimeUnit.SECONDS);
     }
 
-    void merge(Address newTargetAddress) {
+    public void merge(Address newTargetAddress) {
         if (preparingToMerge.compareAndSet(true, false)) {
             node.getJoiner().setTargetAddress(newTargetAddress);
             final LifecycleServiceImpl lifecycleService = node.hazelcastInstance.getLifecycleService();
@@ -804,6 +804,7 @@ public final class ClusterServiceImpl implements ClusterService, ConnectionListe
                         service.reset();
                     }
                     node.onRestart();
+                    node.nodeEngine.reset();
                     node.connectionManager.restart();
                     node.rejoin();
                     final Collection<Future> futures = new LinkedList<Future>();

--- a/hazelcast/src/main/java/com/hazelcast/spi/WaitNotifyService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/WaitNotifyService.java
@@ -22,8 +22,35 @@ package com.hazelcast.spi;
  */
 public interface WaitNotifyService {
 
+    /**
+     * Causes the current operation to wait in WaitNotifyService until it is notified
+     * by a {@link com.hazelcast.spi.Notifier} operation or timeout specified by
+     * {@link WaitSupport#getWaitTimeout()} passes.
+     * <p/>
+     * {@link com.hazelcast.spi.WaitSupport} operation will be registered using {@link com.hazelcast.spi.WaitNotifyKey}
+     * returned from method {@link WaitSupport#getWaitKey()}.
+     * <p/>
+     * When operation is notified, it's re-executed by related scheduled mechanism.
+     * <p/>
+     * If wait time-outs, {@link WaitSupport#onWaitExpire()} method is called.
+     * <p/>
+     * This method should be called in the thread executes the actual {@link com.hazelcast.spi.WaitSupport} operation.
+     *
+     * @param waitSupport operation which will wait for notification
+     */
     void await(WaitSupport waitSupport);
 
+    /**
+     * Notifies the waiting {@link com.hazelcast.spi.WaitSupport} operation to wake-up and continue executing.
+     * <p/>
+     * A waiting operation registered with the {@link Notifier#getNotifiedKey()} will be notified and deregistered.
+     * This method has no effect if there isn't any operation registered
+     * for related {@link com.hazelcast.spi.WaitNotifyKey}.
+     * <p/>
+     * This method should be called in the thread executes the actual {@link com.hazelcast.spi.Notifier} operation.
+     *
+     * @param notifier operation which will notify a corresponding waiting operation
+     */
     void notify(Notifier notifier);
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/BasicOperationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/BasicOperationService.java
@@ -410,6 +410,18 @@ final class BasicOperationService implements InternalOperationService {
     }
 
     @Override
+    public void reset() {
+        for (BasicInvocation invocation : invocations.values()) {
+            try {
+                invocation.notify(new MemberLeftException());
+            } catch (Throwable e) {
+                logger.warning(invocation + " could not be notified with reset message -> " + e.getMessage());
+            }
+        }
+        invocations.clear();
+    }
+
+    @Override
     public void shutdown() {
         logger.finest("Stopping operation threads...");
         for (BasicInvocation invocation : invocations.values()) {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/InternalOperationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/InternalOperationService.java
@@ -59,6 +59,12 @@ public interface InternalOperationService extends OperationService {
     void executeOperation(Packet packet);
 
     /**
+     * Resets internal state of InternalOperationService.
+     * Notifies registered invocations with an error message.
+     */
+    void reset();
+
+    /**
      * Shuts down this InternalOperationService.
      */
     void shutdown();

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
@@ -381,6 +381,12 @@ public class NodeEngineImpl implements NodeEngine {
     }
 
     @PrivateApi
+    public void reset() {
+        waitNotifyService.reset();
+        operationService.reset();
+    }
+
+    @PrivateApi
     public void shutdown(final boolean terminate) {
         logger.finest("Shutting down services...");
         waitNotifyService.shutdown();

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/WaitNotifyServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/WaitNotifyServiceImpl.java
@@ -89,7 +89,9 @@ class WaitNotifyServiceImpl implements WaitNotifyService {
         nodeEngine.getOperationService().executeOperation(waitingOp);
     }
 
-    // runs after queue lock
+    // Runs in operation thread, we can assume that
+    // here we have an implicit lock for specific WaitNotifyKey.
+    // see javadoc
     @Override
     public void await(WaitSupport waitSupport) {
         final WaitNotifyKey key = waitSupport.getWaitKey();
@@ -103,7 +105,9 @@ class WaitNotifyServiceImpl implements WaitNotifyService {
         }
     }
 
-    // runs after queue lock
+    // Runs in operation thread, we can assume that
+    // here we have an implicit lock for specific WaitNotifyKey.
+    // see javadoc
     @Override
     public void notify(Notifier notifier) {
         WaitNotifyKey key = notifier.getNotifiedKey();
@@ -129,9 +133,18 @@ class WaitNotifyServiceImpl implements WaitNotifyService {
                 }
                 waitingOp.setValid(false);
             }
-            q.poll();
             // consume
+            q.poll();
+
             waitingOp = q.peek();
+
+            // If q.peek() returns null, we should deregister this specific
+            // key to avoid memory leak. By contract we know that await() and notify()
+            // cannot be called in parallel.
+            // We can safely remove this queue from registration map here.
+            if (waitingOp == null) {
+                mapWaitingOps.remove(key);
+            }
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/WaitNotifyServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/WaitNotifyServiceImpl.java
@@ -135,6 +135,20 @@ class WaitNotifyServiceImpl implements WaitNotifyService {
         }
     }
 
+    // for testing purposes only
+    int getAwaitQueueCount() {
+        return mapWaitingOps.size();
+    }
+
+    // for testing purposes only
+    int getTotalWaitingOperationCount() {
+        int count = 0;
+        for (Queue<WaitingOp> queue : mapWaitingOps.values()) {
+            count += queue.size();
+        }
+        return count;
+    }
+
     // invalidated waiting ops will removed from queue eventually by notifiers.
     void onMemberLeft(MemberImpl leftMember) {
         invalidateWaitingOps(leftMember.getUuid());
@@ -195,6 +209,11 @@ class WaitNotifyServiceImpl implements WaitNotifyService {
                 }
             }
         }
+    }
+
+    void reset() {
+        delayQueue.clear();
+        mapWaitingOps.clear();
     }
 
     void shutdown() {

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/InvocationNetworkSplitTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/InvocationNetworkSplitTest.java
@@ -1,0 +1,262 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi.impl;
+
+import com.hazelcast.cluster.ClusterServiceImpl;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.MemberLeftException;
+import com.hazelcast.instance.Node;
+import com.hazelcast.instance.TestUtil;
+import com.hazelcast.spi.AbstractOperation;
+import com.hazelcast.spi.AbstractWaitNotifyKey;
+import com.hazelcast.spi.ExceptionAction;
+import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.OperationService;
+import com.hazelcast.spi.WaitNotifyKey;
+import com.hazelcast.spi.WaitSupport;
+import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.util.EmptyStatement;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category(QuickTest.class)
+public class InvocationNetworkSplitTest extends HazelcastTestSupport {
+
+    @Test
+    public void testWaitingInvocations_whenNodeSplitFromCluster() throws Exception {
+        SplitAction action = new FullSplitAction();
+        testWaitingInvocations_whenNodeSplitFromCluster(action);
+    }
+
+    @Test
+    public void testWaitingInvocations_whenNodePartiallySplitFromCluster_scenario1() throws Exception {
+        SplitAction action = new PartialSplitAction();
+        testWaitingInvocations_whenNodeSplitFromCluster(action);
+    }
+
+    @Test
+    public void testWaitingInvocations_whenNodePartiallySplitFromCluster_scenario2() throws Exception {
+        SplitAction action = new HalfPartialSplitAction();
+        testWaitingInvocations_whenNodeSplitFromCluster(action);
+    }
+
+    private void testWaitingInvocations_whenNodeSplitFromCluster(SplitAction splitAction) throws Exception {
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(3);
+        HazelcastInstance hz1 = factory.newHazelcastInstance();
+        HazelcastInstance hz2 = factory.newHazelcastInstance();
+        HazelcastInstance hz3 = factory.newHazelcastInstance();
+
+        Node node1 = TestUtil.getNode(hz1);
+        Node node2 = TestUtil.getNode(hz2);
+        Node node3 = TestUtil.getNode(hz3);
+
+        warmUpPartitions(hz1, hz2, hz3);
+        int partitionId = getPartitionId(hz2);
+
+        NodeEngineImpl nodeEngine3 = node3.getNodeEngine();
+        OperationService operationService3 = nodeEngine3.getOperationService();
+        Operation op = new AlwaysBlockingOperation();
+        Future<Object> future = operationService3.invokeOnPartition("", op, partitionId);
+
+        // just wait a little to make sure
+        // operation is landed on wait-queue
+        sleepSeconds(1);
+
+        // execute the given split action
+        splitAction.run(node1, node2, node3);
+
+        // Let node3 detect the split and merge it back to other two.
+        ClusterServiceImpl clusterService3 = node3.getClusterService();
+        clusterService3.prepareToMerge(node1.address);
+        clusterService3.merge(node1.address);
+
+        assertEquals(3, node1.getClusterService().getSize());
+        assertEquals(3, node2.getClusterService().getSize());
+        assertEquals(3, node3.getClusterService().getSize());
+
+        try {
+            future.get(1, TimeUnit.MINUTES);
+            fail("Future.get() should fail with a MemberLeftException!");
+        } catch (MemberLeftException e) {
+            // expected
+            EmptyStatement.ignore(e);
+        } catch (Exception e) {
+            fail(e.getClass().getName() + ": " + e.getMessage());
+        }
+    }
+
+    @Test
+    public void testWaitNotifyService_whenNodeSplitFromCluster() throws Exception {
+        SplitAction action = new FullSplitAction();
+        testWaitNotifyService_whenNodeSplitFromCluster(action);
+    }
+
+    @Test
+    public void testWaitNotifyService_whenNodePartiallySplitFromCluster() throws Exception {
+        SplitAction action = new PartialSplitAction();
+        testWaitNotifyService_whenNodeSplitFromCluster(action);
+    }
+
+    private void testWaitNotifyService_whenNodeSplitFromCluster(SplitAction action) throws Exception {
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(5);
+        HazelcastInstance hz1 = factory.newHazelcastInstance();
+        HazelcastInstance hz2 = factory.newHazelcastInstance();
+        HazelcastInstance hz3 = factory.newHazelcastInstance();
+
+        final Node node1 = TestUtil.getNode(hz1);
+        Node node2 = TestUtil.getNode(hz2);
+        Node node3 = TestUtil.getNode(hz3);
+
+        warmUpPartitions(hz1, hz2, hz3);
+        int partitionId = getPartitionId(hz3);
+
+        NodeEngineImpl nodeEngine1 = node1.getNodeEngine();
+        OperationService operationService1 = nodeEngine1.getOperationService();
+        operationService1.invokeOnPartition("", new AlwaysBlockingOperation(), partitionId);
+
+        final WaitNotifyServiceImpl waitNotifyService3 = (WaitNotifyServiceImpl) node3.getNodeEngine().getWaitNotifyService();
+        assertEqualsEventually(new Callable<Integer>() {
+            @Override
+            public Integer call() throws Exception {
+                return waitNotifyService3.getTotalWaitingOperationCount();
+            }
+        }, 1);
+
+        action.run(node1, node2, node3);
+
+        // create a new node to prevent same partition assignments
+        // after node3 rejoins
+        factory.newHazelcastInstance();
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                Assert.assertEquals(0, node1.partitionService.getMigrationQueueSize());
+            }
+        });
+
+        // Let node3 detect the split and merge it back to other two.
+        ClusterServiceImpl clusterService3 = node3.getClusterService();
+        clusterService3.prepareToMerge(node1.address);
+        clusterService3.merge(node1.address);
+
+        assertEquals(4, node1.getClusterService().getSize());
+        assertEquals(4, node2.getClusterService().getSize());
+        assertEquals(4, node3.getClusterService().getSize());
+
+        assertEquals(0, waitNotifyService3.getTotalWaitingOperationCount());
+    }
+
+    private static class AlwaysBlockingOperation extends AbstractOperation implements WaitSupport {
+
+        @Override
+        public void run() throws Exception {
+        }
+
+        @Override
+        public WaitNotifyKey getWaitKey() {
+            return new AbstractWaitNotifyKey(getServiceName(), "test") {};
+        }
+
+        @Override
+        public boolean shouldWait() {
+            return true;
+        }
+
+        @Override
+        public void onWaitExpire() {
+            getResponseHandler().sendResponse(new TimeoutException());
+        }
+
+        @Override
+        public String getServiceName() {
+            return "AlwaysBlockingOperationService";
+        }
+
+        @Override
+        public ExceptionAction onException(Throwable throwable) {
+            return ExceptionAction.THROW_EXCEPTION;
+        }
+    }
+
+    private interface SplitAction {
+        void run(Node node1, Node node2, Node node3);
+    }
+
+    private static class FullSplitAction implements SplitAction {
+        @Override
+        public void run(Node node1, Node node2, Node node3) {
+            // Artificially create a network-split
+            node1.clusterService.removeAddress(node3.address);
+            node2.clusterService.removeAddress(node3.address);
+
+            node3.clusterService.removeAddress(node1.address);
+            node3.clusterService.removeAddress(node2.address);
+
+            assertEquals(2, node1.getClusterService().getSize());
+            assertEquals(2, node2.getClusterService().getSize());
+            assertEquals(1, node3.getClusterService().getSize());
+
+        }
+    }
+
+    private static class PartialSplitAction implements SplitAction {
+        @Override
+        public void run(Node node1, Node node2, Node node3) {
+            // Artificially create a partial network-split;
+            // node1 and node2 will be split from node3
+            // but node 3 will not be able to detect that.
+            node1.clusterService.removeAddress(node3.address);
+            node2.clusterService.removeAddress(node3.address);
+
+            assertEquals(2, node1.getClusterService().getSize());
+            assertEquals(2, node2.getClusterService().getSize());
+            assertEquals(3, node3.getClusterService().getSize());
+        }
+    }
+
+    private static class HalfPartialSplitAction implements SplitAction {
+        @Override
+        public void run(Node node1, Node node2, Node node3) {
+            // Artificially create a partial network-split;
+            // node1 and node2 will be split from node3
+            // but node 3 will not be able to detect that.
+            node1.clusterService.removeAddress(node3.address);
+            node2.clusterService.removeAddress(node3.address);
+            node3.clusterService.removeAddress(node1.address);
+
+            assertEquals(2, node1.getClusterService().getSize());
+            assertEquals(2, node2.getClusterService().getSize());
+            assertEquals(2, node3.getClusterService().getSize());
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/WaitNotifyServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/WaitNotifyServiceTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2008-2014, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi.impl;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.HazelcastInstanceNotActiveException;
+import com.hazelcast.core.ILock;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.locks.LockSupport;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category(QuickTest.class)
+public class WaitNotifyServiceTest extends HazelcastTestSupport {
+
+    @Test
+    public void testAwaitQueueCount_shouldNotExceedBlockedThreadCount() {
+        final HazelcastInstance hz = createHazelcastInstance();
+        NodeEngineImpl nodeEngine = getNode(hz).nodeEngine;
+        WaitNotifyServiceImpl waitNotifyService = (WaitNotifyServiceImpl) nodeEngine.getWaitNotifyService();
+
+        final int keyCount = 1000;
+        int nThreads = 4;
+        CountDownLatch latch = new CountDownLatch(nThreads);
+
+        for (int i = 0; i < nThreads; i++) {
+            new Thread(new LockWaitAndUnlockTask(hz, keyCount, latch)).start();
+        }
+
+        while (latch.getCount() > 0) {
+            LockSupport.parkNanos(1);
+            int awaitQueueCount = waitNotifyService.getAwaitQueueCount();
+            Assert.assertTrue(
+                    "Await queue count should be smaller than total number of threads: " + awaitQueueCount + " VS "
+                            + nThreads, awaitQueueCount < nThreads);
+        }
+    }
+
+    private static class LockWaitAndUnlockTask implements Runnable {
+        private final HazelcastInstance hz;
+        private final int keyCount;
+        private final CountDownLatch latch;
+
+        public LockWaitAndUnlockTask(HazelcastInstance hz, int keyCount, CountDownLatch latch) {
+            this.hz = hz;
+            this.keyCount = keyCount;
+            this.latch = latch;
+        }
+
+        @Override
+        public void run() {
+            for (int i = 0; i < keyCount; i++) {
+                try {
+                    ILock lock = hz.getLock("key" + i);
+                    lock.lock();
+                    LockSupport.parkNanos(1);
+                    lock.unlock();
+                } catch (HazelcastInstanceNotActiveException ignored) {
+                }
+            }
+            latch.countDown();
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
@@ -24,12 +24,14 @@ import com.hazelcast.core.PartitionService;
 import com.hazelcast.instance.HazelcastInstanceFactory;
 import com.hazelcast.instance.Node;
 import com.hazelcast.instance.TestUtil;
+import com.hazelcast.partition.InternalPartition;
 import com.hazelcast.partition.InternalPartitionService;
 
 import java.util.Collection;
 import java.util.Map;
 import java.util.Random;
 import java.util.UUID;
+import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -280,6 +282,16 @@ public abstract class HazelcastTestSupport {
         assertEquals(String.format(message, expected, actual), expected, actual);
     }
 
+
+    public static <E> void assertEqualsEventually(final Callable<E> task, final E value) {
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertEquals(value, task.call());
+            }
+        });
+    }
+
     protected final TestHazelcastInstanceFactory createHazelcastInstanceFactory(int nodeCount) {
         if (factory != null) {
             throw new IllegalStateException("Node factory is already created!");
@@ -323,6 +335,31 @@ public abstract class HazelcastTestSupport {
             throw new RuntimeException(e);
         }
     }
+
+    public static InternalPartitionService getPartitionService(HazelcastInstance hz) {
+        Node node = getNode(hz);
+        return node.partitionService;
+    }
+
+     /**
+     * Gets a partition id owned by this particular member.
+      *
+     * @param hz
+     * @return
+     */
+     public static int getPartitionId(HazelcastInstance hz) {
+         warmUpPartitions(hz);
+         Node node = getNode(hz);
+
+         InternalPartitionService partitionService = getPartitionService(hz);
+         for (InternalPartition p : partitionService.getPartitions()) {
+             if (node.getThisAddress().equals(p.getOwnerOrNull())) {
+                 return p.getPartitionId();
+             }
+         }
+
+         throw new RuntimeException("No local partitions are found for hz: " + hz.getName());
+     }
 
     public static String generateKeyOwnedBy(HazelcastInstance instance) {
         final Member localMember = instance.getCluster().getLocalMember();


### PR DESCRIPTION
Backport two WaitNotifyService issues to 3.3.6 branch:

1- Fixed leaking waiting ops and invocations after a partial network split: https://github.com/hazelcast/hazelcast/pull/4679

2- Fixed memory leak caused by empty await queues in WaitNotifyService. Await queues becoming empty should be removed from registration map: https://github.com/hazelcast/hazelcast/pull/4441