### PR TITLE
Enhance IDE integration

### DIFF
--- a/hazelcast-spring/src/main/resources/hazelcast-spring-3.5.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-3.5.xsd
@@ -944,7 +944,9 @@
                 Configure the hazelcast instance
             </xs:documentation>
             <xs:appinfo>
-                <tool:exports type="com.hazelcast.core.HazelcastInstance"/>
+                <tool:annotation>
+                    <tool:exports type="com.hazelcast.core.HazelcastInstance"/>
+                </tool:annotation>
             </xs:appinfo>
         </xs:annotation>
         <xs:complexType>
@@ -964,7 +966,9 @@
                 Configure the hazelcast client
             </xs:documentation>
             <xs:appinfo>
-                <tool:exports type="com.hazelcast.client.HazelcastClient"/>
+                <tool:annotation>
+                    <tool:exports type="com.hazelcast.core.HazelcastInstance"/>
+                </tool:annotation>
             </xs:appinfo>
         </xs:annotation>
         <xs:complexType>
@@ -989,19 +993,162 @@
         </xs:complexType>
     </xs:element>
 
-    <xs:element name="map" type="hazelcast-type"/>
-    <xs:element name="multiMap" type="hazelcast-type"/>
-    <xs:element name="queue" type="hazelcast-type"/>
-    <xs:element name="topic" type="hazelcast-type"/>
-    <xs:element name="set" type="hazelcast-type"/>
-    <xs:element name="list" type="hazelcast-type"/>
-    <xs:element name="executorService" type="hazelcast-type"/>
-    <xs:element name="idGenerator" type="hazelcast-type"/>
-    <xs:element name="atomicLong" type="hazelcast-type"/>
-    <xs:element name="atomicReference" type="hazelcast-type"/>
-    <xs:element name="countDownLatch" type="hazelcast-type"/>
-    <xs:element name="semaphore" type="hazelcast-type"/>
-    <xs:element name="lock" type="hazelcast-type"/>
+    <xs:element name="map" type="hazelcast-type">
+        <xs:annotation>
+            <xs:documentation>
+                Retrive an hazelcast IMap instance
+            </xs:documentation>
+            <xs:appinfo>
+                <tool:annotation>
+                    <tool:exports type="com.hazelcast.core.IMap"/>
+                </tool:annotation>
+            </xs:appinfo>
+        </xs:annotation>
+    </xs:element>
+    <xs:element name="multiMap" type="hazelcast-type">
+        <xs:annotation>
+            <xs:documentation>
+                Retrive an hazelcast MultiMap instance
+            </xs:documentation>
+            <xs:appinfo>
+                <tool:annotation>
+                    <tool:exports type="com.hazelcast.core.MultiMap"/>
+                </tool:annotation>
+            </xs:appinfo>
+        </xs:annotation>
+    </xs:element>
+    <xs:element name="queue" type="hazelcast-type">
+        <xs:annotation>
+            <xs:documentation>
+                Retrive an hazelcast IQueue instance
+            </xs:documentation>
+            <xs:appinfo>
+                <tool:annotation>
+                    <tool:exports type="com.hazelcast.core.IQueue"/>
+                </tool:annotation>
+            </xs:appinfo>
+        </xs:annotation>
+    </xs:element>
+    <xs:element name="topic" type="hazelcast-type">
+        <xs:annotation>
+            <xs:documentation>
+                Retrive an hazelcast ITopic instance
+            </xs:documentation>
+            <xs:appinfo>
+                <tool:annotation>
+                    <tool:exports type="com.hazelcast.core.ITopic"/>
+                </tool:annotation>
+            </xs:appinfo>
+        </xs:annotation>
+    </xs:element>
+    <xs:element name="set" type="hazelcast-type">
+        <xs:annotation>
+            <xs:documentation>
+                Retrive an hazelcast ISet instance
+            </xs:documentation>
+            <xs:appinfo>
+                <tool:annotation>
+                    <tool:exports type="com.hazelcast.core.ISet"/>
+                </tool:annotation>
+            </xs:appinfo>
+        </xs:annotation>
+    </xs:element>
+    <xs:element name="list" type="hazelcast-type">
+        <xs:annotation>
+            <xs:documentation>
+                Retrive an hazelcast IList instance
+            </xs:documentation>
+            <xs:appinfo>
+                <tool:annotation>
+                    <tool:exports type="com.hazelcast.core.IList"/>
+                </tool:annotation>
+            </xs:appinfo>
+        </xs:annotation>
+    </xs:element>
+    <xs:element name="executorService" type="hazelcast-type">
+        <xs:annotation>
+            <xs:documentation>
+                Retrive an hazelcast IExecutorService instance
+            </xs:documentation>
+            <xs:appinfo>
+                <tool:annotation>
+                    <tool:exports type="com.hazelcast.core.IExecutorService"/>
+                </tool:annotation>
+            </xs:appinfo>
+        </xs:annotation>
+    </xs:element>
+    <xs:element name="idGenerator" type="hazelcast-type">
+        <xs:annotation>
+            <xs:documentation>
+                Retrive an hazelcast IdGenerator instance
+            </xs:documentation>
+            <xs:appinfo>
+                <tool:annotation>
+                    <tool:exports type="com.hazelcast.core.IdGenerator"/>
+                </tool:annotation>
+            </xs:appinfo>
+        </xs:annotation>
+    </xs:element>
+    <xs:element name="atomicLong" type="hazelcast-type">
+        <xs:annotation>
+            <xs:documentation>
+                Retrive an hazelcast IAtomicLong instance
+            </xs:documentation>
+            <xs:appinfo>
+                <tool:annotation>
+                    <tool:exports type="com.hazelcast.core.IAtomicLong"/>
+                </tool:annotation>
+            </xs:appinfo>
+        </xs:annotation>
+    </xs:element>
+    <xs:element name="atomicReference" type="hazelcast-type">
+        <xs:annotation>
+            <xs:documentation>
+                Retrive an hazelcast IAtomicReference instance
+            </xs:documentation>
+            <xs:appinfo>
+                <tool:annotation>
+                    <tool:exports type="com.hazelcast.core.IAtomicReference"/>
+                </tool:annotation>
+            </xs:appinfo>
+        </xs:annotation>
+    </xs:element>
+    <xs:element name="countDownLatch" type="hazelcast-type">
+        <xs:annotation>
+            <xs:documentation>
+                Retrive an hazelcast ICountDownLatch instance
+            </xs:documentation>
+            <xs:appinfo>
+                <tool:annotation>
+                    <tool:exports type="com.hazelcast.core.ICountDownLatch"/>
+                </tool:annotation>
+            </xs:appinfo>
+        </xs:annotation>
+    </xs:element>
+    <xs:element name="semaphore" type="hazelcast-type">
+        <xs:annotation>
+            <xs:documentation>
+                Retrive an hazelcast ISemaphore instance
+            </xs:documentation>
+            <xs:appinfo>
+                <tool:annotation>
+                    <tool:exports type="com.hazelcast.core.ISemaphore"/>
+                </tool:annotation>
+            </xs:appinfo>
+        </xs:annotation>
+    </xs:element>
+    <xs:element name="lock" type="hazelcast-type">
+        <xs:annotation>
+            <xs:documentation>
+                Retrive an hazelcast ILock instance
+            </xs:documentation>
+            <xs:appinfo>
+                <tool:annotation>
+                    <tool:exports type="com.hazelcast.core.ILock"/>
+                </tool:annotation>
+            </xs:appinfo>
+        </xs:annotation>
+    </xs:element>
 
     <xs:element name="hibernate-region-factory" type="hibernate-cache"/>
 

--- a/hazelcast-spring/src/main/resources/hazelcast-spring-3.5.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-3.5.xsd
@@ -17,10 +17,12 @@
 
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
            xmlns="http://www.hazelcast.com/schema/spring"
+           xmlns:tool="http://www.springframework.org/schema/tool"
            targetNamespace="http://www.hazelcast.com/schema/spring"
            elementFormDefault="qualified"
            attributeFormDefault="unqualified">
 
+    <xs:import namespace="http://www.springframework.org/schema/tool" schemaLocation="http://www.springframework.org/schema/tool/spring-tool.xsd"/>
     <xs:element name="config">
         <xs:complexType>
             <xs:complexContent>
@@ -937,6 +939,14 @@
     </xs:complexType>
 
     <xs:element name="hazelcast">
+        <xs:annotation>
+            <xs:documentation>
+                Configure the hazelcast instance
+            </xs:documentation>
+            <xs:appinfo>
+                <tool:exports type="com.hazelcast.core.HazelcastInstance"/>
+            </xs:appinfo>
+        </xs:annotation>
         <xs:complexType>
             <xs:complexContent>
                 <xs:extension base="hazelcast-bean">
@@ -949,6 +959,14 @@
     </xs:element>
 
     <xs:element name="client">
+        <xs:annotation>
+            <xs:documentation>
+                Configure the hazelcast client
+            </xs:documentation>
+            <xs:appinfo>
+                <tool:exports type="com.hazelcast.client.HazelcastClient"/>
+            </xs:appinfo>
+        </xs:annotation>
         <xs:complexType>
             <xs:complexContent>
                 <xs:extension base="hazelcast-bean">


### PR DESCRIPTION
Until now, when using the hazelcast spring namespace, the IDEs were not able to know what type of beans were created when using <hz:client/>, <hz:map/>, ...

I have added the requiered information in the xsd to seriously enhance the spring integration with IntelliJ for instance.

Before in IntelliJ: 
![image](https://cloud.githubusercontent.com/assets/2642023/6731447/4f83e69c-ce45-11e4-9572-f19dbae62aac.png)
![image](https://cloud.githubusercontent.com/assets/2642023/6731479/73b9c14e-ce45-11e4-965e-3d2d0f67df72.png)

Now: 
![image](https://cloud.githubusercontent.com/assets/2642023/6731504/96773162-ce45-11e4-82b6-3a653bf6c4dc.png)

This is more or less the same with all kind of hz objects.

