### PR TITLE
generate thread dump (with their locks) on test failure before "tearDown...

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/test/AbstractHazelcastClassRunner.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/AbstractHazelcastClassRunner.java
@@ -20,15 +20,22 @@ import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.test.annotation.Repeat;
 
+import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadInfo;
+import java.lang.management.ThreadMXBean;
 import java.lang.reflect.Method;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Random;
 import java.util.Set;
 
+import org.junit.After;
+import org.junit.internal.runners.statements.RunAfters;
 import org.junit.runners.BlockJUnit4ClassRunner;
 import org.junit.runners.model.FrameworkMethod;
 import org.junit.runners.model.InitializationError;
+import org.junit.runners.model.MultipleFailureException;
 import org.junit.runners.model.Statement;
 
 /**
@@ -36,6 +43,9 @@ import org.junit.runners.model.Statement;
  * Date: 11/27/13
  */
 public abstract class AbstractHazelcastClassRunner extends BlockJUnit4ClassRunner {
+
+    protected static final boolean DISABLE_THREAD_DUMP_ON_FAILURE =
+            Boolean.getBoolean("hazelcast.test.disableThreadDumpOnFailure");
 
     static {
         final String logging = "hazelcast.logging.type";
@@ -73,6 +83,60 @@ public abstract class AbstractHazelcastClassRunner extends BlockJUnit4ClassRunne
         final List<FrameworkMethod> children = super.getChildren();
         Collections.shuffle(children);
         return children;
+    }
+
+    @Override
+    protected Statement withAfters(FrameworkMethod method, Object target,
+                                   Statement statement) {
+        List<FrameworkMethod> afters = getTestClass().getAnnotatedMethods(After.class);
+        if (afters.isEmpty()) {
+            return statement;
+        } else {
+            if (!DISABLE_THREAD_DUMP_ON_FAILURE) {
+                return new ThreadDumpAwareRunAfters(method, statement, afters, target);
+            } else {
+                return new RunAfters(statement, afters, target);
+            }
+        }
+    }
+
+    protected class ThreadDumpAwareRunAfters extends Statement {
+
+        private final FrameworkMethod method;
+        private final Statement next;
+        private final Object target;
+        private final List<FrameworkMethod> afters;
+
+        protected ThreadDumpAwareRunAfters(FrameworkMethod method, Statement next,
+                                           List<FrameworkMethod> afters, Object target) {
+            this.method = method;
+            this.next = next;
+            this.afters = afters;
+            this.target = target;
+        }
+
+        @Override
+        public void evaluate() throws Throwable {
+            List<Throwable> errors = new ArrayList<Throwable>();
+            try {
+                next.evaluate();
+            } catch (Throwable e) {
+                System.err.println("THREAD DUMP FOR TEST FAILURE: " +
+                                   "\"" + e.getMessage() + "\" at " +
+                                   "\"" + method.getName() + "\"" + "\n");
+                System.err.println(generateThreadDump());
+                errors.add(e);
+            } finally {
+                for (FrameworkMethod each : afters) {
+                    try {
+                        each.invokeExplosively(target);
+                    } catch (Throwable e) {
+                        errors.add(e);
+                    }
+                }
+            }
+            MultipleFailureException.assertEmpty(errors);
+        }
     }
 
     @Override
@@ -116,15 +180,13 @@ public abstract class AbstractHazelcastClassRunner extends BlockJUnit4ClassRunne
         };
     }
 
-    private class TestRepeater extends Statement {
+    protected class TestRepeater extends Statement {
 
         private final Statement statement;
-
         private final Method testMethod;
-
         private final int repeat;
 
-        public TestRepeater(Statement statement, Method testMethod, int repeat) {
+        protected TestRepeater(Statement statement, Method testMethod, int repeat) {
             this.statement = statement;
             this.testMethod = testMethod;
             this.repeat = Math.max(1, repeat);
@@ -145,5 +207,38 @@ public abstract class AbstractHazelcastClassRunner extends BlockJUnit4ClassRunne
                 statement.evaluate();
             }
         }
+
     }
+
+    protected String generateThreadDump() {
+        final StringBuilder dump = new StringBuilder();
+        final ThreadMXBean threadMXBean = ManagementFactory.getThreadMXBean();
+        final ThreadInfo[] threadInfos = threadMXBean.dumpAllThreads(true, true);
+        final long currentThreadId = Thread.currentThread().getId();
+        for (ThreadInfo threadInfo : threadInfos) {
+            if (threadInfo.getThreadId() == currentThreadId) {
+                continue;
+            }
+            dump.append('"');
+            dump.append(threadInfo.getThreadName());
+            dump.append("\" ");
+            final Thread.State state = threadInfo.getThreadState();
+            dump.append("\n\tjava.lang.Thread.State: ");
+            dump.append(state);
+            if (threadInfo.getLockName() != null) {
+                dump.append(" on lock=" + threadInfo.getLockName());
+            }
+            if (threadInfo.getLockOwnerName() != null) {
+                dump.append(" owned by " + threadInfo.getLockOwnerName() + " id=" + threadInfo.getLockOwnerId());
+            }
+            final StackTraceElement[] stackTraceElements = threadInfo.getStackTrace();
+            for (StackTraceElement stackTraceElement : stackTraceElements) {
+                dump.append("\n\t\tat ");
+                dump.append(stackTraceElement);
+            }
+            dump.append("\n\n");
+        }
+        return dump.toString();
+    }
+
 }

--- a/hazelcast/src/test/java/com/hazelcast/test/AbstractHazelcastClassRunner.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/AbstractHazelcastClassRunner.java
@@ -89,14 +89,13 @@ public abstract class AbstractHazelcastClassRunner extends BlockJUnit4ClassRunne
     protected Statement withAfters(FrameworkMethod method, Object target,
                                    Statement statement) {
         List<FrameworkMethod> afters = getTestClass().getAnnotatedMethods(After.class);
+        if (!DISABLE_THREAD_DUMP_ON_FAILURE) {
+            return new ThreadDumpAwareRunAfters(method, statement, afters, target);
+        }
         if (afters.isEmpty()) {
             return statement;
         } else {
-            if (!DISABLE_THREAD_DUMP_ON_FAILURE) {
-                return new ThreadDumpAwareRunAfters(method, statement, afters, target);
-            } else {
-                return new RunAfters(statement, afters, target);
-            }
+            return new RunAfters(statement, afters, target);
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
@@ -564,8 +564,6 @@ public abstract class HazelcastTestSupport {
             }
             sleepMillis(sleepMillis);
         }
-
-        printAllStackTraces();
         throw error;
     }
 


### PR DESCRIPTION
Wraps JUnit `Statement` and in case of error (also before `tearDown`of test) dumps threads.

Sample output:

```
Started Running Test: JCacheListenerTest.testSyncListener_shouldNotHang_whenCacheDestroyed
ASSERT_TRUE_EVENTUALLY_TIMEOUT = 120
THREAD DUMP FOR TEST FAILURE: "expected:<1> but was:<0>" at "testSyncListener_shouldNotHang_whenCacheDestroyed"

"hz._hzInstance_2_dev.HealthMonitor" 
	java.lang.Thread.State: TIMED_WAITING
		at java.lang.Thread.sleep(Native Method)
		at com.hazelcast.util.HealthMonitor.run(HealthMonitor.java:129)

"cached4" 
	java.lang.Thread.State: TIMED_WAITING on lock=java.util.concurrent.SynchronousQueue$TransferStack@6feb2ae7
		at sun.misc.Unsafe.park(Native Method)
		at java.util.concurrent.locks.LockSupport.parkNanos(LockSupport.java:226)
		at java.util.concurrent.SynchronousQueue$TransferStack.awaitFulfill(SynchronousQueue.java:460)
		at java.util.concurrent.SynchronousQueue$TransferStack.transfer(SynchronousQueue.java:359)
		at java.util.concurrent.SynchronousQueue.poll(SynchronousQueue.java:942)
		at java.util.concurrent.ThreadPoolExecutor.getTask(ThreadPoolExecutor.java:1068)
		at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1130)
		at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
		at java.lang.Thread.run(Thread.java:745)
		at com.hazelcast.util.executor.HazelcastManagedThread.executeRun(HazelcastManagedThread.java:76)
		at com.hazelcast.util.executor.HazelcastManagedThread.run(HazelcastManagedThread.java:92)

"cached3" 
	java.lang.Thread.State: WAITING on lock=java.util.concurrent.SynchronousQueue$TransferStack@384ddd18
		at sun.misc.Unsafe.park(Native Method)
		at java.util.concurrent.locks.LockSupport.park(LockSupport.java:186)
		at java.util.concurrent.SynchronousQueue$TransferStack.awaitFulfill(SynchronousQueue.java:458)
		at java.util.concurrent.SynchronousQueue$TransferStack.transfer(SynchronousQueue.java:359)
		at java.util.concurrent.SynchronousQueue.take(SynchronousQueue.java:925)
		at java.util.concurrent.ThreadPoolExecutor.getTask(ThreadPoolExecutor.java:1068)
		at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1130)
		at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
		at java.lang.Thread.run(Thread.java:745)
		at com.hazelcast.util.executor.HazelcastManagedThread.executeRun(HazelcastManagedThread.java:76)
		at com.hazelcast.util.executor.HazelcastManagedThread.run(HazelcastManagedThread.java:92)

"cached3" 
	java.lang.Thread.State: TIMED_WAITING on lock=java.util.concurrent.SynchronousQueue$TransferStack@6feb2ae7
		at sun.misc.Unsafe.park(Native Method)
		at java.util.concurrent.locks.LockSupport.parkNanos(LockSupport.java:226)
		at java.util.concurrent.SynchronousQueue$TransferStack.awaitFulfill(SynchronousQueue.java:460)
		at java.util.concurrent.SynchronousQueue$TransferStack.transfer(SynchronousQueue.java:359)
		at java.util.concurrent.SynchronousQueue.poll(SynchronousQueue.java:942)
		at java.util.concurrent.ThreadPoolExecutor.getTask(ThreadPoolExecutor.java:1068)
		at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1130)
		at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
		at java.lang.Thread.run(Thread.java:745)
		at com.hazelcast.util.executor.HazelcastManagedThread.executeRun(HazelcastManagedThread.java:76)
		at com.hazelcast.util.executor.HazelcastManagedThread.run(HazelcastManagedThread.java:92)

"cached2" 
	java.lang.Thread.State: TIMED_WAITING on lock=java.util.concurrent.SynchronousQueue$TransferStack@6feb2ae7
		at sun.misc.Unsafe.park(Native Method)
		at java.util.concurrent.locks.LockSupport.parkNanos(LockSupport.java:226)
		at java.util.concurrent.SynchronousQueue$TransferStack.awaitFulfill(SynchronousQueue.java:460)
		at java.util.concurrent.SynchronousQueue$TransferStack.transfer(SynchronousQueue.java:359)
		at java.util.concurrent.SynchronousQueue.poll(SynchronousQueue.java:942)
		at java.util.concurrent.ThreadPoolExecutor.getTask(ThreadPoolExecutor.java:1068)
		at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1130)
		at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
		at java.lang.Thread.run(Thread.java:745)
		at com.hazelcast.util.executor.HazelcastManagedThread.executeRun(HazelcastManagedThread.java:76)
		at com.hazelcast.util.executor.HazelcastManagedThread.run(HazelcastManagedThread.java:92)

"cached1" 
	java.lang.Thread.State: TIMED_WAITING on lock=java.util.concurrent.SynchronousQueue$TransferStack@6feb2ae7
		at sun.misc.Unsafe.park(Native Method)
		at java.util.concurrent.locks.LockSupport.parkNanos(LockSupport.java:226)
		at java.util.concurrent.SynchronousQueue$TransferStack.awaitFulfill(SynchronousQueue.java:460)
		at java.util.concurrent.SynchronousQueue$TransferStack.transfer(SynchronousQueue.java:359)
		at java.util.concurrent.SynchronousQueue.poll(SynchronousQueue.java:942)
		at java.util.concurrent.ThreadPoolExecutor.getTask(ThreadPoolExecutor.java:1068)
		at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1130)
		at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
		at java.lang.Thread.run(Thread.java:745)
		at com.hazelcast.util.executor.HazelcastManagedThread.executeRun(HazelcastManagedThread.java:76)
		at com.hazelcast.util.executor.HazelcastManagedThread.run(HazelcastManagedThread.java:92)

"cached2" 
	java.lang.Thread.State: WAITING on lock=java.util.concurrent.SynchronousQueue$TransferStack@384ddd18
		at sun.misc.Unsafe.park(Native Method)
		at java.util.concurrent.locks.LockSupport.park(LockSupport.java:186)
		at java.util.concurrent.SynchronousQueue$TransferStack.awaitFulfill(SynchronousQueue.java:458)
		at java.util.concurrent.SynchronousQueue$TransferStack.transfer(SynchronousQueue.java:359)
		at java.util.concurrent.SynchronousQueue.take(SynchronousQueue.java:925)
		at java.util.concurrent.ThreadPoolExecutor.getTask(ThreadPoolExecutor.java:1068)
		at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1130)
		at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
		at java.lang.Thread.run(Thread.java:745)
		at com.hazelcast.util.executor.HazelcastManagedThread.executeRun(HazelcastManagedThread.java:76)
		at com.hazelcast.util.executor.HazelcastManagedThread.run(HazelcastManagedThread.java:92)

"cached1" 
	java.lang.Thread.State: WAITING on lock=java.util.concurrent.SynchronousQueue$TransferStack@384ddd18
		at sun.misc.Unsafe.park(Native Method)
		at java.util.concurrent.locks.LockSupport.park(LockSupport.java:186)
		at java.util.concurrent.SynchronousQueue$TransferStack.awaitFulfill(SynchronousQueue.java:458)
		at java.util.concurrent.SynchronousQueue$TransferStack.transfer(SynchronousQueue.java:359)
		at java.util.concurrent.SynchronousQueue.take(SynchronousQueue.java:925)
		at java.util.concurrent.ThreadPoolExecutor.getTask(ThreadPoolExecutor.java:1068)
		at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1130)
		at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
		at java.lang.Thread.run(Thread.java:745)
		at com.hazelcast.util.executor.HazelcastManagedThread.executeRun(HazelcastManagedThread.java:76)
		at com.hazelcast.util.executor.HazelcastManagedThread.run(HazelcastManagedThread.java:92)

"hz._hzInstance_2_dev.migration" 
	java.lang.Thread.State: TIMED_WAITING
		at java.lang.Thread.sleep(Native Method)
		at com.hazelcast.partition.impl.InternalPartitionServiceImpl$MigrationThread.doRun(InternalPartitionServiceImpl.java:1789)
		at com.hazelcast.partition.impl.InternalPartitionServiceImpl$MigrationThread.run(InternalPartitionServiceImpl.java:1754)

"hz._hzInstance_2_dev.wait-notify" 
	java.lang.Thread.State: TIMED_WAITING on lock=java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject@7fee6f88
		at sun.misc.Unsafe.park(Native Method)
		at java.util.concurrent.locks.LockSupport.parkNanos(LockSupport.java:226)
		at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.awaitNanos(AbstractQueuedSynchronizer.java:2082)
		at java.util.concurrent.DelayQueue.poll(DelayQueue.java:256)
		at com.hazelcast.spi.impl.WaitNotifyServiceImpl$ExpirationTask.doRun(WaitNotifyServiceImpl.java:450)
		at com.hazelcast.spi.impl.WaitNotifyServiceImpl$ExpirationTask.run(WaitNotifyServiceImpl.java:435)
		at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:471)
		at java.util.concurrent.FutureTask.run(FutureTask.java:262)
		at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
		at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
		at java.lang.Thread.run(Thread.java:745)
		at com.hazelcast.util.executor.HazelcastManagedThread.executeRun(HazelcastManagedThread.java:76)
		at com.hazelcast.util.executor.HazelcastManagedThread.run(HazelcastManagedThread.java:92)

"hz._hzInstance_2_dev.event-10" 
	java.lang.Thread.State: WAITING on lock=java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject@7edc8b55
		at sun.misc.Unsafe.park(Native Method)
		at java.util.concurrent.locks.LockSupport.park(LockSupport.java:186)
		at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:2043)
		at java.util.concurrent.LinkedBlockingQueue.take(LinkedBlockingQueue.java:442)
		at com.hazelcast.util.executor.StripedExecutor$Worker.run(StripedExecutor.java:173)

"hz._hzInstance_2_dev.event-9" 
	java.lang.Thread.State: WAITING on lock=java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject@413fba84
		at sun.misc.Unsafe.park(Native Method)
		at java.util.concurrent.locks.LockSupport.park(LockSupport.java:186)
		at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:2043)
		at java.util.concurrent.LinkedBlockingQueue.take(LinkedBlockingQueue.java:442)
		at com.hazelcast.util.executor.StripedExecutor$Worker.run(StripedExecutor.java:173)

"hz._hzInstance_2_dev.event-8" 
	java.lang.Thread.State: WAITING on lock=java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject@3eee5193
		at sun.misc.Unsafe.park(Native Method)
		at java.util.concurrent.locks.LockSupport.park(LockSupport.java:186)
		at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:2043)
		at java.util.concurrent.LinkedBlockingQueue.take(LinkedBlockingQueue.java:442)
		at com.hazelcast.util.executor.StripedExecutor$Worker.run(StripedExecutor.java:173)

"hz._hzInstance_2_dev.event-7" 
	java.lang.Thread.State: WAITING on lock=java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject@102daa2c
		at sun.misc.Unsafe.park(Native Method)
		at java.util.concurrent.locks.LockSupport.park(LockSupport.java:186)
		at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:2043)
		at java.util.concurrent.LinkedBlockingQueue.take(LinkedBlockingQueue.java:442)
		at com.hazelcast.util.executor.StripedExecutor$Worker.run(StripedExecutor.java:173)

"hz._hzInstance_2_dev.event-6" 
	java.lang.Thread.State: WAITING on lock=java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject@25ff3700
		at sun.misc.Unsafe.park(Native Method)
		at java.util.concurrent.locks.LockSupport.park(LockSupport.java:186)
		at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:2043)
		at java.util.concurrent.LinkedBlockingQueue.take(LinkedBlockingQueue.java:442)
		at com.hazelcast.util.executor.StripedExecutor$Worker.run(StripedExecutor.java:173)

"hz._hzInstance_2_dev.CleanupThread" 
	java.lang.Thread.State: TIMED_WAITING
		at java.lang.Thread.sleep(Native Method)
		at com.hazelcast.spi.impl.BasicOperationService$CleanupThread.sleep(BasicOperationService.java:1102)
		at com.hazelcast.spi.impl.BasicOperationService$CleanupThread.run(BasicOperationService.java:1091)

"hz._hzInstance_2_dev.SlowOperationDetectorThread" 
	java.lang.Thread.State: TIMED_WAITING
		at java.lang.Thread.sleep(Native Method)
		at java.lang.Thread.sleep(Thread.java:340)
		at java.util.concurrent.TimeUnit.sleep(TimeUnit.java:360)
		at com.hazelcast.spi.impl.SlowOperationDetector$SlowOperationDetectorThread.sleepInterval(SlowOperationDetector.java:218)
		at com.hazelcast.spi.impl.SlowOperationDetector$SlowOperationDetectorThread.run(SlowOperationDetector.java:122)

"hz._hzInstance_2_dev.response" 
	java.lang.Thread.State: WAITING on lock=java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject@1673f47d
		at sun.misc.Unsafe.park(Native Method)
		at java.util.concurrent.locks.LockSupport.park(LockSupport.java:186)
		at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:2043)
		at java.util.concurrent.LinkedBlockingQueue.take(LinkedBlockingQueue.java:442)
		at com.hazelcast.spi.impl.operationexecutor.classic.ResponseThread.doRun(ResponseThread.java:57)
		at com.hazelcast.spi.impl.operationexecutor.classic.ResponseThread.run(ResponseThread.java:46)

"hz._hzInstance_2_dev.generic-operation.thread-1" 
	java.lang.Thread.State: WAITING on lock=java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject@16b8460f
		at sun.misc.Unsafe.park(Native Method)
		at java.util.concurrent.locks.LockSupport.park(LockSupport.java:186)
		at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:2043)
		at java.util.concurrent.LinkedBlockingQueue.take(LinkedBlockingQueue.java:442)
		at com.hazelcast.spi.impl.operationexecutor.classic.DefaultScheduleQueue.take(DefaultScheduleQueue.java:79)
		at com.hazelcast.spi.impl.operationexecutor.classic.OperationThread.doRun(OperationThread.java:73)
		at com.hazelcast.spi.impl.operationexecutor.classic.OperationThread.run(OperationThread.java:60)

"hz._hzInstance_2_dev.generic-operation.thread-0" 
	java.lang.Thread.State: WAITING on lock=java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject@16b8460f
		at sun.misc.Unsafe.park(Native Method)
		at java.util.concurrent.locks.LockSupport.park(LockSupport.java:186)
		at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:2043)
		at java.util.concurrent.LinkedBlockingQueue.take(LinkedBlockingQueue.java:442)
		at com.hazelcast.spi.impl.operationexecutor.classic.DefaultScheduleQueue.take(DefaultScheduleQueue.java:79)
		at com.hazelcast.spi.impl.operationexecutor.classic.OperationThread.doRun(OperationThread.java:73)
		at com.hazelcast.spi.impl.operationexecutor.classic.OperationThread.run(OperationThread.java:60)

"hz._hzInstance_2_dev.partition-operation.thread-3" 
	java.lang.Thread.State: WAITING on lock=java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject@1bff8e70
		at sun.misc.Unsafe.park(Native Method)
		at java.util.concurrent.locks.LockSupport.park(LockSupport.java:186)
		at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:2043)
		at java.util.concurrent.LinkedBlockingQueue.take(LinkedBlockingQueue.java:442)
		at com.hazelcast.spi.impl.operationexecutor.classic.DefaultScheduleQueue.take(DefaultScheduleQueue.java:79)
		at com.hazelcast.spi.impl.operationexecutor.classic.OperationThread.doRun(OperationThread.java:73)
		at com.hazelcast.spi.impl.operationexecutor.classic.OperationThread.run(OperationThread.java:60)

"hz._hzInstance_2_dev.partition-operation.thread-2" 
	java.lang.Thread.State: WAITING on lock=java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject@26e0696c
		at sun.misc.Unsafe.park(Native Method)
		at java.util.concurrent.locks.LockSupport.park(LockSupport.java:186)
		at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:2043)
		at java.util.concurrent.LinkedBlockingQueue.take(LinkedBlockingQueue.java:442)
		at com.hazelcast.spi.impl.operationexecutor.classic.DefaultScheduleQueue.take(DefaultScheduleQueue.java:79)
		at com.hazelcast.spi.impl.operationexecutor.classic.OperationThread.doRun(OperationThread.java:73)
		at com.hazelcast.spi.impl.operationexecutor.classic.OperationThread.run(OperationThread.java:60)

"hz._hzInstance_2_dev.partition-operation.thread-1" 
	java.lang.Thread.State: WAITING on lock=java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject@57294564
		at sun.misc.Unsafe.park(Native Method)
		at java.util.concurrent.locks.LockSupport.park(LockSupport.java:186)
		at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:2043)
		at java.util.concurrent.LinkedBlockingQueue.take(LinkedBlockingQueue.java:442)
		at com.hazelcast.spi.impl.operationexecutor.classic.DefaultScheduleQueue.take(DefaultScheduleQueue.java:79)
		at com.hazelcast.spi.impl.operationexecutor.classic.OperationThread.doRun(OperationThread.java:73)
		at com.hazelcast.spi.impl.operationexecutor.classic.OperationThread.run(OperationThread.java:60)

"hz._hzInstance_2_dev.partition-operation.thread-0" 
	java.lang.Thread.State: WAITING on lock=java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject@568ad4f0
		at sun.misc.Unsafe.park(Native Method)
		at java.util.concurrent.locks.LockSupport.park(LockSupport.java:186)
		at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:2043)
		at java.util.concurrent.LinkedBlockingQueue.take(LinkedBlockingQueue.java:442)
		at com.hazelcast.spi.impl.operationexecutor.classic.DefaultScheduleQueue.take(DefaultScheduleQueue.java:79)
		at com.hazelcast.spi.impl.operationexecutor.classic.OperationThread.doRun(OperationThread.java:73)
		at com.hazelcast.spi.impl.operationexecutor.classic.OperationThread.run(OperationThread.java:60)

"scheduled" 
	java.lang.Thread.State: TIMED_WAITING on lock=java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject@34a204f3
		at sun.misc.Unsafe.park(Native Method)
		at java.util.concurrent.locks.LockSupport.parkNanos(LockSupport.java:226)
		at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.awaitNanos(AbstractQueuedSynchronizer.java:2082)
		at java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue.take(ScheduledThreadPoolExecutor.java:1090)
		at java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue.take(ScheduledThreadPoolExecutor.java:807)
		at java.util.concurrent.ThreadPoolExecutor.getTask(ThreadPoolExecutor.java:1068)
		at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1130)
		at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
		at java.lang.Thread.run(Thread.java:745)
		at com.hazelcast.util.executor.HazelcastManagedThread.executeRun(HazelcastManagedThread.java:76)
		at com.hazelcast.util.executor.HazelcastManagedThread.run(HazelcastManagedThread.java:92)

"hz._hzInstance_1_dev.HealthMonitor" 
	java.lang.Thread.State: TIMED_WAITING
		at java.lang.Thread.sleep(Native Method)
		at com.hazelcast.util.HealthMonitor.run(HealthMonitor.java:129)

"hz._hzInstance_1_dev.migration" 
	java.lang.Thread.State: TIMED_WAITING
		at java.lang.Thread.sleep(Native Method)
		at com.hazelcast.partition.impl.InternalPartitionServiceImpl$MigrationThread.doRun(InternalPartitionServiceImpl.java:1789)
		at com.hazelcast.partition.impl.InternalPartitionServiceImpl$MigrationThread.run(InternalPartitionServiceImpl.java:1754)

"hz._hzInstance_1_dev.wait-notify" 
	java.lang.Thread.State: TIMED_WAITING on lock=java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject@78f30883
		at sun.misc.Unsafe.park(Native Method)
		at java.util.concurrent.locks.LockSupport.parkNanos(LockSupport.java:226)
		at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.awaitNanos(AbstractQueuedSynchronizer.java:2082)
		at java.util.concurrent.DelayQueue.poll(DelayQueue.java:256)
		at com.hazelcast.spi.impl.WaitNotifyServiceImpl$ExpirationTask.doRun(WaitNotifyServiceImpl.java:450)
		at com.hazelcast.spi.impl.WaitNotifyServiceImpl$ExpirationTask.run(WaitNotifyServiceImpl.java:435)
		at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:471)
		at java.util.concurrent.FutureTask.run(FutureTask.java:262)
		at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
		at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
		at java.lang.Thread.run(Thread.java:745)
		at com.hazelcast.util.executor.HazelcastManagedThread.executeRun(HazelcastManagedThread.java:76)
		at com.hazelcast.util.executor.HazelcastManagedThread.run(HazelcastManagedThread.java:92)

"hz._hzInstance_1_dev.event-5" 
	java.lang.Thread.State: WAITING on lock=java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject@1bb40e7e
		at sun.misc.Unsafe.park(Native Method)
		at java.util.concurrent.locks.LockSupport.park(LockSupport.java:186)
		at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:2043)
		at java.util.concurrent.LinkedBlockingQueue.take(LinkedBlockingQueue.java:442)
		at com.hazelcast.util.executor.StripedExecutor$Worker.run(StripedExecutor.java:173)

"hz._hzInstance_1_dev.event-4" 
	java.lang.Thread.State: WAITING on lock=java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject@4a238067
		at sun.misc.Unsafe.park(Native Method)
		at java.util.concurrent.locks.LockSupport.park(LockSupport.java:186)
		at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:2043)
		at java.util.concurrent.LinkedBlockingQueue.take(LinkedBlockingQueue.java:442)
		at com.hazelcast.util.executor.StripedExecutor$Worker.run(StripedExecutor.java:173)

"hz._hzInstance_1_dev.event-3" 
	java.lang.Thread.State: WAITING on lock=java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject@60c31037
		at sun.misc.Unsafe.park(Native Method)
		at java.util.concurrent.locks.LockSupport.park(LockSupport.java:186)
		at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:2043)
		at java.util.concurrent.LinkedBlockingQueue.take(LinkedBlockingQueue.java:442)
		at com.hazelcast.util.executor.StripedExecutor$Worker.run(StripedExecutor.java:173)

"hz._hzInstance_1_dev.event-2" 
	java.lang.Thread.State: WAITING on lock=java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject@265dbc82
		at sun.misc.Unsafe.park(Native Method)
		at java.util.concurrent.locks.LockSupport.park(LockSupport.java:186)
		at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:2043)
		at java.util.concurrent.LinkedBlockingQueue.take(LinkedBlockingQueue.java:442)
		at com.hazelcast.util.executor.StripedExecutor$Worker.run(StripedExecutor.java:173)

"hz._hzInstance_1_dev.event-1" 
	java.lang.Thread.State: WAITING on lock=java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject@54030e7b
		at sun.misc.Unsafe.park(Native Method)
		at java.util.concurrent.locks.LockSupport.park(LockSupport.java:186)
		at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:2043)
		at java.util.concurrent.LinkedBlockingQueue.take(LinkedBlockingQueue.java:442)
		at com.hazelcast.util.executor.StripedExecutor$Worker.run(StripedExecutor.java:173)

"hz._hzInstance_1_dev.CleanupThread" 
	java.lang.Thread.State: TIMED_WAITING
		at java.lang.Thread.sleep(Native Method)
		at com.hazelcast.spi.impl.BasicOperationService$CleanupThread.sleep(BasicOperationService.java:1102)
		at com.hazelcast.spi.impl.BasicOperationService$CleanupThread.run(BasicOperationService.java:1091)

"hz._hzInstance_1_dev.SlowOperationDetectorThread" 
	java.lang.Thread.State: TIMED_WAITING
		at java.lang.Thread.sleep(Native Method)
		at java.lang.Thread.sleep(Thread.java:340)
		at java.util.concurrent.TimeUnit.sleep(TimeUnit.java:360)
		at com.hazelcast.spi.impl.SlowOperationDetector$SlowOperationDetectorThread.sleepInterval(SlowOperationDetector.java:218)
		at com.hazelcast.spi.impl.SlowOperationDetector$SlowOperationDetectorThread.run(SlowOperationDetector.java:122)

"hz._hzInstance_1_dev.response" 
	java.lang.Thread.State: WAITING on lock=java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject@14abd854
		at sun.misc.Unsafe.park(Native Method)
		at java.util.concurrent.locks.LockSupport.park(LockSupport.java:186)
		at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:2043)
		at java.util.concurrent.LinkedBlockingQueue.take(LinkedBlockingQueue.java:442)
		at com.hazelcast.spi.impl.operationexecutor.classic.ResponseThread.doRun(ResponseThread.java:57)
		at com.hazelcast.spi.impl.operationexecutor.classic.ResponseThread.run(ResponseThread.java:46)

"hz._hzInstance_1_dev.generic-operation.thread-1" 
	java.lang.Thread.State: WAITING on lock=java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject@1e077d66
		at sun.misc.Unsafe.park(Native Method)
		at java.util.concurrent.locks.LockSupport.park(LockSupport.java:186)
		at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:2043)
		at java.util.concurrent.LinkedBlockingQueue.take(LinkedBlockingQueue.java:442)
		at com.hazelcast.spi.impl.operationexecutor.classic.DefaultScheduleQueue.take(DefaultScheduleQueue.java:79)
		at com.hazelcast.spi.impl.operationexecutor.classic.OperationThread.doRun(OperationThread.java:73)
		at com.hazelcast.spi.impl.operationexecutor.classic.OperationThread.run(OperationThread.java:60)

"hz._hzInstance_1_dev.generic-operation.thread-0" 
	java.lang.Thread.State: WAITING on lock=java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject@1e077d66
		at sun.misc.Unsafe.park(Native Method)
		at java.util.concurrent.locks.LockSupport.park(LockSupport.java:186)
		at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:2043)
		at java.util.concurrent.LinkedBlockingQueue.take(LinkedBlockingQueue.java:442)
		at com.hazelcast.spi.impl.operationexecutor.classic.DefaultScheduleQueue.take(DefaultScheduleQueue.java:79)
		at com.hazelcast.spi.impl.operationexecutor.classic.OperationThread.doRun(OperationThread.java:73)
		at com.hazelcast.spi.impl.operationexecutor.classic.OperationThread.run(OperationThread.java:60)

"hz._hzInstance_1_dev.partition-operation.thread-3" 
	java.lang.Thread.State: WAITING on lock=java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject@7db9c2f0
		at sun.misc.Unsafe.park(Native Method)
		at java.util.concurrent.locks.LockSupport.park(LockSupport.java:186)
		at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:2043)
		at java.util.concurrent.LinkedBlockingQueue.take(LinkedBlockingQueue.java:442)
		at com.hazelcast.spi.impl.operationexecutor.classic.DefaultScheduleQueue.take(DefaultScheduleQueue.java:79)
		at com.hazelcast.spi.impl.operationexecutor.classic.OperationThread.doRun(OperationThread.java:73)
		at com.hazelcast.spi.impl.operationexecutor.classic.OperationThread.run(OperationThread.java:60)

"hz._hzInstance_1_dev.partition-operation.thread-2" 
	java.lang.Thread.State: WAITING on lock=java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject@2ead5b0c
		at sun.misc.Unsafe.park(Native Method)
		at java.util.concurrent.locks.LockSupport.park(LockSupport.java:186)
		at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:2043)
		at java.util.concurrent.LinkedBlockingQueue.take(LinkedBlockingQueue.java:442)
		at com.hazelcast.spi.impl.operationexecutor.classic.DefaultScheduleQueue.take(DefaultScheduleQueue.java:79)
		at com.hazelcast.spi.impl.operationexecutor.classic.OperationThread.doRun(OperationThread.java:73)
		at com.hazelcast.spi.impl.operationexecutor.classic.OperationThread.run(OperationThread.java:60)

"hz._hzInstance_1_dev.partition-operation.thread-1" 
	java.lang.Thread.State: WAITING on lock=java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject@773488c4
		at sun.misc.Unsafe.park(Native Method)
		at java.util.concurrent.locks.LockSupport.park(LockSupport.java:186)
		at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:2043)
		at java.util.concurrent.LinkedBlockingQueue.take(LinkedBlockingQueue.java:442)
		at com.hazelcast.spi.impl.operationexecutor.classic.DefaultScheduleQueue.take(DefaultScheduleQueue.java:79)
		at com.hazelcast.spi.impl.operationexecutor.classic.OperationThread.doRun(OperationThread.java:73)
		at com.hazelcast.spi.impl.operationexecutor.classic.OperationThread.run(OperationThread.java:60)

"hz._hzInstance_1_dev.partition-operation.thread-0" 
	java.lang.Thread.State: WAITING on lock=java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject@19ff3900
		at sun.misc.Unsafe.park(Native Method)
		at java.util.concurrent.locks.LockSupport.park(LockSupport.java:186)
		at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:2043)
		at java.util.concurrent.LinkedBlockingQueue.take(LinkedBlockingQueue.java:442)
		at com.hazelcast.spi.impl.operationexecutor.classic.DefaultScheduleQueue.take(DefaultScheduleQueue.java:79)
		at com.hazelcast.spi.impl.operationexecutor.classic.OperationThread.doRun(OperationThread.java:73)
		at com.hazelcast.spi.impl.operationexecutor.classic.OperationThread.run(OperationThread.java:60)

"scheduled" 
	java.lang.Thread.State: TIMED_WAITING on lock=java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject@42f73c55
		at sun.misc.Unsafe.park(Native Method)
		at java.util.concurrent.locks.LockSupport.parkNanos(LockSupport.java:226)
		at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.awaitNanos(AbstractQueuedSynchronizer.java:2082)
		at java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue.take(ScheduledThreadPoolExecutor.java:1090)
		at java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue.take(ScheduledThreadPoolExecutor.java:807)
		at java.util.concurrent.ThreadPoolExecutor.getTask(ThreadPoolExecutor.java:1068)
		at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1130)
		at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
		at java.lang.Thread.run(Thread.java:745)
		at com.hazelcast.util.executor.HazelcastManagedThread.executeRun(HazelcastManagedThread.java:76)
		at com.hazelcast.util.executor.HazelcastManagedThread.run(HazelcastManagedThread.java:92)

"Monitor Ctrl-Break" 
	java.lang.Thread.State: RUNNABLE
		at java.net.PlainSocketImpl.socketAccept(Native Method)
		at java.net.AbstractPlainSocketImpl.accept(AbstractPlainSocketImpl.java:398)
		at java.net.ServerSocket.implAccept(ServerSocket.java:530)
		at java.net.ServerSocket.accept(ServerSocket.java:498)
		at com.intellij.rt.execution.application.AppMain$1.run(AppMain.java:85)
		at java.lang.Thread.run(Thread.java:745)

"Signal Dispatcher" 
	java.lang.Thread.State: RUNNABLE

"Finalizer" 
	java.lang.Thread.State: WAITING on lock=java.lang.ref.ReferenceQueue$Lock@759a12cb
		at java.lang.Object.wait(Native Method)
		at java.lang.ref.ReferenceQueue.remove(ReferenceQueue.java:135)
		at java.lang.ref.ReferenceQueue.remove(ReferenceQueue.java:151)
		at java.lang.ref.Finalizer$FinalizerThread.run(Finalizer.java:209)

"Reference Handler" 
	java.lang.Thread.State: WAITING on lock=java.lang.ref.Reference$Lock@564809be
		at java.lang.Object.wait(Native Method)
		at java.lang.Object.wait(Object.java:503)
		at java.lang.ref.Reference$ReferenceHandler.run(Reference.java:133)



java.lang.AssertionError: 
Expected :1
Actual   :0
 <Click to see difference>
	at org.junit.Assert.fail(Assert.java:88)
	at org.junit.Assert.failNotEquals(Assert.java:743)
	at org.junit.Assert.assertEquals(Assert.java:118)
	at org.junit.Assert.assertEquals(Assert.java:555)
	at org.junit.Assert.assertEquals(Assert.java:542)
	at com.hazelcast.cache.JCacheListenerTest.testSyncListener_shouldNotHang_whenCacheDestroyed(JCacheListenerTest.java:270)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:47)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:44)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at com.hazelcast.test.AbstractHazelcastClassRunner$ThreadDumpAwareRunAfters.evaluate(AbstractHazelcastClassRunner.java:122)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:271)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:70)
	at com.hazelcast.test.HazelcastSerialClassRunner.runChild(HazelcastSerialClassRunner.java:37)
	at com.hazelcast.test.HazelcastSerialClassRunner.runChild(HazelcastSerialClassRunner.java:26)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:238)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:63)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:236)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:53)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:229)
	at com.hazelcast.test.AbstractHazelcastClassRunner$1.evaluate(AbstractHazelcastClassRunner.java:171)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:309)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:160)
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:74)
	at com.intellij.rt.execution.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:211)
	at com.intellij.rt.execution.junit.JUnitStarter.main(JUnitStarter.java:67)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
	at com.intellij.rt.execution.application.AppMain.main(AppMain.java:134)

Finished Running Test: JCacheListenerTest.testSyncListener_shouldNotHang_whenCacheDestroyed in 1.863 seconds.
```