### PR TITLE
hazelcast-client-full xml revision

### DIFF
--- a/hazelcast-client-new/src/main/resources/hazelcast-client-full.xml
+++ b/hazelcast-client-new/src/main/resources/hazelcast-client-full.xml
@@ -23,20 +23,34 @@
         <name>dev</name>
         <password>dev-pass</password>
     </group>
+    <license-key>HAZELCAST_ENTERPRISE_LICENSE_KEY</license-key>
     <properties>
-        <property name="hazelcast.client.connection.timeout">10000</property>
-        <property name="hazelcast.client.retry.count">6</property>
+        <property name="hazelcast.client.shuffle.member.list">true</property>
+        <property name="hazelcast.client.heartbeat.timeout">60000</property>
+        <property name="hazelcast.client.heartbeat.interval">5000</property>
+        <property name="hazelcast.client.event.thread.count">5</property>
+        <property name="hazelcast.client.event.queue.capacity">1000000</property>
+        <property name="hazelcast.client.invocation.timeout.seconds">120</property>
     </properties>
 
     <network>
-        <connection-attempt-limit>0</connection-attempt-limit>
         <cluster-members>
             <address>127.0.0.1</address>
             <address>127.0.0.2</address>
         </cluster-members>
         <smart-routing>true</smart-routing>
         <redo-operation>true</redo-operation>
-
+        <connection-timeout>60000</connection-timeout>
+        <connection-attempt-period>3000</connection-attempt-period>
+        <connection-attempt-limit>2</connection-attempt-limit>
+        <socket-options>
+            <tcp-no-delay>false</tcp-no-delay>
+            <keep-alive>true</keep-alive>
+            <reuse-address>true</reuse-address>
+            <linger-seconds>3</linger-seconds>
+            <timeout>-1</timeout>
+            <buffer-size>32</buffer-size>
+        </socket-options>
         <socket-interceptor enabled="true">
             <class-name>com.hazelcast.examples.MySocketInterceptor</class-name>
             <properties>
@@ -44,6 +58,9 @@
             </properties>
         </socket-interceptor>
 
+        <ssl enabled="false">
+            <factory-class-name>com.hazelcast.examples.MySslFactory</factory-class-name>
+        </ssl>
         <aws enabled="true" connection-timeout-seconds="11">
             <inside-aws>true</inside-aws>
             <access-key>TEST_ACCESS_KEY</access-key>
@@ -92,22 +109,29 @@
         <check-class-def-errors>true</check-class-def-errors>
     </serialization>
 
+    <native-memory enabled="false" allocator-type="POOLED">
+        <size unit="MEGABYTES" value="128" />
+        <min-block-size>1</min-block-size>
+        <page-size>1</page-size>
+        <metadata-space-percentage>40.5</metadata-space-percentage>
+    </native-memory>
+
     <proxy-factories>
         <proxy-factory class-name="com.hazelcast.examples.ProxyXYZ1" service="sampleService1"/>
         <proxy-factory class-name="com.hazelcast.examples.ProxyXYZ2" service="sampleService1"/>
         <proxy-factory class-name="com.hazelcast.examples.ProxyXYZ3" service="sampleService3"/>
-
     </proxy-factories>
 
     <load-balancer type="random"/>
 
-    <near-cache name="asd">
+    <near-cache name="default">
         <max-size>2000</max-size>
         <time-to-live-seconds>90</time-to-live-seconds>
         <max-idle-seconds>100</max-idle-seconds>
         <eviction-policy>LFU</eviction-policy>
         <invalidate-on-change>true</invalidate-on-change>
         <in-memory-format>OBJECT</in-memory-format>
+        <local-update-policy>INVALIDATE</local-update-policy>
     </near-cache>
 
     <query-caches>

--- a/hazelcast-client-new/src/test/java/com/hazelcast/client/config/XmlClientConfigBuilderTest.java
+++ b/hazelcast-client-new/src/test/java/com/hazelcast/client/config/XmlClientConfigBuilderTest.java
@@ -60,7 +60,6 @@ import java.util.Map;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -147,15 +146,14 @@ public class XmlClientConfigBuilderTest {
 
     @Test
     public void testProperties() {
-        assertEquals(2, clientConfig.getProperties().size());
-        assertEquals("10000", clientConfig.getProperty("hazelcast.client.connection.timeout"));
-        assertEquals("6", clientConfig.getProperty("hazelcast.client.retry.count"));
+        assertEquals(6, clientConfig.getProperties().size());
+        assertEquals("60000", clientConfig.getProperty("hazelcast.client.heartbeat.timeout"));
     }
 
     @Test
     public void testNetworkConfig() {
         final ClientNetworkConfig networkConfig = clientConfig.getNetworkConfig();
-        assertEquals(0, networkConfig.getConnectionAttemptLimit());
+        assertEquals(2, networkConfig.getConnectionAttemptLimit());
         assertEquals(2, networkConfig.getAddresses().size());
         assertTrue(networkConfig.getAddresses().contains("127.0.0.1"));
         assertTrue(networkConfig.getAddresses().contains("127.0.0.2"));
@@ -223,7 +221,6 @@ public class XmlClientConfigBuilderTest {
 
     @Test
     public void testNearCacheConfigs() {
-        assertNull(clientConfig.getNearCacheConfig("undefined"));
         assertEquals(1, clientConfig.getNearCacheConfigMap().size());
         final NearCacheConfig nearCacheConfig = clientConfig.getNearCacheConfig("asd");
 

--- a/hazelcast-client/src/main/resources/hazelcast-client-full.xml
+++ b/hazelcast-client/src/main/resources/hazelcast-client-full.xml
@@ -23,20 +23,34 @@
         <name>dev</name>
         <password>dev-pass</password>
     </group>
+    <license-key>HAZELCAST_ENTERPRISE_LICENSE_KEY</license-key>
     <properties>
-        <property name="hazelcast.client.connection.timeout">10000</property>
-        <property name="hazelcast.client.retry.count">6</property>
+        <property name="hazelcast.client.shuffle.member.list">true</property>
+        <property name="hazelcast.client.heartbeat.timeout">60000</property>
+        <property name="hazelcast.client.heartbeat.interval">5000</property>
+        <property name="hazelcast.client.event.thread.count">5</property>
+        <property name="hazelcast.client.event.queue.capacity">1000000</property>
+        <property name="hazelcast.client.invocation.timeout.seconds">120</property>
     </properties>
 
     <network>
-        <connection-attempt-limit>0</connection-attempt-limit>
         <cluster-members>
             <address>127.0.0.1</address>
             <address>127.0.0.2</address>
         </cluster-members>
         <smart-routing>true</smart-routing>
         <redo-operation>true</redo-operation>
-
+        <connection-timeout>60000</connection-timeout>
+        <connection-attempt-period>3000</connection-attempt-period>
+        <connection-attempt-limit>2</connection-attempt-limit>
+        <socket-options>
+            <tcp-no-delay>false</tcp-no-delay>
+            <keep-alive>true</keep-alive>
+            <reuse-address>true</reuse-address>
+            <linger-seconds>3</linger-seconds>
+            <timeout>-1</timeout>
+            <buffer-size>32</buffer-size>
+        </socket-options>
         <socket-interceptor enabled="true">
             <class-name>com.hazelcast.examples.MySocketInterceptor</class-name>
             <properties>
@@ -44,6 +58,9 @@
             </properties>
         </socket-interceptor>
 
+        <ssl enabled="false">
+           <factory-class-name>com.hazelcast.examples.MySslFactory</factory-class-name>
+        </ssl>
         <aws enabled="true" connection-timeout-seconds="11">
             <inside-aws>true</inside-aws>
             <access-key>TEST_ACCESS_KEY</access-key>
@@ -92,22 +109,29 @@
         <check-class-def-errors>true</check-class-def-errors>
     </serialization>
 
+    <native-memory enabled="false" allocator-type="POOLED">
+        <size unit="MEGABYTES" value="128" />
+        <min-block-size>1</min-block-size>
+        <page-size>1</page-size>
+        <metadata-space-percentage>40.5</metadata-space-percentage>
+    </native-memory>
+    
     <proxy-factories>
         <proxy-factory class-name="com.hazelcast.examples.ProxyXYZ1" service="sampleService1"/>
         <proxy-factory class-name="com.hazelcast.examples.ProxyXYZ2" service="sampleService1"/>
         <proxy-factory class-name="com.hazelcast.examples.ProxyXYZ3" service="sampleService3"/>
-
     </proxy-factories>
 
     <load-balancer type="random"/>
 
-    <near-cache name="asd">
+    <near-cache name="default">
         <max-size>2000</max-size>
         <time-to-live-seconds>90</time-to-live-seconds>
         <max-idle-seconds>100</max-idle-seconds>
         <eviction-policy>LFU</eviction-policy>
         <invalidate-on-change>true</invalidate-on-change>
         <in-memory-format>OBJECT</in-memory-format>
+        <local-update-policy>INVALIDATE</local-update-policy>
     </near-cache>
 
     <query-caches>

--- a/hazelcast-client/src/test/java/com/hazelcast/client/config/XmlClientConfigBuilderTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/config/XmlClientConfigBuilderTest.java
@@ -60,7 +60,6 @@ import java.util.Map;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -147,15 +146,14 @@ public class XmlClientConfigBuilderTest {
 
     @Test
     public void testProperties() {
-        assertEquals(2, clientConfig.getProperties().size());
-        assertEquals("10000", clientConfig.getProperty("hazelcast.client.connection.timeout"));
-        assertEquals("6", clientConfig.getProperty("hazelcast.client.retry.count"));
+        assertEquals(6, clientConfig.getProperties().size());
+        assertEquals("60000", clientConfig.getProperty("hazelcast.client.heartbeat.timeout"));
     }
 
     @Test
     public void testNetworkConfig() {
         final ClientNetworkConfig networkConfig = clientConfig.getNetworkConfig();
-        assertEquals(0, networkConfig.getConnectionAttemptLimit());
+        assertEquals(2, networkConfig.getConnectionAttemptLimit());
         assertEquals(2, networkConfig.getAddresses().size());
         assertTrue(networkConfig.getAddresses().contains("127.0.0.1"));
         assertTrue(networkConfig.getAddresses().contains("127.0.0.2"));
@@ -223,7 +221,6 @@ public class XmlClientConfigBuilderTest {
 
     @Test
     public void testNearCacheConfigs() {
-        assertNull(clientConfig.getNearCacheConfig("undefined"));
         assertEquals(1, clientConfig.getNearCacheConfigMap().size());
         final NearCacheConfig nearCacheConfig = clientConfig.getNearCacheConfig("asd");
 


### PR DESCRIPTION
i deleted some configs that we don't use anymore. ( as i talked with @sancar )
also there are some missing configs that i added to full-xml.

now client-xml includes all things from hazelcast-client-xsd.

i didn't write validation test because we have already a test, see: https://github.com/hazelcast/hazelcast/blob/master/hazelcast-client/src/test/java/com/hazelcast/client/config/XmlClientConfigBuilderTest.java#L255
