### PR TITLE
Performance: Add InvocationBuilder.setExecutionCallback

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/Callback.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/Callback.java
@@ -19,8 +19,11 @@ package com.hazelcast.spi;
 /**
  * A callback interface; make it possible to receive a callback.
  *
+ * This interface has been deprecated since Hazelcast 3.5. Please use the {@link com.hazelcast.core.ExecutionCallback} instead.
+ *
  * @param <T>
  */
+@Deprecated
 public interface Callback<T> {
 
     void notify(T object);

--- a/hazelcast/src/main/java/com/hazelcast/spi/InvocationBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/InvocationBuilder.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.spi;
 
+import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.nio.Address;
 import com.hazelcast.partition.InternalPartition;
 import com.hazelcast.spi.impl.NodeEngineImpl;
@@ -59,6 +60,7 @@ public abstract class InvocationBuilder {
     protected final int partitionId;
     protected final Address target;
     protected Callback<Object> callback;
+    protected ExecutionCallback<Object> executionCallback;
 
     protected long callTimeout = DEFAULT_CALL_TIMEOUT;
     protected int replicaIndex;
@@ -219,12 +221,47 @@ public abstract class InvocationBuilder {
         return callTimeout;
     }
 
+    /**
+     * This method is deprecated since HZ 3.5. Please use the {@link #getExecutionCallback()}
+     */
+    @Deprecated
     public Callback getCallback() {
         return callback;
     }
 
+    /**
+     * This method is deprecated since HZ 3.5. Please use the {@link #setExecutionCallback(ExecutionCallback)}
+     */
+    @Deprecated
     public InvocationBuilder setCallback(Callback<Object> callback) {
+        if (executionCallback != null) {
+            throw new IllegalStateException("Can't set the callback if executionCallback already is set");
+        }
         this.callback = callback;
+        return this;
+    }
+
+    /**
+     * Gets the ExecutionCallback. If none is set, null is returned.
+     *
+     * @return gets the ExecutionCallback.
+     */
+    public ExecutionCallback<Object> getExecutionCallback() {
+        return executionCallback;
+    }
+
+    /**
+     * Sets the ExecutionCallback.
+     *
+     * @param executionCallback the new ExecutionCallback. If null is passed, the ExecutionCallback is unset.
+     * @return the updated InvocationBuilder.
+     * @throws java.lang.IllegalStateException if a {@link com.hazelcast.spi.Callback} already has been set.
+     */
+    public InvocationBuilder setExecutionCallback(ExecutionCallback<Object> executionCallback) {
+        if (callback != null) {
+            throw new IllegalStateException("Can't set the executionCallback if callback already is set");
+        }
+        this.executionCallback = executionCallback;
         return this;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/InternalOperationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/InternalOperationService.java
@@ -16,9 +16,9 @@
 
 package com.hazelcast.spi.impl.operationservice;
 
+import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.internal.management.dto.SlowOperationDTO;
 import com.hazelcast.nio.Address;
-import com.hazelcast.spi.Callback;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.OperationService;
 import com.hazelcast.spi.impl.PartitionSpecificRunnable;
@@ -86,7 +86,7 @@ public interface InternalOperationService extends OperationService {
      */
     List<SlowOperationDTO> getSlowOperationDTOs();
 
-    <E> void asyncInvokeOnPartition(String serviceName, Operation op, int partitionId, Callback<E> callback);
+    <V> void asyncInvokeOnPartition(String serviceName, Operation op, int partitionId, ExecutionCallback<V> callback);
 
-    <E> void asyncInvokeOnTarget(String serviceName, Operation op, Address target, Callback<E> callback);
+    <V> void asyncInvokeOnTarget(String serviceName, Operation op, Address target, ExecutionCallback<V> callback);
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/Invocation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/Invocation.java
@@ -22,7 +22,6 @@ import com.hazelcast.instance.MemberImpl;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Address;
 import com.hazelcast.partition.InternalPartition;
-import com.hazelcast.spi.Callback;
 import com.hazelcast.spi.ExceptionAction;
 import com.hazelcast.spi.ExecutionService;
 import com.hazelcast.spi.Operation;
@@ -109,7 +108,7 @@ abstract class Invocation implements ResponseHandler, Runnable {
     private volatile int invokeCount;
 
     Invocation(NodeEngineImpl nodeEngine, String serviceName, Operation op, int partitionId,
-               int replicaIndex, int tryCount, long tryPauseMillis, long callTimeout, Callback<Object> callback,
+               int replicaIndex, int tryCount, long tryPauseMillis, long callTimeout, Object callback,
                boolean resultDeserialized) {
         this.operationService = (OperationServiceImpl) nodeEngine.getOperationService();
         this.logger = operationService.invocationLogger;

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationBuilderImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationBuilderImpl.java
@@ -42,6 +42,11 @@ public class InvocationBuilderImpl extends InvocationBuilder {
 
     @Override
     public InternalCompletableFuture invoke() {
+        Object callback = this.callback;
+        if (callback == null) {
+            callback = this.executionCallback;
+        }
+
         if (target == null) {
             return new PartitionInvocation(nodeEngine, serviceName, op, partitionId, replicaIndex,
                     tryCount, tryPauseMillis, callTimeout, callback, resultDeserialized).invoke();

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationFuture.java
@@ -51,13 +51,19 @@ final class InvocationFuture<E> implements InternalCompletableFuture<E> {
     private final Invocation invocation;
     private volatile ExecutionCallbackNode<E> callbackHead;
 
-    InvocationFuture(OperationServiceImpl operationService, Invocation invocation, Callback<E> callback) {
+    InvocationFuture(OperationServiceImpl operationService, Invocation invocation, Object callback) {
         this.invocation = invocation;
         this.operationService = operationService;
 
         if (callback != null) {
-            ExecutorCallbackAdapter<E> adapter = new ExecutorCallbackAdapter<E>(callback);
-            callbackHead = new ExecutionCallbackNode<E>(adapter, operationService.asyncExecutor, null);
+            ExecutionCallback executionCallback;
+            if (callback instanceof ExecutionCallback) {
+                executionCallback = (ExecutionCallback) callback;
+            } else {
+                executionCallback = new ExecutorCallbackAdapter<E>((Callback) callback);
+            }
+
+            callbackHead = new ExecutionCallbackNode<E>(executionCallback, operationService.asyncExecutor, null);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
@@ -17,6 +17,7 @@
 package com.hazelcast.spi.impl.operationservice.impl;
 
 import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.instance.MemberImpl;
 import com.hazelcast.instance.Node;
 import com.hazelcast.internal.management.dto.SlowOperationDTO;
@@ -26,7 +27,6 @@ import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.Packet;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.partition.InternalPartitionService;
-import com.hazelcast.spi.Callback;
 import com.hazelcast.spi.ExecutionService;
 import com.hazelcast.spi.InternalCompletableFuture;
 import com.hazelcast.spi.InvocationBuilder;
@@ -281,7 +281,7 @@ public final class OperationServiceImpl implements InternalOperationService {
 
     @Override
     @SuppressWarnings("unchecked")
-    public <E> void asyncInvokeOnPartition(String serviceName, Operation op, int partitionId, Callback<E> callback) {
+    public <V> void asyncInvokeOnPartition(String serviceName, Operation op, int partitionId, ExecutionCallback<V> callback) {
         new PartitionInvocation(nodeEngine, serviceName, op, partitionId, DEFAULT_REPLICA_INDEX,
                 DEFAULT_TRY_COUNT, DEFAULT_TRY_PAUSE_MILLIS,
                 DEFAULT_CALL_TIMEOUT, callback, DEFAULT_DESERIALIZE_RESULT).invokeAsync();
@@ -289,7 +289,7 @@ public final class OperationServiceImpl implements InternalOperationService {
 
     @Override
     @SuppressWarnings("unchecked")
-    public <E> void asyncInvokeOnTarget(String serviceName, Operation op, Address target, Callback<E> callback) {
+    public <V> void asyncInvokeOnTarget(String serviceName, Operation op, Address target, ExecutionCallback<V> callback) {
         new TargetInvocation(nodeEngine, serviceName, op, target, DEFAULT_TRY_COUNT,
                 DEFAULT_TRY_PAUSE_MILLIS,
                 DEFAULT_CALL_TIMEOUT, callback, DEFAULT_DESERIALIZE_RESULT).invokeAsync();

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/PartitionInvocation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/PartitionInvocation.java
@@ -17,7 +17,6 @@
 package com.hazelcast.spi.impl.operationservice.impl;
 
 import com.hazelcast.nio.Address;
-import com.hazelcast.spi.Callback;
 import com.hazelcast.spi.ExceptionAction;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.impl.NodeEngineImpl;
@@ -30,7 +29,7 @@ public final class PartitionInvocation extends Invocation {
 
     public PartitionInvocation(NodeEngineImpl nodeEngine, String serviceName, Operation op, int partitionId,
                                int replicaIndex, int tryCount, long tryPauseMillis, long callTimeout,
-                               Callback callback, boolean resultDeserialized) {
+                               Object callback, boolean resultDeserialized) {
         super(nodeEngine, serviceName, op, partitionId, replicaIndex, tryCount, tryPauseMillis,
                 callTimeout, callback, resultDeserialized);
     }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/TargetInvocation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/TargetInvocation.java
@@ -18,7 +18,6 @@ package com.hazelcast.spi.impl.operationservice.impl;
 
 import com.hazelcast.core.MemberLeftException;
 import com.hazelcast.nio.Address;
-import com.hazelcast.spi.Callback;
 import com.hazelcast.spi.ExceptionAction;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.impl.NodeEngineImpl;
@@ -33,7 +32,7 @@ public final class TargetInvocation extends Invocation {
 
     public TargetInvocation(NodeEngineImpl nodeEngine, String serviceName, Operation op,
                             Address target, int tryCount, long tryPauseMillis, long callTimeout,
-                            Callback callback, boolean resultDeserialized) {
+                            Object callback, boolean resultDeserialized) {
         super(nodeEngine, serviceName, op, op.getPartitionId(), op.getReplicaIndex(),
                 tryCount, tryPauseMillis, callTimeout, callback, resultDeserialized);
         this.target = target;

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/AsyncInvocationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/AsyncInvocationTest.java
@@ -1,5 +1,6 @@
 package com.hazelcast.spi.impl.operationservice.impl;
 
+import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.HazelcastInstanceAware;
 import com.hazelcast.core.IMap;
@@ -56,12 +57,15 @@ public class AsyncInvocationTest extends HazelcastTestSupport {
             PutOperation op = new PutOperation((String) entry.getValue(), key, val, -1);
             int partitionId = nodeEngine.getPartitionService().getPartitionId(key);
             operationService.asyncInvokeOnPartition(MapService.SERVICE_NAME, op, partitionId,
-                    new Callback<Object>() {
+                    new ExecutionCallback<Object>() {
                         @Override
-                        public void notify(Object object) {
-                            if (!(object instanceof Throwable)) {
-                                latch.countDown();
-                            }
+                        public void onResponse(Object response) {
+                            latch.countDown();
+                        }
+
+                        @Override
+                        public void onFailure(Throwable t) {
+
                         }
                     });
             return null;


### PR DESCRIPTION
Before you were forced to use the Callback which gets adapted to an ExecutionCallback. 

So this PR is going to reduce object litter by providing a more performance-friendly method.