### PR TITLE
Calling InetSocketAddress::getHostName only when the selector hack is enabled.

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnectionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnectionManager.java
@@ -339,8 +339,7 @@ public class TcpIpConnectionManager implements ConnectionManager {
 
     TcpIpConnection assignSocketChannel(SocketChannelWrapper channel, Address endpoint) {
         InetSocketAddress remoteSocketAddress = (InetSocketAddress) channel.socket().getRemoteSocketAddress();
-        String remoteHost = remoteSocketAddress.getHostName();
-        int index = getSelectorIndex(remoteHost);
+        int index = getSelectorIndex(remoteSocketAddress);
 
         final TcpIpConnection connection = new TcpIpConnection(this, inSelectors[index],
                 outSelectors[index], connectionIdGen.incrementAndGet(), channel);
@@ -357,9 +356,10 @@ public class TcpIpConnectionManager implements ConnectionManager {
         return connection;
     }
 
-    private int getSelectorIndex(String remoteHost) {
+    private int getSelectorIndex(InetSocketAddress remoteSocketAddress) {
         Integer index;
         if (selectorImbalanceWorkaroundEnabled) {
+            String remoteHost = remoteSocketAddress.getHostName();
             synchronized (selectorIndexPerHostMap) {
                 index = selectorIndexPerHostMap.get(remoteHost);
                 if (index == null) {


### PR DESCRIPTION
Fixing #5072

The other alternative is to remove the selector hack altogether. There is less need for it given the existence of IOBalancer. 