### PR TITLE
Fixing HAZELCAST_HOME. Home directory is parent of script directory.

### DIFF
--- a/hazelcast/src/main/resources/server.sh
+++ b/hazelcast/src/main/resources/server.sh
@@ -2,7 +2,7 @@
 
 PRG="$0"
 PRGDIR=`dirname "$PRG"`
-HAZELCAST_HOME=../$PRGDIR
+HAZELCAST_HOME=$PRGDIR/..
 
 if [ $JAVA_HOME ]
 then


### PR DESCRIPTION
The home directory is not set correctly in server.sh.

PRGDIR is set to `<hazelcastRoot>/bin`, so the home directory should be `$PRGDIR/..`.