### PR TITLE
spring native-memory config support added

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -498,6 +498,7 @@
 
     <!-- Spring-->
     <suppress checks="MethodCount" files="com.hazelcast.spring.HazelcastConfigBeanDefinitionParser"/>
+    <suppress checks="MethodLength" files="com.hazelcast.spring.HazelcastConfigBeanDefinitionParser"/>
     <suppress checks="CyclomaticComplexity|NPathComplexity" files="com.hazelcast.spring.HazelcastConfigBeanDefinitionParser"/>
 
     <!-- Spring Framework breaks the rule IllegalTypeCheck in its own implementation -->

--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastConfigBeanDefinitionParser.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastConfigBeanDefinitionParser.java
@@ -42,6 +42,7 @@ import com.hazelcast.config.MemberAttributeConfig;
 import com.hazelcast.config.MemberGroupConfig;
 import com.hazelcast.config.MultiMapConfig;
 import com.hazelcast.config.MulticastConfig;
+import com.hazelcast.config.NativeMemoryConfig;
 import com.hazelcast.config.NearCacheConfig;
 import com.hazelcast.config.NetworkConfig;
 import com.hazelcast.config.PartitionGroupConfig;
@@ -63,6 +64,8 @@ import com.hazelcast.config.TopicConfig;
 import com.hazelcast.config.WanReplicationConfig;
 import com.hazelcast.config.WanReplicationRef;
 import com.hazelcast.config.WanTargetClusterConfig;
+import com.hazelcast.memory.MemorySize;
+import com.hazelcast.memory.MemoryUnit;
 import com.hazelcast.nio.ClassLoaderUtil;
 import com.hazelcast.spi.ServiceConfigurationParser;
 import com.hazelcast.util.ExceptionUtil;
@@ -193,6 +196,8 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
                         handlePartitionGroup(node);
                     } else if ("serialization".equals(nodeName)) {
                         handleSerialization(node);
+                    } else if ("native-memory".equals(nodeName)) {
+                        handleNativeMemory(node);
                     } else if ("security".equals(nodeName)) {
                         handleSecurity(node);
                     } else if ("member-attributes".equals(nodeName)) {
@@ -806,6 +811,29 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
             }
             memberAttributeConfigBuilder.addPropertyValue("attributes", attributes);
             configBuilder.addPropertyValue("memberAttributeConfig", beanDefinition);
+        }
+
+        private void handleNativeMemory(final Node node) {
+            final BeanDefinitionBuilder nativeMemoryConfigBuilder = createBeanBuilder(NativeMemoryConfig.class);
+            final AbstractBeanDefinition beanDefinition = nativeMemoryConfigBuilder.getBeanDefinition();
+            fillAttributeValues(node, nativeMemoryConfigBuilder);
+            for (Node child : new IterableNodeList(node, Node.ELEMENT_NODE)) {
+                final String nodeName = cleanNodeName(child);
+                if ("size".equals(nodeName)) {
+                    handleMemorySizeConfig(child, nativeMemoryConfigBuilder);
+                }
+            }
+            configBuilder.addPropertyValue("nativeMemoryConfig", beanDefinition);
+        }
+
+        private void handleMemorySizeConfig(Node node, BeanDefinitionBuilder nativeMemoryConfigBuilder) {
+            BeanDefinitionBuilder memorySizeConfigBuilder = createBeanBuilder(MemorySize.class);
+            final NamedNodeMap attrs = node.getAttributes();
+            final Node value = attrs.getNamedItem("value");
+            final Node unit = attrs.getNamedItem("unit");
+            memorySizeConfigBuilder.addConstructorArgValue(getTextContent(value));
+            memorySizeConfigBuilder.addConstructorArgValue(MemoryUnit.valueOf(getTextContent(unit)));
+            nativeMemoryConfigBuilder.addPropertyValue("size", memorySizeConfigBuilder.getBeanDefinition());
         }
 
         private void handleSecurityInterceptors(final Node node, final BeanDefinitionBuilder securityConfigBuilder) {

--- a/hazelcast-spring/src/main/resources/hazelcast-spring-3.5.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-3.5.xsd
@@ -846,6 +846,7 @@
                         </xs:element>
                         <xs:element name="listeners" type="listeners" minOccurs="0" maxOccurs="1"/>
                         <xs:element name="serialization" type="serialization" minOccurs="0" maxOccurs="1"/>
+                        <xs:element name="native-memory" type="native-memory" minOccurs="0" maxOccurs="1"/>
                         <xs:element name="security" type="security" minOccurs="0" maxOccurs="1"/>
                         <xs:element name="member-attributes" minOccurs="0" maxOccurs="1">
                             <xs:complexType>
@@ -1978,4 +1979,41 @@
         <xs:attribute name="name" use="required" type="xs:string"/>
         <xs:attribute name="merge-policy" use="required" type="xs:string"/>
     </xs:complexType>
+    <xs:complexType name="native-memory">
+        <xs:all>
+            <xs:element name="size" type="memory-size" minOccurs="0" maxOccurs="1"/>
+        </xs:all>
+        <xs:attribute name="min-block-size"  use="optional" type="xs:positiveInteger"/>
+        <xs:attribute name="page-size" use="optional" type="xs:positiveInteger"/>
+        <xs:attribute name="metadata-space-percentage" use="optional">
+            <xs:simpleType>
+                <xs:restriction base="xs:decimal">
+                    <xs:totalDigits value="3"/>
+                    <xs:fractionDigits value="1"/>
+                    <xs:minInclusive value="5"/>
+                    <xs:maxInclusive value="95"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="allocator-type" default="POOLED" type="memory-allocator-type"/>
+        <xs:attribute name="enabled" default="false" type="xs:boolean"/>
+    </xs:complexType>
+    <xs:complexType name="memory-size">
+        <xs:attribute name="value" type="xs:int" default="128"/>
+        <xs:attribute name="unit" type="memory-unit" default="MEGABYTES"/>
+    </xs:complexType>
+    <xs:simpleType name="memory-unit">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="BYTES"/>
+            <xs:enumeration value="KILOBYTES"/>
+            <xs:enumeration value="MEGABYTES"/>
+            <xs:enumeration value="GIGABYTES"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="memory-allocator-type">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="STANDARD"/>
+            <xs:enumeration value="POOLED"/>
+        </xs:restriction>
+    </xs:simpleType>
 </xs:schema>

--- a/hazelcast-spring/src/main/resources/hazelcast-spring-3.5.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-3.5.xsd
@@ -1996,7 +1996,7 @@
             </xs:simpleType>
         </xs:attribute>
         <xs:attribute name="allocator-type" default="POOLED" type="memory-allocator-type"/>
-        <xs:attribute name="enabled" default="false" type="xs:boolean"/>
+        <xs:attribute name="enabled" default="true" type="xs:boolean"/>
     </xs:complexType>
     <xs:complexType name="memory-size">
         <xs:attribute name="value" type="xs:int" default="128"/>

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
@@ -35,6 +35,7 @@ import com.hazelcast.config.MaxSizeConfig;
 import com.hazelcast.config.MemberAttributeConfig;
 import com.hazelcast.config.MemberGroupConfig;
 import com.hazelcast.config.MultiMapConfig;
+import com.hazelcast.config.NativeMemoryConfig;
 import com.hazelcast.config.NearCacheConfig;
 import com.hazelcast.config.NetworkConfig;
 import com.hazelcast.config.PartitionGroupConfig;
@@ -71,6 +72,7 @@ import com.hazelcast.core.MembershipListener;
 import com.hazelcast.core.MultiMap;
 import com.hazelcast.core.ReplicatedMap;
 import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.memory.MemoryUnit;
 import com.hazelcast.nio.SocketInterceptor;
 import com.hazelcast.nio.serialization.DataSerializableFactory;
 import com.hazelcast.nio.serialization.PortableFactory;
@@ -614,6 +616,18 @@ public class TestFullApplicationContext {
         GlobalSerializerConfig globalSerializerConfig = serializationConfig.getGlobalSerializerConfig();
         assertNotNull(globalSerializerConfig);
         assertEquals(dummySerializer, globalSerializerConfig.getImplementation());
+    }
+
+    @Test
+    public void testNativeMemoryConfig() {
+        NativeMemoryConfig nativeMemoryConfig = config.getNativeMemoryConfig();
+        assertFalse(nativeMemoryConfig.isEnabled());
+        assertEquals(MemoryUnit.MEGABYTES,nativeMemoryConfig.getSize().getUnit());
+        assertEquals(256,nativeMemoryConfig.getSize().getValue());
+        assertEquals(20,nativeMemoryConfig.getPageSize());
+        assertEquals(NativeMemoryConfig.MemoryAllocatorType.POOLED,nativeMemoryConfig.getAllocatorType());
+        assertEquals(10.2,nativeMemoryConfig.getMetadataSpacePercentage(),0.1);
+        assertEquals(10,nativeMemoryConfig.getMinBlockSize());
     }
 
     @Test

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/clientNetworkConfig-applicationContext.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/clientNetworkConfig-applicationContext.xml
@@ -22,7 +22,7 @@
        xsi:schemaLocation="http://www.springframework.org/schema/beans
 		http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
 		http://www.hazelcast.com/schema/spring
-		http://www.hazelcast.com/schema/spring/hazelcast-spring-3.5.xsd">
+		http://www.hazelcast.com/schema/spring/hazelcast-spring.xsd">
 
     <bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer"
           p:systemPropertiesModeName="SYSTEM_PROPERTIES_MODE_OVERRIDE">

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/clientNetworkConfig-applicationContext.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/clientNetworkConfig-applicationContext.xml
@@ -22,7 +22,7 @@
        xsi:schemaLocation="http://www.springframework.org/schema/beans
 		http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
 		http://www.hazelcast.com/schema/spring
-		http://www.hazelcast.com/schema/spring/hazelcast-spring-3.2.xsd">
+		http://www.hazelcast.com/schema/spring/hazelcast-spring-3.5.xsd">
 
     <bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer"
           p:systemPropertiesModeName="SYSTEM_PROPERTIES_MODE_OVERRIDE">

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullcacheconfig-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullcacheconfig-applicationContext-hazelcast.xml
@@ -267,6 +267,10 @@
                 </hz:serializers>
             </hz:serialization>
 
+            <hz:native-memory enabled="false" allocator-type="POOLED" metadata-space-percentage="10.2" min-block-size="10"
+                              page-size="20">
+                <hz:size unit="MEGABYTES" value="256"/>
+            </hz:native-memory>
             <hz:member-attributes>
                 <hz:attribute name="cluster.group.name">spring-group</hz:attribute>
                 <hz:attribute name="cluster.port.int" type="int">5700</hz:attribute>


### PR DESCRIPTION
this PR solves #4772 
an example for configuring `native-memory`
```
           <hz:native-memory enabled="false" allocator-type="POOLED" metadata-space-percentage="10.2" min-block-size="10"
                              page-size="20">
                <hz:size unit="MEGABYTES" value="256"/>
           </hz:native-memory>
```
i can make <hz:size> as attribute but at that time it will not very compatible with server configuration.