### PR TITLE
fixes #4750. Membership events are ordered via client uuid used as key. 

### DIFF
--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/impl/ClusterAuthenticator.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/impl/ClusterAuthenticator.java
@@ -37,7 +37,7 @@ public class ClusterAuthenticator implements Authenticator {
     @Override
     public void authenticate(ClientConnection connection) throws AuthenticationException, IOException {
         final ClientClusterServiceImpl clusterService = (ClientClusterServiceImpl) client.getClientClusterService();
-        final ClientPrincipal principal = clusterService.getClusterListenerSupport().getPrincipal();
+        final ClientPrincipal principal = clusterService.getPrincipal();
         final SerializationService ss = client.getSerializationService();
         AuthenticationRequest auth = new AuthenticationRequest(credentials, principal);
         connection.init();

--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/spi/ClientClusterService.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/spi/ClientClusterService.java
@@ -90,4 +90,11 @@ public interface ClientClusterService {
      */
     boolean removeMembershipListener(String registrationId);
 
+    /**
+     * Owner connection is opened to owner member of the client in the cluster.
+     * If owner member dies, other members of the cluster assumes this client dead.
+     *
+     * @return address of owner connection
+     */
+    Address getOwnerConnectionAddress();
 }

--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/spi/impl/ClientNonSmartInvocationServiceImpl.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/spi/impl/ClientNonSmartInvocationServiceImpl.java
@@ -2,6 +2,7 @@ package com.hazelcast.client.spi.impl;
 
 import com.hazelcast.client.connection.nio.ClientConnection;
 import com.hazelcast.client.impl.HazelcastClientInstanceImpl;
+import com.hazelcast.client.spi.ClientClusterService;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.Connection;
 
@@ -9,14 +10,9 @@ import java.io.IOException;
 
 public class ClientNonSmartInvocationServiceImpl extends ClientInvocationServiceSupport {
 
-    private final ClusterListenerSupport clusterListenerSupport;
-
     public ClientNonSmartInvocationServiceImpl(HazelcastClientInstanceImpl client) {
         super(client);
-        final ClientClusterServiceImpl clusterService = (ClientClusterServiceImpl) client.getClientClusterService();
-        clusterListenerSupport = clusterService.getClusterListenerSupport();
     }
-
 
     @Override
     public void invokeOnRandomTarget(ClientInvocation invocation) throws IOException {
@@ -42,11 +38,12 @@ public class ClientNonSmartInvocationServiceImpl extends ClientInvocationService
     }
 
     private void sendToOwner(ClientInvocation invocation) throws IOException {
-        final Address ownerConnectionAddress = clusterListenerSupport.getOwnerConnectionAddress();
+        ClientClusterService clusterService = client.getClientClusterService();
+        Address ownerConnectionAddress = clusterService.getOwnerConnectionAddress();
         if (ownerConnectionAddress == null) {
             throw new IOException("Packet is not send to owner address");
         }
-        final Connection conn = connectionManager.getConnection(ownerConnectionAddress);
+        Connection conn = connectionManager.getConnection(ownerConnectionAddress);
         if (conn == null) {
             throw new IOException("Packet is not send to owner address :" + ownerConnectionAddress);
         }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/ClusterAuthenticator.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/ClusterAuthenticator.java
@@ -37,7 +37,7 @@ public class ClusterAuthenticator implements Authenticator {
     @Override
     public void authenticate(ClientConnection connection) throws AuthenticationException, IOException {
         final ClientClusterServiceImpl clusterService = (ClientClusterServiceImpl) client.getClientClusterService();
-        final ClientPrincipal principal = clusterService.getClusterListenerSupport().getPrincipal();
+        final ClientPrincipal principal = clusterService.getPrincipal();
         final SerializationService ss = client.getSerializationService();
         AuthenticationRequest auth = new AuthenticationRequest(credentials, principal);
         connection.init();

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/ClientClusterService.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/ClientClusterService.java
@@ -90,4 +90,11 @@ public interface ClientClusterService {
      */
     boolean removeMembershipListener(String registrationId);
 
+    /**
+     * Owner connection is opened to owner member of the client in the cluster.
+     * If owner member dies, other members of the cluster assumes this client dead.
+     *
+     * @return address of owner connection
+     */
+    Address getOwnerConnectionAddress();
 }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientNonSmartInvocationServiceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientNonSmartInvocationServiceImpl.java
@@ -2,6 +2,7 @@ package com.hazelcast.client.spi.impl;
 
 import com.hazelcast.client.connection.nio.ClientConnection;
 import com.hazelcast.client.impl.HazelcastClientInstanceImpl;
+import com.hazelcast.client.spi.ClientClusterService;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.Connection;
 
@@ -9,12 +10,8 @@ import java.io.IOException;
 
 public class ClientNonSmartInvocationServiceImpl extends ClientInvocationServiceSupport {
 
-    private final ClusterListenerSupport clusterListenerSupport;
-
     public ClientNonSmartInvocationServiceImpl(HazelcastClientInstanceImpl client) {
         super(client);
-        final ClientClusterServiceImpl clusterService = (ClientClusterServiceImpl) client.getClientClusterService();
-        clusterListenerSupport = clusterService.getClusterListenerSupport();
     }
 
     @Override
@@ -41,11 +38,12 @@ public class ClientNonSmartInvocationServiceImpl extends ClientInvocationService
     }
 
     private void sendToOwner(ClientInvocation invocation) throws IOException {
-        final Address ownerConnectionAddress = clusterListenerSupport.getOwnerConnectionAddress();
+        ClientClusterService clusterService = client.getClientClusterService();
+        Address ownerConnectionAddress = clusterService.getOwnerConnectionAddress();
         if (ownerConnectionAddress == null) {
             throw new IOException("Packet is not send to owner address");
         }
-        final Connection conn = connectionManager.getConnection(ownerConnectionAddress);
+        Connection conn = connectionManager.getConnection(ownerConnectionAddress);
         if (conn == null) {
             throw new IOException("Packet is not send to owner address :" + ownerConnectionAddress);
         }

--- a/hazelcast/src/main/java/com/hazelcast/client/ClientEndpoint.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/ClientEndpoint.java
@@ -2,7 +2,6 @@ package com.hazelcast.client;
 
 import com.hazelcast.client.impl.client.ClientPrincipal;
 import com.hazelcast.nio.Connection;
-import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.security.Credentials;
 import com.hazelcast.transaction.TransactionContext;
 
@@ -23,7 +22,7 @@ public interface ClientEndpoint {
 
     void sendResponse(Object response, int callId);
 
-    void sendEvent(Data key, Object event, int callId);
+    void sendEvent(Object key, Object event, int callId);
 
     void setListenerRegistration(String service, String topic, String id);
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEndpointImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEndpointImpl.java
@@ -25,7 +25,6 @@ import com.hazelcast.core.ClientType;
 import com.hazelcast.core.HazelcastInstanceNotActiveException;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Connection;
-import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.DefaultData;
 import com.hazelcast.nio.tcp.TcpIpConnection;
 import com.hazelcast.security.Credentials;
@@ -270,7 +269,7 @@ public final class ClientEndpointImpl implements Client, ClientEndpoint {
     }
 
     @Override
-    public void sendEvent(Data key, Object event, int callId) {
+    public void sendEvent(Object key, Object event, int callId) {
         clientEngine.sendResponse(this, key, event, callId, false, true);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngineImpl.java
@@ -173,7 +173,7 @@ public class ClientEngineImpl implements ClientEngine, CoreService, PostJoinAwar
         return nodeEngine.getProxyService();
     }
 
-    public void sendResponse(ClientEndpoint endpoint, Data key, Object response, int callId, boolean isError, boolean isEvent) {
+    public void sendResponse(ClientEndpoint endpoint, Object key, Object response, int callId, boolean isError, boolean isEvent) {
         Data data = serializationService.toData(response);
         ClientResponse clientResponse = new ClientResponse(data, callId, isError);
         Data responseData = serializationService.toData(clientResponse);

--- a/hazelcast/src/main/java/com/hazelcast/cluster/client/RegisterMembershipListenerRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/client/RegisterMembershipListenerRequest.java
@@ -78,7 +78,7 @@ public final class RegisterMembershipListenerRequest extends CallableClientReque
             ClusterService service = getService();
             Collection<MemberImpl> memberList = service.getMemberList();
             ClientInitialMembershipEvent event = new ClientInitialMembershipEvent(memberList);
-            endpoint.sendEvent(null, event, getCallId());
+            endpoint.sendEvent(endpoint.getUuid(), event, getCallId());
         }
 
         @Override
@@ -90,7 +90,7 @@ public final class RegisterMembershipListenerRequest extends CallableClientReque
             MemberImpl member = (MemberImpl) membershipEvent.getMember();
             ClientInitialMembershipEvent event =
                     new ClientInitialMembershipEvent(member, ClientInitialMembershipEvent.MEMBER_ADDED);
-            endpoint.sendEvent(null, event, getCallId());
+            endpoint.sendEvent(endpoint.getUuid(), event, getCallId());
         }
 
         @Override
@@ -102,7 +102,7 @@ public final class RegisterMembershipListenerRequest extends CallableClientReque
             MemberImpl member = (MemberImpl) membershipEvent.getMember();
             ClientInitialMembershipEvent event =
                     new ClientInitialMembershipEvent(member, ClientInitialMembershipEvent.MEMBER_REMOVED);
-            endpoint.sendEvent(null, event, getCallId());
+            endpoint.sendEvent(endpoint.getUuid(), event, getCallId());
         }
 
         @Override
@@ -118,7 +118,7 @@ public final class RegisterMembershipListenerRequest extends CallableClientReque
             Object value = memberAttributeEvent.getValue();
             MemberAttributeChange memberAttributeChange = new MemberAttributeChange(uuid, op, key, value);
             ClientInitialMembershipEvent event = new ClientInitialMembershipEvent(member, memberAttributeChange);
-            endpoint.sendEvent(null, event, getCallId());
+            endpoint.sendEvent(endpoint.getUuid(), event, getCallId());
         }
     }
 }


### PR DESCRIPTION
Initial member list is waited at startup to make the behaviour consistent.