### PR TITLE
Expose isClusterSafe and isLocalMemberSafe through MBeans

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/jmx/PartitionServiceMBean.java
+++ b/hazelcast/src/main/java/com/hazelcast/jmx/PartitionServiceMBean.java
@@ -58,4 +58,16 @@ public class PartitionServiceMBean extends HazelcastMBean<InternalPartitionServi
         InetSocketAddress address = hazelcastInstance.getCluster().getLocalMember().getSocketAddress();
         return managedObject.getMemberPartitions(new Address(address)).size();
     }
+
+    @ManagedAnnotation("isClusterSafe")
+    @ManagedDescription("Is the cluster in a safe state")
+    public boolean isClusterSafe() {
+        return hazelcastInstance.getPartitionService().isClusterSafe();
+    }
+
+    @ManagedAnnotation("isLocalMemberSafe")
+    @ManagedDescription("Is the local member safe to shutdown")
+    public boolean isLocalMemberSafe() {
+        return hazelcastInstance.getPartitionService().isLocalMemberSafe();
+    }
 }


### PR DESCRIPTION
Adding those two attributes will be really helpful to know the state of the cluster. Using the PartitionService from HazelcastClient throws an UnsupportedOperationException.

Using an MBean seems to be the easiest way.

I've exposed it as an attribute. I don't know if getting these information is costly. If it is, you might want to expose an operation instead.