### PR TITLE
BackPressureRegulator simplification

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/instance/GroupProperties.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/GroupProperties.java
@@ -216,8 +216,18 @@ public class GroupProperties {
     public static final String PROP_BACKPRESSURE_ENABLED = "hazelcast.backpressure.enabled";
 
     /**
-     * This property only has meaning when back-pressure is enabled. The larger the sync-window the less frequent a
-     * asynchronous backup is converted to a sync backup.
+     * Control the frequency of a BackupAwareOperation getting its async backups converted to a sync backups. This is needed
+     * to prevent an accumulation of asynchronous backups and eventually running into stability issues.
+     *
+     * A sync window of 10 means that 1 in 10 BackupAwareOperations get their async backups convert to sync backups.
+     *
+     * A sync window of 1 means that every BackupAwareOperation get their async backups converted to sync backups. This
+     * is also the smallest legal value for the sync window.
+     *
+     * There is some randomization going on to prevent resonance. So with a sync window of n, not every n'th BackupAwareOperation
+     * operation is getting its async backups converted to sync.
+     *
+     * This property only has meaning when backpressure is enabled.
      */
     public static final String PROP_BACKPRESSURE_SYNCWINDOW = "hazelcast.backpressure.syncwindow";
 

--- a/hazelcast/src/main/java/com/hazelcast/nio/Bits.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/Bits.java
@@ -45,6 +45,10 @@ public final class Bits {
      * Double size in bytes
      */
     public static final int DOUBLE_SIZE_IN_BYTES = 8;
+    /**
+     * Length of the data blocks used by the CPU cache sub-system in bytes.
+     */
+    public static final int CACHE_LINE_LENGTH = 64;
 
     private Bits() {
     }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/CallIdSequence.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/CallIdSequence.java
@@ -6,6 +6,8 @@ import com.hazelcast.spi.BackupAwareOperation;
 import java.util.concurrent.atomic.AtomicLongArray;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 
+import static com.hazelcast.nio.Bits.CACHE_LINE_LENGTH;
+import static com.hazelcast.nio.Bits.LONG_SIZE_IN_BYTES;
 import static com.hazelcast.spi.Operation.CALL_ID_LOCAL_SKIPPED;
 
 /**
@@ -25,10 +27,9 @@ import static com.hazelcast.spi.Operation.CALL_ID_LOCAL_SKIPPED;
  * In the future we could add a CallIdSequence per partition or using some 'concurrency level' and do a mod based on the
  * partition-id. The advantage is that you reduce contention and improved isolation, at the expensive of:
  * <ol>
- *     <li>increased complexity</li>
- *     <li>not always being able to fully utilize the number of invocations.</li>
+ * <li>increased complexity</li>
+ * <li>not always being able to fully utilize the number of invocations.</li>
  * </ol>
- *
  */
 public abstract class CallIdSequence {
 
@@ -127,7 +128,7 @@ public abstract class CallIdSequence {
         private static final int INDEX_TAIL = 15;
 
         // instead of using 2 AtomicLongs, we use an array if width of 3 cache lines to prevent any false sharing.
-        private final AtomicLongArray longs = new AtomicLongArray(24);
+        private final AtomicLongArray longs = new AtomicLongArray(3 * CACHE_LINE_LENGTH / LONG_SIZE_IN_BYTES);
 
         private final int maxConcurrentInvocations;
         private final long backoffTimeoutMs;

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OperationBackupHandlerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OperationBackupHandlerTest.java
@@ -50,7 +50,7 @@ public class OperationBackupHandlerTest extends HazelcastTestSupport {
     public void setup(boolean backPressureEnabled) {
         Config config = new Config()
                 .setProperty(PROP_BACKPRESSURE_ENABLED, ""+backPressureEnabled)
-                .setProperty(PROP_BACKPRESSURE_SYNCWINDOW, "0");
+                .setProperty(PROP_BACKPRESSURE_SYNCWINDOW, "1");
 
         // we create a nice big cluster so that we have enough backups.
         HazelcastInstance[] cluster = createHazelcastInstanceFactory(BACKUPS + 1).newInstances(config);


### PR DESCRIPTION
No threadsafety is required for the sync delays since they will only be accessed by partition threads and at any given moment only 1 partition thread will touch a sync delay.

There is some additional cleanup:
- no more logging on warning if a backup replica doesn't find an invocation. This is something which can happen + it caused huge log files in the nightly build with the back pressure stress test
- the invocation registry will log the number of operations timeout or backup timeout it has found on every run (if something is found.. else no logging)
- sync window has 1 as lowest value.. meaning on every run.
- minor cleanup in invocation to be checkstyle complient
- solved the async invocation async backup nightly failure. Caused by too small backup timeout 
