### PR TITLE
Prevent running operations on unwanted threads

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/nio/NIOThread.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/NIOThread.java
@@ -1,7 +1,0 @@
-package com.hazelcast.nio;
-
-/**
- * Marker interface for non-blocking IO threads.
- */
-public interface NIOThread {
-}

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/IOSelector.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/IOSelector.java
@@ -16,11 +16,11 @@
 
 package com.hazelcast.nio.tcp;
 
-import com.hazelcast.nio.NIOThread;
+import com.hazelcast.spi.impl.operationexecutor.OperationHostileThread;
 
 import java.nio.channels.Selector;
 
-public interface IOSelector extends NIOThread {
+public interface IOSelector extends OperationHostileThread {
 
     Selector getSelector();
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/OperationHostileThread.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/OperationHostileThread.java
@@ -1,0 +1,7 @@
+package com.hazelcast.spi.impl.operationexecutor;
+
+/**
+ * Marker interface for threads that are not allowed to run operations.
+ */
+public interface OperationHostileThread {
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/classic/ClassicOperationExecutor.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/classic/ClassicOperationExecutor.java
@@ -22,7 +22,7 @@ import com.hazelcast.instance.NodeExtension;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.LoggingService;
 import com.hazelcast.nio.Address;
-import com.hazelcast.nio.NIOThread;
+import com.hazelcast.spi.impl.operationexecutor.OperationHostileThread;
 import com.hazelcast.nio.Packet;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.impl.operationexecutor.ResponsePacketHandler;
@@ -208,7 +208,7 @@ public final class ClassicOperationExecutor implements OperationExecutor {
         Thread currentThread = Thread.currentThread();
 
         // IO threads are not allowed to run any operation
-        if (currentThread instanceof NIOThread) {
+        if (currentThread instanceof OperationHostileThread) {
             return false;
         }
 
@@ -244,7 +244,7 @@ public final class ClassicOperationExecutor implements OperationExecutor {
         Thread currentThread = Thread.currentThread();
 
         // IO threads are not allowed to run any operation
-        if (currentThread instanceof NIOThread) {
+        if (currentThread instanceof OperationHostileThread) {
             return false;
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/classic/ResponseThread.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/classic/ResponseThread.java
@@ -2,6 +2,7 @@ package com.hazelcast.spi.impl.operationexecutor.classic;
 
 import com.hazelcast.instance.HazelcastThreadGroup;
 import com.hazelcast.logging.ILogger;
+import com.hazelcast.spi.impl.operationexecutor.OperationHostileThread;
 import com.hazelcast.nio.Packet;
 import com.hazelcast.spi.impl.operationexecutor.ResponsePacketHandler;
 
@@ -20,8 +21,11 @@ import static com.hazelcast.instance.OutOfMemoryErrorDispatcher.inspectOutputMem
  * The reason that the IO thread doesn't immediately deals with the response is that deserializing the
  * {@link com.hazelcast.spi.impl.operationservice.impl.responses.Response} and let the invocation-future
  * deal with the response can be rather expensive currently.
+ *
+ * This class needs to implement the OperationHostileThread interface to make sure that the OperationExecutor
+ * is not going to schedule any operations on this task due to retry.
  */
-public final class ResponseThread extends Thread {
+public final class ResponseThread extends Thread implements OperationHostileThread {
 
     final BlockingQueue<Packet> workQueue = new LinkedBlockingQueue<Packet>();
     // field is only written by the response-thread itself, but can be read by other threads.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationRegistry.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationRegistry.java
@@ -5,6 +5,7 @@ import com.hazelcast.core.MemberLeftException;
 import com.hazelcast.instance.MemberImpl;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Address;
+import com.hazelcast.spi.impl.operationexecutor.OperationHostileThread;
 import com.hazelcast.partition.ReplicaErrorLogger;
 import com.hazelcast.spi.BackupAwareOperation;
 import com.hazelcast.spi.Operation;
@@ -297,8 +298,11 @@ public class InvocationRegistry {
      * <p/>
      * But it should also check if a 'is still running' check needs to be done. This removed complexity from
      * the invocation.waitForResponse which is too complicated too understand.
+     *
+     * This class needs to implement the OperationHostileThread interface to make sure that the OperationExecutor
+     * is not going to schedule any operations on this task due to retry.
      */
-    class InspectionThread extends Thread {
+    class InspectionThread extends Thread implements OperationHostileThread {
 
         private volatile boolean shutdown;
 

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/classic/AbstractClassicOperationExecutorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/classic/AbstractClassicOperationExecutorTest.java
@@ -7,7 +7,7 @@ import com.hazelcast.instance.GroupProperties;
 import com.hazelcast.instance.HazelcastThreadGroup;
 import com.hazelcast.logging.LoggingServiceImpl;
 import com.hazelcast.nio.Address;
-import com.hazelcast.nio.NIOThread;
+import com.hazelcast.spi.impl.operationexecutor.OperationHostileThread;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.Packet;
@@ -227,8 +227,8 @@ public abstract class AbstractClassicOperationExecutorTest extends HazelcastTest
         }
     }
 
-    protected static class DummyNioThread extends Thread implements NIOThread {
-        protected DummyNioThread(Runnable task) {
+    protected static class DummyOperationHostileThread extends Thread implements OperationHostileThread {
+        protected DummyOperationHostileThread(Runnable task) {
             super(task);
         }
     }

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/classic/IsAllowedToRunInCurrentThreadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/classic/IsAllowedToRunInCurrentThreadTest.java
@@ -74,7 +74,7 @@ public class IsAllowedToRunInCurrentThreadTest extends AbstractClassicOperationE
     }
 
     @Test
-    public void test_whenGenericOperation_andCallingFromNioThread() {
+    public void test_whenGenericOperation_andCallingFromOperationHostileThread() {
         initExecutor();
 
         final DummyGenericOperation genericOperation = new DummyGenericOperation();
@@ -86,8 +86,8 @@ public class IsAllowedToRunInCurrentThreadTest extends AbstractClassicOperationE
             }
         });
 
-        DummyNioThread nioThread = new DummyNioThread(futureTask);
-        nioThread.start();
+        DummyOperationHostileThread thread = new DummyOperationHostileThread(futureTask);
+        thread.start();
 
         assertEqualsEventually(futureTask, Boolean.FALSE);
     }
@@ -162,7 +162,7 @@ public class IsAllowedToRunInCurrentThreadTest extends AbstractClassicOperationE
     }
 
     @Test
-    public void test_whenPartitionOperation_andCallingFromNioThread() {
+    public void test_whenPartitionOperation_andCallingFromOperationHostileThread() {
         initExecutor();
 
         final DummyPartitionOperation operation = new DummyPartitionOperation();
@@ -174,8 +174,8 @@ public class IsAllowedToRunInCurrentThreadTest extends AbstractClassicOperationE
             }
         });
 
-        DummyNioThread nioThread = new DummyNioThread(futureTask);
-        nioThread.start();
+        DummyOperationHostileThread thread = new DummyOperationHostileThread(futureTask);
+        thread.start();
 
         assertEqualsEventually(futureTask, Boolean.FALSE);
     }

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/classic/IsInvocationAllowedFromCurrentThreadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/classic/IsInvocationAllowedFromCurrentThreadTest.java
@@ -72,7 +72,7 @@ public class IsInvocationAllowedFromCurrentThreadTest extends AbstractClassicOpe
     }
 
     @Test
-    public void test_whenGenericOperation_andCallingFromNioThread() {
+    public void test_whenGenericOperation_andCallingFromOperationHostileThread() {
         initExecutor();
 
         final DummyGenericOperation genericOperation = new DummyGenericOperation();
@@ -84,14 +84,14 @@ public class IsInvocationAllowedFromCurrentThreadTest extends AbstractClassicOpe
             }
         });
 
-        DummyNioThread nioThread = new DummyNioThread(futureTask);
-        nioThread.start();
+        DummyOperationHostileThread thread = new DummyOperationHostileThread(futureTask);
+        thread.start();
 
         assertEqualsEventually(futureTask, Boolean.FALSE);
     }
 
     @Test
-    public void test_whenGenericOperation_andCallingFromNioThread_andAsync() {
+    public void test_whenGenericOperation_andCallingFromOperationHostileThread_andAsync() {
         initExecutor();
 
         final DummyGenericOperation genericOperation = new DummyGenericOperation();
@@ -103,8 +103,8 @@ public class IsInvocationAllowedFromCurrentThreadTest extends AbstractClassicOpe
             }
         });
 
-        DummyNioThread nioThread = new DummyNioThread(futureTask);
-        nioThread.start();
+        DummyOperationHostileThread hostileThread = new DummyOperationHostileThread(futureTask);
+        hostileThread.start();
 
         assertEqualsEventually(futureTask, Boolean.FALSE);
     }
@@ -197,7 +197,7 @@ public class IsInvocationAllowedFromCurrentThreadTest extends AbstractClassicOpe
     }
 
     @Test
-    public void test_whenPartitionOperation_andCallingFromNioThread() {
+    public void test_whenPartitionOperation_andCallingFromOperationHostileThread() {
         initExecutor();
 
         final Operation operation = new DummyOperation(1);
@@ -209,14 +209,14 @@ public class IsInvocationAllowedFromCurrentThreadTest extends AbstractClassicOpe
             }
         });
 
-        DummyNioThread nioThread = new DummyNioThread(futureTask);
-        nioThread.start();
+        DummyOperationHostileThread thread = new DummyOperationHostileThread(futureTask);
+        thread.start();
 
         assertEqualsEventually(futureTask, Boolean.FALSE);
     }
 
     @Test
-    public void test_whenPartitionOperation_andCallingFromNioThread_andAsync() {
+    public void test_whenPartitionOperation_andCallingFromOperationHostileThread_andAsync() {
         initExecutor();
 
         final Operation operation = new DummyOperation(1);
@@ -228,8 +228,8 @@ public class IsInvocationAllowedFromCurrentThreadTest extends AbstractClassicOpe
             }
         });
 
-        DummyNioThread nioThread = new DummyNioThread(futureTask);
-        nioThread.start();
+        DummyOperationHostileThread thread = new DummyOperationHostileThread(futureTask);
+        thread.start();
 
         assertEqualsEventually(futureTask, Boolean.FALSE);
     }

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/classic/RunOperationOnCallingThreadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/classic/RunOperationOnCallingThreadTest.java
@@ -103,8 +103,8 @@ public class RunOperationOnCallingThreadTest extends AbstractClassicOperationExe
             }
         });
 
-        DummyNioThread nioThread = new DummyNioThread(futureTask);
-        nioThread.start();
+        DummyOperationHostileThread thread = new DummyOperationHostileThread(futureTask);
+        thread.start();
 
         assertEqualsEventually(futureTask, Boolean.TRUE);
     }
@@ -210,8 +210,8 @@ public class RunOperationOnCallingThreadTest extends AbstractClassicOperationExe
             }
         });
 
-        DummyNioThread nioThread = new DummyNioThread(futureTask);
-        nioThread.start();
+        DummyOperationHostileThread thread = new DummyOperationHostileThread(futureTask);
+        thread.start();
 
         assertEqualsEventually(futureTask, Boolean.TRUE);
     }


### PR DESCRIPTION

ResponseThread and InvocationRegistry.InspectionThread reset and retry operations. Since these threads didn't implement NIOTHread, the OperationExecutor is free to execute tasks on these threads and that is not something desirable.

Running operations on these threads could lead to performance problems, cluster stability problems and deadlocks.

Fixes #4929