### PR TITLE
Use SecureRandom to prevent memory leak

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/util/UuidUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/UuidUtil.java
@@ -18,7 +18,7 @@ package com.hazelcast.util;
 
 import com.hazelcast.nio.Address;
 
-import java.util.Random;
+import java.security.SecureRandom;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -27,32 +27,7 @@ import java.util.concurrent.atomic.AtomicLong;
  */
 public final class UuidUtil {
 
-    private static final ThreadLocal<Random> RANDOMIZERS = new ThreadLocal<Random>() {
-        @Override
-        protected Random initialValue() {
-            // Using the same way as the OpenJDK version just to
-            // make sure this happens on every JDK implementation
-            // since there are some out there that just use System.currentTimeMillis()
-            return new Random(seedUniquifier() ^ System.nanoTime());
-        }
-    };
-
-    private static final AtomicLong SEED_UNIQUIFIER = new AtomicLong(8682522807148012L);
-    private static final long MOTHER_OF_MAGIC_NUMBERS = 181783497276652981L;
-
     private UuidUtil() {
-    }
-
-    private static long seedUniquifier() {
-        // L'Ecuyer, "Tables of Linear Congruential Generators of
-        // Different Sizes and Good Lattice Structure", 1999
-        for (;;) {
-            long current = SEED_UNIQUIFIER.get();
-            long next = current * MOTHER_OF_MAGIC_NUMBERS;
-            if (SEED_UNIQUIFIER.compareAndSet(current, next)) {
-                return next;
-            }
-        }
     }
 
     public static String createMemberUuid(Address endpoint) {
@@ -70,7 +45,7 @@ public final class UuidUtil {
     public static UUID buildRandomUUID() {
         //CHECKSTYLE:OFF  suppressed because of magic numbers
         byte[] data = new byte[16];
-        RANDOMIZERS.get().nextBytes(data);
+        new SecureRandom().nextBytes(data);
         /* clear version        */
         data[6] &= 0x0f;
         /* set to version 4     */


### PR DESCRIPTION
This simplifies the code to just use SecureRandom rather than a specialized random number generator.  This also removes the use of ThreadLocal which does not get cleaned up causing the problem depicted in #4354.

Fixes #4354.