### PR TITLE
Fixed partition backup replica handling for member join and removal cond...

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/ServiceConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ServiceConfig.java
@@ -84,6 +84,11 @@ public class ServiceConfig {
         return this;
     }
 
+    public ServiceConfig addProperty(String propertyName, String value) {
+        properties.setProperty(propertyName, value);
+        return this;
+    }
+
     public ServiceConfig setConfigObject(Object configObject) {
         this.configObject = configObject;
         return this;

--- a/hazelcast/src/main/java/com/hazelcast/partition/impl/InternalPartitionImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/impl/InternalPartitionImpl.java
@@ -118,6 +118,15 @@ class InternalPartitionImpl implements InternalPartition {
         return false;
     }
 
+    int getReplicaIndex(Address address) {
+        for (int i = 0; i < MAX_REPLICA_COUNT; i++) {
+            if (address.equals(getReplicaAddress(i))) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
     void reset() {
         addresses = new Address[MAX_REPLICA_COUNT];
         setMigrating(false);

--- a/hazelcast/src/main/java/com/hazelcast/partition/impl/InternalPartitionServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/impl/InternalPartitionServiceImpl.java
@@ -399,7 +399,7 @@ public class InternalPartitionServiceImpl implements InternalPartitionService, M
         }
     }
 
-    private void cancelReplicaSync(int partitionId) {
+    void cancelReplicaSync(int partitionId) {
         ReplicaSyncInfo syncInfo = replicaSyncRequests.get(partitionId);
         if (syncInfo != null && replicaSyncRequests.compareAndSet(partitionId, syncInfo, null)) {
             replicaSyncScheduler.cancel(partitionId);
@@ -928,7 +928,7 @@ public class InternalPartitionServiceImpl implements InternalPartitionService, M
         return node.clusterService.getMember(address);
     }
 
-    private InternalPartitionImpl getPartitionImpl(int partitionId) {
+    InternalPartitionImpl getPartitionImpl(int partitionId) {
         return partitions[partitionId];
     }
 
@@ -1317,13 +1317,15 @@ public class InternalPartitionServiceImpl implements InternalPartitionService, M
     void clearReplicaSync(int partitionId, int replicaIndex) {
         ReplicaSyncInfo syncInfo = new ReplicaSyncInfo(partitionId, replicaIndex, null);
         ReplicaSyncInfo currentSyncInfo = replicaSyncRequests.get(partitionId);
-        replicaSyncScheduler.cancel(partitionId);
 
         if (syncInfo.equals(currentSyncInfo)
                 && replicaSyncRequests.compareAndSet(partitionId, currentSyncInfo, null)) {
+            replicaSyncScheduler.cancel(partitionId);
             finishReplicaSyncProcess();
         } else if (currentSyncInfo != null) {
-            logger.severe(syncInfo + " VS " + currentSyncInfo);
+            if (logger.isFinestEnabled()) {
+                logger.finest("Not able to cancel sync! " + syncInfo + " VS " + currentSyncInfo);
+            }
         }
     }
 
@@ -1844,21 +1846,16 @@ public class InternalPartitionServiceImpl implements InternalPartitionService, M
             if (replicaIndex == 0 && newAddress == null && node.isActive() && node.joined()) {
                 logOwnerOfPartitionIsRemoved(event);
             }
-            if (partitionService.node.isMaster()) {
+            if (node.isMaster()) {
                 partitionService.stateVersion.incrementAndGet();
             }
         }
 
-        private void clearPartition(int partitionId, int replicaIndex) {
-            InternalPartitionImpl partition = partitionService.partitions[partitionId];
-            // not owner or backup, clear partition data
-            if (!partition.isOwnerOrBackup(thisAddress)) {
-                NodeEngine nodeEngine = partitionService.nodeEngine;
-                ClearReplicaOperation op = new ClearReplicaOperation();
-                op.setPartitionId(partitionId).setNodeEngine(nodeEngine).setService(partitionService);
-                nodeEngine.getOperationService().executeOperation(op);
-                partitionService.cancelReplicaSync(partitionId);
-            }
+        private void clearPartition(final int partitionId, final int oldReplicaIndex) {
+            NodeEngine nodeEngine = partitionService.nodeEngine;
+            ClearReplicaOperation op = new ClearReplicaOperation(oldReplicaIndex);
+            op.setPartitionId(partitionId).setNodeEngine(nodeEngine).setService(partitionService);
+            nodeEngine.getOperationService().executeOperation(op);
         }
 
         private void synchronizePartition(int partitionId, int replicaIndex) {
@@ -1907,14 +1904,15 @@ public class InternalPartitionServiceImpl implements InternalPartitionService, M
             for (ScheduledEntry<Integer, ReplicaSyncInfo> entry : entries) {
                 ReplicaSyncInfo syncInfo = entry.getValue();
                 int partitionId = syncInfo.partitionId;
-                ReplicaSyncInfo current = partitionService.replicaSyncRequests.get(partitionId);
-                if (current != null) {
-                    partitionService.logger.warning("Current: " + current + " --- " + "Other: " + syncInfo);
-                }
                 if (partitionService.replicaSyncRequests.compareAndSet(partitionId, syncInfo, null)) {
                     partitionService.finishReplicaSyncProcess();
                 }
-                partitionService.triggerPartitionReplicaSync(partitionId, syncInfo.replicaIndex, 0L);
+
+                InternalPartitionImpl partition = partitionService.getPartitionImpl(partitionId);
+                int currentReplicaIndex = partition.getReplicaIndex(partitionService.node.getThisAddress());
+                if (currentReplicaIndex > 0) {
+                    partitionService.triggerPartitionReplicaSync(partitionId, currentReplicaIndex, 0L);
+                }
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/partition/impl/ReplicaSyncRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/impl/ReplicaSyncRequest.java
@@ -34,6 +34,7 @@ import com.hazelcast.spi.ServiceInfo;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
@@ -107,6 +108,11 @@ public final class ReplicaSyncRequest extends Operation implements PartitionAwar
         }
 
         if (currentVersion == 0) {
+            if (logger.isFinestEnabled()) {
+                logger.finest("Current replica version = 0, sending empty response for partition: "
+                        + getPartitionId() + ", replica: " + getReplicaIndex() + ", versions: "
+                        + Arrays.toString(replicaVersions));
+            }
             sendEmptyResponse();
             return false;
         }

--- a/hazelcast/src/main/java/com/hazelcast/partition/impl/ResetReplicaVersionOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/impl/ResetReplicaVersionOperation.java
@@ -18,12 +18,14 @@ package com.hazelcast.partition.impl;
 
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.partition.InternalPartition;
 import com.hazelcast.partition.InternalPartitionService;
 import com.hazelcast.partition.MigrationCycleOperation;
 import com.hazelcast.spi.AbstractOperation;
 import com.hazelcast.spi.PartitionAwareOperation;
 
 import java.io.IOException;
+import java.util.Arrays;
 
 // runs locally...
 final class ResetReplicaVersionOperation extends AbstractOperation
@@ -34,6 +36,10 @@ final class ResetReplicaVersionOperation extends AbstractOperation
         int partitionId = getPartitionId();
         InternalPartitionService partitionService = getService();
         long[] versions = partitionService.getPartitionReplicaVersions(partitionId);
+        // InternalPartitionService.getPartitionReplicaVersions() returns internal
+        // version array, we need to clone it here
+        versions = Arrays.copyOf(versions, InternalPartition.MAX_BACKUP_COUNT);
+
         // clear and set replica versions back to ensure backup replica does not have
         // version numbers of prior replicas
         partitionService.clearPartitionReplicaVersions(partitionId);

--- a/hazelcast/src/test/java/com/hazelcast/spi/MigrationAwareServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/MigrationAwareServiceTest.java
@@ -1,0 +1,364 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.ServiceConfig;
+import com.hazelcast.core.HazelcastException;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.instance.Node;
+import com.hazelcast.instance.TestUtil;
+import com.hazelcast.partition.MigrationEndpoint;
+import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.LockSupport;
+
+import static com.hazelcast.instance.GroupProperties.PROP_PARTITION_COUNT;
+import static com.hazelcast.instance.GroupProperties.PROP_PARTITION_MAX_PARALLEL_REPLICATIONS;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category(QuickTest.class)
+public class MigrationAwareServiceTest extends HazelcastTestSupport {
+
+    private static final String BACKUP_COUNT_PROP = "backups.count";
+    private static final int PARTITION_COUNT = 271;
+    private static final int PARALLEL_REPLICATIONS = PARTITION_COUNT / 3;
+
+    private TestHazelcastInstanceFactory factory;
+
+    @Before
+    public void setup() {
+        factory = createHazelcastInstanceFactory(10);
+    }
+
+    @Test
+    public void testPartitionDataSize_whenNodesStartedSequentially_withSingleBackup() throws InterruptedException {
+       testPartitionDataSize_whenNodesStartedSequentially(1);
+    }
+
+    @Test
+    public void testPartitionDataSize_whenNodesStartedSequentially_withTwoBackups() throws InterruptedException {
+        testPartitionDataSize_whenNodesStartedSequentially(2);
+    }
+
+    @Test
+    public void testPartitionDataSize_whenNodesStartedSequentially_withThreeBackups() throws InterruptedException {
+        testPartitionDataSize_whenNodesStartedSequentially(3);
+    }
+
+    private void testPartitionDataSize_whenNodesStartedSequentially(int backupCount) throws InterruptedException {
+        Config config = getConfig(backupCount);
+
+        HazelcastInstance hz = factory.newHazelcastInstance(config);
+        fill(hz);
+        assertSize(backupCount);
+
+        for (int i = 1; i < backupCount + 3; i++) {
+            startNodes(config, 1);
+            assertSize(backupCount);
+        }
+    }
+
+    @Test
+    public void testPartitionDataSize_whenNodesStartedParallel_withSingleBackup() throws InterruptedException {
+        testPartitionDataSize_whenNodesStartedParallel(1);
+    }
+
+    @Test
+    public void testPartitionDataSize_whenNodesStartedParallel_withTwoBackups() throws InterruptedException {
+        testPartitionDataSize_whenNodesStartedParallel(2);
+    }
+
+    @Test
+    public void testPartitionDataSize_whenNodesStartedParallel_withThreeBackups() throws InterruptedException {
+        testPartitionDataSize_whenNodesStartedParallel(3);
+    }
+
+    private void testPartitionDataSize_whenNodesStartedParallel(int backupCount) throws InterruptedException {
+        Config config = getConfig(backupCount);
+
+        HazelcastInstance hz = factory.newHazelcastInstance(config);
+        fill(hz);
+        assertSize(backupCount);
+
+        startNodes(config, backupCount + 3);
+        assertSize(backupCount);
+    }
+
+    @Test
+    public void testPartitionDataSize_whenBackupNodesTerminated_withSingleBackup() throws InterruptedException {
+        testPartitionDataSize_whenBackupNodesTerminated(1);
+    }
+
+    @Test
+    public void testPartitionDataSize_whenBackupNodesTerminated_withTwoBackups() throws InterruptedException {
+        testPartitionDataSize_whenBackupNodesTerminated(2);
+    }
+
+    @Test
+    public void testPartitionDataSize_whenBackupNodesTerminated_withThreeBackups() throws InterruptedException {
+        testPartitionDataSize_whenBackupNodesTerminated(3);
+    }
+
+    private void testPartitionDataSize_whenBackupNodesTerminated(int backupCount) throws InterruptedException {
+        Config config = getConfig(backupCount);
+
+        startNodes(config, backupCount + 4);
+        HazelcastInstance hz = factory.getAllHazelcastInstances().iterator().next();
+        fill(hz);
+        assertSize(backupCount);
+
+        terminateNodes(backupCount);
+        assertSize(backupCount);
+    }
+
+    private void fill(HazelcastInstance hz) {
+        NodeEngine nodeEngine = getNode(hz).nodeEngine;
+        for (int i = 0; i < PARTITION_COUNT; i++) {
+            nodeEngine.getOperationService().invokeOnPartition(null, new SamplePutOperation(), i);
+        }
+    }
+
+    private void startNodes(final Config config, int count) throws InterruptedException {
+        if (count == 1) {
+            factory.newHazelcastInstance(config);
+        } else {
+            final CountDownLatch latch = new CountDownLatch(count);
+            for (int i = 0; i < count; i++) {
+                new Thread() {
+                    public void run() {
+                        factory.newHazelcastInstance(config);
+                        latch.countDown();
+                    }
+                }.start();
+            }
+            assertTrue(latch.await(2, TimeUnit.MINUTES));
+        }
+    }
+
+    private void terminateNodes(int count) throws InterruptedException {
+        List<HazelcastInstance> instances = new ArrayList<HazelcastInstance>(factory.getAllHazelcastInstances());
+        Collections.shuffle(instances);
+
+        if (count == 1) {
+            TestUtil.terminateInstance(instances.get(0));
+        } else {
+            int min = Math.min(count, instances.size());
+            final CountDownLatch latch = new CountDownLatch(min);
+
+            for (int i = 0; i < min; i++) {
+                final HazelcastInstance hz = instances.get(i);
+                new Thread() {
+                    public void run() {
+                        TestUtil.terminateInstance(hz);
+                        latch.countDown();
+                    }
+                }.start();
+            }
+            assertTrue(latch.await(2, TimeUnit.MINUTES));
+        }
+    }
+
+    private void assertSize(final int backupCount) {
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                Collection<HazelcastInstance> instances = factory.getAllHazelcastInstances();
+                int expectedSize = PARTITION_COUNT * Math.min(backupCount + 1, instances.size());
+
+                int total = 0;
+                for (HazelcastInstance hz : instances) {
+                    SampleMigrationAwareService service = getService(hz);
+                    total += service.size();
+                }
+                assertEquals(expectedSize, total);
+            }
+        });
+    }
+
+    private SampleMigrationAwareService getService(HazelcastInstance hz) {
+        Node node = getNode(hz);
+        return node.nodeEngine.getService(SampleMigrationAwareService.SERVICE_NAME);
+    }
+
+    private Config getConfig(int backupCount) {
+        Config config = new Config();
+        ServiceConfig serviceConfig = new ServiceConfig()
+                .setEnabled(true).setName(SampleMigrationAwareService.SERVICE_NAME)
+                .setClassName(SampleMigrationAwareService.class.getName())
+                .addProperty(BACKUP_COUNT_PROP, String.valueOf(backupCount));
+
+        config.getServicesConfig().addServiceConfig(serviceConfig);
+        config.setProperty(PROP_PARTITION_COUNT, String.valueOf(PARTITION_COUNT));
+        config.setProperty(PROP_PARTITION_MAX_PARALLEL_REPLICATIONS, String.valueOf(PARALLEL_REPLICATIONS));
+        return config;
+    }
+
+    private static class SampleMigrationAwareService implements ManagedService, MigrationAwareService {
+
+        static final String SERVICE_NAME = "SampleMigrationAwareService";
+
+        private final ConcurrentMap<Integer, Object> data
+                = new ConcurrentHashMap<Integer, Object>();
+
+        private volatile int backupCount;
+        private volatile NodeEngine nodeEngine;
+
+        @Override
+        public void init(NodeEngine nodeEngine, Properties properties) {
+            this.nodeEngine = nodeEngine;
+            backupCount = Integer.parseInt(properties.getProperty(BACKUP_COUNT_PROP, "1"));
+        }
+
+        @Override
+        public void reset() {
+        }
+
+        @Override
+        public void shutdown(boolean terminate) {
+        }
+
+        int size() {
+            return data.size();
+        }
+
+        @Override
+        public Operation prepareReplicationOperation(PartitionReplicationEvent event) {
+            if (event.getReplicaIndex() > backupCount) {
+                return null;
+            }
+            if (!data.containsKey(event.getPartitionId())) {
+                throw new HazelcastException("No data found for " + event);
+            }
+            return new SampleReplicationOperation();
+        }
+
+        @Override
+        public void beforeMigration(PartitionMigrationEvent event) {
+        }
+
+        @Override
+        public void commitMigration(PartitionMigrationEvent event) {
+            if (event.getMigrationEndpoint() == MigrationEndpoint.SOURCE) {
+                data.remove(event.getPartitionId());
+            }
+        }
+
+        @Override
+        public void rollbackMigration(PartitionMigrationEvent event) {
+            if (event.getMigrationEndpoint() == MigrationEndpoint.DESTINATION) {
+                data.remove(event.getPartitionId());
+            }
+        }
+
+        @Override
+        public void clearPartitionReplica(int partitionId) {
+            data.remove(partitionId);
+        }
+    }
+
+    private static class SamplePutOperation extends AbstractOperation implements BackupAwareOperation {
+        @Override
+        public void run() throws Exception {
+            SampleMigrationAwareService service = getService();
+            service.data.put(getPartitionId(), Boolean.TRUE);
+        }
+
+        @Override
+        public boolean shouldBackup() {
+            return true;
+        }
+
+        @Override
+        public int getSyncBackupCount() {
+            SampleMigrationAwareService service = getService();
+            return service.backupCount;
+        }
+
+        @Override
+        public int getAsyncBackupCount() {
+            return 0;
+        }
+
+        @Override
+        public Operation getBackupOperation() {
+            return new SampleBackupPutOperation();
+        }
+
+        @Override
+        public String getServiceName() {
+            return SampleMigrationAwareService.SERVICE_NAME;
+        }
+    }
+
+    private static class SampleBackupPutOperation extends AbstractOperation {
+        @Override
+        public void run() throws Exception {
+            SampleMigrationAwareService service = getService();
+            service.data.put(getPartitionId(), Boolean.TRUE);
+        }
+
+        @Override
+        public String getServiceName() {
+            return SampleMigrationAwareService.SERVICE_NAME;
+        }
+    }
+
+    private static class SampleReplicationOperation extends AbstractOperation {
+
+        public SampleReplicationOperation() {
+        }
+
+        @Override
+        public void run() throws Exception {
+            // artificial latency!
+            randomLatency();
+            SampleMigrationAwareService service = getService();
+            service.data.put(getPartitionId(), Boolean.TRUE);
+        }
+
+        private void randomLatency() {
+            long duration = (long) (Math.random() * 100);
+            LockSupport.parkNanos(TimeUnit.MICROSECONDS.toNanos(duration) + 100);
+        }
+
+        @Override
+        public String getServiceName() {
+            return SampleMigrationAwareService.SERVICE_NAME;
+        }
+    }
+
+}


### PR DESCRIPTION
...itions.

 - When multiple nodes join sequentially after partitions are assigned/distributed, old nodes were failing to clean backup replicas larger than configured backup-count. This was causing a memory leak. See issue #4687.

 - When multiple nodes leave the cluster at the same time (or in a short period), new partition owner was loosing some partition replica versions and this was causing backup nodes for those specific replica-indexes to fail syncing data from owner node, although owner node holds the whole partition data.

 Added MigrationAwareServiceTest to verify all these behaviours.

Fixes #4687 