### PR TITLE
Reduce log level of "No configuration found for ..., using default config!"

### DIFF
--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/config/ClientConfig.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/config/ClientConfig.java
@@ -631,7 +631,7 @@ public class ClientConfig {
             return configPatterns.get(configPatternKey);
         }
         if (!"default".equals(itemName) && !itemName.startsWith("hz:")) {
-            LOGGER.warning("No configuration found for " + itemName + ", using default config!");
+            LOGGER.finest("No configuration found for " + itemName + ", using default config!");
         }
         return null;
     }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientConfig.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientConfig.java
@@ -631,7 +631,7 @@ public class ClientConfig {
             return configPatterns.get(configPatternKey);
         }
         if (!"default".equals(itemName) && !itemName.startsWith("hz:")) {
-            LOGGER.warning("No configuration found for " + itemName + ", using default config!");
+            LOGGER.finest("No configuration found for " + itemName + ", using default config!");
         }
         return null;
     }

--- a/hazelcast/src/main/java/com/hazelcast/config/Config.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/Config.java
@@ -908,7 +908,7 @@ public class Config {
             return configPatterns.get(configPatternKey);
         }
         if (!"default".equals(itemName) && !itemName.startsWith("hz:")) {
-            LOGGER.warning("No configuration found for " + itemName + ", using default config!");
+            LOGGER.finest("No configuration found for " + itemName + ", using default config!");
         }
         return null;
     }


### PR DESCRIPTION
Set log level of "No configuration found for ..., using default config!" from `WARNING` to `FINEST`.

Fixes issue #4790.