### PR TITLE
Fix for issue #3373.

### DIFF
--- a/hazelcast-hibernate/hazelcast-hibernate3/src/test/java/com/hazelcast/hibernate/HibernateStatisticsTestSupport.java
+++ b/hazelcast-hibernate/hazelcast-hibernate3/src/test/java/com/hazelcast/hibernate/HibernateStatisticsTestSupport.java
@@ -163,7 +163,7 @@ public abstract class HibernateStatisticsTestSupport extends HibernateTestSuppor
         for (int i = 0; i < queryCount; i++) {
             list = executeQuery(sf);
             assertEquals(entityCount, list.size());
-            sleep(2);
+            sleepAtLeastSeconds(1);
         }
 
         assertNotNull(list);

--- a/hazelcast-hibernate/hazelcast-hibernate3/src/test/java/com/hazelcast/hibernate/HibernateTestSupport.java
+++ b/hazelcast-hibernate/hazelcast-hibernate3/src/test/java/com/hazelcast/hibernate/HibernateTestSupport.java
@@ -19,6 +19,7 @@ package com.hazelcast.hibernate;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
+import com.hazelcast.test.HazelcastTestSupport;
 import org.hibernate.SessionFactory;
 import org.hibernate.cfg.Configuration;
 import org.junit.After;
@@ -28,7 +29,7 @@ import org.junit.BeforeClass;
 import java.net.URL;
 import java.util.Properties;
 
-public abstract class HibernateTestSupport {
+public abstract class HibernateTestSupport extends HazelcastTestSupport {
 
     private final ILogger logger = Logger.getLogger(getClass());
 

--- a/hazelcast-hibernate/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/HibernateStatisticsTestSupport.java
+++ b/hazelcast-hibernate/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/HibernateStatisticsTestSupport.java
@@ -163,7 +163,7 @@ public abstract class HibernateStatisticsTestSupport extends HibernateTestSuppor
         for (int i = 0; i < queryCount; i++) {
             list = executeQuery(sf);
             assertEquals(entityCount, list.size());
-            sleep(2);
+            sleepAtLeastSeconds(1);
         }
 
         assertNotNull(list);

--- a/hazelcast-hibernate/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/HibernateTestSupport.java
+++ b/hazelcast-hibernate/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/HibernateTestSupport.java
@@ -19,6 +19,7 @@ package com.hazelcast.hibernate;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
+import com.hazelcast.test.HazelcastTestSupport;
 import org.hibernate.SessionFactory;
 import org.hibernate.cfg.Configuration;
 import org.junit.After;
@@ -28,7 +29,7 @@ import org.junit.BeforeClass;
 import java.net.URL;
 import java.util.Properties;
 
-public abstract class HibernateTestSupport {
+public abstract class HibernateTestSupport extends HazelcastTestSupport {
 
     private final ILogger logger = Logger.getLogger(getClass());
 


### PR DESCRIPTION
System.currentTimeMillis() has non-monotonic behaviour, query test in hibernate is  failing in Nightly builds. Using sleepAtLeastSeconds() method in HazelcastTestSupport class instead of sleep() between each hibernate query in tests. Increasing sleep value did not solve issue #3373. sleepAtLeastSeconds() will make busy wait until 1 second has passed even though the test is running on a fast machine.