### PR TITLE
Fixing Cache Null issue.

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/cache/CacheConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CacheConfigTest.java
@@ -31,6 +31,7 @@ import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.util.EmptyStatement;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -53,7 +54,12 @@ import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.CountDownLatch;
 
-import static junit.framework.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
@@ -207,7 +213,8 @@ public class CacheConfigTest extends HazelcastTestSupport {
         try {
             cacheManager.createCache(cacheName, null);
             fail("NullPointerException expected");
-        }catch (NullPointerException expected){
+        } catch (NullPointerException expected) {
+            EmptyStatement.ignore(expected);
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/cache/CacheConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CacheConfigTest.java
@@ -53,11 +53,7 @@ import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.CountDownLatch;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertFalse;
-import static junit.framework.Assert.assertNotNull;
-import static junit.framework.Assert.assertNull;
-import static junit.framework.Assert.assertTrue;
+import static junit.framework.Assert.*;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
@@ -200,6 +196,21 @@ public class CacheConfigTest extends HazelcastTestSupport {
 
         Cache testCache = cacheManager.getCache("default");
         assertNull(testCache);
+    }
+
+    @Test
+    public void createCache_WhenCacheConfigIsNull() {
+        String cacheName = "cacheNull";
+
+        CacheManager cacheManager = Caching.getCachingProvider().getCacheManager();
+
+        try {
+            cacheManager.createCache(cacheName, null);
+            fail("NullPointerException expected");
+        }catch (NullPointerException expected){
+        }
+
+        cacheManager.destroyCache(cacheName);
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/cache/CacheConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CacheConfigTest.java
@@ -42,6 +42,7 @@ import org.junit.runner.RunWith;
 import javax.cache.Cache;
 import javax.cache.CacheManager;
 import javax.cache.Caching;
+import javax.cache.configuration.Configuration;
 import javax.cache.configuration.Factory;
 import javax.cache.event.CacheEntryCreatedListener;
 import javax.cache.event.CacheEntryListenerException;
@@ -211,7 +212,7 @@ public class CacheConfigTest extends HazelcastTestSupport {
         CacheManager cacheManager = Caching.getCachingProvider().getCacheManager();
 
         try {
-            cacheManager.createCache(cacheName, null);
+            cacheManager.createCache(cacheName, (Configuration<Object, Object>) null);
             fail("NullPointerException expected");
         } catch (NullPointerException expected) {
             EmptyStatement.ignore(expected);

--- a/hazelcast/src/test/java/com/hazelcast/cache/CacheConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CacheConfigTest.java
@@ -209,8 +209,6 @@ public class CacheConfigTest extends HazelcastTestSupport {
             fail("NullPointerException expected");
         }catch (NullPointerException expected){
         }
-
-        cacheManager.destroyCache(cacheName);
     }
 
     @Test


### PR DESCRIPTION
During investigation those two issues:
- https://github.com/hazelcast/hazelcast/issues/4849 
- https://github.com/hazelcast/hazelcast-simulator/issues/568 

we found that when we put NULL into the cache - it throws NullPointerException.

This unit test was created to catch this situation. 

This test is PASSED.