### PR TITLE
Fixed NPE in SlowOperationDetector

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/slowoperationdetector/SlowOperationDetectorBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/slowoperationdetector/SlowOperationDetectorBasicTest.java
@@ -41,9 +41,7 @@ public class SlowOperationDetectorBasicTest extends SlowOperationDetectorAbstrac
 
     @After
     public void teardown() {
-        if (instance != null) {
-            shutdownOperationService(instance);
-        }
+        shutdownOperationService(instance);
         shutdownNodeFactory();
     }
 
@@ -254,6 +252,7 @@ public class SlowOperationDetectorBasicTest extends SlowOperationDetectorAbstrac
     }
 
     private static class SlowRecursiveOperation extends AbstractOperation {
+
         private final int recursionDepth;
         private final int sleepSeconds;
 


### PR DESCRIPTION
* fixed NPE in `SlowOperationDetector`
* simplified `totalInvocation` increment (no contention, so `AtomicInteger` doesn't hurt)
* got rid of double stored `id` in `Invocation` (can be fetched from map entry)
* cleanup of custom test methods

Fixes issue #4855.