### PR TITLE
Minor changes to logging of slow operations

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/instance/GroupProperties.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/GroupProperties.java
@@ -188,6 +188,13 @@ public class GroupProperties {
     public static final String PROP_SLOW_OPERATION_DETECTOR_LOG_PURGE_INTERVAL_SECONDS
             = "hazelcast.slow.operation.detector.log.purge.interval.seconds";
 
+    /**
+     * Defines if the stack traces of slow operations are logged in the log file. Stack traces will always be reported to the
+     * Management Center, but as default they are not printed to keep the log size small.
+     */
+    public static final String PROP_SLOW_OPERATION_DETECTOR_STACK_TRACE_LOGGING_ENABLED
+            = "hazelcast.slow.operation.detector.stacktrace.logging.enabled";
+
     // OLD ELASTIC MEMORY PROPS
     public static final String PROP_ELASTIC_MEMORY_ENABLED = "hazelcast.elastic.memory.enabled";
     public static final String PROP_ELASTIC_MEMORY_TOTAL_SIZE = "hazelcast.elastic.memory.total.size";
@@ -407,6 +414,7 @@ public class GroupProperties {
     public final GroupProperty SLOW_OPERATION_DETECTOR_THRESHOLD_MILLIS;
     public final GroupProperty SLOW_OPERATION_DETECTOR_LOG_RETENTION_SECONDS;
     public final GroupProperty SLOW_OPERATION_DETECTOR_LOG_PURGE_INTERVAL_SECONDS;
+    public final GroupProperty SLOW_OPERATION_DETECTOR_STACK_TRACE_LOGGING_ENABLED;
 
     public final GroupProperty ELASTIC_MEMORY_ENABLED;
 
@@ -533,6 +541,8 @@ public class GroupProperties {
                 = new GroupProperty(config, PROP_SLOW_OPERATION_DETECTOR_LOG_RETENTION_SECONDS, "3600");
         SLOW_OPERATION_DETECTOR_LOG_PURGE_INTERVAL_SECONDS
                 = new GroupProperty(config, PROP_SLOW_OPERATION_DETECTOR_LOG_PURGE_INTERVAL_SECONDS, "300");
+        SLOW_OPERATION_DETECTOR_STACK_TRACE_LOGGING_ENABLED
+                = new GroupProperty(config, PROP_SLOW_OPERATION_DETECTOR_STACK_TRACE_LOGGING_ENABLED, "false");
 
         ELASTIC_MEMORY_ENABLED = new GroupProperty(config, PROP_ELASTIC_MEMORY_ENABLED, "false");
         ELASTIC_MEMORY_TOTAL_SIZE = new GroupProperty(config, PROP_ELASTIC_MEMORY_TOTAL_SIZE, "128M");

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/dto/SlowOperationInvocationDTO.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/dto/SlowOperationInvocationDTO.java
@@ -5,6 +5,7 @@ import com.hazelcast.internal.management.JsonSerializable;
 
 import static com.hazelcast.util.JsonUtil.getInt;
 import static com.hazelcast.util.JsonUtil.getLong;
+import static com.hazelcast.util.JsonUtil.getString;
 
 /**
  * A Serializable DTO for {@link com.hazelcast.spi.impl.operationexecutor.slowoperationdetector.SlowOperationLog.Invocation}.
@@ -12,14 +13,16 @@ import static com.hazelcast.util.JsonUtil.getLong;
 public class SlowOperationInvocationDTO implements JsonSerializable {
 
     public int id;
+    public String operationDetails;
     public long startedAt;
     public int durationMs;
 
     public SlowOperationInvocationDTO() {
     }
 
-    public SlowOperationInvocationDTO(int id, long startedAt, int durationMs) {
+    public SlowOperationInvocationDTO(int id, String operationDetails, long startedAt, int durationMs) {
         this.id = id;
+        this.operationDetails = operationDetails;
         this.startedAt = startedAt;
         this.durationMs = durationMs;
     }
@@ -27,6 +30,7 @@ public class SlowOperationInvocationDTO implements JsonSerializable {
     public JsonObject toJson() {
         JsonObject root = new JsonObject();
         root.add("id", id);
+        root.add("details", operationDetails);
         root.add("startedAt", startedAt);
         root.add("durationMs", durationMs);
         return root;
@@ -35,6 +39,7 @@ public class SlowOperationInvocationDTO implements JsonSerializable {
     @Override
     public void fromJson(JsonObject json) {
         id = getInt(json, "id");
+        operationDetails = getString(json, "details");
         startedAt = getLong(json, "startedAt");
         durationMs = getInt(json, "durationMs");
     }

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/slowoperationdetector/SlowOperationDetectorAbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/slowoperationdetector/SlowOperationDetectorAbstractTest.java
@@ -140,7 +140,8 @@ abstract class SlowOperationDetectorAbstractTest extends HazelcastTestSupport {
 
     static void assertEntryProcessorOperation(SlowOperationLog log) {
         String operation = log.operation;
-        assertEqualsStringFormat("Expected operation %s, but was %s", "PartitionWideEntryWithPredicateOperation{}", operation);
+        assertEqualsStringFormat("Expected operation %s, but was %s",
+                "com.hazelcast.map.impl.operation.PartitionWideEntryWithPredicateOperation", operation);
     }
 
     static void assertOperationContainsClassName(SlowOperationLog log, String className) {

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/slowoperationdetector/SlowOperationDetector_JsonTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/slowoperationdetector/SlowOperationDetector_JsonTest.java
@@ -59,8 +59,14 @@ public class SlowOperationDetector_JsonTest extends SlowOperationDetectorAbstrac
 
     @Test
     public void testJSON() throws InterruptedException {
+        final String operationDetails = "FakeOperation(id=255, partitionId=2)";
+        Object operation = new Object() {
+            @Override
+            public String toString() {
+                return operationDetails;
+            }
+        };
         String stackTrace = "stackTrace";
-        String operation = "fakeOperation";
         int id = 5;
         int durationMs = 4444;
         long nowMillis = System.currentTimeMillis();
@@ -69,20 +75,22 @@ public class SlowOperationDetector_JsonTest extends SlowOperationDetectorAbstrac
 
         SlowOperationLog log = new SlowOperationLog(stackTrace, operation);
         log.totalInvocations.incrementAndGet();
-        log.getOrCreate(id, durationNanos, nowNanos, nowMillis);
+        log.getOrCreate(id, operationDetails, durationNanos, nowNanos, nowMillis);
 
         JsonObject json = log.createDTO().toJson();
         logger.finest(json.toString());
 
         SlowOperationDTO slowOperationDTO = new SlowOperationDTO();
         slowOperationDTO.fromJson(json);
+        assertTrue(format("Expected operation '%s' to contain inner class", slowOperationDTO.operation),
+                slowOperationDTO.operation.contains("SlowOperationDetector_JsonTest$1"));
         assertEqualsStringFormat("Expected stack trace '%s', but was '%s'", stackTrace, slowOperationDTO.stackTrace);
-        assertEqualsStringFormat("Expected operation '%s', but was '%s'", operation, slowOperationDTO.operation);
         assertEqualsStringFormat("Expected totalInvocations '%d', but was '%d'", 1, slowOperationDTO.totalInvocations);
         assertEqualsStringFormat("Expected invocations.size() '%d', but was '%d'", 1, slowOperationDTO.invocations.size());
 
         SlowOperationInvocationDTO invocationDTO = slowOperationDTO.invocations.get(0);
         assertEqualsStringFormat("Expected id '%d', but was '%d'", id, invocationDTO.id);
+        assertEqualsStringFormat("Expected details '%s', but was '%s'", operationDetails, invocationDTO.operationDetails);
         assertEqualsStringFormat("Expected startedAt '%d', but was '%d'", nowMillis - durationMs, invocationDTO.startedAt);
         assertEqualsStringFormat("Expected durationMs '%d', but was '%d'", durationMs, invocationDTO.durationMs);
     }


### PR DESCRIPTION
* Changed the content of operation in slow operation logs to contain the fully qualified classname instead of `operation.toString()`.
* Added `operation.toString()` as details to each invocation and `SlowOperationInvocationDTO`.
* Added a property to switch off stack trace logging.

Fixes #5041 and #5043.