### PR TITLE
Minor concurrent package renaming to containers

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/AtomicLongService.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/AtomicLongService.java
@@ -46,7 +46,7 @@ public class AtomicLongService implements ManagedService, RemoteService, Migrati
     public static final String SERVICE_NAME = "hz:impl:atomicLongService";
 
     private NodeEngine nodeEngine;
-    private final ConcurrentMap<String, LongContainer> numbers = new ConcurrentHashMap<String, LongContainer>();
+    private final ConcurrentMap<String, LongContainer> containers = new ConcurrentHashMap<String, LongContainer>();
     private final ConstructorFunction<String, LongContainer> atomicLongConstructorFunction =
             new ConstructorFunction<String, LongContainer>() {
                 public LongContainer createNew(String key) {
@@ -57,13 +57,13 @@ public class AtomicLongService implements ManagedService, RemoteService, Migrati
     public AtomicLongService() {
     }
 
-    public LongContainer getNumber(String name) {
-        return getOrPutIfAbsent(numbers, name, atomicLongConstructorFunction);
+    public LongContainer getLongContainer(String name) {
+        return getOrPutIfAbsent(containers, name, atomicLongConstructorFunction);
     }
 
     // need for testing..
     public boolean containsAtomicLong(String name) {
-        return numbers.containsKey(name);
+        return containers.containsKey(name);
     }
 
     @Override
@@ -73,7 +73,7 @@ public class AtomicLongService implements ManagedService, RemoteService, Migrati
 
     @Override
     public void reset() {
-        numbers.clear();
+        containers.clear();
     }
 
     @Override
@@ -88,7 +88,7 @@ public class AtomicLongService implements ManagedService, RemoteService, Migrati
 
     @Override
     public void destroyDistributedObject(String name) {
-        numbers.remove(name);
+        containers.remove(name);
     }
 
     @Override
@@ -103,10 +103,10 @@ public class AtomicLongService implements ManagedService, RemoteService, Migrati
 
         Map<String, Long> data = new HashMap<String, Long>();
         int partitionId = event.getPartitionId();
-        for (String name : numbers.keySet()) {
+        for (String name : containers.keySet()) {
             if (partitionId == getPartitionId(name)) {
-                LongContainer number = numbers.get(name);
-                data.put(name, number.get());
+                LongContainer container = containers.get(name);
+                data.put(name, container.get());
             }
         }
         return data.isEmpty() ? null : new AtomicLongReplicationOperation(data);
@@ -121,24 +121,24 @@ public class AtomicLongService implements ManagedService, RemoteService, Migrati
     @Override
     public void commitMigration(PartitionMigrationEvent partitionMigrationEvent) {
         if (partitionMigrationEvent.getMigrationEndpoint() == MigrationEndpoint.SOURCE) {
-            removeNumber(partitionMigrationEvent.getPartitionId());
+            removeContainers(partitionMigrationEvent.getPartitionId());
         }
     }
 
     @Override
     public void rollbackMigration(PartitionMigrationEvent partitionMigrationEvent) {
         if (partitionMigrationEvent.getMigrationEndpoint() == MigrationEndpoint.DESTINATION) {
-            removeNumber(partitionMigrationEvent.getPartitionId());
+            removeContainers(partitionMigrationEvent.getPartitionId());
         }
     }
 
     @Override
     public void clearPartitionReplica(int partitionId) {
-        removeNumber(partitionId);
+        removeContainers(partitionId);
     }
 
-    public void removeNumber(int partitionId) {
-        final Iterator<String> iterator = numbers.keySet().iterator();
+    public void removeContainers(int partitionId) {
+        final Iterator<String> iterator = containers.keySet().iterator();
         while (iterator.hasNext()) {
             String name = iterator.next();
             if (getPartitionId(name) == partitionId) {

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/AbstractAlterOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/AbstractAlterOperation.java
@@ -43,6 +43,11 @@ public abstract class AbstractAlterOperation extends AtomicLongBackupAwareOperat
     }
 
     @Override
+    public Operation getBackupOperation() {
+        return new SetBackupOperation(name, backup);
+    }
+
+    @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
         out.writeObject(function);
@@ -52,10 +57,5 @@ public abstract class AbstractAlterOperation extends AtomicLongBackupAwareOperat
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
         function = in.readObject();
-    }
-
-    @Override
-    public Operation getBackupOperation() {
-        return new SetBackupOperation(name, backup);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/AddAndGetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/AddAndGetOperation.java
@@ -39,13 +39,18 @@ public class AddAndGetOperation extends AtomicLongBackupAwareOperation {
 
     @Override
     public void run() throws Exception {
-        LongContainer number = getNumber();
-        returnValue = number.addAndGet(delta);
+        LongContainer longContainer = getLongContainer();
+        returnValue = longContainer.addAndGet(delta);
     }
 
     @Override
     public Object getResponse() {
         return returnValue;
+    }
+
+    @Override
+    public Operation getBackupOperation() {
+        return new AddBackupOperation(name, delta);
     }
 
     @Override
@@ -63,10 +68,5 @@ public class AddAndGetOperation extends AtomicLongBackupAwareOperation {
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
         delta = in.readLong();
-    }
-
-    @Override
-    public Operation getBackupOperation() {
-        return new AddBackupOperation(name, delta);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/AddBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/AddBackupOperation.java
@@ -38,8 +38,8 @@ public class AddBackupOperation extends AtomicLongBaseOperation implements Backu
 
     @Override
     public void run() throws Exception {
-        LongContainer number = getNumber();
-        number.addAndGet(delta);
+        LongContainer longContainer = getLongContainer();
+        longContainer.addAndGet(delta);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/AlterAndGetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/AlterAndGetOperation.java
@@ -30,22 +30,22 @@ public class AlterAndGetOperation extends AbstractAlterOperation {
     }
 
     @Override
-    public int getId() {
-        return AtomicLongDataSerializerHook.ALTER_AND_GET;
-    }
-
-    @Override
     public void run() throws Exception {
-        LongContainer number = getNumber();
+        LongContainer longContainer = getLongContainer();
 
-        long input = number.get();
+        long input = longContainer.get();
         long output = function.apply(input);
         shouldBackup = input != output;
         if (shouldBackup) {
             backup = output;
-            number.set(output);
+            longContainer.set(output);
         }
 
         response = output;
+    }
+
+    @Override
+    public int getId() {
+        return AtomicLongDataSerializerHook.ALTER_AND_GET;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/AlterOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/AlterOperation.java
@@ -36,14 +36,14 @@ public class AlterOperation extends AbstractAlterOperation {
 
     @Override
     public void run() throws Exception {
-        LongContainer reference = getNumber();
+        LongContainer longContainer = getLongContainer();
 
-        long input = reference.get();
+        long input = longContainer.get();
         long output = function.apply(input);
         shouldBackup = input != output;
         if (shouldBackup) {
             backup = output;
-            reference.set(backup);
+            longContainer.set(backup);
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/ApplyOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/ApplyOperation.java
@@ -39,15 +39,14 @@ public class ApplyOperation<R> extends AtomicLongBaseOperation {
 
     @Override
     public void run() throws Exception {
-        LongContainer number = getNumber();
-        returnValue = function.apply(number.get());
+        LongContainer longContainer = getLongContainer();
+        returnValue = function.apply(longContainer.get());
     }
 
     @Override
     public R getResponse() {
         return returnValue;
     }
-
 
     @Override
     public int getId() {

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/AtomicLongBaseOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/AtomicLongBaseOperation.java
@@ -39,29 +39,9 @@ public abstract class AtomicLongBaseOperation extends Operation
         this.name = name;
     }
 
-    public LongContainer getNumber() {
+    public LongContainer getLongContainer() {
         AtomicLongService service = getService();
-        return service.getNumber(name);
-    }
-
-    @Override
-    public int getFactoryId() {
-        return AtomicLongDataSerializerHook.F_ID;
-    }
-
-    @Override
-    public String getServiceName() {
-        return AtomicLongService.SERVICE_NAME;
-    }
-
-    @Override
-    protected void writeInternal(ObjectDataOutput out) throws IOException {
-        out.writeUTF(name);
-    }
-
-    @Override
-    protected void readInternal(ObjectDataInput in) throws IOException {
-        name = in.readUTF();
+        return service.getLongContainer(name);
     }
 
     @Override
@@ -81,4 +61,25 @@ public abstract class AtomicLongBaseOperation extends Operation
     public boolean returnsResponse() {
         return true;
     }
+
+    @Override
+    public String getServiceName() {
+        return AtomicLongService.SERVICE_NAME;
+    }
+
+    @Override
+    public int getFactoryId() {
+        return AtomicLongDataSerializerHook.F_ID;
+    }
+
+    @Override
+    protected void writeInternal(ObjectDataOutput out) throws IOException {
+        out.writeUTF(name);
+    }
+
+    @Override
+    protected void readInternal(ObjectDataInput in) throws IOException {
+        name = in.readUTF();
+    }
+
 }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/AtomicLongReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/AtomicLongReplicationOperation.java
@@ -45,9 +45,9 @@ public class AtomicLongReplicationOperation extends AbstractOperation
         AtomicLongService atomicLongService = getService();
         for (Map.Entry<String, Long> longEntry : migrationData.entrySet()) {
             String name = longEntry.getKey();
-            LongContainer number = atomicLongService.getNumber(name);
+            LongContainer longContainer = atomicLongService.getLongContainer(name);
             Long value = longEntry.getValue();
-            number.set(value);
+            longContainer.set(value);
         }
     }
 
@@ -81,8 +81,8 @@ public class AtomicLongReplicationOperation extends AbstractOperation
         migrationData = new HashMap<String, Long>(mapSize);
         for (int i = 0; i < mapSize; i++) {
             String name = in.readUTF();
-            Long number = in.readLong();
-            migrationData.put(name, number);
+            Long longContainer = in.readLong();
+            migrationData.put(name, longContainer);
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/CompareAndSetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/CompareAndSetOperation.java
@@ -41,14 +41,19 @@ public class CompareAndSetOperation extends AtomicLongBackupAwareOperation {
 
     @Override
     public void run() throws Exception {
-        LongContainer number = getNumber();
-        returnValue = number.compareAndSet(expect, update);
+        LongContainer longContainer = getLongContainer();
+        returnValue = longContainer.compareAndSet(expect, update);
         shouldBackup = !returnValue;
     }
 
     @Override
     public Object getResponse() {
         return returnValue;
+    }
+
+    @Override
+    public Operation getBackupOperation() {
+        return new SetBackupOperation(name, update);
     }
 
     @Override
@@ -68,9 +73,5 @@ public class CompareAndSetOperation extends AtomicLongBackupAwareOperation {
         super.readInternal(in);
         expect = in.readLong();
         update = in.readLong();
-    }
-
-    public Operation getBackupOperation() {
-        return new SetBackupOperation(name, update);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/GetAndAddOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/GetAndAddOperation.java
@@ -39,13 +39,18 @@ public class GetAndAddOperation extends AtomicLongBackupAwareOperation {
 
     @Override
     public void run() throws Exception {
-        LongContainer number = getNumber();
-        returnValue = number.getAndAdd(delta);
+        LongContainer longContainer = getLongContainer();
+        returnValue = longContainer.getAndAdd(delta);
     }
 
     @Override
     public Object getResponse() {
         return returnValue;
+    }
+
+    @Override
+    public Operation getBackupOperation() {
+        return new AddBackupOperation(name, delta);
     }
 
     @Override
@@ -63,9 +68,5 @@ public class GetAndAddOperation extends AtomicLongBackupAwareOperation {
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
         delta = in.readLong();
-    }
-
-    public Operation getBackupOperation() {
-        return new AddBackupOperation(name, delta);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/GetAndAlterOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/GetAndAlterOperation.java
@@ -30,21 +30,21 @@ public class GetAndAlterOperation extends AbstractAlterOperation {
     }
 
     @Override
-    public int getId() {
-        return AtomicLongDataSerializerHook.GET_AND_ALTER;
-    }
-
-    @Override
     public void run() throws Exception {
-        LongContainer number = getNumber();
+        LongContainer longContainer = getLongContainer();
 
-        long input = number.get();
+        long input = longContainer.get();
         response = input;
         long output = function.apply(input);
         shouldBackup = input != output;
         if (shouldBackup) {
             backup = output;
-            number.set(output);
+            longContainer.set(output);
         }
+    }
+
+    @Override
+    public int getId() {
+        return AtomicLongDataSerializerHook.GET_AND_ALTER;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/GetAndSetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/GetAndSetOperation.java
@@ -39,13 +39,18 @@ public class GetAndSetOperation extends AtomicLongBackupAwareOperation {
 
     @Override
     public void run() throws Exception {
-        LongContainer number = getNumber();
-        returnValue = number.getAndSet(newValue);
+        LongContainer longContainer = getLongContainer();
+        returnValue = longContainer.getAndSet(newValue);
     }
 
     @Override
     public Object getResponse() {
         return returnValue;
+    }
+
+    @Override
+    public Operation getBackupOperation() {
+        return new SetBackupOperation(name, newValue);
     }
 
     @Override
@@ -63,10 +68,5 @@ public class GetAndSetOperation extends AtomicLongBackupAwareOperation {
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
         newValue = in.readLong();
-    }
-
-    @Override
-    public Operation getBackupOperation() {
-        return new SetBackupOperation(name, newValue);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/GetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/GetOperation.java
@@ -32,17 +32,17 @@ public class GetOperation extends AtomicLongBaseOperation {
 
     @Override
     public void run() throws Exception {
-        LongContainer number = getNumber();
-        returnValue = number.get();
-    }
-
-    @Override
-    public int getId() {
-        return AtomicLongDataSerializerHook.GET;
+        LongContainer longContainer = getLongContainer();
+        returnValue = longContainer.get();
     }
 
     @Override
     public Object getResponse() {
         return returnValue;
+    }
+
+    @Override
+    public int getId() {
+        return AtomicLongDataSerializerHook.GET;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/SetBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/SetBackupOperation.java
@@ -38,8 +38,8 @@ public class SetBackupOperation extends AtomicLongBaseOperation implements Backu
 
     @Override
     public void run() throws Exception {
-        LongContainer number = getNumber();
-        number.set(newValue);
+        LongContainer longContainer = getLongContainer();
+        longContainer.set(newValue);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/SetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/SetOperation.java
@@ -38,8 +38,13 @@ public class SetOperation extends AtomicLongBackupAwareOperation {
 
     @Override
     public void run() throws Exception {
-        LongContainer number = getNumber();
-        number.set(newValue);
+        LongContainer longContainer = getLongContainer();
+        longContainer.set(newValue);
+    }
+
+    @Override
+    public Operation getBackupOperation() {
+        return new SetBackupOperation(name, newValue);
     }
 
     @Override
@@ -57,10 +62,5 @@ public class SetOperation extends AtomicLongBackupAwareOperation {
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
         newValue = in.readLong();
-    }
-
-    @Override
-    public Operation getBackupOperation() {
-        return new SetBackupOperation(name, newValue);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/AtomicReferenceService.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/AtomicReferenceService.java
@@ -47,7 +47,7 @@ public class AtomicReferenceService implements ManagedService, RemoteService, Mi
     public static final String SERVICE_NAME = "hz:impl:atomicReferenceService";
 
     private NodeEngine nodeEngine;
-    private final ConcurrentMap<String, ReferenceContainer> references = new ConcurrentHashMap<String, ReferenceContainer>();
+    private final ConcurrentMap<String, ReferenceContainer> containers = new ConcurrentHashMap<String, ReferenceContainer>();
     private final ConstructorFunction<String, ReferenceContainer> atomicReferenceConstructorFunction =
             new ConstructorFunction<String, ReferenceContainer>() {
                 public ReferenceContainer createNew(String key) {
@@ -58,13 +58,13 @@ public class AtomicReferenceService implements ManagedService, RemoteService, Mi
     public AtomicReferenceService() {
     }
 
-    public ReferenceContainer getReference(String name) {
-        return getOrPutIfAbsent(references, name, atomicReferenceConstructorFunction);
+    public ReferenceContainer getReferenceContainer(String name) {
+        return getOrPutIfAbsent(containers, name, atomicReferenceConstructorFunction);
     }
 
     // need for testing..
-    public boolean containsAtomicReference(String name) {
-        return references.containsKey(name);
+    public boolean containsReferenceContainer(String name) {
+        return containers.containsKey(name);
     }
 
     @Override
@@ -74,7 +74,7 @@ public class AtomicReferenceService implements ManagedService, RemoteService, Mi
 
     @Override
     public void reset() {
-        references.clear();
+        containers.clear();
     }
 
     @Override
@@ -89,7 +89,7 @@ public class AtomicReferenceService implements ManagedService, RemoteService, Mi
 
     @Override
     public void destroyDistributedObject(String name) {
-        references.remove(name);
+        containers.remove(name);
     }
 
     @Override
@@ -104,9 +104,9 @@ public class AtomicReferenceService implements ManagedService, RemoteService, Mi
 
         Map<String, Data> data = new HashMap<String, Data>();
         int partitionId = event.getPartitionId();
-        for (String name : references.keySet()) {
+        for (String name : containers.keySet()) {
             if (partitionId == getPartitionId(name)) {
-                ReferenceContainer referenceContainer = references.get(name);
+                ReferenceContainer referenceContainer = containers.get(name);
                 Data value = referenceContainer.get();
                 data.put(name, value);
             }
@@ -118,7 +118,7 @@ public class AtomicReferenceService implements ManagedService, RemoteService, Mi
     public void commitMigration(PartitionMigrationEvent partitionMigrationEvent) {
         if (partitionMigrationEvent.getMigrationEndpoint() == MigrationEndpoint.SOURCE) {
             int partitionId = partitionMigrationEvent.getPartitionId();
-            removeReference(partitionId);
+            removeContainers(partitionId);
         }
     }
 
@@ -126,17 +126,17 @@ public class AtomicReferenceService implements ManagedService, RemoteService, Mi
     public void rollbackMigration(PartitionMigrationEvent partitionMigrationEvent) {
         if (partitionMigrationEvent.getMigrationEndpoint() == MigrationEndpoint.DESTINATION) {
             int partitionId = partitionMigrationEvent.getPartitionId();
-            removeReference(partitionId);
+            removeContainers(partitionId);
         }
     }
 
     @Override
     public void clearPartitionReplica(int partitionId) {
-        removeReference(partitionId);
+        removeContainers(partitionId);
     }
 
-    public void removeReference(int partitionId) {
-        final Iterator<String> iterator = references.keySet().iterator();
+    public void removeContainers(int partitionId) {
+        final Iterator<String> iterator = containers.keySet().iterator();
         while (iterator.hasNext()) {
             String name = iterator.next();
             if (getPartitionId(name) == partitionId) {

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/AbstractAlterOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/AbstractAlterOperation.java
@@ -56,6 +56,11 @@ public abstract class AbstractAlterOperation extends AtomicReferenceBackupAwareO
     }
 
     @Override
+    public Operation getBackupOperation() {
+        return new SetBackupOperation(name, backup);
+    }
+
+    @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
         out.writeData(function);
@@ -65,10 +70,5 @@ public abstract class AbstractAlterOperation extends AtomicReferenceBackupAwareO
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
         function = in.readData();
-    }
-
-    @Override
-    public Operation getBackupOperation() {
-        return new SetBackupOperation(name, backup);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/AlterAndGetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/AlterAndGetOperation.java
@@ -35,14 +35,14 @@ public class AlterAndGetOperation extends AbstractAlterOperation {
     public void run() throws Exception {
         NodeEngine nodeEngine = getNodeEngine();
         IFunction f = nodeEngine.toObject(function);
-        ReferenceContainer reference = getReference();
+        ReferenceContainer referenceContainer = getReferenceContainer();
 
-        Object input = nodeEngine.toObject(reference.get());
+        Object input = nodeEngine.toObject(referenceContainer.get());
         //noinspection unchecked
         Object output = f.apply(input);
         shouldBackup = true;
         backup = nodeEngine.toData(output);
-        reference.set(backup);
+        referenceContainer.set(backup);
         response = output;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/AlterOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/AlterOperation.java
@@ -35,7 +35,7 @@ public class AlterOperation extends AbstractAlterOperation {
     public void run() throws Exception {
         NodeEngine nodeEngine = getNodeEngine();
         IFunction f = nodeEngine.toObject(function);
-        ReferenceContainer reference = getReference();
+        ReferenceContainer reference = getReferenceContainer();
 
         Object input = nodeEngine.toObject(reference.get());
         //noinspection unchecked

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/ApplyOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/ApplyOperation.java
@@ -32,7 +32,6 @@ public class ApplyOperation extends AtomicReferenceBaseOperation {
     protected Data returnValue;
 
     public ApplyOperation() {
-        super();
     }
 
     public ApplyOperation(String name, Data function) {
@@ -44,9 +43,9 @@ public class ApplyOperation extends AtomicReferenceBaseOperation {
     public void run() throws Exception {
         NodeEngine nodeEngine = getNodeEngine();
         IFunction f = nodeEngine.toObject(function);
-        ReferenceContainer reference = getReference();
+        ReferenceContainer referenceContainer = getReferenceContainer();
 
-        Object input = nodeEngine.toObject(reference.get());
+        Object input = nodeEngine.toObject(referenceContainer.get());
         //noinspection unchecked
         Object output = f.apply(input);
         returnValue = nodeEngine.toData(output);
@@ -55,6 +54,11 @@ public class ApplyOperation extends AtomicReferenceBaseOperation {
     @Override
     public Object getResponse() {
         return returnValue;
+    }
+
+    @Override
+    public int getId() {
+        return AtomicReferenceDataSerializerHook.APPLY;
     }
 
     @Override
@@ -67,10 +71,5 @@ public class ApplyOperation extends AtomicReferenceBaseOperation {
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
         function = in.readData();
-    }
-
-    @Override
-    public int getId() {
-        return AtomicReferenceDataSerializerHook.APPLY;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/AtomicReferenceBackupAwareOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/AtomicReferenceBackupAwareOperation.java
@@ -35,7 +35,6 @@ public abstract class AtomicReferenceBackupAwareOperation extends AtomicReferenc
         return shouldBackup;
     }
 
-
     @Override
     public int getSyncBackupCount() {
         return 1;

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/AtomicReferenceBaseOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/AtomicReferenceBaseOperation.java
@@ -33,7 +33,6 @@ public abstract class AtomicReferenceBaseOperation extends Operation
     protected String name;
 
     public AtomicReferenceBaseOperation() {
-        super();
     }
 
     public AtomicReferenceBaseOperation(String name) {
@@ -45,9 +44,27 @@ public abstract class AtomicReferenceBaseOperation extends Operation
         return AtomicReferenceService.SERVICE_NAME;
     }
 
-    public ReferenceContainer getReference() {
+    public ReferenceContainer getReferenceContainer() {
         AtomicReferenceService service = getService();
-        return service.getReference(name);
+        return service.getReferenceContainer(name);
+    }
+
+    @Override
+    public void beforeRun() throws Exception {
+    }
+
+    @Override
+    public void afterRun() throws Exception {
+    }
+
+    @Override
+    public Object getResponse() {
+        return null;
+    }
+
+    @Override
+    public boolean returnsResponse() {
+        return true;
     }
 
     @Override
@@ -63,23 +80,5 @@ public abstract class AtomicReferenceBaseOperation extends Operation
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         name = in.readUTF();
-    }
-
-    @Override
-    public void afterRun() throws Exception {
-    }
-
-    @Override
-    public void beforeRun() throws Exception {
-    }
-
-    @Override
-    public Object getResponse() {
-        return null;
-    }
-
-    @Override
-    public boolean returnsResponse() {
-        return true;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/AtomicReferenceReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/AtomicReferenceReplicationOperation.java
@@ -46,9 +46,9 @@ public class AtomicReferenceReplicationOperation extends AbstractOperation
         AtomicReferenceService atomicReferenceService = getService();
         for (Map.Entry<String, Data> entry : migrationData.entrySet()) {
             String name = entry.getKey();
-            ReferenceContainer reference = atomicReferenceService.getReference(name);
+            ReferenceContainer referenceContainer = atomicReferenceService.getReferenceContainer(name);
             Data value = entry.getValue();
-            reference.set(value);
+            referenceContainer.set(value);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/CompareAndSetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/CompareAndSetOperation.java
@@ -42,14 +42,24 @@ public class CompareAndSetOperation extends AtomicReferenceBackupAwareOperation 
 
     @Override
     public void run() throws Exception {
-        ReferenceContainer reference = getReference();
-        returnValue = reference.compareAndSet(expect, update);
+        ReferenceContainer referenceContainer = getReferenceContainer();
+        returnValue = referenceContainer.compareAndSet(expect, update);
         shouldBackup = !returnValue;
     }
 
     @Override
     public Object getResponse() {
         return returnValue;
+    }
+
+    @Override
+    public boolean shouldBackup() {
+        return shouldBackup;
+    }
+
+    @Override
+    public Operation getBackupOperation() {
+        return new SetBackupOperation(name, update);
     }
 
     @Override
@@ -69,16 +79,6 @@ public class CompareAndSetOperation extends AtomicReferenceBackupAwareOperation 
         super.readInternal(in);
         expect = in.readData();
         update = in.readData();
-    }
-
-    @Override
-    public boolean shouldBackup() {
-        return shouldBackup;
-    }
-
-    @Override
-    public Operation getBackupOperation() {
-        return new SetBackupOperation(name, update);
     }
 }
 

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/ContainsOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/ContainsOperation.java
@@ -39,8 +39,8 @@ public class ContainsOperation extends AtomicReferenceBaseOperation {
 
     @Override
     public void run() throws Exception {
-        ReferenceContainer reference = getReference();
-        returnValue = reference.contains(contains);
+        ReferenceContainer referenceContainer = getReferenceContainer();
+        returnValue = referenceContainer.contains(contains);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/GetAndAlterOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/GetAndAlterOperation.java
@@ -35,16 +35,16 @@ public class GetAndAlterOperation extends AbstractAlterOperation {
     public void run() throws Exception {
         NodeEngine nodeEngine = getNodeEngine();
         IFunction f = nodeEngine.toObject(function);
-        ReferenceContainer reference = getReference();
+        ReferenceContainer referenceContainer = getReferenceContainer();
 
-        Object input = nodeEngine.toObject(reference.get());
+        Object input = nodeEngine.toObject(referenceContainer.get());
         response = input;
         //noinspection unchecked
         Object output = f.apply(input);
         shouldBackup = !isEquals(input, output);
         if (shouldBackup) {
             backup = nodeEngine.toData(output);
-            reference.set(backup);
+            referenceContainer.set(backup);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/GetAndSetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/GetAndSetOperation.java
@@ -40,13 +40,18 @@ public class GetAndSetOperation extends AtomicReferenceBackupAwareOperation {
 
     @Override
     public void run() throws Exception {
-        ReferenceContainer reference = getReference();
-        returnValue = reference.getAndSet(newValue);
+        ReferenceContainer referenceContainer = getReferenceContainer();
+        returnValue = referenceContainer.getAndSet(newValue);
     }
 
     @Override
     public Object getResponse() {
         return returnValue;
+    }
+
+    @Override
+    public Operation getBackupOperation() {
+        return new SetBackupOperation(name, newValue);
     }
 
     @Override
@@ -64,11 +69,6 @@ public class GetAndSetOperation extends AtomicReferenceBackupAwareOperation {
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
         newValue = in.readData();
-    }
-
-    @Override
-    public Operation getBackupOperation() {
-        return new SetBackupOperation(name, newValue);
     }
 }
 

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/GetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/GetOperation.java
@@ -32,16 +32,16 @@ public class GetOperation extends AtomicReferenceBaseOperation {
 
     @Override
     public void run() throws Exception {
-        returnValue = getReference().get();
-    }
-
-    @Override
-    public int getId() {
-        return AtomicReferenceDataSerializerHook.GET;
+        returnValue = getReferenceContainer().get();
     }
 
     @Override
     public Object getResponse() {
         return returnValue;
+    }
+
+    @Override
+    public int getId() {
+        return AtomicReferenceDataSerializerHook.GET;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/IsNullOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/IsNullOperation.java
@@ -24,7 +24,6 @@ public class IsNullOperation extends AtomicReferenceBaseOperation {
     private boolean returnValue;
 
     public IsNullOperation() {
-        super();
     }
 
     public IsNullOperation(String name) {
@@ -33,8 +32,8 @@ public class IsNullOperation extends AtomicReferenceBaseOperation {
 
     @Override
     public void run() throws Exception {
-        ReferenceContainer reference = getReference();
-        returnValue = reference.isNull();
+        ReferenceContainer referenceContainer = getReferenceContainer();
+        returnValue = referenceContainer.isNull();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/SetAndGetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/SetAndGetOperation.java
@@ -40,14 +40,19 @@ public class SetAndGetOperation extends AtomicReferenceBackupAwareOperation {
 
     @Override
     public void run() throws Exception {
-        ReferenceContainer reference = getReference();
-        reference.getAndSet(newValue);
+        ReferenceContainer referenceContainer = getReferenceContainer();
+        referenceContainer.getAndSet(newValue);
         returnValue = newValue;
     }
 
     @Override
     public Object getResponse() {
         return returnValue;
+    }
+
+    @Override
+    public Operation getBackupOperation() {
+        return new SetBackupOperation(name, newValue);
     }
 
     @Override
@@ -65,10 +70,5 @@ public class SetAndGetOperation extends AtomicReferenceBackupAwareOperation {
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
         newValue = in.readData();
-    }
-
-    @Override
-    public Operation getBackupOperation() {
-        return new SetBackupOperation(name, newValue);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/SetBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/SetBackupOperation.java
@@ -39,8 +39,8 @@ public class SetBackupOperation extends AtomicReferenceBaseOperation implements 
 
     @Override
     public void run() throws Exception {
-        ReferenceContainer reference = getReference();
-        reference.set(newValue);
+        ReferenceContainer referenceContainer = getReferenceContainer();
+        referenceContainer.set(newValue);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/SetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/SetOperation.java
@@ -39,13 +39,18 @@ public class SetOperation extends AtomicReferenceBackupAwareOperation {
 
     @Override
     public void run() throws Exception {
-        ReferenceContainer reference = getReference();
-        reference.set(newValue);
+        ReferenceContainer referenceContainer = getReferenceContainer();
+        referenceContainer.set(newValue);
     }
 
     @Override
     public Object getResponse() {
         return null;
+    }
+
+    @Override
+    public Operation getBackupOperation() {
+        return new SetBackupOperation(name, newValue);
     }
 
     @Override
@@ -63,10 +68,5 @@ public class SetOperation extends AtomicReferenceBackupAwareOperation {
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
         newValue = in.readData();
-    }
-
-    @Override
-    public Operation getBackupOperation() {
-        return new SetBackupOperation(name, newValue);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/countdownlatch/CountDownLatchContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/countdownlatch/CountDownLatchContainer.java
@@ -22,15 +22,15 @@ import com.hazelcast.nio.serialization.DataSerializable;
 
 import java.io.IOException;
 
-public class CountDownLatchInfo implements DataSerializable {
+public class CountDownLatchContainer implements DataSerializable {
 
     private String name;
     private int count;
 
-    public CountDownLatchInfo() {
+    public CountDownLatchContainer() {
     }
 
-    public CountDownLatchInfo(String name) {
+    public CountDownLatchContainer(String name) {
         this.name = name;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/countdownlatch/operations/AwaitOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/countdownlatch/operations/AwaitOperation.java
@@ -32,6 +32,7 @@ public class AwaitOperation extends BaseCountDownLatchOperation implements WaitS
         setWaitTimeout(timeout);
     }
 
+    @Override
     public void run() throws Exception {
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/countdownlatch/operations/BackupAwareCountDownLatchOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/countdownlatch/operations/BackupAwareCountDownLatchOperation.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.concurrent.countdownlatch.operations;
 
-import com.hazelcast.concurrent.countdownlatch.CountDownLatchInfo;
+import com.hazelcast.concurrent.countdownlatch.CountDownLatchContainer;
 import com.hazelcast.concurrent.countdownlatch.CountDownLatchService;
 import com.hazelcast.spi.BackupAwareOperation;
 import com.hazelcast.spi.Operation;
@@ -34,8 +34,8 @@ abstract class BackupAwareCountDownLatchOperation extends BaseCountDownLatchOper
     @Override
     public Operation getBackupOperation() {
         CountDownLatchService service = getService();
-        CountDownLatchInfo latch = service.getLatch(name);
-        int count = latch != null ? latch.getCount() : 0;
+        CountDownLatchContainer latchContainer = service.getCountDownLatchContainer(name);
+        int count = latchContainer != null ? latchContainer.getCount() : 0;
         return new CountDownLatchBackupOperation(name, count);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/countdownlatch/operations/CountDownLatchBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/countdownlatch/operations/CountDownLatchBackupOperation.java
@@ -38,6 +38,7 @@ public class CountDownLatchBackupOperation extends BaseCountDownLatchOperation
         this.count = count;
     }
 
+    @Override
     public void run() throws Exception {
         CountDownLatchService service = getService();
         service.setCountDirect(name, count);
@@ -46,6 +47,16 @@ public class CountDownLatchBackupOperation extends BaseCountDownLatchOperation
     @Override
     public Object getResponse() {
         return Boolean.TRUE;
+    }
+
+    @Override
+    public int getFactoryId() {
+        return CountDownLatchDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return CountDownLatchDataSerializerHook.COUNT_DOWN_LATCH_BACKUP_OPERATION;
     }
 
     @Override
@@ -58,15 +69,5 @@ public class CountDownLatchBackupOperation extends BaseCountDownLatchOperation
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
         count = in.readInt();
-    }
-
-    @Override
-    public int getFactoryId() {
-        return CountDownLatchDataSerializerHook.F_ID;
-    }
-
-    @Override
-    public int getId() {
-        return CountDownLatchDataSerializerHook.COUNT_DOWN_LATCH_BACKUP_OPERATION;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/countdownlatch/operations/CountDownLatchReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/countdownlatch/operations/CountDownLatchReplicationOperation.java
@@ -17,7 +17,7 @@
 package com.hazelcast.concurrent.countdownlatch.operations;
 
 import com.hazelcast.concurrent.countdownlatch.CountDownLatchDataSerializerHook;
-import com.hazelcast.concurrent.countdownlatch.CountDownLatchInfo;
+import com.hazelcast.concurrent.countdownlatch.CountDownLatchContainer;
 import com.hazelcast.concurrent.countdownlatch.CountDownLatchService;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
@@ -30,49 +30,30 @@ import java.util.Collection;
 
 public class CountDownLatchReplicationOperation extends AbstractOperation implements IdentifiedDataSerializable {
 
-    private Collection<CountDownLatchInfo> data;
+    private Collection<CountDownLatchContainer> data;
 
     public CountDownLatchReplicationOperation() {
     }
 
-    public CountDownLatchReplicationOperation(Collection<CountDownLatchInfo> data) {
+    public CountDownLatchReplicationOperation(Collection<CountDownLatchContainer> data) {
         this.data = data;
     }
 
     @Override
     public void run() throws Exception {
-        if (data != null) {
-            CountDownLatchService service = getService();
-            for (CountDownLatchInfo latchInfo : data) {
-                service.add(latchInfo);
-            }
+        if (data == null) {
+            return;
+        }
+
+        CountDownLatchService service = getService();
+        for (CountDownLatchContainer latchContainer : data) {
+            service.add(latchContainer);
         }
     }
 
     @Override
-    protected void writeInternal(ObjectDataOutput out) throws IOException {
-        super.writeInternal(out);
-        int len = data != null ? data.size() : 0;
-        out.writeInt(len);
-        if (len > 0) {
-            for (CountDownLatchInfo latch : data) {
-                latch.writeData(out);
-            }
-        }
-    }
-
-    @Override
-    protected void readInternal(ObjectDataInput in) throws IOException {
-        super.readInternal(in);
-        int len = in.readInt();
-        if (len > 0) {
-            data = new ArrayList<CountDownLatchInfo>();
-            for (int i = 0; i < len; i++) {
-                CountDownLatchInfo latch = new CountDownLatchInfo();
-                latch.readData(in);
-                data.add(latch);
-            }
-        }
+    public String getServiceName() {
+        return CountDownLatchService.SERVICE_NAME;
     }
 
     @Override
@@ -86,7 +67,28 @@ public class CountDownLatchReplicationOperation extends AbstractOperation implem
     }
 
     @Override
-    public String getServiceName() {
-        return CountDownLatchService.SERVICE_NAME;
+    protected void writeInternal(ObjectDataOutput out) throws IOException {
+        super.writeInternal(out);
+        int len = data != null ? data.size() : 0;
+        out.writeInt(len);
+        if (len > 0) {
+            for (CountDownLatchContainer latchContainer : data) {
+                latchContainer.writeData(out);
+            }
+        }
+    }
+
+    @Override
+    protected void readInternal(ObjectDataInput in) throws IOException {
+        super.readInternal(in);
+        int len = in.readInt();
+        if (len > 0) {
+            data = new ArrayList<CountDownLatchContainer>();
+            for (int i = 0; i < len; i++) {
+                CountDownLatchContainer latchContainer = new CountDownLatchContainer();
+                latchContainer.readData(in);
+                data.add(latchContainer);
+            }
+        }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/countdownlatch/operations/SetCountOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/countdownlatch/operations/SetCountOperation.java
@@ -37,6 +37,7 @@ public class SetCountOperation extends BackupAwareCountDownLatchOperation implem
         this.count = count;
     }
 
+    @Override
     public void run() throws Exception {
         CountDownLatchService service = getService();
         response = service.setCount(name, count);
@@ -53,6 +54,16 @@ public class SetCountOperation extends BackupAwareCountDownLatchOperation implem
     }
 
     @Override
+    public int getFactoryId() {
+        return CountDownLatchDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return CountDownLatchDataSerializerHook.SET_COUNT_OPERATION;
+    }
+
+    @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
         out.writeInt(count);
@@ -62,15 +73,5 @@ public class SetCountOperation extends BackupAwareCountDownLatchOperation implem
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
         count = in.readInt();
-    }
-
-    @Override
-    public int getFactoryId() {
-        return CountDownLatchDataSerializerHook.F_ID;
-    }
-
-    @Override
-    public int getId() {
-        return CountDownLatchDataSerializerHook.SET_COUNT_OPERATION;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/LockOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/LockOperation.java
@@ -65,11 +65,6 @@ public class LockOperation extends BaseLockOperation implements WaitSupport, Bac
     }
 
     @Override
-    public int getId() {
-        return LockDataSerializerHook.LOCK;
-    }
-
-    @Override
     public final void onWaitExpire() {
         Object response;
         long timeout = getWaitTimeout();
@@ -79,5 +74,10 @@ public class LockOperation extends BaseLockOperation implements WaitSupport, Bac
             response = Boolean.FALSE;
         }
         getResponseHandler().sendResponse(response);
+    }
+
+    @Override
+    public int getId() {
+        return LockDataSerializerHook.LOCK;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/LockReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/LockReplicationOperation.java
@@ -63,6 +63,10 @@ public class LockReplicationOperation extends AbstractOperation
         return LockServiceImpl.SERVICE_NAME;
     }
 
+    public boolean isEmpty() {
+        return locks.isEmpty();
+    }
+
     @Override
     public int getFactoryId() {
         return LockDataSerializerHook.F_ID;
@@ -96,9 +100,5 @@ public class LockReplicationOperation extends AbstractOperation
                 locks.add(ls);
             }
         }
-    }
-
-    public boolean isEmpty() {
-        return locks.isEmpty();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/SemaphoreContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/SemaphoreContainer.java
@@ -25,7 +25,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
-public class Permit implements DataSerializable {
+public class SemaphoreContainer implements DataSerializable {
 
     public static final int INITIAL_CAPACITY = 10;
 
@@ -36,10 +36,10 @@ public class Permit implements DataSerializable {
     private int asyncBackupCount;
     private boolean initialized;
 
-    public Permit() {
+    public SemaphoreContainer() {
     }
 
-    public Permit(int partitionId, SemaphoreConfig config) {
+    public SemaphoreContainer(int partitionId, SemaphoreConfig config) {
         this.partitionId = partitionId;
         this.backupCount = config.getBackupCount();
         this.asyncBackupCount = config.getAsyncBackupCount();
@@ -148,6 +148,10 @@ public class Permit implements DataSerializable {
         this.initialized = true;
     }
 
+    public int getTotalBackupCount() {
+        return backupCount + asyncBackupCount;
+    }
+
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
         out.writeInt(available);
@@ -194,7 +198,4 @@ public class Permit implements DataSerializable {
         return sb.toString();
     }
 
-    public int getTotalBackupCount() {
-        return backupCount + asyncBackupCount;
-    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/AcquireBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/AcquireBackupOperation.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.concurrent.semaphore.operations;
 
-import com.hazelcast.concurrent.semaphore.Permit;
+import com.hazelcast.concurrent.semaphore.SemaphoreContainer;
 import com.hazelcast.concurrent.semaphore.SemaphoreDataSerializerHook;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
@@ -32,8 +32,8 @@ public class AcquireBackupOperation extends SemaphoreBackupOperation
 
     @Override
     public void run() throws Exception {
-        Permit permit = getPermit();
-        permit.acquire(permitCount, firstCaller);
+        SemaphoreContainer semaphoreContainer = getSemaphoreContainer();
+        semaphoreContainer.acquire(permitCount, firstCaller);
         response = true;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/AcquireOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/AcquireOperation.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.concurrent.semaphore.operations;
 
-import com.hazelcast.concurrent.semaphore.Permit;
+import com.hazelcast.concurrent.semaphore.SemaphoreContainer;
 import com.hazelcast.concurrent.semaphore.SemaphoreDataSerializerHook;
 import com.hazelcast.concurrent.semaphore.SemaphoreWaitNotifyKey;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
@@ -38,8 +38,8 @@ public class AcquireOperation extends SemaphoreBackupAwareOperation
 
     @Override
     public void run() throws Exception {
-        Permit permit = getPermit();
-        response = permit.acquire(permitCount, getCallerUuid());
+        SemaphoreContainer semaphoreContainer = getSemaphoreContainer();
+        response = semaphoreContainer.acquire(permitCount, getCallerUuid());
     }
 
     @Override
@@ -49,8 +49,8 @@ public class AcquireOperation extends SemaphoreBackupAwareOperation
 
     @Override
     public boolean shouldWait() {
-        Permit permit = getPermit();
-        return getWaitTimeout() != 0 && !permit.isAvailable(permitCount);
+        SemaphoreContainer semaphoreContainer = getSemaphoreContainer();
+        return getWaitTimeout() != 0 && !semaphoreContainer.isAvailable(permitCount);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/AvailableOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/AvailableOperation.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.concurrent.semaphore.operations;
 
+import com.hazelcast.concurrent.semaphore.SemaphoreContainer;
 import com.hazelcast.concurrent.semaphore.SemaphoreDataSerializerHook;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
@@ -30,7 +31,8 @@ public class AvailableOperation extends SemaphoreOperation implements Identified
 
     @Override
     public void run() throws Exception {
-        response = getPermit().getAvailable();
+        SemaphoreContainer semaphoreContainer = getSemaphoreContainer();
+        response = semaphoreContainer.getAvailable();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/DeadMemberBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/DeadMemberBackupOperation.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.concurrent.semaphore.operations;
 
-import com.hazelcast.concurrent.semaphore.Permit;
+import com.hazelcast.concurrent.semaphore.SemaphoreContainer;
 import com.hazelcast.concurrent.semaphore.SemaphoreDataSerializerHook;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
@@ -32,8 +32,8 @@ public class DeadMemberBackupOperation extends SemaphoreBackupOperation
 
     @Override
     public void run() throws Exception {
-        Permit permit = getPermit();
-        permit.memberRemoved(firstCaller);
+        SemaphoreContainer semaphoreContainer = getSemaphoreContainer();
+        semaphoreContainer.memberRemoved(firstCaller);
         response = true;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/DrainBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/DrainBackupOperation.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.concurrent.semaphore.operations;
 
-import com.hazelcast.concurrent.semaphore.Permit;
+import com.hazelcast.concurrent.semaphore.SemaphoreContainer;
 import com.hazelcast.concurrent.semaphore.SemaphoreDataSerializerHook;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
@@ -31,8 +31,8 @@ public class DrainBackupOperation extends SemaphoreBackupOperation implements Id
 
     @Override
     public void run() throws Exception {
-        Permit permit = getPermit();
-        permit.drain(firstCaller);
+        SemaphoreContainer semaphoreContainer = getSemaphoreContainer();
+        semaphoreContainer.drain(firstCaller);
         response = true;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/DrainOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/DrainOperation.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.concurrent.semaphore.operations;
 
-import com.hazelcast.concurrent.semaphore.Permit;
+import com.hazelcast.concurrent.semaphore.SemaphoreContainer;
 import com.hazelcast.concurrent.semaphore.SemaphoreDataSerializerHook;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.Operation;
@@ -32,8 +32,8 @@ public class DrainOperation extends SemaphoreBackupAwareOperation implements Ide
 
     @Override
     public void run() throws Exception {
-        Permit permit = getPermit();
-        response = permit.drain(getCallerUuid());
+        SemaphoreContainer semaphoreContainer = getSemaphoreContainer();
+        response = semaphoreContainer.drain(getCallerUuid());
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/InitBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/InitBackupOperation.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.concurrent.semaphore.operations;
 
-import com.hazelcast.concurrent.semaphore.Permit;
+import com.hazelcast.concurrent.semaphore.SemaphoreContainer;
 import com.hazelcast.concurrent.semaphore.SemaphoreDataSerializerHook;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
@@ -31,8 +31,8 @@ public class InitBackupOperation extends SemaphoreBackupOperation implements Ide
 
     @Override
     public void run() throws Exception {
-        Permit permit = getPermit();
-        permit.init(permitCount);
+        SemaphoreContainer semaphoreContainer = getSemaphoreContainer();
+        semaphoreContainer.init(permitCount);
         response = true;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/InitOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/InitOperation.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.concurrent.semaphore.operations;
 
-import com.hazelcast.concurrent.semaphore.Permit;
+import com.hazelcast.concurrent.semaphore.SemaphoreContainer;
 import com.hazelcast.concurrent.semaphore.SemaphoreDataSerializerHook;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.Operation;
@@ -32,8 +32,8 @@ public class InitOperation extends SemaphoreBackupAwareOperation implements Iden
 
     @Override
     public void run() throws Exception {
-        Permit permit = getPermit();
-        response = permit.init(permitCount);
+        SemaphoreContainer semaphoreContainer = getSemaphoreContainer();
+        response = semaphoreContainer.init(permitCount);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/ReduceBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/ReduceBackupOperation.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.concurrent.semaphore.operations;
 
-import com.hazelcast.concurrent.semaphore.Permit;
+import com.hazelcast.concurrent.semaphore.SemaphoreContainer;
 import com.hazelcast.concurrent.semaphore.SemaphoreDataSerializerHook;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
@@ -31,8 +31,8 @@ public class ReduceBackupOperation extends SemaphoreBackupOperation implements I
 
     @Override
     public void run() throws Exception {
-        Permit permit = getPermit();
-        permit.reduce(permitCount);
+        SemaphoreContainer semaphoreContainer = getSemaphoreContainer();
+        semaphoreContainer.reduce(permitCount);
         response = true;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/ReduceOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/ReduceOperation.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.concurrent.semaphore.operations;
 
-import com.hazelcast.concurrent.semaphore.Permit;
+import com.hazelcast.concurrent.semaphore.SemaphoreContainer;
 import com.hazelcast.concurrent.semaphore.SemaphoreDataSerializerHook;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.Operation;
@@ -32,8 +32,8 @@ public class ReduceOperation extends SemaphoreBackupAwareOperation implements Id
 
     @Override
     public void run() throws Exception {
-        Permit permit = getPermit();
-        response = permit.reduce(permitCount);
+        SemaphoreContainer semaphoreContainer = getSemaphoreContainer();
+        response = semaphoreContainer.reduce(permitCount);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/ReleaseBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/ReleaseBackupOperation.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.concurrent.semaphore.operations;
 
-import com.hazelcast.concurrent.semaphore.Permit;
+import com.hazelcast.concurrent.semaphore.SemaphoreContainer;
 import com.hazelcast.concurrent.semaphore.SemaphoreDataSerializerHook;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
@@ -31,8 +31,8 @@ public class ReleaseBackupOperation extends SemaphoreBackupOperation implements 
 
     @Override
     public void run() throws Exception {
-        Permit permit = getPermit();
-        permit.release(permitCount, firstCaller);
+        SemaphoreContainer semaphoreContainer = getSemaphoreContainer();
+        semaphoreContainer.release(permitCount, firstCaller);
         response = true;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/ReleaseOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/ReleaseOperation.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.concurrent.semaphore.operations;
 
-import com.hazelcast.concurrent.semaphore.Permit;
+import com.hazelcast.concurrent.semaphore.SemaphoreContainer;
 import com.hazelcast.concurrent.semaphore.SemaphoreDataSerializerHook;
 import com.hazelcast.concurrent.semaphore.SemaphoreWaitNotifyKey;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
@@ -35,8 +35,8 @@ public class ReleaseOperation extends SemaphoreBackupAwareOperation implements N
 
     @Override
     public void run() throws Exception {
-        Permit permit = getPermit();
-        permit.release(permitCount, getCallerUuid());
+        SemaphoreContainer semaphoreContainer = getSemaphoreContainer();
+        semaphoreContainer.release(permitCount, getCallerUuid());
         response = true;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/SemaphoreBackupAwareOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/SemaphoreBackupAwareOperation.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.concurrent.semaphore.operations;
 
-import com.hazelcast.concurrent.semaphore.Permit;
+import com.hazelcast.concurrent.semaphore.SemaphoreContainer;
 import com.hazelcast.spi.BackupAwareOperation;
 
 public abstract class SemaphoreBackupAwareOperation extends SemaphoreOperation implements BackupAwareOperation {
@@ -30,13 +30,13 @@ public abstract class SemaphoreBackupAwareOperation extends SemaphoreOperation i
 
     @Override
     public int getAsyncBackupCount() {
-        Permit permit = getPermit();
-        return permit.getAsyncBackupCount();
+        SemaphoreContainer semaphoreContainer = getSemaphoreContainer();
+        return semaphoreContainer.getAsyncBackupCount();
     }
 
     @Override
     public int getSyncBackupCount() {
-        Permit permit = getPermit();
-        return permit.getSyncBackupCount();
+        SemaphoreContainer semaphoreContainer = getSemaphoreContainer();
+        return semaphoreContainer.getSyncBackupCount();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/SemaphoreDeadMemberOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/SemaphoreDeadMemberOperation.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.concurrent.semaphore.operations;
 
-import com.hazelcast.concurrent.semaphore.Permit;
+import com.hazelcast.concurrent.semaphore.SemaphoreContainer;
 import com.hazelcast.concurrent.semaphore.SemaphoreDataSerializerHook;
 import com.hazelcast.concurrent.semaphore.SemaphoreWaitNotifyKey;
 import com.hazelcast.nio.ObjectDataInput;
@@ -43,13 +43,8 @@ public class SemaphoreDeadMemberOperation extends SemaphoreBackupAwareOperation
 
     @Override
     public void run() throws Exception {
-        Permit permit = getPermit();
-        response = permit.memberRemoved(firstCaller);
-    }
-
-    @Override
-    public boolean shouldBackup() {
-        return Boolean.TRUE.equals(response);
+        SemaphoreContainer semaphoreContainer = getSemaphoreContainer();
+        response = semaphoreContainer.memberRemoved(firstCaller);
     }
 
     @Override
@@ -58,20 +53,13 @@ public class SemaphoreDeadMemberOperation extends SemaphoreBackupAwareOperation
     }
 
     @Override
+    public boolean shouldBackup() {
+        return Boolean.TRUE.equals(response);
+    }
+
+    @Override
     public Operation getBackupOperation() {
         return new DeadMemberBackupOperation(name, firstCaller);
-    }
-
-    @Override
-    public void writeInternal(ObjectDataOutput out) throws IOException {
-        super.writeInternal(out);
-        out.writeUTF(firstCaller);
-    }
-
-    @Override
-    public void readInternal(ObjectDataInput in) throws IOException {
-        super.readInternal(in);
-        firstCaller = in.readUTF();
     }
 
     @Override
@@ -92,5 +80,17 @@ public class SemaphoreDeadMemberOperation extends SemaphoreBackupAwareOperation
     @Override
     public int getId() {
         return SemaphoreDataSerializerHook.SEMAPHORE_DEAD_MEMBER_OPERATION;
+    }
+
+    @Override
+    public void writeInternal(ObjectDataOutput out) throws IOException {
+        super.writeInternal(out);
+        out.writeUTF(firstCaller);
+    }
+
+    @Override
+    public void readInternal(ObjectDataInput in) throws IOException {
+        super.readInternal(in);
+        firstCaller = in.readUTF();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/SemaphoreOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/SemaphoreOperation.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.concurrent.semaphore.operations;
 
-import com.hazelcast.concurrent.semaphore.Permit;
+import com.hazelcast.concurrent.semaphore.SemaphoreContainer;
 import com.hazelcast.concurrent.semaphore.SemaphoreService;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
@@ -49,9 +49,9 @@ public abstract class SemaphoreOperation extends AbstractNamedOperation
         return response;
     }
 
-    public Permit getPermit() {
+    public SemaphoreContainer getSemaphoreContainer() {
         SemaphoreService service = getService();
-        return service.getOrCreatePermit(name);
+        return service.getSemaphoreContainer(name);
     }
 
     @Override


### PR DESCRIPTION
Renames the storage wrappers to containers. 

So:
LongContainer
ReferenceContainer
SemaphoreContainer
CountdownLatchContainer

Sime minor cleanup in the operations. Mostly correct ordering of methods so that serialization is always at the bottom.