### PR TITLE
Introduction of spring-aware tag for hz namespace

### DIFF
--- a/hazelcast-documentation/src/SpringIntegration.md
+++ b/hazelcast-documentation/src/SpringIntegration.md
@@ -205,12 +205,12 @@ Hazelcast Distributed Objects could be marked with @SpringAware if the object wa
 - to apply factory callbacks such as `ApplicationContextAware`, `BeanNameAware`,
 - to apply bean post-processing annotations such as `InitializingBean`, `@PostConstruct`.
 
-Hazelcast Distributed `ExecutorService`, or more generally any Hazelcast managed object, can benefit from these features. To enable SpringAware objects, you must first configure `HazelcastInstance` as explained in the [Spring Configuration section](#spring-configuration).
+Hazelcast Distributed `ExecutorService`, or more generally any Hazelcast managed object, can benefit from these features. To enable SpringAware objects, you must first configure `HazelcastInstance` using *hazelcast* namespace as explained in the [Spring Configuration section](#spring-configuration) and add `<hz:spring-aware />` tag.
 
 #### SpringAware Examples
 
 - Configure a Hazelcast Instance (3.3.x) via Spring Configuration and define *someBean* as Spring Bean.
-
+- Add `<hz:spring-aware />` to Hazelcast configuration to enable @SpringAware
 
 ```xml
 <beans xmlns="http://www.springframework.org/schema/beans"
@@ -228,6 +228,7 @@ Hazelcast Distributed `ExecutorService`, or more generally any Hazelcast managed
 
   <hz:hazelcast id="instance">
     <hz:config>
+      <hz:spring-aware />
       <hz:group name="dev" password="password"/>
       <hz:network port="5701" port-auto-increment="false">
         <hz:join>

--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/AbstractHazelcastBeanDefinitionParser.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/AbstractHazelcastBeanDefinitionParser.java
@@ -21,6 +21,7 @@ import com.hazelcast.config.GlobalSerializerConfig;
 import com.hazelcast.config.SerializationConfig;
 import com.hazelcast.config.SerializerConfig;
 import com.hazelcast.config.SocketInterceptorConfig;
+import com.hazelcast.spring.context.SpringManagedContext;
 import org.springframework.beans.factory.config.RuntimeBeanReference;
 import org.springframework.beans.factory.support.AbstractBeanDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
@@ -39,10 +40,10 @@ import java.util.HashSet;
  * Base class of all Hazelcast BeanDefinitionParser implementations.
  * <p/>
  * <ul>
- *     <li>{@link com.hazelcast.spring.HazelcastClientBeanDefinitionParser}</li>
- *     <li>{@link com.hazelcast.spring.HazelcastConfigBeanDefinitionParser}</li>
- *     <li>{@link com.hazelcast.spring.HazelcastInstanceDefinitionParser}</li>
- *     <li>{@link com.hazelcast.spring.HazelcastTypeBeanDefinitionParser}</li>
+ *     <li>{@link HazelcastClientBeanDefinitionParser}</li>
+ *     <li>{@link HazelcastConfigBeanDefinitionParser}</li>
+ *     <li>{@link HazelcastInstanceDefinitionParser}</li>
+ *     <li>{@link HazelcastTypeBeanDefinitionParser}</li>
  * </ul>
  *
  */
@@ -333,6 +334,11 @@ public abstract class AbstractHazelcastBeanDefinitionParser extends AbstractBean
                 properties.put(propertyName, value);
             }
             beanDefinitionBuilder.addPropertyValue("properties", properties);
+        }
+
+        protected void handleSpringAware() {
+            BeanDefinitionBuilder managedContextBeanBuilder = createBeanBuilder(SpringManagedContext.class);
+            configBuilder.addPropertyValue("managedContext", managedContextBeanBuilder.getBeanDefinition());
         }
     }
 }

--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastClientBeanDefinitionParser.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastClientBeanDefinitionParser.java
@@ -28,7 +28,6 @@ import com.hazelcast.config.GroupConfig;
 import com.hazelcast.config.ListenerConfig;
 import com.hazelcast.config.NearCacheConfig;
 import com.hazelcast.config.SSLConfig;
-import com.hazelcast.spring.context.SpringManagedContext;
 import org.springframework.beans.factory.support.AbstractBeanDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.support.ManagedMap;
@@ -87,9 +86,6 @@ public class HazelcastClientBeanDefinitionParser extends AbstractHazelcastBeanDe
 
             this.configBuilder = BeanDefinitionBuilder.rootBeanDefinition(ClientConfig.class);
             configBuilder.addPropertyValue("nearCacheConfigMap", nearCacheConfigMap);
-
-            BeanDefinitionBuilder managedContextBeanBuilder = createBeanBuilder(SpringManagedContext.class);
-            this.configBuilder.addPropertyValue("managedContext", managedContextBeanBuilder.getBeanDefinition());
         }
 
         public AbstractBeanDefinition getBeanDefinition() {
@@ -99,7 +95,7 @@ public class HazelcastClientBeanDefinitionParser extends AbstractHazelcastBeanDe
         public void handleClient(Element element) {
             handleCommonBeanAttributes(element, builder, parserContext);
             handleClientAttributes(element);
-            for (org.w3c.dom.Node node : new IterableNodeList(element, Node.ELEMENT_NODE)) {
+            for (Node node : new IterableNodeList(element, Node.ELEMENT_NODE)) {
                 final String nodeName = cleanNodeName(node.getNodeName());
                 if ("group".equals(nodeName)) {
                     createAndFillBeanBuilder(node, GroupConfig.class, "groupConfig", configBuilder);
@@ -119,6 +115,8 @@ public class HazelcastClientBeanDefinitionParser extends AbstractHazelcastBeanDe
                     handleLoadBalancer(node);
                 } else if ("near-cache".equals(nodeName)) {
                     handleNearCache(node);
+                } else if ("spring-aware".equals(nodeName)) {
+                    handleSpringAware();
                 }
             }
             builder.addConstructorArgValue(configBuilder.getBeanDefinition());
@@ -144,7 +142,7 @@ public class HazelcastClientBeanDefinitionParser extends AbstractHazelcastBeanDe
             final BeanDefinitionBuilder clientNetworkConfig = createBeanBuilder(ClientNetworkConfig.class);
             List<String> members = new ArrayList<String>(INITIAL_CAPACITY);
             fillAttributeValues(node, clientNetworkConfig);
-            for (org.w3c.dom.Node child : new IterableNodeList(node, Node.ELEMENT_NODE)) {
+            for (Node child : new IterableNodeList(node, Node.ELEMENT_NODE)) {
                 final String nodeName = cleanNodeName(child);
                 if ("member".equals(nodeName)) {
                     members.add(getTextContent(child));
@@ -176,7 +174,7 @@ public class HazelcastClientBeanDefinitionParser extends AbstractHazelcastBeanDe
             if (implementation != null) {
                 sslConfigBuilder.addPropertyReference(xmlToJavaName(implAttribute), implementation);
             }
-            for (org.w3c.dom.Node child : new IterableNodeList(node, Node.ELEMENT_NODE)) {
+            for (Node child : new IterableNodeList(node, Node.ELEMENT_NODE)) {
                 final String name = cleanNodeName(child);
                 if ("properties".equals(name)) {
                     handleProperties(child, sslConfigBuilder);

--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastConfigBeanDefinitionParser.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastConfigBeanDefinitionParser.java
@@ -65,7 +65,6 @@ import com.hazelcast.config.WanReplicationRef;
 import com.hazelcast.config.WanTargetClusterConfig;
 import com.hazelcast.nio.ClassLoaderUtil;
 import com.hazelcast.spi.ServiceConfigurationParser;
-import com.hazelcast.spring.context.SpringManagedContext;
 import com.hazelcast.util.ExceptionUtil;
 import org.springframework.beans.factory.support.AbstractBeanDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
@@ -145,9 +144,6 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
             this.wanReplicationManagedMap = createManagedMap("wanReplicationConfigs");
             this.jobTrackerManagedMap = createManagedMap("jobTrackerConfigs");
             this.replicatedMapManagedMap = createManagedMap("replicatedMapConfigs");
-
-            BeanDefinitionBuilder managedContextBeanBuilder = createBeanBuilder(SpringManagedContext.class);
-            this.configBuilder.addPropertyValue("managedContext", managedContextBeanBuilder.getBeanDefinition());
         }
 
         private ManagedMap createManagedMap(String configName) {
@@ -162,7 +158,7 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
 
         public void handleConfig(final Element element) {
             handleCommonBeanAttributes(element, configBuilder, parserContext);
-            for (org.w3c.dom.Node node : new IterableNodeList(element, Node.ELEMENT_NODE)) {
+            for (Node node : new IterableNodeList(element, Node.ELEMENT_NODE)) {
                 final String nodeName = cleanNodeName(node.getNodeName());
                 if ("network".equals(nodeName)) {
                     handleNetwork(node);
@@ -213,6 +209,8 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
                     handleManagementCenter(node);
                 } else if ("services".equals(nodeName)) {
                     handleServices(node);
+                } else if ("spring-aware".equals(nodeName)) {
+                    handleSpringAware();
                 }
             }
         }
@@ -222,7 +220,7 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
             final AbstractBeanDefinition beanDefinition = servicesConfigBuilder.getBeanDefinition();
             fillAttributeValues(node, servicesConfigBuilder);
             ManagedList<AbstractBeanDefinition> serviceConfigManagedList = new ManagedList<AbstractBeanDefinition>();
-            for (org.w3c.dom.Node child : new IterableNodeList(node, Node.ELEMENT_NODE)) {
+            for (Node child : new IterableNodeList(node, Node.ELEMENT_NODE)) {
                 final String nodeName = cleanNodeName(child);
                 if ("service".equals(nodeName)) {
                     serviceConfigManagedList.add(handleService(child));
@@ -237,7 +235,7 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
             BeanDefinitionBuilder serviceConfigBuilder = createBeanBuilder(ServiceConfig.class);
             final AbstractBeanDefinition beanDefinition = serviceConfigBuilder.getBeanDefinition();
             fillAttributeValues(node, serviceConfigBuilder);
-            for (org.w3c.dom.Node child : new IterableNodeList(node, Node.ELEMENT_NODE)) {
+            for (Node child : new IterableNodeList(node, Node.ELEMENT_NODE)) {
                 final String nodeName = cleanNodeName(child);
                 if ("name".equals(nodeName)) {
                     serviceConfigBuilder.addPropertyValue(xmlToJavaName(nodeName), getTextContent(child));
@@ -266,7 +264,7 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
             final Node attName = node.getAttributes().getNamedItem("name");
             final String name = getTextContent(attName);
             fillAttributeValues(node, replicatedMapConfigBuilder);
-            for (org.w3c.dom.Node childNode : new IterableNodeList(node.getChildNodes(), Node.ELEMENT_NODE)) {
+            for (Node childNode : new IterableNodeList(node.getChildNodes(), Node.ELEMENT_NODE)) {
                 if ("entry-listeners".equals(cleanNodeName(childNode))) {
                     ManagedList listeners = parseListeners(childNode, EntryListenerConfig.class);
                     replicatedMapConfigBuilder.addPropertyValue("listenerConfigs", listeners);
@@ -279,7 +277,7 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
             BeanDefinitionBuilder networkConfigBuilder = createBeanBuilder(NetworkConfig.class);
             final AbstractBeanDefinition beanDefinition = networkConfigBuilder.getBeanDefinition();
             fillAttributeValues(node, networkConfigBuilder);
-            for (org.w3c.dom.Node child : new IterableNodeList(node, Node.ELEMENT_NODE)) {
+            for (Node child : new IterableNodeList(node, Node.ELEMENT_NODE)) {
                 final String nodeName = cleanNodeName(child);
                 if ("join".equals(nodeName)) {
                     handleJoin(child, networkConfigBuilder);
@@ -332,14 +330,14 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
             final NamedNodeMap atts = node.getAttributes();
             if (atts != null) {
                 for (int a = 0; a < atts.getLength(); a++) {
-                    final org.w3c.dom.Node att = atts.item(a);
+                    final Node att = atts.item(a);
                     final String name = xmlToJavaName(att.getNodeName());
                     final String value = att.getNodeValue();
                     builder.addPropertyValue(name, value);
                 }
             }
             ManagedList interfacesSet = new ManagedList();
-            for (org.w3c.dom.Node n : new IterableNodeList(node, Node.ELEMENT_NODE)) {
+            for (Node n : new IterableNodeList(node, Node.ELEMENT_NODE)) {
                 String name = xmlToJavaName(cleanNodeName(n));
                 String value = getTextContent(n);
                 if ("interface".equals(name)) {
@@ -353,7 +351,7 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
         public void handleJoin(Node node, BeanDefinitionBuilder networkConfigBuilder) {
             BeanDefinitionBuilder joinConfigBuilder = createBeanBuilder(JoinConfig.class);
             final AbstractBeanDefinition beanDefinition = joinConfigBuilder.getBeanDefinition();
-            for (org.w3c.dom.Node child : new IterableNodeList(node, Node.ELEMENT_NODE)) {
+            for (Node child : new IterableNodeList(node, Node.ELEMENT_NODE)) {
                 final String name = cleanNodeName(child);
                 if ("multicast".equals(name)) {
                     handleMulticast(child, joinConfigBuilder);
@@ -369,7 +367,7 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
 
         private void handleOutboundPorts(final Node node, final BeanDefinitionBuilder networkConfigBuilder) {
             ManagedList outboundPorts = new ManagedList();
-            for (org.w3c.dom.Node child : new IterableNodeList(node, Node.ELEMENT_NODE)) {
+            for (Node child : new IterableNodeList(node, Node.ELEMENT_NODE)) {
                 final String name = cleanNodeName(child);
                 if ("ports".equals(name)) {
                     String value = getTextContent(child);
@@ -393,7 +391,7 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
             if (implementation != null) {
                 sslConfigBuilder.addPropertyReference(xmlToJavaName(implAttribute), implementation);
             }
-            for (org.w3c.dom.Node child : new IterableNodeList(node, Node.ELEMENT_NODE)) {
+            for (Node child : new IterableNodeList(node, Node.ELEMENT_NODE)) {
                 final String name = cleanNodeName(child);
                 if ("properties".equals(name)) {
                     handleProperties(child, sslConfigBuilder);
@@ -421,7 +419,7 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
                             joinConfigBuilder,
                             "interface", "member", "members");
             final ManagedList members = new ManagedList();
-            for (org.w3c.dom.Node n : new IterableNodeList(node.getChildNodes(), Node.ELEMENT_NODE)) {
+            for (Node n : new IterableNodeList(node.getChildNodes(), Node.ELEMENT_NODE)) {
                 String name = xmlToJavaName(cleanNodeName(n.getNodeName()));
                 if ("member".equals(name) || "members".equals(name) || "interface".equals(name)) {
                     String value = getTextContent(n);
@@ -440,7 +438,7 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
             final Node attName = node.getAttributes().getNamedItem("name");
             final String name = getTextContent(attName);
             fillAttributeValues(node, queueConfigBuilder);
-            for (org.w3c.dom.Node childNode : new IterableNodeList(node.getChildNodes(), Node.ELEMENT_NODE)) {
+            for (Node childNode : new IterableNodeList(node.getChildNodes(), Node.ELEMENT_NODE)) {
                 final String nodeName = cleanNodeName(childNode);
                 if ("item-listeners".equals(nodeName)) {
                     ManagedList listeners = parseListeners(childNode, ItemListenerConfig.class);
@@ -455,7 +453,7 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
         public void handleQueueStoreConfig(Node node, BeanDefinitionBuilder queueConfigBuilder) {
             BeanDefinitionBuilder queueStoreConfigBuilder = createBeanBuilder(QueueStoreConfig.class);
             final AbstractBeanDefinition beanDefinition = queueStoreConfigBuilder.getBeanDefinition();
-            for (org.w3c.dom.Node child : new IterableNodeList(node, Node.ELEMENT_NODE)) {
+            for (Node child : new IterableNodeList(node, Node.ELEMENT_NODE)) {
                 if ("properties".equals(cleanNodeName(child))) {
                     handleProperties(child, queueStoreConfigBuilder);
                     break;
@@ -481,7 +479,7 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
             final Node attName = node.getAttributes().getNamedItem("name");
             final String name = getTextContent(attName);
             fillAttributeValues(node, listConfigBuilder);
-            for (org.w3c.dom.Node childNode : new IterableNodeList(node.getChildNodes(), Node.ELEMENT_NODE)) {
+            for (Node childNode : new IterableNodeList(node.getChildNodes(), Node.ELEMENT_NODE)) {
                 if ("item-listeners".equals(cleanNodeName(childNode))) {
                     ManagedList listeners = parseListeners(childNode, ItemListenerConfig.class);
                     listConfigBuilder.addPropertyValue("itemListenerConfigs", listeners);
@@ -495,7 +493,7 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
             final Node attName = node.getAttributes().getNamedItem("name");
             final String name = getTextContent(attName);
             fillAttributeValues(node, setConfigBuilder);
-            for (org.w3c.dom.Node childNode : new IterableNodeList(node.getChildNodes(), Node.ELEMENT_NODE)) {
+            for (Node childNode : new IterableNodeList(node.getChildNodes(), Node.ELEMENT_NODE)) {
                 if ("item-listeners".equals(cleanNodeName(childNode))) {
                     ManagedList listeners = parseListeners(childNode, ItemListenerConfig.class);
                     setConfigBuilder.addPropertyValue("itemListenerConfigs", listeners);
@@ -524,7 +522,7 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
                         .addPropertyValue(xmlToJavaName(cleanNodeName(maxSizePolicyNode))
                                 , MaxSizeConfig.MaxSizePolicy.valueOf(getTextContent(maxSizePolicyNode)));
             }
-            for (org.w3c.dom.Node childNode : new IterableNodeList(node.getChildNodes(), Node.ELEMENT_NODE)) {
+            for (Node childNode : new IterableNodeList(node.getChildNodes(), Node.ELEMENT_NODE)) {
                 final String nodeName = cleanNodeName(childNode.getNodeName());
                 if ("map-store".equals(nodeName)) {
                     handleMapStoreConfig(childNode, mapConfigBuilder);
@@ -557,7 +555,7 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
             final Node attName = node.getAttributes().getNamedItem("name");
             final String name = getTextContent(attName);
             fillAttributeValues(node, cacheConfigBuilder);
-            for (org.w3c.dom.Node childNode : new IterableNodeList(node.getChildNodes(), Node.ELEMENT_NODE)) {
+            for (Node childNode : new IterableNodeList(node.getChildNodes(), Node.ELEMENT_NODE)) {
                 if ("eviction".equals(cleanNodeName(childNode))) {
                     final CacheEvictionConfig evictionConfig = new CacheEvictionConfig();
                     final Node size = childNode.getAttributes().getNamedItem("size");
@@ -639,12 +637,12 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
             fillAttributeValues(node, partitionConfigBuilder);
 
             ManagedList memberGroups = new ManagedList();
-            for (org.w3c.dom.Node child : new IterableNodeList(node.getChildNodes(), Node.ELEMENT_NODE)) {
+            for (Node child : new IterableNodeList(node.getChildNodes(), Node.ELEMENT_NODE)) {
                 final String name = cleanNodeName(child.getNodeName());
                 if ("member-group".equals(name)) {
                     BeanDefinitionBuilder memberGroupBuilder = createBeanBuilder(MemberGroupConfig.class);
                     ManagedList interfaces = new ManagedList();
-                    for (org.w3c.dom.Node n : new IterableNodeList(child.getChildNodes(), Node.ELEMENT_NODE)) {
+                    for (Node n : new IterableNodeList(child.getChildNodes(), Node.ELEMENT_NODE)) {
                         if ("interface".equals(cleanNodeName(n.getNodeName()))) {
                             interfaces.add(getTextContent(n));
                         }
@@ -668,7 +666,7 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
         public void handleMapStoreConfig(Node node, BeanDefinitionBuilder mapConfigBuilder) {
             BeanDefinitionBuilder mapStoreConfigBuilder = createBeanBuilder(MapStoreConfig.class);
             final AbstractBeanDefinition beanDefinition = mapStoreConfigBuilder.getBeanDefinition();
-            for (org.w3c.dom.Node child : new IterableNodeList(node, Node.ELEMENT_NODE)) {
+            for (Node child : new IterableNodeList(node, Node.ELEMENT_NODE)) {
                 if ("properties".equals(cleanNodeName(child))) {
                     handleProperties(child, mapStoreConfigBuilder);
                     break;
@@ -703,7 +701,7 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
             final Node attName = node.getAttributes().getNamedItem("name");
             final String name = getTextContent(attName);
             fillAttributeValues(node, multiMapConfigBuilder);
-            for (org.w3c.dom.Node childNode : new IterableNodeList(node.getChildNodes(), Node.ELEMENT_NODE)) {
+            for (Node childNode : new IterableNodeList(node.getChildNodes(), Node.ELEMENT_NODE)) {
                 if ("entry-listeners".equals(cleanNodeName(childNode))) {
                     ManagedList listeners = parseListeners(childNode, EntryListenerConfig.class);
                     multiMapConfigBuilder.addPropertyValue("entryListenerConfigs", listeners);
@@ -717,7 +715,7 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
             final Node attName = node.getAttributes().getNamedItem("name");
             final String name = getTextContent(attName);
             fillAttributeValues(node, topicConfigBuilder);
-            for (org.w3c.dom.Node childNode : new IterableNodeList(node.getChildNodes(), Node.ELEMENT_NODE)) {
+            for (Node childNode : new IterableNodeList(node.getChildNodes(), Node.ELEMENT_NODE)) {
                 if ("message-listeners".equals(cleanNodeName(childNode))) {
                     ManagedList listeners = parseListeners(childNode, ListenerConfig.class);
                     topicConfigBuilder.addPropertyValue("messageListenerConfigs", listeners);
@@ -803,7 +801,7 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
 
         private void handleSecurityInterceptors(final Node node, final BeanDefinitionBuilder securityConfigBuilder) {
             final List lms = new ManagedList();
-            for (org.w3c.dom.Node child : new IterableNodeList(node.getChildNodes())) {
+            for (Node child : new IterableNodeList(node.getChildNodes())) {
                 final String nodeName = cleanNodeName(child.getNodeName());
                 if ("interceptor".equals(nodeName)) {
                     final BeanDefinitionBuilder siConfigBuilder = createBeanBuilder(SecurityInterceptorConfig.class);
@@ -840,7 +838,7 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
             }
             Assert.isTrue(className != null || implementation != null, "One of 'class-name' or 'implementation' "
                     + "attributes is required to create CredentialsFactory!");
-            for (org.w3c.dom.Node child : new IterableNodeList(node.getChildNodes())) {
+            for (Node child : new IterableNodeList(node.getChildNodes())) {
                 final String nodeName = cleanNodeName(child.getNodeName());
                 if ("properties".equals(nodeName)) {
                     handleProperties(child, credentialsConfigBuilder);
@@ -852,7 +850,7 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
 
         private void handleLoginModules(final Node node, final BeanDefinitionBuilder securityConfigBuilder, boolean member) {
             final List lms = new ManagedList();
-            for (org.w3c.dom.Node child : new IterableNodeList(node.getChildNodes())) {
+            for (Node child : new IterableNodeList(node.getChildNodes())) {
                 final String nodeName = cleanNodeName(child.getNodeName());
                 if ("login-module".equals(nodeName)) {
                     handleLoginModule(child, lms);
@@ -865,11 +863,11 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
             }
         }
 
-        private void handleLoginModule(final org.w3c.dom.Node node, List list) {
+        private void handleLoginModule(final Node node, List list) {
             final BeanDefinitionBuilder lmConfigBuilder = createBeanBuilder(LoginModuleConfig.class);
             final AbstractBeanDefinition beanDefinition = lmConfigBuilder.getBeanDefinition();
             fillAttributeValues(node, lmConfigBuilder);
-            for (org.w3c.dom.Node child : new IterableNodeList(node.getChildNodes())) {
+            for (Node child : new IterableNodeList(node.getChildNodes())) {
                 final String nodeName = cleanNodeName(child.getNodeName());
                 if ("properties".equals(nodeName)) {
                     handleProperties(child, lmConfigBuilder);
@@ -893,7 +891,7 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
             }
             Assert.isTrue(className != null || implementation != null, "One of 'class-name' or 'implementation' "
                     + "attributes is required to create PermissionPolicy!");
-            for (org.w3c.dom.Node child : new IterableNodeList(node.getChildNodes())) {
+            for (Node child : new IterableNodeList(node.getChildNodes())) {
                 final String nodeName = cleanNodeName(child.getNodeName());
                 if ("properties".equals(nodeName)) {
                     handleProperties(child, permPolicyConfigBuilder);
@@ -905,7 +903,7 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
 
         private void handleSecurityPermissions(final Node node, final BeanDefinitionBuilder securityConfigBuilder) {
             final Set permissions = new ManagedSet();
-            for (org.w3c.dom.Node child : new IterableNodeList(node.getChildNodes())) {
+            for (Node child : new IterableNodeList(node.getChildNodes())) {
                 final String nodeName = cleanNodeName(child.getNodeName());
                 PermissionType type = PermissionType.getType(nodeName);
 
@@ -931,7 +929,7 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
             permissionConfigBuilder.addPropertyValue("principal", principal);
             final List endpoints = new ManagedList();
             final List actions = new ManagedList();
-            for (org.w3c.dom.Node child : new IterableNodeList(node.getChildNodes())) {
+            for (Node child : new IterableNodeList(node.getChildNodes())) {
                 final String nodeName = cleanNodeName(child.getNodeName());
                 if ("endpoints".equals(nodeName)) {
                     handleSecurityPermissionEndpoints(child, endpoints);
@@ -945,7 +943,7 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
         }
 
         private void handleSecurityPermissionEndpoints(final Node node, final List endpoints) {
-            for (org.w3c.dom.Node child : new IterableNodeList(node.getChildNodes())) {
+            for (Node child : new IterableNodeList(node.getChildNodes())) {
                 final String nodeName = cleanNodeName(child.getNodeName());
                 if ("endpoint".equals(nodeName)) {
                     endpoints.add(getTextContent(child));
@@ -954,7 +952,7 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
         }
 
         private void handleSecurityPermissionActions(final Node node, final List actions) {
-            for (org.w3c.dom.Node child : new IterableNodeList(node.getChildNodes())) {
+            for (Node child : new IterableNodeList(node.getChildNodes())) {
                 final String nodeName = cleanNodeName(child.getNodeName());
                 if ("action".equals(nodeName)) {
                     actions.add(getTextContent(child));

--- a/hazelcast-spring/src/main/resources/hazelcast-spring-3.5.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-3.5.xsd
@@ -26,6 +26,7 @@
             <xs:complexContent>
                 <xs:extension base="hazelcast-bean">
                     <xs:sequence>
+                        <xs:element name="spring-aware" type="xs:string" minOccurs="0" maxOccurs="1"/>
                         <xs:element name="instance-name" type="xs:string" minOccurs="0" maxOccurs="1"/>
                         <xs:element name="group" type="group" minOccurs="0" maxOccurs="1"/>
                         <xs:element name="license-key" type="xs:string" minOccurs="0" maxOccurs="1"/>
@@ -946,6 +947,7 @@
             <xs:complexContent>
                 <xs:extension base="hazelcast-bean">
                     <xs:sequence>
+                        <xs:element name="spring-aware" type="xs:string" minOccurs="0" maxOccurs="1"/>
                         <xs:element name="group" type="group" minOccurs="0" maxOccurs="1"/>
                         <xs:element name="properties" type="properties" minOccurs="0" maxOccurs="1"/>
                         <xs:element name="network" type="network-client" minOccurs="0" maxOccurs="1"/>
@@ -1788,5 +1790,4 @@
         <xs:attribute name="max-size-policy" type="cache-max-size-policy" default="ENTRY_COUNT" use="optional"/>
         <xs:attribute name="eviction-policy" type="eviction-policy" default="LRU" use="optional"/>
     </xs:complexType>
-
 </xs:schema>

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/springaware/TestDisabledSpringAwareAnnotation.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/springaware/TestDisabledSpringAwareAnnotation.java
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 
-package com.hazelcast.spring;
+package com.hazelcast.spring.springaware;
 
 import com.hazelcast.client.HazelcastClient;
 import com.hazelcast.client.impl.HazelcastClientProxy;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.spring.CustomSpringJUnit4ClassRunner;
 import com.hazelcast.spring.context.SpringManagedContext;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
@@ -36,9 +37,9 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(CustomSpringJUnit4ClassRunner.class)
-@ContextConfiguration(locations = {"beans-applicationContext-hazelcast.xml"})
+@ContextConfiguration(locations = {"springAware-disabled-applicationContext-hazelcast.xml"})
 @Category(QuickTest.class)
-public class TestBeansApplicationContext {
+public class TestDisabledSpringAwareAnnotation {
 
     @BeforeClass
     @AfterClass
@@ -51,29 +52,12 @@ public class TestBeansApplicationContext {
     private ApplicationContext context;
 
     @Test
-    public void testApplicationContext() {
-        assertTrue(Hazelcast.getAllHazelcastInstances().isEmpty());
-        assertTrue(HazelcastClient.getAllHazelcastClients().isEmpty());
-
-        context.getBean("map2");
-
-        assertEquals(1, Hazelcast.getAllHazelcastInstances().size());
-        assertEquals(1, HazelcastClient.getAllHazelcastClients().size());
-
-        HazelcastInstance hazelcast = Hazelcast.getAllHazelcastInstances().iterator().next();
-        assertEquals(2, hazelcast.getDistributedObjects().size());
-
-        context.getBean("client");
-        context.getBean("client");
-        assertEquals(3, HazelcastClient.getAllHazelcastClients().size());
-        HazelcastClientProxy client = (HazelcastClientProxy) HazelcastClient.getAllHazelcastClients().iterator().next();
-        assertNull(client.getClientConfig().getManagedContext());
-
-
+    public void testDisabledSpringManagedContext() {
         HazelcastInstance instance = (HazelcastInstance) context.getBean("instance");
-        assertEquals(1, Hazelcast.getAllHazelcastInstances().size());
-        assertEquals(instance, Hazelcast.getAllHazelcastInstances().iterator().next());
         assertNull(instance.getConfig().getManagedContext());
+
+        HazelcastClientProxy client = (HazelcastClientProxy) context.getBean("client");
+        assertNull(client.getClientConfig().getManagedContext());
     }
 
 }

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/springaware/TestEnabledSpringAwareAnnotation.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/springaware/TestEnabledSpringAwareAnnotation.java
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 
-package com.hazelcast.spring;
+package com.hazelcast.spring.springaware;
 
 import com.hazelcast.client.HazelcastClient;
 import com.hazelcast.client.impl.HazelcastClientProxy;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.spring.CustomSpringJUnit4ClassRunner;
 import com.hazelcast.spring.context.SpringManagedContext;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
@@ -32,13 +33,12 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.test.context.ContextConfiguration;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(CustomSpringJUnit4ClassRunner.class)
-@ContextConfiguration(locations = {"beans-applicationContext-hazelcast.xml"})
+@ContextConfiguration(locations = {"springAware-enabled-applicationContext-hazelcast.xml"})
 @Category(QuickTest.class)
-public class TestBeansApplicationContext {
+public class TestEnabledSpringAwareAnnotation {
 
     @BeforeClass
     @AfterClass
@@ -51,29 +51,12 @@ public class TestBeansApplicationContext {
     private ApplicationContext context;
 
     @Test
-    public void testApplicationContext() {
-        assertTrue(Hazelcast.getAllHazelcastInstances().isEmpty());
-        assertTrue(HazelcastClient.getAllHazelcastClients().isEmpty());
-
-        context.getBean("map2");
-
-        assertEquals(1, Hazelcast.getAllHazelcastInstances().size());
-        assertEquals(1, HazelcastClient.getAllHazelcastClients().size());
-
-        HazelcastInstance hazelcast = Hazelcast.getAllHazelcastInstances().iterator().next();
-        assertEquals(2, hazelcast.getDistributedObjects().size());
-
-        context.getBean("client");
-        context.getBean("client");
-        assertEquals(3, HazelcastClient.getAllHazelcastClients().size());
-        HazelcastClientProxy client = (HazelcastClientProxy) HazelcastClient.getAllHazelcastClients().iterator().next();
-        assertNull(client.getClientConfig().getManagedContext());
-
-
+    public void testSpringManagedContext() {
         HazelcastInstance instance = (HazelcastInstance) context.getBean("instance");
-        assertEquals(1, Hazelcast.getAllHazelcastInstances().size());
-        assertEquals(instance, Hazelcast.getAllHazelcastInstances().iterator().next());
-        assertNull(instance.getConfig().getManagedContext());
+        assertTrue(instance.getConfig().getManagedContext() instanceof SpringManagedContext);
+
+        HazelcastClientProxy client = (HazelcastClientProxy) context.getBean("client");
+        assertTrue(client.getClientConfig().getManagedContext() instanceof SpringManagedContext);
     }
 
 }

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/context/managedContext-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/context/managedContext-applicationContext-hazelcast.xml
@@ -37,6 +37,7 @@
 
     <hz:hazelcast id="instance1">
         <hz:config>
+            <hz:spring-aware />
             <hz:group name="dev" password="dev-pass"/>
             <hz:network port="5701" port-auto-increment="false">
                 <hz:join>
@@ -55,6 +56,7 @@
 
     <hz:hazelcast id="instance2">
         <hz:config>
+            <hz:spring-aware />
             <hz:group name="dev" password="dev-pass"/>
             <hz:network port="5702" port-auto-increment="false">
                 <hz:join>

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/springaware/springAware-disabled-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/springaware/springAware-disabled-applicationContext-hazelcast.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:hz="http://www.hazelcast.com/schema/spring"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+		http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+		http://www.hazelcast.com/schema/spring
+		http://www.hazelcast.com/schema/spring/hazelcast-spring.xsd">
+
+    <hz:hazelcast id="instance" lazy-init="true" scope="singleton">
+        <hz:config>
+            <hz:group name="${cluster.group.name}" password="${cluster.group.password}"/>
+            <hz:network port="5701" port-auto-increment="false">
+                <hz:join>
+                    <hz:multicast enabled="false"/>
+                    <hz:tcp-ip enabled="true">
+                        <hz:interface>127.0.0.1:5701</hz:interface>
+                        <hz:interface>127.0.0.1:5702</hz:interface>
+                    </hz:tcp-ip>
+                </hz:join>
+                <hz:interfaces enabled="true">
+                    <hz:interface>127.0.0.1</hz:interface>
+                </hz:interfaces>
+            </hz:network>
+        </hz:config>
+    </hz:hazelcast>
+
+    <hz:client id="client" lazy-init="true" scope="prototype">
+        <hz:group name="${cluster.group.name}" password="${cluster.group.password}" />
+        <hz:network connection-attempt-limit="3"
+                    connection-attempt-period="3000"
+                    connection-timeout="1000"
+                    redo-operation="true"
+                    smart-routing="true">
+
+            <hz:member>127.0.0.1:5701</hz:member>
+
+            <hz:socket-options buffer-size="32"
+                               keep-alive="false"
+                               linger-seconds="3"
+                               reuse-address="false"
+                               tcp-no-delay="false"/>
+        </hz:network>
+    </hz:client>
+</beans>

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/springaware/springAware-enabled-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/springaware/springAware-enabled-applicationContext-hazelcast.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:hz="http://www.hazelcast.com/schema/spring"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+		http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+		http://www.hazelcast.com/schema/spring
+		http://www.hazelcast.com/schema/spring/hazelcast-spring.xsd">
+
+    <hz:hazelcast id="instance" lazy-init="true" scope="singleton">
+        <hz:config>
+            <hz:spring-aware />
+            <hz:group name="${cluster.group.name}" password="${cluster.group.password}"/>
+            <hz:network port="5701" port-auto-increment="false">
+                <hz:join>
+                    <hz:multicast enabled="false"/>
+                    <hz:tcp-ip enabled="true">
+                        <hz:interface>127.0.0.1:5701</hz:interface>
+                        <hz:interface>127.0.0.1:5702</hz:interface>
+                    </hz:tcp-ip>
+                </hz:join>
+                <hz:interfaces enabled="true">
+                    <hz:interface>127.0.0.1</hz:interface>
+                </hz:interfaces>
+            </hz:network>
+        </hz:config>
+    </hz:hazelcast>
+
+    <hz:client id="client" lazy-init="true" scope="prototype">
+        <hz:spring-aware />
+        <hz:group name="${cluster.group.name}" password="${cluster.group.password}" />
+        <hz:network connection-attempt-limit="3"
+                    connection-attempt-period="3000"
+                    connection-timeout="1000"
+                    redo-operation="true"
+                    smart-routing="true">
+
+            <hz:member>127.0.0.1:5701</hz:member>
+
+            <hz:socket-options buffer-size="32"
+                               keep-alive="false"
+                               linger-seconds="3"
+                               reuse-address="false"
+                               tcp-no-delay="false"/>
+        </hz:network>
+    </hz:client>
+</beans>


### PR DESCRIPTION
`spring-aware` config element added to `hazelcast-spring-3.5.xsd`.

By default hz uses `SpringManagedContext` to scan `SpringAware` annotations. This may cause some performance penalty even if users don't use `SpringAware`. 
Starting with 3.5 `SpringManagedContext`will be disabled by default. To enable it `<hz:spring-aware />` tag is needed to be added to the config.