### PR TITLE
Map loader failover

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapLoaderExceptionHandlingTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapLoaderExceptionHandlingTest.java
@@ -11,11 +11,6 @@ import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.QuickTest;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
 
 import java.util.Collection;
 import java.util.HashSet;
@@ -24,6 +19,12 @@ import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
@@ -59,9 +60,8 @@ public class ClientMapLoaderExceptionHandlingTest extends HazelcastTestSupport {
                 } catch (Exception e) {
                     exception = e;
                 }
-                assertNotNull(exception);
+                assertNotNull("Exception not propagated to client", exception);
                 assertEquals(ClassCastException.class, exception.getClass());
-
             }
         });
     }

--- a/hazelcast/src/main/java/com/hazelcast/instance/BuildInfoProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/BuildInfoProvider.java
@@ -58,7 +58,13 @@ public final class BuildInfoProvider {
         } else {
             build = String.valueOf(hazelcastBuild);
         }
-        int buildNumber = Integer.parseInt(build);
+        int buildNumber = -1;
+
+        try {
+            buildNumber = Integer.parseInt(build);
+        } catch (Exception ignored) {
+            EmptyStatement.ignore(ignored);
+        }
 
         return new BuildInfo(version, build, revision, buildNumber, enterprise);
     }

--- a/hazelcast/src/main/java/com/hazelcast/instance/BuildInfoProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/BuildInfoProvider.java
@@ -58,13 +58,7 @@ public final class BuildInfoProvider {
         } else {
             build = String.valueOf(hazelcastBuild);
         }
-        int buildNumber = -1;
-
-        try {
-            buildNumber = Integer.parseInt(build);
-        } catch (Exception ignored) {
-            EmptyStatement.ignore(ignored);
-        }
+        int buildNumber = Integer.parseInt(build);
 
         return new BuildInfo(version, build, revision, buildNumber, enterprise);
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/AbstractRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/AbstractRecordStore.java
@@ -19,6 +19,7 @@ package com.hazelcast.map.impl;
 import com.hazelcast.concurrent.lock.LockService;
 import com.hazelcast.concurrent.lock.LockStore;
 import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.map.impl.mapstore.MapStoreContext;
 import com.hazelcast.map.impl.record.Record;
 import com.hazelcast.map.impl.record.RecordFactory;
 import com.hazelcast.nio.serialization.Data;
@@ -72,7 +73,6 @@ abstract class AbstractRecordStore implements RecordStore {
         this.recordFactory = mapContainer.getRecordFactory();
         this.sizeEstimator = createMapSizeEstimator();
     }
-
 
     @Override
     public String getName() {
@@ -209,8 +209,8 @@ abstract class AbstractRecordStore implements RecordStore {
         }
     }
 
-    protected RecordStoreLoader createRecordStoreLoader() {
-        return mapContainer.getMapStoreContext().getMapStoreWrapper() == null
+    protected RecordStoreLoader createRecordStoreLoader(MapStoreContext mapStoreContext) {
+        return mapStoreContext.getMapStoreWrapper() == null
                 ? RecordStoreLoader.EMPTY_LOADER : new BasicRecordStoreLoader(this);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/BasicRecordStoreLoader.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/BasicRecordStoreLoader.java
@@ -27,6 +27,7 @@ import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.OperationAccessor;
 import com.hazelcast.spi.OperationService;
 import com.hazelcast.spi.ResponseHandler;
+import com.hazelcast.util.ExceptionUtil;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -165,6 +166,7 @@ class BasicRecordStoreLoader implements RecordStoreLoader {
             entries = mapDataStore.loadAll(keys);
         } catch (Throwable t) {
             logger.warning("Could not load keys from map store", t);
+            ExceptionUtil.rethrow(t);
         }
         return getKeyValueSequence(entries);
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/BasicRecordStoreLoader.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/BasicRecordStoreLoader.java
@@ -18,40 +18,35 @@ package com.hazelcast.map.impl;
 
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.map.impl.mapstore.MapDataStore;
-import com.hazelcast.map.impl.mapstore.MapStoreContext;
-import com.hazelcast.map.impl.operation.PutAllOperation;
 import com.hazelcast.map.impl.operation.PutFromLoadAllOperation;
 import com.hazelcast.map.impl.record.Record;
-import com.hazelcast.nio.Address;
 import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.partition.InternalPartitionService;
-import com.hazelcast.spi.Callback;
 import com.hazelcast.spi.ExecutionService;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.OperationAccessor;
 import com.hazelcast.spi.OperationService;
 import com.hazelcast.spi.ResponseHandler;
-import com.hazelcast.util.ExceptionUtil;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+
+import static com.hazelcast.spi.ExecutionService.MAP_LOADER_EXECUTOR;
 
 /**
  * Responsible for loading keys from configured map store.
  */
 class BasicRecordStoreLoader implements RecordStoreLoader {
-
-    private static final String MAP_INITIAL_LOAD_EXECUTOR = "hz:map-initialLoad";
 
     private final AtomicBoolean loaded;
 
@@ -67,8 +62,6 @@ class BasicRecordStoreLoader implements RecordStoreLoader {
 
     private final int partitionId;
 
-    private volatile Throwable throwable;
-
     public BasicRecordStoreLoader(RecordStore recordStore) {
         this.recordStore = recordStore;
         final MapContainer mapContainer = recordStore.getMapContainer();
@@ -81,67 +74,13 @@ class BasicRecordStoreLoader implements RecordStoreLoader {
     }
 
     @Override
-    public boolean isLoaded() {
-        return loaded.get();
+    public Future<?> loadValues(List<Data> keys, boolean replaceExistingValues) {
+        final Callable task = new GivenKeysLoaderTask(keys, replaceExistingValues);
+        return executeTask(MAP_LOADER_EXECUTOR, task);
     }
 
-    @Override
-    public void setLoaded(boolean loaded) {
-        this.loaded.set(loaded);
-    }
-
-    @Override
-    public void loadAll(List<Data> keys, boolean replaceExistingValues) {
-        setLoaded(false);
-
-        final Runnable task = new GivenKeysLoaderTask(keys, replaceExistingValues);
-        final String executorName = ExecutionService.MAP_LOAD_ALL_KEYS_EXECUTOR;
-        executeTask(executorName, task);
-    }
-
-    /**
-     * Every partition (record-store) loads its own key set.
-     */
-    @Override
-    public void loadInitialKeys(boolean replaceExisting) {
-        if (isLoaded()) {
-            return;
-        }
-        if (!isOwner()) {
-            setLoaded(true);
-            return;
-        }
-
-        final Runnable task = new InitialKeysLoaderTask(replaceExisting);
-        final String executorName = MAP_INITIAL_LOAD_EXECUTOR;
-        executeTask(executorName, task);
-    }
-
-    private final class InitialKeysLoaderTask implements Runnable {
-
-        private final boolean replaceExisting;
-
-        public InitialKeysLoaderTask(boolean replaceExisting) {
-            this.replaceExisting = replaceExisting;
-        }
-
-        @Override
-        public void run() {
-            try {
-                loadAllKeysInternal(replaceExisting);
-            } catch (Throwable t) {
-                setLoaderException(t);
-            }
-        }
-    }
-
-    private void setLoaderException(Throwable t) {
-        BasicRecordStoreLoader.this.throwable = t;
-    }
-
-    private void executeTask(String executorName, Runnable task) {
-        getExecutionService().submit(executorName, task);
-
+    private Future<?> executeTask(String executorName, Callable task) {
+        return getExecutionService().submit(executorName, task);
     }
 
     private ExecutionService getExecutionService() {
@@ -149,23 +88,11 @@ class BasicRecordStoreLoader implements RecordStoreLoader {
         return nodeEngine.getExecutionService();
     }
 
-    @Override
-    public Throwable getExceptionOrNull() {
-        return throwable;
-    }
-
-    private boolean isOwner() {
-        final NodeEngine nodeEngine = mapServiceContext.getNodeEngine();
-        final Address partitionOwner = nodeEngine.getPartitionService().getPartitionOwner(partitionId);
-        return nodeEngine.getThisAddress().equals(partitionOwner);
-    }
-
-
     /**
-     * Task for loading given keys.
+     * Task for loading values of given keys.
      * This task is used to make load in an outer thread instead of partition thread.
      */
-    private final class GivenKeysLoaderTask implements Runnable {
+    private final class GivenKeysLoaderTask implements Callable<Object> {
 
         private final List<Data> keys;
         private final boolean replaceExistingValues;
@@ -176,25 +103,14 @@ class BasicRecordStoreLoader implements RecordStoreLoader {
         }
 
         @Override
-        public void run() {
-            loadKeysInternal(keys, replaceExistingValues);
+        public Object call() throws Exception {
+            loadValuesInternal(keys, replaceExistingValues);
+            return null;
         }
     }
 
-    private void loadAllKeysInternal(boolean replaceExistingValues) throws Exception {
-        final MapContainer mapContainer = recordStore.getMapContainer();
-        final MapStoreContext basicMapStoreContext = mapContainer.getMapStoreContext();
-        basicMapStoreContext.waitInitialLoadFinish();
+    private void loadValuesInternal(List<Data> keys, boolean replaceExistingValues) throws Exception {
 
-        final Map<Data, Object> loadedKeys = basicMapStoreContext.getInitialKeys();
-        if (loadedKeys == null || loadedKeys.isEmpty()) {
-            setLoaded(true);
-            return;
-        }
-        doChunkedLoad(loadedKeys, mapServiceContext.getNodeEngine(), replaceExistingValues);
-    }
-
-    private void loadKeysInternal(List<Data> keys, boolean replaceExistingValues) {
         if (!replaceExistingValues) {
             removeExistingKeys(keys);
         }
@@ -204,13 +120,19 @@ class BasicRecordStoreLoader implements RecordStoreLoader {
             loaded.set(true);
             return;
         }
-        doBatchLoad(keys);
+
+        List<Future> futures = doBatchLoad(keys);
+        for (Future future: futures) {
+            future.get();
+        }
     }
 
-    private void doBatchLoad(List<Data> keys) {
+    private List<Future> doBatchLoad(List<Data> keys) {
         final Queue<List<Data>> batchChunks = createBatchChunks(keys);
         final int size = batchChunks.size();
         final AtomicInteger finishedBatchCounter = new AtomicInteger(size);
+        List<Future> futures = new ArrayList<Future>();
+
         while (!batchChunks.isEmpty()) {
             final List<Data> chunk = batchChunks.poll();
             final List<Data> keyValueSequence = loadAndGet(chunk);
@@ -220,8 +142,10 @@ class BasicRecordStoreLoader implements RecordStoreLoader {
                 }
                 continue;
             }
-            sendOperation(keyValueSequence, finishedBatchCounter);
+            futures.add(sendOperation(keyValueSequence, finishedBatchCounter));
         }
+
+        return futures;
     }
 
     private Queue<List<Data>> createBatchChunks(List<Data> keys) {
@@ -281,10 +205,11 @@ class BasicRecordStoreLoader implements RecordStoreLoader {
         return list.subList(start, end);
     }
 
-    private void sendOperation(List<Data> keyValueSequence, AtomicInteger finishedBatchCounter) {
+    private Future<?> sendOperation(List<Data> keyValueSequence, AtomicInteger finishedBatchCounter) {
         OperationService operationService = mapServiceContext.getNodeEngine().getOperationService();
         final Operation operation = createOperation(keyValueSequence, finishedBatchCounter);
-        operationService.executeOperation(operation);
+        //operationService.executeOperation(operation);
+        return operationService.invokeOnPartition(MapService.SERVICE_NAME, operation, partitionId);
     }
 
     private Operation createOperation(List<Data> keyValueSequence, final AtomicInteger finishedBatchCounter) {
@@ -299,6 +224,7 @@ class BasicRecordStoreLoader implements RecordStoreLoader {
                 }
             }
 
+            @Override
             public boolean isLocal() {
                 return true;
             }
@@ -339,129 +265,5 @@ class BasicRecordStoreLoader implements RecordStoreLoader {
 
     private int getLoadBatchSize() {
         return mapServiceContext.getNodeEngine().getGroupProperties().MAP_LOAD_CHUNK_SIZE.getInteger();
-    }
-
-    private boolean shouldLoad(Data key, boolean replaceExisting) {
-        Record record = recordStore.getRecord(key);
-
-        if (record != null) {
-            if (!mapDataStore.loadable(key)) {
-                return false;
-            }
-
-            return replaceExisting;
-        }
-
-        return true;
-    }
-
-    private void doChunkedLoad(Map<Data, Object> loadedKeys, NodeEngine nodeEngine, boolean replaceExisting) {
-        int mapLoadChunkSize = getLoadBatchSize();
-        Queue<Map> chunks = new LinkedList<Map>();
-        Map<Data, Object> partitionKeys = new HashMap<Data, Object>();
-        InternalPartitionService partitionService = nodeEngine.getPartitionService();
-        Iterator<Map.Entry<Data, Object>> iterator = loadedKeys.entrySet().iterator();
-
-        while (iterator.hasNext()) {
-            final Map.Entry<Data, Object> entry = iterator.next();
-            final Data key = entry.getKey();
-
-            if (partitionId == partitionService.getPartitionId(key) && shouldLoad(key, replaceExisting)) {
-
-                partitionKeys.put(key, entry.getValue());
-                //split into chunks
-                if (partitionKeys.size() >= mapLoadChunkSize) {
-                    chunks.add(partitionKeys);
-                    partitionKeys = new HashMap<Data, Object>();
-                }
-                iterator.remove();
-            }
-        }
-        if (!partitionKeys.isEmpty()) {
-            chunks.add(partitionKeys);
-        }
-        if (chunks.isEmpty()) {
-            setLoaded(true);
-            return;
-        }
-        try {
-            this.throwable = null;
-            final AtomicInteger checkIfMapLoaded = new AtomicInteger(chunks.size());
-            ExecutionService executionService = nodeEngine.getExecutionService();
-            Map<Data, Object> chunkedKeys;
-            while ((chunkedKeys = chunks.poll()) != null) {
-                final Callback<Throwable> callback = createCallbackForThrowable();
-                MapLoadAllTask task = new MapLoadAllTask(chunkedKeys, checkIfMapLoaded, callback);
-                executionService.submit(ExecutionService.MAP_LOADER_EXECUTOR, task);
-            }
-        } catch (Throwable t) {
-            throw ExceptionUtil.rethrow(t);
-        }
-    }
-
-
-    private Callback<Throwable> createCallbackForThrowable() {
-        return new Callback<Throwable>() {
-            @Override
-            public void notify(Throwable throwable) {
-                setLoaderException(throwable);
-            }
-        };
-    }
-
-    private final class MapLoadAllTask implements Runnable {
-        private final Map<Data, Object> keys;
-        private final AtomicInteger checkIfMapLoaded;
-        private final Callback callback;
-
-        private MapLoadAllTask(Map<Data, Object> keys, AtomicInteger checkIfMapLoaded, Callback callback) {
-            this.keys = keys;
-            this.checkIfMapLoaded = checkIfMapLoaded;
-            this.callback = callback;
-        }
-
-        public void run() {
-            final NodeEngine nodeEngine = mapServiceContext.getNodeEngine();
-            try {
-                Map values = mapDataStore.loadAll(keys.values());
-                if (values == null || values.isEmpty()) {
-                    decrementCounterAndMarkAsLoaded();
-                    return;
-                }
-
-                final MapEntrySet entrySet = new MapEntrySet();
-                for (Data dataKey : keys.keySet()) {
-                    Object key = keys.get(dataKey);
-                    Object value = values.get(key);
-                    if (value != null) {
-                        Data dataValue = mapServiceContext.toData(value);
-                        entrySet.add(dataKey, dataValue);
-                    }
-                }
-
-                PutAllOperation operation = new PutAllOperation(name, entrySet, true);
-                final OperationService operationService = nodeEngine.getOperationService();
-                operationService.createInvocationBuilder(MapService.SERVICE_NAME, operation, partitionId)
-                        .setCallback(new Callback<Object>() {
-                            @Override
-                            public void notify(Object obj) {
-                                if (obj instanceof Throwable) {
-                                    return;
-                                }
-                                decrementCounterAndMarkAsLoaded();
-                            }
-                        }).invoke();
-            } catch (Throwable t) {
-                decrementCounterAndMarkAsLoaded();
-                logger.warning("Exception while load all task:" + t.toString());
-                callback.notify(t);
-            }
-        }
-
-        private void decrementCounterAndMarkAsLoaded() {
-            if (checkIfMapLoaded.decrementAndGet() == 0) {
-                setLoaded(true);
-            }
-        }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/DefaultRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/DefaultRecordStore.java
@@ -89,7 +89,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore implements 
     @Override
     public void loadAll(boolean replaceExistingValues) {
         logger.info("Starting to load all keys for map " + name + " on partitionId=" + partitionId);
-        Future<?> loadingKeysFuture = keyLoader.sendKeys(mapStoreContext, replaceExistingValues);
+        Future<?> loadingKeysFuture = keyLoader.startLoading(mapStoreContext, replaceExistingValues);
         loadingFutures.add(loadingKeysFuture);
     }
 
@@ -100,15 +100,17 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore implements 
             loadingFutures.add(f);
         }
 
+        keyLoader.trackLoading(lastBatch);
+
         if (lastBatch) {
             logger.finest("Completed loading map " + name + " on partitionId=" + partitionId);
-            keyLoader.completeLoading();
         }
     }
 
     @Override
     public void maybeDoInitialLoad() {
-        if (!keyLoader.isLoadInitiated()) {
+
+        if (keyLoader.shouldDoInitialLoad()) {
             loadAll(false);
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/DefaultRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/DefaultRecordStore.java
@@ -20,6 +20,7 @@ package com.hazelcast.map.impl;
 import com.hazelcast.concurrent.lock.LockService;
 import com.hazelcast.concurrent.lock.LockStore;
 import com.hazelcast.core.EntryView;
+import com.hazelcast.logging.ILogger;
 import com.hazelcast.map.impl.mapstore.MapDataStore;
 import com.hazelcast.map.impl.mapstore.MapStoreContext;
 import com.hazelcast.map.impl.mapstore.MapStoreManager;
@@ -31,6 +32,7 @@ import com.hazelcast.spi.DefaultObjectNamespace;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.exception.RetryableHazelcastException;
 import com.hazelcast.util.ExceptionUtil;
+import com.hazelcast.util.FutureUtil;
 
 import java.util.AbstractMap;
 import java.util.ArrayList;
@@ -43,6 +45,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.Future;
 
 import static com.hazelcast.map.impl.ExpirationTimeSetter.updateExpiryTime;
 
@@ -51,50 +54,78 @@ import static com.hazelcast.map.impl.ExpirationTimeSetter.updateExpiryTime;
  */
 public class DefaultRecordStore extends AbstractEvictableRecordStore implements RecordStore {
 
+    private final ILogger logger;
     private final LockStore lockStore;
     private final MapDataStore<Data, Object> mapDataStore;
+    private final MapStoreContext mapStoreContext;
     private final RecordStoreLoader recordStoreLoader;
+    private final MapKeyLoader keyLoader;
+    private final Collection<Future> loadingFutures = new ArrayList<Future>();
 
-    public DefaultRecordStore(MapContainer mapContainer, int partitionId) {
+    public DefaultRecordStore(MapContainer mapContainer, int partitionId,
+            MapKeyLoader keyLoader, ILogger logger) {
         super(mapContainer, partitionId);
-        this.lockStore = createLockStore();
-        final MapStoreContext mapStoreContext = mapContainer.getMapStoreContext();
-        final MapStoreManager mapStoreManager = mapStoreContext.getMapStoreManager();
-        this.mapDataStore = mapStoreManager.getMapDataStore(partitionId);
 
-        this.recordStoreLoader = createRecordStoreLoader();
-        this.recordStoreLoader.loadInitialKeys(true);
+        this.logger = logger;
+        this.keyLoader = keyLoader;
+        this.lockStore = createLockStore();
+        this.mapStoreContext = mapContainer.getMapStoreContext();
+        MapStoreManager mapStoreManager = mapStoreContext.getMapStoreManager();
+        this.mapDataStore = mapStoreManager.getMapDataStore(partitionId);
+        this.recordStoreLoader = createRecordStoreLoader(mapStoreContext);
+    }
+
+    public void startLoading() {
+        if (mapStoreContext.isMapLoader()) {
+            loadingFutures.add(keyLoader.startInitialLoad(mapStoreContext, partitionId));
+        }
     }
 
     @Override
     public boolean isLoaded() {
-        return recordStoreLoader.isLoaded();
+        return FutureUtil.allDone(loadingFutures);
     }
 
     @Override
-    public void setLoaded(boolean loaded) {
-        recordStoreLoader.setLoaded(loaded);
+    public void loadAll(boolean replaceExistingValues) {
+        logger.info("Starting to load all keys for map " + name + " on partitionId=" + partitionId);
+        Future<?> loadingKeysFuture = keyLoader.sendKeys(mapStoreContext, replaceExistingValues);
+        loadingFutures.add(loadingKeysFuture);
     }
 
     @Override
-    public void loadAllFromStore(boolean replaceExisting) {
-        recordStoreLoader.setLoaded(false);
-        recordStoreLoader.loadInitialKeys(replaceExisting);
+    public void loadAllFromStore(List<Data> keys, boolean replaceExistingValues, boolean lastBatch) {
+        if (!keys.isEmpty()) {
+            Future f = recordStoreLoader.loadValues(keys, replaceExistingValues);
+            loadingFutures.add(f);
+        }
+
+        if (lastBatch) {
+            logger.finest("Completed loading map " + name + " on partitionId=" + partitionId);
+            keyLoader.completeLoading();
+        }
+    }
+
+    @Override
+    public void maybeDoInitialLoad() {
+        if (!keyLoader.isLoadInitiated()) {
+            loadAll(false);
+        }
     }
 
     @Override
     public void checkIfLoaded() {
-        Throwable throwable = null;
-        final RecordStoreLoader recordStoreLoader = this.recordStoreLoader;
-        final Throwable exception = recordStoreLoader.getExceptionOrNull();
-        if (exception == null && !recordStoreLoader.isLoaded()) {
-            throwable = new RetryableHazelcastException("Map "
-                    + getName() + " is still loading data from external store");
-        } else if (exception != null) {
-            throwable = exception;
-        }
-        if (throwable != null) {
-            throw ExceptionUtil.rethrow(throwable);
+        if (isLoaded()) {
+            try {
+                // check all loading futures for exceptions
+                FutureUtil.checkAllDone(loadingFutures);
+                loadingFutures.clear();
+            } catch (Exception e) {
+                ExceptionUtil.rethrow(e);
+            }
+        } else {
+            throw new RetryableHazelcastException("Map " + getName()
+                    + " is still loading data from external store");
         }
     }
 
@@ -175,7 +206,6 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore implements 
         return records;
     }
 
-
     @Override
     public void clearPartition() {
         final NodeEngine nodeEngine = mapServiceContext.getNodeEngine();
@@ -213,7 +243,6 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore implements 
         checkIfLoaded();
         return records.isEmpty();
     }
-
 
     @Override
     public boolean containsValue(Object value) {
@@ -982,14 +1011,6 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore implements 
         return oldValue;
     }
 
-
-    @Override
-    public void loadAllFromStore(List<Data> keys, boolean replaceExistingValues) {
-        if (keys.isEmpty()) {
-            return;
-        }
-        recordStoreLoader.loadAll(keys, replaceExistingValues);
-    }
 
     @Override
     public MapDataStore<Data, Object> getMapDataStore() {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapKeyLoader.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapKeyLoader.java
@@ -1,0 +1,297 @@
+package com.hazelcast.map.impl;
+
+import com.hazelcast.config.MaxSizeConfig;
+import com.hazelcast.config.MaxSizeConfig.MaxSizePolicy;
+import com.hazelcast.core.ExecutionCallback;
+import com.hazelcast.core.IFunction;
+import com.hazelcast.core.MapLoader;
+import com.hazelcast.map.impl.mapstore.MapStoreContext;
+import com.hazelcast.map.impl.operation.LoadAllOperation;
+import com.hazelcast.map.impl.operation.PartitionCheckIfLoadedOperation;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.partition.InternalPartitionService;
+import com.hazelcast.spi.ExecutionService;
+import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.OperationService;
+import com.hazelcast.spi.impl.AbstractCompletableFuture;
+import com.hazelcast.util.CollectionUtil;
+import com.hazelcast.util.UnmodifiableIterator;
+import com.hazelcast.util.ValidationUtil;
+
+import java.io.Closeable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static com.hazelcast.map.impl.MapService.SERVICE_NAME;
+import static com.hazelcast.map.impl.eviction.MaxSizeChecker.getApproximateMaxSize;
+import static com.hazelcast.nio.IOUtil.closeResource;
+import static com.hazelcast.spi.ExecutionService.MAP_LOAD_ALL_KEYS_EXECUTOR;
+import static com.hazelcast.util.IterableUtil.limit;
+import static com.hazelcast.util.IterableUtil.map;
+
+/**
+ * Loads keys from a {@link MapLoader} and sends them to all partitions for loading
+ */
+public class MapKeyLoader {
+
+    private String mapName;
+    private OperationService opService;
+    private InternalPartitionService partitionService;
+    private IFunction<Object, Data> toData;
+    private ExecutionService execService;
+
+    private int maxSize;
+    private int maxBatch;
+    private int mapNamePartition;
+    private boolean loadInitiated;
+
+    private LoadFinishedFuture loadFinished = new LoadFinishedFuture(true);
+
+    public MapKeyLoader(String mapName, OperationService opService, InternalPartitionService ps,
+            ExecutionService execService, IFunction<Object, Data> serialize) {
+        this.mapName = mapName;
+        this.opService = opService;
+        this.partitionService = ps;
+        this.toData = serialize;
+        this.execService = execService;
+    }
+
+    /**
+     * Sends keys to all partitions in batches.
+     */
+    public Future<?> sendKeys(final MapStoreContext mapStoreContext, final boolean replaceExistingValues) {
+
+        if (loadFinished.isDone()) {
+
+            loadFinished = new LoadFinishedFuture();
+            loadInitiated = true;
+
+            Future<Boolean> sent = execService.submit(MAP_LOAD_ALL_KEYS_EXECUTOR, new Callable<Boolean>() {
+                @Override
+                public Boolean call() throws Exception {
+                    Iterable<Object> allKeys = mapStoreContext.loadAllKeys();
+                    sendKeysInBatches(allKeys, replaceExistingValues);
+                    return false;
+                }
+            });
+
+            execService.asCompletableFuture(sent).andThen(loadFinished);
+        }
+
+        return loadFinished;
+    }
+
+    /**
+     * Check if loaded on loader partition. Triggers key loading if it hadn't started
+     */
+    public Future triggerLoading() {
+
+        if (loadFinished.isDone()) {
+
+            loadFinished = new LoadFinishedFuture();
+
+            execService.execute(MAP_LOAD_ALL_KEYS_EXECUTOR, new Runnable() {
+                @Override
+                public void run() {
+                    Operation op = new PartitionCheckIfLoadedOperation(mapName, true);
+                    opService.<Boolean>invokeOnPartition(SERVICE_NAME, op, mapNamePartition).andThen(loadFinished);
+                }
+            });
+        }
+
+        return loadFinished;
+    }
+
+    public void completeLoading() {
+        if (!loadFinished.isDone()) {
+            loadFinished.setResult(true);
+        }
+    }
+
+    public Future startInitialLoad(MapStoreContext mapStoreContext, int partitionId) {
+
+        this.mapNamePartition = partitionService.getPartitionId(toData.apply(mapName));
+
+        if (!partitionService.isPartitionOwner(partitionId)) {
+            return loadFinished;
+        }
+
+        if (partitionId == mapNamePartition) {
+            return sendKeys(mapStoreContext, false);
+        } else {
+            return triggerLoading();
+        }
+    }
+
+    private void sendKeysInBatches(Iterable<Object> allKeys, boolean replaceExistingValues) {
+
+        Iterator<Object> keys = allKeys.iterator();
+        Iterator<Data> dataKeys = map(keys, toData);
+
+        if (maxSize > 0) {
+            dataKeys = limit(dataKeys, maxSize);
+        }
+
+        Iterator<Entry<Integer, Data>> partitionsAndKeys = map(dataKeys, toPartition());
+        Iterator<Map<Integer, List<Data>>> batches = toBatches(partitionsAndKeys, maxBatch);
+
+        while (batches.hasNext()) {
+            Map<Integer, List<Data>> batch = batches.next();
+            sendBatch(batch, replaceExistingValues);
+        }
+
+        sendLoadCompleted(partitionService.getPartitionCount(), replaceExistingValues);
+
+        if (keys instanceof Closeable) {
+            closeResource((Closeable) keys);
+        }
+    }
+
+    public static Iterator<Map<Integer, List<Data>>> toBatches(final Iterator<Entry<Integer, Data>> entries,
+            final int maxBatch) {
+
+        return new UnmodifiableIterator<Map<Integer, List<Data>>>() {
+            @Override
+            public boolean hasNext() {
+                return entries.hasNext();
+            }
+
+            @Override
+            public Map<Integer, List<Data>> next() {
+                ValidationUtil.checkHasNext(entries, "No next element");
+                return nextBatch(entries, maxBatch);
+            }
+        };
+    }
+
+    private IFunction<Data, Entry<Integer, Data>> toPartition() {
+        return new IFunction<Data, Entry<Integer, Data>>() {
+            @Override
+            public Entry<Integer, Data> apply(Data input) {
+                Integer partition = partitionService.getPartitionId(input);
+                return new MapEntrySimple<Integer, Data>(partition, input);
+            }
+        };
+    }
+
+    private static Map<Integer, List<Data>> nextBatch(Iterator<Entry<Integer, Data>> entries, int maxBatch) {
+
+        Map<Integer, List<Data>> batch = new HashMap<Integer, List<Data>>();
+
+        while (entries.hasNext()) {
+            Entry<Integer, Data> e = entries.next();
+            List<Data> partitionKeys = CollectionUtil.addToValueList(batch, e.getKey(), e.getValue());
+
+            if (partitionKeys.size() >= maxBatch) {
+                break;
+            }
+        }
+
+        return batch;
+    }
+
+    private void sendBatch(Map<Integer, List<Data>> batch, boolean replaceExistingValues) {
+
+        for (Entry<Integer, List<Data>> e : batch.entrySet()) {
+            int partitionId = e.getKey();
+            List<Data> keys = e.getValue();
+            LoadAllOperation op = new LoadAllOperation(mapName, keys, replaceExistingValues, false);
+            opService.invokeOnPartition(SERVICE_NAME, op, partitionId);
+        }
+
+    }
+
+    private List<Future<Object>> sendLoadCompleted(int partitions, boolean replaceExistingValues) {
+
+        List<Future<Object>> futures = new ArrayList<Future<Object>>();
+        boolean lastBatch = true;
+
+        for (int partitionId = 0; partitionId < partitions; partitionId++) {
+            LoadAllOperation op = new LoadAllOperation(mapName, Collections.<Data>emptyList(), replaceExistingValues, lastBatch);
+            futures.add(opService.invokeOnPartition(SERVICE_NAME, op, partitionId));
+        }
+
+        return futures;
+    }
+
+    public static int getMaxSize(int clusterSize, MaxSizeConfig maxSizeConfig) {
+        int maxSizePerNode = getApproximateMaxSize(maxSizeConfig, MaxSizePolicy.PER_NODE);
+        if (maxSizePerNode == MaxSizeConfig.DEFAULT_MAX_SIZE) {
+            // unlimited
+            return -1;
+        }
+        int maxSize = clusterSize * maxSizePerNode;
+        return maxSize;
+    }
+
+    public boolean isLoadInitiated() {
+        return loadInitiated;
+    }
+
+    public void setMaxBatch(int maxBatch) {
+        this.maxBatch = maxBatch;
+    }
+
+    public void setMaxSize(int maxSize) {
+        this.maxSize = maxSize;
+    }
+
+    private static final class LoadFinishedFuture extends AbstractCompletableFuture<Boolean>
+        implements ExecutionCallback<Boolean> {
+
+        private LoadFinishedFuture() {
+            super(null, null);
+        }
+
+        private LoadFinishedFuture(Boolean result) {
+            super(null, null);
+            setResult(result);
+        }
+
+        @Override
+        public Boolean get(long timeout, TimeUnit timeUnit) throws InterruptedException, ExecutionException, TimeoutException {
+            if (isDone()) {
+                return getResult();
+            }
+            throw new UnsupportedOperationException("Future is not done yet");
+        }
+
+        @Override
+        public void onResponse(Boolean loaded) {
+            if (loaded) {
+                setResult(loaded);
+            }
+            // if not loaded yet we wait for the last batch to arrive
+        }
+
+        @Override
+        public void onFailure(Throwable t) {
+            setResult(t);
+        }
+
+        @Override
+        public boolean isCancelled() {
+            return false;
+        }
+
+        @Override
+        public boolean cancel(boolean mayInterruptIfRunning) {
+            return false;
+        }
+
+        @Override
+        public String toString() {
+            return getClass().getSimpleName() + "{done=" + isDone() + "}";
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapKeyLoader.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapKeyLoader.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.map.impl;
 
 import com.hazelcast.core.ExecutionCallback;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapKeyLoaderUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapKeyLoaderUtil.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl;
+
+import com.hazelcast.config.MaxSizeConfig;
+import com.hazelcast.config.MaxSizeConfig.MaxSizePolicy;
+import com.hazelcast.core.IFunction;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.partition.InternalPartitionService;
+import com.hazelcast.util.CollectionUtil;
+import com.hazelcast.util.UnmodifiableIterator;
+import com.hazelcast.util.ValidationUtil;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import static com.hazelcast.map.impl.eviction.MaxSizeChecker.getApproximateMaxSize;
+
+public final class MapKeyLoaderUtil {
+
+    private MapKeyLoaderUtil() {
+    }
+
+    static MapKeyLoader.Role assignRole(InternalPartitionService partitionService, int mapNamePartition, int partitionId) {
+
+        boolean isPartitionOwner = partitionService.isPartitionOwner(partitionId);
+        boolean isMapPartition = (mapNamePartition == partitionId);
+
+        if (isMapPartition) {
+            return isPartitionOwner ? MapKeyLoader.Role.SENDER : MapKeyLoader.Role.SENDER_BACKUP;
+        }
+
+        return isPartitionOwner ? MapKeyLoader.Role.RECEIVER : MapKeyLoader.Role.NONE;
+    }
+
+    static Iterator<Map<Integer, List<Data>>> toBatches(final Iterator<Entry<Integer, Data>> entries,
+            final int maxBatch) {
+
+        return new UnmodifiableIterator<Map<Integer, List<Data>>>() {
+            @Override
+            public boolean hasNext() {
+                return entries.hasNext();
+            }
+
+            @Override
+            public Map<Integer, List<Data>> next() {
+                ValidationUtil.checkHasNext(entries, "No next element");
+                return nextBatch(entries, maxBatch);
+            }
+        };
+    }
+
+    static Map<Integer, List<Data>> nextBatch(Iterator<Entry<Integer, Data>> entries, int maxBatch) {
+
+        Map<Integer, List<Data>> batch = new HashMap<Integer, List<Data>>();
+
+        while (entries.hasNext()) {
+            Entry<Integer, Data> e = entries.next();
+            List<Data> partitionKeys = CollectionUtil.addToValueList(batch, e.getKey(), e.getValue());
+
+            if (partitionKeys.size() >= maxBatch) {
+                break;
+            }
+        }
+
+        return batch;
+    }
+
+    public static int getMaxSize(int clusterSize, MaxSizeConfig maxSizeConfig) {
+        int maxSizePerNode = getApproximateMaxSize(maxSizeConfig, MaxSizePolicy.PER_NODE);
+        if (maxSizePerNode == MaxSizeConfig.DEFAULT_MAX_SIZE) {
+            // unlimited
+            return -1;
+        }
+        int maxSize = clusterSize * maxSizePerNode;
+        return maxSize;
+    }
+
+    static IFunction<Data, Entry<Integer, Data>> toPartition(final InternalPartitionService partitionService) {
+        return new IFunction<Data, Entry<Integer, Data>>() {
+            @Override
+            public Entry<Integer, Data> apply(Data input) {
+                Integer partition = partitionService.getPartitionId(input);
+                return new MapEntrySimple<Integer, Data>(partition, input);
+            }
+        };
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapMigrationAwareService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapMigrationAwareService.java
@@ -47,7 +47,6 @@ class MapMigrationAwareService implements MigrationAwareService {
 
     @Override
     public void beforeMigration(PartitionMigrationEvent event) {
-
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContext.java
@@ -84,14 +84,6 @@ public interface MapServiceContext extends MapServiceContextInterceptorSupport, 
 
     void reloadOwnedPartitions();
 
-    /**
-     * Check if key belongs on partitions of the this node
-     *
-     * @param key key to be queried.
-     * @return true if this node owns the key
-     */
-    boolean isOwnedKey(Data key);
-
     AtomicInteger getWriteBehindQueueItemCounter();
 
     ExpirationManager getExpirationManager();

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
@@ -18,14 +18,12 @@ package com.hazelcast.map.impl;
 
 import com.hazelcast.config.Config;
 import com.hazelcast.config.MapConfig;
-import com.hazelcast.core.HazelcastException;
 import com.hazelcast.core.PartitioningStrategy;
 import com.hazelcast.map.MapInterceptor;
 import com.hazelcast.map.impl.eviction.EvictionOperator;
 import com.hazelcast.map.impl.eviction.ExpirationManager;
 import com.hazelcast.map.listener.MapPartitionLostListener;
 import com.hazelcast.map.merge.MergePolicyProvider;
-import com.hazelcast.nio.Address;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.partition.InternalPartitionService;
 import com.hazelcast.spi.EventFilter;
@@ -33,6 +31,7 @@ import com.hazelcast.spi.EventRegistration;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.util.ConcurrencyUtil;
 import com.hazelcast.util.ConstructorFunction;
+
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashSet;
@@ -218,18 +217,6 @@ class MapServiceContextImpl implements MapServiceContext {
             partitions = Collections.emptySet();
         }
         ownedPartitions.set(Collections.unmodifiableSet(new LinkedHashSet<Integer>(partitions)));
-    }
-
-    @Override
-    public boolean isOwnedKey(Data key) {
-        InternalPartitionService partitionService = nodeEngine.getPartitionService();
-        Integer partitionId = partitionService.getPartitionId(key);
-        try {
-            Address owner = partitionService.getPartitionOwnerOrWait(partitionId);
-            return nodeEngine.getThisAddress().equals(owner);
-        } catch (InterruptedException e) {
-            throw new HazelcastException(e);
-        }
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapStoreWrapper.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapStoreWrapper.java
@@ -77,7 +77,7 @@ public class MapStoreWrapper implements MapStore, MapLoaderLifecycleSupport {
         return (mapStore != null);
     }
 
-    private boolean isMapLoader() {
+    public boolean isMapLoader() {
         return (mapLoader != null);
     }
 
@@ -112,9 +112,9 @@ public class MapStoreWrapper implements MapStore, MapLoaderLifecycleSupport {
     }
 
     @Override
-    public Iterable loadAllKeys() {
+    public Iterable<Object> loadAllKeys() {
         if (isMapLoader()) {
-            Iterable allKeys;
+            Iterable<Object> allKeys;
             try {
                 allKeys = mapLoader.loadAllKeys();
             } catch (AbstractMethodError e) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/PartitionContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/PartitionContainer.java
@@ -32,7 +32,7 @@ import com.hazelcast.util.ConstructorFunction;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
-import static com.hazelcast.map.impl.MapKeyLoader.getMaxSize;
+import static com.hazelcast.map.impl.MapKeyLoaderUtil.getMaxSize;
 
 public class PartitionContainer {
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/PartitionContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/PartitionContainer.java
@@ -16,14 +16,23 @@
 
 package com.hazelcast.map.impl;
 
+import com.hazelcast.cluster.ClusterService;
 import com.hazelcast.concurrent.lock.LockService;
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.partition.InternalPartitionService;
 import com.hazelcast.spi.DefaultObjectNamespace;
+import com.hazelcast.spi.ExecutionService;
 import com.hazelcast.spi.NodeEngine;
+import com.hazelcast.spi.OperationService;
 import com.hazelcast.util.ConcurrencyUtil;
 import com.hazelcast.util.ConstructorFunction;
 
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+
+import static com.hazelcast.map.impl.MapKeyLoader.getMaxSize;
 
 public class PartitionContainer {
 
@@ -35,11 +44,30 @@ public class PartitionContainer {
 
     private final ConstructorFunction<String, RecordStore> recordStoreConstructor
             = new ConstructorFunction<String, RecordStore>() {
+
         public RecordStore createNew(String name) {
-            final MapContainer mapContainer = mapService.getMapServiceContext().getMapContainer(name);
-            return new DefaultRecordStore(mapContainer, partitionId);
+            MapServiceContext serviceContext = mapService.getMapServiceContext();
+            MapContainer mapContainer = serviceContext.getMapContainer(name);
+            MapConfig mapConfig = mapContainer.getMapConfig();
+            NodeEngine nodeEngine = serviceContext.getNodeEngine();
+            InternalPartitionService ps = nodeEngine.getPartitionService();
+            OperationService opService = nodeEngine.getOperationService();
+            ExecutionService execService = nodeEngine.getExecutionService();
+            ClusterService clusterService = nodeEngine.getClusterService();
+            GroupProperties groupProperties = nodeEngine.getGroupProperties();
+
+            MapKeyLoader keyLoader = new MapKeyLoader(name, opService, ps, execService, mapContainer.toData());
+            keyLoader.setMaxBatch(groupProperties.MAP_LOAD_CHUNK_SIZE.getInteger());
+            keyLoader.setMaxSize(getMaxSize(clusterService.getSize(), mapConfig.getMaxSizeConfig()));
+
+            ILogger logger = nodeEngine.getLogger(DefaultRecordStore.class);
+            DefaultRecordStore recordStore = new DefaultRecordStore(mapContainer, partitionId, keyLoader, logger);
+            recordStore.startLoading();
+
+            return recordStore;
         }
     };
+
     /**
      * Flag to check if there is a {@link com.hazelcast.map.impl.operation.ClearExpiredOperation}
      * is running on this partition at this moment or not.
@@ -130,4 +158,5 @@ public class PartitionContainer {
     public void setLastCleanupTimeCopy(long lastCleanupTimeCopy) {
         this.lastCleanupTimeCopy = lastCleanupTimeCopy;
     }
+
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/RecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/RecordStore.java
@@ -21,6 +21,7 @@ import com.hazelcast.map.impl.mapstore.MapDataStore;
 import com.hazelcast.map.impl.record.Record;
 import com.hazelcast.map.merge.MapMergePolicy;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.spi.exception.RetryableHazelcastException;
 
 import java.util.Collection;
 import java.util.Iterator;
@@ -227,9 +228,7 @@ public interface RecordStore {
 
     boolean isLoaded();
 
-    void checkIfLoaded();
-
-    void setLoaded(boolean loaded);
+    void checkIfLoaded() throws RetryableHazelcastException;
 
     int clear();
 
@@ -250,19 +249,13 @@ public interface RecordStore {
     boolean isExpirable();
 
     /**
-     * Loads all keys from the map store.
-     *
-     * @param replaceExistingValues <code>true</code> if need to replace existing values otherwise <code>false</code>
-     */
-    void loadAllFromStore(boolean replaceExistingValues);
-
-    /**
      * Loads all given keys from defined map store.
      *
      * @param keys                  keys to be loaded.
      * @param replaceExistingValues <code>true</code> if need to replace existing values otherwise <code>false</code>
+     * @param lastBatch when keys are sent is batches this indicates the last batch. Used to indicate loading is complete.
      */
-    void loadAllFromStore(List<Data> keys, boolean replaceExistingValues);
+    void loadAllFromStore(List<Data> keys, boolean replaceExistingValues, boolean lastBatch);
 
     MapDataStore<Data, Object> getMapDataStore();
 
@@ -279,4 +272,13 @@ public interface RecordStore {
 
     void evictEntries(long now, boolean backup);
 
+    /**
+     * Loads all keys and values
+     *
+     * @param replaceExistingValues <code>true</code> if need to replace existing values otherwise <code>false</code>
+     **/
+    void loadAll(boolean replaceExistingValues);
+
+    /** Performs initial loading from a MapLoader if it has not been done before  **/
+    void maybeDoInitialLoad();
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/RecordStoreLoader.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/RecordStoreLoader.java
@@ -19,6 +19,7 @@ package com.hazelcast.map.impl;
 import com.hazelcast.nio.serialization.Data;
 
 import java.util.List;
+import java.util.concurrent.Future;
 
 /**
  * Loader contract for a {@link RecordStore}.
@@ -26,64 +27,18 @@ import java.util.List;
 interface RecordStoreLoader {
 
     RecordStoreLoader EMPTY_LOADER = new RecordStoreLoader() {
-
         @Override
-        public boolean isLoaded() {
-            // return true when there is no map store.
-            return true;
-        }
-
-        @Override
-        public void setLoaded(boolean loaded) {
-
-        }
-
-        @Override
-        public void loadAll(List<Data> keys, boolean replaceExistingValues) {
-
-        }
-
-        @Override
-        public void loadInitialKeys(boolean replaceExisting) {
-
-        }
-
-        @Override
-        public Throwable getExceptionOrNull() {
+        public Future loadValues(List<Data> keys, boolean replaceExistingValues) {
             return null;
         }
     };
-
-    /**
-     * Query whether load operation finished or not for a particular {@link RecordStore}
-     *
-     * @return <code>true</code> if load finished successfully, <code>false</code> otherwise.
-     */
-    boolean isLoaded();
-
-    void setLoaded(boolean loaded);
-
 
     /**
      * Loads all keys from defined map store.
      *
      * @param keys                  keys to be loaded.
      * @param replaceExistingValues <code>true</code> if need to replace existing values otherwise <code>false</code>
+     * @return future for checking when loading is complete
      */
-    void loadAll(List<Data> keys, boolean replaceExistingValues);
-
-    /**
-     * Loads initial keys.
-     * @param replaceExisting keys
-     */
-    void loadInitialKeys(boolean replaceExisting);
-
-    /**
-     * Picks and returns any one of throwables during load all process.
-     * Returns null if there is no exception occurred.
-     *
-     * @return exception or null.
-     */
-    Throwable getExceptionOrNull();
-
+    Future<?> loadValues(List<Data> keys, boolean replaceExistingValues);
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/eviction/MaxSizeChecker.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/eviction/MaxSizeChecker.java
@@ -89,8 +89,10 @@ public class MaxSizeChecker {
         return result;
     }
 
+
     private boolean isEvictablePerNode(MapContainer mapContainer) {
         int nodeTotalSize = 0;
+
         final MaxSizeConfig maxSizeConfig = mapContainer.getMapConfig().getMaxSizeConfig();
         final int maxSize = getApproximateMaxSize(maxSizeConfig.getSize());
         final String mapName = mapContainer.getName();

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/MapStoreContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/MapStoreContext.java
@@ -20,10 +20,7 @@ import com.hazelcast.config.MapStoreConfig;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.map.impl.MapServiceContext;
 import com.hazelcast.map.impl.MapStoreWrapper;
-import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.SerializationService;
-
-import java.util.Map;
 
 /**
  * A context which provides/initializes map store specific functionality.
@@ -42,8 +39,6 @@ public interface MapStoreContext {
 
     MapStoreManager getMapStoreManager();
 
-    Map<Data, Object> getInitialKeys();
-
     MapStoreWrapper getMapStoreWrapper();
 
     boolean isWriteBehindMapStoreEnabled();
@@ -58,7 +53,10 @@ public interface MapStoreContext {
 
     MapStoreConfig getMapStoreConfig();
 
-    void waitInitialLoadFinish() throws Exception;
+    Iterable<Object> loadAllKeys();
 
-    void triggerInitialKeyLoad();
+    /**
+     * @return true if MapLoader or MapStore is defined
+     */
+    boolean isMapLoader();
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/MapStoreContextFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/MapStoreContextFactory.java
@@ -22,11 +22,9 @@ import com.hazelcast.logging.ILogger;
 import com.hazelcast.map.impl.MapContainer;
 import com.hazelcast.map.impl.MapServiceContext;
 import com.hazelcast.map.impl.MapStoreWrapper;
-import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.SerializationService;
 
 import java.util.Collections;
-import java.util.Map;
 
 import static com.hazelcast.map.impl.mapstore.MapStoreManagers.emptyMapStoreManager;
 
@@ -58,11 +56,6 @@ public final class MapStoreContextFactory {
         }
 
         @Override
-        public Map<Data, Object> getInitialKeys() {
-            return Collections.emptyMap();
-        }
-
-        @Override
         public MapStoreWrapper getMapStoreWrapper() {
             // keep it null. do not throw exception.
             return null;
@@ -70,21 +63,15 @@ public final class MapStoreContextFactory {
 
         @Override
         public void start() {
-
         }
 
         @Override
         public void stop() {
-
         }
 
         @Override
         public boolean isWriteBehindMapStoreEnabled() {
             return false;
-        }
-
-        @Override
-        public void triggerInitialKeyLoad() {
         }
 
         @Override
@@ -113,7 +100,13 @@ public final class MapStoreContextFactory {
         }
 
         @Override
-        public void waitInitialLoadFinish() {
+        public Iterable<Object> loadAllKeys() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public boolean isMapLoader() {
+            return false;
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/LoadAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/LoadAllOperation.java
@@ -38,6 +38,7 @@ public class LoadAllOperation extends AbstractMapOperation implements PartitionA
     private List<Data> keys;
 
     private boolean replaceExistingValues;
+    private boolean lastBatch = true;
 
     public LoadAllOperation() {
         keys = Collections.emptyList();
@@ -49,13 +50,20 @@ public class LoadAllOperation extends AbstractMapOperation implements PartitionA
         this.replaceExistingValues = replaceExistingValues;
     }
 
+    public LoadAllOperation(String name, List<Data> keys, boolean replaceExistingValues, boolean lastBatch) {
+        super(name);
+        this.keys = keys;
+        this.replaceExistingValues = replaceExistingValues;
+        this.lastBatch = lastBatch;
+    }
+
     @Override
     public void run() throws Exception {
         final int partitionId = getPartitionId();
         MapServiceContext mapServiceContext = mapService.getMapServiceContext();
         final RecordStore recordStore = mapServiceContext.getRecordStore(partitionId, name);
         keys = selectThisPartitionsKeys(this.keys);
-        recordStore.loadAllFromStore(keys, replaceExistingValues);
+        recordStore.loadAllFromStore(keys, replaceExistingValues, lastBatch);
     }
 
     private List<Data> selectThisPartitionsKeys(Collection<Data> keys) {
@@ -86,6 +94,7 @@ public class LoadAllOperation extends AbstractMapOperation implements PartitionA
             out.writeData(key);
         }
         out.writeBoolean(replaceExistingValues);
+        out.writeBoolean(lastBatch);
     }
 
     @Override
@@ -100,5 +109,6 @@ public class LoadAllOperation extends AbstractMapOperation implements PartitionA
             keys.add(data);
         }
         replaceExistingValues = in.readBoolean();
+        lastBatch = in.readBoolean();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/LoadMapOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/LoadMapOperation.java
@@ -18,7 +18,6 @@ package com.hazelcast.map.impl.operation;
 
 import com.hazelcast.map.impl.MapServiceContext;
 import com.hazelcast.map.impl.RecordStore;
-import com.hazelcast.map.impl.mapstore.MapStoreContext;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 
@@ -42,14 +41,8 @@ public class LoadMapOperation extends AbstractMapOperation {
     @Override
     public void run() throws Exception {
         MapServiceContext mapServiceContext = mapService.getMapServiceContext();
-        MapStoreContext mapStoreContext = mapContainer.getMapStoreContext();
-
-        mapStoreContext.triggerInitialKeyLoad();
-
-        for (int partition :  mapServiceContext.getOwnedPartitions()) {
-            RecordStore recordStore = mapServiceContext.getRecordStore(partition, name);
-            recordStore.loadAllFromStore(replaceExistingValues);
-        }
+        RecordStore recordStore = mapServiceContext.getRecordStore(getPartitionId(), name);
+        recordStore.loadAll(replaceExistingValues);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapReplicationOperation.java
@@ -83,7 +83,6 @@ public class MapReplicationOperation extends AbstractOperation implements Mutati
         readDelayedEntries(container);
     }
 
-
     private void readDelayedEntries(PartitionContainer container) {
         delayedEntries = new HashMap<String, Collection<DelayedEntry>>(container.getMaps().size());
         for (Entry<String, RecordStore> entry : container.getMaps().entrySet()) {
@@ -111,6 +110,7 @@ public class MapReplicationOperation extends AbstractOperation implements Mutati
                 final String mapName = dataEntry.getKey();
                 RecordStore recordStore = mapServiceContext.getRecordStore(getPartitionId(), mapName);
                 recordStore.reset();
+
                 for (RecordReplicationInfo recordReplicationInfo : recordReplicationInfos) {
                     Data key = recordReplicationInfo.getKey();
                     final Data value = recordReplicationInfo.getValue();
@@ -119,8 +119,6 @@ public class MapReplicationOperation extends AbstractOperation implements Mutati
                     applyRecordInfo(newRecord, recordReplicationInfo);
                     recordStore.putRecord(key, newRecord);
                 }
-                recordStore.setLoaded(true);
-
             }
         }
         for (Entry<String, Collection<DelayedEntry>> entry : delayedEntries.entrySet()) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionCheckIfLoadedOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionCheckIfLoadedOperation.java
@@ -18,12 +18,17 @@ package com.hazelcast.map.impl.operation;
 
 import com.hazelcast.map.impl.MapServiceContext;
 import com.hazelcast.map.impl.RecordStore;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.spi.PartitionAwareOperation;
 import com.hazelcast.spi.ReadonlyOperation;
+
+import java.io.IOException;
 
 public class PartitionCheckIfLoadedOperation extends AbstractMapOperation implements PartitionAwareOperation, ReadonlyOperation {
 
     private boolean isFinished;
+    private boolean doLoad;
 
     public PartitionCheckIfLoadedOperation() {
     }
@@ -32,15 +37,35 @@ public class PartitionCheckIfLoadedOperation extends AbstractMapOperation implem
         super(name);
     }
 
+    public PartitionCheckIfLoadedOperation(String name, boolean doLoad) {
+        super(name);
+        this.doLoad = doLoad;
+    }
+
     @Override
     public void run() {
         MapServiceContext mapServiceContext = mapService.getMapServiceContext();
         RecordStore recordStore = mapServiceContext.getRecordStore(getPartitionId(), name);
         isFinished = recordStore.isLoaded();
+        if (doLoad) {
+            recordStore.maybeDoInitialLoad();
+        }
     }
 
     @Override
     public Object getResponse() {
         return isFinished;
+    }
+
+    @Override
+    protected void writeInternal(ObjectDataOutput out) throws IOException {
+        super.writeInternal(out);
+        out.writeBoolean(doLoad);
+    }
+
+    @Override
+    protected void readInternal(ObjectDataInput in) throws IOException {
+        super.readInternal(in);
+        doLoad = in.readBoolean();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
@@ -105,6 +105,7 @@ import com.hazelcast.spi.InternalCompletableFuture;
 import com.hazelcast.spi.InvocationBuilder;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.OperationFactory;
 import com.hazelcast.spi.OperationService;
 import com.hazelcast.spi.impl.BinaryOperationFactory;
 import com.hazelcast.util.ExceptionUtil;
@@ -132,6 +133,7 @@ import java.util.concurrent.TimeUnit;
 import static com.hazelcast.map.impl.MapService.SERVICE_NAME;
 import static com.hazelcast.util.IterableUtil.nullToEmpty;
 import static com.hazelcast.util.Preconditions.checkNotNull;
+import static java.util.Collections.singleton;
 
 abstract class MapProxySupport extends AbstractDistributedObject<MapService> implements InitializingObject {
 
@@ -144,12 +146,16 @@ abstract class MapProxySupport extends AbstractDistributedObject<MapService> imp
     protected final LocalMapStatsImpl localMapStats;
     protected final LockProxySupport lockSupport;
     protected final PartitioningStrategy partitionStrategy;
+    private MapServiceContext mapServiceContext;
+    private InternalPartitionService partitionService;
 
     protected MapProxySupport(final String name, final MapService service, NodeEngine nodeEngine) {
         super(nodeEngine, service);
         this.name = name;
-        partitionStrategy = service.getMapServiceContext().getMapContainer(name).getPartitioningStrategy();
-        localMapStats = service.getMapServiceContext().getLocalMapStatsProvider().getLocalMapStatsImpl(name);
+        this.mapServiceContext = service.getMapServiceContext();
+        partitionStrategy = mapServiceContext.getMapContainer(name).getPartitioningStrategy();
+        localMapStats = mapServiceContext.getLocalMapStatsProvider().getLocalMapStatsImpl(name);
+        this.partitionService = getNodeEngine().getPartitionService();
         lockSupport = new LockProxySupport(new DefaultObjectNamespace(MapService.SERVICE_NAME, name));
     }
 
@@ -513,12 +519,11 @@ abstract class MapProxySupport extends AbstractDistributedObject<MapService> imp
     protected void loadAllInternal(boolean replaceExistingValues) {
         NodeEngine nodeEngine = getNodeEngine();
         OperationService operationService = nodeEngine.getOperationService();
-        Collection<MemberImpl> members = nodeEngine.getClusterService().getMemberList();
+        InternalPartitionService partitionService = nodeEngine.getPartitionService();
+        int mapNamePartition = partitionService.getPartitionId(name);
 
-        for (MemberImpl member : members) {
-            Operation operation = new LoadMapOperation(name, replaceExistingValues);
-            operationService.invokeOnTarget(MapService.SERVICE_NAME, operation, member.getAddress());
-        }
+        Operation operation = new LoadMapOperation(name, replaceExistingValues);
+        operationService.invokeOnPartition(MapService.SERVICE_NAME, operation, mapNamePartition);
 
         waitUntilLoaded();
     }
@@ -542,6 +547,7 @@ abstract class MapProxySupport extends AbstractDistributedObject<MapService> imp
             final Operation operation = createLoadAllOperation(correspondingKeys, replaceExistingValues);
             nodeEngine.getOperationService().invokeOnPartition(SERVICE_NAME, operation, partitionId);
         }
+
         waitUntilLoaded();
     }
 
@@ -620,32 +626,46 @@ abstract class MapProxySupport extends AbstractDistributedObject<MapService> imp
     public void waitUntilLoaded() {
         final NodeEngine nodeEngine = getNodeEngine();
         try {
-            Map<Integer, Object> results = nodeEngine.getOperationService()
-                    .invokeOnAllPartitions(SERVICE_NAME, new PartitionCheckIfLoadedOperationFactory(name));
-            Iterator<Entry<Integer, Object>> iterator = results.entrySet().iterator();
-            boolean isFinished = false;
-            final Set<Integer> retrySet = new HashSet<Integer>();
-            while (!isFinished) {
-                while (iterator.hasNext()) {
-                    final Entry<Integer, Object> entry = iterator.next();
-                    if (Boolean.TRUE.equals(entry.getValue())) {
-                        iterator.remove();
-                    } else {
-                        retrySet.add(entry.getKey());
-                    }
-                }
-                if (retrySet.size() > 0) {
-                    results = retryPartitions(retrySet);
-                    iterator = results.entrySet().iterator();
-                    final int oneSecond = 1000;
-                    Thread.sleep(oneSecond);
-                    retrySet.clear();
-                } else {
-                    isFinished = true;
-                }
-            }
+            OperationService operationService = nodeEngine.getOperationService();
+            OperationFactory opFactory = new PartitionCheckIfLoadedOperationFactory(name);
+
+            Map<Integer, Object> results;
+            Collection<Integer> mapNamePartition = getPartitionsForKeys(singleton(toData(name)));
+
+            results = operationService.invokeOnPartitions(SERVICE_NAME, opFactory, mapNamePartition);
+            waitAllTrue(results);
+
+            results = operationService.invokeOnAllPartitions(SERVICE_NAME, opFactory);
+            waitAllTrue(results);
+
         } catch (Throwable t) {
             throw ExceptionUtil.rethrow(t);
+        }
+    }
+
+    private void waitAllTrue(Map<Integer, Object> results)
+            throws InterruptedException {
+        Iterator<Entry<Integer, Object>> iterator = results.entrySet().iterator();
+        boolean isFinished = false;
+        final Set<Integer> retrySet = new HashSet<Integer>();
+        while (!isFinished) {
+            while (iterator.hasNext()) {
+                final Entry<Integer, Object> entry = iterator.next();
+                if (Boolean.TRUE.equals(entry.getValue())) {
+                    iterator.remove();
+                } else {
+                    retrySet.add(entry.getKey());
+                }
+            }
+            if (retrySet.size() > 0) {
+                results = retryPartitions(retrySet);
+                iterator = results.entrySet().iterator();
+                final int oneSecond = 1000;
+                Thread.sleep(oneSecond);
+                retrySet.clear();
+            } else {
+                isFinished = true;
+            }
         }
     }
 
@@ -754,7 +774,7 @@ abstract class MapProxySupport extends AbstractDistributedObject<MapService> imp
     }
 
     private Collection<Integer> getPartitionsForKeys(Set<Data> keys) {
-        InternalPartitionService partitionService = getNodeEngine().getPartitionService();
+
         int partitions = partitionService.getPartitionCount();
         //todo: is there better way to estimate size?
         int capacity = Math.min(partitions, keys.size());

--- a/hazelcast/src/main/java/com/hazelcast/partition/InternalPartitionService.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/InternalPartitionService.java
@@ -61,7 +61,7 @@ public interface InternalPartitionService extends CoreService {
      * @return owner of partition
      * @throws InterruptedException
      */
-    Address getPartitionOwnerOrWait(int partitionId) throws InterruptedException;
+    Address getPartitionOwnerOrWait(int partitionId);
 
     /**
      * Returns the InternalPartition for a given partitionId.
@@ -182,4 +182,10 @@ public interface InternalPartitionService extends CoreService {
 
     boolean hasOnGoingMigrationLocal();
 
+    /**
+     * Check if this node is the owner of a  partition
+     * @param partitionId
+     * @return true if it owns the partition. false if it doesn't or partition hasn't been assigned yet.
+     */
+    boolean isPartitionOwner(int partitionId);
 }

--- a/hazelcast/src/main/java/com/hazelcast/partition/impl/InternalPartitionServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/impl/InternalPartitionServiceImpl.java
@@ -59,6 +59,7 @@ import com.hazelcast.spi.ResponseHandler;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.impl.ResponseHandlerFactory;
 import com.hazelcast.util.Clock;
+import com.hazelcast.util.ExceptionUtil;
 import com.hazelcast.util.FutureUtil.ExceptionHandler;
 import com.hazelcast.util.scheduler.CoalescingDelayedTrigger;
 import com.hazelcast.util.scheduler.EntryTaskScheduler;
@@ -261,10 +262,14 @@ public class InternalPartitionServiceImpl implements InternalPartitionService, M
     }
 
     @Override
-    public Address getPartitionOwnerOrWait(int partition) throws InterruptedException {
+    public Address getPartitionOwnerOrWait(int partition) {
         Address owner = getPartitionOwner(partition);
         while (owner == null) {
-            Thread.sleep(PARTITION_OWNERSHIP_WAIT_MILLIS);
+            try {
+                Thread.sleep(PARTITION_OWNERSHIP_WAIT_MILLIS);
+            } catch (InterruptedException e) {
+                ExceptionUtil.rethrow(e);
+            }
             owner = getPartitionOwner(partition);
         }
         return owner;
@@ -1523,6 +1528,12 @@ public class InternalPartitionServiceImpl implements InternalPartitionService, M
 
     public Node getNode() {
         return node;
+    }
+
+    @Override
+    public boolean isPartitionOwner(int partitionId) {
+        InternalPartitionImpl partition = getPartition(partitionId);
+        return node.getThisAddress().equals(partition.getOwnerOrNull());
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/util/CollectionUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/CollectionUtil.java
@@ -16,7 +16,10 @@
 
 package com.hazelcast.util;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Various collection utility methods, mainly targeted to use internally.
@@ -44,5 +47,25 @@ public final class CollectionUtil {
      */
     public static boolean isNotEmpty(Collection collection) {
         return !isEmpty(collection);
+    }
+
+    /**
+     * Add value to list of values in the map. Creates a new list if it doesn't exist for the key
+     *
+     * @param map
+     * @param key
+     * @param value
+     * @return the updated list of values.
+     */
+    public static <K, V> List<V> addToValueList(Map<K, List<V>> map, K key, V value) {
+
+        List<V> values = map.get(key);
+        if (values == null) {
+            values = new ArrayList<V>();
+            map.put(key, values);
+        }
+        values.add(value);
+
+        return values;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/util/FutureUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/FutureUtil.java
@@ -300,6 +300,7 @@ public final class FutureUtil {
         if (future instanceof InternalCompletableFuture) {
             return ((InternalCompletableFuture<V>) future).getSafely();
         }
+
         return future.get();
     }
 
@@ -318,5 +319,32 @@ public final class FutureUtil {
      */
     public interface ExceptionHandler {
         void handleException(Throwable throwable);
+    }
+
+    /**
+     * Check if all futures are done
+     * @param futures
+     * @return true if all futures are done. false otherwise
+     */
+    public static boolean allDone(Collection<Future> futures) {
+        for (Future f: futures) {
+            if (!f.isDone()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Rethrow exeception of the fist future that completed with an exception
+     * @param futures
+     * @throws Exception
+     */
+    public static void checkAllDone(Collection<Future> futures) throws Exception {
+        for (Future f: futures) {
+            if (f.isDone()) {
+                f.get();
+            }
+        }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/util/IterableUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/IterableUtil.java
@@ -48,7 +48,7 @@ public final class IterableUtil {
     }
 
     /** Transform the Iterator by applying a function to each element  **/
-    private static <T, R> Iterator<R> map(final Iterator<T> iterator, final IFunction<T, R> mapper) {
+    public static <T, R> Iterator<R> map(final Iterator<T> iterator, final IFunction<T, R> mapper) {
         return new Iterator<R>() {
             @Override
             public boolean hasNext() {
@@ -67,9 +67,32 @@ public final class IterableUtil {
         };
     }
 
+    public static <T, R> Iterator<R> limit(final Iterator<R> iterator, final int limit) {
+        return new Iterator<R>() {
+            private int iterated;
+
+            @Override
+            public boolean hasNext() {
+                return iterated < limit && iterator.hasNext();
+            }
+
+            @Override
+            public R next() {
+                iterated++;
+                return iterator.next();
+            }
+
+            @Override
+            public void remove() {
+                iterator.remove();
+            }
+        };
+    }
+
     /** Return empty Iterable if argument is null **/
     public static <T> Iterable<T> nullToEmpty(Iterable<T> iterable) {
         return iterable == null ? Collections.<T>emptyList() : iterable;
     }
+
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/util/StateMachine.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/StateMachine.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package com.hazelcast.util;
 
 import java.util.EnumSet;

--- a/hazelcast/src/main/java/com/hazelcast/util/StateMachine.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/StateMachine.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hazelcast.util;
+
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static com.hazelcast.util.ValidationUtil.checkNotNull;
+import static com.hazelcast.util.ValidationUtil.checkState;
+
+/**
+ * Simple state machine using an Enum as possible states.
+ *
+ * @param <T>
+ */
+public class StateMachine<T extends Enum<T>> {
+
+    private Map<T, Set<T>> transitions = new HashMap<T, Set<T>>();
+    private T currentState;
+
+    public StateMachine(T initialState) {
+        currentState = initialState;
+    }
+
+    public static <T extends Enum<T>> StateMachine<T> of(T initialState) {
+        return new StateMachine<T>(initialState);
+    }
+
+    /**
+     * Add a valid transition from one state to one or more states
+     **/
+    public StateMachine<T> withTransition(T from, T to, T... moreTo) {
+        transitions.put(from, EnumSet.of(to, moreTo));
+        return this;
+    }
+
+    /**
+     * Transition to next state
+     * @throws IllegalStateException if transition is not allowed
+     */
+    public StateMachine<T> next(T nextState) throws IllegalStateException {
+        Set<T> allowed = transitions.get(currentState);
+        checkNotNull(allowed, "No transitions from state " + currentState);
+        checkState(allowed.contains(nextState), "Transition not allowed from state " + currentState + " to " + nextState);
+        currentState = nextState;
+        return this;
+    }
+
+    /**
+     * Transition to next state if not already there
+     */
+    public void nextOrStay(T nextState) {
+        if (!is(nextState)) {
+            next(nextState);
+        }
+    }
+
+    /**
+     * Check if current state is one of given states
+     */
+    public boolean is(T state, T ... otherStates) {
+        return EnumSet.of(state, otherStates).contains(currentState);
+    }
+
+    @Override
+    public String toString() {
+        return "StateMachine{state=" + currentState + "}";
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/util/UnmodifiableIterator.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/UnmodifiableIterator.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package com.hazelcast.util;
 
 import java.util.Iterator;

--- a/hazelcast/src/main/java/com/hazelcast/util/UnmodifiableIterator.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/UnmodifiableIterator.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hazelcast.util;
+
+import java.util.Iterator;
+
+/**
+ * An iterator where items cannot be removed
+ *
+ * @param <E> element type
+ */
+public abstract class UnmodifiableIterator<E> implements Iterator<E> {
+    @Override
+    public final void remove() {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/util/ValidationUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/ValidationUtil.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.util;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+import static java.lang.String.format;
+
+/**
+ * A utility class for validating arguments and state.
+ */
+public final class ValidationUtil {
+
+    private ValidationUtil() {
+    }
+
+    /**
+     * Tests if an argument is not null.
+     *
+     * @param argument the argument tested to see if it is not null.
+     * @param message  message thrown if argument is null.
+     * @return the argument that was tested.
+     * @throws java.lang.NullPointerException if argument is null
+     */
+    public static <T> T checkNotNull(T argument, String message) {
+        if (argument == null) {
+            throw new NullPointerException(message);
+        }
+        return argument;
+    }
+
+    /**
+     * Tests if a string contains text.
+     *
+     * @param argument the string tested to see if it contains text.
+     * @param argName  the string name (used in message if an error is thrown).
+     * @return the string argument that was tested.
+     * @throws java.lang.IllegalArgumentException if the string is empty
+     */
+    public static String hasText(String argument, String argName) {
+        isNotNull(argument, argName);
+
+        if (argument.isEmpty()) {
+            throw new IllegalArgumentException(format("argument '%s' can't be an empty string", argName));
+        }
+
+        return argument;
+    }
+
+    /**
+     * Tests if a string is not null.
+     *
+     * @param argument the string tested to see if it is not null.
+     * @param argName  the string name (used in message if an error is thrown).
+     * @return the string argument that was tested.
+     * @throws java.lang.IllegalArgumentException if the string is null.
+     */
+    public static <E> E isNotNull(E argument, String argName) {
+        if (argument == null) {
+            throw new IllegalArgumentException(format("argument '%s' can't be null", argName));
+        }
+
+        return argument;
+    }
+
+    /**
+     * Tests if a long value is not negative.
+     *
+     * @param value        the long value tested to see if it is not negative.
+     * @param argumentName the value name (used in message if an error is thrown).
+     * @throws java.lang.IllegalArgumentException if the value is negative.
+     */
+    public static void isNotNegative(long value, String argumentName) {
+        if (value < 0) {
+            throw new IllegalArgumentException(argumentName + " cannot be negative!");
+        }
+    }
+
+    /**
+     * Tests if a long value is positive.
+     *
+     * @param value        the long value tested to see if it is positive.
+     * @param argumentName the value name (used in message if an error is thrown).
+     * @throws java.lang.IllegalArgumentException if the value is not positive.
+     */
+    public static void shouldBePositive(long value, String argumentName) {
+        if (value <= 0) {
+            throw new IllegalArgumentException(argumentName + " should be positive!");
+        }
+    }
+
+
+    /**
+     * Tests whether the supplied object is an instance of the supplied class type.
+     *
+     * @param type         the expected type.
+     * @param object       the object tested against the expected type.
+     * @param argumentName the argument name of the object.
+     * @return the object argument.
+     * @throws java.lang.IllegalArgumentException if the object is not an instance of the expected type.
+     */
+    public static <E> E checkInstanceOf(Class type, E object, String argumentName) {
+        isNotNull(type, "type");
+        if (!type.isInstance(object)) {
+            throw new IllegalArgumentException(argumentName + " should be an instance of " + type
+                    + ", but found " + object);
+        }
+        return object;
+    }
+
+    /**
+     * Tests the supplied object to see if it is not a type of the supplied class.
+     *
+     * @param type         the type that is not of the supplied class.
+     * @param object       the object tested against the type.
+     * @param argumentName the argument name of the object.
+     * @return the object argument.
+     * @throws java.lang.IllegalArgumentException if the object is an instance of the type that is not of the expected class.
+     */
+    public static <E> E checkNotInstanceOf(Class type, E object, String argumentName) {
+        isNotNull(type, "type");
+        if (type.isInstance(object)) {
+            throw new IllegalArgumentException(argumentName + " can not be an instance of " + type);
+        }
+        return object;
+    }
+
+    /**
+     * Tests whether the supplied expression is {@code false}.
+     *
+     * @param expression the expression tested to see if it is {@code false}.
+     * @param message    exception message in case the supplied expression is not {@code false}.
+     * @throws java.lang.IllegalArgumentException if the supplied expression is {@code true}.
+     */
+    public static void checkFalse(boolean expression, String message) {
+        if (expression) {
+            throw new IllegalArgumentException(message);
+        }
+    }
+
+    /**
+     * Check if iterator has next element. If not throw NoSuchElementException
+     *
+     * @param iterator
+     * @param message
+     * @return the iterator itself
+     * @throws NoSuchElementException if iterator.hasNext returns false
+     */
+    public static <T> Iterator<T> checkHasNext(Iterator<T> iterator, String message) throws NoSuchElementException {
+        if (!iterator.hasNext()) {
+            throw new NoSuchElementException(message);
+        }
+        return iterator;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/util/ValidationUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/ValidationUtil.java
@@ -167,4 +167,16 @@ public final class ValidationUtil {
         }
         return iterator;
     }
+
+    /**
+     * Check the state of a condition
+     * @param condition
+     * @param message
+     * @throws IllegalStateException if condition if false
+     */
+    public static void checkState(boolean condition, String message) throws IllegalStateException {
+        if (!condition) {
+            throw new IllegalStateException(message);
+        }
+    }
 }

--- a/hazelcast/src/test/java/com/hazelcast/map/mapstore/CountingMapLoader.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/mapstore/CountingMapLoader.java
@@ -11,10 +11,15 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class CountingMapLoader extends SimpleMapLoader {
 
     private AtomicInteger loadedValueCount = new AtomicInteger();
+    private AtomicInteger loadAllKeysInvocations = new AtomicInteger();
     private AtomicBoolean loadAllKeysClosed = new AtomicBoolean();
 
     CountingMapLoader(int size) {
         super(size, false);
+    }
+
+    CountingMapLoader(int size, boolean slow) {
+        super(size, slow);
     }
 
     @Override
@@ -39,12 +44,17 @@ public class CountingMapLoader extends SimpleMapLoader {
     @Override
     public Iterable<Integer> loadAllKeys() {
         final Iterable<Integer> allKeys = super.loadAllKeys();
+        loadAllKeysInvocations.incrementAndGet();
         return new Iterable<Integer>() {
             @Override
             public Iterator<Integer> iterator() {
                 return new CloseableIterator<Integer>(allKeys.iterator());
             }
         };
+    }
+
+    public int getLoadAllKeysInvocations() {
+        return loadAllKeysInvocations.get();
     }
 
     private class CloseableIterator<T> implements Iterator<T>, Closeable {

--- a/hazelcast/src/test/java/com/hazelcast/map/mapstore/LoadAllTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/mapstore/LoadAllTest.java
@@ -115,6 +115,7 @@ public class LoadAllTest extends HazelcastTestSupport {
         populateMap(map, itemCount);
         map.evictAll();
         map.putTransient(0, -1, 0, SECONDS);
+
         map.loadAll(false);
 
         assertEquals(itemCount, map.size());

--- a/hazelcast/src/test/java/com/hazelcast/map/mapstore/MapLoaderFailoverTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/mapstore/MapLoaderFailoverTest.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.mapstore;
+
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.GroupConfig;
+import com.hazelcast.config.MapStoreConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.core.MapLoader;
+import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.QuickTest;
+
+import java.util.concurrent.Future;
+
+import static com.hazelcast.config.MapStoreConfig.InitialLoadMode.LAZY;
+import static com.hazelcast.test.TimeConstants.MINUTE;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category(QuickTest.class)
+public class MapLoaderFailoverTest extends HazelcastTestSupport {
+
+    private static final int MAP_STORE_ENTRY_COUNT = 10000;
+    private static final int BATCH_SIZE = 100;
+    private static final int NODE_COUNT = 3;
+
+    private TestHazelcastInstanceFactory nodeFactory;
+    private CountingMapLoader mapLoader;
+
+    @Before
+    public void setUp() throws Exception {
+        nodeFactory = createHazelcastInstanceFactory(NODE_COUNT + 2);
+        mapLoader = new CountingMapLoader(MAP_STORE_ENTRY_COUNT);
+    }
+
+    @Test(timeout = MINUTE)
+    public void testDoesntLoadAgain_whenLoaderNodeGoesDown() throws Exception {
+        Config cfg = newConfig("default", LAZY);
+        HazelcastInstance[] nodes = nodeFactory.newInstances(cfg, 3);
+        HazelcastInstance hz3 = nodes[2];
+
+        String mapName = generateKeyOwnedBy(hz3);
+        IMap<Object, Object> map = nodes[0].getMap(mapName);
+
+        map.size();
+        assertSizeAndLoadCount(map);
+
+        System.err.println("terminate");
+        hz3.getLifecycleService().terminate();
+        waitAllForSafeState(nodeFactory.getAllHazelcastInstances());
+
+        assertSizeAndLoadCount(map);
+        assertEquals(1, mapLoader.getLoadAllKeysInvocations());
+    }
+
+    @Test(timeout = MINUTE)
+    public void testLoads_whenInitialLoaderNodeRemoved() throws Exception {
+        Config cfg = newConfig("default", LAZY);
+        HazelcastInstance[] nodes = nodeFactory.newInstances(cfg, 3);
+        HazelcastInstance hz3 = nodes[2];
+
+        String mapName = generateKeyOwnedBy(hz3);
+        IMap<Object, Object> map = nodes[0].getMap(mapName);
+        hz3.getLifecycleService().terminate();
+
+        // trigger loading
+        map.size();
+
+        assertEquals(1, mapLoader.getLoadAllKeysInvocations());
+        assertSizeAndLoadCount(map);
+    }
+
+    @Test(timeout = MINUTE)
+    public void testLoadsAll_whenInitialLoaderNodeRemovedAfterLoading() throws Exception {
+        Config cfg = newConfig("default", LAZY);
+        HazelcastInstance[] nodes = nodeFactory.newInstances(cfg, 3);
+        HazelcastInstance hz3 = nodes[2];
+
+        String mapName = generateKeyOwnedBy(hz3);
+        IMap<Object, Object> map = nodes[0].getMap(mapName);
+
+        map.size();
+        assertSizeAndLoadCount(map);
+
+        hz3.getLifecycleService().terminate();
+        assertClusterSize(2, nodes[0]);
+        map.loadAll(true);
+
+        assertSizeEventually(MAP_STORE_ENTRY_COUNT, map);
+        assertEquals(2, mapLoader.getLoadAllKeysInvocations());
+        assertEquals(2 * MAP_STORE_ENTRY_COUNT, mapLoader.getLoadedValueCount());
+    }
+
+    @Test(timeout = MINUTE)
+    public void testLoadsAll_whenInitialLoaderNodeRemovedWhileLoading() throws Exception {
+        PausingMapLoader<Integer, Integer> pausingLoader = new PausingMapLoader<Integer, Integer>(mapLoader, 5000);
+
+        Config cfg = newConfig("default", LAZY, 1, pausingLoader);
+        HazelcastInstance[] nodes = nodeFactory.newInstances(cfg, 3);
+        HazelcastInstance hz3 = nodes[2];
+
+        String mapName = generateKeyOwnedBy(hz3);
+        IMap<Object, Object> map = nodes[0].getMap(mapName);
+
+        // trigger loading and pause half way through
+        Future<Object> asyncVal = map.getAsync(1);
+        pausingLoader.awaitPause();
+
+        hz3.getLifecycleService().terminate();
+        assertClusterSize(2, nodes[0]);
+
+        pausingLoader.resume();
+
+        assertEquals(1, asyncVal.get());
+        assertSizeEventually(MAP_STORE_ENTRY_COUNT, map);
+        assertTrue(mapLoader.getLoadedValueCount() >= MAP_STORE_ENTRY_COUNT);
+        assertEquals(2, mapLoader.getLoadAllKeysInvocations());
+    }
+
+    @Test(timeout = MINUTE)
+    public void testLoadsAll_whenInitialLoaderNodeRemovedWhileLoadingAndNoBackups() throws Exception {
+        PausingMapLoader<Integer, Integer> pausingLoader = new PausingMapLoader<Integer, Integer>(mapLoader, 5000);
+
+        Config cfg = newConfig("default", LAZY, 0, pausingLoader);
+        HazelcastInstance[] nodes = nodeFactory.newInstances(cfg, 3);
+        HazelcastInstance hz3 = nodes[2];
+
+        String mapName = generateKeyOwnedBy(hz3);
+        System.err.println(mapName);
+        IMap<Object, Object> map = nodes[0].getMap(mapName);
+
+        // trigger loading and pause half way through
+        map.putAsync(1, 2);
+        pausingLoader.awaitPause();
+
+        System.err.println("terminate");
+        hz3.getLifecycleService().terminate();
+        waitAllForSafeState(nodeFactory.getAllHazelcastInstances());
+
+        pausingLoader.resume();
+
+        int size = map.size();
+        assertEquals(MAP_STORE_ENTRY_COUNT, size);
+        assertTrue(mapLoader.getLoadedValueCount() >= MAP_STORE_ENTRY_COUNT);
+        assertEquals(2, mapLoader.getLoadAllKeysInvocations());
+    }
+
+    private void assertSizeAndLoadCount(IMap<Object, Object> map) {
+        assertSizeEventually(MAP_STORE_ENTRY_COUNT, map);
+        assertEquals(MAP_STORE_ENTRY_COUNT, mapLoader.getLoadedValueCount());
+    }
+
+    private Config newConfig(String mapName, MapStoreConfig.InitialLoadMode loadMode) {
+        return newConfig(mapName, loadMode, 1, mapLoader);
+    }
+
+    private Config newConfig(String mapName, MapStoreConfig.InitialLoadMode loadMode, int backups, MapLoader loader) {
+        Config cfg = new Config();
+        cfg.setGroupConfig(new GroupConfig(getClass().getSimpleName()));
+        cfg.setProperty(GroupProperties.PROP_MAP_LOAD_CHUNK_SIZE, Integer.toString(BATCH_SIZE));
+        cfg.setProperty(GroupProperties.PROP_PARTITION_COUNT, "31");
+
+        MapStoreConfig mapStoreConfig = new MapStoreConfig()
+                .setImplementation(loader).setInitialLoadMode(loadMode);
+
+        cfg.getMapConfig(mapName).setMapStoreConfig(mapStoreConfig).setBackupCount(backups);
+
+        return cfg;
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/map/mapstore/MapLoaderFailoverTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/mapstore/MapLoaderFailoverTest.java
@@ -71,7 +71,6 @@ public class MapLoaderFailoverTest extends HazelcastTestSupport {
         map.size();
         assertSizeAndLoadCount(map);
 
-        System.err.println("terminate");
         hz3.getLifecycleService().terminate();
         waitAllForSafeState(nodeFactory.getAllHazelcastInstances());
 
@@ -152,14 +151,12 @@ public class MapLoaderFailoverTest extends HazelcastTestSupport {
         HazelcastInstance hz3 = nodes[2];
 
         String mapName = generateKeyOwnedBy(hz3);
-        System.err.println(mapName);
         IMap<Object, Object> map = nodes[0].getMap(mapName);
 
         // trigger loading and pause half way through
         map.putAsync(1, 2);
         pausingLoader.awaitPause();
 
-        System.err.println("terminate");
         hz3.getLifecycleService().terminate();
         waitAllForSafeState(nodeFactory.getAllHazelcastInstances());
 

--- a/hazelcast/src/test/java/com/hazelcast/map/mapstore/MapLoaderMultiNodeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/mapstore/MapLoaderMultiNodeTest.java
@@ -1,0 +1,232 @@
+package com.hazelcast.map.mapstore;
+
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.GroupConfig;
+import com.hazelcast.config.MapStoreConfig;
+import com.hazelcast.config.MapStoreConfig.InitialLoadMode;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.core.MapLoader;
+import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.QuickTest;
+
+import static com.hazelcast.config.MapStoreConfig.InitialLoadMode.EAGER;
+import static com.hazelcast.config.MapStoreConfig.InitialLoadMode.LAZY;
+import static com.hazelcast.test.TimeConstants.MINUTE;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class MapLoaderMultiNodeTest extends HazelcastTestSupport {
+
+    private static final int MAP_STORE_ENTRY_COUNT = 10000;
+    private static final int BATCH_SIZE = 100;
+    private static final int NODE_COUNT = 3;
+
+    private TestHazelcastInstanceFactory nodeFactory;
+    private CountingMapLoader mapLoader;
+    private final String mapName = getClass().getSimpleName();
+
+    @Before
+    public void setUp() throws Exception {
+        nodeFactory = createHazelcastInstanceFactory(NODE_COUNT + 2);
+        mapLoader = new CountingMapLoader(MAP_STORE_ENTRY_COUNT);
+    }
+
+    @Test(timeout = MINUTE)
+    public void testLoads_whenMapLazyAndCheckingSize() throws Exception {
+        Config cfg = newConfig(mapName, LAZY);
+
+        IMap<Object, Object> map = getMap(mapName, cfg);
+
+        assertSizeAndLoadCount(map);
+    }
+
+    @Test(timeout = MINUTE)
+    public void testLoadsAll_whenMapCreatedInEager() throws Exception {
+        Config cfg = newConfig(mapName, EAGER);
+
+        IMap<Object, Object> map = getMap(mapName, cfg);
+
+        assertSizeAndLoadCount(map);
+    }
+
+    @Test(timeout = MINUTE)
+    public void testLoadsNothing_whenMapCreatedLazy() throws Exception {
+        Config cfg = newConfig(mapName, InitialLoadMode.LAZY);
+
+        getMap(mapName, cfg);
+
+        assertEquals(0, mapLoader.getLoadedValueCount());
+    }
+
+    @Test(timeout = MINUTE)
+    public void testLoadsMap_whenLazyAndValueRetrieved() throws Exception {
+        Config cfg = newConfig(mapName, InitialLoadMode.LAZY);
+
+        IMap<Object, Object> map = getMap(mapName, cfg);
+
+        assertEquals(1, map.get(1));
+        assertSizeAndLoadCount(map);
+    }
+
+    @Test(timeout = MINUTE)
+    public void testLoadsAll_whenLazyModeAndLoadAll() throws Exception {
+        Config cfg = newConfig(mapName, LAZY);
+
+        IMap<Object, Object> map = getMap(mapName, cfg);
+        map.loadAll(true);
+
+        assertEquals(1, mapLoader.getLoadAllKeysInvocations());
+        assertSizeAndLoadCount(map);
+    }
+
+    @Test(timeout = MINUTE)
+    public void testDoesNotLoadAgain_whenLoadedAndNodeAdded() throws Exception {
+        Config cfg = newConfig(mapName, EAGER);
+
+        IMap<Object, Object> map = getMap(mapName, cfg);
+        nodeFactory.newHazelcastInstance(cfg);
+
+        assertEquals(1, mapLoader.getLoadAllKeysInvocations());
+        assertSizeAndLoadCount(map);
+    }
+
+    @Test(timeout = MINUTE)
+    public void testDoesNotLoadAgain_whenLoadedLazyAndNodeAdded() throws Exception {
+        Config cfg = newConfig(mapName, LAZY);
+
+        IMap<Object, Object> map = getMap(mapName, cfg);
+        map.loadAll(true);
+        nodeFactory.newHazelcastInstance(cfg);
+
+        assertEquals(1, mapLoader.getLoadAllKeysInvocations());
+        assertSizeAndLoadCount(map);
+    }
+
+    @Test(timeout = MINUTE)
+    public void testLoadAgain_whenLoadedAllCalledMultipleTimes() throws Exception {
+        Config cfg = newConfig(mapName, LAZY);
+
+        IMap<Object, Object> map = getMap(mapName, cfg);
+        map.loadAll(true);
+        map.loadAll(true);
+
+        assertEquals(2, mapLoader.getLoadAllKeysInvocations());
+        assertSizeEventually(MAP_STORE_ENTRY_COUNT, map);
+        assertEquals(2*MAP_STORE_ENTRY_COUNT, mapLoader.getLoadedValueCount());
+    }
+
+    @Test(timeout = MINUTE)
+    public void testLoadsOnce_whenSizeCheckedTwice() throws Exception {
+
+        mapLoader = new CountingMapLoader(MAP_STORE_ENTRY_COUNT, true);
+        Config cfg = newConfig(mapName, LAZY);
+
+        IMap<Object, Object> map = getMap(mapName, cfg);
+        map.size();
+        map.size();
+
+        assertEquals(1, mapLoader.getLoadAllKeysInvocations());
+        assertSizeAndLoadCount(map);
+    }
+
+    @Test(timeout = MINUTE)
+    public void testLoads_whenInitialLoaderNodeRemoved() throws Exception {
+        Config cfg = newConfig("default", LAZY);
+        HazelcastInstance[] nodes = nodeFactory.newInstances(cfg, 3);
+        HazelcastInstance hz3 = nodes[2];
+
+        String mapName = generateKeyOwnedBy(hz3);
+        IMap<Object, Object> map = nodes[0].getMap(mapName);
+        hz3.getLifecycleService().terminate();
+
+        // trigger loading
+        map.size();
+
+        assertEquals(1, mapLoader.getLoadAllKeysInvocations());
+        assertSizeAndLoadCount(map);
+    }
+
+    @Test(timeout = MINUTE)
+    public void testDoesntLoadAgain_whenLoaderNodeGoesDown() throws Exception {
+        Config cfg = newConfig("default", LAZY);
+        HazelcastInstance[] nodes = nodeFactory.newInstances(cfg, 3);
+        HazelcastInstance hz3 = nodes[2];
+
+        String mapName = generateKeyOwnedBy(hz3);
+        IMap<Object, Object> map = nodes[0].getMap(mapName);
+
+        map.size();
+        assertSizeAndLoadCount(map);
+
+        hz3.getLifecycleService().terminate();
+        waitAllForSafeState(nodeFactory.getAllHazelcastInstances());
+
+        assertSizeAndLoadCount(map);
+        assertEquals(1, mapLoader.getLoadAllKeysInvocations());
+    }
+
+    @Test(timeout = MINUTE)
+    public void testLoadsAll_whenInitialLoaderNodeRemovedAfterLoading() throws Exception {
+        Config cfg = newConfig("default", LAZY);
+        HazelcastInstance[] nodes = nodeFactory.newInstances(cfg, 3);
+        HazelcastInstance hz3 = nodes[2];
+
+        String mapName = generateKeyOwnedBy(hz3);
+        IMap<Object, Object> map = nodes[0].getMap(mapName);
+
+        map.size();
+        assertSizeAndLoadCount(map);
+
+        hz3.getLifecycleService().terminate();
+        assertClusterSize(2, nodes[0]);
+        map.loadAll(true);
+
+        assertSizeEventually(MAP_STORE_ENTRY_COUNT, map);
+        assertEquals(2, mapLoader.getLoadAllKeysInvocations());
+        assertEquals(2 * MAP_STORE_ENTRY_COUNT, mapLoader.getLoadedValueCount());
+    }
+
+    private void assertSizeAndLoadCount(IMap<Object, Object> map) {
+        assertSizeEventually(MAP_STORE_ENTRY_COUNT, map);
+        assertEquals(MAP_STORE_ENTRY_COUNT, mapLoader.getLoadedValueCount());
+    }
+
+    private IMap<Object, Object> getMap(final String mapName, Config cfg) {
+        HazelcastInstance hz = nodeFactory.newInstances(cfg, NODE_COUNT)[0];
+        assertClusterSizeEventually(NODE_COUNT, hz);
+        IMap<Object, Object> map = hz.getMap(mapName);
+        waitClusterForSafeState(hz);
+        return map;
+    }
+
+    private Config newConfig(String mapName, MapStoreConfig.InitialLoadMode loadMode) {
+        return newConfig(mapName, loadMode, 1, mapLoader);
+    }
+
+    private Config newConfig(String mapName, MapStoreConfig.InitialLoadMode loadMode, int backups, MapLoader loader) {
+        Config cfg = new Config();
+        cfg.setGroupConfig(new GroupConfig(getClass().getSimpleName()));
+        cfg.setProperty(GroupProperties.PROP_MAP_LOAD_CHUNK_SIZE, Integer.toString(BATCH_SIZE));
+        cfg.setProperty(GroupProperties.PROP_PARTITION_COUNT, "31");
+
+        MapStoreConfig mapStoreConfig = new MapStoreConfig()
+                .setImplementation(loader).setInitialLoadMode(loadMode);
+
+        cfg.getMapConfig(mapName).setMapStoreConfig(mapStoreConfig).setBackupCount(backups);
+
+        return cfg;
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/map/mapstore/MapLoaderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/mapstore/MapLoaderTest.java
@@ -17,9 +17,6 @@ import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.QuickTest;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
 
 import java.io.Serializable;
 import java.util.Arrays;
@@ -36,8 +33,13 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static java.lang.String.format;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 
 @RunWith(HazelcastSerialClassRunner.class)
@@ -114,7 +116,7 @@ public class MapLoaderTest extends HazelcastTestSupport {
         node = nodeBuilder.getRandomNode();
         map = node.getMap(mapName);
 
-        assertLoadAllKeysCount(loader, nodeCount);
+        assertLoadAllKeysCount(loader, 1);
         assertPredicateResultCorrect(map, predicate);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/map/mapstore/MapStoreTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/mapstore/MapStoreTest.java
@@ -1084,7 +1084,6 @@ public class MapStoreTest extends HazelcastTestSupport {
         }
 
         public void store(Object key, Object value) {
-            System.err.println("store call: " + key);
             store.put(key, value);
             callCount.incrementAndGet();
             latchStore.countDown();

--- a/hazelcast/src/test/java/com/hazelcast/map/mapstore/MapStoreWriteBehindTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/mapstore/MapStoreWriteBehindTest.java
@@ -1,0 +1,839 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.mapstore;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.config.MapStoreConfig;
+import com.hazelcast.config.MapStoreConfig.InitialLoadMode;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.core.MapStore;
+import com.hazelcast.core.MapStoreAdapter;
+import com.hazelcast.core.TransactionalMap;
+import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.map.impl.MapService;
+import com.hazelcast.map.impl.MapServiceContext;
+import com.hazelcast.map.impl.RecordStore;
+import com.hazelcast.map.impl.mapstore.MapDataStore;
+import com.hazelcast.map.impl.mapstore.writebehind.WriteBehindStore;
+import com.hazelcast.map.mapstore.MapStoreTest.MapStoreWithStoreCount;
+import com.hazelcast.map.mapstore.MapStoreTest.SimpleMapStore;
+import com.hazelcast.map.mapstore.MapStoreTest.TestEventBasedMapStore;
+import com.hazelcast.map.mapstore.MapStoreTest.TestMapStore;
+import com.hazelcast.map.mapstore.writebehind.TestMapUsingMapStoreBuilder;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.transaction.TransactionContext;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static com.hazelcast.map.mapstore.MapStoreTest.newConfig;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+
+/**
+ * @author enesakar 1/21/13
+ */
+@RunWith(HazelcastParallelClassRunner.class)
+@Category(QuickTest.class)
+public class MapStoreWriteBehindTest extends HazelcastTestSupport {
+
+    @Test(timeout = 120000)
+    public void testOneMemberWriteBehindWithMaxIdle() throws Exception {
+        final TestEventBasedMapStore testMapStore = new TestEventBasedMapStore();
+        Config config = newConfig(testMapStore, 5, InitialLoadMode.EAGER);
+        config.setProperty(GroupProperties.PROP_PARTITION_COUNT, "1");
+        config.getMapConfig("default").setMaxIdleSeconds(10);
+        HazelcastInstance h1 = createHazelcastInstance(config);
+        final IMap map = h1.getMap("default");
+
+        final int total = 10;
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertEquals(TestEventBasedMapStore.STORE_EVENTS.LOAD_ALL_KEYS, testMapStore.getEvents().poll());
+            }
+        });
+
+        for (int i = 0; i < total; i++) {
+            map.put(i, "value" + i);
+        }
+
+        sleepSeconds(11);
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertEquals(0, map.size());
+            }
+        });
+        assertEquals(total, testMapStore.getStore().size());
+    }
+
+    @Test(timeout = 120000)
+    public void testOneMemberWriteBehindWithEvictions() throws Exception {
+        final String mapName = "testOneMemberWriteBehindWithEvictions";
+        final TestEventBasedMapStore testMapStore = new TestEventBasedMapStore();
+        testMapStore.loadAllLatch = new CountDownLatch(1);
+        final Config config = newConfig(testMapStore, 2, InitialLoadMode.EAGER);
+        final HazelcastInstance node1 = createHazelcastInstance(config);
+        final IMap map = node1.getMap(mapName);
+        // check if load all called.
+        assertTrue("map store loadAllKeys must be called", testMapStore.loadAllLatch.await(10, TimeUnit.SECONDS));
+        // map population count.
+        final int populationCount = 100;
+        // latch for store & storeAll events.
+        testMapStore.storeLatch = new CountDownLatch(populationCount);
+        //populate map.
+        for (int i = 0; i < populationCount; i++) {
+            map.put(i, "value" + i);
+        }
+        //wait for all store ops.
+        assertOpenEventually(testMapStore.storeLatch);
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertEquals(0, writeBehindQueueSize(node1, mapName));
+            }
+        });
+
+        // init before eviction.
+        testMapStore.storeLatch = new CountDownLatch(populationCount);
+        //evict.
+        for (int i = 0; i < populationCount; i++) {
+            map.evict(i);
+        }
+        //expect no store op.
+        assertEquals(populationCount, testMapStore.storeLatch.getCount());
+        //check store size
+        assertEquals(populationCount, testMapStore.getStore().size());
+        //check map size
+        assertEquals(0, map.size());
+        //re-populate map.
+        for (int i = 0; i < populationCount; i++) {
+            map.put(i, "value" + i);
+        }
+        //evict again.
+        for (int i = 0; i < populationCount; i++) {
+            map.evict(i);
+        }
+        //wait for all store ops.
+        testMapStore.storeLatch.await(10, TimeUnit.SECONDS);
+        //check store size
+        assertEquals(populationCount, testMapStore.getStore().size());
+        //check map size
+        assertEquals(0, map.size());
+
+        //re-populate map.
+        for (int i = 0; i < populationCount; i++) {
+            map.put(i, "value" + i);
+        }
+        testMapStore.deleteLatch = new CountDownLatch(populationCount);
+        //clear map.
+        for (int i = 0; i < populationCount; i++) {
+            map.remove(i);
+        }
+        testMapStore.deleteLatch.await(10, TimeUnit.SECONDS);
+        //check map size
+        assertEquals(0, map.size());
+    }
+
+    private int writeBehindQueueSize(HazelcastInstance node, String mapName) {
+        int size = 0;
+        final NodeEngineImpl nodeEngine = getNode(node).getNodeEngine();
+        MapService mapService = nodeEngine.getService(MapService.SERVICE_NAME);
+        final MapServiceContext mapServiceContext = mapService.getMapServiceContext();
+        final int partitionCount = nodeEngine.getPartitionService().getPartitionCount();
+        for (int i = 0; i < partitionCount; i++) {
+            final RecordStore recordStore = mapServiceContext.getExistingRecordStore(i, mapName);
+            if (recordStore == null) {
+                continue;
+            }
+            final MapDataStore<Data, Object> mapDataStore
+                    = recordStore.getMapDataStore();
+            size += ((WriteBehindStore) mapDataStore).getWriteBehindQueue().size();
+        }
+        return size;
+    }
+
+
+    @Test(timeout = 120000)
+    public void testOneMemberWriteBehind() throws Exception {
+        MapStoreTest.TestMapStore testMapStore = new TestMapStore(1, 1, 1);
+        testMapStore.setLoadAllKeys(false);
+        Config config = newConfig(testMapStore, 2);
+        TestHazelcastInstanceFactory nodeFactory = createHazelcastInstanceFactory(3);
+        HazelcastInstance h1 = nodeFactory.newHazelcastInstance(config);
+        testMapStore.insert("1", "value1");
+        IMap map = h1.getMap("default");
+        assertEquals(0, map.size());
+        assertEquals("value1", map.get("1"));
+        assertEquals("value1", map.put("1", "value2"));
+        assertEquals("value2", map.get("1"));
+        // store should have the old data as we will write-behind
+        assertEquals("value1", testMapStore.getStore().get("1"));
+        assertEquals(1, map.size());
+        map.flush();
+        assertTrue(map.evict("1"));
+        assertEquals("value2", testMapStore.getStore().get("1"));
+        assertEquals(0, map.size());
+        assertEquals(1, testMapStore.getStore().size());
+        assertEquals("value2", map.get("1"));
+        assertEquals(1, map.size());
+        map.remove("1");
+        // store should have the old data as we will delete-behind
+        assertEquals(1, testMapStore.getStore().size());
+        assertEquals(0, map.size());
+        testMapStore.assertAwait(12);
+        assertEquals(0, testMapStore.getStore().size());
+    }
+
+    @Test(timeout = 120000)
+    public void testWriteBehindUpdateSameKey() throws Exception {
+        final TestMapStore testMapStore = new TestMapStore(2, 0, 0);
+        testMapStore.setLoadAllKeys(false);
+        Config config = newConfig(testMapStore, 5);
+        TestHazelcastInstanceFactory nodeFactory = createHazelcastInstanceFactory(2);
+        HazelcastInstance h1 = nodeFactory.newHazelcastInstance(config);
+        HazelcastInstance h2 = nodeFactory.newHazelcastInstance(config);
+        IMap<Object, Object> map = h1.getMap("map");
+        map.put("key", "value");
+        Thread.sleep(2000);
+        map.put("key", "value2");
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertEquals("value2", testMapStore.getStore().get("key"));
+            }
+        });
+    }
+
+    @Test(timeout = 120000)
+    public void testOneMemberWriteBehindFlush() throws Exception {
+        TestMapStore testMapStore = new TestMapStore(1, 1, 1);
+        testMapStore.setLoadAllKeys(false);
+        Config config = newConfig(testMapStore, 2);
+        TestHazelcastInstanceFactory nodeFactory = createHazelcastInstanceFactory(3);
+        HazelcastInstance h1 = nodeFactory.newHazelcastInstance(config);
+        IMap map = h1.getMap("default");
+        assertEquals(0, map.size());
+        assertEquals(null, map.put("1", "value1"));
+        assertEquals("value1", map.get("1"));
+        assertEquals(null, testMapStore.getStore().get("1"));
+        assertEquals(1, map.size());
+        map.flush();
+        assertEquals("value1", testMapStore.getStore().get("1"));
+    }
+
+    @Test(timeout = 120000)
+    public void testOneMemberWriteBehind2() throws Exception {
+        final TestEventBasedMapStore testMapStore = new TestEventBasedMapStore();
+        testMapStore.setLoadAllKeys(false);
+        Config config = newConfig(testMapStore, 1, InitialLoadMode.EAGER);
+        HazelcastInstance h1 = createHazelcastInstance(config);
+        IMap map = h1.getMap("default");
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                Object event = testMapStore.getEvents().poll();
+                assertEquals(TestEventBasedMapStore.STORE_EVENTS.LOAD_ALL_KEYS, event);
+            }
+        });
+
+        map.put("1", "value1");
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertEquals(TestEventBasedMapStore.STORE_EVENTS.LOAD, testMapStore.getEvents().poll());
+            }
+        });
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertEquals(TestEventBasedMapStore.STORE_EVENTS.STORE, testMapStore.getEvents().poll());
+            }
+        });
+
+        map.remove("1");
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertEquals(TestEventBasedMapStore.STORE_EVENTS.DELETE, testMapStore.getEvents().poll());
+            }
+        });
+
+    }
+
+
+    @Test(timeout = 120000)
+    //issue#2747:when MapStore configured with write behind, distributed objects' destroy method does not work.
+    public void testWriteBehindDestroy() throws InterruptedException {
+        final int writeDelaySeconds = 3;
+        String mapName = randomMapName();
+
+        final MapStore<String, String> store = new SimpleMapStore<String, String>();
+
+        Config config = newConfig(mapName, store, writeDelaySeconds);
+        HazelcastInstance hzInstance = createHazelcastInstance(config);
+        IMap<String, String> map = hzInstance.getMap(mapName);
+
+        map.put("key", "value");
+
+        map.destroy();
+
+        sleepSeconds(2 * writeDelaySeconds);
+
+        assertNotEquals("value", store.load("key"));
+    }
+
+    @Test(timeout = 120000)
+    public void testKeysWithPredicateShouldLoadMapStore() throws InterruptedException {
+        TestEventBasedMapStore testMapStore = new TestEventBasedMapStore()
+                .insert("key1", 17)
+                .insert("key2", 23)
+                .insert("key3", 47);
+
+        HazelcastInstance instance = createHazelcastInstance(newConfig(testMapStore, 0));
+        final IMap map = instance.getMap("default");
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                Set result = map.keySet();
+                assertTrue(result.contains("key1"));
+                assertTrue(result.contains("key2"));
+                assertTrue(result.contains("key3"));
+            }
+        });
+
+    }
+
+    @Test(timeout = 120000)
+    public void testIssue1085WriteBehindBackup() throws InterruptedException {
+        Config config = new Config();
+        String name = "testIssue1085WriteBehindBackup";
+        MapConfig writeBehindBackup = config.getMapConfig(name);
+        MapStoreConfig mapStoreConfig = new MapStoreConfig();
+        mapStoreConfig.setWriteDelaySeconds(5);
+        int size = 1000;
+        MapStoreWithStoreCount mapStore = new MapStoreWithStoreCount(size, 120);
+        mapStoreConfig.setImplementation(mapStore);
+        writeBehindBackup.setMapStoreConfig(mapStoreConfig);
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(3);
+        HazelcastInstance instance = factory.newHazelcastInstance(config);
+        HazelcastInstance instance2 = factory.newHazelcastInstance(config);
+        final IMap map = instance.getMap(name);
+        for (int i = 0; i < size; i++) {
+            map.put(i, i);
+        }
+        instance2.getLifecycleService().shutdown();
+        mapStore.awaitStores();
+    }
+
+    @Test(timeout = 120000)
+    public void testIssue1085WriteBehindBackupWithLongRunnigMapStore() throws InterruptedException {
+        final String name = randomMapName("testIssue1085WriteBehindBackup");
+        final int expectedStoreCount = 3;
+        final int nodeCount = 3;
+        Config config = new Config();
+        config.setProperty(GroupProperties.PROP_MAP_REPLICA_SCHEDULED_TASK_DELAY_SECONDS, "30");
+        MapConfig writeBehindBackupConfig = config.getMapConfig(name);
+        MapStoreConfig mapStoreConfig = new MapStoreConfig();
+        mapStoreConfig.setWriteDelaySeconds(5);
+        final MapStoreWithStoreCount mapStore = new MapStoreWithStoreCount(expectedStoreCount, 300, 50);
+        mapStoreConfig.setImplementation(mapStore);
+        writeBehindBackupConfig.setMapStoreConfig(mapStoreConfig);
+        // create nodes.
+        final TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(nodeCount);
+        HazelcastInstance node1 = factory.newHazelcastInstance(config);
+        HazelcastInstance node2 = factory.newHazelcastInstance(config);
+        HazelcastInstance node3 = factory.newHazelcastInstance(config);
+        // create corresponding keys.
+        final String keyOwnedByNode1 = generateKeyOwnedBy(node1);
+        final String keyOwnedByNode2 = generateKeyOwnedBy(node2);
+        final String keyOwnedByNode3 = generateKeyOwnedBy(node3);
+        // put one key value pair per node.
+        final IMap map = node1.getMap(name);
+        map.put(keyOwnedByNode1, 1);
+        map.put(keyOwnedByNode2, 2);
+        map.put(keyOwnedByNode3, 3);
+        // shutdown node2.
+        node2.getLifecycleService().shutdown();
+        // wait store ops. finish.
+        mapStore.awaitStores();
+        // we should see at least expected store count.
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                int storeOperationCount = mapStore.count.intValue();
+                assertTrue("expected : " + expectedStoreCount
+                        + ", actual : " + storeOperationCount, expectedStoreCount <= storeOperationCount);
+            }
+        });
+    }
+
+
+    @Test(timeout = 120000)
+    public void testMapDelete_whenLoadFails() throws Exception {
+        final FailingLoadMapStore mapStore = new FailingLoadMapStore();
+        final IMap<Object, Object> map = TestMapUsingMapStoreBuilder.create()
+                .withMapStore(mapStore)
+                .withNodeCount(1)
+                .withNodeFactory(createHazelcastInstanceFactory(1))
+                .build();
+
+        try {
+            map.delete(1);
+        } catch (IllegalStateException e) {
+            fail();
+        }
+    }
+
+    @Test(timeout = 120000, expected = IllegalStateException.class)
+    public void testMapRemove_whenMapStoreLoadFails() throws Exception {
+        final FailingLoadMapStore mapStore = new FailingLoadMapStore();
+        final IMap<Object, Object> map = TestMapUsingMapStoreBuilder.create()
+                .withMapStore(mapStore)
+                .withNodeCount(1)
+                .withNodeFactory(createHazelcastInstanceFactory(1))
+                .build();
+
+        map.remove(1);
+    }
+
+    @Test(timeout = 120000)
+    public void testIssue1085WriteBehindBackupTransactional() throws InterruptedException {
+        final String name = randomMapName();
+        final int size = 1000;
+        MapStoreTest.MapStoreWithStoreCount mapStore = new MapStoreTest.MapStoreWithStoreCount(size, 120);
+        Config config = newConfig(name, mapStore, 5);
+
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(3);
+        HazelcastInstance instance = factory.newHazelcastInstance(config);
+        HazelcastInstance instance2 = factory.newHazelcastInstance(config);
+
+        TransactionContext context = instance.newTransactionContext();
+        context.beginTransaction();
+        TransactionalMap<Object, Object> tmap = context.getMap(name);
+        for (int i = 0; i < size; i++) {
+            tmap.put(i, i);
+        }
+        context.commitTransaction();
+        instance2.getLifecycleService().shutdown();
+        mapStore.awaitStores();
+    }
+
+    @Test(timeout = 120000)
+    public void testWriteBehindSameSecondSameKey() throws Exception {
+        final TestMapStore testMapStore = new TestMapStore(100, 0, 0); // In some cases 2 store operation may happened
+        testMapStore.setLoadAllKeys(false);
+        Config config = newConfig(testMapStore, 2);
+        HazelcastInstance h1 = createHazelcastInstance(config);
+        IMap<Object, Object> map = h1.getMap("testWriteBehindSameSecondSameKey");
+        final int size1 = 20;
+        final int size2 = 10;
+
+        for (int i = 0; i < size1; i++) {
+            map.put("key", "value" + i);
+        }
+        for (int i = 0; i < size2; i++) {
+            map.put("key" + i, "value" + i);
+        }
+
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertEquals("value" + (size1 - 1), testMapStore.getStore().get("key"));
+            }
+        });
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertEquals("value" + (size2 - 1), testMapStore.getStore().get("key" + (size2 - 1)));
+            }
+        });
+
+
+    }
+
+    @Test(timeout = 120000)
+    public void testWriteBehindWriteRemoveOrderOfSameKey() throws Exception {
+        final String mapName = randomMapName("_testWriteBehindWriteRemoveOrderOfSameKey_");
+        final int iterationCount = 5;
+        final int delaySeconds = 1;
+        final int putOps = 3;
+        final int removeOps = 2;
+        final int expectedStoreSizeEventually = 1;
+        final RecordingMapStore store = new RecordingMapStore(iterationCount * putOps, iterationCount * removeOps);
+        final Config config = newConfig(mapName, store, delaySeconds);
+        final HazelcastInstance node = createHazelcastInstance(config);
+        final IMap<String, String> map = node.getMap(mapName);
+
+        String key = "key";
+
+        for (int i = 0; i < iterationCount; i++) {
+            String value = "value" + i;
+
+            map.put(key, value);
+            map.remove(key);
+
+            map.put(key, value);
+            map.remove(key);
+
+            map.put(key, value);
+        }
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertEquals(expectedStoreSizeEventually, store.getStore().size());
+            }
+        });
+
+        assertEquals("value" + (iterationCount - 1), map.get(key));
+    }
+
+    @Test(timeout = 120000)
+    public void mapStore_setOnIMapDoesNotRemoveKeyFromWriteBehindDeleteQueue() throws Exception {
+        MapStoreConfig mapStoreConfig = new MapStoreConfig()
+                .setEnabled(true)
+                .setImplementation(new SimpleMapStore<String, String>())
+                .setWriteDelaySeconds(Integer.MAX_VALUE);
+
+        Config config = new Config().addMapConfig(new MapConfig("map").setMapStoreConfig(mapStoreConfig));
+
+        HazelcastInstance instance = createHazelcastInstance(config);
+        IMap<String, String> map = instance.getMap("map");
+        map.put("foo", "bar");
+        map.remove("foo");
+        map.set("foo", "bar");
+
+        assertEquals("bar", map.get("foo"));
+    }
+
+    @Test(timeout = 120000)
+    public void testDelete_thenPutIfAbsent_withWriteBehindEnabled() throws Exception {
+        TestMapStore testMapStore = new TestMapStore(1, 1, 1);
+        Config config = newConfig(testMapStore, 100);
+        TestHazelcastInstanceFactory nodeFactory = createHazelcastInstanceFactory(1);
+        HazelcastInstance instance = nodeFactory.newHazelcastInstance(config);
+        IMap map = instance.getMap("default");
+        map.put(1, 1);
+        map.delete(1);
+        final Object putIfAbsent = map.putIfAbsent(1, 2);
+
+        assertNull(putIfAbsent);
+    }
+
+    public static class RecordingMapStore implements MapStore<String, String> {
+
+        private static final boolean DEBUG = false;
+
+        private final CountDownLatch expectedStore;
+        private final CountDownLatch expectedRemove;
+
+        private final ConcurrentHashMap<String, String> store;
+
+        public RecordingMapStore(int expectedStore, int expectedRemove) {
+            this.expectedStore = new CountDownLatch(expectedStore);
+            this.expectedRemove = new CountDownLatch(expectedRemove);
+            this.store = new ConcurrentHashMap<String, String>();
+        }
+
+        public ConcurrentHashMap<String, String> getStore() {
+            return store;
+        }
+
+        @Override
+        public String load(String key) {
+            log("load(" + key + ") called.");
+            return store.get(key);
+        }
+
+        @Override
+        public Map<String, String> loadAll(Collection<String> keys) {
+            if (DEBUG) {
+                List<String> keysList = new ArrayList<String>(keys);
+                Collections.sort(keysList);
+                log("loadAll(" + keysList + ") called.");
+            }
+            Map<String, String> result = new HashMap<String, String>();
+            for (String key : keys) {
+                String value = store.get(key);
+                if (value != null) {
+                    result.put(key, value);
+                }
+            }
+            return result;
+        }
+
+        @Override
+        public Set<String> loadAllKeys() {
+            log("loadAllKeys() called.");
+            Set<String> result = new HashSet<String>(store.keySet());
+            log("loadAllKeys result = " + result);
+            return result;
+        }
+
+        @Override
+        public void store(String key, String value) {
+            log("store(" + key + ") called.");
+            String valuePrev = store.put(key, value);
+            expectedStore.countDown();
+            if (valuePrev != null) {
+                log("- Unexpected Update (operations reordered?): " + key);
+            }
+        }
+
+        @Override
+        public void storeAll(Map<String, String> map) {
+            if (DEBUG) {
+                TreeSet<String> setSorted = new TreeSet<String>(map.keySet());
+                log("storeAll(" + setSorted + ") called.");
+            }
+            store.putAll(map);
+            final int size = map.keySet().size();
+            for (int i = 0; i < size; i++) {
+                expectedStore.countDown();
+            }
+        }
+
+        @Override
+        public void delete(String key) {
+            log("delete(" + key + ") called.");
+            String valuePrev = store.remove(key);
+            expectedRemove.countDown();
+            if (valuePrev == null) {
+                log("- Unnecessary delete (operations reordered?): " + key);
+            }
+        }
+
+        @Override
+        public void deleteAll(Collection<String> keys) {
+            if (DEBUG) {
+                List<String> keysList = new ArrayList<String>(keys);
+                Collections.sort(keysList);
+                log("deleteAll(" + keysList + ") called.");
+            }
+            for (String key : keys) {
+                String valuePrev = store.remove(key);
+                expectedRemove.countDown();
+                if (valuePrev == null) {
+                    log("- Unnecessary delete (operations reordered?): " + key);
+                }
+            }
+        }
+
+        public void awaitStores() {
+            assertOpenEventually(expectedStore);
+        }
+
+        public void awaitRemoves() {
+            assertOpenEventually(expectedRemove);
+        }
+
+        private void log(String msg) {
+            if (DEBUG) {
+                System.out.println(msg);
+            }
+        }
+
+    }
+
+
+
+    public static class FailAwareMapStore implements MapStore {
+
+        final Map db = new ConcurrentHashMap();
+
+        final AtomicLong deletes = new AtomicLong();
+        final AtomicLong deleteAlls = new AtomicLong();
+        final AtomicLong stores = new AtomicLong();
+        final AtomicLong storeAlls = new AtomicLong();
+        final AtomicLong loads = new AtomicLong();
+        final AtomicLong loadAlls = new AtomicLong();
+        final AtomicLong loadAllKeys = new AtomicLong();
+        final AtomicBoolean storeFail = new AtomicBoolean(false);
+        final AtomicBoolean loadFail = new AtomicBoolean(false);
+        final List<BlockingQueue> listeners = new CopyOnWriteArrayList<BlockingQueue>();
+
+        public void addListener(BlockingQueue obj) {
+            listeners.add(obj);
+        }
+
+        public void notifyListeners() {
+            for (BlockingQueue listener : listeners) {
+                listener.offer(new Object());
+            }
+        }
+
+        public void delete(Object key) {
+            try {
+                if (storeFail.get()) {
+                    throw new RuntimeException();
+                } else {
+                    db.remove(key);
+                }
+            } finally {
+                deletes.incrementAndGet();
+                notifyListeners();
+            }
+        }
+
+        public void setFail(boolean shouldFail, boolean loadFail) {
+            this.storeFail.set(shouldFail);
+            this.loadFail.set(loadFail);
+        }
+
+        public int dbSize() {
+            return db.size();
+        }
+
+        public boolean dbContainsKey(Object key) {
+            return db.containsKey(key);
+        }
+
+        public Object dbGet(Object key) {
+            return db.get(key);
+        }
+
+        public void store(Object key, Object value) {
+            try {
+                if (storeFail.get()) {
+                    throw new RuntimeException();
+                } else {
+                    db.put(key, value);
+                }
+            } finally {
+                stores.incrementAndGet();
+                notifyListeners();
+            }
+        }
+
+        public Set loadAllKeys() {
+            try {
+                return db.keySet();
+            } finally {
+                loadAllKeys.incrementAndGet();
+            }
+        }
+
+        public Object load(Object key) {
+            try {
+                if (loadFail.get()) {
+                    throw new RuntimeException();
+                } else {
+                    return db.get(key);
+                }
+            } finally {
+                loads.incrementAndGet();
+            }
+        }
+
+        public void storeAll(Map map) {
+            try {
+                if (storeFail.get()) {
+                    throw new RuntimeException();
+                } else {
+                    db.putAll(map);
+                }
+            } finally {
+                storeAlls.incrementAndGet();
+                notifyListeners();
+            }
+        }
+
+        public Map loadAll(Collection keys) {
+            try {
+                if (loadFail.get()) {
+                    throw new RuntimeException();
+                } else {
+                    Map results = new HashMap();
+                    for (Object key : keys) {
+                        Object value = db.get(key);
+                        if (value != null) {
+                            results.put(key, value);
+                        }
+                    }
+                    return results;
+                }
+            } finally {
+                loadAlls.incrementAndGet();
+                notifyListeners();
+            }
+        }
+
+        public void deleteAll(Collection keys) {
+            try {
+                if (storeFail.get()) {
+                    throw new RuntimeException();
+                } else {
+                    for (Object key : keys) {
+                        db.remove(key);
+                    }
+                }
+            } finally {
+                deleteAlls.incrementAndGet();
+                notifyListeners();
+            }
+        }
+    }
+
+
+    class FailingLoadMapStore extends MapStoreAdapter {
+        @Override
+        public Object load(Object key) {
+            throw new IllegalStateException();
+        }
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/map/mapstore/MapStoreWriteThroughTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/mapstore/MapStoreWriteThroughTest.java
@@ -1,0 +1,291 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.mapstore;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.EvictionPolicy;
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.config.MaxSizeConfig;
+import com.hazelcast.core.EntryAdapter;
+import com.hazelcast.core.EntryEvent;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.instance.TestUtil;
+import com.hazelcast.map.mapstore.MapStoreTest.TestMapStore;
+import com.hazelcast.map.mapstore.MapStoreWriteBehindTest.FailAwareMapStore;
+import com.hazelcast.query.SampleObjects.Employee;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.QuickTest;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static com.hazelcast.map.mapstore.MapStoreTest.newConfig;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+
+/**
+ * @author enesakar 1/21/13
+ */
+@RunWith(HazelcastParallelClassRunner.class)
+@Category(QuickTest.class)
+public class MapStoreWriteThroughTest extends HazelcastTestSupport {
+
+    @Test(timeout = 120000)
+    public void testOneMemberWriteThroughWithIndex() throws Exception {
+        TestMapStore testMapStore = new TestMapStore(1, 1, 1);
+        testMapStore.setLoadAllKeys(false);
+        Config config = newConfig(testMapStore, 0);
+        TestHazelcastInstanceFactory nodeFactory = createHazelcastInstanceFactory(3);
+        HazelcastInstance h1 = nodeFactory.newHazelcastInstance(config);
+        testMapStore.insert("1", "value1");
+        IMap map = h1.getMap("default");
+        assertEquals(0, map.size());
+        assertTrue(map.tryLock("1", 1, TimeUnit.SECONDS));
+        assertEquals("value1", map.get("1"));
+        map.unlock("1");
+        assertEquals("value1", map.put("1", "value2"));
+        assertEquals("value2", map.get("1"));
+        assertEquals("value2", testMapStore.getStore().get("1"));
+        assertEquals(1, map.size());
+        assertTrue(map.evict("1"));
+        assertEquals(0, map.size());
+        assertEquals(1, testMapStore.getStore().size());
+        assertEquals("value2", map.get("1"));
+        assertEquals(1, map.size());
+        map.remove("1");
+        assertEquals(0, map.size());
+        assertEquals(0, testMapStore.getStore().size());
+        testMapStore.assertAwait(1);
+        assertEquals(1, testMapStore.getInitCount());
+        assertEquals("default", testMapStore.getMapName());
+        assertEquals(TestUtil.getNode(h1), TestUtil.getNode(testMapStore.getHazelcastInstance()));
+    }
+
+    @Test(timeout = 120000)
+    public void testOneMemberWriteThroughWithLRU() throws Exception {
+        final int size = 10000;
+        TestMapStore testMapStore = new TestMapStore(size * 2, 1, 1);
+        testMapStore.setLoadAllKeys(false);
+        Config config = newConfig(testMapStore, 0);
+        config.setProperty(GroupProperties.PROP_PARTITION_COUNT, "1");
+        MaxSizeConfig maxSizeConfig = new MaxSizeConfig();
+        maxSizeConfig.setSize(size);
+        MapConfig mapConfig = config.getMapConfig("default");
+        mapConfig.setEvictionPolicy(EvictionPolicy.LRU);
+        mapConfig.setMaxSizeConfig(maxSizeConfig);
+        TestHazelcastInstanceFactory nodeFactory = createHazelcastInstanceFactory(3);
+
+        HazelcastInstance h1 = nodeFactory.newHazelcastInstance(config);
+        IMap map = h1.getMap("default");
+        final CountDownLatch countDownLatch = new CountDownLatch(size);
+        map.addEntryListener(new EntryAdapter() {
+            @Override
+            public void entryEvicted(EntryEvent event) {
+                countDownLatch.countDown();
+            }
+        }, false);
+
+        for (int i = 0; i < size * 2; i++) {
+            // trigger eviction.
+            if (i == (size * 2) - 1 || i == size) {
+                sleepMillis(1001);
+            }
+            map.put(i, new Employee("joe", i, true, 100.00));
+        }
+        assertEquals(testMapStore.getStore().size(), size * 2);
+        assertOpenEventually(countDownLatch);
+        final String msgFailure = String.format("map size: %d put count: %d", map.size(), size);
+        assertTrue(msgFailure, map.size() > size / 2);
+        assertTrue(msgFailure, map.size() <= size);
+        assertEquals(testMapStore.getStore().size(), size * 2);
+    }
+
+    @Test(timeout = 120000)
+    public void testOneMemberWriteThrough() throws Exception {
+        TestMapStore testMapStore = new TestMapStore(1, 1, 1);
+        testMapStore.setLoadAllKeys(false);
+        Config config = newConfig(testMapStore, 0);
+        HazelcastInstance h1 = createHazelcastInstance(config);
+        Employee employee = new Employee("joe", 25, true, 100.00);
+        Employee newEmployee = new Employee("ali", 26, true, 1000);
+        testMapStore.insert("1", employee);
+        testMapStore.insert("2", employee);
+        testMapStore.insert("3", employee);
+        testMapStore.insert("4", employee);
+        testMapStore.insert("5", employee);
+        testMapStore.insert("6", employee);
+        testMapStore.insert("7", employee);
+
+        IMap map = h1.getMap("default");
+        map.addIndex("name", false);
+        assertEquals(0, map.size());
+        assertEquals(employee, map.get("1"));
+        assertEquals(employee, testMapStore.getStore().get("1"));
+        assertEquals(1, map.size());
+        assertEquals(employee, map.put("2", newEmployee));
+        assertEquals(newEmployee, testMapStore.getStore().get("2"));
+        assertEquals(2, map.size());
+
+        map.remove("1");
+        map.put("1", employee, 1, TimeUnit.SECONDS);
+        map.put("1", employee);
+        Thread.sleep(2000);
+        assertEquals(employee, testMapStore.getStore().get("1"));
+        assertEquals(employee, map.get("1"));
+
+        map.evict("2");
+        assertEquals(newEmployee, map.get("2"));
+
+        assertEquals(employee, map.get("3"));
+        assertEquals(employee, map.put("3", newEmployee));
+        assertEquals(newEmployee, map.get("3"));
+
+        assertEquals(employee, map.remove("4"));
+
+        assertEquals(employee, map.get("5"));
+        assertEquals(employee, map.remove("5"));
+
+        assertEquals(employee, map.putIfAbsent("6", newEmployee));
+        assertEquals(employee, map.get("6"));
+        assertEquals(employee, testMapStore.getStore().get("6"));
+
+        assertTrue(map.containsKey("7"));
+        assertEquals(employee, map.get("7"));
+
+        assertNull(map.get("8"));
+        assertFalse(map.containsKey("8"));
+        assertNull(map.putIfAbsent("8", employee));
+        assertEquals(employee, map.get("8"));
+        assertEquals(employee, testMapStore.getStore().get("8"));
+    }
+
+    @Test(timeout = 120000)
+    public void testTwoMemberWriteThrough() throws Exception {
+        TestMapStore testMapStore = new TestMapStore(1, 1, 1);
+        testMapStore.setLoadAllKeys(false);
+        Config config = newConfig(testMapStore, 0);
+        TestHazelcastInstanceFactory nodeFactory = createHazelcastInstanceFactory(3);
+        HazelcastInstance h1 = nodeFactory.newHazelcastInstance(config);
+        HazelcastInstance h2 = nodeFactory.newHazelcastInstance(config);
+        Employee employee = new Employee("joe", 25, true, 100.00);
+        Employee employee2 = new Employee("jay", 35, false, 100.00);
+        testMapStore.insert("1", employee);
+        IMap map = h1.getMap("default");
+        map.addIndex("name", false);
+        assertEquals(0, map.size());
+        assertEquals(employee, map.get("1"));
+        assertEquals(employee, testMapStore.getStore().get("1"));
+        assertEquals(1, map.size());
+        map.put("2", employee2);
+        assertEquals(employee2, testMapStore.getStore().get("2"));
+        assertEquals(2, testMapStore.getStore().size());
+        assertEquals(2, map.size());
+        map.remove("2");
+        assertEquals(1, testMapStore.getStore().size());
+        assertEquals(1, map.size());
+        testMapStore.assertAwait(10);
+        assertEquals(5, testMapStore.callCount.get());
+    }
+
+    @Test(timeout = 300000)
+    public void testTwoMemberWriteThrough2() throws Exception {
+        int items = 1000;
+        TestMapStore testMapStore = new TestMapStore(items, 0, 0);
+        Config config = newConfig(testMapStore, 0);
+        TestHazelcastInstanceFactory nodeFactory = createHazelcastInstanceFactory(3);
+        HazelcastInstance h1 = nodeFactory.newHazelcastInstance(config);
+        HazelcastInstance h2 = nodeFactory.newHazelcastInstance(config);
+
+        IMap map1 = h1.getMap("default");
+        IMap map2 = h2.getMap("default");
+
+        for (int i = 0; i < items; i++) {
+            map1.put(i, "value" + i);
+        }
+
+        assertTrue("store operations could not be done wisely ", testMapStore.latchStore.await(30, TimeUnit.SECONDS));
+        assertEquals(items, testMapStore.getStore().size());
+        assertEquals(items, map1.size());
+        assertEquals(items, map2.size());
+
+        testMapStore.assertAwait(10);
+        // N put-load N put-store call and 1 loadAllKeys
+        assertEquals(items*2+1, testMapStore.callCount.get());
+    }
+
+    @Test(timeout = 120000)
+    public void testOneMemberWriteThroughFailingStore() throws Exception {
+        FailAwareMapStore testMapStore = new FailAwareMapStore();
+        testMapStore.setFail(true, true);
+        Config config = newConfig(testMapStore, 0);
+        TestHazelcastInstanceFactory nodeFactory = createHazelcastInstanceFactory(3);
+        HazelcastInstance h1 = nodeFactory.newHazelcastInstance(config);
+        IMap map = h1.getMap("default");
+        assertEquals(0, map.size());
+        try {
+            map.get("1");
+            fail("should have thrown exception");
+        } catch (Exception e) {
+        }
+        assertEquals(1, testMapStore.loads.get());
+        try {
+            map.get("1");
+            fail("should have thrown exception");
+        } catch (Exception e) {
+        }
+        assertEquals(2, testMapStore.loads.get());
+        try {
+            map.put("1", "value");
+            fail("should have thrown exception");
+        } catch (Exception e) {
+        }
+        assertEquals(0, testMapStore.stores.get());
+        assertEquals(0, map.size());
+    }
+
+    @Test(timeout = 120000)
+    public void testOneMemberWriteThroughFailingStore2() throws Exception {
+        FailAwareMapStore testMapStore = new FailAwareMapStore();
+        testMapStore.setFail(true, false);
+        Config config = newConfig(testMapStore, 0);
+        TestHazelcastInstanceFactory nodeFactory = createHazelcastInstanceFactory(3);
+        HazelcastInstance h1 = nodeFactory.newHazelcastInstance(config);
+        IMap map = h1.getMap("default");
+        assertEquals(0, map.size());
+
+        try {
+            map.put("1", "value");
+            fail("should have thrown exception");
+        } catch (Exception e) {
+        }
+        assertEquals(0, map.size());
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/map/mapstore/PausingMapLoader.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/mapstore/PausingMapLoader.java
@@ -1,0 +1,72 @@
+package com.hazelcast.map.mapstore;
+
+import com.hazelcast.core.IFunction;
+import com.hazelcast.core.MapLoader;
+import com.hazelcast.util.ExceptionUtil;
+import com.hazelcast.util.IterableUtil;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+
+/** MapLoader that pauses once while loading keys until resumed using {@link #resume()} **/
+public class PausingMapLoader<K, V> implements MapLoader<K, V> {
+
+    private MapLoader<K, V> delegate;
+
+    private int pauseAt;
+    private int counter;
+    private CountDownLatch resumeLatch = new CountDownLatch(1);
+    private CountDownLatch pauseLatch = new CountDownLatch(1);
+
+    public PausingMapLoader(MapLoader<K, V> delegate, int pauseAt) {
+        this.delegate = delegate;
+        this.pauseAt = pauseAt;
+    }
+
+    @Override
+    public V load(K key) {
+        return delegate.load(key);
+    }
+
+    @Override
+    public Map<K, V> loadAll(Collection<K> keys) {
+        return delegate.loadAll(keys);
+    }
+
+    @Override
+    public Iterable<K> loadAllKeys() {
+        Iterable<K> allKeys = delegate.loadAllKeys();
+
+        return IterableUtil.map(allKeys, new IFunction<K, K>() {
+            @Override
+            public K apply(K key) {
+                if (counter++ == pauseAt) {
+                    pause();
+                }
+                return key;
+            }
+        });
+    }
+
+    private void pause() {
+        try {
+            pauseLatch.countDown();
+            resumeLatch.await();
+        } catch (InterruptedException e) {
+            ExceptionUtil.rethrow(e);
+        }
+    }
+
+    public void awaitPause() {
+        try {
+            pauseLatch.await();
+        } catch (InterruptedException e) {
+            ExceptionUtil.rethrow(e);
+        }
+    }
+
+    public void resume() {
+        resumeLatch.countDown();
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/util/IterableUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/IterableUtilTest.java
@@ -27,6 +27,7 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -52,6 +53,15 @@ public class IterableUtilTest {
         for(Integer i : numbers) {
             assertEquals(i.toString(), iter.next());
         }
+    }
+
+    @Test
+    public void testUpToNElement_whenIteratorLimited() throws Exception {
+        Iterator<Integer> limitedIterator = IterableUtil.limit(numbers.iterator(), 2);
+
+        assertEquals(Integer.valueOf(1), limitedIterator.next());
+        assertEquals(Integer.valueOf(2), limitedIterator.next());
+        assertFalse( limitedIterator.hasNext() );
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/util/StateMachineTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/StateMachineTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.util;
+
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category(QuickTest.class)
+public class StateMachineTest {
+
+    private enum State {
+        A, B, C
+    }
+
+    private StateMachine<State> machine = StateMachine.of(State.A).withTransition(State.A, State.B)
+            .withTransition(State.B, State.C);
+
+    @Test
+    public void testIsInInitialState_whenCreated() {
+        assertTrue(machine.is(State.A));
+    }
+
+    @Test
+    public void testChangesState_whenTransitionValid() {
+        machine.next(State.B);
+        assertTrue(machine.is(State.B));
+
+        machine.next(State.C);
+        assertTrue(machine.is(State.C));
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testThrowsException_whenTransitionInvalid() {
+        machine.next(State.C);
+    }
+
+    @Test
+    public void testStaysAtState_whenAlreadyThere() {
+        machine.nextOrStay(State.A);
+        assertTrue( machine.is(State.A) );
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/util/ValidationUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/ValidationUtilTest.java
@@ -1,0 +1,94 @@
+package com.hazelcast.util;
+
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+
+import java.math.BigInteger;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+import static com.hazelcast.util.ValidationUtil.checkFalse;
+import static com.hazelcast.util.ValidationUtil.checkInstanceOf;
+import static com.hazelcast.util.ValidationUtil.checkNotInstanceOf;
+import static junit.framework.Assert.assertNull;
+import static junit.framework.Assert.fail;
+import static junit.framework.TestCase.assertEquals;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category(QuickTest.class)
+public class ValidationUtilTest {
+
+    @Test
+    public void test_checkInstanceOf() throws Exception {
+        int value = checkInstanceOf(Number.class, Integer.MAX_VALUE, "argumentName");
+        assertEquals("Returned value should be " + Integer.MAX_VALUE, Integer.MAX_VALUE, value);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void test_checkInstanceOf_whenSuppliedObjectIsNotInstanceOfExpectedType() throws Exception {
+        checkInstanceOf(Integer.class, BigInteger.ONE, "argumentName");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void test_checkInstanceOf_withNullType() throws Exception {
+        checkInstanceOf(null, Integer.MAX_VALUE, "argumentName");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void test_checkInstanceOf_withNullObject() throws Exception {
+        checkInstanceOf(Number.class, null, "argumentName");
+    }
+
+    @Test
+    public void test_checkNotInstanceOf() throws Exception {
+        BigInteger value = checkNotInstanceOf(Integer.class, BigInteger.ONE, "argumentName");
+        assertEquals("Returned value should be equal to BigInteger.ONE", BigInteger.ONE, value);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void test_checkNotInstanceOf_whenSuppliedObjectIsInstanceOfExpectedType() throws Exception {
+        checkNotInstanceOf(Integer.class, Integer.MAX_VALUE, "argumentName");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void test_checkNotInstanceOf_withNullType() throws Exception {
+        checkNotInstanceOf(null, BigInteger.ONE, "argumentName");
+    }
+
+    @Test
+    public void test_checkNotInstanceOf_withNullObject() throws Exception {
+        Object value = checkNotInstanceOf(Integer.class, null, "argumentName");
+        assertNull(value);
+    }
+
+    @Test
+    public void test_checkFalse() throws Exception {
+        try {
+            checkFalse(Boolean.FALSE, "comparison cannot be true");
+        } catch (Exception e) {
+            fail("checkFalse method should not throw this exception " + e);
+        }
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void test_checkFalse_whenComparisonTrue() throws Exception {
+        checkFalse(Boolean.TRUE, "comparison cannot be true");
+    }
+
+    @Test(expected = NoSuchElementException.class)
+    public void test_hasNextThrowsException_whenEmptyIteratorGiven() throws Exception {
+        ValidationUtil.checkHasNext(Collections.emptyList().iterator(), "");
+    }
+
+    @Test
+    public void test_hasNextReturnsIterator_whenNonEmptyIteratorGiven() throws Exception {
+        Iterator<Integer> iterator = Arrays.asList(1, 2).iterator();
+        assertEquals(iterator, ValidationUtil.checkHasNext(iterator, ""));
+    }
+}


### PR DESCRIPTION
Follow up work of #4949

Single node loads map's keys and sends to all other nodes in batches. Its the node owning the partition of map's name.
At the end of sending it notifies it's first replica that loading is complete. If the replica becomes a primary and loading was not complete then the replica starts loading from scratch. Loading happens with replaceExistingValues=false. 

Also introducing StateMachine util for easier state transition tracking.