### PR TITLE
added test for async-invocation internal api

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/AsyncInvocationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/AsyncInvocationTest.java
@@ -1,0 +1,97 @@
+package com.hazelcast.spi.impl.operationservice.impl;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.HazelcastInstanceAware;
+import com.hazelcast.core.IMap;
+import com.hazelcast.instance.Node;
+import com.hazelcast.map.EntryBackupProcessor;
+import com.hazelcast.map.EntryProcessor;
+import com.hazelcast.map.impl.MapService;
+import com.hazelcast.map.impl.operation.PutOperation;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.partition.InternalPartitionService;
+import com.hazelcast.spi.Callback;
+import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category(QuickTest.class)
+public class AsyncInvocationTest extends HazelcastTestSupport {
+
+    @Test
+    @Ignore
+    public void testAsyncInvocation_SamePartitionThread_DifferentPartition() {
+        HazelcastInstance instance = createHazelcastInstance();
+        String name = randomString();
+        String key = randomString();
+        IMap<String, String> map = instance.getMap(name);
+        map.put(key, name);
+        map.executeOnKey(key, new InvocationEntryProcessor());
+        assertOpenEventually(InvocationEntryProcessor.latch, 10);
+    }
+
+    public static class InvocationEntryProcessor implements EntryProcessor, HazelcastInstanceAware {
+
+        public static final CountDownLatch latch = new CountDownLatch(1);
+
+        transient HazelcastInstance instance;
+
+        @Override
+        public Object process(Map.Entry entry) {
+            Node node = getNode(instance);
+            NodeEngineImpl nodeEngine = node.nodeEngine;
+            OperationServiceImpl operationService = (OperationServiceImpl) nodeEngine.getOperationService();
+            Data sourceKey = nodeEngine.toData(entry.getKey());
+            Data key = generateKey_FallsToSamePartitionThread_ButDifferentPartition(nodeEngine, sourceKey);
+            Data val = nodeEngine.toData(randomString());
+            PutOperation op = new PutOperation((String) entry.getValue(), key, val, -1);
+            int partitionId = nodeEngine.getPartitionService().getPartitionId(key);
+            operationService.asyncInvokeOnPartition(MapService.SERVICE_NAME, op, partitionId,
+                    new Callback<Object>() {
+                        @Override
+                        public void notify(Object object) {
+                            if (!(object instanceof Throwable)) {
+                                latch.countDown();
+                            }
+                        }
+                    });
+            return null;
+        }
+
+        private Data generateKey_FallsToSamePartitionThread_ButDifferentPartition(NodeEngineImpl nodeEngine, Data sourceKey) {
+            InternalPartitionService partitionService = nodeEngine.getPartitionService();
+            int sourcePartitionId = partitionService.getPartitionId(sourceKey);
+            OperationServiceImpl operationService = (OperationServiceImpl) nodeEngine.getOperationService();
+            int threadCount = operationService.operationExecutor.getPartitionOperationThreadCount();
+            int sourceThreadId = sourcePartitionId % threadCount;
+
+            while (true) {
+                Data key = nodeEngine.toData(randomString());
+                int partitionId = partitionService.getPartitionId(key);
+                int threadId = partitionId % threadCount;
+                if (sourcePartitionId != partitionId && sourceThreadId == threadId) {
+                    return key;
+                }
+            }
+        }
+
+        @Override
+        public EntryBackupProcessor getBackupProcessor() {
+            return null;
+        }
+
+        @Override
+        public void setHazelcastInstance(HazelcastInstance hazelcastInstance) {
+            instance = hazelcastInstance;
+        }
+    }
+}


### PR DESCRIPTION
With the newly introduced async api one can make invocation within partitionOperationThread.
But after the check in `Invocation` class we do another check which fails because it has not idea if the invocation is async or not. The test in this PR reproduces it (tagged with @Ignore)

We have the 'checking thread' logic in 3 places :
- https://github.com/hazelcast/hazelcast/blob/master/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/classic/ClassicOperationExecutor.java#L203
- https://github.com/hazelcast/hazelcast/blob/master/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/classic/ClassicOperationExecutor.java#L239
- https://github.com/hazelcast/hazelcast/blob/master/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImpl.java#L175

This logic should be centralized