### PR TITLE
PartitionClientRequest makes use of efficient partitionid method

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/client/PartitionClientRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/client/PartitionClientRequest.java
@@ -52,7 +52,7 @@ public abstract class PartitionClientRequest extends ClientRequest {
         ClientEndpoint endpoint = getEndpoint();
         Operation op = prepareOperation();
         op.setCallerUuid(endpoint.getUuid());
-        InvocationBuilder builder = operationService.createInvocationBuilder(getServiceName(), op, getPartition())
+        InvocationBuilder builder = operationService.createInvocationBuilder(getServiceName(), op, partitionId())
                 .setReplicaIndex(getReplicaIndex())
                 .setTryCount(TRY_COUNT)
                 .setResultDeserialized(false)


### PR DESCRIPTION
Resolves #4940

Once the build is green, I'll remove the getPartitionId code since it doesn't serve any purpose.