### PR TITLE
NotEqualPredicate and Exception on unordered index with null value fixed

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/query/Predicates.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/Predicates.java
@@ -731,6 +731,11 @@ public final class Predicates {
 
         @Override
         public boolean apply(Map.Entry entry) {
+            Comparable entryValue = readAttribute(entry);
+            if (entryValue == null) {
+                return false;
+            }
+
             return !super.apply(entry);
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/TypeConverters.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/TypeConverters.java
@@ -49,7 +49,7 @@ final class TypeConverters {
         @Override
         public Comparable convert(Comparable value) {
             if (value == null) {
-                return null;
+                return IndexImpl.NULL;
             }
             String enumString = value.toString();
             if (enumString.contains(".")) {
@@ -63,6 +63,9 @@ final class TypeConverters {
     static class SqlDateConverter implements TypeConverter {
         @Override
         public Comparable convert(Comparable value) {
+            if (value == null) {
+                return IndexImpl.NULL;
+            }
             if (value instanceof java.sql.Date) {
                 return value;
             }
@@ -80,6 +83,9 @@ final class TypeConverters {
     static class SqlTimestampConverter implements TypeConverter {
         @Override
         public Comparable convert(Comparable value) {
+            if (value == null) {
+                return IndexImpl.NULL;
+            }
             if (value instanceof Timestamp) {
                 return value;
             }
@@ -97,6 +103,9 @@ final class TypeConverters {
     static class DateConverter implements TypeConverter {
         @Override
         public Comparable convert(Comparable value) {
+            if (value == null) {
+                return IndexImpl.NULL;
+            }
             if (value instanceof Date) {
                 return value;
             }
@@ -114,6 +123,9 @@ final class TypeConverters {
     static class DoubleConverter implements TypeConverter {
         @Override
         public Comparable convert(Comparable value) {
+            if (value == null) {
+                return IndexImpl.NULL;
+            }
             if (value instanceof Double) {
                 return value;
             }
@@ -131,6 +143,9 @@ final class TypeConverters {
     static class LongConverter implements TypeConverter {
         @Override
         public Comparable convert(Comparable value) {
+            if (value == null) {
+                return IndexImpl.NULL;
+            }
             if (value instanceof Long) {
                 return value;
             }
@@ -148,6 +163,9 @@ final class TypeConverters {
     static class BigIntegerConverter implements TypeConverter {
         @Override
         public Comparable convert(Comparable value) {
+            if (value == null) {
+                return IndexImpl.NULL;
+            }
             if (value instanceof BigInteger) {
                 return value;
             }
@@ -158,6 +176,9 @@ final class TypeConverters {
     static class BigDecimalConverter implements TypeConverter {
         @Override
         public Comparable convert(Comparable value) {
+            if (value == null) {
+                return IndexImpl.NULL;
+            }
             if (value instanceof BigDecimal) {
                 return value;
             }
@@ -171,6 +192,9 @@ final class TypeConverters {
     static class IntegerConverter implements TypeConverter {
         @Override
         public Comparable convert(Comparable value) {
+            if (value == null) {
+                return IndexImpl.NULL;
+            }
             if (value instanceof Integer) {
                 return value;
             }
@@ -201,6 +225,9 @@ final class TypeConverters {
     static class FloatConverter implements TypeConverter {
         @Override
         public Comparable convert(Comparable value) {
+            if (value == null) {
+                return IndexImpl.NULL;
+            }
             if (value instanceof Float) {
                 return value;
             }
@@ -218,6 +245,9 @@ final class TypeConverters {
     static class ShortConverter implements TypeConverter {
         @Override
         public Comparable convert(Comparable value) {
+            if (value == null) {
+                return IndexImpl.NULL;
+            }
             if (value instanceof Short) {
                 return value;
             }
@@ -235,6 +265,9 @@ final class TypeConverters {
     static class BooleanConverter implements TypeConverter {
         @Override
         public Comparable convert(Comparable value) {
+            if (value == null) {
+                return IndexImpl.NULL;
+            }
             if (value instanceof Boolean) {
                 return value;
             }
@@ -252,6 +285,9 @@ final class TypeConverters {
     static class ByteConverter implements TypeConverter {
         @Override
         public Comparable convert(Comparable value) {
+            if (value == null) {
+                return IndexImpl.NULL;
+            }
             if (value instanceof Byte) {
                 return value;
             }
@@ -269,6 +305,9 @@ final class TypeConverters {
     static class CharConverter implements TypeConverter {
         @Override
         public Comparable convert(Comparable value) {
+            if (value == null) {
+                return IndexImpl.NULL;
+            }
             if (value.getClass() == char.class) {
                 return value;
             }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/UnsortedIndexStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/UnsortedIndexStore.java
@@ -134,19 +134,19 @@ public class UnsortedIndexStore extends BaseIndexStore {
             Set<Comparable> values = recordMap.keySet();
             for (Comparable value : values) {
                 boolean valid;
-                int result = value.compareTo(searchedValue);
+                int result = searchedValue.compareTo(value);
                 switch (comparisonType) {
                     case LESSER:
-                        valid = result < 0;
-                        break;
-                    case LESSER_EQUAL:
-                        valid = result <= 0;
-                        break;
-                    case GREATER:
                         valid = result > 0;
                         break;
-                    case GREATER_EQUAL:
+                    case LESSER_EQUAL:
                         valid = result >= 0;
+                        break;
+                    case GREATER:
+                        valid = result < 0;
+                        break;
+                    case GREATER_EQUAL:
+                        valid = result <= 0;
                         break;
                     case NOT_EQUAL:
                         valid = result != 0;

--- a/hazelcast/src/test/java/com/hazelcast/query/PredicatesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/PredicatesTest.java
@@ -175,6 +175,7 @@ public class PredicatesTest extends HazelcastTestSupport {
         assertFalse_withNullEntry(greaterThan("nullField", 1));
         assertFalse_withNullEntry(equal("nullField", 1));
         assertFalse_withNullEntry(notEqual("nullField", null));
+        assertFalse_withNullEntry(notEqual("nullField", 1));
         assertFalse_withNullEntry(between("nullField", 1, 1));
         assertTrue_withNullEntry(like("nullField", null));
         assertTrue_withNullEntry(ilike("nullField", null));

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/IndexTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/IndexTest.java
@@ -121,6 +121,31 @@ public class IndexTest {
         assertEquals(1, is.query(new AndPredicate(new EqualPredicate("d", "1"), new EqualPredicate("bool", false))).size());
     }
 
+    @Test
+    public void testIndexWithNull() throws QueryException {
+        IndexService is = new IndexService();
+        Index strIndex = is.addOrGetIndex("str", true);
+
+        Data value = ss.toData(new MainPortable(false, 1, null));
+        Data key1 = ss.toData(0);
+        is.saveEntryIndex(new QueryEntry(ss, key1, key1, value));
+
+        value = ss.toData(new MainPortable(false, 2, null));
+        Data key2 = ss.toData(1);
+        is.saveEntryIndex(new QueryEntry(ss, key2, key2, value));
+
+
+        for (int i = 2; i < 1000; i++) {
+            Data key = ss.toData(i);
+            value = ss.toData(new MainPortable(false, 1 * (i + 1), "joe" + i));
+            is.saveEntryIndex(new QueryEntry(ss, key, key, value));
+        }
+
+        Comparable c = null;
+        assertEquals(2, strIndex.getRecords(c).size());
+        assertEquals(998, strIndex.getSubRecords(ComparisonType.NOT_EQUAL, null).size());
+    }
+
     private class TestPortableFactory implements PortableFactory {
 
         public Portable create(int classId) {


### PR DESCRIPTION
This pull request solves two related issues #4525 and #4373. 

For #4525, as I commented under the issue, hazelcast replicates the SQL behavior, so when something is searched as `notEqual(someValue)` we should not include null entries to the result set. When indexing is used, since IndexStores store null values in a separate map named `recordsWithNullValue` we achieve this behavior. However, when indexing is not used we do a full scan only with the predicate. 

Thus, in the not equal predicate before calling `super.apply()` (which is EqualPredicate's function), we should check if the entry is null as follows:

```java
@Override
        public boolean apply(Map.Entry entry) {
            Comparable entryValue = readAttribute(entry);
            if (entryValue == null) {
                return false;
            }

            return !super.apply(entry);
        }
```

This way, if the entry is null, it will not be included in the result set no matter what.

For #4373, I've used the @mdogan's proposed patch, also I've added `null` guards to the `TypeConverter` class. Before this `getSubRecords()` function was throwing an exception which was causing us to do full scan on every partition instead of using index.


Fixes #4525 
Fixes #4373