### PR TITLE
Change AbstractJoiner and PartitionService to sleep for exponentially in...

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/AbstractJoiner.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/AbstractJoiner.java
@@ -32,6 +32,7 @@ import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.OperationService;
 import com.hazelcast.util.Clock;
 import com.hazelcast.util.EmptyStatement;
+import com.hazelcast.util.ExponentialBackoffSleeper;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -134,13 +135,14 @@ public abstract class AbstractJoiner implements Joiner {
         if (node.joined()) {
             logger.finest("Waiting for all connections");
             int connectAllWaitSeconds = node.groupProperties.CONNECT_ALL_WAIT_SECONDS.getInteger();
-            int checkCount = 0;
-            while (checkCount++ < connectAllWaitSeconds && !allConnected) {
-                try {
-                    //noinspection BusyWait
-                    Thread.sleep(1000);
-                } catch (InterruptedException ignored) {
-                }
+            ExponentialBackoffSleeper sleeper = ExponentialBackoffSleeper.builder()
+                    .factor(1.3)
+                    .initialMs(50)
+                    .maxMs(1000)
+                    .timeoutMs(TimeUnit.SECONDS.toMillis(connectAllWaitSeconds))
+                    .build();
+            while (sleeper.isTimedOut() && !allConnected) {
+                sleeper.sleepQuietly();
 
                 allConnected = true;
                 Collection<Member> members = node.getClusterService().getMembers();

--- a/hazelcast/src/main/java/com/hazelcast/util/ExponentialBackoffSleeper.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/ExponentialBackoffSleeper.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.util;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Utility class that allows for polling of state, with an exponentially increasing delay. The
+ * {@link Builder#factor exponential factor} can be specified to control how fast the wait time increases between
+ * subsequent invocations of {@link #sleep}.
+ * <p>
+ * Optionally, a {@link Builder#timeoutMs timeout} can be specified to limit the sleep time to a global timeout.
+ */
+public final class ExponentialBackoffSleeper {
+    /**
+     * Default exponential factor
+     */
+    public static final double DEFAULT_FACTOR = 1.3d;
+    /**
+     * Default initial sleep period in milliseconds
+     */
+    public static final long DEFAULT_INITIAL_MS = 50;
+    /**
+     * Default maximum sleep period in milliseconds
+     */
+    public static final long DEFAULT_MAX_MS = TimeUnit.SECONDS.toMillis(1);
+
+    private final double factor;
+    private final long max;
+    private final long timeoutTimestamp;
+    private long next;
+
+    private ExponentialBackoffSleeper(Builder builder) {
+        factor = builder.factor;
+        max = builder.maxMs;
+        next = builder.initialMs;
+        timeoutTimestamp = builder.timeoutMs > 0 ? Clock.currentTimeMillis() + builder.timeoutMs : Long.MAX_VALUE;
+    }
+
+    /**
+     * @return a new {@link Builder} instance
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * @return {@code true} if a {@link Builder#timeoutMs timeout} was specified and more time has elapsed since the
+     *         construction of the sleeper instance than the specified timeout.
+     */
+    public boolean isTimedOut() {
+        return Clock.currentTimeMillis() >  timeoutTimestamp;
+    }
+
+    /**
+     * Sleeps for max(maxMs, initialMs * factor^iteration) milliseconds.
+     *
+     * @return time in ms actually spent sleeping
+     * @throws InterruptedException
+     */
+    public long sleep() throws InterruptedException {
+        long timeToTimeout = timeoutTimestamp - Clock.currentTimeMillis();
+        long sleepMs = Math.min(next, timeToTimeout);
+        Thread.sleep(sleepMs);
+
+        next = Math.min(max, Math.round(factor * next));
+        return sleepMs;
+    }
+
+    /**
+     * Same as {@link #sleep} but swallows the {@code InterruptedException} if thrown.
+     * @return time in ms actually spent sleeping
+     */
+    public long sleepQuietly() {
+        try {
+            return sleep();
+        } catch (InterruptedException ie) {
+            return 0L;
+        }
+    }
+
+    /**
+     * Builder for {@link ExponentialBackoffSleeper}
+     */
+    public static class Builder {
+        private double factor = DEFAULT_FACTOR;
+        private long initialMs = DEFAULT_INITIAL_MS;
+        private long maxMs = DEFAULT_MAX_MS;
+        private long timeoutMs;
+
+        public Builder() {
+        }
+
+        public ExponentialBackoffSleeper build() {
+            return new ExponentialBackoffSleeper(this);
+        }
+
+        /**
+         * Sets the exponential factor that controls the increase in sleep time for subsequent calls to {@link #sleep}
+         *
+         * @param value the factor, must be greater than {@code 1.0}. A value of {@code 1.0} implies no change in sleep.
+         * @return the builder
+         */
+        public Builder factor(double value) {
+            if (value < 1) {
+                throw new IllegalArgumentException("factor must be greater than or equal to 1, was " + value);
+            }
+            factor = value;
+            return this;
+        }
+
+        /**
+         * @param value the initial sleep time in milliseconds
+         * @return the builder
+         */
+        public Builder initialMs(long value) {
+            if (value <= 0) {
+                throw new IllegalArgumentException("initialMs must be greater than 0, was " + value);
+            }
+            initialMs = value;
+            return this;
+        }
+
+        /**
+         * @param value the maximum sleep time (per call to {@link #sleep} in milliseconds
+         * @return the builder
+         */
+        public Builder maxMs(long value) {
+            if (value <= 0) {
+                throw new IllegalArgumentException("maxMs must be greater than 0, was " + value);
+            }
+            maxMs = value;
+            return this;
+        }
+
+        /**
+         * @param value the global timeout in milliseconds, measured from the time of construction of the
+         * {@link ExponentialBackoffSleeper}
+         *
+         * @return the builder
+         */
+        public Builder timeoutMs(long value) {
+            if (value <= 0) {
+                throw new IllegalArgumentException("timeoutMs must be greater than 0, was " + value);
+            }
+            timeoutMs = value;
+            return this;
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/util/ExponentialBackoffSleeper.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/ExponentialBackoffSleeper.java
@@ -63,7 +63,7 @@ public final class ExponentialBackoffSleeper {
      *         construction of the sleeper instance than the specified timeout.
      */
     public boolean isTimedOut() {
-        return Clock.currentTimeMillis() >  timeoutTimestamp;
+        return Clock.currentTimeMillis() >= timeoutTimestamp;
     }
 
     /**
@@ -74,6 +74,11 @@ public final class ExponentialBackoffSleeper {
      */
     public long sleep() throws InterruptedException {
         long timeToTimeout = timeoutTimestamp - Clock.currentTimeMillis();
+        if (timeToTimeout <= 0) {
+            // the sleeper has timed out already, don't sleep any longer
+            return 0L;
+        }
+
         long sleepMs = Math.min(next, timeToTimeout);
         Thread.sleep(sleepMs);
 

--- a/hazelcast/src/test/java/com/hazelcast/util/ExponentialBackoffSleeperTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/ExponentialBackoffSleeperTest.java
@@ -1,0 +1,74 @@
+package com.hazelcast.util;
+
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@RunWith (HazelcastSerialClassRunner.class)
+@Category (QuickTest.class)
+public class ExponentialBackoffSleeperTest
+{
+    @Test
+    public void testSleep() throws InterruptedException
+    {
+        ExponentialBackoffSleeper sleeper = ExponentialBackoffSleeper.builder()
+                .factor(1.2)
+                .initialMs(20)
+                .maxMs(35)
+                .build();
+
+        assertEquals(20L, sleeper.sleep());
+        assertEquals(24L, sleeper.sleep());
+        assertEquals(29L, sleeper.sleep());
+        assertEquals(35L, sleeper.sleep());
+        assertEquals(35L, sleeper.sleep());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testFactorNegative() {
+        ExponentialBackoffSleeper.builder().factor(-2d);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testFactorTooSmall() {
+        ExponentialBackoffSleeper.builder().factor(0.9d);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInitialNegative() {
+        ExponentialBackoffSleeper.builder().initialMs(-100);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testMaxTooSmall() {
+        ExponentialBackoffSleeper.builder().maxMs(-100);
+    }
+
+    @Test
+    public void testTimeout() throws InterruptedException {
+        ExponentialBackoffSleeper sleeper = ExponentialBackoffSleeper.builder()
+                .factor(1.1)
+                .initialMs(100)
+                .timeoutMs(250)
+                .build();
+
+        assertEquals(100L, sleeper.sleep());
+        assertEquals(110L, sleeper.sleep());
+        assertFalse(sleeper.isTimedOut());
+
+        long time = sleeper.sleep();
+        // Expected = 250 - (100 + 110) = 40ms
+        // In verification, allow 20ms leeway either way for test randomness and build agent slowness
+        String realSleepTime = "actual sleep time was " + time;
+        assertTrue(realSleepTime, time <= 60L);
+        assertTrue(realSleepTime, time >= 20L);
+        assertTrue(sleeper.isTimedOut());
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/util/ExponentialBackoffSleeperTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/ExponentialBackoffSleeperTest.java
@@ -69,6 +69,9 @@ public class ExponentialBackoffSleeperTest
         String realSleepTime = "actual sleep time was " + time;
         assertTrue(realSleepTime, time <= 60L);
         assertTrue(realSleepTime, time >= 20L);
-        assertTrue(sleeper.isTimedOut());
+        assertTrue(realSleepTime + ", but the sleeper isn't detecting it's timed out", sleeper.isTimedOut());
+
+        // verify that no further sleeps are done after the timer has timed out
+        assertEquals(0L, sleeper.sleep());
     }
 }


### PR DESCRIPTION
...creasing time

This introduces `ExponentialBackoffSleeper`, a utility class that makes it easy to
sleep for exponentially increasing times. This is useful for methods that need to
wait for a particular state to be reached where initially the state should be
checked frequently for responsiveness, but the check interval should be increased
to prevent high CPU usage.
