### PR TITLE
Improved OperationService termination

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/instance/Node.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/Node.java
@@ -66,6 +66,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static com.hazelcast.instance.NodeShutdownHelper.shutdownNodeByFiringEvents;
@@ -402,7 +403,13 @@ public class Node {
             connectionManager.shutdown();
 
             logger.info("Shutting down node engine...");
-            nodeEngine.shutdown(terminate);
+            try {
+                nodeEngine.shutdown(terminate);
+            } catch (TimeoutException e) {
+                logger.warning("Failed do terminate NodeEngine due to a timeout");
+            } catch (InterruptedException e) {
+                logger.warning("Failed do terminate NodeEngine, the calling thread was interrupted");
+            }
 
             if (securityContext != null) {
                 securityContext.destroy();

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalOperationStatsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalOperationStatsImpl.java
@@ -21,7 +21,7 @@ import com.eclipsesource.json.JsonObject;
 import com.hazelcast.instance.Node;
 import com.hazelcast.monitor.LocalOperationStats;
 import com.hazelcast.spi.impl.InternalOperationService;
-import com.hazelcast.spi.impl.SlowOperationLog;
+import com.hazelcast.spi.impl.slowoperationdetector.SlowOperationLog;
 
 import java.util.Collection;
 import java.util.concurrent.ConcurrentLinkedQueue;

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/BasicOperationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/BasicOperationService.java
@@ -1141,12 +1141,17 @@ public final class BasicOperationService implements InternalOperationService {
             }
 
             for (BasicInvocation invocation : invocations.values()) {
+                if(shutdown){
+                    return;
+                }
+
                 try {
                     invocation.handleOperationTimeout();
                 } catch (Throwable t) {
                     inspectOutputMemoryError(t);
                     logger.severe("Failed to handle operation timeout of invocation:" + invocation, t);
                 }
+
                 try {
                     invocation.handleBackupTimeout(backupOperationTimeoutMillis);
                 } catch (Throwable t) {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/BasicOperationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/BasicOperationService.java
@@ -55,6 +55,8 @@ import com.hazelcast.spi.impl.operationexecutor.OperationRunnerFactory;
 import com.hazelcast.spi.impl.operationexecutor.OperationRunner;
 import com.hazelcast.spi.impl.operationexecutor.ResponsePacketHandler;
 import com.hazelcast.spi.impl.operationexecutor.classic.ClassicOperationExecutor;
+import com.hazelcast.spi.impl.slowoperationdetector.SlowOperationDetector;
+import com.hazelcast.spi.impl.slowoperationdetector.SlowOperationLog;
 import com.hazelcast.util.EmptyStatement;
 import com.hazelcast.util.ExceptionUtil;
 import com.hazelcast.util.executor.ExecutorType;
@@ -72,6 +74,7 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Level;
 
@@ -81,6 +84,7 @@ import static com.hazelcast.spi.OperationAccessor.setCallId;
 import static com.hazelcast.spi.OperationAccessor.setCallerAddress;
 import static com.hazelcast.spi.OperationAccessor.setConnection;
 import static com.hazelcast.spi.impl.ResponseHandlerFactory.setRemoteResponseHandler;
+import static com.hazelcast.util.ThreadUtil.awaitTermination;
 import static java.lang.Math.min;
 
 /**
@@ -105,7 +109,9 @@ import static java.lang.Math.min;
  * @see com.hazelcast.spi.impl.BasicPartitionInvocation
  * @see com.hazelcast.spi.impl.BasicTargetInvocation
  */
-final class BasicOperationService implements InternalOperationService {
+public final class BasicOperationService implements InternalOperationService {
+
+    public static final long TERMINATION_TIMEOUT_MS = TimeUnit.SECONDS.toMillis(3);
 
     private static final int INITIAL_CAPACITY = 1000;
     private static final float LOAD_FACTOR = 0.75f;
@@ -131,8 +137,7 @@ final class BasicOperationService implements InternalOperationService {
     private final OperationBackupHandler operationBackupHandler;
     private final BasicBackPressureService backPressureService;
     private final SlowOperationDetector slowOperationDetector;
-
-    private volatile boolean shutdown;
+    private final CleanupThread cleanupThread;
 
     BasicOperationService(NodeEngineImpl nodeEngine) {
         this.nodeEngine = nodeEngine;
@@ -166,12 +171,13 @@ final class BasicOperationService implements InternalOperationService {
         this.slowOperationDetector = new SlowOperationDetector(operationExecutor.getGenericOperationRunners(),
                 operationExecutor.getPartitionOperationRunners(), node.groupProperties, node.getHazelcastThreadGroup());
 
-        startCleanupThread();
+        this.cleanupThread = initCleanupThread();
     }
 
-    private void startCleanupThread() {
+    private CleanupThread initCleanupThread() {
         CleanupThread t = new CleanupThread();
         t.start();
+        return t;
     }
 
     @Override
@@ -499,8 +505,7 @@ final class BasicOperationService implements InternalOperationService {
     }
 
     @Override
-    public void shutdown() {
-        shutdown = true;
+    public void shutdown() throws InterruptedException, TimeoutException {
         logger.finest("Stopping operation threads...");
         for (BasicInvocation invocation : invocations.values()) {
             try {
@@ -510,8 +515,14 @@ final class BasicOperationService implements InternalOperationService {
             }
         }
         invocations.clear();
+
         operationExecutor.shutdown();
         slowOperationDetector.shutdown();
+        cleanupThread.shutdown();
+
+        operationExecutor.awaitTermination(TERMINATION_TIMEOUT_MS);
+        slowOperationDetector.awaitTermination(TERMINATION_TIMEOUT_MS);
+        awaitTermination(TERMINATION_TIMEOUT_MS, cleanupThread);
     }
 
     /**
@@ -1090,6 +1101,8 @@ final class BasicOperationService implements InternalOperationService {
 
         public static final int DELAY_MILLIS = 1000;
 
+        private volatile boolean shutdown;
+
         private CleanupThread() {
             super(node.getHazelcastThreadGroup().getThreadNamePrefix("CleanupThread"));
         }
@@ -1102,11 +1115,15 @@ final class BasicOperationService implements InternalOperationService {
                     backPressureService.cleanup();
                     sleep();
                 }
-
             } catch (Throwable t) {
                 inspectOutputMemoryError(t);
                 logger.severe("Failed to run", t);
             }
+        }
+
+        private void shutdown() {
+            shutdown = true;
+            interrupt();
         }
 
         private void sleep() {
@@ -1139,5 +1156,4 @@ final class BasicOperationService implements InternalOperationService {
             }
         }
     }
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/InternalOperationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/InternalOperationService.java
@@ -21,8 +21,10 @@ import com.hazelcast.nio.Address;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.OperationService;
 import com.hazelcast.spi.impl.operationexecutor.OperationExecutor;
+import com.hazelcast.spi.impl.slowoperationdetector.SlowOperationLog;
 
 import java.util.Collection;
+import java.util.concurrent.TimeoutException;
 
 /**
  * This is the interface that needs to be implemented by actual InternalOperationService. Currently there is a single
@@ -69,7 +71,7 @@ public interface InternalOperationService extends OperationService {
     /**
      * Returns information about long running operations.
      * <p/>
-     * Do not modify this collection, because it is the original data structure used by the {@link SlowOperationDetector}.
+     * Do not modify this collection.
      *
      * @return collection of long running operation logs.
      */
@@ -84,5 +86,5 @@ public interface InternalOperationService extends OperationService {
     /**
      * Shuts down this InternalOperationService.
      */
-    void shutdown();
+    void shutdown() throws InterruptedException, TimeoutException;
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
@@ -49,6 +49,7 @@ import com.hazelcast.wan.WanReplicationService;
 
 import java.util.Collection;
 import java.util.LinkedList;
+import java.util.concurrent.TimeoutException;
 
 public class NodeEngineImpl implements NodeEngine {
 
@@ -309,7 +310,7 @@ public class NodeEngineImpl implements NodeEngine {
     }
 
     @PrivateApi
-    public void shutdown(final boolean terminate) {
+    public void shutdown(final boolean terminate) throws TimeoutException, InterruptedException {
         logger.finest("Shutting down services...");
         waitNotifyService.shutdown();
         proxyService.shutdown();

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/OperationExecutor.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/OperationExecutor.java
@@ -4,18 +4,20 @@ import com.hazelcast.nio.Packet;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.impl.PartitionSpecificRunnable;
 
+import java.util.concurrent.TimeoutException;
+
 /**
  * The OperationExecutor is responsible for scheduling work (packets/operations) to be executed. It can be compared
  * to a {@link java.util.concurrent.Executor} with the big difference that it is designed for assigning packets,
  * operations and PartitionSpecificRunnable to a thread instead of only runnables.
- *
+ * <p/>
  * It depends on the implementation if an operation is executed on the calling thread or not. For example the
  * {@link com.hazelcast.spi.impl.operationexecutor.classic.ClassicOperationExecutor} will always offload a partition specific
  * Operation to the correct partition-operation-thread.
- *
+ * <p/>
  * The actual processing of a operation-packet, Operation, or a PartitionSpecificRunnable is forwarded to the
  * {@link OperationRunner}.
- *
+ * <p/>
  * In case of a response packet, the {@link ResponsePacketHandler} is used to handle the response.
  */
 public interface OperationExecutor {
@@ -142,4 +144,13 @@ public interface OperationExecutor {
      */
     void shutdown();
 
+    /**
+     * Awaits for this OperationExecutor to be fully terminated.
+     * <p/>
+     * Normally this method is called by the same thread that calls {@link #shutdown()}
+     *
+     * @throws java.lang.InterruptedException if the thread is interrupted while waiting.
+     * @throws java.util.concurrent.TimeoutException if the thread didn't manage to complete within the given timeout.
+     */
+    void awaitTermination(long timeoutMs) throws InterruptedException, TimeoutException;
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/package-info.java
@@ -15,6 +15,10 @@
  */
 
 /**
- * Contains the {@link com.hazelcast.spi.impl.operationexecutor.OperationRunner} code.
+ * Contains the logic for executing/running Operations.
+ *
+ * This logic has been pulled out of the {@link com.hazelcast.spi.OperationService} so you get a separation of concerns. The
+ * actual processing can be done there, while the assignment of an operation to a thread is the responsibility of the
+ * {@link com.hazelcast.spi.impl.operationexecutor.OperationExecutor}.
  */
 package com.hazelcast.spi.impl.operationexecutor;

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/slowoperationdetector/SlowOperationLog.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/slowoperationdetector/SlowOperationLog.java
@@ -14,13 +14,12 @@
  * limitations under the License.
  */
 
-package com.hazelcast.spi.impl;
+package com.hazelcast.spi.impl.slowoperationdetector;
 
 import com.eclipsesource.json.JsonArray;
 import com.eclipsesource.json.JsonObject;
 import com.eclipsesource.json.JsonValue;
 import com.hazelcast.management.JsonSerializable;
-import com.hazelcast.util.ConcurrencyUtil;
 import com.hazelcast.util.ConstructorFunction;
 
 import java.util.Collection;
@@ -28,6 +27,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 
+import static com.hazelcast.util.ConcurrencyUtil.getOrPutIfAbsent;
 import static com.hazelcast.util.JsonUtil.getArray;
 import static com.hazelcast.util.JsonUtil.getInt;
 import static com.hazelcast.util.JsonUtil.getLong;
@@ -98,7 +98,7 @@ public final class SlowOperationLog implements JsonSerializable {
     Invocation getOrCreateInvocation(int operationHashCode, long lastDurationNanos, long nowNanos, long nowMillis) {
         totalInvocations++;
 
-        Invocation invocation = ConcurrencyUtil.getOrPutIfAbsent(invocations, operationHashCode, INVOCATION_CONSTRUCTOR_FUNCTION);
+        Invocation invocation = getOrPutIfAbsent(invocations, operationHashCode, INVOCATION_CONSTRUCTOR_FUNCTION);
         invocation.id = operationHashCode;
         invocation.startedAt = nowMillis - invocation.durationNanos;
         invocation.durationNanos = TimeUnit.NANOSECONDS.toMillis(lastDurationNanos);
@@ -124,9 +124,9 @@ public final class SlowOperationLog implements JsonSerializable {
         StringBuilder sb = new StringBuilder();
 
         sb.append("SlowOperationLog{operation='").append(operation)
-          .append("', stackTrace='").append(stackTrace)
-          .append("', totalInvocations=").append(totalInvocations)
-          .append(", invocations='");
+                .append("', stackTrace='").append(stackTrace)
+                .append("', totalInvocations=").append(totalInvocations)
+                .append(", invocations='");
 
         String prefix = "";
         for (Invocation log : invocations.values()) {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/slowoperationdetector/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/slowoperationdetector/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * Contains functionality for the SlowOperationDetector.
+ *
+ * The SlowOperationDetector scans the generic and partition {@link com.hazelcast.spi.impl.operationexecutor.OperationRunner}
+ * instances and detects which operations have been running for a too long period.
+ */
+package com.hazelcast.spi.impl.slowoperationdetector;

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/slowoperationdetector/SlowOperationDetectorAbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/slowoperationdetector/SlowOperationDetectorAbstractTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.hazelcast.spi.impl;
+package com.hazelcast.spi.impl.slowoperationdetector;
 
 import com.eclipsesource.json.JsonArray;
 import com.eclipsesource.json.JsonObject;
@@ -29,6 +29,9 @@ import com.hazelcast.map.EntryBackupProcessor;
 import com.hazelcast.map.EntryProcessor;
 import com.hazelcast.monitor.TimedMemberState;
 import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.impl.BasicOperationService;
+import com.hazelcast.spi.impl.InternalOperationService;
+import com.hazelcast.spi.impl.slowoperationdetector.SlowOperationLog;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/slowoperationdetector/SlowOperationDetectorBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/slowoperationdetector/SlowOperationDetectorBasicTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.hazelcast.spi.impl;
+package com.hazelcast.spi.impl.slowoperationdetector;
 
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
@@ -23,6 +23,7 @@ import com.hazelcast.instance.GroupProperties;
 import com.hazelcast.instance.TestUtil;
 import com.hazelcast.spi.AbstractOperation;
 import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.impl.PartitionSpecificRunnable;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.SlowTest;
 import org.junit.Test;

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/slowoperationdetector/SlowOperationDetector_EntryProcessorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/slowoperationdetector/SlowOperationDetector_EntryProcessorTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.hazelcast.spi.impl;
+package com.hazelcast.spi.impl.slowoperationdetector;
 
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/slowoperationdetector/SlowOperationDetector_jsonTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/slowoperationdetector/SlowOperationDetector_jsonTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.hazelcast.spi.impl;
+package com.hazelcast.spi.impl.slowoperationdetector;
 
 import com.eclipsesource.json.JsonArray;
 import com.eclipsesource.json.JsonObject;

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/slowoperationdetector/SlowOperationDetector_purgeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/slowoperationdetector/SlowOperationDetector_purgeTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.hazelcast.spi.impl;
+package com.hazelcast.spi.impl.slowoperationdetector;
 
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
@@ -22,24 +22,32 @@ import com.hazelcast.core.IMap;
 import com.hazelcast.instance.GroupProperties;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.SlowTest;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.util.Collection;
+import java.util.concurrent.TimeoutException;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category(SlowTest.class)
 public class SlowOperationDetector_purgeTest extends SlowOperationDetectorAbstractTest {
 
-    @Test
-    public void testPurging() {
+    private HazelcastInstance instance;
+
+    @Before
+    public void setup(){
         Config config = new Config();
         config.setProperty(GroupProperties.PROP_SLOW_OPERATION_DETECTOR_THRESHOLD_MILLIS, "1000");
         config.setProperty(GroupProperties.PROP_SLOW_OPERATION_DETECTOR_LOG_RETENTION_SECONDS, "3");
         config.setProperty(GroupProperties.PROP_SLOW_OPERATION_DETECTOR_LOG_PURGE_INTERVAL_SECONDS, "1");
 
-        HazelcastInstance instance = getSingleNodeCluster(config);
+        instance = getSingleNodeCluster(config);
+    }
+
+    @Test
+    public void testPurging() throws InterruptedException, TimeoutException {
         IMap<String, String> map = getMapWithSingleElement(instance);
 
         // all of these entry processors are executed after each other, not in parallel


### PR DESCRIPTION
Fixes #4757

The BasicOperationService was termination its threads too slowly, and this can lead to unexpected behavior when terminating and starting instances.

This pr contains a cleanup of the termination of OperationService cleanupthread, slow operation detector and operation executor. Also the SlowOperationDetector was moved to its own package to reduce the amount of noise.