### PR TITLE
Fix local map stats thread safety problems without breaking the API

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapBasicTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapBasicTest.java
@@ -1089,7 +1089,6 @@ public class ClientMapBasicTest {
     @Test
     public void testMapStatistics_withClientOperations() {
         final String mapName = randomString();
-        final LocalMapStats serverMapStats = server.getMap(mapName).getLocalMapStats();
 
         final IMap map = client.getMap(mapName);
         final int operationCount = 1123;
@@ -1098,6 +1097,8 @@ public class ClientMapBasicTest {
             map.get(i);
             map.remove(i);
         }
+
+        final LocalMapStats serverMapStats = server.getMap(mapName).getLocalMapStats();
 
         assertEquals("put count", operationCount, serverMapStats.getPutOperationCount());
         assertEquals("get count", operationCount, serverMapStats.getGetOperationCount());

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapBasicTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapBasicTest.java
@@ -1089,16 +1089,15 @@ public class ClientMapBasicTest {
     @Test
     public void testMapStatistics_withClientOperations() {
         final String mapName = randomString();
-
         final IMap map = client.getMap(mapName);
+        final LocalMapStats serverMapStats = server.getMap(mapName).getLocalMapStats();
+
         final int operationCount = 1123;
         for (int i = 0; i < operationCount; i++) {
             map.put(i, i);
             map.get(i);
             map.remove(i);
         }
-
-        final LocalMapStats serverMapStats = server.getMap(mapName).getLocalMapStats();
 
         assertEquals("put count", operationCount, serverMapStats.getPutOperationCount());
         assertEquals("get count", operationCount, serverMapStats.getGetOperationCount());

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapTest.java
@@ -845,6 +845,7 @@ public class ClientMapTest {
     public void testMapStatistics() throws Exception {
         String name = randomString();
         final IMap map = client.getMap(name);
+        final LocalMapStats localMapStats = server.getMap(name).getLocalMapStats();
 
         final int operationCount = 1000;
         for (int i = 0; i < operationCount; i++) {
@@ -852,8 +853,6 @@ public class ClientMapTest {
             map.get(i);
             map.remove(i);
         }
-
-        final LocalMapStats localMapStats = server.getMap(name).getLocalMapStats();
 
         assertEquals("put count", operationCount, localMapStats.getPutOperationCount());
         assertEquals("get count", operationCount, localMapStats.getGetOperationCount());

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapTest.java
@@ -844,7 +844,6 @@ public class ClientMapTest {
     @Test
     public void testMapStatistics() throws Exception {
         String name = randomString();
-        final LocalMapStats localMapStats = server.getMap(name).getLocalMapStats();
         final IMap map = client.getMap(name);
 
         final int operationCount = 1000;
@@ -853,6 +852,8 @@ public class ClientMapTest {
             map.get(i);
             map.remove(i);
         }
+
+        final LocalMapStats localMapStats = server.getMap(name).getLocalMapStats();
 
         assertEquals("put count", operationCount, localMapStats.getPutOperationCount());
         assertEquals("get count", operationCount, localMapStats.getGetOperationCount());

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/LocalMapStatsProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/LocalMapStatsProvider.java
@@ -27,8 +27,10 @@ public class LocalMapStatsProvider {
     private static final int WAIT_PARTITION_TABLE_UPDATE_MILLIS = 100;
     private static final int RETRY_COUNT = 3;
 
-    private final ConcurrentMap<String, LocalMapStatsImpl> statsMap = new ConcurrentHashMap<String, LocalMapStatsImpl>(1000);
-    private final ConstructorFunction<String, LocalMapStatsImpl> constructorFunction = new ConstructorFunction<String, LocalMapStatsImpl>() {
+    private final ConcurrentMap<String, LocalMapStatsImpl> statsMap
+            = new ConcurrentHashMap<String, LocalMapStatsImpl>(1000);
+    private final ConstructorFunction<String, LocalMapStatsImpl> constructorFunction
+            = new ConstructorFunction<String, LocalMapStatsImpl>() {
         public LocalMapStatsImpl createNew(String key) {
             return new LocalMapStatsImpl();
         }
@@ -73,8 +75,8 @@ public class LocalMapStatsProvider {
             if (owner.equals(thisAddress)) {
                 addOwnerPartitionStats(localMapStats, localMapOnDemandCalculatedStats, mapName, partitionId);
             } else {
-                addReplicaPartitionStats(localMapOnDemandCalculatedStats, mapName, partitionId, partition, partitionService, backupCount,
-                        thisAddress);
+                addReplicaPartitionStats(localMapOnDemandCalculatedStats, mapName, partitionId,
+                        partition, partitionService, backupCount, thisAddress);
             }
         }
 
@@ -87,7 +89,8 @@ public class LocalMapStatsProvider {
      * Calculates and adds owner partition stats.
      */
     private void addOwnerPartitionStats(LocalMapStatsImpl localMapStats,
-                                        LocalMapOnDemandCalculatedStats localMapOnDemandCalculatedStats, String mapName, int partitionId) {
+                                        LocalMapOnDemandCalculatedStats localMapOnDemandCalculatedStats,
+                                        String mapName, int partitionId) {
         final RecordStore recordStore = getRecordStoreOrNull(mapName, partitionId);
         if (!hasRecords(recordStore)) {
             return;
@@ -137,8 +140,9 @@ public class LocalMapStatsProvider {
     /**
      * Calculates and adds replica partition stats.
      */
-    private void addReplicaPartitionStats(LocalMapOnDemandCalculatedStats localMapOnDemandCalculatedStats, String mapName, int partitionId,
-                                          InternalPartition partition, InternalPartitionService partitionService, int backupCount,
+    private void addReplicaPartitionStats(LocalMapOnDemandCalculatedStats localMapOnDemandCalculatedStats,
+                                          String mapName, int partitionId, InternalPartition partition,
+                                          InternalPartitionService partitionService, int backupCount,
                                           Address thisAddress) {
         long heapCost = 0;
         long backupEntryCount = 0;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/LocalMapStatsProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/LocalMapStatsProvider.java
@@ -51,7 +51,7 @@ public class LocalMapStatsProvider {
     public LocalMapStatsImpl createLocalMapStats(String mapName) {
         final NodeEngine nodeEngine = this.nodeEngine;
         final MapContainer mapContainer = mapServiceContext.getMapContainer(mapName);
-        final LocalMapStatsImpl localMapStats = getLocalMapStatsImpl(mapName);
+        final LocalMapStatsImpl localMapStats = new LocalMapStatsImpl(getLocalMapStatsImpl(mapName));
         if (!mapContainer.getMapConfig().isStatisticsEnabled()) {
             return localMapStats;
         }
@@ -60,7 +60,6 @@ public class LocalMapStatsProvider {
         final InternalPartitionService partitionService = nodeEngine.getPartitionService();
         final Address thisAddress = clusterService.getThisAddress();
 
-        localMapStats.init();
         localMapStats.setBackupCount(backupCount);
         addNearCacheStats(localMapStats, mapContainer);
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/NearCache.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/NearCache.java
@@ -158,6 +158,7 @@ public class NearCache {
     }
 
     private NearCacheStatsImpl createNearCacheStats() {
+        final NearCacheStatsImpl nearCacheStats = new NearCacheStatsImpl(this.nearCacheStats);
         long ownedEntryCount = 0;
         long ownedEntryMemoryCost = 0;
         for (CacheRecord record : cache.values()) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/NearCache.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/NearCache.java
@@ -158,7 +158,6 @@ public class NearCache {
     }
 
     private NearCacheStatsImpl createNearCacheStats() {
-        final NearCacheStatsImpl nearCacheStats = new NearCacheStatsImpl(this.nearCacheStats);
         long ownedEntryCount = 0;
         long ownedEntryMemoryCost = 0;
         for (CacheRecord record : cache.values()) {

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalMapStatsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalMapStatsImpl.java
@@ -77,7 +77,7 @@ public class LocalMapStatsImpl implements LocalMapStats {
     private volatile long maxRemoveLatency;
 
 
-    private long creationTime;
+    private volatile long creationTime;
     private long ownedEntryCount;
     private long backupEntryCount;
     private long ownedEntryMemoryCost;
@@ -96,25 +96,21 @@ public class LocalMapStatsImpl implements LocalMapStats {
         creationTime = Clock.currentTimeMillis();
     }
 
-
-    /**
-     * Only init these fields for every {@link com.hazelcast.map.impl.LocalMapStatsProvider#createLocalMapStats}
-     * call since they represent current map state.
-     * However other fields hold historical data from the creation of a map like {@link #putCount#getCount}
-     * and they should not be touched here.
-     *
-     * @see com.hazelcast.map.impl.LocalMapStatsProvider#createLocalMapStats
-     */
-    public void init() {
-        ownedEntryCount = 0;
-        backupEntryCount = 0;
-        ownedEntryMemoryCost = 0;
-        backupEntryMemoryCost = 0;
-        heapCost = 0;
-        lockedEntryCount = 0;
-        dirtyEntryCount = 0;
-        backupCount = 0;
-        hits = 0;
+    public LocalMapStatsImpl(LocalMapStatsImpl other) {
+        this.creationTime = other.creationTime;
+        this.lastAccessTime = other.lastAccessTime;
+        this.lastUpdateTime = other.lastUpdateTime;
+        this.numberOfOtherOperations = other.numberOfOtherOperations;
+        this.numberOfEvents = other.numberOfEvents;
+        this.getCount = other.getCount;
+        this.putCount = other.putCount;
+        this.removeCount = other.removeCount;
+        this.totalGetLatencies = other.totalGetLatencies;
+        this.totalPutLatencies = other.totalPutLatencies;
+        this.totalRemoveLatencies = other.totalRemoveLatencies;
+        this.maxGetLatency = other.maxGetLatency;
+        this.maxPutLatency = other.maxPutLatency;
+        this.maxRemoveLatency = other.maxRemoveLatency;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalReplicatedMapStatsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalReplicatedMapStatsImpl.java
@@ -81,11 +81,29 @@ public class LocalReplicatedMapStatsImpl
     private volatile long maxPutLatency;
     private volatile long maxRemoveLatency;
 
+    private volatile long creationTime;
     private long ownedEntryCount;
-    private long creationTime;
 
     public LocalReplicatedMapStatsImpl() {
         creationTime = Clock.currentTimeMillis();
+    }
+
+    public LocalReplicatedMapStatsImpl(LocalReplicatedMapStatsImpl other) {
+        this.creationTime = other.creationTime;
+        this.lastAccessTime = other.lastAccessTime;
+        this.lastUpdateTime = other.lastUpdateTime;
+        this.numberOfOtherOperations = other.numberOfOtherOperations;
+        this.numberOfEvents = other.numberOfEvents;
+        this.numberOfReplicationEvents = other.numberOfReplicationEvents;
+        this.getCount = other.getCount;
+        this.putCount = other.putCount;
+        this.removeCount = other.removeCount;
+        this.totalGetLatencies = other.totalGetLatencies;
+        this.totalPutLatencies = other.totalPutLatencies;
+        this.totalRemoveLatencies = other.totalRemoveLatencies;
+        this.maxGetLatency = other.maxGetLatency;
+        this.maxPutLatency = other.maxPutLatency;
+        this.maxRemoveLatency = other.maxRemoveLatency;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalReplicatedMapStatsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalReplicatedMapStatsImpl.java
@@ -82,28 +82,10 @@ public class LocalReplicatedMapStatsImpl
     private volatile long maxRemoveLatency;
 
     private volatile long creationTime;
-    private long ownedEntryCount;
+    private volatile long ownedEntryCount;
 
     public LocalReplicatedMapStatsImpl() {
         creationTime = Clock.currentTimeMillis();
-    }
-
-    public LocalReplicatedMapStatsImpl(LocalReplicatedMapStatsImpl other) {
-        this.creationTime = other.creationTime;
-        this.lastAccessTime = other.lastAccessTime;
-        this.lastUpdateTime = other.lastUpdateTime;
-        this.numberOfOtherOperations = other.numberOfOtherOperations;
-        this.numberOfEvents = other.numberOfEvents;
-        this.numberOfReplicationEvents = other.numberOfReplicationEvents;
-        this.getCount = other.getCount;
-        this.putCount = other.putCount;
-        this.removeCount = other.removeCount;
-        this.totalGetLatencies = other.totalGetLatencies;
-        this.totalPutLatencies = other.totalPutLatencies;
-        this.totalRemoveLatencies = other.totalRemoveLatencies;
-        this.maxGetLatency = other.maxGetLatency;
-        this.maxPutLatency = other.maxPutLatency;
-        this.maxRemoveLatency = other.maxRemoveLatency;
     }
 
     @Override
@@ -131,23 +113,23 @@ public class LocalReplicatedMapStatsImpl
 
     @Override
     public void fromJson(JsonObject json) {
-        GET_COUNT_UPDATER.set(this, getLong(json, "getCount", -1L));
-        PUT_COUNT_UPDATER.set(this, getLong(json, "putCount", -1L));
-        REMOVE_COUNT_UPDATER.set(this, getLong(json, "removeCount", -1L));
-        NUMBER_OF_OTHER_OPERATIONS_UPDATER.set(this, getLong(json, "numberOfOtherOperations", -1L));
-        NUMBER_OF_EVENTS_UPDATER.set(this, getLong(json, "numberOfEvents", -1L));
-        NUMBER_OF_REPLICATION_EVENTS_UPDATER.set(this, getLong(json, "numberOfReplicationEvents", -1L));
-        LAST_ACCESS_TIME_UPDATER.set(this, getLong(json, "lastAccessTime", -1L));
-        LAST_UPDATE_TIME_UPDATER.set(this, getLong(json, "lastUpdateTime", -1L));
-        HITS_UPDATER.set(this, getLong(json, "hits", -1L));
+        getCount = getLong(json, "getCount", -1L);
+        putCount = getLong(json, "putCount", -1L);
+        removeCount = getLong(json, "removeCount", -1L);
+        numberOfOtherOperations = getLong(json, "numberOfOtherOperations", -1L);
+        numberOfEvents = getLong(json, "numberOfEvents", -1L);
+        numberOfReplicationEvents = getLong(json, "numberOfReplicationEvents", -1L);
+        lastAccessTime = getLong(json, "lastAccessTime", -1L);
+        lastUpdateTime = getLong(json, "lastUpdateTime", -1L);
+        hits = getLong(json, "hits", -1L);
         ownedEntryCount = getLong(json, "ownedEntryCount", -1L);
         creationTime = getLong(json, "creationTime", -1L);
-        TOTAL_GET_LATENCIES_UPDATER.set(this, getLong(json, "totalGetLatencies", -1L));
-        TOTAL_PUT_LATENCIES_UPDATER.set(this, getLong(json, "totalPutLatencies", -1L));
-        TOTAL_REMOVE_LATENCIES_UPDATER.set(this, getLong(json, "totalRemoveLatencies", -1L));
-        MAX_GET_LATENCY_UPDATER.set(this, getLong(json, "maxGetLatency", -1L));
-        MAX_PUT_LATENCY_UPDATER.set(this, getLong(json, "maxPutLatency", -1L));
-        MAX_REMOVE_LATENCY_UPDATER.set(this, getLong(json, "maxRemoveLatency", -1L));
+        totalGetLatencies = getLong(json, "totalGetLatencies", -1L);
+        totalPutLatencies = getLong(json, "totalPutLatencies", -1L);
+        totalRemoveLatencies = getLong(json, "totalRemoveLatencies", -1L);
+        maxGetLatency = getLong(json, "maxGetLatency", -1L);
+        maxPutLatency = getLong(json, "maxPutLatency", -1L);
+        maxRemoveLatency = getLong(json, "maxRemoveLatency", -1L);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/NearCacheStatsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/NearCacheStatsImpl.java
@@ -17,7 +17,7 @@ public class NearCacheStatsImpl
             .newUpdater(NearCacheStatsImpl.class, "misses");
     private long ownedEntryCount;
     private long ownedEntryMemoryCost;
-    private long creationTime;
+    private volatile long creationTime;
 
     // These fields are only accessed through the updaters
     private volatile long hits;
@@ -25,6 +25,12 @@ public class NearCacheStatsImpl
 
     public NearCacheStatsImpl() {
         this.creationTime = Clock.currentTimeMillis();
+    }
+
+    public NearCacheStatsImpl(NearCacheStatsImpl other) {
+        this.creationTime = other.creationTime;
+        this.hits = other.hits;
+        this.misses = other.misses;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/NearCacheStatsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/NearCacheStatsImpl.java
@@ -15,8 +15,8 @@ public class NearCacheStatsImpl
             .newUpdater(NearCacheStatsImpl.class, "hits");
     private static final AtomicLongFieldUpdater<NearCacheStatsImpl> MISSES_UPDATER = AtomicLongFieldUpdater
             .newUpdater(NearCacheStatsImpl.class, "misses");
-    private long ownedEntryCount;
-    private long ownedEntryMemoryCost;
+    private volatile long ownedEntryCount;
+    private volatile long ownedEntryMemoryCost;
     private volatile long creationTime;
 
     // These fields are only accessed through the updaters
@@ -25,12 +25,6 @@ public class NearCacheStatsImpl
 
     public NearCacheStatsImpl() {
         this.creationTime = Clock.currentTimeMillis();
-    }
-
-    public NearCacheStatsImpl(NearCacheStatsImpl other) {
-        this.creationTime = other.creationTime;
-        this.hits = other.hits;
-        this.misses = other.misses;
     }
 
     @Override
@@ -100,8 +94,8 @@ public class NearCacheStatsImpl
         ownedEntryCount = getLong(json, "ownedEntryCount", -1L);
         ownedEntryMemoryCost = getLong(json, "ownedEntryMemoryCost", -1L);
         creationTime = getLong(json, "creationTime", -1L);
-        HITS_UPDATER.set(this, getLong(json, "hits", -1L));
-        MISSES_UPDATER.set(this, getLong(json, "misses", -1L));
+        hits = getLong(json, "hits", -1L);
+        misses = getLong(json, "misses", -1L);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/AbstractBaseReplicatedRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/AbstractBaseReplicatedRecordStore.java
@@ -124,7 +124,7 @@ abstract class AbstractBaseReplicatedRecordStore<K, V>
     }
 
     public LocalReplicatedMapStats createReplicatedMapStats() {
-        LocalReplicatedMapStatsImpl stats = mapStats;
+        LocalReplicatedMapStatsImpl stats = new LocalReplicatedMapStatsImpl(getReplicatedMapStats());
         stats.setOwnedEntryCount(storage.size());
 
         List<ReplicatedRecord<K, V>> records = new ArrayList<ReplicatedRecord<K, V>>(storage.values());

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/AbstractBaseReplicatedRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/AbstractBaseReplicatedRecordStore.java
@@ -124,7 +124,7 @@ abstract class AbstractBaseReplicatedRecordStore<K, V>
     }
 
     public LocalReplicatedMapStats createReplicatedMapStats() {
-        LocalReplicatedMapStatsImpl stats = new LocalReplicatedMapStatsImpl(getReplicatedMapStats());
+        LocalReplicatedMapStatsImpl stats = getReplicatedMapStats();
         stats.setOwnedEntryCount(storage.size());
 
         List<ReplicatedRecord<K, V>> records = new ArrayList<ReplicatedRecord<K, V>>(storage.values());

--- a/hazelcast/src/test/java/com/hazelcast/map/LocalMapStatsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/LocalMapStatsTest.java
@@ -14,6 +14,7 @@ import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.util.Clock;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -28,37 +29,55 @@ import static org.junit.Assert.assertTrue;
 @Category(QuickTest.class)
 public class LocalMapStatsTest extends HazelcastTestSupport {
 
-    private final String name = "fooMap";
-
     @Test
-    public void testPutAndGetExpectHitsGenerated() throws Exception {
+    public void testHitsGenerated() throws Exception {
         HazelcastInstance h1 = createHazelcastInstance();
-        IMap<Integer, Integer> map = h1.getMap("hits");
+        IMap<Integer, Integer> map = h1.getMap(randomMapName());
         for (int i = 0; i < 100; i++) {
             map.put(i, i);
             map.get(i);
         }
         LocalMapStats localMapStats = map.getLocalMapStats();
         assertEquals(100, localMapStats.getHits());
-        assertEquals(100, localMapStats.getPutOperationCount());
-        assertEquals(100, localMapStats.getGetOperationCount());
     }
 
     @Test
-    public void testPutAndGetExpectHitsGenerated_updatedConcurrently() throws Exception {
+    public void testPutAndHitsGenerated() throws Exception {
         HazelcastInstance h1 = createHazelcastInstance();
-        final IMap<Integer, Integer> map = h1.getMap("hits");
+        IMap<Integer, Integer> map = h1.getMap(randomMapName());
+        for (int i = 0; i < 100; i++) {
+            map.put(i, i);
+            map.get(i);
+        }
+        LocalMapStats localMapStats = map.getLocalMapStats();
+        assertEquals(100, localMapStats.getPutOperationCount());
+        assertEquals(100, localMapStats.getHits());
+    }
+
+    @Test
+    public void testGetAndHitsGenerated() throws Exception {
+        HazelcastInstance h1 = createHazelcastInstance();
+        IMap<Integer, Integer> map = h1.getMap(randomMapName());
+        for (int i = 0; i < 100; i++) {
+            map.put(i, i);
+            map.get(i);
+        }
+        LocalMapStats localMapStats = map.getLocalMapStats();
+        assertEquals(100, localMapStats.getGetOperationCount());
+        assertEquals(100, localMapStats.getHits());
+    }
+
+    @Test
+    public void testHitsGenerated_updatedConcurrently() throws Exception {
+        HazelcastInstance h1 = createHazelcastInstance();
+        final IMap<Integer, Integer> map = h1.getMap(randomMapName());
         final int actionCount = 100;
         for (int i = 0; i < actionCount; i++) {
             map.put(i, i);
             map.get(i);
         }
         LocalMapStats localMapStats = map.getLocalMapStats();
-
-        assertEquals(actionCount, localMapStats.getHits());
-        assertEquals(actionCount, localMapStats.getPutOperationCount());
-        assertEquals(actionCount, localMapStats.getGetOperationCount());
-
+        final long initialHits = localMapStats.getHits();
 
         final Thread updatingThread = new Thread(new Runnable() {
             @Override
@@ -73,6 +92,7 @@ public class LocalMapStatsTest extends HazelcastTestSupport {
         updatingThread.start();
         updatingThread.join();
 
+        assertEquals(actionCount, initialHits);
         assertEquals(actionCount * 2, localMapStats.getHits());
     }
 
@@ -82,7 +102,7 @@ public class LocalMapStatsTest extends HazelcastTestSupport {
         final long startTime = timeUnit.toMillis(System.nanoTime());
 
         HazelcastInstance h1 = createHazelcastInstance();
-        IMap<String, String> map1 = h1.getMap(name);
+        IMap<String, String> map1 = h1.getMap(randomMapName());
 
         String key = "key";
         map1.put(key, "value");
@@ -98,18 +118,16 @@ public class LocalMapStatsTest extends HazelcastTestSupport {
 
     @Test
     public void testLastAccessTime_updatedConcurrently() throws InterruptedException {
-        final TimeUnit timeUnit = TimeUnit.NANOSECONDS;
-        final long startTime = timeUnit.toMillis(System.nanoTime());
+        final long startTime = Clock.currentTimeMillis();
 
         final HazelcastInstance h1 = createHazelcastInstance();
-        final IMap<String, String> map1 = h1.getMap(name);
+        final IMap<String, String> map1 = h1.getMap(randomMapName());
 
         final String key = "key";
         map1.put(key, "value");
 
         final LocalMapStats localMapStats = map1.getLocalMapStats();
         final long lastUpdateTime = localMapStats.getLastUpdateTime();
-        assertTrue(lastUpdateTime >= startTime);
 
         final Thread updatingThread = new Thread(new Runnable() {
             @Override
@@ -122,16 +140,15 @@ public class LocalMapStatsTest extends HazelcastTestSupport {
         updatingThread.start();
         updatingThread.join();
 
-        Thread.sleep(5);
-
         long lastUpdateTime2 = localMapStats.getLastUpdateTime();
+        assertTrue(lastUpdateTime >= startTime);
         assertTrue(lastUpdateTime2 > lastUpdateTime);
     }
 
     @Test
     public void testEvictAll() throws Exception {
         HazelcastInstance h1 = createHazelcastInstance();
-        IMap<String, String> map = h1.getMap(name);
+        IMap<String, String> map = h1.getMap(randomMapName());
         map.put("key", "value");
         map.evictAll();
 


### PR DESCRIPTION
 * This change has an effect on the API.
 * Before this fix, a LocalMapStats object returned to the user is effected from subsequent map operations.
 * After this fix, stats objects are snapshots and not-updated after returned to the user.

 Fixes #4497