### PR TITLE
Introduced Blackbox

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -148,6 +148,10 @@
     <suppress checks="JavadocMethod" files="com.hazelcast.internal.storage[\\/]"/>
     <suppress checks="JavadocVariable" files="com.hazelcast.internal.storage[\\/]"/>
 
+    <!-- we don't care about return count here since there are just many types to deal with -->
+    <suppress checks="ReturnCount" files="com.hazelcast.internal.blackbox.impl.FieldSensor"/>
+    <suppress checks="ReturnCount" files="com.hazelcast.internal.blackbox.impl.MethodSensor"/>
+
 
     <!-- client -->
     <!-- TODO: These javadoc issues need to be addressed -->
@@ -436,6 +440,7 @@
 
     <suppress checks="" files="com.hazelcast.util.DebugUtil"/>
 
+    <suppress checks="IllegalImport" files="com.hazelcast.util.counters.SwCounter"/>
 
     <suppress checks="" files="com.hazelcast.util.HashUtil"/>
     <suppress checks="MagicNumber" files="com.hazelcast.util.QuickMath"/>

--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/ClusterClockImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/ClusterClockImpl.java
@@ -17,18 +17,22 @@
 package com.hazelcast.cluster.impl;
 
 import com.hazelcast.cluster.ClusterClock;
+import com.hazelcast.internal.blackbox.SensorInput;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.util.Clock;
 
 public class ClusterClockImpl implements ClusterClock {
 
     private final ILogger logger;
+
+    @SensorInput(name = "clusterTimeDiff")
     private volatile long clusterTimeDiff = Long.MAX_VALUE;
 
     public ClusterClockImpl(ILogger logger) {
         this.logger = logger;
     }
 
+    @SensorInput(name = "clusterTime")
     @Override
     public long getClusterTime() {
         return Clock.currentTimeMillis() + ((clusterTimeDiff == Long.MAX_VALUE) ? 0 : clusterTimeDiff);

--- a/hazelcast/src/main/java/com/hazelcast/instance/GroupProperties.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/GroupProperties.java
@@ -57,11 +57,32 @@ public class GroupProperties {
      * <p/>
      * The performance monitor logs all metrics into the log file.
      */
-    public static final String PROP_PERFORMANCE_MONITORING_ENABLED = "hazelcast.performance.monitoring.enabled";
+    public static final String PROP_PERFORMANCE_MONITOR_ENABLED = "hazelcast.performance.monitoring.enabled";
+
     /**
-     * The delay in seconds between monitoring of the performance.
+     * The delay in seconds between monitor of the performance.
      */
-    public static final String PROP_PERFORMANCE_MONITORING_DELAY_SECONDS = "hazelcast.performance.monitoring.delay.seconds";
+    public static final String PROP_PERFORMANCE_MONITOR_DELAY_SECONDS
+            = "hazelcast.performance.monitor.delay.seconds";
+
+    /**
+     * The PerformanceMonitor uses a rolling file approach to prevent eating too much disk space.
+     *
+     * This property sets the maximum size in MB for a single file.
+     *
+     * Every HazelcastInstance will get its own history of log files.
+     */
+    public static final String PROP_PERFORMANCE_MONITOR_MAX_ROLLED_FILE_SIZE
+            = "hazelcast.performance.monitor.max.rolled.file.size";
+
+    /**
+     * The PerformanceMonitor uses a rolling file approach to prevent eating too much disk space.
+     *
+     * This property sets the maximum number of rolling files to keep on disk.
+     */
+    public static final String PROP_PERFORMANCE_MONITOR_MAX_ROLLED_FILE_COUNT
+            = "hazelcast.performance.monitor.max.rolled.file.count";
+
 
     public static final String PROP_VERSION_CHECK_ENABLED = "hazelcast.version.check.enabled";
     public static final String PROP_PREFER_IPv4_STACK = "hazelcast.prefer.ipv4.stack";
@@ -327,9 +348,13 @@ public class GroupProperties {
 
     public final GroupProperty HEALTH_MONITORING_DELAY_SECONDS;
 
-    public final GroupProperty PERFORMANCE_MONITORING_ENABLED;
+    public final GroupProperty PERFORMANCE_MONITOR_ENABLED;
 
-    public final GroupProperty PERFORMANCE_MONITORING_DELAY_SECONDS;
+    public final GroupProperty PERFORMANCE_MONITOR_DELAY_SECONDS;
+
+    public final GroupProperty PERFORMANCE_MONITOR_MAX_ROLLED_FILE_SIZE;
+
+    public final GroupProperty PERFORMANCE_MONITOR_MAX_ROLLED_FILE_COUNT;
 
     public final GroupProperty IO_THREAD_COUNT;
 
@@ -496,11 +521,17 @@ public class GroupProperties {
     public GroupProperties(Config config) {
         HEALTH_MONITORING_LEVEL
                 = new GroupProperty(config, PROP_HEALTH_MONITORING_LEVEL, HealthMonitorLevel.SILENT.toString());
-        HEALTH_MONITORING_DELAY_SECONDS = new GroupProperty(config, PROP_HEALTH_MONITORING_DELAY_SECONDS, "30");
+        HEALTH_MONITORING_DELAY_SECONDS
+                = new GroupProperty(config, PROP_HEALTH_MONITORING_DELAY_SECONDS, "30");
 
-        PERFORMANCE_MONITORING_ENABLED
-                = new GroupProperty(config, PROP_PERFORMANCE_MONITORING_ENABLED, "false");
-        PERFORMANCE_MONITORING_DELAY_SECONDS = new GroupProperty(config, PROP_PERFORMANCE_MONITORING_DELAY_SECONDS, "30");
+        PERFORMANCE_MONITOR_ENABLED
+                = new GroupProperty(config, PROP_PERFORMANCE_MONITOR_ENABLED, "false");
+        PERFORMANCE_MONITOR_DELAY_SECONDS
+                = new GroupProperty(config, PROP_PERFORMANCE_MONITOR_DELAY_SECONDS, "30");
+        PERFORMANCE_MONITOR_MAX_ROLLED_FILE_SIZE
+                = new GroupProperty(config, PROP_PERFORMANCE_MONITOR_MAX_ROLLED_FILE_SIZE, "10");
+        PERFORMANCE_MONITOR_MAX_ROLLED_FILE_COUNT
+                = new GroupProperty(config, PROP_PERFORMANCE_MONITOR_MAX_ROLLED_FILE_COUNT, "10");
 
         VERSION_CHECK_ENABLED = new GroupProperty(config, PROP_VERSION_CHECK_ENABLED, "true");
         PREFER_IPv4_STACK = new GroupProperty(config, PROP_PREFER_IPv4_STACK, "true");
@@ -654,6 +685,10 @@ public class GroupProperties {
 
         public boolean getBoolean() {
             return Boolean.valueOf(this.value);
+        }
+
+        public float getFloat() {
+            return Float.valueOf(this.value);
         }
 
         public String getString() {

--- a/hazelcast/src/main/java/com/hazelcast/instance/HazelcastInstanceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/HazelcastInstanceImpl.java
@@ -53,7 +53,6 @@ import com.hazelcast.core.PartitionService;
 import com.hazelcast.core.ReplicatedMap;
 import com.hazelcast.executor.impl.DistributedExecutorService;
 import com.hazelcast.internal.monitors.HealthMonitor;
-import com.hazelcast.internal.monitors.HealthMonitorLevel;
 import com.hazelcast.internal.monitors.PerformanceMonitor;
 import com.hazelcast.jmx.ManagementService;
 import com.hazelcast.logging.ILogger;
@@ -101,9 +100,15 @@ public class HazelcastInstanceImpl implements HazelcastInstance {
 
     final ConcurrentMap<String, Object> userContext = new ConcurrentHashMap<String, Object>();
 
+    final PerformanceMonitor performanceMonitor;
+
+    final HealthMonitor healthMonitor;
+
     HazelcastInstanceImpl(String name, Config config, NodeContext nodeContext)
             throws Exception {
         this.name = name;
+
+
         lifecycleService = new LifecycleServiceImpl(this);
         ManagedContext configuredManagedContext = config.getManagedContext();
         managedContext = new HazelcastManagedContext(this, configuredManagedContext);
@@ -125,7 +130,9 @@ public class HazelcastInstanceImpl implements HazelcastInstance {
 
             managementService = new ManagementService(this);
             initManagedContext(configuredManagedContext);
-            initMonitors();
+
+            this.performanceMonitor = new PerformanceMonitor(this).start();
+            this.healthMonitor = new HealthMonitor(this).start();
         } catch (Throwable e) {
             try {
                 // Terminate the node by terminating node engine,
@@ -138,38 +145,12 @@ public class HazelcastInstanceImpl implements HazelcastInstance {
         }
     }
 
-    private void initMonitors() {
-        initHealthMonitor();
-        initPerformanceMonitor();
-    }
-
     private void initManagedContext(ManagedContext configuredManagedContext) {
         if (configuredManagedContext != null) {
             if (configuredManagedContext instanceof HazelcastInstanceAware) {
                 ((HazelcastInstanceAware) configuredManagedContext).setHazelcastInstance(this);
             }
         }
-    }
-
-    private void initHealthMonitor() {
-        String healthMonitorLevelString = node.getGroupProperties().HEALTH_MONITORING_LEVEL.getString();
-        HealthMonitorLevel healthLevel = HealthMonitorLevel.valueOf(healthMonitorLevelString);
-        if (healthLevel != HealthMonitorLevel.OFF) {
-            logger.finest("Starting health monitor");
-            int delaySeconds = node.getGroupProperties().HEALTH_MONITORING_DELAY_SECONDS.getInteger();
-            new HealthMonitor(this, healthLevel, delaySeconds).start();
-        }
-    }
-
-    private void initPerformanceMonitor() {
-        boolean enabled = node.getGroupProperties().PERFORMANCE_MONITORING_ENABLED.getBoolean();
-        if (!enabled) {
-            return;
-        }
-
-        logger.finest("Starting performance monitor");
-        int delaySeconds = node.getGroupProperties().PERFORMANCE_MONITORING_DELAY_SECONDS.getInteger();
-        new PerformanceMonitor(this, delaySeconds).start();
     }
 
     public ManagementService getManagementService() {

--- a/hazelcast/src/main/java/com/hazelcast/internal/blackbox/Blackbox.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/blackbox/Blackbox.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.blackbox;
+
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * The Blackbox is responsible for recording all kinds of Hazelcast/JVM specific information to
+ * help out with all kinds of issues.
+ *
+ * Each HazelcastInstance has its own Blackbox.
+ *
+ * A sensor for the Blackbox is build up of the following parts:
+ * <ol>
+ * <li>Parameter: uniquely identifies a Sensor</li>
+ * <li>Sensor input: responsible for providing a value. An input can be a field/method with the @SensorInput, but
+ * it can also be a {@link LongSensorInput} or {@link DoubleSensorInput}</li>
+ * </ol>
+ *
+ * <h1>Duplicate Registrations</h1>
+ * The Blackbox is also lenient regarding duplicate registrations of sensors. So if a Sensor is created and
+ * an SensorInput is set and a new registration for the same Sensor is done, the old SensorInput is overwritten.
+ * The reason to be lenient is that the Blackbox should not throw exception. Of course there will be a log
+ * warning.
+ *
+ * <h1>Performance</h1>
+ * The Blackbox is designed for low overhead sensors. So once a sensor is registered, there is no overhead
+ * for the provider of the sensor data. The provider could have for example a volatile long field and increment
+ * this using a lazy-set. As long as the Blackbox can frequently read out this field, the Blackbox is perfectly
+ * happy with such low overhead sensor-inputs. So it is up to the provider of the sensor-input how much overhead
+ * is required.
+ */
+public interface Blackbox {
+
+    /**
+     * Scans the source object for any fields/methods that have been annotated with {@link SensorInput} annotation, and
+     * registering these fields/methods as sensors.
+     *
+     * If the same object already is registered, nothing bad happens.
+     *
+     * If an object has no sensor annotations, the call is ignored.
+     *
+     * @param source          the object to scan.
+     * @param parameterPrefix the parameter prefix.
+     * @throws java.lang.NullPointerException if parameterPrefix  or source is null.
+     */
+    <S> void scanAndRegister(S source, String parameterPrefix);
+
+    /**
+     * Registers a sensor.
+     *
+     * If a Sensor with the given name already has a SensorInput, that SensorInput will be overwritten.
+     *
+     * @param parameter the name of the sensor.
+     * @param input     the input for the sensor.
+     */
+    <S> void register(S source, String parameter, LongSensorInput<S> input);
+
+    /**
+     * Registers a sensor.
+     *
+     * If a Sensor with the given name already has a SensorInput, that SensorInput will be overwritten.
+     *
+     * @param parameter the name of the sensor.
+     * @param input     the input for the sensor.
+     * @throws java.lang.NullPointerException if parameter or input is null.
+     */
+    <S> void register(S source, String parameter, DoubleSensorInput<S> input);
+
+
+    /**
+     * Deregisters an scanned object. So all sensors that were created by checking for its Sensor annotations are removed.
+     *
+     * If the object already is deregistered, the call is ignored.
+     *
+     * If the object was never registered, the call is ignored.
+     *
+     * @param source the object to deregister
+     * @throws java.lang.NullPointerException if source is null.
+     */
+    <S> void deregister(S source);
+
+    /**
+     * Schedules a publisher to be executed at a fixed rate.
+     *
+     * Probably this method will be removed in the future, but we need a mechanism for complex sensors that require some
+     * calculation to provide their values.
+     *
+     * @param publisher the published task that needs to be executed
+     * @param period    the time between executions
+     * @param timeUnit  the timeunit for period
+     * @throws java.lang.NullPointerException if publisher or timeUnit is null.
+     */
+    void scheduleAtFixedRate(Runnable publisher, long period, TimeUnit timeUnit);
+
+    /**
+     * Gets the Sensor for a given parameter.
+     *
+     * If no sensor exists for the parameter, it will be created but no SensorInput is set. The reason to do so is
+     * that you don't want to depend on the order of registration. Perhaps you want to read out e.g. operations.count
+     * sensor, but the OperationService has not started yet and the sensor is not yet available.
+     *
+     * @param parameter the parameter
+     * @return the Sensor. Multiple calls with the same parameter, return the same Sensor instance.
+     * @throws java.lang.NullPointerException if parameter is null.
+     */
+    Sensor getSensor(String parameter);
+
+    /**
+     * Gets a set of all current parameters.
+     *
+     * @return set of all current parameters.
+     */
+    Set<String> getParameters();
+
+    /**
+     * Returns the modCount. Every time a sensor is added or removed, the modCount is increased.
+     *
+     * Returned modcount will always be equal or larger than 0.
+     *
+     * @return the modCount.
+     */
+    int modCount();
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/blackbox/DoubleSensorInput.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/blackbox/DoubleSensorInput.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.blackbox;
+
+/**
+ * A function that provides a double value and can be used to create a sensor using
+ * {@link Blackbox#register(Object, String, DoubleSensorInput)}
+ *
+ * @param <S> the type of the source object.
+ */
+public interface DoubleSensorInput<S> {
+
+    /**
+     * Gets the current value.
+     *
+     * @param source the source
+     * @return the current value.
+     * @throws Exception if something fails while getting the value.
+     */
+    double get(S source) throws Exception;
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/blackbox/LongSensorInput.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/blackbox/LongSensorInput.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.blackbox;
+
+/**
+ * A function that provides a long value and can be used to create a sensor using
+ * {@link Blackbox#register(Object, String, LongSensorInput)}
+ *
+ * @param <S> the type of the source object.
+ */
+public interface LongSensorInput<S> {
+
+    /**
+     * Gets the current value.
+     *
+     * @param source the source
+     * @return the current value
+     * @throws Exception if something fails while getting the value.
+     */
+    long get(S source) throws Exception;
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/blackbox/Sensor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/blackbox/Sensor.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.blackbox;
+
+/**
+ * A {@link Sensor} provides access to measure long/double value.
+ *
+ * If the Sensor is obtained before it is registered, the Sensor is without input. As soon as the registration happens, the
+ * input is set on the sensor and the current information will be retrieved.
+ *
+ * A Sensor can be used before it is registered and there has no input/source set. In this case the {@link #readDouble()} and
+ * {@link #readDouble()} return 0.
+ *
+ * A Sensor can be used after the {@link Blackbox#deregister(Object)} is called. In this case the {@link #readDouble()} and
+ * {@link #readDouble()} return 0.
+ *
+ * Some future improvements:
+ * <ol>
+ * <li>return type type, floating point or not</li>
+ * <li>provide insight if the source is set</li>
+ * </ol>
+ * For the time being they are not needed, so therefor not implemented.
+ */
+public interface Sensor {
+
+    /**
+     * Reads the current available value as a long.
+     *
+     * If the underlying sensor input providing a floating point value, then the value will be rounded using
+     * {@link Math#round(double)}.
+     *
+     * If no input is available, or there a problems obtaining a value from the input, 0 is returned.
+     *
+     * @return the current value.
+     */
+    long readLong();
+
+    /**
+     * Reads the current available value as a double.
+     *
+     * If the underlying sensor input doesn't provide a floating point value, then the value will be converted to
+     * a floating point value.
+     *
+     * If no input is available, or there a problems obtaining a value from the input, 0 is returned.
+     *
+     * @return the current value.
+     */
+    double readDouble();
+
+    /**
+     * Gets the parameter that identifies this sensor. The returned value will never change and never be null.
+     *
+     * @return the parameter.
+     */
+    String getParameter();
+
+    /**
+     * Renders the Sensor.
+     *
+     * @param sb the StringBuilder to write to.
+     * @throws NullPointerException if sb is null
+     */
+    void render(StringBuilder sb);
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/blackbox/SensorInput.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/blackbox/SensorInput.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.blackbox;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Annotation that can be placed on a field or method of an object to indicate that it should be tracked by the
+ * Blackbox when the {@link Blackbox#scanAndRegister(Object, String)} is called.
+ *
+ * Prefer placing a SensorInput to a field above a method if the type is a primitive. The {@link java.lang.reflect.Field}
+ * provides access to the actual field without the need for autoboxing. With the {@link java.lang.reflect.Method} a wrapper
+ * object is created when a primitive is returned by the method. Therefor fields produce less garbage than methods.
+ *
+ * A SensorInput can be placed on field or methods with the following (return) type:
+ * <ol>
+ * <li>byte</li>
+ * <li>short</li>
+ * <li>int</li>
+ * <li>float</li>
+ * <li>long</li>
+ * <li>double</li>
+ * <li>AtomicInteger</li>
+ * <li>AtomicLong</li>
+ * <li>Counter</li>
+ * <li>Byte</li>
+ * <li>Short</li>
+ * <li>Integer</li>
+ * <li>Float</li>
+ * <li>Double</li>
+ * <li>Collection: it will return the size</li>
+ * <li>Map: it will return the size</li>
+ * </ol>
+ *
+ * If the field or method points to a null reference, it is interpreted as 0.
+ */
+@Retention(value = RUNTIME)
+@Target({FIELD, METHOD })
+public @interface SensorInput {
+
+    /**
+     * The name of the sensor. By default the name of the field or method is used.
+     *
+     * @return the name of the sensor.
+     */
+    String name() default "";
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/blackbox/impl/AccessibleObjectInput.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/blackbox/impl/AccessibleObjectInput.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.blackbox.impl;
+
+import com.hazelcast.util.counters.Counter;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Provides an abstract for {@link FieldSensorInput} and {@link MethodSensorInput}.
+ */
+abstract class AccessibleObjectInput {
+
+    static final int TYPE_PRIMITIVE_LONG = 1;
+    static final int TYPE_LONG_NUMBER = 2;
+
+    static final int TYPE_DOUBLE_PRIMITIVE = 3;
+    static final int TYPE_DOUBLE_NUMBER = 4;
+
+    static final int TYPE_COLLECTION = 5;
+    static final int TYPE_MAP = 6;
+    static final int TYPE_COUNTER = 7;
+
+    private static final Map<Class<?>, Integer> TYPES = new HashMap<Class<?>, Integer>();
+
+    static {
+        TYPES.put(byte.class, TYPE_PRIMITIVE_LONG);
+        TYPES.put(short.class, TYPE_PRIMITIVE_LONG);
+        TYPES.put(int.class, TYPE_PRIMITIVE_LONG);
+        TYPES.put(long.class, TYPE_PRIMITIVE_LONG);
+
+        TYPES.put(Byte.class, TYPE_LONG_NUMBER);
+        TYPES.put(Short.class, TYPE_LONG_NUMBER);
+        TYPES.put(Integer.class, TYPE_LONG_NUMBER);
+        TYPES.put(Long.class, TYPE_LONG_NUMBER);
+        TYPES.put(AtomicInteger.class, TYPE_LONG_NUMBER);
+        TYPES.put(AtomicLong.class, TYPE_LONG_NUMBER);
+
+        TYPES.put(double.class, TYPE_DOUBLE_PRIMITIVE);
+        TYPES.put(float.class, TYPE_DOUBLE_PRIMITIVE);
+
+        TYPES.put(Double.class, TYPE_DOUBLE_NUMBER);
+        TYPES.put(Float.class, TYPE_DOUBLE_NUMBER);
+
+        TYPES.put(Collection.class, TYPE_COLLECTION);
+        TYPES.put(Map.class, TYPE_MAP);
+        TYPES.put(Counter.class, TYPE_COUNTER);
+    }
+
+    /**
+     * True if this AccessibleObjectInput returns a double, false if it returns a long.
+     */
+    abstract boolean isDouble();
+
+    abstract double getDouble(Object source) throws Exception;
+
+    abstract long getLong(Object source) throws Exception;
+
+    static boolean isDouble(int type) {
+        return type == TYPE_DOUBLE_PRIMITIVE || type == TYPE_DOUBLE_NUMBER;
+    }
+
+    /**
+     * @param classType
+     * @return
+     */
+    static int getType(Class classType) {
+        Integer type = TYPES.get(classType);
+        if (type != null) {
+            return type;
+        }
+
+        List<Class<?>> flattenedClasses = new ArrayList<Class<?>>();
+
+        flatten(classType, flattenedClasses);
+
+        for (Class<?> clazz : flattenedClasses) {
+            type = TYPES.get(clazz);
+            if (type != null) {
+                return type;
+            }
+        }
+
+        return -1;
+    }
+
+    static void flatten(Class clazz, List<Class<?>> result) {
+        if (!result.contains(clazz)) {
+            result.add(clazz);
+        }
+
+        if (clazz.getSuperclass() != null) {
+            flatten(clazz.getSuperclass(), result);
+        }
+
+        for (Class interfaze : clazz.getInterfaces()) {
+            if (!result.contains(interfaze)) {
+                result.add(interfaze);
+            }
+
+            flatten(interfaze, result);
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/blackbox/impl/BlackboxImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/blackbox/impl/BlackboxImpl.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.blackbox.impl;
+
+import com.hazelcast.internal.blackbox.Blackbox;
+import com.hazelcast.internal.blackbox.DoubleSensorInput;
+import com.hazelcast.internal.blackbox.LongSensorInput;
+import com.hazelcast.internal.blackbox.Sensor;
+import com.hazelcast.internal.blackbox.sensorpacks.ClassLoadingSensorPack;
+import com.hazelcast.internal.blackbox.sensorpacks.GarbageCollectionSensorPack;
+import com.hazelcast.internal.blackbox.sensorpacks.OperatingSystemSensorPack;
+import com.hazelcast.internal.blackbox.sensorpacks.RuntimeSensorPack;
+import com.hazelcast.internal.blackbox.sensorpacks.ThreadSensorPack;
+import com.hazelcast.logging.ILogger;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static com.hazelcast.util.Preconditions.checkNotNull;
+import static java.lang.String.format;
+
+/**
+ * The {@link Blackbox} implementation.
+ *
+ * Interesting read:
+ * https://source.android.com/devices/sensors/sensor-types.html
+ */
+public class BlackboxImpl implements Blackbox {
+
+    private final ILogger logger;
+    private final ScheduledExecutorService scheduledExecutorService = new ScheduledThreadPoolExecutor(2);
+    private final AtomicInteger modCount = new AtomicInteger();
+    private final ConcurrentMap<String, SensorImpl> sensors = new ConcurrentHashMap<String, SensorImpl>();
+    private final ConcurrentMap<Class<?>, SourceMetadata> metadataMap
+            = new ConcurrentHashMap<Class<?>, SourceMetadata>();
+
+    /**
+     * Creates a BlackboxImpl instance.
+     *
+     * Automatically registers the com.hazelcast.internal.blackbox.sensorpacks.
+     *
+     * @param logger the ILogger used
+     * @throws NullPointerException if logger is null
+     */
+    public BlackboxImpl(ILogger logger) {
+        this.logger = checkNotNull(logger, "Logger can't be null");
+
+        RuntimeSensorPack.register(this);
+        GarbageCollectionSensorPack.register(this);
+        OperatingSystemSensorPack.register(this);
+        ThreadSensorPack.register(this);
+        ClassLoadingSensorPack.register(this);
+    }
+
+    @Override
+    public int modCount() {
+        return modCount.get();
+    }
+
+    @Override
+    public Set<String> getParameters() {
+        return sensors.keySet();
+    }
+
+    SourceMetadata getObjectMetadata(Class<?> clazz) {
+        SourceMetadata metadata = metadataMap.get(clazz);
+        if (metadata == null) {
+            metadata = new SourceMetadata(clazz);
+            SourceMetadata found = metadataMap.putIfAbsent(clazz, metadata);
+            metadata = found == null ? metadata : found;
+        }
+
+        return metadata;
+    }
+
+    @Override
+    public synchronized <S> void scanAndRegister(S source, String parameterPrefix) {
+        checkNotNull(source, "source can't be null");
+        checkNotNull(parameterPrefix, "parameterPrefix can't be null");
+
+        SourceMetadata metadata = getObjectMetadata(source.getClass());
+        metadata.register(this, source, parameterPrefix);
+    }
+
+    @Override
+    public synchronized <S> void register(S source, String parameter, LongSensorInput<S> input) {
+        checkNotNull(parameter, "source can't be null");
+        checkNotNull(parameter, "parameter can't be null");
+        checkNotNull(parameter, "input can't be null");
+
+        registerInternal(source, parameter, input);
+    }
+
+    @Override
+    public synchronized <S> void register(S source, String parameter, DoubleSensorInput<S> input) {
+        checkNotNull(parameter, "source can't be null");
+        checkNotNull(parameter, "parameter can't be null");
+        checkNotNull(parameter, "input can't be null");
+
+        registerInternal(source, parameter, input);
+    }
+
+    <S> void registerInternal(S source, String parameter, Object input) {
+        SensorImpl sensor = sensors.get(parameter);
+        if (sensor == null) {
+            sensor = new SensorImpl<S>(parameter, logger);
+            sensors.put(parameter, sensor);
+        }
+
+        logOverwrite(parameter, sensor);
+
+        if (logger.isFinestEnabled()) {
+            logger.finest("Registered sensor " + parameter);
+        }
+
+        sensor.source = source;
+        sensor.input = input;
+
+        modCount.incrementAndGet();
+    }
+
+    /**
+     * We are going to check if a source or input already exist. If it exists, we are going the log a warning but we
+     * are not going to fail. The blackbox should never fail unless the arguments don't make any sense of course.
+     */
+    private void logOverwrite(String parameter, SensorImpl sensor) {
+        // if an input already exists, we are just going to overwrite it.
+        if (sensor.input != null) {
+            logger.warning(format("Duplicate registration, a SensorInput for Sensor '%s' already exists", parameter));
+        }
+
+        // if a source already exists, we are just going to overwrite it.
+        if (sensor.source != null) {
+            logger.warning(format("Duplicate registration, a source for Sensor '%s' already exists", parameter));
+        }
+    }
+
+    @Override
+    public synchronized Sensor getSensor(String parameter) {
+        checkNotNull(parameter, "parameter can't be null");
+
+        SensorImpl sensor = sensors.get(parameter);
+
+        if (sensor == null) {
+            sensor = new SensorImpl(parameter, logger);
+            sensors.put(parameter, sensor);
+        }
+
+        return sensor;
+    }
+
+    @Override
+    public synchronized <S> void deregister(S source) {
+        checkNotNull(source, "source can't be null");
+
+        boolean changed = false;
+        for (Map.Entry<String, SensorImpl> entry : sensors.entrySet()) {
+            String parameter = entry.getKey();
+            SensorImpl sensor = entry.getValue();
+            if (sensor.source != source) {
+                continue;
+            }
+
+            changed = true;
+            sensors.remove(parameter);
+            sensor.source = null;
+            sensor.input = null;
+
+            if (logger.isFinestEnabled()) {
+                logger.finest("Destroying sensor " + parameter);
+            }
+        }
+
+        if (changed) {
+            modCount.incrementAndGet();
+        }
+    }
+
+    @Override
+    public void scheduleAtFixedRate(final Runnable publisher, long period, TimeUnit timeUnit) {
+        scheduledExecutorService.scheduleAtFixedRate(publisher, 0, period, timeUnit);
+    }
+
+    public void shutdown() {
+        scheduledExecutorService.shutdown();
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/blackbox/impl/FieldSensorInput.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/blackbox/impl/FieldSensorInput.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.blackbox.impl;
+
+import com.hazelcast.internal.blackbox.SensorInput;
+import com.hazelcast.util.counters.Counter;
+
+import java.lang.reflect.Field;
+import java.util.Collection;
+import java.util.Map;
+
+import static java.lang.String.format;
+
+/**
+ * A sensor input that reads out a field that is annotated with {@link SensorInput}.
+ */
+final class FieldSensorInput extends AccessibleObjectInput {
+
+    private final SensorInput sensorInput;
+    private final Field field;
+    private final int type;
+
+    FieldSensorInput(Field field, SensorInput sensorInput) {
+        this.field = field;
+        this.sensorInput = sensorInput;
+        this.type = getType();
+        field.setAccessible(true);
+    }
+
+    private int getType() {
+        int type = getType(field.getType());
+        if (type != -1) {
+            return type;
+        }
+
+        throw new IllegalArgumentException(format("@SensorInput field '%s' is of an unhandled type", field));
+    }
+
+    @Override
+    public boolean isDouble() {
+        return isDouble(type);
+    }
+
+    void register(BlackboxImpl blackbox, Object source, String parameterPrefix) {
+        String parameter = getParameter(parameterPrefix);
+        blackbox.registerInternal(source, parameter, this);
+    }
+
+    private String getParameter(String parameterPrefix) {
+        String sensorName = field.getName();
+        if (!sensorInput.name().equals("")) {
+            sensorName = sensorInput.name();
+        }
+
+        return parameterPrefix + "." + sensorName;
+    }
+
+    @Override
+    public long getLong(Object source) throws Exception {
+        switch (type) {
+            case TYPE_PRIMITIVE_LONG:
+                return field.getLong(source);
+            case TYPE_LONG_NUMBER:
+                Number longNumber = (Number) field.get(source);
+                return longNumber == null ? 0 : longNumber.longValue();
+            case TYPE_MAP:
+                Map<?, ?> map = (Map<?, ?>) field.get(source);
+                return map == null ? 0 : map.size();
+            case TYPE_COLLECTION:
+                Collection<?> collection = (Collection<?>) field.get(source);
+                return collection == null ? 0 : collection.size();
+            case TYPE_COUNTER:
+                Counter counter = (Counter) field.get(source);
+                return counter == null ? 0 : counter.get();
+            default:
+                throw new IllegalStateException("Unhandled type:" + type);
+        }
+    }
+
+    @Override
+    public double getDouble(Object source) throws Exception {
+        switch (type) {
+            case TYPE_DOUBLE_PRIMITIVE:
+                return field.getDouble(source);
+            case TYPE_DOUBLE_NUMBER:
+                Number doubleNumber = (Number) field.get(source);
+                return doubleNumber == null ? 0 : doubleNumber.doubleValue();
+            default:
+                throw new IllegalStateException("Unhandled type:" + type);
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/blackbox/impl/MethodSensorInput.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/blackbox/impl/MethodSensorInput.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.blackbox.impl;
+
+import com.hazelcast.internal.blackbox.SensorInput;
+import com.hazelcast.util.counters.Counter;
+
+import java.lang.reflect.Method;
+import java.util.Collection;
+import java.util.Map;
+
+import static java.lang.String.format;
+
+/**
+ * A sensor input that reads out a method that is annotated with {@link SensorInput}.
+ */
+final class MethodSensorInput extends AccessibleObjectInput {
+
+    private final Method method;
+    private final SensorInput sensorInput;
+    private final int type;
+
+    MethodSensorInput(Method method, SensorInput sensorInput) {
+        this.method = method;
+        this.sensorInput = sensorInput;
+        checkNoArguments();
+        this.type = getType();
+        method.setAccessible(true);
+    }
+
+    private void checkNoArguments() {
+        if (method.getParameterTypes().length != 0) {
+            throw new IllegalArgumentException(format("@SensorInput method '%s.%s' can't have arguments",
+                    method.getDeclaringClass().getName(), method.getName()));
+        }
+    }
+
+    private int getType() {
+        int type = getType(method.getReturnType());
+        if (type != -1) {
+            return type;
+        }
+
+        throw new IllegalArgumentException(format("@SensorInput method '%s.%s() has an unsupported return type'",
+                method.getDeclaringClass().getName(), method.getName()));
+    }
+
+    void register(BlackboxImpl blackbox, Object source, String parameterPrefix) {
+        String parameter = getParameter(parameterPrefix);
+        blackbox.registerInternal(source, parameter, this);
+    }
+
+    private String getParameter(String parameterPrefix) {
+        String sensorName = method.getName();
+        if (!sensorInput.name().equals("")) {
+            sensorName = sensorInput.name();
+        }
+
+        return parameterPrefix + "." + sensorName;
+    }
+
+    @Override
+    public boolean isDouble() {
+        return isDouble(type);
+    }
+
+    @Override
+    public long getLong(Object source) throws Exception {
+        switch (type) {
+            case TYPE_PRIMITIVE_LONG:
+                return ((Number) method.invoke(source)).longValue();
+            case TYPE_LONG_NUMBER:
+                Number longNumber = (Number) method.invoke(source);
+                return longNumber == null ? 0 : longNumber.longValue();
+            case TYPE_MAP:
+                Map<?, ?> map = (Map<?, ?>) method.invoke(source);
+                return map == null ? 0 : map.size();
+            case TYPE_COLLECTION:
+                Collection<?> collection = (Collection<?>) method.invoke(source);
+                return collection == null ? 0 : collection.size();
+            case TYPE_COUNTER:
+                Counter counter = (Counter) method.invoke(source);
+                return counter == null ? 0 : counter.get();
+            default:
+                throw new IllegalStateException("Unrecognized type:" + type);
+        }
+    }
+
+    @Override
+    public double getDouble(Object source) throws Exception {
+        switch (type) {
+            case TYPE_DOUBLE_PRIMITIVE:
+            case TYPE_DOUBLE_NUMBER:
+                Number result = (Number) method.invoke(source);
+                return result == null ? 0 : result.doubleValue();
+            default:
+                throw new IllegalStateException("Unrecognized type:" + type);
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/blackbox/impl/SensorImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/blackbox/impl/SensorImpl.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.blackbox.impl;
+
+import com.hazelcast.internal.blackbox.DoubleSensorInput;
+import com.hazelcast.internal.blackbox.LongSensorInput;
+import com.hazelcast.internal.blackbox.Sensor;
+import com.hazelcast.logging.ILogger;
+
+import static com.hazelcast.util.Preconditions.checkNotNull;
+
+/**
+ * Default {@link Sensor} implementation.
+ *
+ * @param <S>
+ */
+public class SensorImpl<S> implements Sensor {
+
+    volatile Object input;
+    volatile S source;
+
+    private final ILogger logger;
+    private final String parameter;
+
+    public SensorImpl(String parameter, ILogger logger) {
+        this.parameter = parameter;
+        this.logger = logger;
+    }
+
+    @Override
+    public String getParameter() {
+        return parameter;
+    }
+
+    @Override
+    public void render(StringBuilder sb) {
+        checkNotNull(sb, "sb can't be null");
+
+        sb.append(parameter).append('=');
+
+        Object input = this.input;
+        S source = this.source;
+
+        if (input == null || source == null) {
+            sb.append("NA");
+            return;
+        }
+
+        try {
+            if (input instanceof LongSensorInput) {
+                LongSensorInput function = (LongSensorInput) input;
+                sb.append(function.get(source));
+            } else if (input instanceof DoubleSensorInput) {
+                DoubleSensorInput function = (DoubleSensorInput) input;
+                sb.append(function.get(source));
+            } else if (input instanceof AccessibleObjectInput) {
+                AccessibleObjectInput accessibleObjectInput = (AccessibleObjectInput) input;
+                if (accessibleObjectInput.isDouble()) {
+                    sb.append(accessibleObjectInput.getDouble(source));
+                } else {
+                    sb.append(accessibleObjectInput.getLong(source));
+                }
+            }
+        } catch (Exception e) {
+            logger.warning("Failed to update sensor:" + parameter, e);
+            sb.append("NA");
+        }
+    }
+
+    @Override
+    public long readLong() {
+        Object input = this.input;
+        S source = this.source;
+        long result = 0;
+
+        if (input == null || source == null) {
+            return result;
+        }
+
+        try {
+            if (input instanceof AccessibleObjectInput) {
+                AccessibleObjectInput accessibleObjectInput = (AccessibleObjectInput) input;
+                if (accessibleObjectInput.isDouble()) {
+                    double doubleResult = accessibleObjectInput.getDouble(source);
+                    result = Math.round(doubleResult);
+                } else {
+                    result = accessibleObjectInput.getLong(source);
+                }
+            } else if (input instanceof LongSensorInput) {
+                LongSensorInput<S> longInput = (LongSensorInput<S>) input;
+                result = longInput.get(source);
+            } else if (input instanceof DoubleSensorInput) {
+                DoubleSensorInput<S> doubleInput = (DoubleSensorInput<S>) input;
+                double doubleResult = doubleInput.get(source);
+                result = Math.round(doubleResult);
+            }
+            return result;
+        } catch (Exception e) {
+            logger.warning("Failed to update sensor:" + parameter, e);
+            return result;
+        }
+    }
+
+    @Override
+    public double readDouble() {
+        Object input = this.input;
+        S source = this.source;
+        double result = 0;
+
+        if (input == null || source == null) {
+            return result;
+        }
+
+        try {
+            if (input instanceof AccessibleObjectInput) {
+                AccessibleObjectInput accessibleObjectInput = (AccessibleObjectInput) input;
+                if (accessibleObjectInput.isDouble()) {
+                    result = accessibleObjectInput.getDouble(source);
+                } else {
+                    result = accessibleObjectInput.getLong(source);
+                }
+            } else if (input instanceof LongSensorInput) {
+                LongSensorInput<S> longInput = (LongSensorInput<S>) input;
+                result = longInput.get(source);
+            } else {
+                DoubleSensorInput<S> doubleInput = (DoubleSensorInput<S>) input;
+                result = doubleInput.get(source);
+            }
+            return result;
+        } catch (Exception e) {
+            logger.warning("Failed to update sensor:" + parameter, e);
+            return result;
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/blackbox/impl/SourceMetadata.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/blackbox/impl/SourceMetadata.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.blackbox.impl;
+
+import com.hazelcast.internal.blackbox.SensorInput;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.hazelcast.internal.blackbox.impl.AccessibleObjectInput.flatten;
+
+/**
+ * Contains the metadata for an object with @SensorInput fields/methods.
+ *
+ * This object is effectively immutable after it is constructed.
+ */
+final class SourceMetadata {
+    private final List<FieldSensorInput> fields = new ArrayList<FieldSensorInput>();
+    private final List<MethodSensorInput> methods = new ArrayList<MethodSensorInput>();
+
+    SourceMetadata(Class clazz) {
+        // we scan all the methods/fields of the class/interface hierarchy.
+        List<Class<?>> classList = new ArrayList<Class<?>>();
+        flatten(clazz, classList);
+
+        for (Class flattenedClass : classList) {
+            scanFields(flattenedClass);
+            scanMethods(flattenedClass);
+        }
+    }
+
+    void register(BlackboxImpl blackbox, Object source, String parameterPrefix) {
+        for (FieldSensorInput field : fields) {
+            field.register(blackbox, source, parameterPrefix);
+        }
+
+        for (MethodSensorInput method : methods) {
+            method.register(blackbox, source, parameterPrefix);
+        }
+    }
+
+    void scanFields(Class<?> clazz) {
+        for (Field field : clazz.getDeclaredFields()) {
+            SensorInput sensorInput = field.getAnnotation(SensorInput.class);
+
+            if (sensorInput == null) {
+                continue;
+            }
+
+            FieldSensorInput fieldSensorInput = new FieldSensorInput(field, sensorInput);
+            fields.add(fieldSensorInput);
+        }
+    }
+
+    void scanMethods(Class<?> clazz) {
+        for (Method method : clazz.getDeclaredMethods()) {
+            SensorInput sensorInput = method.getAnnotation(SensorInput.class);
+
+            if (sensorInput == null) {
+                continue;
+            }
+
+            MethodSensorInput methodSensor = new MethodSensorInput(method, sensorInput);
+            methods.add(methodSensor);
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/blackbox/impl/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/blackbox/impl/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Contains the {@link com.hazelcast.internal.blackbox.Blackbox} implementation.
+ */
+package com.hazelcast.internal.blackbox.impl;

--- a/hazelcast/src/main/java/com/hazelcast/internal/blackbox/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/blackbox/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Contains the Hazelcast Blackbox.
+ *
+ * The Blackbox records all kinds of internal metrics of Hazelcast, the OS, the JVM etc.
+ */
+package com.hazelcast.internal.blackbox;

--- a/hazelcast/src/main/java/com/hazelcast/internal/blackbox/sensorpacks/ClassLoadingSensorPack.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/blackbox/sensorpacks/ClassLoadingSensorPack.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.blackbox.sensorpacks;
+
+import com.hazelcast.internal.blackbox.Blackbox;
+import com.hazelcast.internal.blackbox.LongSensorInput;
+
+import java.lang.management.ClassLoadingMXBean;
+import java.lang.management.ManagementFactory;
+
+import static com.hazelcast.util.Preconditions.checkNotNull;
+
+/**
+ * A Sensor pack for exposing {@link java.lang.management.ClassLoadingMXBean} sensors.
+ */
+public final class ClassLoadingSensorPack {
+
+    private ClassLoadingSensorPack() {
+    }
+
+    /**
+     * Registers all the sensors in this sensor pack.
+     *
+     * @param blackbox the Blackbox the sensors are registered on.
+     */
+    public static void register(Blackbox blackbox) {
+        checkNotNull(blackbox, "blackBox");
+
+        ClassLoadingMXBean mxBean = ManagementFactory.getClassLoadingMXBean();
+
+        blackbox.register(mxBean, "classloading.loadedClassesCount",
+                new LongSensorInput<ClassLoadingMXBean>() {
+                    @Override
+                    public long get(ClassLoadingMXBean classLoadingMXBean) {
+                        return classLoadingMXBean.getLoadedClassCount();
+                    }
+                }
+        );
+
+        blackbox.register(mxBean, "classloading.totalLoadedClassesCount",
+                new LongSensorInput<ClassLoadingMXBean>() {
+                    @Override
+                    public long get(ClassLoadingMXBean classLoadingMXBean) {
+                        return classLoadingMXBean.getTotalLoadedClassCount();
+                    }
+                }
+        );
+
+        blackbox.register(mxBean, "classloading.unloadedClassCount",
+                new LongSensorInput<ClassLoadingMXBean>() {
+                    @Override
+                    public long get(ClassLoadingMXBean classLoadingMXBean) {
+                        return classLoadingMXBean.getUnloadedClassCount();
+                    }
+                }
+        );
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/blackbox/sensorpacks/GarbageCollectionSensorPack.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/blackbox/sensorpacks/GarbageCollectionSensorPack.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.blackbox.sensorpacks;
+
+
+import com.hazelcast.internal.blackbox.Blackbox;
+import com.hazelcast.internal.blackbox.SensorInput;
+
+import java.lang.management.GarbageCollectorMXBean;
+import java.lang.management.ManagementFactory;
+import java.util.HashSet;
+import java.util.Set;
+
+import static com.hazelcast.util.Preconditions.checkNotNull;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+/**
+ * A Sensor pack for exposing {@link GarbageCollectorMXBean} sensors.
+ */
+public final class GarbageCollectionSensorPack {
+
+    private static final Set<String> YOUNG_GC = new HashSet<String>(3);
+    private static final Set<String> OLD_GC = new HashSet<String>(3);
+    private static final int PUBLISH_FREQUENCY_SECONDS = 1;
+
+    static {
+        YOUNG_GC.add("PS Scavenge");
+        YOUNG_GC.add("ParNew");
+        YOUNG_GC.add("G1 Young Generation");
+
+        OLD_GC.add("PS MarkSweep");
+        OLD_GC.add("ConcurrentMarkSweep");
+        OLD_GC.add("G1 Old Generation");
+    }
+
+    private GarbageCollectionSensorPack() {
+    }
+
+    /**
+     * Registers all the sensors in this sensor pack.
+     *
+     * @param blackbox the Blackbox the sensors are registered on.
+     */
+    public static void register(Blackbox blackbox) {
+        checkNotNull(blackbox, "blackbox");
+
+        GcStats stats = new GcStats();
+        blackbox.scheduleAtFixedRate(stats, PUBLISH_FREQUENCY_SECONDS, SECONDS);
+        blackbox.scanAndRegister(stats, "gc");
+    }
+
+    static class GcStats implements Runnable {
+        @SensorInput
+        volatile long minorCount;
+        @SensorInput
+        volatile long minorTime;
+        @SensorInput
+        volatile long majorCount;
+        @SensorInput
+        volatile long majorTime;
+        @SensorInput
+        volatile long unknownCount;
+        @SensorInput
+        volatile long unknownTime;
+
+        @Override
+        public void run() {
+            long minorCount = 0;
+            long minorTime = 0;
+            long majorCount = 0;
+            long majorTime = 0;
+            long unknownCount = 0;
+            long unknownTime = 0;
+
+            for (GarbageCollectorMXBean gc : ManagementFactory.getGarbageCollectorMXBeans()) {
+                long count = gc.getCollectionCount();
+                if (count == -1) {
+                    continue;
+                }
+
+                if (YOUNG_GC.contains(gc.getName())) {
+                    minorCount += count;
+                    minorTime += gc.getCollectionTime();
+                } else if (OLD_GC.contains(gc.getName())) {
+                    majorCount += count;
+                    majorTime += gc.getCollectionTime();
+                } else {
+                    unknownCount += count;
+                    unknownTime += gc.getCollectionTime();
+                }
+            }
+
+            this.minorCount = minorCount;
+            this.minorTime = minorTime;
+            this.majorCount = majorCount;
+            this.majorTime = majorTime;
+            this.unknownCount = unknownCount;
+            this.unknownTime = unknownTime;
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/blackbox/sensorpacks/OperatingSystemSensorPack.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/blackbox/sensorpacks/OperatingSystemSensorPack.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.blackbox.sensorpacks;
+
+import com.hazelcast.internal.blackbox.Blackbox;
+import com.hazelcast.internal.blackbox.DoubleSensorInput;
+import com.hazelcast.internal.blackbox.LongSensorInput;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.OperatingSystemMXBean;
+import java.lang.reflect.Method;
+
+import static com.hazelcast.util.Preconditions.checkNotNull;
+
+/**
+ * A Sensor pack for exposing {@link java.lang.management.OperatingSystemMXBean} sensors.
+ */
+public final class OperatingSystemSensorPack {
+
+    private static final double PERCENTAGE_MULTIPLIER = 100d;
+
+    private OperatingSystemSensorPack() {
+    }
+
+    /**
+     * Registers all the sensors in this sensor pack.
+     *
+     * @param blackbox the Blackbox the sensors are registered on.
+     */
+    public static void register(Blackbox blackbox) {
+        checkNotNull(blackbox, "blackbox");
+
+        OperatingSystemMXBean mxBean = ManagementFactory.getOperatingSystemMXBean();
+
+        registerMethod(blackbox, mxBean, "getCommittedVirtualMemorySize", "os.committedVirtualMemorySize");
+        registerMethod(blackbox, mxBean, "getFreePhysicalMemorySize", "os.freePhysicalMemorySize");
+        registerMethod(blackbox, mxBean, "getFreeSwapSpaceSize", "os.freeSwapSpaceSize");
+        registerMethod(blackbox, mxBean, "getProcessCpuTime", "os.processCpuTime");
+        registerMethod(blackbox, mxBean, "getTotalPhysicalMemorySize", "os.totalPhysicalMemorySize");
+        registerMethod(blackbox, mxBean, "getTotalSwapSpaceSize", "os.totalSwapSpaceSize");
+        registerMethod(blackbox, mxBean, "getMaxFileDescriptorCount", "os.maxFileDescriptorCount");
+        registerMethod(blackbox, mxBean, "getOpenFileDescriptorCount", "os.openFileDescriptorCount");
+        registerMethod(blackbox, mxBean, "getProcessCpuLoad", "os.processCpuLoad");
+        registerMethod(blackbox, mxBean, "getSystemCpuLoad", "os.systemCpuLoad");
+
+        blackbox.register(mxBean, "os.systemLoadAverage",
+                new DoubleSensorInput<OperatingSystemMXBean>() {
+                    @Override
+                    public double get(OperatingSystemMXBean bean) {
+                        return PERCENTAGE_MULTIPLIER * bean.getSystemLoadAverage();
+                    }
+                }
+        );
+    }
+
+
+    // This method doesn't depend on the OperatingSystemMXBean so it can be tested. Due to not knowing
+    // the exact OperatingSystemMXBean class it is very difficult to get this class tested.
+    static void registerMethod(Blackbox blackBox, Object osBean, String methodName, String parameter) {
+        final Method method = getMethod(osBean, methodName);
+
+        if (method == null) {
+            return;
+        }
+
+        if (long.class.equals(method.getReturnType())) {
+            blackBox.register(osBean, parameter,
+                    new LongSensorInput() {
+                        @Override
+                        public long get(Object bean) throws Exception {
+                            return (Long) method.invoke(bean);
+                        }
+                    });
+        } else {
+            blackBox.register(osBean, parameter,
+                    new DoubleSensorInput() {
+                        @Override
+                        public double get(Object bean) throws Exception {
+                            return (Double) method.invoke(bean);
+                        }
+                    });
+        }
+    }
+
+    private static Method getMethod(Object source, String methodName) {
+        try {
+            Method method = source.getClass().getDeclaredMethod(methodName);
+            method.setAccessible(true);
+            return method;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/blackbox/sensorpacks/RuntimeSensorPack.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/blackbox/sensorpacks/RuntimeSensorPack.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.blackbox.sensorpacks;
+
+import com.hazelcast.internal.blackbox.Blackbox;
+import com.hazelcast.internal.blackbox.LongSensorInput;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.RuntimeMXBean;
+
+import static com.hazelcast.util.Preconditions.checkNotNull;
+
+/**
+ * A Sensor pack for exposing {@link java.lang.Runtime} sensors.
+ */
+public final class RuntimeSensorPack {
+
+    private RuntimeSensorPack() {
+    }
+
+    /**
+     * Registers all the sensors in this sensor pack.
+     *
+     * @param blackbox the Blackbox the sensors are registered on.
+     */
+    public static void register(Blackbox blackbox) {
+        checkNotNull(blackbox, "blackbox");
+
+        Runtime runtime = Runtime.getRuntime();
+        RuntimeMXBean mxBean = ManagementFactory.getRuntimeMXBean();
+
+        blackbox.register(runtime, "runtime.freeMemory", new LongSensorInput<Runtime>() {
+                    @Override
+                    public long get(Runtime runtime) {
+                        return runtime.freeMemory();
+                    }
+                }
+        );
+
+        blackbox.register(runtime, "runtime.totalMemory", new LongSensorInput<Runtime>() {
+                    @Override
+                    public long get(Runtime runtime) {
+                        return runtime.totalMemory();
+                    }
+                }
+        );
+
+        blackbox.register(runtime, "runtime.maxMemory", new LongSensorInput<Runtime>() {
+                    @Override
+                    public long get(Runtime runtime) {
+                        return runtime.maxMemory();
+                    }
+                }
+        );
+
+        blackbox.register(runtime, "runtime.usedMemory", new LongSensorInput<Runtime>() {
+                    @Override
+                    public long get(Runtime runtime) {
+                        return runtime.totalMemory() - runtime.freeMemory();
+                    }
+                }
+        );
+
+        blackbox.register(runtime, "runtime.availableProcessors", new LongSensorInput<Runtime>() {
+                    @Override
+                    public long get(Runtime runtime) {
+                        return runtime.availableProcessors();
+                    }
+                }
+        );
+
+        blackbox.register(mxBean, "runtime.uptime", new LongSensorInput<RuntimeMXBean>() {
+                    @Override
+                    public long get(RuntimeMXBean runtimeMXBean) {
+                        return runtimeMXBean.getUptime();
+                    }
+                }
+        );
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/blackbox/sensorpacks/ThreadSensorPack.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/blackbox/sensorpacks/ThreadSensorPack.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.blackbox.sensorpacks;
+
+import com.hazelcast.internal.blackbox.Blackbox;
+import com.hazelcast.internal.blackbox.LongSensorInput;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadMXBean;
+
+import static com.hazelcast.util.Preconditions.checkNotNull;
+
+/**
+ * A Sensor pack for exposing {@link ThreadMXBean} sensors.
+ */
+public final class ThreadSensorPack {
+
+    private ThreadSensorPack() {
+    }
+
+    /**
+     * Registers all the sensors in this sensor pack.
+     *
+     * @param blackBox the Blackbox the sensors are registered on.
+     */
+    public static void register(Blackbox blackBox) {
+        checkNotNull(blackBox, "blackBox");
+
+        ThreadMXBean mxBean = ManagementFactory.getThreadMXBean();
+
+        blackBox.register(mxBean, "thread.threadCount", new LongSensorInput<ThreadMXBean>() {
+                    @Override
+                    public long get(ThreadMXBean threadMXBean) {
+                        return threadMXBean.getThreadCount();
+                    }
+                }
+        );
+
+        blackBox.register(mxBean, "thread.peakThreadCount", new LongSensorInput<ThreadMXBean>() {
+                    @Override
+                    public long get(ThreadMXBean threadMXBean) {
+                        return threadMXBean.getPeakThreadCount();
+                    }
+                }
+        );
+
+        blackBox.register(mxBean, "thread.daemonThreadCount", new LongSensorInput<ThreadMXBean>() {
+                    @Override
+                    public long get(ThreadMXBean threadMXBean) {
+                        return threadMXBean.getDaemonThreadCount();
+                    }
+                }
+        );
+
+        blackBox.register(mxBean, "thread.totalStartedThreadCount", new LongSensorInput<ThreadMXBean>() {
+                    @Override
+                    public long get(ThreadMXBean threadMXBean) {
+                        return threadMXBean.getTotalStartedThreadCount();
+                    }
+                }
+        );
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/blackbox/sensorpacks/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/blackbox/sensorpacks/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Contains all kinds of sensor packs.
+ */
+package com.hazelcast.internal.blackbox.sensorpacks;
+

--- a/hazelcast/src/main/java/com/hazelcast/internal/monitors/PerformanceLogFile.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/monitors/PerformanceLogFile.java
@@ -1,0 +1,321 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.monitors;
+
+import com.hazelcast.instance.BuildInfo;
+import com.hazelcast.instance.BuildInfoProvider;
+import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.instance.HazelcastInstanceImpl;
+import com.hazelcast.instance.Node;
+import com.hazelcast.internal.blackbox.Blackbox;
+import com.hazelcast.internal.blackbox.Sensor;
+import com.hazelcast.internal.management.dto.SlowOperationDTO;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.spi.impl.operationservice.InternalOperationService;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.lang.management.ManagementFactory;
+import java.lang.management.RuntimeMXBean;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Properties;
+
+import static com.hazelcast.nio.IOUtil.closeResource;
+import static java.lang.Math.round;
+import static java.lang.String.format;
+import static java.lang.System.currentTimeMillis;
+import static java.lang.System.getProperties;
+import static java.lang.System.getProperty;
+import static java.util.Collections.sort;
+
+final class PerformanceLogFile {
+    private static final int ONE_MB = 1024 * 1024;
+
+    volatile File logFile;
+
+    private final Blackbox blackbox;
+    private final HazelcastInstanceImpl hazelcastInstance;
+    private final InternalOperationService operationService;
+    private final ILogger logger;
+
+    private final HeadRenderer headRenderer = new HeadRenderer();
+    private final BodyRendered bodyRendered = new BodyRendered();
+    private final String pathname;
+    private long lastAccessed;
+    private int index;
+    private BufferedWriter writer;
+    private boolean renderHead;
+    private int maxRollingFileCount;
+    private int maxRollingFileSizeBytes;
+
+    PerformanceLogFile(PerformanceMonitor performanceMonitor) {
+        this.logger = performanceMonitor.logger;
+        this.hazelcastInstance = performanceMonitor.hazelcastInstance;
+        Node node = hazelcastInstance.node;
+        this.blackbox = node.nodeEngine.getBlackbox();
+        this.operationService = node.nodeEngine.getOperationService();
+        this.pathname = "performance-" + hazelcastInstance.getName() + "-" + currentTimeMillis() + "-%03d.log";
+        GroupProperties props = node.getGroupProperties();
+        this.maxRollingFileCount = props.PERFORMANCE_MONITOR_MAX_ROLLED_FILE_COUNT.getInteger();
+
+        // we accept a float so it becomes easier to testing to create a small file.
+        this.maxRollingFileSizeBytes = round(ONE_MB * props.PERFORMANCE_MONITOR_MAX_ROLLED_FILE_SIZE.getFloat());
+
+        if (logger.isFinestEnabled()) {
+            logger.finest("max rolling file size: " + maxRollingFileSizeBytes);
+            logger.finest("max rolling file count: " + maxRollingFileCount);
+        }
+    }
+
+    void render() {
+        try {
+            if (logFile == null) {
+                logFile = new File(format(pathname, index));
+                renderHead = true;
+            }
+
+            if (writer == null) {
+                writer = new BufferedWriter(new FileWriter(logFile, true));
+            }
+
+            if (renderHead) {
+                headRenderer.render(writer);
+                renderHead = false;
+            }
+
+            bodyRendered.render(writer);
+            writer.flush();
+            lastAccessed = logFile.lastModified();
+
+            if (logFile.length() > maxRollingFileSizeBytes) {
+                closeResource(writer);
+                writer = null;
+                logFile = null;
+                index++;
+                deleteOld();
+            }
+        } catch (IOException e) {
+            logIOError(e);
+            logFile = null;
+            closeResource(writer);
+            writer = null;
+        }
+    }
+
+    private void logIOError(IOException e) {
+        if (logger.isFinestEnabled()) {
+            logger.finest("PerformanceMonitor failed to output to file:"
+                    + logFile.getAbsolutePath() + " cause:" + e.getMessage(), e);
+        } else {
+            logger.warning("PerformanceMonitor failed to output to file:"
+                    + logFile.getAbsolutePath() + " cause:" + e.getMessage());
+        }
+    }
+
+    private void deleteOld() {
+        File file = new File(format(pathname, index - maxRollingFileCount));
+        file.delete();
+    }
+
+    public boolean forceRender() {
+        if (logFile == null) {
+            return false;
+        }
+
+        return logFile.lastModified() != lastAccessed;
+    }
+
+    private final class BodyRendered {
+
+        private final SimpleDateFormat sdf = new SimpleDateFormat("EEE, d MMM yyyy HH:mm:ss Z");
+        private final List<String> parameters = new ArrayList<String>();
+        private final List<Sensor> sensors = new ArrayList<Sensor>();
+        private final StringBuilder sb = new StringBuilder();
+        // Since the blackbox.modCount starts at 0, by making the lastModCount=-1, we are triggering the loading of the sensors
+        // on the first run.
+        private int lastModCount = -1;
+
+        private void render(BufferedWriter writer) throws IOException {
+            renderHeader(writer);
+            renderBlackbox(writer);
+            writer.append("\n\n");
+            if (renderSlowOperation(writer)) {
+                writer.append("\n\n");
+            }
+        }
+
+        private void renderHeader(BufferedWriter writer) throws IOException {
+            writer.append("================[ Blackbox ]============================================\n");
+            Calendar calendar = Calendar.getInstance();
+            writer.append(sdf.format(calendar.getTime())).append('\n');
+            writer.append("------------------------------------------------------------------------\n");
+        }
+
+        private void renderBlackbox(BufferedWriter writer) throws IOException {
+            updateViews();
+
+            for (Sensor sensorView : sensors) {
+                sensorView.render(sb);
+                writer.append(sb).append('\n');
+                sb.setLength(0);
+            }
+        }
+
+        private void updateViews() {
+            int modCount = blackbox.modCount();
+            if (lastModCount == modCount) {
+                return;
+            }
+
+            lastModCount = modCount;
+
+            // lets get the new list of parameters and get them sorted.
+            parameters.clear();
+            parameters.addAll(blackbox.getParameters());
+            sort(parameters);
+
+            // and we update the sensors. This now contains a sorted list of sensorviews.
+            sensors.clear();
+            for (String parameter : parameters) {
+                sensors.add(blackbox.getSensor(parameter));
+            }
+        }
+
+        private boolean renderSlowOperation(BufferedWriter writer) throws IOException {
+            List<SlowOperationDTO> slowOperations = operationService.getSlowOperationDTOs();
+            if (slowOperations.isEmpty()) {
+                return false;
+            }
+
+            writer.append("================[ Slow Operations ]=====================================\n");
+            int k = 1;
+            for (SlowOperationDTO slowOperation : slowOperations) {
+                writer.append("#" + k)
+                        .append("\n    " + slowOperation.operation)
+                        .append("\n    Invocations: " + slowOperation.totalInvocations)
+                        .append("\n    Stacktrace:\n");
+                writer.append(slowOperation.stackTrace).append("\n\n");
+                k++;
+            }
+            return true;
+        }
+    }
+
+    // Responsible for rendering the head of the file containing the system/config properties.
+    private final class HeadRenderer {
+
+        private void render(BufferedWriter writer) throws IOException {
+            renderBuildInfo(writer);
+            writer.append("\n\n");
+            renderSystemProperties(writer);
+            writer.append("\n\n");
+            renderConfigProperties(writer);
+            writer.append("\n\n");
+            writer.flush();
+        }
+
+        private void renderSystemProperties(BufferedWriter writer) throws IOException {
+            writer.append("================[ System Properties ]===================================\n");
+            writer.append(format("%-30s  %4s\n", "property", "value"));
+            writer.append("------------------------------------------------------------------------\n");
+            List keys = new LinkedList();
+            keys.addAll(getProperties().keySet());
+            sort(keys);
+
+            for (Object key : keys) {
+                String keyString = (String) key;
+                if (ignore(keyString)) {
+                    continue;
+                }
+
+                Object value = getProperty(keyString);
+
+                String s = formatKeyValue(keyString, value);
+                writer.append(s);
+            }
+
+            writer.append(formatKeyValue("jvm.args", getInputArgs()));
+        }
+
+        private String getInputArgs() {
+            RuntimeMXBean runtimeMxBean = ManagementFactory.getRuntimeMXBean();
+            List<String> arguments = runtimeMxBean.getInputArguments();
+
+            StringBuffer sb = new StringBuffer();
+            sb.append("jvm.args=");
+            for (String argument : arguments) {
+                sb.append(argument);
+                sb.append(" ");
+            }
+            return sb.toString();
+        }
+
+        private void renderConfigProperties(BufferedWriter writer) throws IOException {
+            writer.append("=================[ Hazelcast Config ]===================================\n");
+            writer.append(format("%-60s  %4s\n", "property", "value"));
+            writer.append("------------------------------------------------------------------------\n");
+            List keys = new LinkedList();
+            Properties properties = hazelcastInstance.getConfig().getProperties();
+            keys.addAll(properties.keySet());
+            sort(keys);
+
+            for (Object key : keys) {
+                String keyString = (String) key;
+                String value = properties.getProperty(keyString);
+                writer.append(format("%-60s  %4s\n", keyString, value));
+            }
+        }
+
+        private void renderBuildInfo(BufferedWriter writer) throws IOException {
+            writer.append("====================[ Build Info ]======================================\n");
+            writer.append(format("%-30s  %4s\n", "property", "value"));
+            writer.append("------------------------------------------------------------------------\n");
+
+            BuildInfo buildInfo = BuildInfoProvider.getBuildInfo();
+            writer.append(formatKeyValue("Version", buildInfo.getVersion()));
+            writer.append(formatKeyValue("Build", buildInfo.getBuild()));
+            writer.append(formatKeyValue("BuildNumber", buildInfo.getBuildNumber()));
+            writer.append(formatKeyValue("Revision", buildInfo.getVersion()));
+            writer.append(formatKeyValue("Enterprise", buildInfo.isEnterprise()));
+        }
+
+        private String formatKeyValue(String keyString, Object value) {
+            return format("%-30s  %4s\n", keyString, value);
+        }
+
+        private boolean ignore(String systemProperty) {
+            if (systemProperty.startsWith("java.awt")) {
+                return true;
+            }
+
+            if (systemProperty.startsWith("java")
+                    || systemProperty.startsWith("hazelcast")
+                    || systemProperty.startsWith("sun")
+                    || systemProperty.startsWith("os")) {
+                return false;
+            }
+
+            return true;
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/monitors/PerformanceMonitor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/monitors/PerformanceMonitor.java
@@ -16,61 +16,107 @@
 
 package com.hazelcast.internal.monitors;
 
+import com.hazelcast.instance.GroupProperties;
 import com.hazelcast.instance.HazelcastInstanceImpl;
+import com.hazelcast.instance.HazelcastThreadGroup;
 import com.hazelcast.instance.Node;
+import com.hazelcast.internal.blackbox.Blackbox;
 import com.hazelcast.logging.ILogger;
-import com.hazelcast.nio.ConnectionManager;
 import com.hazelcast.spi.impl.operationservice.InternalOperationService;
 
-import java.util.concurrent.TimeUnit;
-
 /**
- * The PerformanceMonitor is responsible for logging all kinds of performance related information. Currently it only
- * shows the read/write events per selector and the operations executed per operation-thread, but new kinds of behavior
- * will be added.
- * <p/>
- * This tool is currently used internally. External users should be experts. In the future it will become more useful
- * for regular developers. It is also likely that most of the metrics we collect will be exposed through JMX at some
- * point in time.
+ * The PerformanceMonitor is a tool that provides insights in internal metrics. Currently the content of the {@link Blackbox}
+ * is being dumped.
  */
-public class PerformanceMonitor extends Thread {
+public class PerformanceMonitor {
 
-    private final ILogger logger;
+    final Blackbox blackbox;
+    final HazelcastInstanceImpl hazelcastInstance;
+    final ILogger logger;
+    final InternalOperationService operationService;
+    final PerformanceLogFile performanceLogFile;
     private final Node node;
-    private final int delaySeconds;
-    private final InternalOperationService operationService;
-    private final ConnectionManager connectionManager;
+    private final MonitorThread monitorThread;
+    private final boolean enabled;
 
-    public PerformanceMonitor(HazelcastInstanceImpl hazelcastInstance, int delaySeconds) {
-        super(hazelcastInstance.node.getHazelcastThreadGroup().getInternalThreadGroup(),
-                hazelcastInstance.node.getHazelcastThreadGroup().getThreadNamePrefix("PerformanceMonitor"));
-        setDaemon(true);
-
-        this.delaySeconds = delaySeconds;
+    public PerformanceMonitor(HazelcastInstanceImpl hazelcastInstance) {
+        this.hazelcastInstance = hazelcastInstance;
         this.node = hazelcastInstance.node;
-        this.logger = node.getLogger(PerformanceMonitor.class.getName());
         this.operationService = node.nodeEngine.getOperationService();
-        this.connectionManager = node.connectionManager;
+        this.logger = node.getLogger(PerformanceMonitor.class);
+        this.blackbox = hazelcastInstance.node.nodeEngine.getBlackbox();
+        this.enabled = node.getGroupProperties().PERFORMANCE_MONITOR_ENABLED.getBoolean();
+        this.performanceLogFile = new PerformanceLogFile(this);
+        this.monitorThread = initMonitorThread();
     }
 
-    @Override
-    public void run() {
-        StringBuffer sb = new StringBuffer();
+    private MonitorThread initMonitorThread() {
+        if (!enabled) {
+            return null;
+        }
 
-        while (node.isActive()) {
-            sb.append("\n");
-            sb.append("ConnectionManager metrics\n");
-            connectionManager.dumpPerformanceMetrics(sb);
-            sb.append("OperationService metrics\n");
-            operationService.dumpPerformanceMetrics(sb);
+        GroupProperties props = node.getGroupProperties();
+        int delaySeconds = props.PERFORMANCE_MONITOR_DELAY_SECONDS.getInteger();
 
-            logger.info(sb.toString());
+        HazelcastThreadGroup threadGroup = node.getHazelcastThreadGroup();
+        return new MonitorThread(threadGroup, delaySeconds);
+    }
 
-            sb.setLength(0);
+    public PerformanceMonitor start() {
+        if (!enabled) {
+            logger.finest("PerformanceMonitor disabled");
+            return this;
+        }
+
+        logger.info("PerformanceMonitor started");
+
+        GroupProperties.GroupProperty slowOperationDetectorEnabled = node.getGroupProperties().SLOW_OPERATION_DETECTOR_ENABLED;
+        if (!slowOperationDetectorEnabled.getBoolean()) {
+            logger.info("To enable the SlowOperationDetector in the Performance log, set the following property:\n"
+                    + "-D" + slowOperationDetectorEnabled.getName() + "=true");
+        }
+
+        monitorThread.start();
+        return this;
+    }
+
+    private final class MonitorThread extends Thread {
+        private static final int DELAY_MILLIS = 1000;
+        private final int delaySeconds;
+
+        private MonitorThread(HazelcastThreadGroup threadGroup, int delaySeconds) {
+            super(threadGroup.getInternalThreadGroup(), threadGroup.getThreadNamePrefix("PerformanceMonitor"));
+            this.delaySeconds = delaySeconds;
+        }
+
+        @Override
+        public void run() {
             try {
-                Thread.sleep(TimeUnit.SECONDS.toMillis(delaySeconds));
-            } catch (InterruptedException e) {
-                return;
+                while (node.isActive()) {
+                    performanceLogFile.render();
+                    sleep();
+                }
+
+                // always write the sensors at the end when shutting down.
+                performanceLogFile.render();
+            } catch (Throwable t) {
+                logger.warning(t.getMessage(), t);
+            }
+        }
+
+        private void sleep() {
+            for (int k = 0; k < delaySeconds; k++) {
+                try {
+                    Thread.sleep(DELAY_MILLIS);
+                } catch (InterruptedException e) {
+                    // we can eat the interrupt since
+                    return;
+                }
+
+                if (performanceLogFile.forceRender()) {
+                    logger.info("Detected a request to update the Performance Log");
+                    return;
+                }
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/nio/ConnectionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/ConnectionManager.java
@@ -46,9 +46,4 @@ public interface ConnectionManager {
     void restart();
 
     void addConnectionListener(ConnectionListener connectionListener);
-
-    /**
-     * Dumps all kinds of performance metrics. It is up to the implementation to add anything.
-     */
-    void dumpPerformanceMetrics(StringBuffer sb);
 }

--- a/hazelcast/src/main/java/com/hazelcast/nio/IOService.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/IOService.java
@@ -21,6 +21,7 @@ import com.hazelcast.internal.ascii.TextCommandService;
 import com.hazelcast.config.SSLConfig;
 import com.hazelcast.config.SocketInterceptorConfig;
 import com.hazelcast.config.SymmetricEncryptionConfig;
+import com.hazelcast.internal.blackbox.Blackbox;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.SerializationService;
@@ -35,6 +36,8 @@ import java.util.Collection;
 public interface IOService {
 
     int KILO_BYTE = 1024;
+
+    Blackbox getBlackbox();
 
     boolean isActive();
 

--- a/hazelcast/src/main/java/com/hazelcast/nio/NodeIOService.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/NodeIOService.java
@@ -26,6 +26,7 @@ import com.hazelcast.instance.HazelcastThreadGroup;
 import com.hazelcast.instance.MemberImpl;
 import com.hazelcast.instance.Node;
 import com.hazelcast.instance.OutOfMemoryErrorDispatcher;
+import com.hazelcast.internal.blackbox.Blackbox;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.SerializationService;
@@ -53,6 +54,11 @@ public class NodeIOService implements IOService {
         this.node = node;
         this.nodeEngine = node.nodeEngine;
         this.packetTransceiver = nodeEngine.getPacketTransceiver();
+    }
+
+    @Override
+    public Blackbox getBlackbox() {
+        return nodeEngine.getBlackbox();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/OutSelectorImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/OutSelectorImpl.java
@@ -16,35 +16,28 @@
 
 package com.hazelcast.nio.tcp;
 
+import com.hazelcast.internal.blackbox.SensorInput;
 import com.hazelcast.logging.ILogger;
+import com.hazelcast.util.counters.SwCounter;
 
 import java.nio.channels.SelectionKey;
+
+import static com.hazelcast.util.counters.SwCounter.newSwCounter;
 
 public final class OutSelectorImpl extends AbstractIOSelector {
 
     // This field will be incremented by a single thread --> the OutSelectorImpl. It can be read by multiple threads.
-    private volatile long writeEvents;
+    @SensorInput
+    private final SwCounter writeEvents = newSwCounter();
 
     public OutSelectorImpl(ThreadGroup threadGroup, String tname, ILogger logger, IOSelectorOutOfMemoryHandler oomeHandler) {
         super(threadGroup, tname, logger, oomeHandler);
     }
 
-    /**
-     * Returns the current number of write events that have been processed by this OutSelectorImpl.
-     *
-     * This method is thread-safe.
-     *
-     * @return the number of write events.
-     */
-    public long getWriteEvents() {
-        return writeEvents;
-    }
-
     @Override
-    @edu.umd.cs.findbugs.annotations.SuppressWarnings({"VO_VOLATILE_INCREMENT" })
     protected void handleSelectionKey(SelectionKey sk) {
         if (sk.isValid() && sk.isWritable()) {
-            writeEvents++;
+            writeEvents.inc();
             SelectionHandler handler = (SelectionHandler) sk.attachment();
             handler.handle();
         }

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnection.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnection.java
@@ -62,8 +62,11 @@ public final class TcpIpConnection implements Connection {
 
     private TcpIpConnectionMonitor monitor;
 
-    public TcpIpConnection(TcpIpConnectionManager connectionManager, IOSelector in, IOSelector out,
-                           int connectionId, SocketChannelWrapper socketChannel) {
+    public TcpIpConnection(TcpIpConnectionManager connectionManager,
+                           IOSelector in,
+                           IOSelector out,
+                           int connectionId,
+                           SocketChannelWrapper socketChannel) {
         this.connectionId = connectionId;
         this.logger = connectionManager.ioService.getLogger(TcpIpConnection.class.getName());
         this.connectionManager = connectionManager;
@@ -217,7 +220,8 @@ public final class TcpIpConnection implements Connection {
         } catch (Exception e) {
             logger.warning(e);
         }
-        Object connAddress = (endPoint == null) ? socketChannel.socket().getRemoteSocketAddress() : endPoint;
+
+        Object connAddress = getConnectionAddress();
         String message = "Connection [" + connAddress + "] lost. Reason: ";
         if (t != null) {
             message += t.getClass().getName() + "[" + t.getMessage() + "]";
@@ -231,6 +235,10 @@ public final class TcpIpConnection implements Connection {
         if (t != null && monitor != null) {
             monitor.onError(t);
         }
+    }
+
+    Object getConnectionAddress() {
+        return (endPoint == null) ? socketChannel.socket().getRemoteSocketAddress() : endPoint;
     }
 
     public int getConnectionId() {

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnectionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnectionManager.java
@@ -19,6 +19,8 @@ package com.hazelcast.nio.tcp;
 import com.hazelcast.cluster.impl.BindMessage;
 import com.hazelcast.config.SocketInterceptorConfig;
 import com.hazelcast.instance.HazelcastThreadGroup;
+import com.hazelcast.internal.blackbox.Blackbox;
+import com.hazelcast.internal.blackbox.SensorInput;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.LoggingService;
 import com.hazelcast.nio.Address;
@@ -33,6 +35,9 @@ import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.tcp.handlermigration.IOBalancer;
 import com.hazelcast.util.ConcurrencyUtil;
 import com.hazelcast.util.ConstructorFunction;
+import com.hazelcast.util.counters.Counter;
+import com.hazelcast.util.counters.MwCounter;
+import com.hazelcast.util.counters.SwCounter;
 import com.hazelcast.util.executor.StripedRunnable;
 
 import java.io.IOException;
@@ -47,6 +52,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
+
+import static com.hazelcast.util.counters.SwCounter.newSwCounter;
 
 public class TcpIpConnectionManager implements ConnectionManager {
 
@@ -75,25 +82,33 @@ public class TcpIpConnectionManager implements ConnectionManager {
 
     private final boolean socketNoDelay;
 
+    @SensorInput(name = "count")
     private final ConcurrentHashMap<Address, Connection> connectionsMap = new ConcurrentHashMap<Address, Connection>(100);
 
+    @SensorInput(name = "monitorCount")
     private final ConcurrentHashMap<Address, TcpIpConnectionMonitor> monitors =
             new ConcurrentHashMap<Address, TcpIpConnectionMonitor>(100);
 
+    @SensorInput(name = "inProgressCount")
     private final Set<Address> connectionsInProgress =
             Collections.newSetFromMap(new ConcurrentHashMap<Address, Boolean>());
 
+    @SensorInput(name = "connectionListenerCount")
     private final Set<ConnectionListener> connectionListeners = new CopyOnWriteArraySet<ConnectionListener>();
 
+    @SensorInput(name = "acceptedSocketCount")
     private final Set<SocketChannelWrapper> acceptedSockets =
             Collections.newSetFromMap(new ConcurrentHashMap<SocketChannelWrapper, Boolean>());
 
+    @SensorInput(name = "activeCount")
     private final Set<TcpIpConnection> activeConnections =
             Collections.newSetFromMap(new ConcurrentHashMap<TcpIpConnection, Boolean>());
 
+    @SensorInput(name = "textCount")
     private final AtomicInteger allTextConnections = new AtomicInteger();
 
     private final AtomicInteger connectionIdGen = new AtomicInteger();
+    private final Blackbox blackbox;
 
     private volatile boolean live;
 
@@ -124,9 +139,15 @@ public class TcpIpConnectionManager implements ConnectionManager {
     private IOBalancer ioBalancer;
     private final LoggingService loggingService;
 
+    @SensorInput
+    private final MwCounter openedCount = new MwCounter();
+    @SensorInput
+    private final MwCounter closedCount = new MwCounter();
+
     public TcpIpConnectionManager(IOService ioService, ServerSocketChannel serverSocketChannel,
                                   HazelcastThreadGroup hazelcastThreadGroup, LoggingService loggingService) {
         this.ioService = ioService;
+        this.blackbox = ioService.getBlackbox();
         this.hazelcastThreadGroup = hazelcastThreadGroup;
         this.serverSocketChannel = serverSocketChannel;
         this.logger = loggingService.getLogger(TcpIpConnectionManager.class.getName());
@@ -145,6 +166,12 @@ public class TcpIpConnectionManager implements ConnectionManager {
         this.outboundPorts.addAll(ports);
         this.socketChannelWrapperFactory = ioService.getSocketChannelWrapperFactory();
         this.loggingService = loggingService;
+
+        blackbox.scanAndRegister(this, "tcp.connection");
+    }
+
+    public Blackbox getBlackbox() {
+        return blackbox;
     }
 
     public void interceptSocket(Socket socket, boolean onAccept) throws IOException {
@@ -329,6 +356,7 @@ public class TcpIpConnectionManager implements ConnectionManager {
         connection.start();
 
         log(Level.INFO, "Established socket connection between " + channel.socket().getLocalSocketAddress());
+        openedCount.inc();
 
         return connection;
     }
@@ -380,6 +408,7 @@ public class TcpIpConnectionManager implements ConnectionManager {
         if (logger.isFinestEnabled()) {
             log(Level.FINEST, "Destroying " + connection);
         }
+
         activeConnections.remove(connection);
         final Address endPoint = connection.getEndPoint();
         if (endPoint != null) {
@@ -404,6 +433,7 @@ public class TcpIpConnectionManager implements ConnectionManager {
         }
         if (connection.isAlive()) {
             connection.close();
+            closedCount.inc();
         }
     }
 
@@ -431,18 +461,24 @@ public class TcpIpConnectionManager implements ConnectionManager {
             }
         };
         for (int i = 0; i < inSelectors.length; i++) {
-            inSelectors[i] = new InSelectorImpl(
+            InSelectorImpl inSelector = new InSelectorImpl(
                     ioService.getThreadGroup(),
                     ioService.getThreadPrefix() + "in-" + i,
                     ioService.getLogger(InSelectorImpl.class.getName()),
-                    oomeHandler);
-            outSelectors[i] = new OutSelectorImpl(
+                    oomeHandler
+            );
+            inSelectors[i] = inSelector;
+            blackbox.scanAndRegister(inSelector, "tcp." + inSelector.getName());
+            inSelector.start();
+
+            OutSelectorImpl outSelector = new OutSelectorImpl(
                     ioService.getThreadGroup(),
                     ioService.getThreadPrefix() + "out-" + i,
                     ioService.getLogger(OutSelectorImpl.class.getName()),
                     oomeHandler);
-            inSelectors[i].start();
-            outSelectors[i].start();
+            outSelectors[i] = outSelector;
+            blackbox.scanAndRegister(outSelector, "tcp." + outSelector.getName());
+            outSelector.start();
         }
         startIOBalancer();
 
@@ -460,6 +496,11 @@ public class TcpIpConnectionManager implements ConnectionManager {
         ioBalancer = new IOBalancer(inSelectors, outSelectors,
                 hazelcastThreadGroup, handlerMigrationIntervalSeconds, loggingService);
         ioBalancer.start();
+        blackbox.scanAndRegister(ioBalancer, "tcp.balancer");
+    }
+
+    public IOBalancer getIoBalancer() {
+        return ioBalancer;
     }
 
     @Override
@@ -555,6 +596,7 @@ public class TcpIpConnectionManager implements ConnectionManager {
         }
     }
 
+    @SensorInput(name = "clientCount")
     @Override
     public int getCurrentClientConnections() {
         int count = 0;
@@ -592,21 +634,6 @@ public class TcpIpConnectionManager implements ConnectionManager {
             final Integer port = outboundPorts.removeFirst();
             outboundPorts.addLast(port);
             return port;
-        }
-    }
-
-    @Override
-    public void dumpPerformanceMetrics(StringBuffer sb) {
-        for (int k = 0; k < inSelectors.length; k++) {
-            InSelectorImpl inSelector = inSelectors[k];
-            sb.append(inSelector.getName()).append(".readEvents=")
-                    .append(inSelector.getReadEvents()).append("\n");
-        }
-
-        for (int k = 0; k < outSelectors.length; k++) {
-            OutSelectorImpl outSelector = outSelectors[k];
-            sb.append(outSelector.getName()).append(".writeEvents=")
-                    .append(outSelector.getWriteEvents()).append("\n");
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/EventServiceSegment.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/EventServiceSegment.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.spi.impl.eventservice.impl;
 
+import com.hazelcast.internal.blackbox.SensorInput;
 import com.hazelcast.nio.Address;
 import com.hazelcast.util.ConcurrencyUtil;
 import com.hazelcast.util.ConstructorFunction;
@@ -33,13 +34,15 @@ public class EventServiceSegment {
     private final ConcurrentMap<String, Collection<Registration>> registrations
             = new ConcurrentHashMap<String, Collection<Registration>>();
 
+    @SensorInput(name = "listenerCount")
     private final ConcurrentMap<String, Registration> registrationIdMap = new ConcurrentHashMap<String, Registration>();
 
+    @SensorInput(name = "publicationCount")
     private final AtomicLong totalPublishes = new AtomicLong();
 
     public EventServiceSegment(String serviceName) {
         this.serviceName = serviceName;
-    }
+     }
 
     public Collection<Registration> getRegistrations(String topic, boolean forceCreate) {
         Collection<Registration> listenerList = registrations.get(topic);

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/OperationExecutor.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/OperationExecutor.java
@@ -60,10 +60,6 @@ public interface OperationExecutor {
     @Deprecated
     int getGenericOperationThreadCount();
 
-    // Will be replaced by the black-box
-    @Deprecated
-    void dumpPerformanceMetrics(StringBuffer sb);
-
     /**
      * Gets all the operation handlers for the partitions. Each partition will have its own operation handler. So if
      * there are 271 partitions, then the size of the array will be 271.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/InternalOperationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/InternalOperationService.java
@@ -37,24 +37,6 @@ import java.util.List;
 public interface InternalOperationService extends OperationService {
 
     /**
-     * Returns the percentage of the the used invocations. With back pressure there is a cap on the number
-     * of concurrent invocations. This call sends back the percentage of used invocations compared to that cap.
-     *
-     * @return percentage of used invocations.
-     */
-    double getInvocationUsagePercentage();
-
-    /**
-     * Gets the current number of pending invocations. Each map.put or a queue.take, is a pending
-     * invocation until it is answered. In most cases the number of pending invocations is bound
-     * by the number of concurrent threads, but if you use async API's, the number of pending
-     * invocations is not bound to the number of threads.
-     *
-     * @return number of pending invocations
-     */
-    int getPendingInvocationCount();
-
-    /**
      * Checks if this call is timed out. A timed out call is not going to be executed.
      *
      * @param op the operation to check.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationRegistry.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationRegistry.java
@@ -20,6 +20,7 @@ import com.hazelcast.core.HazelcastInstanceNotActiveException;
 import com.hazelcast.core.MemberLeftException;
 import com.hazelcast.instance.GroupProperties;
 import com.hazelcast.instance.MemberImpl;
+import com.hazelcast.internal.blackbox.SensorInput;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Address;
 import com.hazelcast.partition.ReplicaErrorLogger;
@@ -32,6 +33,8 @@ import com.hazelcast.spi.impl.operationservice.impl.responses.ErrorResponse;
 import com.hazelcast.spi.impl.operationservice.impl.responses.NormalResponse;
 import com.hazelcast.spi.impl.operationservice.impl.responses.Response;
 import com.hazelcast.util.EmptyStatement;
+import com.hazelcast.util.counters.MwCounter;
+import com.hazelcast.util.counters.SwCounter;
 
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -40,6 +43,7 @@ import java.util.concurrent.TimeUnit;
 import static com.hazelcast.instance.OutOfMemoryErrorDispatcher.inspectOutputMemoryError;
 import static com.hazelcast.spi.Operation.CALL_ID_LOCAL_SKIPPED;
 import static com.hazelcast.spi.OperationAccessor.setCallId;
+import static com.hazelcast.util.counters.SwCounter.newSwCounter;
 
 /**
  * The InvocationsRegistry is responsible for the registration of all pending invocations.
@@ -56,6 +60,7 @@ import static com.hazelcast.spi.OperationAccessor.setCallId;
  * the PartitionInvocation and TargetInvocation can be folded into Invocation.
  */
 public class InvocationRegistry {
+
     private static final long SCHEDULE_DELAY = 1111;
     private static final int INITIAL_CAPACITY = 1000;
     private static final float LOAD_FACTOR = 0.75f;
@@ -63,12 +68,27 @@ public class InvocationRegistry {
     private static final double HUNDRED_PERCENT = 100d;
 
     private final long backupTimeoutMillis;
+
+    @SensorInput(name = "invocations.pending")
     private final ConcurrentMap<Long, Invocation> invocations;
     private final OperationServiceImpl operationService;
     private final NodeEngineImpl nodeEngine;
     private final ILogger logger;
     private final InspectionThread inspectionThread;
     private final CallIdSequence callIdSequence;
+
+    @SensorInput(name = "response.normal.count")
+    private final SwCounter responseNormalCounter = newSwCounter();
+    @SensorInput(name = "response.timeout.count")
+    private final SwCounter responseTimeoutCounter = newSwCounter();
+    @SensorInput(name = "response.backup.count")
+    private final MwCounter responseBackupCounter = new MwCounter();
+    @SensorInput(name = "response.error.count")
+    private final SwCounter responseErrorCounter = newSwCounter();
+    @SensorInput(name = "invocations.backupTimeouts")
+    private final SwCounter backupTimeoutsCounter = newSwCounter();
+    @SensorInput(name = "invocations.normalTimeouts")
+    private final SwCounter normalTimeoutsCounter = newSwCounter();
 
     public InvocationRegistry(OperationServiceImpl operationService, int concurrencyLevel) {
         this.operationService = operationService;
@@ -80,7 +100,19 @@ public class InvocationRegistry {
         this.backupTimeoutMillis = props.OPERATION_BACKUP_TIMEOUT_MILLIS.getLong();
         this.invocations = new ConcurrentHashMap<Long, Invocation>(INITIAL_CAPACITY, LOAD_FACTOR, concurrencyLevel);
         this.inspectionThread = new InspectionThread();
+
         inspectionThread.start();
+        nodeEngine.getBlackbox().scanAndRegister(this, "operation");
+    }
+
+    @SensorInput(name = "invocations.usedPercentage")
+    private double invocationsUsedPercentage() {
+        int maxConcurrentInvocations = callIdSequence.getMaxConcurrentInvocations();
+        if (maxConcurrentInvocations == Integer.MAX_VALUE) {
+            return 0;
+        }
+
+        return (HUNDRED_PERCENT * invocations.size()) / maxConcurrentInvocations;
     }
 
     public long getLastCallId() {
@@ -127,10 +159,6 @@ public class InvocationRegistry {
         assert deleted : "failed to deregister callId:" + callId + " " + invocation;
     }
 
-    public double getInvocationUsagePercentage() {
-        return (HUNDRED_PERCENT * invocations.size()) / callIdSequence.getMaxConcurrentInvocations();
-    }
-
     /**
      * Returns the number of pending invocations.
      *
@@ -170,6 +198,8 @@ public class InvocationRegistry {
     }
 
     public void notifyBackupComplete(long callId) {
+        responseBackupCounter.inc();
+
         try {
             Invocation invocation = invocations.get(callId);
 
@@ -190,6 +220,8 @@ public class InvocationRegistry {
     }
 
     private void notifyErrorResponse(ErrorResponse response) {
+        responseErrorCounter.inc();
+
         Invocation invocation = invocations.get(response.getCallId());
 
         if (invocation == null) {
@@ -203,6 +235,8 @@ public class InvocationRegistry {
     }
 
     private void notifyNormalResponse(NormalResponse response) {
+        responseNormalCounter.inc();
+
         Invocation invocation = invocations.get(response.getCallId());
 
         if (invocation == null) {
@@ -215,6 +249,8 @@ public class InvocationRegistry {
     }
 
     private void notifyCallTimeout(CallTimeoutResponse response) {
+        responseTimeoutCounter.inc();
+
         Invocation invocation = invocations.get(response.getCallId());
 
         if (invocation == null) {
@@ -311,7 +347,6 @@ public class InvocationRegistry {
                 return;
             }
 
-            // todo: these 2 measurements should be added to the black-box.
             int backupTimeouts = 0;
             int invocationTimeouts = 0;
             for (Invocation invocation : invocations.values()) {
@@ -338,6 +373,8 @@ public class InvocationRegistry {
                 }
             }
 
+            backupTimeoutsCounter.inc(backupTimeouts);
+            normalTimeoutsCounter.inc(invocationTimeouts);
             log(backupTimeouts, invocationTimeouts);
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/util/counters/Counter.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/counters/Counter.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.util.counters;
+
+/**
+ * A Counter.
+ *
+ * It depends on the counter if increments are thread-safe.
+ *
+ * The get is thread-safe in the sense that it will see a recently published value. It doesn't need to mean that it
+ * will see the most recently published value.
+ */
+public interface Counter {
+
+    /**
+     * Gets the current value.
+     *
+     * @return the current value.
+     */
+    long get();
+
+    /**
+     * Increments the counter by one.
+     */
+    void inc();
+
+    /**
+     * Increments the counter by the given amount.
+     *
+     * @param amount the amount to increase the counter with.
+     */
+    void inc(int amount);
+}

--- a/hazelcast/src/main/java/com/hazelcast/util/counters/MwCounter.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/counters/MwCounter.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.util.counters;
+
+import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
+import static java.util.concurrent.atomic.AtomicLongFieldUpdater.newUpdater;
+
+/**
+ * A {@link Counter} that is thread-safe; so can be incremented by multiple threads concurrently.
+ *
+ * The MwCounter is not meant for a huge amount of contention. In that case it would be better to create a counter
+ * on the {@link java.util.concurrent.atomic.LongAdder}.
+ *
+ * This counter does not provide padding to prevent false sharing.
+ */
+public final class MwCounter implements Counter {
+
+    private static final AtomicLongFieldUpdater<MwCounter> COUNTER = newUpdater(MwCounter.class, "value");
+
+    private volatile long value;
+
+    /**
+     * Creates a new MwCounter with 0 as initial value.
+     */
+    public MwCounter() {
+        this(0);
+    }
+
+    /**
+     * Creates a new MwCounter with the given initial value.
+     *
+     * @param initialValue the initial value.
+     */
+    public MwCounter(int initialValue) {
+        this.value = initialValue;
+    }
+
+    @Override
+    public long get() {
+        return value;
+    }
+
+    @Override
+    public void inc() {
+        COUNTER.incrementAndGet(this);
+    }
+
+    @Override
+    public void inc(int amount) {
+        COUNTER.addAndGet(this, amount);
+    }
+
+    @Override
+    public String toString() {
+        return "Counter{"
+                + "value=" + value
+                + '}';
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/util/counters/SwCounter.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/counters/SwCounter.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.util.counters;
+
+import com.hazelcast.nio.UnsafeHelper;
+import sun.misc.Unsafe;
+
+import java.lang.reflect.Field;
+import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
+import static com.hazelcast.util.EmptyStatement.ignore;
+import static java.util.concurrent.atomic.AtomicLongFieldUpdater.newUpdater;
+
+/**
+ * A {@link Counter} that is made to be used by a single writing thread.
+ *
+ * It makes use of the lazy-set to provide a lower overhead than a volatile write on X86 systems. The volatile write requires
+ * waiting for the store buffer to be drained which isn't needed for the lazySet.
+ *
+ * This counter does not provide padding to prevent false sharing.
+ */
+public abstract class SwCounter implements Counter {
+
+    private SwCounter() {
+    }
+
+    /**
+     * Creates a new SwCounter with 0 as initial value.
+     *
+     * @return the created SwCounter.
+     */
+    public static SwCounter newSwCounter() {
+        return newSwCounter(0);
+    }
+
+    /**
+     * Creates a new SwCounter with the given initial value.
+     *
+     * @return the created SwCounter.
+     */
+    public static SwCounter newSwCounter(int initialValue) {
+        if (UnsafeHelper.UNSAFE_AVAILABLE) {
+            return new UnsafeSwCounter(initialValue);
+        } else {
+            return new SafeSwCounter(initialValue);
+        }
+    }
+
+    /**
+     * The UnsafeSwCounter relies on the same {@link Unsafe#putOrderedLong(Object, long, long)} as the
+     * {@link AtomicLongFieldUpdater#lazySet(Object, long)} but it removes all kinds of checks.
+     *
+     * For the AtomicLongFieldUpdater these checks are needed since an arbitrary object can be passed to the
+     * lazySet method and that needs to be verified. In our case we always pass UnsafeSwCounter instance so
+     * there is no need for all these checks.
+     */
+    static final class UnsafeSwCounter extends SwCounter {
+        private static final Unsafe UNSAFE = UnsafeHelper.UNSAFE;
+        private static final long OFFSET;
+
+        static {
+            Field field = null;
+            try {
+                field = UnsafeSwCounter.class.getDeclaredField("value");
+            } catch (NoSuchFieldException ignore) {
+                ignore(ignore);
+            }
+            OFFSET = UnsafeHelper.UNSAFE.objectFieldOffset(field);
+        }
+
+        private volatile long value;
+
+        protected UnsafeSwCounter(int initialValue) {
+            this.value = initialValue;
+        }
+
+        @Override
+        public void inc() {
+            UNSAFE.putOrderedLong(this, OFFSET, value + 1);
+        }
+
+        @Override
+        public void inc(int amount) {
+            UNSAFE.putOrderedLong(this, OFFSET, value + amount);
+        }
+
+        @Override
+        public long get() {
+            return value;
+        }
+
+        @Override
+        public String toString() {
+            return "Counter{"
+                    + "value=" + value
+                    + '}';
+        }
+    }
+
+    /**
+     * Makes use of the AtomicLongFieldUpdater.lazySet.
+     */
+    static final class SafeSwCounter extends SwCounter {
+
+        private static final AtomicLongFieldUpdater<SafeSwCounter> COUNTER
+                = newUpdater(SafeSwCounter.class, "value");
+
+        private volatile long value;
+
+        protected SafeSwCounter(int initialValue) {
+            this.value = initialValue;
+        }
+
+        @Override
+        public void inc() {
+            COUNTER.lazySet(this, value + 1);
+        }
+
+        @Override
+        public void inc(int amount) {
+            COUNTER.lazySet(this, value + amount);
+        }
+
+        @Override
+        public long get() {
+            return value;
+        }
+
+        @Override
+        public String toString() {
+            return "Counter{"
+                    + "value=" + value
+                    + '}';
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/util/counters/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/counters/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Provides various counter implementations.
+ */
+package com.hazelcast.util.counters;

--- a/hazelcast/src/main/java/com/hazelcast/util/executor/ManagedExecutorService.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/executor/ManagedExecutorService.java
@@ -16,19 +16,26 @@
 
 package com.hazelcast.util.executor;
 
+import com.hazelcast.internal.blackbox.SensorInput;
+
 import java.util.concurrent.ExecutorService;
 
 public interface ManagedExecutorService extends ExecutorService {
 
     String getName();
 
+    @SensorInput(name = "completedTaskCount")
     long getCompletedTaskCount();
 
+    @SensorInput(name = "maximumPoolSize")
     int getMaximumPoolSize();
 
+    @SensorInput(name = "poolSize")
     int getPoolSize();
 
+    @SensorInput(name = "queueSize")
     int getQueueSize();
 
+    @SensorInput(name = "remainingQueueCapacity")
     int getRemainingQueueCapacity();
 }

--- a/hazelcast/src/test/java/com/hazelcast/instance/TestUtil.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/TestUtil.java
@@ -33,7 +33,6 @@ import java.util.List;
 public final class TestUtil {
 
     static final private SerializationService serializationService = new DefaultSerializationServiceBuilder().build();
-
     private TestUtil() {
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/blackbox/impl/BlackboxImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/blackbox/impl/BlackboxImplTest.java
@@ -1,0 +1,97 @@
+package com.hazelcast.internal.blackbox.impl;
+
+import com.hazelcast.internal.blackbox.LongSensorInput;
+import com.hazelcast.internal.blackbox.Sensor;
+import com.hazelcast.logging.Logger;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class BlackboxImplTest extends HazelcastTestSupport {
+
+    private BlackboxImpl blackbox;
+
+    @Before
+    public void setup() {
+        blackbox = new BlackboxImpl(Logger.getLogger(BlackboxImpl.class));
+    }
+
+    @Test
+    public void modCount() {
+        long modCount = blackbox.modCount();
+        blackbox.register(this, "foo", new LongSensorInput() {
+            @Override
+            public long get(Object obj) throws Exception {
+                return 1;
+            }
+        });
+        assertEquals(modCount + 1, blackbox.modCount());
+
+        blackbox.deregister(this);
+        assertEquals(modCount + 2, blackbox.modCount());
+    }
+
+    // ================ getSensor ======================
+
+    @Test(expected = NullPointerException.class)
+    public void getSensor_whenNullParameter() {
+        blackbox.getSensor(null);
+    }
+
+    @Test
+    public void getSensor_whenNoneExistingSensor() {
+        Sensor sensor = blackbox.getSensor("foo");
+        assertNotNull(sensor);
+        assertEquals("foo", sensor.getParameter());
+        assertEquals(0, sensor.readLong());
+    }
+
+    @Test
+    public void getSensor_whenExistingSensor() {
+        Sensor first = blackbox.getSensor("foo");
+        Sensor second = blackbox.getSensor("foo");
+
+        assertSame(first, second);
+    }
+
+    @Test
+    public void getSensors() {
+        Set<String> expected = new HashSet<String>();
+        expected.add("first");
+        expected.add("second");
+        expected.add("third");
+
+        for (String parameter : expected) {
+            blackbox.register(this, parameter, new LongSensorInput() {
+                @Override
+                public long get(Object obj) throws Exception {
+                    return 0;
+                }
+            });
+        }
+
+        Set<String> parameters = blackbox.getParameters();
+        for (String parameter : expected) {
+            assertTrue(parameters.contains(parameter));
+        }
+    }
+
+    @Test
+    public void shutdown(){
+        blackbox.shutdown();
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/blackbox/impl/BlackboxUtils.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/blackbox/impl/BlackboxUtils.java
@@ -1,0 +1,15 @@
+package com.hazelcast.internal.blackbox.impl;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class BlackboxUtils {
+
+    public static Map createMap(int size){
+        Map map = new HashMap();
+        for(int k=0;k<size;k++){
+            map.put(k,k);
+        }
+        return map;
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/blackbox/impl/FieldSensorInputTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/blackbox/impl/FieldSensorInputTest.java
@@ -1,0 +1,214 @@
+package com.hazelcast.internal.blackbox.impl;
+
+import com.hazelcast.util.counters.Counter;
+import com.hazelcast.internal.blackbox.SensorInput;
+import com.hazelcast.util.counters.SwCounter;
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static com.hazelcast.util.counters.SwCounter.newSwCounter;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+
+public class FieldSensorInputTest {
+
+    @Test
+    public void whenUnknownType() throws NoSuchFieldException {
+        UnknownFieldType unknownFieldType= new UnknownFieldType();
+        Field field = unknownFieldType.getClass().getDeclaredField("field");
+        SensorInput sensorInput = field.getAnnotation(SensorInput.class);
+
+        try {
+            new FieldSensorInput(field, sensorInput);
+            fail();
+        }catch (IllegalArgumentException e){
+        }
+    }
+
+    private class UnknownFieldType{
+        @SensorInput
+        private String field;
+    }
+
+    @Test
+    public void getLong() throws Exception {
+        getLong("byteField", 10);
+        getLong("shortField", 10);
+        getLong("intField", 10);
+        getLong("longField", 10);
+        getLong("atomicLongField", 10);
+        getLong("atomicIntegerField", 10);
+        getLong("counterField", 10);
+        getLong("collectionField", 10);
+        getLong("mapField", 10);
+
+        getLong("ByteField", 10);
+        getLong("ShortField", 10);
+        getLong("IntegerField", 10);
+        getLong("LongField", 10);
+
+        getLong("nullAtomicLongField", 0);
+        getLong("nullAtomicIntegerField", 0);
+        getLong("nullCounterField", 0);
+        getLong("nullCollectionField", 0);
+        getLong("nullMapField", 0);
+        getLong("nullByteField", 0);
+        getLong("nullShortField", 0);
+        getLong("nullIntegerField", 0);
+        getLong("nullLongField", 0);
+    }
+
+    public void getLong(String fieldName, int expectedValue) throws Exception {
+        SomeSource source = new SomeSource();
+        Field field = source.getClass().getDeclaredField(fieldName);
+        SensorInput sensorInput = field.getAnnotation(SensorInput.class);
+        FieldSensorInput fieldSensorInput = new FieldSensorInput(field, sensorInput);
+        assertFalse(fieldSensorInput.isDouble());
+
+        long value = fieldSensorInput.getLong(source);
+
+        assertEquals(expectedValue, value);
+    }
+
+    @Test
+    public void getLong_whenDouble() throws Exception {
+        getLong_whenDouble("floatField");
+        getLong_whenDouble("doubleField");
+    }
+
+    public void getLong_whenDouble(String fieldName) throws Exception {
+        SomeSource source = new SomeSource();
+        Field field = source.getClass().getDeclaredField(fieldName);
+        SensorInput sensorInput = field.getAnnotation(SensorInput.class);
+        FieldSensorInput fieldSensorInput = new FieldSensorInput(field, sensorInput);
+
+        try {
+            fieldSensorInput.getLong(source);
+            fail();
+        } catch (IllegalStateException expected) {
+
+        }
+    }
+
+    @Test
+    public void getDouble() throws Exception {
+        getDouble("floatField", 10);
+        getDouble("doubleField", 10);
+        getDouble("DoubleField", 10);
+        getDouble("FloatField", 10);
+        getDouble("nullDoubleField", 0);
+        getDouble("nullFloatField", 0);
+    }
+
+    public void getDouble(String fieldName, double expected) throws Exception {
+        SomeSource source = new SomeSource();
+        Field field = source.getClass().getDeclaredField(fieldName);
+        SensorInput sensorInput = field.getAnnotation(SensorInput.class);
+
+        FieldSensorInput fieldSensorInput = new FieldSensorInput(field, sensorInput);
+        assertTrue(fieldSensorInput.isDouble());
+
+        double value = fieldSensorInput.getDouble(source);
+
+        assertEquals(expected, value, 0.1);
+    }
+
+    @Test
+    public void getDouble_whenLong() throws Exception {
+        getDouble_whenLong("byteField");
+        getDouble_whenLong("shortField");
+        getDouble_whenLong("intField");
+        getDouble_whenLong("longField");
+        getDouble_whenLong("atomicLongField");
+        getDouble_whenLong("atomicIntegerField");
+        getDouble_whenLong("counterField");
+        getDouble_whenLong("collectionField");
+    }
+
+    public void getDouble_whenLong(String fieldName) throws Exception {
+        SomeSource source = new SomeSource();
+        Field field = source.getClass().getDeclaredField(fieldName);
+        SensorInput sensorInput = field.getAnnotation(SensorInput.class);
+        FieldSensorInput fieldSensorInput = new FieldSensorInput(field, sensorInput);
+
+        try {
+            fieldSensorInput.getDouble(source);
+            fail();
+        } catch (IllegalStateException expected) {
+
+        }
+    }
+
+    private class SomeSource {
+        @SensorInput
+        private byte byteField = 10;
+        @SensorInput
+        private short shortField = 10;
+        @SensorInput
+        private int intField = 10;
+        @SensorInput
+        private long longField = 10;
+
+        @SensorInput
+        private float floatField = 10;
+        @SensorInput
+        private double doubleField = 10;
+
+        @SensorInput
+        private AtomicLong atomicLongField = new AtomicLong(10);
+        @SensorInput
+        private AtomicLong nullAtomicLongField;
+        @SensorInput
+        private AtomicInteger atomicIntegerField = new AtomicInteger(10);
+        @SensorInput
+        private AtomicInteger nullAtomicIntegerField;
+        @SensorInput
+        private Counter counterField = newSwCounter(10);
+        @SensorInput
+        private Counter nullCounterField;
+        @SensorInput
+        private Collection collectionField = Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+        @SensorInput
+        private Collection nullCollectionField;
+        @SensorInput
+        private Map mapField = BlackboxUtils.createMap(10);
+        @SensorInput
+        private Map nullMapField;
+
+
+        @SensorInput
+        private Byte ByteField = (byte) 10;
+        @SensorInput
+        private Short ShortField = (short) 10;
+        @SensorInput
+        private Integer IntegerField = 10;
+        @SensorInput
+        private Long LongField = (long) 10;
+        @SensorInput
+        private Float FloatField = (float) 10;
+        @SensorInput
+        private Double DoubleField = (double) 10;
+
+        @SensorInput
+        private Byte nullByteField;
+        @SensorInput
+        private Short nullShortField;
+        @SensorInput
+        private Integer nullIntegerField;
+        @SensorInput
+        private Long nullLongField;
+        @SensorInput
+        private Float nullFloatField;
+        @SensorInput
+        private Double nullDoubleField;
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/blackbox/impl/MethodSensorInputTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/blackbox/impl/MethodSensorInputTest.java
@@ -1,0 +1,280 @@
+package com.hazelcast.internal.blackbox.impl;
+
+import com.hazelcast.util.counters.Counter;
+import com.hazelcast.internal.blackbox.SensorInput;
+import com.hazelcast.util.counters.SwCounter;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static com.hazelcast.util.counters.SwCounter.newSwCounter;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class MethodSensorInputTest {
+
+    @Test
+    public void getLong() throws Exception {
+        getLong("byteMethod", 10);
+        getLong("shortMethod", 10);
+        getLong("intMethod", 10);
+        getLong("longMethod", 10);
+        getLong("atomicLongMethod", 10);
+        getLong("atomicIntegerMethod", 10);
+        getLong("counterMethod", 10);
+        getLong("collectionMethod", 10);
+        getLong("mapMethod", 10);
+
+        getLong("ByteMethod", 10);
+        getLong("ShortMethod", 10);
+        getLong("IntegerMethod", 10);
+        getLong("LongMethod", 10);
+
+        getLong("nullAtomicLongMethod", 0);
+        getLong("nullAtomicIntegerMethod", 0);
+        getLong("nullCounterMethod", 0);
+        getLong("nullCollectionMethod", 0);
+        getLong("nullMapMethod", 0);
+        getLong("nullByteMethod", 0);
+        getLong("nullShortMethod", 0);
+        getLong("nullIntegerMethod", 0);
+        getLong("nullLongMethod", 0);
+    }
+
+    public void getLong(String fieldName, int expectedValue) throws Exception {
+        SomeSource source = new SomeSource();
+        Method method = source.getClass().getDeclaredMethod(fieldName);
+        SensorInput sensorInput = method.getAnnotation(SensorInput.class);
+        MethodSensorInput input = new MethodSensorInput(method, sensorInput);
+        assertFalse(input.isDouble());
+
+        long value = input.getLong(source);
+
+        assertEquals(expectedValue, value);
+    }
+
+    @Test
+    public void getLong_whenDouble() throws Exception {
+        getLong_whenDouble("floatMethod");
+        getLong_whenDouble("doubleMethod");
+    }
+
+    public void getLong_whenDouble(String fieldName) throws Exception {
+        SomeSource source = new SomeSource();
+        Method method = source.getClass().getDeclaredMethod(fieldName);
+        SensorInput sensorInput = method.getAnnotation(SensorInput.class);
+        MethodSensorInput fieldSensorInput = new MethodSensorInput(method, sensorInput);
+
+        try {
+            fieldSensorInput.getLong(source);
+            fail();
+        } catch (IllegalStateException expected) {
+
+        }
+    }
+
+    @Test
+    public void getDouble() throws Exception {
+        getDouble("floatMethod", 10);
+        getDouble("doubleMethod", 10);
+        getDouble("DoubleMethod", 10);
+        getDouble("FloatMethod", 10);
+        getDouble("nullDoubleMethod", 0);
+        getDouble("nullFloatMethod", 0);
+    }
+
+    public void getDouble(String fieldName, double expected) throws Exception {
+        SomeSource source = new SomeSource();
+        Method method = source.getClass().getDeclaredMethod(fieldName);
+        SensorInput sensorInput = method.getAnnotation(SensorInput.class);
+
+        MethodSensorInput fieldSensorInput = new MethodSensorInput(method, sensorInput);
+        assertTrue(fieldSensorInput.isDouble());
+
+        double value = fieldSensorInput.getDouble(source);
+
+        assertEquals(expected, value, 0.1);
+    }
+
+    @Test
+    public void getDouble_whenLong() throws Exception {
+        getDouble_whenLong("byteMethod");
+        getDouble_whenLong("shortMethod");
+        getDouble_whenLong("intMethod");
+        getDouble_whenLong("longMethod");
+        getDouble_whenLong("atomicLongMethod");
+        getDouble_whenLong("atomicIntegerMethod");
+        getDouble_whenLong("counterMethod");
+        getDouble_whenLong("collectionMethod");
+    }
+
+    public void getDouble_whenLong(String fieldName) throws Exception {
+        SomeSource source = new SomeSource();
+        Method field = source.getClass().getDeclaredMethod(fieldName);
+        SensorInput sensorInput = field.getAnnotation(SensorInput.class);
+        MethodSensorInput fieldSensorInput = new MethodSensorInput(field, sensorInput);
+
+        try {
+            fieldSensorInput.getDouble(source);
+            fail();
+        } catch (IllegalStateException expected) {
+
+        }
+    }
+
+    private class SomeSource {
+        @SensorInput
+        private byte byteMethod() {
+            return 10;
+        }
+
+        @SensorInput
+        private short shortMethod() {
+            return 10;
+        }
+
+        @SensorInput
+        private int intMethod() {
+            return 10;
+        }
+
+        @SensorInput
+        private long longMethod() {
+            return 10;
+        }
+
+        @SensorInput
+        private float floatMethod() {
+            return 10;
+        }
+
+        @SensorInput
+        private double doubleMethod() {
+            return 10;
+        }
+
+        @SensorInput
+        private AtomicLong atomicLongMethod() {
+            return new AtomicLong(10);
+
+        }
+
+        @SensorInput
+        private AtomicLong nullAtomicLongMethod() {
+            return null;
+        }
+
+        @SensorInput
+        private AtomicInteger atomicIntegerMethod() {
+            return new AtomicInteger(10);
+        }
+
+        @SensorInput
+        private AtomicInteger nullAtomicIntegerMethod() {
+            return null;
+        }
+
+        @SensorInput
+        private Counter counterMethod() {
+            return newSwCounter(10);
+        }
+
+        @SensorInput
+        private Counter nullCounterMethod() {
+            return null;
+        }
+
+        @SensorInput
+        private Collection collectionMethod() {
+            return Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+        }
+
+        @SensorInput
+        private Collection nullCollectionMethod() {
+            return null;
+        }
+
+        @SensorInput
+        private Map mapMethod() {
+            return BlackboxUtils.createMap(10);
+        }
+
+        @SensorInput
+        private Map nullMapMethod() {
+            return null;
+        }
+
+        @SensorInput
+        private Byte ByteMethod() {
+            return (byte) 10;
+        }
+
+        @SensorInput
+        private Short ShortMethod() {
+            return (short) 10;
+        }
+
+        @SensorInput
+        private Integer IntegerMethod() {
+            return 10;
+        }
+
+        @SensorInput
+        private Long LongMethod() {
+            return (long) 10;
+        }
+
+        @SensorInput
+        private Float FloatMethod() {
+            return (float) 10;
+        }
+
+        @SensorInput
+        private Double DoubleMethod() {
+            return (double) 10;
+        }
+
+        @SensorInput
+        private Byte nullByteMethod() {
+            return null;
+        }
+
+        @SensorInput
+        private Short nullShortMethod() {
+            return null;
+        }
+
+        @SensorInput
+        private Integer nullIntegerMethod() {
+            return null;
+        }
+
+        @SensorInput
+        private Long nullLongMethod() {
+            return null;
+        }
+
+        @SensorInput
+        private Float nullFloatMethod() {
+            return null;
+        }
+
+        @SensorInput
+        private Double nullDoubleMethod() {
+            return null;
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/blackbox/impl/RegisterAnnotatedFieldsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/blackbox/impl/RegisterAnnotatedFieldsTest.java
@@ -1,0 +1,168 @@
+package com.hazelcast.internal.blackbox.impl;
+
+import com.hazelcast.util.counters.Counter;
+import com.hazelcast.internal.blackbox.SensorInput;
+import com.hazelcast.internal.blackbox.Sensor;
+import com.hazelcast.util.counters.SwCounter;
+import com.hazelcast.logging.Logger;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static com.hazelcast.util.counters.SwCounter.newSwCounter;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class RegisterAnnotatedFieldsTest extends HazelcastTestSupport {
+
+    private BlackboxImpl blackbox;
+
+    @Before
+    public void setup() {
+        blackbox = new BlackboxImpl(Logger.getLogger(BlackboxImpl.class));
+    }
+
+    @Test
+    public void register_customName() {
+        ObjectLongSensorFieldWithName object = new ObjectLongSensorFieldWithName();
+        blackbox.scanAndRegister(object, "foo");
+
+        Sensor sensor = blackbox.getSensor("foo.myfield");
+        object.field = 10;
+        assertEquals(object.field, sensor.readLong());
+    }
+
+    public class ObjectLongSensorFieldWithName {
+        @SensorInput(name = "myfield")
+        private long field;
+    }
+
+    @Test
+    public void register_primitiveInteger() {
+        PrimitiveIntegerField object = new PrimitiveIntegerField();
+        blackbox.scanAndRegister(object, "foo");
+
+        Sensor sensor = blackbox.getSensor("foo.field");
+        object.field = 10;
+        assertEquals(object.field, sensor.readLong());
+    }
+
+    public class PrimitiveIntegerField {
+        @SensorInput
+        private int field;
+    }
+
+    @Test
+    public void register_primitiveLong() {
+        PrimitiveLongField object = new PrimitiveLongField();
+        blackbox.scanAndRegister(object, "foo");
+
+        Sensor sensor = blackbox.getSensor("foo.field");
+        object.field = 10;
+        assertEquals(object.field, sensor.readLong());
+    }
+
+    public class PrimitiveLongField {
+        @SensorInput
+        private long field;
+    }
+
+    @Test
+    public void register_primitiveDouble() {
+        PrimitiveDoubleField object = new PrimitiveDoubleField();
+        blackbox.scanAndRegister(object, "foo");
+
+        Sensor sensor = blackbox.getSensor("foo.field");
+        object.field = 10;
+        assertEquals(object.field, sensor.readDouble(),0.1);
+    }
+
+    public class PrimitiveDoubleField {
+        @SensorInput
+        private double field;
+    }
+
+    @Test
+    public void register_concurrentHashMap() {
+        ConcurrentMapField object = new ConcurrentMapField();
+        object.field.put("foo", "foo");
+        object.field.put("bar", "bar");
+        blackbox.scanAndRegister(object, "foo");
+
+        Sensor sensor = blackbox.getSensor("foo.field");
+        assertEquals(object.field.size(), sensor.readLong());
+
+        object.field = null;
+        assertEquals(0, sensor.readLong());
+    }
+
+    public class ConcurrentMapField {
+        @SensorInput
+        private ConcurrentHashMap field = new ConcurrentHashMap();
+    }
+
+    @Test
+    public void register_counterSensorField() {
+        CounterField object = new CounterField();
+        object.field.inc(10);
+        blackbox.scanAndRegister(object, "foo");
+
+        Sensor sensor = blackbox.getSensor("foo.field");
+        assertEquals(10, sensor.readLong());
+
+        object.field = null;
+        assertEquals(0, sensor.readLong());
+    }
+
+    public class CounterField {
+        @SensorInput
+        private Counter field = newSwCounter();
+    }
+
+    @Test
+    public void register_staticField() {
+        StaticField object = new StaticField();
+        StaticField.field.set(10);
+        blackbox.scanAndRegister(object, "foo");
+
+        Sensor sensor = blackbox.getSensor("foo.field");
+        assertEquals(10, sensor.readLong());
+
+        StaticField.field = null;
+        assertEquals(0, sensor.readLong());
+    }
+
+    public static class StaticField {
+        @SensorInput
+        static AtomicInteger field = new AtomicInteger();
+    }
+
+    @Test
+    public void register_superclassRegistration() {
+        Subclass object = new Subclass();
+        blackbox.scanAndRegister(object, "foo");
+
+        Sensor sensor = blackbox.getSensor("foo.field");
+        assertEquals(0, sensor.readLong());
+
+        object.field = 10;
+        assertEquals(10, sensor.readLong());
+    }
+
+    public static class SuperClass{
+        @SensorInput
+        int field;
+    }
+
+    public static class Subclass extends SuperClass{
+
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/blackbox/impl/RegisterAnnotatedMethodsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/blackbox/impl/RegisterAnnotatedMethodsTest.java
@@ -1,0 +1,352 @@
+package com.hazelcast.internal.blackbox.impl;
+
+import com.hazelcast.util.counters.Counter;
+import com.hazelcast.internal.blackbox.Sensor;
+import com.hazelcast.internal.blackbox.SensorInput;
+import com.hazelcast.util.counters.SwCounter;
+import com.hazelcast.logging.Logger;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.QuickTest;
+import freemarker.ext.util.IdentityHashMap;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static com.hazelcast.util.counters.SwCounter.newSwCounter;
+import static org.junit.Assert.assertEquals;
+
+//todo: testing of null return value
+//todo: testing of exception return value
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class RegisterAnnotatedMethodsTest extends HazelcastTestSupport {
+
+    private BlackboxImpl blackbox;
+
+    @Before
+    public void setup() {
+        blackbox = new BlackboxImpl(Logger.getLogger(BlackboxImpl.class));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void register_methodWithArguments() {
+        MethodWithArgument object = new MethodWithArgument();
+        blackbox.scanAndRegister(object, "foo");
+    }
+
+    public class MethodWithArgument {
+        @SensorInput
+        private long method(int x) {
+            return 10;
+        }
+    }
+
+    @Test
+    public void register_withCustomName() {
+        SensorMethodWithName object = new SensorMethodWithName();
+        blackbox.scanAndRegister(object, "foo");
+
+        Sensor sensor = blackbox.getSensor("foo.mymethod");
+        assertEquals(10, sensor.readLong());
+    }
+
+    public class SensorMethodWithName {
+        @SensorInput(name = "mymethod")
+        private long method() {
+            return 10;
+        }
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void register_methodReturnsVoid() {
+        VoidMethod object = new VoidMethod();
+        blackbox.scanAndRegister(object, "foo");
+    }
+
+    public class VoidMethod {
+        @SensorInput
+        private void method() {
+        }
+    }
+
+    @Test
+    public void register_primitiveByte() {
+        PrimitiveByteMethod object = new PrimitiveByteMethod();
+        blackbox.scanAndRegister(object, "foo");
+
+        Sensor sensor = blackbox.getSensor("foo.method");
+        assertEquals(object.method(), sensor.readLong());
+    }
+
+    public class PrimitiveByteMethod {
+        @SensorInput
+        private byte method() {
+            return 10;
+        }
+    }
+
+    @Test
+    public void register_primitiveShort() {
+        PrimitiveShortMethod object = new PrimitiveShortMethod();
+        blackbox.scanAndRegister(object, "foo");
+
+        Sensor sensor = blackbox.getSensor("foo.method");
+        assertEquals(object.method(), sensor.readLong());
+    }
+
+    public class PrimitiveShortMethod {
+        @SensorInput
+        private short method() {
+            return 10;
+        }
+    }
+
+
+    @Test
+    public void register_primitiveInt() {
+        PrimitiveIntMethod object = new PrimitiveIntMethod();
+        blackbox.scanAndRegister(object, "foo");
+
+        Sensor sensor = blackbox.getSensor("foo.method");
+        assertEquals(10, sensor.readLong());
+    }
+
+    public class PrimitiveIntMethod {
+        @SensorInput
+        private int method() {
+            return 10;
+        }
+    }
+
+    @Test
+    public void register_primitiveLong() {
+        PrimitiveLongMethod object = new PrimitiveLongMethod();
+        blackbox.scanAndRegister(object, "foo");
+
+        Sensor sensor = blackbox.getSensor("foo.method");
+        assertEquals(10, sensor.readLong());
+    }
+
+
+    public class PrimitiveLongMethod {
+        @SensorInput
+        private long method() {
+            return 10;
+        }
+    }
+
+    @Test
+    public void register_primitiveFloat() {
+        PrimitiveFloatMethod object = new PrimitiveFloatMethod();
+        blackbox.scanAndRegister(object, "foo");
+
+        Sensor sensor = blackbox.getSensor("foo.method");
+        assertEquals(object.method(), sensor.readDouble(), 0.1);
+    }
+
+    public class PrimitiveFloatMethod {
+        @SensorInput
+        private float method() {
+            return 10f;
+        }
+    }
+
+    @Test
+    public void register_primitiveDouble() {
+        PrimitiveDoubleMethod object = new PrimitiveDoubleMethod();
+        blackbox.scanAndRegister(object, "foo");
+
+        Sensor sensor = blackbox.getSensor("foo.method");
+        assertEquals(object.method(), sensor.readDouble(), 0.1);
+    }
+
+    public class PrimitiveDoubleMethod {
+        @SensorInput
+        private double method() {
+            return 10d;
+        }
+    }
+
+    @Test
+    public void register_atomicLong() {
+        AtomicLongMethod object = new AtomicLongMethod();
+        blackbox.scanAndRegister(object, "foo");
+
+        Sensor sensor = blackbox.getSensor("foo.method");
+        assertEquals(object.method().get(), sensor.readLong());
+    }
+
+    public class AtomicLongMethod {
+        @SensorInput
+        private AtomicLong method() {
+            return new AtomicLong(10);
+        }
+    }
+
+    @Test
+    public void register_atomicInteger() {
+        AtomicIntegerMethod object = new AtomicIntegerMethod();
+        blackbox.scanAndRegister(object, "foo");
+
+        Sensor sensor = blackbox.getSensor("foo.method");
+        assertEquals(object.method().get(), sensor.readLong());
+    }
+
+    public class AtomicIntegerMethod {
+        @SensorInput
+        private AtomicInteger method() {
+            return new AtomicInteger(10);
+        }
+    }
+
+    @Test
+    public void register_counter() {
+        CounterMethod object = new CounterMethod();
+        blackbox.scanAndRegister(object, "foo");
+
+        Sensor sensor = blackbox.getSensor("foo.method");
+        assertEquals(object.method().get(), sensor.readLong());
+    }
+
+    public class CounterMethod {
+        @SensorInput
+        private Counter method() {
+            Counter counter = newSwCounter();
+            counter.inc(10);
+            return counter;
+        }
+    }
+
+    @Test
+    public void register_collection() {
+        CollectionMethod object = new CollectionMethod();
+        blackbox.scanAndRegister(object, "foo");
+
+        Sensor sensor = blackbox.getSensor("foo.method");
+        assertEquals(object.method().size(), sensor.readLong());
+    }
+
+    public class CollectionMethod {
+        @SensorInput
+        private Collection method() {
+            ArrayList list = new ArrayList();
+            for (int k = 0; k < 10; k++) {
+                list.add(k);
+            }
+            return list;
+        }
+    }
+
+    @Test
+    public void register_map() {
+        MapMethod object = new MapMethod();
+        blackbox.scanAndRegister(object, "foo");
+
+        Sensor sensor = blackbox.getSensor("foo.method");
+        assertEquals(object.method().size(), sensor.readLong());
+    }
+
+    public class MapMethod {
+        @SensorInput
+        private Map method() {
+            HashMap map = new HashMap();
+            for (int k = 0; k < 10; k++) {
+                map.put(k, k);
+            }
+            return map;
+        }
+    }
+
+    @Test
+    public void register_subclass() {
+        SubclassMethod object = new SubclassMethod();
+        blackbox.scanAndRegister(object, "foo");
+
+        Sensor sensor = blackbox.getSensor("foo.method");
+        assertEquals(object.method().size(), sensor.readLong());
+    }
+
+    public class SubclassMethod {
+        @SensorInput
+        private IdentityHashMap method() {
+            IdentityHashMap map = new IdentityHashMap();
+            for (int k = 0; k < 10; k++) {
+                map.put(k, k);
+            }
+            return map;
+        }
+    }
+
+
+    @Test
+    public void register_staticMethod() {
+        StaticMethod object = new StaticMethod();
+        blackbox.scanAndRegister(object, "foo");
+
+        Sensor sensor = blackbox.getSensor("foo.method");
+        assertEquals(StaticMethod.method(), sensor.readLong());
+    }
+
+    public static class StaticMethod {
+        @SensorInput
+        private static long method() {
+            return 10;
+        }
+    }
+
+    @Test
+    public void register_interfaceWithSensors() {
+        SomeInterfaceImplementation object = new SomeInterfaceImplementation();
+        blackbox.scanAndRegister(object, "foo");
+
+        Sensor sensor = blackbox.getSensor("foo.method");
+        assertEquals(10, sensor.readLong());
+    }
+
+    public  interface SomeInterface{
+        @SensorInput
+        int method();
+    }
+
+    public static class SomeInterfaceImplementation implements SomeInterface{
+        @Override
+        public int method() {
+            return 10;
+        }
+    }
+
+    @Test
+    public void register_superclassWithSensorMethods() {
+        SubclassWithSensor object = new SubclassWithSensor();
+        blackbox.scanAndRegister(object, "foo");
+
+        Sensor methodSensor = blackbox.getSensor("foo.method");
+        assertEquals(object.method(), methodSensor.readLong());
+
+        Sensor fieldSensor = blackbox.getSensor("foo.field");
+        assertEquals(object.field, fieldSensor.readLong());
+    }
+
+    public static abstract class ClassWithSensor{
+        @SensorInput
+        int method(){
+            return 10;
+        }
+
+        @SensorInput
+        int field=10;
+    }
+
+    public static class SubclassWithSensor extends ClassWithSensor{
+
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/blackbox/impl/RegisterSensorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/blackbox/impl/RegisterSensorTest.java
@@ -1,0 +1,142 @@
+package com.hazelcast.internal.blackbox.impl;
+
+import com.hazelcast.internal.blackbox.SensorInput;
+import com.hazelcast.internal.blackbox.Sensor;
+import com.hazelcast.logging.Logger;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.io.OutputStream;
+import java.util.LinkedList;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category(QuickTest.class)
+public class RegisterSensorTest extends HazelcastTestSupport {
+
+    private BlackboxImpl blackbox;
+
+    @Before
+    public void setup() {
+        blackbox = new BlackboxImpl(Logger.getLogger(BlackboxImpl.class));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void whenParameterPrefixNull() {
+        blackbox.scanAndRegister(new SomeField(), null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void whenObjectNull() {
+        blackbox.scanAndRegister(null, "bar");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void whenUnrecognizedField() {
+        blackbox.scanAndRegister(new SomeUnrecognizedField(), "bar");
+    }
+
+    @Test
+    public void whenNoSensorField_thenIgnore() {
+        blackbox.scanAndRegister(new LinkedList(), "bar");
+
+        for (String parameter : blackbox.getParameters()) {
+            assertFalse(parameter.startsWith("bar"));
+        }
+    }
+
+    public class SomeField {
+        @SensorInput
+        long field;
+    }
+
+    public class SomeUnrecognizedField {
+        @SensorInput
+        OutputStream field;
+    }
+
+    @Test
+    public void deregister_whenNotRegistered() {
+        MultiFieldAndMethod multiFieldAndMethod = new MultiFieldAndMethod();
+        multiFieldAndMethod.field1 = 1;
+        multiFieldAndMethod.field2 = 2;
+        blackbox.deregister(multiFieldAndMethod);
+
+        // make sure that the the sensors have been removed from the parameters
+        Set<String> parameters = blackbox.getParameters();
+        assertFalse(parameters.contains("foo.field1"));
+        assertFalse(parameters.contains("foo.field2"));
+        assertFalse(parameters.contains("foo.method1"));
+        assertFalse(parameters.contains("foo.method2"));
+ }
+
+    public class MultiFieldAndMethod {
+        @SensorInput
+        long field1;
+        @SensorInput
+        long field2;
+
+        @SensorInput
+        int method1() {
+            return 1;
+        }
+
+        @SensorInput
+        int method2() {
+            return 2;
+        }
+    }
+
+    @Test
+    public void deregister_whenRegistered() {
+        MultiFieldAndMethod multiFieldAndMethod = new MultiFieldAndMethod();
+        multiFieldAndMethod.field1 = 1;
+        multiFieldAndMethod.field2 = 2;
+        blackbox.scanAndRegister(multiFieldAndMethod, "foo");
+
+        Sensor field1 = blackbox.getSensor("foo.field1");
+        Sensor field2 = blackbox.getSensor("foo.field2");
+        Sensor method1 = blackbox.getSensor("foo.method1");
+        Sensor method2 = blackbox.getSensor("foo.method2");
+
+        blackbox.deregister(multiFieldAndMethod);
+
+        // make sure that the the sensors have been removed from the parameters
+        Set<String> parameters = blackbox.getParameters();
+        assertFalse(parameters.contains("foo.field1"));
+        assertFalse(parameters.contains("foo.field2"));
+        assertFalse(parameters.contains("foo.method1"));
+        assertFalse(parameters.contains("foo.method2"));
+
+        // make sure that the sensors have been disconnected
+        assertEquals(0, field1.readLong());
+        assertEquals(0, field2.readLong());
+        assertEquals(0, method1.readLong());
+        assertEquals(0, method2.readLong());
+    }
+
+    @Test
+    public void deregister_whenAlreadyDeregistered() {
+        MultiFieldAndMethod multiFieldAndMethod = new MultiFieldAndMethod();
+        multiFieldAndMethod.field1 = 1;
+        multiFieldAndMethod.field2 = 2;
+        blackbox.scanAndRegister(multiFieldAndMethod, "foo");
+        blackbox.deregister(multiFieldAndMethod);
+        blackbox.deregister(multiFieldAndMethod);
+
+        // make sure that the the sensors have been removed from the parameters
+        Set<String> parameters = blackbox.getParameters();
+        assertFalse(parameters.contains("foo.field1"));
+        assertFalse(parameters.contains("foo.field2"));
+        assertFalse(parameters.contains("foo.method1"));
+        assertFalse(parameters.contains("foo.method2"));
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/blackbox/impl/SensorImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/blackbox/impl/SensorImplTest.java
@@ -1,0 +1,285 @@
+package com.hazelcast.internal.blackbox.impl;
+
+import com.hazelcast.internal.blackbox.DoubleSensorInput;
+import com.hazelcast.internal.blackbox.LongSensorInput;
+import com.hazelcast.internal.blackbox.Sensor;
+import com.hazelcast.internal.blackbox.SensorInput;
+import com.hazelcast.logging.Logger;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static java.lang.Math.round;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class SensorImplTest {
+
+    private BlackboxImpl blackbox;
+
+    @Before
+    public void setup() {
+        blackbox = new BlackboxImpl(Logger.getLogger(BlackboxImpl.class));
+    }
+
+    class SomeObject {
+        @SensorInput
+        long longField = 10;
+        @SensorInput
+        double doubleField = 10.8;
+    }
+
+    @Test
+    public void getParameter() {
+        Sensor sensor = blackbox.getSensor("foo");
+
+        String actual = sensor.getParameter();
+
+        assertEquals("foo", actual);
+    }
+
+    //  ============ getLong ===========================
+
+    @Test
+    public void readLong_whenNoSensorInput() {
+        Sensor sensor = blackbox.getSensor("foo");
+
+        long actual = sensor.readLong();
+
+        assertEquals(0, actual);
+    }
+
+    @Test
+    public void readLong_whenDoubleSensorFunction() {
+        blackbox.register(this, "foo", new DoubleSensorInput<SensorImplTest>() {
+            @Override
+            public double get(SensorImplTest source) throws Exception {
+                return 10;
+            }
+        });
+
+        Sensor sensor = blackbox.getSensor("foo");
+
+        long actual = sensor.readLong();
+
+        assertEquals(10, actual);
+    }
+
+    @Test
+    public void readLong_whenLongSensorFunction() {
+        blackbox.register(this, "foo", new LongSensorInput() {
+            @Override
+            public long get(Object o) throws Exception {
+                return 10;
+            }
+        });
+
+        Sensor sensor = blackbox.getSensor("foo");
+        assertEquals(10, sensor.readLong());
+    }
+
+    @Test
+    public void readLong_whenExceptionalInput() {
+        blackbox.register(this, "foo", new LongSensorInput() {
+            @Override
+            public long get(Object o) {
+                throw new RuntimeException();
+            }
+        });
+
+        Sensor sensor = blackbox.getSensor("foo");
+
+        long actual = sensor.readLong();
+
+        assertEquals(0, actual);
+    }
+
+    @Test
+    public void readLong_whenLongSensorField() {
+        SomeObject someSensor = new SomeObject();
+        blackbox.scanAndRegister(someSensor, "foo");
+
+        Sensor sensor = blackbox.getSensor("foo.longField");
+        assertEquals(10, sensor.readLong());
+    }
+
+    @Test
+    public void readLong_whenDoubleSensorField() {
+        SomeObject someSensor = new SomeObject();
+        blackbox.scanAndRegister(someSensor, "foo");
+
+        Sensor sensor = blackbox.getSensor("foo.doubleField");
+        assertEquals(round(someSensor.doubleField), sensor.readLong());
+    }
+
+    // ============ readDouble ===========================
+
+    @Test
+    public void readDouble_whenNoSensorInput() {
+        Sensor sensor = blackbox.getSensor("foo");
+
+        double actual = sensor.readDouble();
+
+        assertEquals(0, actual, 0.1);
+    }
+
+    @Test
+    public void readDouble_whenExceptionalInput() {
+        blackbox.register(this, "foo", new DoubleSensorInput() {
+            @Override
+            public double get(Object o) {
+                throw new RuntimeException();
+            }
+        });
+
+        Sensor sensor = blackbox.getSensor("foo");
+
+        double actual = sensor.readDouble();
+
+        assertEquals(0, actual, 0.1);
+    }
+
+    @Test
+    public void readDouble_whenDoubleSensorInput() {
+        blackbox.register(this, "foo", new DoubleSensorInput() {
+            @Override
+            public double get(Object o) {
+                return 10;
+            }
+        });
+        Sensor sensor = blackbox.getSensor("foo");
+
+        double actual = sensor.readDouble();
+
+        assertEquals(10, actual, 0.1);
+    }
+
+    @Test
+    public void readDouble_whenLongSensorInput() {
+        blackbox.register(this, "foo", new LongSensorInput() {
+            @Override
+            public long get(Object o) throws Exception {
+                return 10;
+            }
+        });
+        Sensor sensor = blackbox.getSensor("foo");
+
+        double actual = sensor.readDouble();
+
+        assertEquals(10, actual, 0.1);
+    }
+
+    @Test
+    public void readDouble_whenLongSensorField() {
+        SomeObject someSensor = new SomeObject();
+        blackbox.scanAndRegister(someSensor, "foo");
+
+        Sensor sensor = blackbox.getSensor("foo.longField");
+        assertEquals(someSensor.longField, sensor.readDouble(), 0.1);
+    }
+
+    @Test
+    public void readDouble_whenDoubleSensorField() {
+        SomeObject someSensor = new SomeObject();
+        blackbox.scanAndRegister(someSensor, "foo");
+
+        Sensor sensor = blackbox.getSensor("foo.doubleField");
+        assertEquals(someSensor.doubleField, sensor.readDouble(), 0.1);
+    }
+
+    // ====================== render ===================================
+
+    @Test
+    public void render_whenDoubleSensorInput() {
+        blackbox.register(this, "foo", new DoubleSensorInput() {
+            @Override
+            public double get(Object o) {
+                return 10;
+            }
+        });
+        Sensor sensor = blackbox.getSensor("foo");
+        StringBuilder sb = new StringBuilder();
+
+        sensor.render(sb);
+
+        assertEquals("foo=10.0", sb.toString());
+    }
+
+    @Test
+    public void render_whenLongSensorFunction() {
+        blackbox.register(this, "foo", new LongSensorInput() {
+            @Override
+            public long get(Object o) {
+                return 10;
+            }
+        });
+        Sensor sensor = blackbox.getSensor("foo");
+        StringBuilder sb = new StringBuilder();
+
+        sensor.render(sb);
+
+        assertEquals("foo=10", sb.toString());
+    }
+
+    @Test
+    public void render_whenNoSensorInput() {
+        Sensor sensor = blackbox.getSensor("foo");
+        StringBuilder sb = new StringBuilder();
+
+        sensor.render(sb);
+
+        assertEquals("foo=NA", sb.toString());
+    }
+
+    @Test
+    public void render_whenNoSource() {
+        Sensor sensor = blackbox.getSensor("foo");
+        StringBuilder sb = new StringBuilder();
+
+        sensor.render(sb);
+
+        assertEquals("foo=NA", sb.toString());
+    }
+
+    @Test
+    public void render_whenDoubleField() {
+        SomeObject someSensor = new SomeObject();
+        blackbox.scanAndRegister(someSensor, "foo");
+        Sensor sensor = blackbox.getSensor("foo.doubleField");
+        StringBuilder sb = new StringBuilder();
+
+        sensor.render(sb);
+        assertEquals("foo.doubleField=10.8", sb.toString());
+    }
+
+    @Test
+    public void render_whenLongField() {
+        SomeObject someSensor = new SomeObject();
+        blackbox.scanAndRegister(someSensor, "foo");
+        Sensor sensor = blackbox.getSensor("foo.longField");
+        StringBuilder sb = new StringBuilder();
+
+        sensor.render(sb);
+        assertEquals("foo.longField=10", sb.toString());
+    }
+
+    @Test
+    public void render_whenException() {
+        blackbox.register(this, "foo", new LongSensorInput() {
+            @Override
+            public long get(Object o) {
+                throw new RuntimeException();
+            }
+        });
+        Sensor sensor = blackbox.getSensor("foo");
+        StringBuilder sb = new StringBuilder();
+
+        sensor.render(sb);
+
+        assertEquals("foo=NA", sb.toString());
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/blackbox/sensorpacks/ClassLoadingSensorPackTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/blackbox/sensorpacks/ClassLoadingSensorPackTest.java
@@ -1,0 +1,74 @@
+package com.hazelcast.internal.blackbox.sensorpacks;
+
+import com.hazelcast.internal.blackbox.Sensor;
+import com.hazelcast.internal.blackbox.impl.BlackboxImpl;
+import com.hazelcast.logging.Logger;
+import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.lang.management.ClassLoadingMXBean;
+import java.lang.management.ManagementFactory;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class ClassLoadingSensorPackTest extends HazelcastTestSupport {
+
+    private static final ClassLoadingMXBean BEAN = ManagementFactory.getClassLoadingMXBean();
+
+    private BlackboxImpl blackbox;
+
+    @Before
+    public void setup() {
+        blackbox = new BlackboxImpl(Logger.getLogger(BlackboxImpl.class));
+    }
+
+    @Test
+    public void utilityConstructor(){
+        assertUtilityConstructor(ClassLoadingSensorPack.class);
+    }
+
+    @Test
+    public void loadedClassesCount() {
+        final Sensor sensor = blackbox.getSensor("classloading.loadedClassesCount");
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertEquals(BEAN.getLoadedClassCount(), sensor.readLong(), 100);
+            }
+        });
+    }
+
+    @Test
+    public void totalLoadedClassesCount() {
+        final Sensor sensor = blackbox.getSensor("classloading.totalLoadedClassesCount");
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertEquals(BEAN.getTotalLoadedClassCount(), sensor.readLong(), 100);
+            }
+        });
+    }
+
+    @Test
+    public void unloadedClassCount() {
+        final Sensor sensor = blackbox.getSensor("classloading.unloadedClassCount");
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertEquals(BEAN.getUnloadedClassCount(), sensor.readLong(), 100);
+            }
+        });
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/blackbox/sensorpacks/GarbageCollectionSensorPackTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/blackbox/sensorpacks/GarbageCollectionSensorPackTest.java
@@ -1,0 +1,108 @@
+package com.hazelcast.internal.blackbox.sensorpacks;
+
+import com.hazelcast.internal.blackbox.Sensor;
+import com.hazelcast.internal.blackbox.impl.BlackboxImpl;
+import com.hazelcast.logging.Logger;
+import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class GarbageCollectionSensorPackTest extends HazelcastTestSupport {
+
+    private BlackboxImpl blackbox;
+    private GarbageCollectionSensorPack.GcStats gcStats;
+
+    @Before
+    public void setup() {
+        blackbox = new BlackboxImpl(Logger.getLogger(BlackboxImpl.class));
+        gcStats = new GarbageCollectionSensorPack.GcStats();
+    }
+
+    @Test
+    public void utilityConstructor(){
+        assertUtilityConstructor(GarbageCollectionSensorPack.class);
+    }
+
+    @Test
+    public void minorCount() {
+        final Sensor sensor = blackbox.getSensor("gc.minorCount");
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                gcStats.run();
+                 assertEquals(gcStats.minorCount, sensor.readLong(), 1);
+            }
+        });
+    }
+
+    @Test
+    public void minorTime() throws InterruptedException {
+        final Sensor sensor = blackbox.getSensor("gc.minorTime");
+         assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                gcStats.run();
+                assertEquals(gcStats.minorTime, sensor.readLong(), SECONDS.toMillis(1));
+            }
+        });
+    }
+
+    @Test
+    public void majorCount() {
+        final Sensor sensor = blackbox.getSensor("gc.majorCount");
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                gcStats.run();
+                assertEquals(gcStats.majorCount, sensor.readLong(), 1);
+            }
+        });
+    }
+
+    @Test
+    public void majorTime() {
+        final Sensor sensor = blackbox.getSensor("gc.majorTime");
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                gcStats.run();
+                assertEquals(gcStats.majorTime, sensor.readLong(), SECONDS.toMillis(1));
+            }
+        });
+    }
+
+
+    @Test
+    public void unknownCount() {
+        final Sensor sensor = blackbox.getSensor("gc.unknownCount");
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                gcStats.run();
+                assertEquals(gcStats.unknownCount, sensor.readLong(), 1);
+            }
+        });
+    }
+
+    @Test
+    public void unknownTime() {
+        final Sensor sensor = blackbox.getSensor("gc.unknownTime");
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                gcStats.run();
+                assertEquals(gcStats.unknownTime, sensor.readLong(), SECONDS.toMillis(1));
+            }
+        });
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/blackbox/sensorpacks/OperatingSystemSensorPackTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/blackbox/sensorpacks/OperatingSystemSensorPackTest.java
@@ -1,0 +1,134 @@
+package com.hazelcast.internal.blackbox.sensorpacks;
+
+import com.hazelcast.internal.blackbox.Sensor;
+import com.hazelcast.internal.blackbox.impl.BlackboxImpl;
+import com.hazelcast.logging.Logger;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.OperatingSystemMXBean;
+
+import static com.hazelcast.internal.blackbox.sensorpacks.OperatingSystemSensorPack.registerMethod;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
+
+// The operating system sensor pack is very hard to test because you never know the
+// concrete implementation of the OperatingSystemMXBean.
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class OperatingSystemSensorPackTest extends HazelcastTestSupport {
+
+    private BlackboxImpl blackbox;
+
+    @Before
+    public void setup() {
+        blackbox = new BlackboxImpl(Logger.getLogger(BlackboxImpl.class));
+    }
+
+    @Test
+    public void utilityConstructor(){
+        assertUtilityConstructor(OperatingSystemSensorPack.class);
+    }
+
+    @Test
+    public void testComSunManagementUnixOperatingSystem() {
+        assertContainsSensor("os.systemLoadAverage");
+
+        assumeOperatingSystemMXBean("com.sun.management.UnixOperatingSystem");
+
+        assertContainsSensor("os.committedVirtualMemorySize");
+        assertContainsSensor("os.freePhysicalMemorySize");
+        assertContainsSensor("os.freeSwapSpaceSize");
+        assertContainsSensor("os.processCpuTime");
+        assertContainsSensor("os.totalPhysicalMemorySize");
+        assertContainsSensor("os.totalSwapSpaceSize");
+        assertContainsSensor("os.maxFileDescriptorCount");
+        assertContainsSensor("os.openFileDescriptorCount");
+
+        //only available on java 7+
+        //assertContainsSensor("os.processCpuLoad");
+        //assertContainsSensor("os.systemCpuLoad");
+    }
+
+    @Test
+    public void testSunManagementOperatingSystemImpl() {
+        assertContainsSensor("os.systemLoadAverage");
+
+        assumeOperatingSystemMXBean("sun.management.OperatingSystemImpl");
+
+        assertContainsSensor("os.committedVirtualMemorySize");
+        assertContainsSensor("os.freePhysicalMemorySize");
+        assertContainsSensor("os.freeSwapSpaceSize");
+        assertContainsSensor("os.processCpuTime");
+        assertContainsSensor("os.totalPhysicalMemorySize");
+        assertContainsSensor("os.totalSwapSpaceSize");
+        assertContainsSensor("os.maxFileDescriptorCount");
+        assertContainsSensor("os.openFileDescriptorCount");
+
+        assertContainsSensor("os.processCpuLoad");
+        assertContainsSensor("os.systemCpuLoad");
+    }
+
+    private void assertContainsSensor(String parameter) {
+        boolean contains = blackbox.getParameters().contains(parameter);
+        assertTrue("sensor:" + parameter + " is not found", contains);
+    }
+
+    private void assumeOperatingSystemMXBean(String expected) {
+        OperatingSystemMXBean bean = ManagementFactory.getOperatingSystemMXBean();
+
+        String foundClass = bean.getClass().getName();
+
+        assumeTrue(foundClass + " is not usable", expected.equals(foundClass));
+    }
+
+    @Test
+    public void registerMethod_whenDouble() {
+        FakeOperatingSystemBean fakeOperatingSystemBean = new FakeOperatingSystemBean();
+        registerMethod(blackbox, fakeOperatingSystemBean, "doubleMethod", "doubleMethod");
+
+        Sensor sensor = blackbox.getSensor("doubleMethod");
+        assertEquals(fakeOperatingSystemBean.doubleMethod(), sensor.readDouble(), 0.1);
+    }
+
+    @Test
+    public void registerMethod_whenLong() {
+        blackbox = new BlackboxImpl(Logger.getLogger(BlackboxImpl.class));
+
+        FakeOperatingSystemBean fakeOperatingSystemBean = new FakeOperatingSystemBean();
+        registerMethod(blackbox, fakeOperatingSystemBean, "longMethod", "longMethod");
+
+        Sensor sensor = blackbox.getSensor("longMethod");
+        assertEquals(fakeOperatingSystemBean.longMethod(), sensor.readLong());
+    }
+
+    @Test
+    public void registerMethod_whenNotExist() {
+        blackbox = new BlackboxImpl(Logger.getLogger(BlackboxImpl.class));
+
+        FakeOperatingSystemBean fakeOperatingSystemBean = new FakeOperatingSystemBean();
+        registerMethod(blackbox, fakeOperatingSystemBean, "notexist", "notexist");
+
+        boolean parameterExist = blackbox.getParameters().contains("notexist");
+        assertFalse(parameterExist);
+    }
+
+    public class FakeOperatingSystemBean {
+        double doubleMethod() {
+            return 10;
+        }
+
+        long longMethod() {
+            return 10;
+        }
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/blackbox/sensorpacks/RuntimeSensorPackTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/blackbox/sensorpacks/RuntimeSensorPackTest.java
@@ -1,0 +1,105 @@
+package com.hazelcast.internal.blackbox.sensorpacks;
+
+import com.hazelcast.internal.blackbox.Sensor;
+import com.hazelcast.internal.blackbox.impl.BlackboxImpl;
+import com.hazelcast.logging.Logger;
+import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.lang.management.ManagementFactory;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class RuntimeSensorPackTest extends HazelcastTestSupport {
+
+    private final static int TEN_MB = 10 * 1024 * 1024;
+
+    private BlackboxImpl blackbox;
+    private Runtime runtime;
+
+    @Before
+    public void setup() {
+        blackbox = new BlackboxImpl(Logger.getLogger(BlackboxImpl.class));
+        runtime = Runtime.getRuntime();
+    }
+
+    @Test
+    public void utilityConstructor(){
+        assertUtilityConstructor(RuntimeSensorPack.class);
+    }
+
+    @Test
+    public void freeMemory() {
+        final Sensor sensor = blackbox.getSensor("runtime.freeMemory");
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertEquals(runtime.freeMemory(), sensor.readLong(), TEN_MB);
+            }
+        });
+    }
+
+    @Test
+    public void totalMemory() {
+        final Sensor sensor = blackbox.getSensor("runtime.totalMemory");
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertEquals(runtime.totalMemory(), sensor.readLong(), TEN_MB);
+            }
+        });
+    }
+
+    @Test
+    public void maxMemory() {
+        final Sensor sensor = blackbox.getSensor("runtime.maxMemory");
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertEquals(runtime.maxMemory(), sensor.readLong(), TEN_MB);
+            }
+        });
+    }
+
+    @Test
+    public void usedMemory() {
+        final Sensor sensor = blackbox.getSensor("runtime.usedMemory");
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                double expected = runtime.totalMemory() - runtime.freeMemory();
+                assertEquals(expected, sensor.readLong(), TEN_MB);
+            }
+        });
+    }
+
+    @Test
+    public void availableProcessors() {
+        Sensor sensor = blackbox.getSensor("runtime.availableProcessors");
+        assertEquals(runtime.availableProcessors(), sensor.readLong());
+    }
+
+    @Test
+    public void uptime() {
+        final Sensor sensor = blackbox.getSensor("runtime.uptime");
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                double expected = ManagementFactory.getRuntimeMXBean().getUptime();
+                assertEquals(expected, sensor.readLong(), TimeUnit.MINUTES.toMillis(1));
+            }
+        });
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/blackbox/sensorpacks/ThreadSensorPackTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/blackbox/sensorpacks/ThreadSensorPackTest.java
@@ -1,0 +1,85 @@
+package com.hazelcast.internal.blackbox.sensorpacks;
+
+import com.hazelcast.internal.blackbox.Sensor;
+import com.hazelcast.internal.blackbox.impl.BlackboxImpl;
+import com.hazelcast.logging.Logger;
+import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadMXBean;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class ThreadSensorPackTest extends HazelcastTestSupport {
+
+    private static final ThreadMXBean MX_BEAN = ManagementFactory.getThreadMXBean();
+
+    private BlackboxImpl blackbox;
+
+    @Before
+    public void setup() {
+        blackbox = new BlackboxImpl(Logger.getLogger(BlackboxImpl.class));
+    }
+
+    @Test
+    public void utilityConstructor(){
+        assertUtilityConstructor(ThreadSensorPack.class);
+    }
+
+    @Test
+    public void threadCount() {
+        final Sensor sensor = blackbox.getSensor("thread.threadCount");
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertEquals(MX_BEAN.getThreadCount(), sensor.readLong(), 10);
+            }
+        });
+    }
+
+    @Test
+    public void peakThreadCount() {
+        final Sensor sensor = blackbox.getSensor("thread.peakThreadCount");
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertEquals(MX_BEAN.getPeakThreadCount(), sensor.readLong(), 10);
+            }
+        });
+    }
+
+    @Test
+    public void daemonThreadCount() {
+        final Sensor sensor = blackbox.getSensor("thread.daemonThreadCount");
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertEquals(MX_BEAN.getDaemonThreadCount(), sensor.readLong(), 10);
+            }
+        });
+    }
+
+    @Test
+    public void totalStartedThreadCount() {
+        final Sensor sensor = blackbox.getSensor("thread.totalStartedThreadCount");
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertEquals(MX_BEAN.getTotalStartedThreadCount(), sensor.readLong(), 10);
+            }
+        });
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/monitors/PerformanceMonitorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/monitors/PerformanceMonitorTest.java
@@ -1,0 +1,201 @@
+package com.hazelcast.internal.monitors;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.instance.HazelcastInstanceImpl;
+import com.hazelcast.instance.Node;
+import com.hazelcast.internal.blackbox.Blackbox;
+import com.hazelcast.internal.blackbox.LongSensorInput;
+import com.hazelcast.spi.AbstractOperation;
+import com.hazelcast.spi.impl.operationservice.InternalOperationService;
+import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.lang.reflect.Field;
+
+import static com.hazelcast.instance.GroupProperties.PROP_PERFORMANCE_MONITOR_DELAY_SECONDS;
+import static com.hazelcast.instance.GroupProperties.PROP_PERFORMANCE_MONITOR_ENABLED;
+import static com.hazelcast.instance.GroupProperties.PROP_PERFORMANCE_MONITOR_MAX_ROLLED_FILE_COUNT;
+import static com.hazelcast.instance.GroupProperties.PROP_PERFORMANCE_MONITOR_MAX_ROLLED_FILE_SIZE;
+import static com.hazelcast.instance.GroupProperties.PROP_SLOW_OPERATION_DETECTOR_ENABLED;
+import static com.hazelcast.instance.GroupProperties.PROP_SLOW_OPERATION_DETECTOR_THRESHOLD_MILLIS;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class PerformanceMonitorTest extends HazelcastTestSupport {
+
+    private PerformanceMonitor performanceMonitor;
+    private PerformanceLogFile performanceLogFile;
+    private InternalOperationService operationService;
+    private Blackbox blackbox;
+
+    @Before
+    public void setup() {
+        Config config = new Config();
+        config.setProperty(PROP_PERFORMANCE_MONITOR_ENABLED, "true");
+        config.setProperty(PROP_PERFORMANCE_MONITOR_DELAY_SECONDS, "1");
+        config.setProperty(PROP_PERFORMANCE_MONITOR_MAX_ROLLED_FILE_SIZE, "0.2");
+        config.setProperty(PROP_PERFORMANCE_MONITOR_MAX_ROLLED_FILE_COUNT, "3");
+
+        config.setProperty(PROP_SLOW_OPERATION_DETECTOR_ENABLED, "true");
+        config.setProperty(PROP_SLOW_OPERATION_DETECTOR_THRESHOLD_MILLIS, "2000");
+
+        HazelcastInstance hz = createHazelcastInstance(config);
+        performanceMonitor = getPerformanceMonitor(hz);
+        performanceLogFile = performanceMonitor.performanceLogFile;
+        operationService = getOperationService(hz);
+        blackbox = getBlackbox(hz);
+    }
+
+    @After
+    public void after() {
+
+    }
+
+    @Test
+    public void testHazelcastConfig() {
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                String content = loadLogfile();
+                assertNotNull(content);
+
+                assertTrue(content.contains("Hazelcast Config"));
+
+            }
+        });
+    }
+
+    @Test
+    public void testBlackbox() {
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                String content = loadLogfile();
+                assertNotNull(content);
+
+                assertTrue(content.contains("Blackbox"));
+                assertTrue(content.contains("operation.completed.count"));
+            }
+        });
+    }
+
+    @Test
+    public void testSystemProperties() {
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                String content = loadLogfile();
+                assertNotNull(content);
+                assertTrue(content.contains("System Properties"));
+                assertTrue(content.contains("java.home"));
+            }
+        });
+    }
+
+    @Test
+    public void testBuildInfo() {
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                String content = loadLogfile();
+                assertNotNull(content);
+
+                assertTrue(content.contains("Build Info"));
+                assertTrue(content.contains("BuildNumber"));
+            }
+        });
+    }
+
+//    @Test
+//    public void testRollover() {
+//        StringBuffer sb = new StringBuffer();
+//        for (int k = 0; k < 10000; k++) {
+//            sb.append('a');
+//        }
+//
+//        for (int k = 0; k < 5; k++) {
+//            blackbox.register(this, sb.toString() + k, new LongSensorInput<PerformanceMonitorTest>() {
+//                @Override
+//                public long get(PerformanceMonitorTest source) throws Exception {
+//                    return 0;
+//                }
+//            });
+//        }
+//
+//        sleepSeconds(600);
+//    }
+
+    @Test
+    public void testSlowOperationTest() throws InterruptedException {
+        operationService.invokeOnPartition(null, new MySlowOperation(), 1);
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                String content = loadLogfile();
+                assertNotNull(content);
+
+                assertTrue(content.contains("Slow Operations"));
+                assertTrue(content.contains("MySlowOperation"));
+            }
+        });
+    }
+
+    private String loadLogfile() {
+        File file = performanceLogFile.logFile;
+        if (file == null || !file.exists()) {
+            return null;
+        }
+
+        try {
+            BufferedReader br = new BufferedReader(new FileReader(file));
+            try {
+                StringBuilder sb = new StringBuilder();
+                String line = br.readLine();
+
+                while (line != null) {
+                    sb.append(line);
+                    sb.append("\n");
+                    line = br.readLine();
+                }
+                return sb.toString();
+            } finally {
+                br.close();
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public PerformanceMonitor getPerformanceMonitor(HazelcastInstance hazelcastInstance) {
+        try {
+            Field field = HazelcastInstanceImpl.class.getDeclaredField("performanceMonitor");
+            Node node = getNode(hazelcastInstance);
+            field.setAccessible(true);
+            return (PerformanceMonitor) field.get(node.hazelcastInstance);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static class MySlowOperation extends AbstractOperation {
+        @Override
+        public void run() throws Exception {
+            Thread.sleep(10000);
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/classic/AbstractClassicOperationExecutorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/classic/AbstractClassicOperationExecutorTest.java
@@ -5,6 +5,8 @@ import com.hazelcast.instance.BuildInfo;
 import com.hazelcast.instance.DefaultNodeExtension;
 import com.hazelcast.instance.GroupProperties;
 import com.hazelcast.instance.HazelcastThreadGroup;
+import com.hazelcast.internal.blackbox.impl.BlackboxImpl;
+import com.hazelcast.logging.Logger;
 import com.hazelcast.logging.LoggingServiceImpl;
 import com.hazelcast.nio.Address;
 import com.hazelcast.spi.impl.operationexecutor.OperationHostileThread;
@@ -51,6 +53,7 @@ public abstract class AbstractClassicOperationExecutorTest extends HazelcastTest
     protected ResponsePacketHandler responsePacketHandler;
     protected ClassicOperationExecutor executor;
     protected Config config;
+    protected BlackboxImpl blackbox;
 
     @Before
     public void setup() throws Exception {
@@ -69,6 +72,7 @@ public abstract class AbstractClassicOperationExecutorTest extends HazelcastTest
         nodeExtension = new DefaultNodeExtension();
         handlerFactory = new DummyOperationRunnerFactory();
 
+        blackbox = new BlackboxImpl(Logger.getLogger(BlackboxImpl.class));
         responsePacketHandler = new DummyResponsePacketHandler();
     }
 
@@ -76,7 +80,7 @@ public abstract class AbstractClassicOperationExecutorTest extends HazelcastTest
         groupProperties = new GroupProperties(config);
         executor = new ClassicOperationExecutor(
                 groupProperties, loggingService, thisAddress, handlerFactory, responsePacketHandler,
-                threadGroup, nodeExtension);
+                threadGroup, nodeExtension, blackbox);
         return executor;
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/classic/ClassicOperationExecutorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/classic/ClassicOperationExecutorTest.java
@@ -83,16 +83,4 @@ public class ClassicOperationExecutorTest extends AbstractClassicOperationExecut
             }
         });
     }
-
-    @Test
-    public void test_dumpPerformanceMetrics() {
-        initExecutor();
-
-        StringBuffer sb = new StringBuffer();
-        executor.dumpPerformanceMetrics(sb);
-        String content = sb.toString();
-
-
-        assertTrue(content.contains("processedCount="));
-    }
 }

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImplTest.java
@@ -9,6 +9,7 @@ import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.ResponseHandler;
 import com.hazelcast.spi.WaitNotifyKey;
 import com.hazelcast.spi.WaitSupport;
+import com.hazelcast.spi.impl.operationexecutor.OperationRunner;
 import com.hazelcast.spi.impl.operationservice.impl.responses.CallTimeoutResponse;
 import com.hazelcast.spi.impl.operationservice.impl.responses.NormalResponse;
 import com.hazelcast.test.ExpectedRuntimeException;
@@ -51,11 +52,13 @@ public class OperationRunnerImplTest extends HazelcastTestSupport {
         remote = cluster[1];
         operationService = (OperationServiceImpl) getOperationService(local);
         clusterService = getClusterService(local);
-        operationRunner = new OperationRunnerImpl(operationService, getPartitionId(local));
+        int partitionId = getPartitionId(local);
+        OperationRunner[] partitionOperationRunners = operationService.getOperationExecutor().getPartitionOperationRunners();
+        operationRunner = (OperationRunnerImpl)partitionOperationRunners[partitionId];
         responseHandler = mock(ResponseHandler.class);
     }
 
-    @Test
+     @Test
     public void runTask() {
         final AtomicLong counter = new AtomicLong();
         operationRunner.run(new Runnable() {

--- a/hazelcast/src/test/java/com/hazelcast/test/TestNodeRegistry.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/TestNodeRegistry.java
@@ -242,10 +242,6 @@ final class TestNodeRegistry {
             }
         }
 
-        @Override
-        public void dumpPerformanceMetrics(StringBuffer sb) {
-        }
-
         public Connection getConnection(Address address) {
             MockConnection conn = mapConnections.get(address);
             if (conn == null) {

--- a/hazelcast/src/test/java/com/hazelcast/util/counters/MwCounterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/counters/MwCounterTest.java
@@ -1,0 +1,44 @@
+package com.hazelcast.util.counters;
+
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.util.counters.MwCounter;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class MwCounterTest {
+    private MwCounter counter;
+
+    @Before
+    public void setup() {
+        counter = new MwCounter();
+    }
+
+    @Test
+    public void inc() {
+        counter.inc();
+        assertEquals(1, counter.get());
+
+    }
+
+    @Test
+    public void inc_withAmount() {
+        counter.inc(10);
+        assertEquals(10, counter.get());
+
+        counter.inc(0);
+        assertEquals(10, counter.get());
+    }
+
+    @Test
+    public void test_toString() {
+        String s = counter.toString();
+        assertEquals("Counter{value=0}", s);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/util/counters/SafeSwCounterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/counters/SafeSwCounterTest.java
@@ -1,0 +1,36 @@
+package com.hazelcast.util.counters;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class SafeSwCounterTest {
+    private SwCounter.SafeSwCounter counter;
+
+    @Before
+    public void setup() {
+        counter = new SwCounter.SafeSwCounter(0);
+    }
+
+    @Test
+    public void inc() {
+        counter.inc();
+        assertEquals(1, counter.get());
+    }
+
+    @Test
+    public void inc_withAmount() {
+        counter.inc(10);
+        assertEquals(10, counter.get());
+
+        counter.inc(0);
+        assertEquals(10, counter.get());
+    }
+
+    @Test
+    public void test_toString() {
+        String s = counter.toString();
+        assertEquals("Counter{value=0}", s);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/util/counters/SwCounterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/counters/SwCounterTest.java
@@ -1,0 +1,50 @@
+package com.hazelcast.util.counters;
+
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.util.counters.SwCounter;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static com.hazelcast.util.counters.SwCounter.newSwCounter;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * If Unsafe is available, this will trigger the testing of the {@link SwCounter.UnsafeSwCounter} class. Otherwise
+ * the {@link SwCounter.SafeSwCounter} is tested.
+ */
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class SwCounterTest {
+
+    private SwCounter counter;
+
+    @Before
+    public void setup() {
+        counter = newSwCounter();
+    }
+
+    @Test
+    public void inc() {
+        counter.inc();
+        assertEquals(1, counter.get());
+
+    }
+
+    @Test
+    public void inc_withAmount() {
+        counter.inc(10);
+        assertEquals(10, counter.get());
+
+        counter.inc(0);
+        assertEquals(10, counter.get());
+    }
+
+    @Test
+    public void test_toString() {
+        String s = counter.toString();
+        assertEquals("Counter{value=0}", s);
+    }
+}


### PR DESCRIPTION
This PR contains the integration of the blackbox sensors.

First the following pr, which contains the actual blackbox, needs to be merged:
https://github.com/hazelcast/hazelcast/pull/5167

The Blackbox provides insight what is happening inside of the Hazelcast member. It can currently be read using the Performance monitor which was completely rewritten for this purpose. In the future we'll add a real storage solution for the blackbox itself.

Lots of sensor points were added into the system. The SlowOperationDetector also dumps to the Performance log.

The blackbox is always on; it can't be disabled. The overhead of the blackbox is very low since it will periodically sample fields/methods of objects to get internal state. These fields can be simple volatile long and can even be written using a lazySet to make it even cheaper than a volatile write.

The blackbox will be the central hub to record/access all kinds of sensor data. Before it was done ad hoc and all over the place. But now all this information is accessible through the blackbox.

Sensor can easily be created by:
```
@SensorInput
private int field;

@SensorInput
int size(){return ....}
```
And then registering an object which such annotations at the blackbox.

The Performance log will not log indefinitely. It uses a rolling file approach and by default it allows for 10 files of 10mb to be kept on disk. This is configurable using properties (e.g. system properties).

An example log:
```
====================[ Build Info ]======================================
property                        value
------------------------------------------------------------------------
version                         3.5-SNAPSHOT
build                           20150411
buildNumber                     20150411
revision                        3.5-SNAPSHOT
enterprise                      false


================[ System Properties ]===================================
property                        value
------------------------------------------------------------------------
java.class.path                 /java/jdk/jdk1.8.0_25/jre/lib/jce.jar:/java/jdk/jdk1.8.0_25/jre/lib/rt.jar:/java/jdk/jdk1.8.0_25/jre/lib/plugin.jar:/java/jdk/jdk1.8.0_25/jre/lib/javaws.jar:/java/jdk/jdk1.8.0_25/jre/lib/charsets.jar:/java/jdk/jdk1.8.0_25/jre/lib/management-agent.jar:/java/jdk/jdk1.8.0_25/jre/lib/resources.jar:/java/jdk/jdk1.8.0_25/jre/lib/deploy.jar:/java/jdk/jdk1.8.0_25/jre/lib/jsse.jar:/java/jdk/jdk1.8.0_25/jre/lib/jfxswt.jar:/java/jdk/jdk1.8.0_25/jre/lib/jfr.jar:/java/jdk/jdk1.8.0_25/jre/lib/ext/localedata.jar:/java/jdk/jdk1.8.0_25/jre/lib/ext/nashorn.jar:/java/jdk/jdk1.8.0_25/jre/lib/ext/jfxrt.jar:/java/jdk/jdk1.8.0_25/jre/lib/ext/sunjce_provider.jar:/java/jdk/jdk1.8.0_25/jre/lib/ext/dnsns.jar:/java/jdk/jdk1.8.0_25/jre/lib/ext/sunec.jar:/java/jdk/jdk1.8.0_25/jre/lib/ext/zipfs.jar:/java/jdk/jdk1.8.0_25/jre/lib/ext/sunpkcs11.jar:/java/jdk/jdk1.8.0_25/jre/lib/ext/cldrdata.jar:/java/projects/Hazelcast/hazelcast/hazelcast-client/target/classes:/java/projects/Hazelcast/hazelcast/hazelcast/target/classes:/home/alarmnummer/.m2/repository/net/sourceforge/findbugs/annotations/1.3.2/annotations-1.3.2.jar:/home/alarmnummer/.m2/repository/com/eclipsesource/minimal-json/minimal-json/0.9.1/minimal-json-0.9.1.jar:/java/tools/idea-IU-139.224.1/lib/idea_rt.jar
java.class.version              52.0
java.endorsed.dirs              /java/jdk/jdk1.8.0_25/jre/lib/endorsed
java.ext.dirs                   /java/jdk/jdk1.8.0_25/jre/lib/ext:/usr/java/packages/lib/ext
java.home                       /java/jdk/jdk1.8.0_25/jre
java.io.tmpdir                  /tmp
java.library.path               /java/tools/idea-IU-139.224.1/bin::/usr/java/packages/lib/amd64:/usr/lib64:/lib64:/lib:/usr/lib
java.runtime.name               Java(TM) SE Runtime Environment
java.runtime.version            1.8.0_25-b17
java.specification.name         Java Platform API Specification
java.specification.vendor       Oracle Corporation
java.specification.version       1.8
java.vendor                     Oracle Corporation
java.vendor.url                 http://java.oracle.com/
java.vendor.url.bug             http://bugreport.sun.com/bugreport/
java.version                    1.8.0_25
java.vm.info                    mixed mode
java.vm.name                    Java HotSpot(TM) 64-Bit Server VM
java.vm.specification.name      Java Virtual Machine Specification
java.vm.specification.vendor    Oracle Corporation
java.vm.specification.version    1.8
java.vm.vendor                  Oracle Corporation
java.vm.version                 25.25-b02
os.arch                         amd64
os.name                         Linux
os.version                      3.14.13-100.fc19.x86_64
sun.arch.data.model               64
sun.boot.class.path             /java/jdk/jdk1.8.0_25/jre/lib/resources.jar:/java/jdk/jdk1.8.0_25/jre/lib/rt.jar:/java/jdk/jdk1.8.0_25/jre/lib/sunrsasign.jar:/java/jdk/jdk1.8.0_25/jre/lib/jsse.jar:/java/jdk/jdk1.8.0_25/jre/lib/jce.jar:/java/jdk/jdk1.8.0_25/jre/lib/charsets.jar:/java/jdk/jdk1.8.0_25/jre/lib/jfr.jar:/java/jdk/jdk1.8.0_25/jre/classes
sun.boot.library.path           /java/jdk/jdk1.8.0_25/jre/lib/amd64
sun.cpu.endian                  little
sun.cpu.isalist                     
sun.io.unicode.encoding         UnicodeLittle
sun.java.command                com.intellij.rt.execution.application.AppMain com.hazelcast.Main
sun.java.launcher               SUN_STANDARD
sun.jnu.encoding                UTF-8
sun.management.compiler         HotSpot 64-Bit Tiered Compilers
sun.os.patch.level              unknown
jvm.args                        jvm.args=-Didea.launcher.port=7538 -Didea.launcher.bin.path=/java/tools/idea-IU-139.224.1/bin -Dfile.encoding=UTF-8 


=================[ Hazelcast Config ]===================================
property                                                      value
------------------------------------------------------------------------
hazelcast.health.monitoring.delay.seconds                        1
hazelcast.performance.monitoring.delay.seconds                  10
hazelcast.performance.monitoring.enabled                      true


================[ Blackbox ]============================================
Mon, 13 Apr 2015 21:46:15 +0300
------------------------------------------------------------------------
client.endpoint.count=0
client.endpoint.totalRegistrations=0
cluster.clock.clusterTime=1428950775167
cluster.clock.clusterTimeDiff=9223372036854775807
cluster.lastHeartBeat=1428950774569
cluster.size=3
event.eventQueueSize=0
event.hz:core:proxyService.listenerCount=3
event.hz:core:proxyService.publicationCount=2
event.hz:impl:replicatedMapService.listenerCount=3
event.hz:impl:replicatedMapService.publicationCount=0
event.queueCapacity=1000000
event.rejectedCount=0
event.threadCount=5
event.totalFailureCount=0
executor.hz:async.activeCount=0
executor.hz:async.completedTaskCount=1
executor.hz:async.maximumPoolSize=8
executor.hz:async.poolSize=1
executor.hz:async.queueSize=0
executor.hz:async.remainingQueueCapacity=100000
executor.hz:client.activeCount=0
executor.hz:client.completedTaskCount=0
executor.hz:client.maximumPoolSize=160
executor.hz:client.poolSize=0
executor.hz:client.queueSize=0
executor.hz:client.remainingQueueCapacity=800000
executor.hz:cluster.activeCount=0
executor.hz:cluster.completedTaskCount=33
executor.hz:cluster.maximumPoolSize=2
executor.hz:cluster.poolSize=0
executor.hz:cluster.queueSize=0
executor.hz:cluster.remainingQueueCapacity=1000
executor.hz:io.queueSize=NA
executor.hz:map-load.queueSize=NA
executor.hz:map-loadAllKeys.queueSize=NA
executor.hz:query.queueSize=NA
executor.hz:scheduled.activeCount=0
executor.hz:scheduled.completedTaskCount=331
executor.hz:scheduled.maximumPoolSize=16
executor.hz:scheduled.poolSize=0
executor.hz:scheduled.queueSize=0
executor.hz:scheduled.remainingQueueCapacity=800000
executor.hz:system.activeCount=0
executor.hz:system.completedTaskCount=8
executor.hz:system.maximumPoolSize=8
executor.hz:system.poolSize=0
executor.hz:system.queueSize=0
executor.hz:system.remainingQueueCapacity=2147483647
gc.majorCount=0
gc.majorTime=0
gc.minorCount=31
gc.minorTime=223
gc.unknownCount=0
gc.unknownTime=0
operation.completed.count=58197
operation.invocations.backupTimeouts=0
operation.invocations.normalTimeouts=0
operation.invocations.pending=1
operation.invocations.used=NA
operation.invocations.usedPercentage=0.0
operation.partition[0].count=0
operation.partition[100].count=354
operation.partition[101].count=0
operation.partition[102].count=340
operation.partition[103].count=302
operation.partition[104].count=323
operation.partition[105].count=346
operation.partition[106].count=310
operation.partition[107].count=331
operation.partition[108].count=317
operation.partition[109].count=331
operation.partition[10].count=319
operation.partition[110].count=0
operation.partition[111].count=318
operation.partition[112].count=318
operation.partition[113].count=308
operation.partition[114].count=305
operation.partition[115].count=0
operation.partition[116].count=337
operation.partition[117].count=328
operation.partition[118].count=372
operation.partition[119].count=0
operation.partition[11].count=0
operation.partition[120].count=342
operation.partition[121].count=317
operation.partition[122].count=0
operation.partition[123].count=326
operation.partition[124].count=311
operation.partition[125].count=320
operation.partition[126].count=304
operation.partition[127].count=0
operation.partition[128].count=0
operation.partition[129].count=0
operation.partition[12].count=304
operation.partition[130].count=0
operation.partition[131].count=315
operation.partition[132].count=0
operation.partition[133].count=0
operation.partition[134].count=327
operation.partition[135].count=0
operation.partition[136].count=341
operation.partition[137].count=349
operation.partition[138].count=347
operation.partition[139].count=282
operation.partition[13].count=300
operation.partition[140].count=309
operation.partition[141].count=310
operation.partition[142].count=318
operation.partition[143].count=360
operation.partition[144].count=319
operation.partition[145].count=306
operation.partition[146].count=293
operation.partition[147].count=299
operation.partition[148].count=0
operation.partition[149].count=307
operation.partition[14].count=0
operation.partition[150].count=303
operation.partition[151].count=0
operation.partition[152].count=326
operation.partition[153].count=330
operation.partition[154].count=342
operation.partition[155].count=0
operation.partition[156].count=0
operation.partition[157].count=304
operation.partition[158].count=0
operation.partition[159].count=331
operation.partition[15].count=337
operation.partition[160].count=312
operation.partition[161].count=334
operation.partition[162].count=0
operation.partition[163].count=322
operation.partition[164].count=0
operation.partition[165].count=0
operation.partition[166].count=0
operation.partition[167].count=0
operation.partition[168].count=316
operation.partition[169].count=321
operation.partition[16].count=348
operation.partition[170].count=319
operation.partition[171].count=335
operation.partition[172].count=295
operation.partition[173].count=334
operation.partition[174].count=0
operation.partition[175].count=0
operation.partition[176].count=313
operation.partition[177].count=0
operation.partition[178].count=0
operation.partition[179].count=322
operation.partition[17].count=291
operation.partition[180].count=0
operation.partition[181].count=333
operation.partition[182].count=348
operation.partition[183].count=306
operation.partition[184].count=0
operation.partition[185].count=337
operation.partition[186].count=321
operation.partition[187].count=0
operation.partition[188].count=0
operation.partition[189].count=0
operation.partition[18].count=0
operation.partition[190].count=0
operation.partition[191].count=0
operation.partition[192].count=0
operation.partition[193].count=337
operation.partition[194].count=0
operation.partition[195].count=0
operation.partition[196].count=0
operation.partition[197].count=322
operation.partition[198].count=330
operation.partition[199].count=0
operation.partition[19].count=306
operation.partition[1].count=335
operation.partition[200].count=0
operation.partition[201].count=0
operation.partition[202].count=0
operation.partition[203].count=315
operation.partition[204].count=344
operation.partition[205].count=304
operation.partition[206].count=331
operation.partition[207].count=356
operation.partition[208].count=0
operation.partition[209].count=346
operation.partition[20].count=321
operation.partition[210].count=0
operation.partition[211].count=303
operation.partition[212].count=323
operation.partition[213].count=334
operation.partition[214].count=337
operation.partition[215].count=364
operation.partition[216].count=325
operation.partition[217].count=308
operation.partition[218].count=331
operation.partition[219].count=329
operation.partition[21].count=313
operation.partition[220].count=341
operation.partition[221].count=0
operation.partition[222].count=337
operation.partition[223].count=357
operation.partition[224].count=0
operation.partition[225].count=0
operation.partition[226].count=328
operation.partition[227].count=0
operation.partition[228].count=322
operation.partition[229].count=323
operation.partition[22].count=0
operation.partition[230].count=0
operation.partition[231].count=0
operation.partition[232].count=313
operation.partition[233].count=0
operation.partition[234].count=301
operation.partition[235].count=377
operation.partition[236].count=308
operation.partition[237].count=326
operation.partition[238].count=339
operation.partition[239].count=0
operation.partition[23].count=356
operation.partition[240].count=304
operation.partition[241].count=321
operation.partition[242].count=274
operation.partition[243].count=317
operation.partition[244].count=341
operation.partition[245].count=342
operation.partition[246].count=337
operation.partition[247].count=313
operation.partition[248].count=326
operation.partition[249].count=0
operation.partition[24].count=343
operation.partition[250].count=0
operation.partition[251].count=306
operation.partition[252].count=320
operation.partition[253].count=311
operation.partition[254].count=304
operation.partition[255].count=301
operation.partition[256].count=0
operation.partition[257].count=0
operation.partition[258].count=0
operation.partition[259].count=308
operation.partition[25].count=0
operation.partition[260].count=321
operation.partition[261].count=334
operation.partition[262].count=300
operation.partition[263].count=299
operation.partition[264].count=309
operation.partition[265].count=0
operation.partition[266].count=0
operation.partition[267].count=0
operation.partition[268].count=0
operation.partition[269].count=0
operation.partition[26].count=294
operation.partition[270].count=343
operation.partition[27].count=308
operation.partition[28].count=336
operation.partition[29].count=340
operation.partition[2].count=331
operation.partition[30].count=0
operation.partition[31].count=329
operation.partition[32].count=0
operation.partition[33].count=0
operation.partition[34].count=322
operation.partition[35].count=0
operation.partition[36].count=311
operation.partition[37].count=0
operation.partition[38].count=345
operation.partition[39].count=329
operation.partition[3].count=330
operation.partition[40].count=333
operation.partition[41].count=288
operation.partition[42].count=321
operation.partition[43].count=307
operation.partition[44].count=349
operation.partition[45].count=332
operation.partition[46].count=343
operation.partition[47].count=291
operation.partition[48].count=327
operation.partition[49].count=324
operation.partition[4].count=0
operation.partition[50].count=303
operation.partition[51].count=264
operation.partition[52].count=318
operation.partition[53].count=0
operation.partition[54].count=0
operation.partition[55].count=374
operation.partition[56].count=340
operation.partition[57].count=341
operation.partition[58].count=341
operation.partition[59].count=309
operation.partition[5].count=0
operation.partition[60].count=356
operation.partition[61].count=0
operation.partition[62].count=340
operation.partition[63].count=320
operation.partition[64].count=0
operation.partition[65].count=331
operation.partition[66].count=0
operation.partition[67].count=277
operation.partition[68].count=314
operation.partition[69].count=0
operation.partition[6].count=312
operation.partition[70].count=298
operation.partition[71].count=0
operation.partition[72].count=0
operation.partition[73].count=339
operation.partition[74].count=0
operation.partition[75].count=0
operation.partition[76].count=0
operation.partition[77].count=312
operation.partition[78].count=300
operation.partition[79].count=0
operation.partition[7].count=342
operation.partition[80].count=294
operation.partition[81].count=319
operation.partition[82].count=304
operation.partition[83].count=345
operation.partition[84].count=356
operation.partition[85].count=320
operation.partition[86].count=301
operation.partition[87].count=339
operation.partition[88].count=326
operation.partition[89].count=313
operation.partition[8].count=331
operation.partition[90].count=282
operation.partition[91].count=338
operation.partition[92].count=351
operation.partition[93].count=0
operation.partition[94].count=322
operation.partition[95].count=0
operation.partition[96].count=0
operation.partition[97].count=0
operation.partition[98].count=333
operation.partition[99].count=0
operation.partition[9].count=308
operation.priority-queue.size=0
operation.queue.size=0
operation.response-queue.size=0
operation.response.backup.count=87132
operation.response.error.count=1
operation.response.normal.count=58271
operation.response.timeout.count=0
operation.running.count=0
os.committedVirtualMemorySize=8645160960
os.freePhysicalMemorySize=2601811968
os.freeSwapSpaceSize=19827253248
os.maxFileDescriptorCount=4096
os.openFileDescriptorCount=109
os.processCpuLoad=19.0
os.processCpuTime=24480000000
os.systemCpuLoad=24.0
os.systemLoadAverage=0.76
os.totalPhysicalMemorySize=10477973504
os.totalSwapSpaceSize=20003876864
proxy.createdCount=0
proxy.destroyedCount=0
proxy.proxyCount=1
runtime.availableMemory=NA
runtime.availableProcessors=8
runtime.freeMemory=45734448
runtime.maxMemory=2330460160
runtime.totalMemory=166723584
runtime.usedMemory=120989136
tcp.connection.acceptedSocketCount=0
tcp.connection.activeCount=2
tcp.connection.clientCount=0
tcp.connection.closedCount=0
tcp.connection.connectionListenerCount=2
tcp.connection.count=2
tcp.connection.inProgressCount=0
tcp.connection.monitorCount=2
tcp.connection.openedCount=2
tcp.connection.textCount=0
tcp.connection[192.168.0.105/192.168.0.105:45968].bytesRead=9862390
tcp.connection[192.168.0.105/192.168.0.105:45968].bytesWritten=13537443
tcp.connection[192.168.0.105/192.168.0.105:45968].lastReadTime=1428950775169
tcp.connection[192.168.0.105/192.168.0.105:45968].lastWriteTime=1428950775169
tcp.connection[192.168.0.105/192.168.0.105:45968].normalPacketsRead=73944
tcp.connection[192.168.0.105/192.168.0.105:45968].normalPacketsWritten=43018
tcp.connection[192.168.0.105/192.168.0.105:45968].normalQueue.size=0
tcp.connection[192.168.0.105/192.168.0.105:45968].priorityPacketsRead=65
tcp.connection[192.168.0.105/192.168.0.105:45968].priorityPacketsWritten=61
tcp.connection[192.168.0.105/192.168.0.105:45968].priorityQueue.size=0
tcp.connection[192.168.0.105/192.168.0.105:45968].readEvents=58573
tcp.connection[192.168.0.105/192.168.0.105:45968].readExceptions=0
tcp.connection[192.168.0.105/192.168.0.105:45968].writeEvents=43044
tcp.connection[192.168.0.105/192.168.0.105:45968].writeExceptions=0
tcp.connection[192.168.0.105/192.168.0.105:57109].bytesRead=8875848
tcp.connection[192.168.0.105/192.168.0.105:57109].bytesWritten=14305625
tcp.connection[192.168.0.105/192.168.0.105:57109].lastReadTime=1428950775169
tcp.connection[192.168.0.105/192.168.0.105:57109].lastWriteTime=1428950775169
tcp.connection[192.168.0.105/192.168.0.105:57109].normalPacketsRead=71472
tcp.connection[192.168.0.105/192.168.0.105:57109].normalPacketsWritten=44219
tcp.connection[192.168.0.105/192.168.0.105:57109].normalQueue.size=0
tcp.connection[192.168.0.105/192.168.0.105:57109].priorityPacketsRead=81
tcp.connection[192.168.0.105/192.168.0.105:57109].priorityPacketsWritten=76
tcp.connection[192.168.0.105/192.168.0.105:57109].priorityQueue.size=0
tcp.connection[192.168.0.105/192.168.0.105:57109].readEvents=58055
tcp.connection[192.168.0.105/192.168.0.105:57109].readExceptions=0
tcp.connection[192.168.0.105/192.168.0.105:57109].writeEvents=44245
tcp.connection[192.168.0.105/192.168.0.105:57109].writeExceptions=0
tcp.hz._hzInstance_1_dev.IO.thread-in-0.readEvents=58055
tcp.hz._hzInstance_1_dev.IO.thread-in-1.readEvents=58573
tcp.hz._hzInstance_1_dev.IO.thread-in-2.readEvents=0
tcp.hz._hzInstance_1_dev.IO.thread-out-0.writeEvents=1
tcp.hz._hzInstance_1_dev.IO.thread-out-1.writeEvents=1
tcp.hz._hzInstance_1_dev.IO.thread-out-2.writeEvents=0
thread.daemonThreadCount=137
thread.peakThreadCount=137
thread.threadCount=137
thread.totalStartedThreadCount=139
```