### PR TITLE
Backport fix for issue #4616 [close() method of a Closeable CacheLoader is called without explicitly calling Cache.close()] and #4617 [Cache.close() doesn't call close() method of registered Closeable CacheEntryListener]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheRecordStore.java
@@ -30,7 +30,6 @@ import com.hazelcast.config.CacheConfig;
 import com.hazelcast.config.CacheEvictionConfig;
 import com.hazelcast.config.EvictionPolicy;
 import com.hazelcast.map.impl.MapEntrySet;
-import com.hazelcast.nio.IOUtil;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.EventRegistration;
 import com.hazelcast.spi.EventService;
@@ -128,6 +127,19 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
         this.evictionPolicyEvaluator = creatEvictionPolicyEvaluator(evictionConfig);
         this.evictionChecker = createEvictionChecker(evictionConfig);
         this.evictionStrategy = creatEvictionStrategy(evictionConfig);
+
+        // Register "cacheWriter" if it is "Closable" to be closed while cache is being destroyed
+        if (cacheWriter instanceof Closeable) {
+            cacheService.addCacheResource(name, (Closeable) cacheWriter);
+        }
+        // Register "cacheLoader" if it is "Closable" to be closed while cache is being destroyed
+        if (cacheLoader instanceof Closeable) {
+            cacheService.addCacheResource(name, (Closeable) cacheLoader);
+        }
+        // Register "defaultExpiryPolicy" if it is "Closable" to be closed while cache is being destroyed
+        if (defaultExpiryPolicy instanceof Closeable) {
+            cacheService.addCacheResource(name, (Closeable) defaultExpiryPolicy);
+        }
     }
     //CHECKSTYLE:ON
 
@@ -1351,7 +1363,6 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
     @Override
     public void destroy() {
         clear();
-        closeResources();
         closeListeners();
     }
 
@@ -1369,23 +1380,6 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
                     EmptyStatement.ignore(e);
                 }
             }
-        }
-    }
-
-    protected void closeResources() {
-        //close the configured CacheWriter
-        if (cacheWriter instanceof Closeable) {
-            IOUtil.closeResource((Closeable) cacheWriter);
-        }
-
-        //close the configured CacheLoader
-        if (cacheLoader instanceof Closeable) {
-            IOUtil.closeResource((Closeable) cacheLoader);
-        }
-
-        //close the configured defaultExpiryPolicy
-        if (defaultExpiryPolicy instanceof Closeable) {
-            IOUtil.closeResource((Closeable) defaultExpiryPolicy);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheService.java
@@ -23,6 +23,7 @@ import com.hazelcast.config.CacheSimpleConfig;
 import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.core.DistributedObject;
 import com.hazelcast.instance.MemberImpl;
+import com.hazelcast.nio.IOUtil;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.partition.MigrationEndpoint;
 import com.hazelcast.spi.EventRegistration;
@@ -34,8 +35,12 @@ import com.hazelcast.spi.PartitionMigrationEvent;
 import com.hazelcast.util.ConcurrencyUtil;
 import com.hazelcast.util.ConstructorFunction;
 
+import javax.cache.event.CacheEntryListener;
+import java.io.Closeable;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Properties;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
@@ -43,7 +48,9 @@ public abstract class AbstractCacheService implements ICacheService {
 
     protected final ConcurrentMap<String, CacheConfig> configs = new ConcurrentHashMap<String, CacheConfig>();
     protected final ConcurrentMap<String, CacheStatisticsImpl> statistics = new ConcurrentHashMap<String, CacheStatisticsImpl>();
-        protected final ConcurrentMap<String, CacheOperationProvider> operationProviderCache =
+    protected final ConcurrentMap<String, Set<Closeable>> resources = new ConcurrentHashMap<String, Set<Closeable>>();
+    protected final ConcurrentMap<String, Closeable> closeableListeners = new ConcurrentHashMap<String, Closeable>();
+    protected final ConcurrentMap<String, CacheOperationProvider> operationProviderCache =
             new ConcurrentHashMap<String, CacheOperationProvider>();
     protected final ConstructorFunction<String, CacheStatisticsImpl> cacheStatisticsConstructorFunction =
             new ConstructorFunction<String, CacheStatisticsImpl>() {
@@ -134,6 +141,7 @@ public abstract class AbstractCacheService implements ICacheService {
         setManagementEnabled(config, objectName, false);
         deleteCacheConfig(objectName);
         deleteCacheStat(objectName);
+        deleteCacheResources(objectName);
         if (!isLocal) {
             destroyCacheOnAllMembers(objectName, callerUuid);
         }
@@ -188,7 +196,6 @@ public abstract class AbstractCacheService implements ICacheService {
             if (enabled) {
                 final CacheStatisticsImpl cacheStatistics = createCacheStatIfAbsent(cacheNameWithPrefix);
                 final CacheStatisticsMXBeanImpl mxBean = new CacheStatisticsMXBeanImpl(cacheStatistics);
-
                 MXBeanUtil.registerCacheObject(mxBean, cacheManagerName, cacheConfig.getName(), true);
             } else {
                 MXBeanUtil.unregisterCacheObject(cacheManagerName, cacheConfig.getName(), true);
@@ -230,8 +237,9 @@ public abstract class AbstractCacheService implements ICacheService {
         //remote check
         final CacheGetConfigOperation op = new CacheGetConfigOperation(cacheNameWithPrefix, cacheName);
         int partitionId = nodeEngine.getPartitionService().getPartitionId(cacheNameWithPrefix);
-        final InternalCompletableFuture<CacheConfig> f = nodeEngine.getOperationService()
-                .invokeOnPartition(CacheService.SERVICE_NAME, op, partitionId);
+        final InternalCompletableFuture<CacheConfig> f =
+                nodeEngine.getOperationService()
+                    .invokeOnPartition(CacheService.SERVICE_NAME, op, partitionId);
         return f.getSafely();
     }
 
@@ -276,8 +284,9 @@ public abstract class AbstractCacheService implements ICacheService {
             case UPDATED:
             case REMOVED:
             case EXPIRED:
-                final CacheEventData cacheEventData = new CacheEventDataImpl(cacheName, eventType, dataKey, dataValue,
-                        dataOldValue, isOldValueAvailable);
+                final CacheEventData cacheEventData =
+                        new CacheEventDataImpl(cacheName, eventType, dataKey, dataValue,
+                                               dataOldValue, isOldValueAvailable);
                 CacheEventSet eventSet = new CacheEventSet(eventType, completionId);
                 eventSet.addEventData(cacheEventData);
                 eventData = eventSet;
@@ -289,8 +298,9 @@ public abstract class AbstractCacheService implements ICacheService {
                 eventData = new CacheEventDataImpl(cacheName, CacheEventType.INVALIDATED, dataKey, null, null, false);
                 break;
             case COMPLETED:
-                CacheEventData completedEventData = new CacheEventDataImpl(cacheName, CacheEventType.COMPLETED,
-                        dataKey, dataValue, null, false);
+                CacheEventData completedEventData =
+                        new CacheEventDataImpl(cacheName, CacheEventType.COMPLETED,
+                                               dataKey, dataValue, null, false);
                 eventSet = new CacheEventSet(eventType, completionId);
                 eventSet.addEventData(completedEventData);
                 eventData = eventSet;
@@ -306,7 +316,6 @@ public abstract class AbstractCacheService implements ICacheService {
     public void publishEvent(String cacheName, CacheEventSet eventSet, int orderKey) {
         final EventService eventService = getNodeEngine().getEventService();
         final Collection<EventRegistration> candidates = eventService.getRegistrations(SERVICE_NAME, cacheName);
-
         if (candidates.isEmpty()) {
             return;
         }
@@ -326,20 +335,46 @@ public abstract class AbstractCacheService implements ICacheService {
     @Override
     public String registerListener(String distributedObjectName, CacheEventListener listener) {
         final EventService eventService = getNodeEngine().getEventService();
-        final EventRegistration registration = eventService
-                .registerListener(AbstractCacheService.SERVICE_NAME, distributedObjectName, listener);
-        return registration.getId();
+        final EventRegistration registration =
+                eventService.registerListener(AbstractCacheService.SERVICE_NAME,
+                                              distributedObjectName,
+                                              listener);
+        final String id = registration.getId();
+        if (listener instanceof Closeable) {
+            closeableListeners.put(id, (Closeable) listener);
+        } else if (listener instanceof CacheEntryListenerProvider) {
+            CacheEntryListener cacheEntryListener = ((CacheEntryListenerProvider) listener).getCacheEntryListener();
+            if (cacheEntryListener instanceof Closeable) {
+                closeableListeners.put(id, (Closeable) cacheEntryListener);
+            }
+        }
+        return id;
     }
 
     @Override
     public boolean deregisterListener(String name, String registrationId) {
         final EventService eventService = getNodeEngine().getEventService();
-        return eventService.deregisterListener(SERVICE_NAME, name, registrationId);
+        final boolean result = eventService.deregisterListener(SERVICE_NAME, name, registrationId);
+        Closeable listener = closeableListeners.remove(registrationId);
+        if (listener != null) {
+            IOUtil.closeResource(listener);
+        }
+        return result;
     }
 
     @Override
     public void deregisterAllListener(String name) {
-        nodeEngine.getEventService().deregisterAllListeners(AbstractCacheService.SERVICE_NAME, name);
+        final EventService eventService = getNodeEngine().getEventService();
+        final Collection<EventRegistration> registrations = eventService.getRegistrations(SERVICE_NAME, name);
+        if (registrations != null) {
+            for (EventRegistration registration : registrations) {
+                Closeable listener = closeableListeners.remove(registration.getId());
+                if (listener != null) {
+                    IOUtil.closeResource(listener);
+                }
+            }
+        }
+        eventService.deregisterAllListeners(AbstractCacheService.SERVICE_NAME, name);
     }
 
     @Override
@@ -359,5 +394,36 @@ public abstract class AbstractCacheService implements ICacheService {
         cacheOperationProvider = new DefaultOperationProvider(nameWithPrefix);
         CacheOperationProvider current = operationProviderCache.putIfAbsent(nameWithPrefix, cacheOperationProvider);
         return current == null ? cacheOperationProvider : current;
+    }
+
+    // This method will be called at cache creation from each partition while creating cache record store.
+    // A better synchronization may be implemented but
+    // since these are not called so much periodically, but it is not needed at this time.
+    public void addCacheResource(String name, Closeable resource) {
+        Set<Closeable> cacheResources = resources.get(name);
+        if (cacheResources == null) {
+            synchronized (resources) {
+                // In case of creation of resource set for specified cache name, we checks double from resources map.
+                // But this happens only once for each cache and this prevents other calls
+                // from unnecessary "synchronized" lock on "resources" instance
+                // since "cacheResources" will not be for specified cache name.
+                cacheResources = resources.get(name);
+                if (cacheResources == null) {
+                    cacheResources = Collections.newSetFromMap(new ConcurrentHashMap<Closeable, Boolean>());
+                    resources.put(name, cacheResources);
+                }
+            }
+        }
+        cacheResources.add(resource);
+    }
+
+    private void deleteCacheResources(String name) {
+        Set<Closeable> cacheResources = resources.remove(name);
+        if (cacheResources != null) {
+            for (Closeable resource : cacheResources) {
+                IOUtil.closeResource(resource);
+            }
+            cacheResources.clear();
+        }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheEntryListenerProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheEntryListenerProvider.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.cache.impl;
+
+import javax.cache.event.CacheEntryListener;
+
+/**
+ * Provides underlying (wrapped) {@link javax.cache.event.CacheEntryListener} instance.
+ *
+ * @see javax.cache.event.CacheEntryListener
+ *
+ * @param <K> type of the key
+ * @param <V> type of the value
+ */
+public interface CacheEntryListenerProvider<K, V> {
+
+    /**
+     * Gets wrapped {@link javax.cache.event.CacheEntryListener}
+     *
+     * @return the wrapped {@link javax.cache.event.CacheEntryListener}
+     */
+    CacheEntryListener<K, V> getCacheEntryListener();
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/cache/BasicCacheTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/BasicCacheTest.java
@@ -59,6 +59,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static junit.framework.Assert.assertTrue;
 import static junit.framework.Assert.assertFalse;
 import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertFalse;
 import static junit.framework.Assert.assertNotNull;
 import static junit.framework.Assert.assertNull;
 import static junit.framework.Assert.fail;

--- a/hazelcast/src/test/java/com/hazelcast/cache/CacheResourceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CacheResourceTest.java
@@ -1,0 +1,238 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.cache;
+
+import com.hazelcast.cache.impl.HazelcastServerCachingProvider;
+import com.hazelcast.config.CacheConfig;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.QuickTest;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import javax.cache.Cache;
+import javax.cache.CacheManager;
+import javax.cache.configuration.CompleteConfiguration;
+import javax.cache.configuration.Factory;
+import javax.cache.configuration.FactoryBuilder;
+import javax.cache.configuration.MutableCacheEntryListenerConfiguration;
+import javax.cache.event.CacheEntryCreatedListener;
+import javax.cache.event.CacheEntryListenerException;
+import javax.cache.integration.CacheLoader;
+import javax.cache.integration.CacheLoaderException;
+import javax.cache.integration.CacheWriter;
+import javax.cache.integration.CacheWriterException;
+import javax.cache.spi.CachingProvider;
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.locks.LockSupport;
+
+import static junit.framework.Assert.assertTrue;
+import static junit.framework.Assert.assertFalse;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class CacheResourceTest
+        extends HazelcastTestSupport {
+
+    private TestHazelcastInstanceFactory factory;
+
+    @Before
+    public void init() {
+        factory = new TestHazelcastInstanceFactory(2);
+    }
+
+    @After
+    public void tear() {
+        factory.shutdownAll();
+    }
+
+    @Test
+    public void testCloseableCacheLoader() throws InterruptedException {
+        CachingProvider provider =
+                HazelcastServerCachingProvider.createCachingProvider(factory.newHazelcastInstance());
+
+        CacheManager cacheManager = provider.getCacheManager();
+
+        CloseableCacheLoader loader = new CloseableCacheLoader();
+
+        Factory<CloseableCacheLoader> loaderFactory = FactoryBuilder.factoryOf(loader);
+        CompleteConfiguration<Object, Object> configuration =
+                new CacheConfig()
+                        .setCacheLoaderFactory(loaderFactory)
+                        .setReadThrough(true);
+
+        Cache<Object, Object> cache = cacheManager.createCache("test", configuration);
+
+        // trigger partition assignment
+        cache.get("key");
+
+        factory.newHazelcastInstance();
+
+        for (int i = 0; i < 1000; i++) {
+            cache.get(i);
+            LockSupport.parkNanos(1000);
+        }
+
+        assertFalse("CacheLoader should not be closed!", loader.closed);
+    }
+
+    private static class CloseableCacheLoader implements CacheLoader, Closeable, Serializable {
+
+        private volatile boolean closed = false;
+
+        @Override
+        public Object load(Object key) throws CacheLoaderException {
+            if (closed) {
+                throw new IllegalStateException();
+            }
+            return null;
+        }
+
+        @Override
+        public Map loadAll(Iterable keys) throws CacheLoaderException {
+            if (closed) {
+                throw new IllegalStateException();
+            }
+            return null;
+        }
+
+        @Override
+        public void close() throws IOException {
+            closed = true;
+        }
+
+    }
+
+    @Test
+    public void testCloseableCacheWriter() throws InterruptedException {
+        CachingProvider provider =
+                HazelcastServerCachingProvider.createCachingProvider(factory.newHazelcastInstance());
+
+        CacheManager cacheManager = provider.getCacheManager();
+
+        CloseableCacheWriter writer = new CloseableCacheWriter();
+
+        Factory<CloseableCacheWriter> writerFactory = FactoryBuilder.factoryOf(writer);
+        CompleteConfiguration<Object, Object> configuration =
+                new CacheConfig()
+                        .setCacheWriterFactory(writerFactory)
+                        .setWriteThrough(true);
+
+        Cache<Object, Object> cache = cacheManager.createCache("test", configuration);
+
+        // trigger partition assignment
+        cache.get("key");
+
+        factory.newHazelcastInstance();
+
+        for (int i = 0; i < 1000; i++) {
+            cache.put(i, i);
+            LockSupport.parkNanos(1000);
+        }
+
+        assertFalse("CacheWriter should not be closed!", writer.closed);
+    }
+
+    private static class CloseableCacheWriter implements CacheWriter, Closeable, Serializable {
+
+        private volatile boolean closed = false;
+
+        @Override
+        public void write(Cache.Entry entry) throws CacheWriterException {
+            if (closed) {
+                throw new IllegalStateException();
+            }
+        }
+
+        @Override
+        public void delete(Object key) throws CacheWriterException {
+            if (closed) {
+                throw new IllegalStateException();
+            }
+        }
+
+        @Override
+        public void deleteAll(Collection keys) throws CacheWriterException {
+            if (closed) {
+                throw new IllegalStateException();
+            }
+        }
+
+        @Override
+        public void writeAll(Collection collection) throws CacheWriterException {
+            if (closed) {
+                throw new IllegalStateException();
+            }
+        }
+
+        @Override
+        public void close() throws IOException {
+            closed = true;
+        }
+
+    }
+
+    @Test
+    public void testCloseableCacheListener() {
+        CachingProvider provider =
+                HazelcastServerCachingProvider
+                        .createCachingProvider(factory.newHazelcastInstance());
+
+        CacheManager cacheManager = provider.getCacheManager();
+
+        CloseableListener listener = new CloseableListener();
+
+        Factory<CloseableListener> listenerFactory = FactoryBuilder.factoryOf(listener);
+        CompleteConfiguration<Object, Object> configuration =
+                new CacheConfig()
+                        .addCacheEntryListenerConfiguration(
+                                new MutableCacheEntryListenerConfiguration(listenerFactory, null, true, false));
+
+        Cache<Object, Object> cache = cacheManager.createCache("test", configuration);
+        cache.close();
+
+        assertTrue("CloseableListener.close() should be called when cache is closed!", listener.closed);
+    }
+
+    private static class CloseableListener implements CacheEntryCreatedListener, Closeable, Serializable {
+
+        private volatile boolean closed = false;
+
+        @Override
+        public void onCreated(Iterable iterable) throws CacheEntryListenerException {
+            if (closed) {
+                throw new IllegalStateException();
+            }
+        }
+
+        @Override
+        public void close() throws IOException {
+            closed = true;
+        }
+
+    }
+
+}


### PR DESCRIPTION
Backport fix for both issues #4616 and #4617