### PR TITLE
hazelcast-spring module pom.xml cleanup

### DIFF
--- a/hazelcast-spring/pom.xml
+++ b/hazelcast-spring/pom.xml
@@ -132,18 +132,6 @@
     <dependencies>
         <dependency>
             <groupId>org.springframework</groupId>
-            <artifactId>spring-core</artifactId>
-            <version>${org.springframework.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-beans</artifactId>
-            <version>${org.springframework.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>
             <version>${org.springframework.version}</version>
             <scope>provided</scope>
@@ -164,13 +152,11 @@
             <groupId>com.hazelcast</groupId>
             <artifactId>hazelcast</artifactId>
             <version>${project.parent.version}</version>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.hazelcast</groupId>
             <artifactId>hazelcast-client</artifactId>
             <version>${project.parent.version}</version>
-            <scope>provided</scope>
             <optional>true</optional>
         </dependency>
         <dependency>


### PR DESCRIPTION
Once this merged, application developers are not required to provide **hazelcast** or **hazelcast-client** dependencies in their pom.xml. **hazelcast-spring** dependency will be sufficient to include hazelcast into spring applications.
