### PR TITLE
Removing hard dependencies to BasicOperationService

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/Backup.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/Backup.java
@@ -102,7 +102,7 @@ final class Backup extends Operation implements BackupOperation, IdentifiedDataS
         if (valid && sync && getCallId() != 0 && originalCaller != null) {
             NodeEngineImpl nodeEngine = (NodeEngineImpl) getNodeEngine();
             long callId = getCallId();
-            InternalOperationService operationService = nodeEngine.operationService;
+            InternalOperationService operationService = nodeEngine.getOperationService();
 
             if (!nodeEngine.getThisAddress().equals(originalCaller)) {
                 BackupResponse backupResponse = new BackupResponse(callId, backupOp.isUrgent());

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/BasicInvocation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/BasicInvocation.java
@@ -145,7 +145,7 @@ abstract class BasicInvocation implements ResponseHandler, Runnable {
     BasicInvocation(NodeEngineImpl nodeEngine, String serviceName, Operation op, int partitionId,
                     int replicaIndex, int tryCount, long tryPauseMillis, long callTimeout, Callback<Object> callback,
                     boolean resultDeserialized) {
-        this.operationService = (BasicOperationService) nodeEngine.operationService;
+        this.operationService = (BasicOperationService) nodeEngine.getOperationService();
         this.logger = operationService.invocationLogger;
         this.nodeEngine = nodeEngine;
         this.serviceName = serviceName;

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/BasicOperationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/BasicOperationService.java
@@ -107,7 +107,7 @@ import static java.lang.Math.min;
  * @see com.hazelcast.spi.impl.BasicPartitionInvocation
  * @see com.hazelcast.spi.impl.BasicTargetInvocation
  */
-final class BasicOperationService implements InternalOperationService {
+public final class BasicOperationService implements InternalOperationService {
 
     private static final int INITIAL_CAPACITY = 1000;
     private static final float LOAD_FACTOR = 0.75f;
@@ -476,7 +476,6 @@ final class BasicOperationService implements InternalOperationService {
         return true;
     }
 
-    @Override
     public void onMemberLeft(final MemberImpl member) {
         // postpone notifying calls since real response may arrive in the mean time.
         nodeEngine.getExecutionService().schedule(new Runnable() {
@@ -493,7 +492,6 @@ final class BasicOperationService implements InternalOperationService {
         }, SCHEDULE_DELAY, TimeUnit.MILLISECONDS);
     }
 
-    @Override
     public void reset() {
         for (BasicInvocation invocation : invocations.values()) {
             try {
@@ -505,7 +503,6 @@ final class BasicOperationService implements InternalOperationService {
         invocations.clear();
     }
 
-    @Override
     public void shutdown() {
         shutdown = true;
         logger.finest("Stopping operation threads...");

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/InternalOperationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/InternalOperationService.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.spi.impl;
 
-import com.hazelcast.instance.MemberImpl;
 import com.hazelcast.internal.management.JsonSerializable;
 import com.hazelcast.nio.Address;
 import com.hazelcast.spi.Operation;
@@ -35,15 +34,13 @@ import java.util.Collection;
  */
 public interface InternalOperationService extends OperationService {
 
-    void onMemberLeft(MemberImpl member);
-
     boolean isCallTimedOut(Operation op);
 
     void notifyBackupCall(long callId);
 
     /**
      * Executes a PartitionSpecificRunnable.
-     *
+     * <p/>
      * This method is typically used by the {@link com.hazelcast.client.ClientEngine} when it has received a Packet containing
      * a request that needs to be processed.
      *
@@ -53,7 +50,7 @@ public interface InternalOperationService extends OperationService {
 
     /**
      * Sends a response to a remote machine.
-     *
+     * <p/>
      * This method is deprecated since 3.5. It is an implementation detail.
      *
      * @param response the response to send.
@@ -76,15 +73,4 @@ public interface InternalOperationService extends OperationService {
      * @return collection of long running operation logs.
      */
     Collection<JsonSerializable> getSlowOperations();
-
-    /**
-     * Resets internal state of InternalOperationService.
-     * Notifies registered invocations with an error message.
-     */
-    void reset();
-
-    /**
-     * Shuts down this InternalOperationService.
-     */
-    void shutdown();
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/IsStillExecutingOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/IsStillExecutingOperation.java
@@ -25,7 +25,7 @@ public class IsStillExecutingOperation extends AbstractOperation implements Urge
     @Override
     public void run() throws Exception {
         NodeEngineImpl nodeEngine = (NodeEngineImpl) getNodeEngine();
-        InternalOperationService operationService = nodeEngine.operationService;
+        InternalOperationService operationService = nodeEngine.getOperationService();
         boolean executing = operationService.isOperationExecuting(getCallerAddress(), getPartitionId(), operationCallId);
         getResponseHandler().sendResponse(executing);
     }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
@@ -33,7 +33,6 @@ import com.hazelcast.partition.MigrationInfo;
 import com.hazelcast.spi.ExecutionService;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.Operation;
-import com.hazelcast.spi.OperationService;
 import com.hazelcast.spi.PostJoinAwareService;
 import com.hazelcast.spi.ProxyService;
 import com.hazelcast.spi.ServiceInfo;
@@ -65,7 +64,6 @@ import java.util.LinkedList;
  */
 public class NodeEngineImpl implements NodeEngine {
 
-    final InternalOperationService operationService;
     final ExecutionServiceImpl executionService;
 
     private final Node node;
@@ -73,6 +71,7 @@ public class NodeEngineImpl implements NodeEngine {
 
     private final WaitNotifyServiceImpl waitNotifyService;
     private final EventServiceImpl eventService;
+    private final BasicOperationService operationService;
     private final ServiceManager serviceManager;
     private final TransactionManagerServiceImpl transactionManagerService;
     private final ProxyServiceImpl proxyService;
@@ -144,7 +143,7 @@ public class NodeEngineImpl implements NodeEngine {
     }
 
     @Override
-    public OperationService getOperationService() {
+    public InternalOperationService getOperationService() {
         return operationService;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/TraceableIsStillExecutingOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/TraceableIsStillExecutingOperation.java
@@ -23,7 +23,7 @@ public class TraceableIsStillExecutingOperation extends AbstractOperation implem
     @Override
     public void run() throws Exception {
         NodeEngineImpl nodeEngine = (NodeEngineImpl) getNodeEngine();
-        InternalOperationService operationService =  nodeEngine.operationService;
+        InternalOperationService operationService =  nodeEngine.getOperationService();
         boolean executing = operationService.isOperationExecuting(getCallerAddress(), getCallerUuid(),
                 serviceName, identifier);
         getResponseHandler().sendResponse(executing);

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/waitnotifyservice/impl/WaitingOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/waitnotifyservice/impl/WaitingOperation.java
@@ -72,7 +72,7 @@ class WaitingOperation extends AbstractOperation implements Delayed, PartitionAw
 
     public boolean isCallTimedOut() {
         final NodeEngineImpl nodeEngine = (NodeEngineImpl) getNodeEngine();
-        InternalOperationService operationService = (InternalOperationService) nodeEngine.getOperationService();
+        InternalOperationService operationService = nodeEngine.getOperationService();
         if (operationService.isCallTimedOut(op)) {
             cancel(new CallTimeoutResponse(op.getCallId(), op.isUrgent()));
             return true;

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/slowoperationdetector/SlowOperationDetector_purgeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/slowoperationdetector/SlowOperationDetector_purgeTest.java
@@ -20,6 +20,7 @@ import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.spi.impl.BasicOperationService;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.SlowTest;
 import org.junit.Test;
@@ -50,7 +51,8 @@ public class SlowOperationDetector_purgeTest extends SlowOperationDetectorAbstra
         map.executeOnEntries(new SlowEntryProcessor(3));
         map.executeOnEntries(new SlowEntryProcessor(2));
 
-        getInternalOperationService(instance).shutdown();
+        BasicOperationService operationService = (BasicOperationService) getInternalOperationService(instance);
+        operationService.shutdown();
 
         Collection<SlowOperationLog> logs = getSlowOperationLogs(instance);
         assertNumberOfSlowOperationLogs(logs, 1);
@@ -84,7 +86,8 @@ public class SlowOperationDetector_purgeTest extends SlowOperationDetectorAbstra
         }
         sleepSeconds(3);
 
-        getInternalOperationService(instance).shutdown();
+        BasicOperationService operationService = (BasicOperationService) getInternalOperationService(instance);
+        operationService.shutdown();
 
         Collection<SlowOperationLog> logs = getSlowOperationLogs(instance);
         assertNumberOfSlowOperationLogs(logs, 0);


### PR DESCRIPTION
Preparation work for Dependency Injection of our services instead of the fragile NodeEngineImpl approach we are currently using. 

I have removed some methods like reset/shutdown from the InternalOperationService because the NodeEngineImpl is allowed to know any lifecycle methods or listener methods of the concrete class. This is exactly the same as within a spring application context, where the context knows the implementation details of a class.