### PR TITLE
Fix for issue #4878 [Client Backward Compatibility Broken by PR #4788]

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/HazelcastClientCacheManager.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/HazelcastClientCacheManager.java
@@ -126,7 +126,7 @@ public final class HazelcastClientCacheManager extends AbstractHazelcastCacheMan
     protected <K, V> CacheConfig<K, V> createConfigOnPartition(CacheConfig<K, V> cacheConfig) {
         try {
             int partitionId = clientContext.getPartitionService().getPartitionId(cacheConfig.getNameWithPrefix());
-            CacheCreateConfigRequest request = new CacheCreateConfigRequest(cacheConfig, false, false, partitionId);
+            CacheCreateConfigRequest request = new CacheCreateConfigRequest(cacheConfig, false, partitionId);
             Future future = clientContext.getInvocationService()
                                 .invokeOnKeyOwner(request, cacheConfig.getNameWithPrefix());
             return (CacheConfig<K, V>) clientContext.getSerializationService().toObject(future.get());
@@ -166,7 +166,7 @@ public final class HazelcastClientCacheManager extends AbstractHazelcastCacheMan
         try {
             int partitionId = clientContext.getPartitionService().getPartitionId(config.getNameWithPrefix());
             CacheCreateConfigRequest request =
-                    new CacheCreateConfigRequest(config, createAlsoOnOthers, false, partitionId);
+                    new CacheCreateConfigRequest(config, createAlsoOnOthers, partitionId);
             Future future = clientContext.getInvocationService().invokeOnKeyOwner(request, cacheName);
             if (syncCreate) {
                 return (CacheConfig<K, V>) clientContext.getSerializationService().toObject(future.get());

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/client/CacheCreateConfigRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/client/CacheCreateConfigRequest.java
@@ -44,18 +44,15 @@ public class CacheCreateConfigRequest
     private static final int TRY_COUNT = 100;
 
     private CacheConfig cacheConfig;
-    private boolean createAlsoOnOthers = true;
-    private boolean ignoreLocal;
+    private boolean createAlsoOnOthers;
     private int partitionId;
 
     public CacheCreateConfigRequest() {
     }
 
-    public CacheCreateConfigRequest(CacheConfig cacheConfig, boolean createAlsoOnOthers, boolean ignoreLocal,
-                                    int partitionId) {
+    public CacheCreateConfigRequest(CacheConfig cacheConfig, boolean createAlsoOnOthers, int partitionId) {
         this.cacheConfig = cacheConfig;
         this.createAlsoOnOthers = createAlsoOnOthers;
-        this.ignoreLocal = ignoreLocal;
         this.partitionId = partitionId;
     }
 
@@ -75,7 +72,7 @@ public class CacheCreateConfigRequest
     }
 
     protected Operation prepareOperation() {
-        return new CacheCreateConfigOperation(cacheConfig, createAlsoOnOthers, ignoreLocal);
+        return new CacheCreateConfigOperation(cacheConfig, createAlsoOnOthers, false);
     }
 
     public final int getFactoryId() {
@@ -93,8 +90,7 @@ public class CacheCreateConfigRequest
 
     public void write(PortableWriter writer)
             throws IOException {
-        writer.writeBoolean("o", createAlsoOnOthers);
-        writer.writeBoolean("l", ignoreLocal);
+        writer.writeBoolean("c", createAlsoOnOthers);
         writer.writeInt("p", partitionId);
         final ObjectDataOutput out = writer.getRawDataOutput();
         out.writeObject(cacheConfig);
@@ -102,8 +98,7 @@ public class CacheCreateConfigRequest
 
     public void read(PortableReader reader)
             throws IOException {
-        createAlsoOnOthers = reader.readBoolean("o");
-        ignoreLocal = reader.readBoolean("l");
+        createAlsoOnOthers = reader.readBoolean("c");
         partitionId = reader.readInt("p");
         final ObjectDataInput in = reader.getRawDataInput();
         cacheConfig = in.readObject();

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheCreateConfigOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheCreateConfigOperation.java
@@ -40,10 +40,10 @@ import java.util.concurrent.atomic.AtomicInteger;
  * <li>Find partition id using the distributed object name of cache as a key.</li>
  * <li>Send the <code>CacheCreateConfigOperation</code> operation to the calculated partition which will force all
  * clusters to be single threaded.</li>
- * <li>{@link CacheService#createCacheConfigIfAbsent(com.hazelcast.config.CacheConfig)} is called.</li>
+ * <li>{@link com.hazelcast.cache.impl.CacheService#createCacheConfigIfAbsent(com.hazelcast.config.CacheConfig)} is called.</li>
  * </ul></p>
  * <p>This operation's purpose is to pass the required parameters into
- * {@link CacheService#createCacheConfigIfAbsent(com.hazelcast.config.CacheConfig)}.</p>
+ * {@link com.hazelcast.cache.impl.CacheService#createCacheConfigIfAbsent(com.hazelcast.config.CacheConfig)}.</p>
  */
 public class CacheCreateConfigOperation
         extends AbstractNamedOperation


### PR DESCRIPTION
There was added new field to `CacheCreateConfigRequest` as `ignoreLocal` to ignoring cache config creation on node that receives request. It was more likely about optimization and configurable request. So when deserializing request at server side it was causing error since previous clients was using `create` field with name `c`, but newer versioned server nodes was expecting fields `createAlsoOnOtherNodes` as `o` and  `ignoreLocal`as `l`.

```
Exception in thread "main" com.hazelcast.nio.serialization.HazelcastSerializationException: Unknown field name: 'o' for ClassDefinition {id: 16, version: 1}
        at com.hazelcast.nio.serialization.DefaultPortableReader.throwUnknownFieldException(DefaultPortableReader.java:221)
        at com.hazelcast.nio.serialization.DefaultPortableReader.readNestedPosition(DefaultPortableReader.java:298)
        at com.hazelcast.nio.serialization.DefaultPortableReader.readPosition(DefaultPortableReader.java:259)
        at com.hazelcast.nio.serialization.DefaultPortableReader.readBoolean(DefaultPortableReader.java:92)
        at com.hazelcast.cache.impl.client.CacheCreateConfigRequest.read(CacheCreateConfigRequest.java:105)
        at com.hazelcast.client.impl.client.ClientRequest.readPortable(ClientRequest.java:116)
        at com.hazelcast.nio.serialization.PortableSerializer.read(PortableSerializer.java:88)
        at com.hazelcast.nio.serialization.PortableSerializer.read(PortableSerializer.java:30)
        at com.hazelcast.nio.serialization.StreamSerializerAdapter.toObject(StreamSerializerAdapter.java:65)
        at com.hazelcast.nio.serialization.SerializationServiceImpl.toObject(SerializationServiceImpl.java:260)
        at com.hazelcast.client.impl.ClientEngineImpl$ClientPacketProcessor.loadRequest(ClientEngineImpl.java:364)
        at com.hazelcast.client.impl.ClientEngineImpl$ClientPacketProcessor.run(ClientEngineImpl.java:340)
        at com.hazelcast.spi.impl.BasicOperationService$BasicDispatcherImpl.dispatch(BasicOperationService.java:585)
        at com.hazelcast.spi.impl.BasicOperationScheduler$OperationThread.process(BasicOperationScheduler.java:466)
        at com.hazelcast.spi.impl.BasicOperationScheduler$OperationThread.doRun(BasicOperationScheduler.java:458)
        at com.hazelcast.spi.impl.BasicOperationScheduler$OperationThread.run(BasicOperationScheduler.java:432)
        at ------ End remote and begin local stack-trace ------.(Unknown Source)
        at com.hazelcast.client.spi.impl.ClientCallFuture.resolveResponse(ClientCallFuture.java:201)
        at com.hazelcast.client.spi.impl.ClientCallFuture.get(ClientCallFuture.java:142)
        at com.hazelcast.client.spi.impl.ClientCallFuture.get(ClientCallFuture.java:118)
        at com.hazelcast.client.cache.impl.HazelcastClientCacheManager.createConfigOnPartition(HazelcastClientCacheManager.java:119)
        at com.hazelcast.cache.impl.AbstractHazelcastCacheManager.createCache(AbstractHazelcastCacheManager.java:99)
        at com.hazelcast.cache.impl.AbstractHazelcastCacheManager.createCache(AbstractHazelcastCacheManager.java:44)
```