### PR TITLE
Allow disabling SpringAware, fixes #4658

### DIFF
--- a/hazelcast-documentation/src/SpringIntegration.md
+++ b/hazelcast-documentation/src/SpringIntegration.md
@@ -205,7 +205,7 @@ Hazelcast Distributed Objects could be marked with @SpringAware if the object wa
 - to apply factory callbacks such as `ApplicationContextAware`, `BeanNameAware`,
 - to apply bean post-processing annotations such as `InitializingBean`, `@PostConstruct`.
 
-Hazelcast Distributed `ExecutorService`, or more generally any Hazelcast managed object, can benefit from these features. To enable SpringAware objects, you must first configure `HazelcastInstance` as explained in the [Spring Configuration section](#spring-configuration).
+Hazelcast Distributed `ExecutorService`, or more generally any Hazelcast managed object, can benefit from these features. To enable SpringAware objects, you must first configure `HazelcastInstance` as explained in the [Spring Configuration section](#spring-configuration). To disable SpringAware objects, you need to add `<hz:spring-aware enabled="false" />` tag to configuration
 
 #### SpringAware Examples
 
@@ -228,6 +228,8 @@ Hazelcast Distributed `ExecutorService`, or more generally any Hazelcast managed
 
   <hz:hazelcast id="instance">
     <hz:config>
+      <!--Uncomment below line to disable SpringAware objects-->
+      <!--<hz:spring-aware enabled="false"-->
       <hz:group name="dev" password="password"/>
       <hz:network port="5701" port-auto-increment="false">
         <hz:join>

--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/AbstractHazelcastBeanDefinitionParser.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/AbstractHazelcastBeanDefinitionParser.java
@@ -21,6 +21,7 @@ import com.hazelcast.config.GlobalSerializerConfig;
 import com.hazelcast.config.SerializationConfig;
 import com.hazelcast.config.SerializerConfig;
 import com.hazelcast.config.SocketInterceptorConfig;
+import com.hazelcast.spring.context.SpringManagedContext;
 import org.springframework.beans.factory.config.RuntimeBeanReference;
 import org.springframework.beans.factory.support.AbstractBeanDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
@@ -333,6 +334,24 @@ public abstract class AbstractHazelcastBeanDefinitionParser extends AbstractBean
                 properties.put(propertyName, value);
             }
             beanDefinitionBuilder.addPropertyValue("properties", properties);
+        }
+
+        protected void handleSpringAware(final Node node) {
+            boolean annotationDriven = true;
+            for (org.w3c.dom.Node element : new IterableNodeList(node, Node.ELEMENT_NODE)) {
+                final String nodeName = cleanNodeName(element.getNodeName());
+                if ("spring-aware".equals(nodeName)) {
+                    String enabled = getTextContent(element.getAttributes().getNamedItem("enabled")).trim();
+                    if ("false".equals(enabled)) {
+                        annotationDriven = false;
+                    }
+                    break;
+                }
+            }
+            if (annotationDriven) {
+                BeanDefinitionBuilder managedContextBeanBuilder = createBeanBuilder(SpringManagedContext.class);
+                configBuilder.addPropertyValue("managedContext", managedContextBeanBuilder.getBeanDefinition());
+            }
         }
     }
 }

--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastClientBeanDefinitionParser.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastClientBeanDefinitionParser.java
@@ -28,7 +28,6 @@ import com.hazelcast.config.GroupConfig;
 import com.hazelcast.config.ListenerConfig;
 import com.hazelcast.config.NearCacheConfig;
 import com.hazelcast.config.SSLConfig;
-import com.hazelcast.spring.context.SpringManagedContext;
 import org.springframework.beans.factory.support.AbstractBeanDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.support.ManagedMap;
@@ -87,9 +86,6 @@ public class HazelcastClientBeanDefinitionParser extends AbstractHazelcastBeanDe
 
             this.configBuilder = BeanDefinitionBuilder.rootBeanDefinition(ClientConfig.class);
             configBuilder.addPropertyValue("nearCacheConfigMap", nearCacheConfigMap);
-
-            BeanDefinitionBuilder managedContextBeanBuilder = createBeanBuilder(SpringManagedContext.class);
-            this.configBuilder.addPropertyValue("managedContext", managedContextBeanBuilder.getBeanDefinition());
         }
 
         public AbstractBeanDefinition getBeanDefinition() {
@@ -99,6 +95,7 @@ public class HazelcastClientBeanDefinitionParser extends AbstractHazelcastBeanDe
         public void handleClient(Element element) {
             handleCommonBeanAttributes(element, builder, parserContext);
             handleClientAttributes(element);
+            handleSpringAware(element);
             for (org.w3c.dom.Node node : new IterableNodeList(element, Node.ELEMENT_NODE)) {
                 final String nodeName = cleanNodeName(node.getNodeName());
                 if ("group".equals(nodeName)) {

--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastConfigBeanDefinitionParser.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastConfigBeanDefinitionParser.java
@@ -65,7 +65,6 @@ import com.hazelcast.config.WanReplicationRef;
 import com.hazelcast.config.WanTargetClusterConfig;
 import com.hazelcast.nio.ClassLoaderUtil;
 import com.hazelcast.spi.ServiceConfigurationParser;
-import com.hazelcast.spring.context.SpringManagedContext;
 import com.hazelcast.util.ExceptionUtil;
 import org.springframework.beans.factory.support.AbstractBeanDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
@@ -145,9 +144,6 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
             this.wanReplicationManagedMap = createManagedMap("wanReplicationConfigs");
             this.jobTrackerManagedMap = createManagedMap("jobTrackerConfigs");
             this.replicatedMapManagedMap = createManagedMap("replicatedMapConfigs");
-
-            BeanDefinitionBuilder managedContextBeanBuilder = createBeanBuilder(SpringManagedContext.class);
-            this.configBuilder.addPropertyValue("managedContext", managedContextBeanBuilder.getBeanDefinition());
         }
 
         private ManagedMap createManagedMap(String configName) {
@@ -162,6 +158,7 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
 
         public void handleConfig(final Element element) {
             handleCommonBeanAttributes(element, configBuilder, parserContext);
+            handleSpringAware(element);
             for (org.w3c.dom.Node node : new IterableNodeList(element, Node.ELEMENT_NODE)) {
                 final String nodeName = cleanNodeName(node.getNodeName());
                 if ("network".equals(nodeName)) {

--- a/hazelcast-spring/src/main/resources/hazelcast-spring-3.4.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-3.4.xsd
@@ -26,6 +26,7 @@
             <xs:complexContent>
                 <xs:extension base="hazelcast-bean">
                     <xs:sequence>
+                        <xs:element name="spring-aware" type="spring-aware" minOccurs="0" maxOccurs="1"/>
                         <xs:element name="instance-name" type="xs:string" minOccurs="0" maxOccurs="1"/>
                         <xs:element name="group" type="group" minOccurs="0" maxOccurs="1"/>
                         <xs:element name="license-key" type="xs:string" minOccurs="0" maxOccurs="1"/>
@@ -946,6 +947,7 @@
             <xs:complexContent>
                 <xs:extension base="hazelcast-bean">
                     <xs:sequence>
+                        <xs:element name="spring-aware" type="spring-aware" minOccurs="0" maxOccurs="1"/>
                         <xs:element name="group" type="group" minOccurs="0" maxOccurs="1"/>
                         <xs:element name="properties" type="properties" minOccurs="0" maxOccurs="1"/>
                         <xs:element name="network" type="network-client" minOccurs="0" maxOccurs="1"/>
@@ -1786,6 +1788,10 @@
         <xs:attribute name="size" type="xs:nonNegativeInteger" default="10000" use="optional"/>
         <xs:attribute name="max-size-policy" type="cache-max-size-policy" default="ENTRY_COUNT" use="optional"/>
         <xs:attribute name="eviction-policy" type="eviction-policy" default="LRU" use="optional"/>
+    </xs:complexType>
+
+    <xs:complexType name="spring-aware">
+        <xs:attribute name="enabled" type="xs:string" default="true" use="optional" />
     </xs:complexType>
 
 </xs:schema>

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/springaware/TestDisabledSpringAwareAnnotation.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/springaware/TestDisabledSpringAwareAnnotation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2013, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 
-package com.hazelcast.spring;
+package com.hazelcast.spring.springaware;
 
 import com.hazelcast.client.HazelcastClient;
 import com.hazelcast.client.impl.HazelcastClientProxy;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.spring.CustomSpringJUnit4ClassRunner;
 import com.hazelcast.spring.context.SpringManagedContext;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
@@ -32,12 +33,13 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.test.context.ContextConfiguration;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(CustomSpringJUnit4ClassRunner.class)
-@ContextConfiguration(locations = {"beans-applicationContext-hazelcast.xml"})
+@ContextConfiguration(locations = {"springAware-disabled-applicationContext-hazelcast.xml"})
 @Category(QuickTest.class)
-public class TestBeansApplicationContext {
+public class TestDisabledSpringAwareAnnotation {
 
     @BeforeClass
     @AfterClass
@@ -50,28 +52,12 @@ public class TestBeansApplicationContext {
     private ApplicationContext context;
 
     @Test
-    public void test() {
-        assertTrue(Hazelcast.getAllHazelcastInstances().isEmpty());
-        assertTrue(HazelcastClient.getAllHazelcastClients().isEmpty());
-
-        context.getBean("map2");
-
-        assertEquals(1, Hazelcast.getAllHazelcastInstances().size());
-        assertEquals(1, HazelcastClient.getAllHazelcastClients().size());
-
-        HazelcastInstance hazelcast = Hazelcast.getAllHazelcastInstances().iterator().next();
-        assertEquals(2, hazelcast.getDistributedObjects().size());
-
-        context.getBean("client");
-        context.getBean("client");
-        assertEquals(3, HazelcastClient.getAllHazelcastClients().size());
-        HazelcastClientProxy client = (HazelcastClientProxy) HazelcastClient.getAllHazelcastClients().iterator().next();
-        assertTrue(client.getClientConfig().getManagedContext() instanceof SpringManagedContext);
-
+    public void testDisabledSpringManagedContext() {
         HazelcastInstance instance = (HazelcastInstance) context.getBean("instance");
-        assertEquals(1, Hazelcast.getAllHazelcastInstances().size());
-        assertEquals(instance, Hazelcast.getAllHazelcastInstances().iterator().next());
-        assertTrue(instance.getConfig().getManagedContext() instanceof SpringManagedContext);
+        assertNull(instance.getConfig().getManagedContext());
+
+        HazelcastClientProxy client = (HazelcastClientProxy) context.getBean("client");
+        assertNull(client.getClientConfig().getManagedContext());
     }
 
 }

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/springaware/TestEnabledSpringAwareAnnotation.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/springaware/TestEnabledSpringAwareAnnotation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2013, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 
-package com.hazelcast.spring;
+package com.hazelcast.spring.springaware;
 
 import com.hazelcast.client.HazelcastClient;
 import com.hazelcast.client.impl.HazelcastClientProxy;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.spring.CustomSpringJUnit4ClassRunner;
 import com.hazelcast.spring.context.SpringManagedContext;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
@@ -35,9 +36,9 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(CustomSpringJUnit4ClassRunner.class)
-@ContextConfiguration(locations = {"beans-applicationContext-hazelcast.xml"})
+@ContextConfiguration(locations = {"springAware-enabled-applicationContext-hazelcast.xml"})
 @Category(QuickTest.class)
-public class TestBeansApplicationContext {
+public class TestEnabledSpringAwareAnnotation {
 
     @BeforeClass
     @AfterClass
@@ -50,28 +51,12 @@ public class TestBeansApplicationContext {
     private ApplicationContext context;
 
     @Test
-    public void test() {
-        assertTrue(Hazelcast.getAllHazelcastInstances().isEmpty());
-        assertTrue(HazelcastClient.getAllHazelcastClients().isEmpty());
-
-        context.getBean("map2");
-
-        assertEquals(1, Hazelcast.getAllHazelcastInstances().size());
-        assertEquals(1, HazelcastClient.getAllHazelcastClients().size());
-
-        HazelcastInstance hazelcast = Hazelcast.getAllHazelcastInstances().iterator().next();
-        assertEquals(2, hazelcast.getDistributedObjects().size());
-
-        context.getBean("client");
-        context.getBean("client");
-        assertEquals(3, HazelcastClient.getAllHazelcastClients().size());
-        HazelcastClientProxy client = (HazelcastClientProxy) HazelcastClient.getAllHazelcastClients().iterator().next();
-        assertTrue(client.getClientConfig().getManagedContext() instanceof SpringManagedContext);
-
+    public void testSpringManagedContext() {
         HazelcastInstance instance = (HazelcastInstance) context.getBean("instance");
-        assertEquals(1, Hazelcast.getAllHazelcastInstances().size());
-        assertEquals(instance, Hazelcast.getAllHazelcastInstances().iterator().next());
         assertTrue(instance.getConfig().getManagedContext() instanceof SpringManagedContext);
+
+        HazelcastClientProxy client = (HazelcastClientProxy) context.getBean("client");
+        assertTrue(client.getClientConfig().getManagedContext() instanceof SpringManagedContext);
     }
 
 }

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/springaware/springAware-disabled-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/springaware/springAware-disabled-applicationContext-hazelcast.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:hz="http://www.hazelcast.com/schema/spring"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+		http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+		http://www.hazelcast.com/schema/spring
+		http://www.hazelcast.com/schema/spring/hazelcast-spring.xsd">
+
+    <hz:hazelcast id="instance" lazy-init="true" scope="singleton">
+        <hz:config>
+            <hz:spring-aware enabled="false"/>
+            <hz:group name="${cluster.group.name}" password="${cluster.group.password}"/>
+            <hz:network port="5701" port-auto-increment="false">
+                <hz:join>
+                    <hz:multicast enabled="false"/>
+                    <hz:tcp-ip enabled="true">
+                        <hz:interface>127.0.0.1:5701</hz:interface>
+                        <hz:interface>127.0.0.1:5702</hz:interface>
+                    </hz:tcp-ip>
+                </hz:join>
+                <hz:interfaces enabled="true">
+                    <hz:interface>127.0.0.1</hz:interface>
+                </hz:interfaces>
+            </hz:network>
+        </hz:config>
+    </hz:hazelcast>
+
+    <hz:client id="client" lazy-init="true" scope="prototype">
+        <hz:spring-aware enabled="false"/>
+        <hz:group name="${cluster.group.name}" password="${cluster.group.password}" />
+        <hz:network connection-attempt-limit="3"
+                    connection-attempt-period="3000"
+                    connection-timeout="1000"
+                    redo-operation="true"
+                    smart-routing="true">
+
+            <hz:member>127.0.0.1:5701</hz:member>
+
+            <hz:socket-options buffer-size="32"
+                               keep-alive="false"
+                               linger-seconds="3"
+                               reuse-address="false"
+                               tcp-no-delay="false"/>
+        </hz:network>
+    </hz:client>
+</beans>

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/springaware/springAware-enabled-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/springaware/springAware-enabled-applicationContext-hazelcast.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:hz="http://www.hazelcast.com/schema/spring"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+		http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+		http://www.hazelcast.com/schema/spring
+		http://www.hazelcast.com/schema/spring/hazelcast-spring.xsd">
+
+    <hz:hazelcast id="instance" lazy-init="true" scope="singleton">
+        <hz:config>
+            <hz:group name="${cluster.group.name}" password="${cluster.group.password}"/>
+            <hz:network port="5701" port-auto-increment="false">
+                <hz:join>
+                    <hz:multicast enabled="false"/>
+                    <hz:tcp-ip enabled="true">
+                        <hz:interface>127.0.0.1:5701</hz:interface>
+                        <hz:interface>127.0.0.1:5702</hz:interface>
+                    </hz:tcp-ip>
+                </hz:join>
+                <hz:interfaces enabled="true">
+                    <hz:interface>127.0.0.1</hz:interface>
+                </hz:interfaces>
+            </hz:network>
+        </hz:config>
+    </hz:hazelcast>
+
+    <hz:client id="client" lazy-init="true" scope="prototype">
+        <hz:spring-aware enabled="true"/>
+        <hz:group name="${cluster.group.name}" password="${cluster.group.password}" />
+        <hz:network connection-attempt-limit="3"
+                    connection-attempt-period="3000"
+                    connection-timeout="1000"
+                    redo-operation="true"
+                    smart-routing="true">
+
+            <hz:member>127.0.0.1:5701</hz:member>
+
+            <hz:socket-options buffer-size="32"
+                               keep-alive="false"
+                               linger-seconds="3"
+                               reuse-address="false"
+                               tcp-no-delay="false"/>
+        </hz:network>
+    </hz:client>
+</beans>


### PR DESCRIPTION
`spring-aware` config element added to `hazelcast-spring-3.4.xsd`.

By default hz uses `SpringManagedContext` to scan `SpringAware` annotations. This may cause some performance penalty even if users don't use `SpringAware`. 
With this pr, it'll be possible to disable it by adding `<hz:spring-aware enabled="false"/>` tag  to the config.

This PR is a slightly modified backport of https://github.com/hazelcast/hazelcast/pull/4711.