### PR TITLE
spring schema supporting aws disabled

### DIFF
--- a/hazelcast-spring/src/main/resources/hazelcast-spring-3.5.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-3.5.xsd
@@ -1273,8 +1273,8 @@
     <xs:complexType name="aws">
         <xs:sequence/>
         <xs:attribute name="enabled" type="xs:string" use="optional" default="true"/>
-        <xs:attribute name="access-key" type="xs:string" use="optional" default=""/>
-        <xs:attribute name="secret-key" type="xs:string" use="optional" default=""/>
+        <xs:attribute name="access-key"  type="xs:string" use="optional"/>
+        <xs:attribute name="secret-key" type="xs:string" use="optional"/>
         <xs:attribute name="region" type="xs:string" use="optional" default="us-east-1"/>
         <xs:attribute name="host-header" type="xs:string" use="optional" default="ec2.amazonaws.com"/>
         <xs:attribute name="security-group-name" type="xs:string" use="optional" default=""/>

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/beans-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/beans-applicationContext-hazelcast.xml
@@ -33,6 +33,7 @@
                         <hz:interface>127.0.0.1:5701</hz:interface>
                         <hz:interface>127.0.0.1:5702</hz:interface>
                     </hz:tcp-ip>
+                    <hz:aws enabled="false"/>
                 </hz:join>
                 <hz:interfaces enabled="true">
                     <hz:interface>127.0.0.1</hz:interface>


### PR DESCRIPTION
default values of secret-key and access-key of aws config were "" ( empty string) in spring xsd.
But in hazelcast aws config we have empty string checking, see:  https://github.com/hazelcast/hazelcast/blob/master/hazelcast/src/main/java/com/hazelcast/config/AwsConfig.java#L74

so in spring xsd we have to remove default values.

this pr closes #4310 