### PR TITLE
Selector Balancer Implemented

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -431,7 +431,7 @@
     <suppress checks="JavadocMethod" files="com.hazelcast.nio[\\/]"/>
     <suppress checks="JavadocType" files="com.hazelcast.nio[\\/]"/>
     <suppress checks="JavadocVariable" files="com.hazelcast.nio[\\/]"/>
-    <suppress checks="ClassDataAbstractionCoupling" files="com.hazelcast.nio.tcp.TcpIpConnectionManager"/>
+    <suppress checks="ExecutableStatementCount|ClassDataAbstractionCoupling|ClassFanOutComplexity" files="com.hazelcast.nio.tcp.TcpIpConnectionManager"/>
 
     <suppress checks="MethodCount|MagicNumber" files="com.hazelcast.nio.serialization.ByteArrayObjectDataInput"/>
     <suppress checks="MethodCount|MagicNumber" files="com.hazelcast.nio.serialization.ByteArrayObjectDataOutput"/>

--- a/hazelcast/src/main/java/com/hazelcast/instance/DefaultNodeContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/DefaultNodeContext.java
@@ -38,6 +38,6 @@ public class DefaultNodeContext implements NodeContext {
     @Override
     public ConnectionManager createConnectionManager(Node node, ServerSocketChannel serverSocketChannel) {
         NodeIOService ioService = new NodeIOService(node);
-        return new TcpIpConnectionManager(ioService, serverSocketChannel);
+        return new TcpIpConnectionManager(ioService, serverSocketChannel, node.getHazelcastThreadGroup(), node.loggingService);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/instance/GroupProperties.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/GroupProperties.java
@@ -62,6 +62,18 @@ public class GroupProperties {
     public static final String PROP_VERSION_CHECK_ENABLED = "hazelcast.version.check.enabled";
     public static final String PROP_PREFER_IPv4_STACK = "hazelcast.prefer.ipv4.stack";
     public static final String PROP_IO_THREAD_COUNT = "hazelcast.io.thread.count";
+
+    /**
+     * The interval in seconds between {@link com.hazelcast.nio.tcp.handlermigration.IOBalancer IOBalancer}
+     * executions. The shorter intervals will catch I/O Imbalance faster, but they will cause higher overhead.
+     *
+     * Please see documentation of {@link com.hazelcast.nio.tcp.handlermigration.IOBalancer IOBalancer} for
+     * detailed explanation of the problem.
+     *
+     * Default value is 20 seconds. A negative value disables the balancer.
+     *
+     */
+    public static final String PROP_IO_BALANCER_INTERVAL_SECONDS = "hazelcast.io.balancer.interval.seconds";
     /**
      * The number of partition threads per Member. If this is less than the number of partitions on a Member, then
      * partition operations will queue behind other operations of different partitions. The default is 4.
@@ -239,6 +251,8 @@ public class GroupProperties {
 
     public final GroupProperty IO_THREAD_COUNT;
 
+    public final GroupProperty IO_BALANCER_INTERVAL_SECONDS;
+
     public final GroupProperty EVENT_QUEUE_CAPACITY;
 
     public final GroupProperty EVENT_QUEUE_TIMEOUT_MILLIS;
@@ -406,6 +420,7 @@ public class GroupProperties {
         VERSION_CHECK_ENABLED = new GroupProperty(config, PROP_VERSION_CHECK_ENABLED, "true");
         PREFER_IPv4_STACK = new GroupProperty(config, PROP_PREFER_IPv4_STACK, "true");
         IO_THREAD_COUNT = new GroupProperty(config, PROP_IO_THREAD_COUNT, "3");
+        IO_BALANCER_INTERVAL_SECONDS = new GroupProperty(config, PROP_IO_BALANCER_INTERVAL_SECONDS, "20");
 
         //-1 means that the value is worked out dynamically.
         PARTITION_OPERATION_THREAD_COUNT = new GroupProperty(config, PROP_PARTITION_OPERATION_THREAD_COUNT, "-1");

--- a/hazelcast/src/main/java/com/hazelcast/nio/IOService.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/IOService.java
@@ -95,6 +95,11 @@ public interface IOService {
 
     int getConnectionMonitorMaxFaults();
 
+    /**
+     * @return Time interval between two I/O imbalance checks.
+     */
+    int getBalancerIntervalSeconds();
+
     void onDisconnect(Address endpoint);
 
     boolean isClient();

--- a/hazelcast/src/main/java/com/hazelcast/nio/NodeIOService.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/NodeIOService.java
@@ -239,6 +239,11 @@ public class NodeIOService implements IOService {
     }
 
     @Override
+    public int getBalancerIntervalSeconds() {
+        return node.groupProperties.IO_BALANCER_INTERVAL_SECONDS.getInteger();
+    }
+
+    @Override
     public void executeAsync(final Runnable runnable) {
         nodeEngine.getExecutionService().execute(ExecutionService.IO_EXECUTOR, runnable);
     }

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/AbstractIOSelector.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/AbstractIOSelector.java
@@ -102,7 +102,24 @@ public abstract class AbstractIOSelector extends Thread implements IOSelector {
             if (runnable == null) {
                 return;
             }
+            executeTask(runnable);
+        }
+    }
+
+    private void executeTask(Runnable runnable) {
+        IOSelector target = getTargetIOSelector(runnable);
+        if (target == this) {
             runnable.run();
+        } else {
+            target.addTask(runnable);
+        }
+    }
+
+    private IOSelector getTargetIOSelector(Runnable runnable) {
+        if (runnable instanceof MigratableHandler) {
+            return ((MigratableHandler) runnable).getOwner();
+        } else {
+            return this;
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/MigratableHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/MigratableHandler.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.nio.tcp;
+
+/**
+ * Read/Write handlers that supports migration between {@link com.hazelcast.nio.tcp.IOSelector}.
+ *
+ */
+public interface MigratableHandler extends SelectionHandler {
+
+    /**
+     * Migrate to a new IOSelector.
+     *
+     * @param newOwner
+     */
+    void migrate(final IOSelector newOwner);
+
+    /**
+     * Get IOSelector currently owning this handler. Handler owner is a thread running this handler.
+     * {@link com.hazelcast.nio.tcp.handlermigration.IOBalancer IOBalancer} can decide to migrate
+     * a handler to another owner.
+     *
+     * @return current owner
+     */
+    IOSelector getOwner();
+
+    /**
+     * Get number of events recorded by the current handler. It can be used to calculate whether
+     * this handler should be migrated to a different {@link com.hazelcast.nio.tcp.IOSelector}
+     *
+     * @return total number of events recorded by this handler
+     */
+    long getEventCount();
+}

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/ReadHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/ReadHandler.java
@@ -31,16 +31,16 @@ import static com.hazelcast.util.StringUtil.bytesToString;
 /**
  * The reading side of the {@link com.hazelcast.nio.Connection}.
  */
-final class ReadHandler
-        extends AbstractSelectionHandler {
+public final class ReadHandler extends AbstractSelectionHandler {
 
     private final ByteBuffer inputBuffer;
-
-    private final IOSelector ioSelector;
 
     private SocketReader socketReader;
 
     private volatile long lastHandle;
+
+    //This field will be incremented by a single thread. It can be read by multiple threads.
+    private volatile long eventCount;
 
     public ReadHandler(TcpIpConnection connection, IOSelector ioSelector) {
         super(connection, ioSelector, SelectionKey.OP_READ);
@@ -61,7 +61,15 @@ final class ReadHandler
     }
 
     @Override
+    public long getEventCount() {
+        return eventCount;
+    }
+
+    @Override
+    @edu.umd.cs.findbugs.annotations.SuppressWarnings(value = "VO_VOLATILE_INCREMENT",
+            justification = "eventCount is accessed by a single thread only.")
     public void handle() {
+        eventCount++;
         lastHandle = Clock.currentTimeMillis();
         if (!connection.isAlive()) {
             String message = "We are being asked to read, but connection is not live so we won't";

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnectionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnectionManager.java
@@ -18,11 +18,14 @@ package com.hazelcast.nio.tcp;
 
 import com.hazelcast.cluster.impl.BindMessage;
 import com.hazelcast.config.SocketInterceptorConfig;
+import com.hazelcast.instance.HazelcastThreadGroup;
 import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.LoggingService;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.ConnectionListener;
 import com.hazelcast.nio.ConnectionManager;
+import com.hazelcast.nio.tcp.handlermigration.IOBalancer;
 import com.hazelcast.nio.IOService;
 import com.hazelcast.nio.IOUtil;
 import com.hazelcast.nio.MemberSocketInterceptor;
@@ -44,12 +47,9 @@ import java.util.LinkedList;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
-
-import static java.lang.Boolean.parseBoolean;
 
 public class TcpIpConnectionManager implements ConnectionManager {
 
@@ -78,9 +78,9 @@ public class TcpIpConnectionManager implements ConnectionManager {
 
     private final boolean socketNoDelay;
 
-    private final ConcurrentMap<Address, Connection> connectionsMap = new ConcurrentHashMap<Address, Connection>(100);
+    private final ConcurrentHashMap<Address, Connection> connectionsMap = new ConcurrentHashMap<Address, Connection>(100);
 
-    private final ConcurrentMap<Address, TcpIpConnectionMonitor> monitors =
+    private final ConcurrentHashMap<Address, TcpIpConnectionMonitor> monitors =
             new ConcurrentHashMap<Address, TcpIpConnectionMonitor>(100);
 
     private final Set<Address> connectionsInProgress =
@@ -114,6 +114,10 @@ public class TcpIpConnectionManager implements ConnectionManager {
 
     private final int outboundPortCount;
 
+    private final int handlerMigrationIntervalSeconds;
+
+    private final HazelcastThreadGroup hazelcastThreadGroup;
+
     // accessed only in synchronized block
     private final LinkedList<Integer> outboundPorts = new LinkedList<Integer>();
 
@@ -124,12 +128,16 @@ public class TcpIpConnectionManager implements ConnectionManager {
     // to deal with this should only be used for the test lab. In the future we need to create a real fix to this problem,
     // but without this hack we can't do reliable benchmarking because the numbers have too much variation.
     private final boolean selectorImbalanceWorkaroundEnabled;
+    private IOBalancer ioBalancer;
     private final Map<String, Integer> selectorIndexPerHostMap;
+    private final LoggingService loggingService;
 
-    public TcpIpConnectionManager(IOService ioService, ServerSocketChannel serverSocketChannel) {
+    public TcpIpConnectionManager(IOService ioService, ServerSocketChannel serverSocketChannel,
+                                  HazelcastThreadGroup hazelcastThreadGroup, LoggingService loggingService) {
         this.ioService = ioService;
+        this.hazelcastThreadGroup = hazelcastThreadGroup;
         this.serverSocketChannel = serverSocketChannel;
-        this.logger = ioService.getLogger(TcpIpConnectionManager.class.getName());
+        this.logger = loggingService.getLogger(TcpIpConnectionManager.class.getName());
         this.socketReceiveBufferSize = ioService.getSocketReceiveBufferSize() * IOService.KILO_BYTE;
         this.socketSendBufferSize = ioService.getSocketSendBufferSize() * IOService.KILO_BYTE;
         this.socketLingerSeconds = ioService.getSocketLingerSeconds();
@@ -137,20 +145,20 @@ public class TcpIpConnectionManager implements ConnectionManager {
         this.socketKeepAlive = ioService.getSocketKeepAlive();
         this.socketNoDelay = ioService.getSocketNoDelay();
         this.selectorThreadCount = ioService.getSelectorThreadCount();
+        this.handlerMigrationIntervalSeconds = ioService.getBalancerIntervalSeconds();
         this.inSelectors = new InSelectorImpl[selectorThreadCount];
         this.outSelectors = new OutSelectorImpl[selectorThreadCount];
         final Collection<Integer> ports = ioService.getOutboundPorts();
-        this.outboundPortCount = ports == null ? 0 : ports.size();
-        if (ports != null) {
-            outboundPorts.addAll(ports);
-        }
+        this.outboundPortCount = ports.size();
+        this.outboundPorts.addAll(ports);
         this.socketChannelWrapperFactory = ioService.getSocketChannelWrapperFactory();
         this.selectorImbalanceWorkaroundEnabled = isSelectorImbalanceEnabled();
         this.selectorIndexPerHostMap = selectorImbalanceWorkaroundEnabled ? new HashMap<String, Integer>() : null;
+        this.loggingService = loggingService;
     }
 
     private boolean isSelectorImbalanceEnabled() {
-        boolean enabled = parseBoolean(System.getProperty("hazelcast.selectorhack.enabled", "false"));
+        boolean enabled = Boolean.getBoolean("hazelcast.selectorhack.enabled");
         if (enabled) {
             logger.severe("WARNING!!!! The 'hazelcast.selectorhack.enabled' has been enabled. This feature should not be used "
                     + "in a production environment. It is a temporary work around to deal with imbalances between selector-load. "
@@ -336,6 +344,8 @@ public class TcpIpConnectionManager implements ConnectionManager {
 
         final TcpIpConnection connection = new TcpIpConnection(this, inSelectors[index],
                 outSelectors[index], connectionIdGen.incrementAndGet(), channel);
+        ioBalancer.connectionAdded(connection);
+
         connection.setEndPoint(endpoint);
         activeConnections.add(connection);
         acceptedSockets.remove(channel);
@@ -429,6 +439,7 @@ public class TcpIpConnectionManager implements ConnectionManager {
         if (endPoint != null) {
             connectionsInProgress.remove(endPoint);
             connectionsMap.remove(endPoint, connection);
+            ioBalancer.connectionRemoved(connection);
             if (live) {
                 ioService.getEventService().executeEventCallback(new StripedRunnable() {
                     @Override
@@ -487,6 +498,7 @@ public class TcpIpConnectionManager implements ConnectionManager {
             inSelectors[i].start();
             outSelectors[i].start();
         }
+        startIOBalancer();
 
         if (socketAcceptorThread != null) {
             logger.warning("SocketAcceptor thread is already live! Shutting down old acceptor...");
@@ -496,6 +508,12 @@ public class TcpIpConnectionManager implements ConnectionManager {
         socketAcceptorThread = new Thread(ioService.getThreadGroup(), acceptRunnable,
                 ioService.getThreadPrefix() + "Acceptor");
         socketAcceptorThread.start();
+    }
+
+    private void startIOBalancer() {
+        ioBalancer = new IOBalancer(inSelectors, outSelectors,
+                hazelcastThreadGroup, handlerMigrationIntervalSeconds, loggingService);
+        ioBalancer.start();
     }
 
     @Override
@@ -530,6 +548,7 @@ public class TcpIpConnectionManager implements ConnectionManager {
     private void stop() {
         live = false;
         log(Level.FINEST, "Stopping ConnectionManager");
+        ioBalancer.stop();
         shutdownSocketAcceptor();
         for (SocketChannelWrapper socketChannel : acceptedSockets) {
             IOUtil.closeResource(socketChannel);
@@ -549,7 +568,6 @@ public class TcpIpConnectionManager implements ConnectionManager {
             }
         }
         shutdownIOSelectors();
-
         acceptedSockets.clear();
         connectionsInProgress.clear();
         connectionsMap.clear();

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/WriteHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/WriteHandler.java
@@ -48,6 +48,8 @@ public final class WriteHandler extends AbstractSelectionHandler implements Runn
     private SocketWritable currentPacket;
     private SocketWriter socketWriter;
     private volatile long lastHandle;
+    //This field will be incremented by a single thread. It can be read by multiple threads.
+    private volatile long eventCount;
 
     WriteHandler(TcpIpConnection connection, IOSelector ioSelector) {
         super(connection, ioSelector, SelectionKey.OP_WRITE);
@@ -164,9 +166,7 @@ public final class WriteHandler extends AbstractSelectionHandler implements Runn
         }
 
         // since everything is written, we are not interested anymore in write-events, so lets unsubscribe
-        // TODO: We need to make sure the selection key is created in the beginning instead of doing it lazily
-        SelectionKey selectionKey = getSelectionKey();
-        selectionKey.interestOps(selectionKey.interestOps() & ~SelectionKey.OP_WRITE);
+        unregisterOp(SelectionKey.OP_WRITE);
         // So the outputBuffer is empty, so we are going to unschedule ourselves.
         scheduled.set(false);
 
@@ -189,9 +189,17 @@ public final class WriteHandler extends AbstractSelectionHandler implements Runn
         ioSelector.addTask(this);
     }
 
-    @SuppressWarnings("unchecked")
     @Override
+    public long getEventCount() {
+        return eventCount;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    @edu.umd.cs.findbugs.annotations.SuppressWarnings(value = "VO_VOLATILE_INCREMENT",
+            justification = "eventCount is accessed by a single thread only.")
     public void handle() {
+        eventCount++;
         lastHandle = Clock.currentTimeMillis();
         if (!connection.isAlive()) {
             return;
@@ -211,7 +219,6 @@ public final class WriteHandler extends AbstractSelectionHandler implements Runn
         } catch (Throwable t) {
             logger.severe("Fatal Error at WriteHandler for endPoint: " + connection.getEndPoint(), t);
         }
-
         unschedule();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/handlermigration/BalancerState.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/handlermigration/BalancerState.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.nio.tcp.handlermigration;
+
+import com.hazelcast.nio.tcp.IOSelector;
+import com.hazelcast.nio.tcp.MigratableHandler;
+import com.hazelcast.util.ItemCounter;
+
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Describes a state of IOSelector (im-)balance.
+ *
+ * It's used by {@link com.hazelcast.nio.tcp.handlermigration.MigrationStrategy} to decide whether and what
+ * {@link com.hazelcast.nio.tcp.SelectionHandler} should be migrated.
+ *
+ *
+ */
+class BalancerState {
+    //number of events recorded by the busiest IOSelector
+    long maximumEvents;
+    //number of events recorded by the least busy IOSelector
+    long minimumEvents;
+    //busiest IOSelector
+    IOSelector sourceSelector;
+    //least busy selector
+    IOSelector destinationSelector;
+
+    private final Map<IOSelector, Set<MigratableHandler>> selectorToHandlers;
+    private final ItemCounter<MigratableHandler> handlerEventsCounter;
+
+    BalancerState(Map<IOSelector, Set<MigratableHandler>> selectorToHandlers,
+                  ItemCounter<MigratableHandler> handlerEventsCounter) {
+        this.selectorToHandlers = selectorToHandlers;
+        this.handlerEventsCounter = handlerEventsCounter;
+    }
+
+    /**
+     * @param selector
+     * @return A set of Handlers owned by the selector
+     */
+    Set<MigratableHandler> getHandlersOwnerBy(IOSelector selector) {
+        return selectorToHandlers.get(selector);
+    }
+
+    /**
+     * @param handler
+     * @return number of events recorded by the handler
+     */
+    long getNoOfEvents(MigratableHandler handler) {
+        return handlerEventsCounter.get(handler);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/handlermigration/IOBalancer.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/handlermigration/IOBalancer.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.nio.tcp.handlermigration;
+
+import com.hazelcast.instance.HazelcastThreadGroup;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.LoggingService;
+import com.hazelcast.nio.Connection;
+import com.hazelcast.nio.tcp.IOSelector;
+import com.hazelcast.nio.tcp.InSelectorImpl;
+import com.hazelcast.nio.tcp.MigratableHandler;
+import com.hazelcast.nio.tcp.OutSelectorImpl;
+import com.hazelcast.nio.tcp.ReadHandler;
+import com.hazelcast.nio.tcp.TcpIpConnection;
+import com.hazelcast.nio.tcp.WriteHandler;
+import com.hazelcast.util.EmptyStatement;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * It attempts to detect and fix a selector imbalance problem.
+ *
+ * By default Hazelcast uses 3 threads to read data from TCP connections and 3 threads to write data to connections.
+ * We have measured significant fluctuations of performance when the threads are not utilized equally.
+ *
+ * <code>com.hazelcast.nio.tcp.handlermigration.HandlerBalancer</code> tries to detect such situations and fix
+ * them by moving {@link com.hazelcast.nio.tcp.ReadHandler} and {@link com.hazelcast.nio.tcp.WriteHandler} between
+ * threads.
+ *
+ * It measures number of events serviced by each handler in a given interval and if imbalance is detected then it
+ * schedules handler migration to fix the situation. The exact migration strategy can be customized via
+ * {@link com.hazelcast.nio.tcp.handlermigration.MigrationStrategy}.
+ *
+ * Measuring interval can be customized via {@link com.hazelcast.instance.GroupProperties#IO_BALANCER_INTERVAL_SECONDS}
+ *
+ * It doesn't leverage {@link com.hazelcast.nio.ConnectionListener} capability
+ * provided by {@link com.hazelcast.nio.ConnectionManager} to observe connections as it has to be notified
+ * right after a physical TCP connection is created whilst <code>ConnectionListener</code> is notified only
+ * after a successful (Hazelcast) binding process.
+ *
+ *
+ */
+public class IOBalancer {
+    private final ILogger log;
+
+    private final int migrationIntervalSeconds;
+    private final MigrationStrategy strategy;
+
+    private final IOSelectorLoadCalculator inCalculator;
+    private final IOSelectorLoadCalculator outCalculator;
+
+    private final HazelcastThreadGroup threadGroup;
+    private volatile boolean isActive;
+
+    public IOBalancer(InSelectorImpl[] inSelectors, OutSelectorImpl[] outSelectors, HazelcastThreadGroup threadGroup,
+                      int migrationIntervalSeconds, LoggingService loggingService) {
+        this.log = loggingService.getLogger(IOBalancer.class);
+        this.migrationIntervalSeconds = migrationIntervalSeconds;
+        this.strategy = new MigrationStrategy();
+        this.threadGroup = threadGroup;
+
+        this.inCalculator = new IOSelectorLoadCalculator(inSelectors, loggingService);
+        this.outCalculator = new IOSelectorLoadCalculator(outSelectors, loggingService);
+
+        this.isActive = shouldStart(inSelectors, outSelectors);
+    }
+
+    public void connectionAdded(Connection connection) {
+        if (!(connection instanceof TcpIpConnection)) {
+            return;
+        }
+
+        ReadHandler readHandler = ((TcpIpConnection) connection).getReadHandler();
+        if (log.isFinestEnabled()) {
+            log.finest("Adding a read handler " + readHandler);
+        }
+        inCalculator.addHandler(readHandler);
+
+        WriteHandler writeHandler = ((TcpIpConnection) connection).getWriteHandler();
+        if (log.isFinestEnabled()) {
+            log.info("Adding a write handler " + writeHandler);
+        }
+        outCalculator.addHandler(writeHandler);
+    }
+
+    public void connectionRemoved(Connection connection) {
+        if (!(connection instanceof TcpIpConnection)) {
+            return;
+        }
+
+        ReadHandler readHandler = ((TcpIpConnection) connection).getReadHandler();
+        if (log.isFinestEnabled()) {
+            log.finest("Removing a read handler " + readHandler);
+        }
+        inCalculator.removeHandler(readHandler);
+
+        WriteHandler writeHandler = ((TcpIpConnection) connection).getWriteHandler();
+        if (log.isFinestEnabled()) {
+            log.finest("Removing a write handler " + readHandler);
+        }
+        outCalculator.removeHandler(writeHandler);
+    }
+
+    public void stop() {
+        isActive = false;
+    }
+
+    public void start() {
+        Thread migratorThread = new IOBalancerThread();
+        migratorThread.start();
+    }
+
+    private void checkWriteHandlers() {
+        scheduleMigrationIfNeeded(outCalculator);
+    }
+
+    private void checkReadHandlers() {
+        scheduleMigrationIfNeeded(inCalculator);
+    }
+
+    public void scheduleMigrationIfNeeded(IOSelectorLoadCalculator stateCalculator) {
+        BalancerState balancerState = stateCalculator.getState();
+        if (strategy.shouldAttemptToScheduleMigration(balancerState)) {
+            tryToMigrate(balancerState);
+        } else {
+            if (log.isFinestEnabled()) {
+                long min = balancerState.minimumEvents;
+                long max = balancerState.maximumEvents;
+                log.finest("No imbalance has been detected. Max. events: " + max + " Min events: " + min + ".");
+            }
+        }
+    }
+
+    private boolean shouldStart(InSelectorImpl[] inSelectors, OutSelectorImpl[] outSelectors) {
+        return inSelectors.length > 1 || outSelectors.length > 1;
+    }
+
+    private void tryToMigrate(BalancerState balancerState) {
+        MigratableHandler handler = strategy.findHandlerToMigrate(balancerState);
+        if (handler == null) {
+            log.finest("There had been imbalance detected, but no suitable migration candidate was found.");
+            return;
+        }
+
+        IOSelector destinationSelector = balancerState.destinationSelector;
+        if (log.isFinestEnabled()) {
+            IOSelector sourceSelector = balancerState.sourceSelector;
+            log.finest("Scheduling a migration of a handler " + handler
+                    + " from a selector thread " + sourceSelector + " to " + destinationSelector);
+        }
+        handler.migrate(destinationSelector);
+    }
+
+    private final class IOBalancerThread extends Thread {
+        private IOBalancerThread() {
+            super(threadGroup.getInternalThreadGroup(), threadGroup.getThreadNamePrefix("IOBalancerThread"));
+        }
+
+        @Override
+        public void run() {
+            try {
+                while (isActive) {
+                    log.finest("Starting IOBalancer thread");
+                    checkReadHandlers();
+                    checkWriteHandlers();
+                    TimeUnit.SECONDS.sleep(migrationIntervalSeconds);
+                }
+            } catch (InterruptedException e) {
+                log.finest("IOBalancer thread stopped");
+                //this thread is about to exit, no reason restoring the interrupt flag
+                EmptyStatement.ignore(e);
+            }
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/handlermigration/IOSelectorLoadCalculator.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/handlermigration/IOSelectorLoadCalculator.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.nio.tcp.handlermigration;
+
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.LoggingService;
+import com.hazelcast.nio.tcp.AbstractIOSelector;
+import com.hazelcast.nio.tcp.IOSelector;
+import com.hazelcast.nio.tcp.MigratableHandler;
+import com.hazelcast.util.ItemCounter;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
+
+import static com.hazelcast.util.StringUtil.getLineSeperator;
+
+/**
+ * Calculates a state describing utilization of IOSelector(s) and creates a mapping between IOSelector -> Handler.
+ *
+ * This class is not thread-safe with the exception of
+ * {@link #addHandler(MigratableHandler)}   and
+ * {@link #removeHandler(MigratableHandler)}
+ *
+ */
+class IOSelectorLoadCalculator {
+    private final ILogger log;
+
+    //all known IO selectors. we assume no. of selectors is constant during a lifespan of a member
+    private final AbstractIOSelector[] selectors;
+    private final Map<IOSelector, Set<MigratableHandler>> selectorToHandlers;
+
+    //no. of events per handler since an instance started
+    private final ItemCounter<MigratableHandler> lastEventCounter = new ItemCounter<MigratableHandler>();
+
+    //no. of events per IOSelector since last calculation
+    private final ItemCounter<IOSelector> selectorEvents = new ItemCounter<IOSelector>();
+    //no. of events per handler since last calculation
+    private final ItemCounter<MigratableHandler> handlerEventsCounter = new ItemCounter<MigratableHandler>();
+
+    //contains all known handlers
+    private final Set<MigratableHandler> handlers = new CopyOnWriteArraySet<MigratableHandler>();
+
+    private final BalancerState state;
+
+    IOSelectorLoadCalculator(AbstractIOSelector[] selectors, LoggingService loggingService) {
+        this.log = loggingService.getLogger(IOSelectorLoadCalculator.class);
+
+        this.selectors = new AbstractIOSelector[selectors.length];
+        System.arraycopy(selectors, 0, this.selectors, 0, selectors.length);
+
+        this.selectorToHandlers = new HashMap<IOSelector, Set<MigratableHandler>>();
+        for (AbstractIOSelector selector : selectors) {
+            selectorToHandlers.put(selector, new HashSet<MigratableHandler>());
+        }
+        this.state = new BalancerState(selectorToHandlers, handlerEventsCounter);
+    }
+
+    /**
+     * Recalculates a new state. Returned instance of {@link com.hazelcast.nio.tcp.handlermigration.BalancerState} are recycled
+     * between invocations therefore they are valid for the last invocation only.
+     *
+     * @return recalculated state
+     */
+    BalancerState getState() {
+        clearWorkingState();
+        calculateNewWorkingState();
+        calculateNewFinalState();
+        printDebugTable();
+        return state;
+    }
+
+    private void calculateNewFinalState() {
+        state.minimumEvents = Long.MAX_VALUE;
+        state.maximumEvents = Long.MIN_VALUE;
+        state.sourceSelector = null;
+        state.destinationSelector = null;
+        for (AbstractIOSelector selector : selectors) {
+            long eventCount = selectorEvents.get(selector);
+            if (eventCount > state.maximumEvents) {
+                state.maximumEvents = eventCount;
+                state.sourceSelector = selector;
+            }
+            if (eventCount < state.minimumEvents) {
+                state.minimumEvents = eventCount;
+                state.destinationSelector = selector;
+            }
+        }
+    }
+
+    private void calculateNewWorkingState() {
+        for (MigratableHandler handler : handlers) {
+            calculateHandlerState(handler);
+        }
+    }
+
+    private void calculateHandlerState(MigratableHandler handler) {
+        long handlerEventCount = getEventCountSinceLastCheck(handler);
+        handlerEventsCounter.set(handler, handlerEventCount);
+        IOSelector owner = handler.getOwner();
+        selectorEvents.add(owner, handlerEventCount);
+        Set<MigratableHandler> handlersOwnedBy = selectorToHandlers.get(owner);
+        handlersOwnedBy.add(handler);
+    }
+
+    private long getEventCountSinceLastCheck(MigratableHandler handler) {
+        long totalNoOfEvents = handler.getEventCount();
+        Long lastNoOfEvents = lastEventCounter.getAndSet(handler, totalNoOfEvents);
+        return totalNoOfEvents - lastNoOfEvents;
+    }
+
+    private void clearWorkingState() {
+        handlerEventsCounter.reset();
+        selectorEvents.reset();
+        for (Set<MigratableHandler> handlerSet : selectorToHandlers.values()) {
+            handlerSet.clear();
+        }
+    }
+
+    void addHandler(MigratableHandler handler) {
+        handlers.add(handler);
+    }
+
+    void removeHandler(MigratableHandler handler) {
+        handlers.remove(handler);
+    }
+
+    private void printDebugTable() {
+        if (!log.isFinestEnabled()) {
+            return;
+        }
+
+        IOSelector minSelector = state.destinationSelector;
+        IOSelector maxSelector = state.sourceSelector;
+        if (minSelector == null || maxSelector == null) {
+            return;
+        }
+        StringBuilder sb = new StringBuilder(getLineSeperator())
+                .append("------------")
+                .append(getLineSeperator());
+        Long noOfEventsPerSelector = selectorEvents.get(minSelector);
+
+        sb.append("Min Selector ")
+                .append(minSelector)
+                .append(" received ")
+                .append(noOfEventsPerSelector)
+                .append(" events. ");
+        sb.append("It contains following handlers: ").
+                append(getLineSeperator());
+        appendSelectorInfo(minSelector, selectorToHandlers, sb);
+
+        noOfEventsPerSelector = selectorEvents.get(maxSelector);
+        sb.append("Max Selector ")
+                .append(maxSelector)
+                .append(" received ")
+                .append(noOfEventsPerSelector)
+                .append(" events. ");
+        sb.append("It contains following handlers: ")
+                .append(getLineSeperator());
+        appendSelectorInfo(maxSelector, selectorToHandlers, sb);
+
+        sb.append("Other Selectors: ")
+                .append(getLineSeperator());
+
+        for (AbstractIOSelector selector : selectors) {
+            if (!selector.equals(minSelector) && !selector.equals(maxSelector)) {
+                noOfEventsPerSelector = selectorEvents.get(selector);
+                sb.append("Selector ")
+                        .append(selector)
+                        .append(" contains ")
+                        .append(noOfEventsPerSelector)
+                        .append(" and has these handlers: ")
+                        .append(getLineSeperator());
+                appendSelectorInfo(selector, selectorToHandlers, sb);
+            }
+        }
+        sb.append("------------")
+                .append(getLineSeperator());
+        log.finest(sb.toString());
+    }
+
+    private void appendSelectorInfo(IOSelector minSelector, Map<IOSelector,
+            Set<MigratableHandler>> selectorToHandlers, StringBuilder sb) {
+        Set<MigratableHandler> handlerSet = selectorToHandlers.get(minSelector);
+        for (MigratableHandler selectionHandler : handlerSet) {
+            Long noOfEventsPerHandler = handlerEventsCounter.get(selectionHandler);
+            sb.append(selectionHandler)
+                    .append(":  ")
+                    .append(noOfEventsPerHandler)
+                    .append(getLineSeperator());
+        }
+        sb.append(getLineSeperator());
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/handlermigration/MigrationStrategy.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/handlermigration/MigrationStrategy.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.nio.tcp.handlermigration;
+
+import com.hazelcast.nio.tcp.MigratableHandler;
+import java.util.Set;
+
+/**
+ * Simple Migration Strategy for Handlers.
+ *
+ * It attempts to trigger a migration if a ratio between least busy and most busy selectors
+ * exceeds {@link #MIN_MAX_RATIO_MIGRATION_THRESHOLD}.
+ *
+ * Once a migration is triggered it tries to find the busiest handler registered in
+ * {@link com.hazelcast.nio.tcp.handlermigration.BalancerState#sourceSelector} which wouldn't cause
+ * overload of the {@link com.hazelcast.nio.tcp.handlermigration.BalancerState#destinationSelector} after a migration.
+ *
+ */
+class MigrationStrategy {
+
+    /**
+     * You can use this property to tune whether the migration will be attempted at all. The higher the number is
+     * the more likely the migration will be attempted. Too higher number will result in unnecessary overhead, too
+     * low number will cause performance degradation due selector imbalance.
+     *
+     * Try to schedule a migration if the least busy IOSelector receives less events
+     * then (MIN_MAX_RATIO_MIGRATION_THRESHOLD * no. of events received by the busiest IOSelector)
+     *
+     */
+    private static final double MIN_MAX_RATIO_MIGRATION_THRESHOLD = 0.8;
+
+    /**
+     * You can use this property to tune a selection process for handler migration. The higher number is the more
+     * aggressive migration process is.
+     */
+    private static final double MAXIMUM_NO_OF_EVENTS_AFTER_MIGRATION_COEFFICIENT = 0.9;
+
+    /**
+     * @param state
+     * @return <code>true</code> if imbalance threshold has been reached and migration should be attempted
+     */
+    boolean shouldAttemptToScheduleMigration(BalancerState state) {
+        long min = state.minimumEvents;
+        long max = state.maximumEvents;
+
+        if (min == Long.MIN_VALUE || max == Long.MAX_VALUE) {
+            return false;
+        }
+        long lowerBound = (long) (MIN_MAX_RATIO_MIGRATION_THRESHOLD * max);
+        return min < lowerBound;
+    }
+
+    /**
+     * Attempt to find a handler to migrate to a new IOSelector.
+     *
+     * @param state describing a snapshot of IOSelector load
+     * @return a handler to migrate to a new IOSelector or null if no suitable handler is found.
+     */
+     MigratableHandler findHandlerToMigrate(BalancerState state) {
+        Set<? extends MigratableHandler> candidates = state.getHandlersOwnerBy(state.sourceSelector);
+        long migrationThreshold = (long) ((state.maximumEvents - state.minimumEvents)
+                * MAXIMUM_NO_OF_EVENTS_AFTER_MIGRATION_COEFFICIENT);
+        MigratableHandler candidate = null;
+        long noOfEventsInSelectedHandler = 0;
+        for (MigratableHandler handler : candidates) {
+            long noOfEvents = state.getNoOfEvents(handler);
+            if (noOfEvents > noOfEventsInSelectedHandler) {
+                if (noOfEvents < migrationThreshold) {
+                    noOfEventsInSelectedHandler = noOfEvents;
+                    candidate = handler;
+                }
+            }
+        }
+        return candidate;
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/handlermigration/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/handlermigration/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Contains Handler Migration classes
+ */
+package com.hazelcast.nio.tcp.handlermigration;

--- a/hazelcast/src/main/java/com/hazelcast/util/ItemCounter.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/ItemCounter.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.util;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Non Thread-Safe Counter of things. It allows to count items without worrying about nulls.
+ *
+ * @param <T>
+ */
+public final class ItemCounter<T> {
+    private final Map<T, MutableLong> map = new HashMap<T, MutableLong>();
+
+    /**
+     * Get current counter for an item item
+     *
+     * @param item
+     * @return current state of a counter for item
+     */
+    public long get(T item) {
+        MutableLong count = map.get(item);
+        return count == null ? 0 : count.value;
+    }
+
+    /**
+     * Set counter of item to value
+     *
+     * @param item to set set the value for
+     * @param value a new value
+     */
+    public void set(T item, long value) {
+        MutableLong entry = map.get(item);
+        if (entry == null) {
+            entry = MutableLong.valueOf(value);
+            map.put(item, entry);
+        } else {
+            entry.value = value;
+        }
+    }
+
+    /**
+     * Add delta to the item
+     *
+     * @param item
+     * @param delta
+     */
+    public void add(T item, long delta) {
+        MutableLong entry = map.get(item);
+        if (entry == null) {
+            entry = MutableLong.valueOf(delta);
+            map.put(item, entry);
+        } else {
+            entry.value += delta;
+        }
+    }
+
+    /**
+     * Reset state of the counter to 0.
+     * It will <b>NOT</b> necessary remove all data referenced.
+     *
+     * Time complexity of this operation is O(n) where n is number of items.
+     *
+     */
+    public void reset() {
+        for (MutableLong entry : map.values()) {
+            entry.value = 0;
+        }
+    }
+
+    /**
+     * Set counter for item and return previous value
+     *
+     * @param item
+     * @param value
+     * @return
+     */
+    public long getAndSet(T item, long value) {
+        MutableLong entry = map.get(item);
+
+        if (entry == null) {
+            entry = MutableLong.valueOf(value);
+            map.put(item, entry);
+            return 0;
+        }
+
+        long oldValue = entry.value;
+        entry.value = value;
+        return oldValue;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        ItemCounter that = (ItemCounter) o;
+
+        if (!map.equals(that.map)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return map.hashCode();
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/util/MutableLong.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/MutableLong.java
@@ -1,0 +1,43 @@
+package com.hazelcast.util;
+
+/**
+ * Mutable integer which can be used for counting purposes.
+ * <p/>
+ * This class is not thread-safe.
+ */
+public class MutableLong {
+
+    //CHECKSTYLE:OFF
+    public long value;
+    //CHECKSTYLE:OFF
+
+    public static MutableLong valueOf(long value) {
+        MutableLong instance = new MutableLong();
+        instance.value = value;
+        return instance;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        MutableLong that = (MutableLong) o;
+        return value == that.value;
+    }
+
+    @Override
+    public int hashCode() {
+        return (int) (value ^ (value >>> 32));
+    }
+
+    @Override
+    public String toString() {
+        return "MutableLong{" +
+                "value=" + value +
+                '}';
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/cluster/SplitBrainHandlerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/SplitBrainHandlerTest.java
@@ -716,7 +716,8 @@ public class SplitBrainHandlerTest extends HazelcastTestSupport {
         @Override
         public ConnectionManager createConnectionManager(Node node, ServerSocketChannel serverSocketChannel) {
             NodeIOService ioService = new NodeIOService(node);
-            return new FirewallingTcpIpConnectionManager(ioService, serverSocketChannel);
+            return new FirewallingTcpIpConnectionManager(node.loggingService,
+                    node.getHazelcastThreadGroup(), ioService, serverSocketChannel);
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/FirewallingTcpIpConnectionManager.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/FirewallingTcpIpConnectionManager.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.nio.tcp;
 
+import com.hazelcast.instance.HazelcastThreadGroup;
+import com.hazelcast.logging.LoggingService;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.NodeIOService;
@@ -29,8 +31,8 @@ public class FirewallingTcpIpConnectionManager extends TcpIpConnectionManager {
 
     final Set<Address> blockedAddresses = Collections.newSetFromMap(new ConcurrentHashMap<Address, Boolean>());
 
-    public FirewallingTcpIpConnectionManager(NodeIOService ioService, ServerSocketChannel serverSocketChannel) {
-        super(ioService, serverSocketChannel);
+    public FirewallingTcpIpConnectionManager(LoggingService loggingService, HazelcastThreadGroup threadGroup, NodeIOService ioService, ServerSocketChannel serverSocketChannel) {
+        super(ioService, serverSocketChannel, threadGroup, loggingService);
     }
 
     @Override


### PR DESCRIPTION
Motivation:
Hazelcast by default uses 3 threads to read data from TCP connections
and 3 threads to write data to the connections. We have measured significant
fluctuations of performance when the threads are not utilized equally.

This Balancer tries to detect such situations and fix them by moving
com.hazelcast.nio.tcp.ReadHandler and com.hazelcast.nio.tcp.WriteHandler
between threads.

Implementation:
It measures number of events serviced by each handler in a given interval
and if imbalance is detected then it schedules handler migration to improve
the situation. The exact migration strategy can be customized via
com.hazelcast.nio.handlermigration.MigrationStrategy.

Configuration:
Measuring interval can be customized via
com.hazelcast.instance.GroupProperties#HANDLER_MIGRATION_INTERVAL_SECONDS

Implementator's Note:
It doesn't leverage com.hazelcast.nio.ConnectionListener capability
provided by com.hazelcast.nio.ConnectionManager to observe connections as it
has to be notified right after a physical TCP connection is created whilst
ConnectionListener is notified only after a successful (Hazelcast) binding process.