### PR TITLE
Map/reduce type variance improvements

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/Job.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/Job.java
@@ -59,7 +59,7 @@ public interface Job<KeyIn, ValueIn> {
      * @param keys keys to be executed against
      * @return instance of this Job with generics changed on usage
      */
-    Job<KeyIn, ValueIn> onKeys(Iterable<KeyIn> keys);
+    Job<KeyIn, ValueIn> onKeys(Iterable<? extends KeyIn> keys);
 
     /**
      * Defines keys to execute the mapper and a possibly defined reducer against. If keys are known before submitting
@@ -99,7 +99,7 @@ public interface Job<KeyIn, ValueIn> {
      * @param predicate predicate implementation to be used to evaluate keys
      * @return instance of this Job with generics changed on usage
      */
-    Job<KeyIn, ValueIn> keyPredicate(KeyPredicate<KeyIn> predicate);
+    Job<KeyIn, ValueIn> keyPredicate(KeyPredicate<? super KeyIn> predicate);
 
     /**
      * Defines the mapper for this task. This method is not idempotent and can be callable only one time. Further

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/KeyValueSource.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/KeyValueSource.java
@@ -162,7 +162,7 @@ public abstract class KeyValueSource<K, V>
      * @param <V> value type of the map
      * @return KeyValueSource implementation based on the specified map
      */
-    public static <K, V> KeyValueSource<K, V> fromMap(IMap<K, V> map) {
+    public static <K, V> KeyValueSource<K, V> fromMap(IMap<? super K, ? extends V> map) {
         return new MapKeyValueSource<K, V>(map.getName());
     }
 
@@ -174,7 +174,7 @@ public abstract class KeyValueSource<K, V>
      * @param <V>      value type of the multiMap
      * @return KeyValueSource implementation based on the specified multiMap
      */
-    public static <K, V> KeyValueSource<K, V> fromMultiMap(MultiMap<K, V> multiMap) {
+    public static <K, V> KeyValueSource<K, V> fromMultiMap(MultiMap<? super K, ? extends V> multiMap) {
         return new MultiMapKeyValueSource<K, V>(multiMap.getName());
     }
 
@@ -188,7 +188,7 @@ public abstract class KeyValueSource<K, V>
      * @param <V>  value type of the list
      * @return KeyValueSource implementation based on the specified list
      */
-    public static <V> KeyValueSource<String, V> fromList(IList<V> list) {
+    public static <V> KeyValueSource<String, V> fromList(IList<? extends V> list) {
         return new ListKeyValueSource<V>(list.getName());
     }
 
@@ -202,7 +202,7 @@ public abstract class KeyValueSource<K, V>
      * @param <V> value type of the set
      * @return KeyValueSource implementation based on the specified set
      */
-    public static <V> KeyValueSource<String, V> fromSet(ISet<V> set) {
+    public static <V> KeyValueSource<String, V> fromSet(ISet<? extends V> set) {
         return new SetKeyValueSource<V>(set.getName());
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/MappingJob.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/MappingJob.java
@@ -16,10 +16,10 @@
 
 package com.hazelcast.mapreduce;
 
-import com.hazelcast.spi.annotation.Beta;
-
 import java.util.List;
 import java.util.Map;
+
+import com.hazelcast.spi.annotation.Beta;
 
 /**
  * <p>
@@ -43,7 +43,7 @@ public interface MappingJob<EntryKey, KeyIn, ValueIn> {
      * @param keys keys to be executed against
      * @return instance of this Job with generics changed on usage
      */
-    MappingJob<EntryKey, KeyIn, ValueIn> onKeys(Iterable<EntryKey> keys);
+    MappingJob<EntryKey, KeyIn, ValueIn> onKeys(Iterable<? extends EntryKey> keys);
 
     /**
      * Defines keys to execute the mapper and a possibly defined reducer against. If keys are known before submitting
@@ -63,7 +63,7 @@ public interface MappingJob<EntryKey, KeyIn, ValueIn> {
      * @param predicate predicate implementation to be used to evaluate keys
      * @return instance of this Job with generics changed on usage
      */
-    MappingJob<EntryKey, KeyIn, ValueIn> keyPredicate(KeyPredicate<EntryKey> predicate);
+    MappingJob<EntryKey, KeyIn, ValueIn> keyPredicate(KeyPredicate<? super EntryKey> predicate);
 
     /**
      * Defines the number of elements per chunk. Whenever the chunk size is reached and a
@@ -93,7 +93,7 @@ public interface MappingJob<EntryKey, KeyIn, ValueIn> {
      * @param <ValueOut>      type of the combined value
      * @return instance of this Job with generics changed on usage
      */
-    <ValueOut> ReducingJob<EntryKey, KeyIn, ValueOut> combiner(CombinerFactory<KeyIn, ValueIn, ValueOut> combinerFactory);
+    <ValueOut> ReducingJob<EntryKey, KeyIn, ValueOut> combiner(CombinerFactory<? super KeyIn, ? super ValueIn, ? extends ValueOut> combinerFactory);
 
     /**
      * Defines the {@link ReducerFactory} for this task. This method is not idempotent and is callable only one time. Further
@@ -103,7 +103,7 @@ public interface MappingJob<EntryKey, KeyIn, ValueIn> {
      * @param <ValueOut>     type of the reduced value
      * @return instance of this Job with generics changed on usage
      */
-    <ValueOut> ReducingSubmittableJob<EntryKey, KeyIn, ValueOut> reducer(ReducerFactory<KeyIn, ValueIn, ValueOut> reducerFactory);
+    <ValueOut> ReducingSubmittableJob<EntryKey, KeyIn, ValueOut> reducer(ReducerFactory<? super KeyIn, ? super ValueIn, ? extends ValueOut> reducerFactory);
 
     /**
      * Submits the task to Hazelcast and executes the defined mapper and reducer on all cluster nodes.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/AbstractJob.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/AbstractJob.java
@@ -61,7 +61,7 @@ public abstract class AbstractJob<KeyIn, ValueIn>
 
     protected Collection<KeyIn> keys;
 
-    protected KeyPredicate<KeyIn> predicate;
+    protected KeyPredicate<? super KeyIn> predicate;
 
     protected int chunkSize = -1;
 
@@ -84,7 +84,7 @@ public abstract class AbstractJob<KeyIn, ValueIn>
     }
 
     @Override
-    public Job<KeyIn, ValueIn> onKeys(Iterable<KeyIn> keys) {
+    public Job<KeyIn, ValueIn> onKeys(Iterable<? extends KeyIn> keys) {
         addKeys(keys);
         return this;
     }
@@ -96,7 +96,7 @@ public abstract class AbstractJob<KeyIn, ValueIn>
     }
 
     @Override
-    public Job<KeyIn, ValueIn> keyPredicate(KeyPredicate<KeyIn> predicate) {
+    public Job<KeyIn, ValueIn> keyPredicate(KeyPredicate<? super KeyIn> predicate) {
         setKeyPredicate(predicate);
         return this;
     }
@@ -137,7 +137,7 @@ public abstract class AbstractJob<KeyIn, ValueIn>
         }
     }
 
-    private void addKeys(Iterable<KeyIn> keys) {
+    private void addKeys(Iterable<? extends KeyIn> keys) {
         if (this.keys == null) {
             this.keys = new HashSet<KeyIn>();
         }
@@ -153,7 +153,7 @@ public abstract class AbstractJob<KeyIn, ValueIn>
         this.keys.addAll(Arrays.asList(keys));
     }
 
-    private void setKeyPredicate(KeyPredicate<KeyIn> predicate) {
+    private void setKeyPredicate(KeyPredicate<? super KeyIn> predicate) {
         ValidationUtil.isNotNull(predicate, "predicate");
         this.predicate = predicate;
     }
@@ -173,7 +173,7 @@ public abstract class AbstractJob<KeyIn, ValueIn>
             implements MappingJob<EntryKey, Key, Value> {
 
         @Override
-        public MappingJob<EntryKey, Key, Value> onKeys(Iterable<EntryKey> keys) {
+        public MappingJob<EntryKey, Key, Value> onKeys(Iterable<? extends EntryKey> keys) {
             addKeys((Iterable<KeyIn>) keys);
             return this;
         }
@@ -185,7 +185,7 @@ public abstract class AbstractJob<KeyIn, ValueIn>
         }
 
         @Override
-        public MappingJob<EntryKey, Key, Value> keyPredicate(KeyPredicate<EntryKey> predicate) {
+        public MappingJob<EntryKey, Key, Value> keyPredicate(KeyPredicate<? super EntryKey> predicate) {
             setKeyPredicate((KeyPredicate<KeyIn>) predicate);
             return this;
         }
@@ -203,7 +203,7 @@ public abstract class AbstractJob<KeyIn, ValueIn>
         }
 
         @Override
-        public <ValueOut> ReducingJob<EntryKey, Key, ValueOut> combiner(CombinerFactory<Key, Value, ValueOut> combinerFactory) {
+        public <ValueOut> ReducingJob<EntryKey, Key, ValueOut> combiner(CombinerFactory<? super Key, ? super Value, ? extends ValueOut> combinerFactory) {
             ValidationUtil.isNotNull(combinerFactory, "combinerFactory");
             if (AbstractJob.this.combinerFactory != null) {
                 throw new IllegalStateException("combinerFactory already set");
@@ -214,7 +214,7 @@ public abstract class AbstractJob<KeyIn, ValueIn>
 
         @Override
         public <ValueOut> ReducingSubmittableJob<EntryKey, Key, ValueOut> reducer(
-                ReducerFactory<Key, Value, ValueOut> reducerFactory) {
+                ReducerFactory<? super Key, ? super Value, ? extends ValueOut> reducerFactory) {
             ValidationUtil.isNotNull(reducerFactory, "reducerFactory");
             if (AbstractJob.this.reducerFactory != null) {
                 throw new IllegalStateException("reducerFactory already set");

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/operation/StartProcessingJobOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/operation/StartProcessingJobOperation.java
@@ -45,12 +45,12 @@ public class StartProcessingJobOperation<K>
     private String name;
     private Collection<K> keys;
     private String jobId;
-    private KeyPredicate<K> predicate;
+    private KeyPredicate<? super K> predicate;
 
     public StartProcessingJobOperation() {
     }
 
-    public StartProcessingJobOperation(String name, String jobId, Collection<K> keys, KeyPredicate<K> predicate) {
+    public StartProcessingJobOperation(String name, String jobId, Collection<K> keys, KeyPredicate<? super K> predicate) {
         this.name = name;
         this.keys = keys;
         this.jobId = jobId;

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/KeyValueSourceMappingPhase.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/KeyValueSourceMappingPhase.java
@@ -35,7 +35,7 @@ import java.util.Map;
 public class KeyValueSourceMappingPhase<KeyIn, ValueIn, KeyOut, ValueOut>
         extends MappingPhase<KeyIn, ValueIn, KeyOut, ValueOut> {
 
-    public KeyValueSourceMappingPhase(Collection<KeyIn> keys, KeyPredicate<KeyIn> predicate) {
+    public KeyValueSourceMappingPhase(Collection<? extends KeyIn> keys, KeyPredicate<? super KeyIn> predicate) {
         super(keys, predicate);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/MappingPhase.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/MappingPhase.java
@@ -38,10 +38,10 @@ public abstract class MappingPhase<KeyIn, ValueIn, KeyOut, ValueOut> {
 
     private final AtomicBoolean cancelled = new AtomicBoolean();
 
-    private final Collection<KeyIn> keys;
-    private final KeyPredicate<KeyIn> predicate;
+    private final Collection<? extends KeyIn> keys;
+    private final KeyPredicate<? super KeyIn> predicate;
 
-    public MappingPhase(Collection<KeyIn> keys, KeyPredicate<KeyIn> predicate) {
+    public MappingPhase(Collection<? extends KeyIn> keys, KeyPredicate<? super KeyIn> predicate) {
         this.keys = keys;
         this.predicate = predicate;
     }


### PR DESCRIPTION
You should be able to pass a more variantly-typed reducer, combiner and predicate to a mapping job. The job does not mutate any data so this is a well defined operation.

The same also holds for the KeyValueSource factory methods.