### PR TITLE
Added a hint to inform partitions upon a map-wide-event 

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapEventPublisher.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapEventPublisher.java
@@ -45,4 +45,14 @@ public interface MapEventPublisher {
 
     void publishMapPartitionLostEvent(Address caller, String mapName, int partitionId);
 
+    /**
+     * Only gives a hint which indicates that a map-wide operation has just been executed on this partition.
+     * This method should not publish an event.
+     * <p/>
+     * Currently a map event is published by the end which calls map#clear or map#evictAll and there is not
+     * any order guarantee between events fired after map#put and map#clear, as a result of that, we may clear
+     * a put after a map#clear, to tackle with that kind of possible anomalies, this hint may be used under
+     * some conditions internally.
+     */
+    void hintMapEvent(Address caller, String mapName, EntryEventType eventType, int numberOfEntriesAffected, int partitionId);
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapEventPublisherImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapEventPublisherImpl.java
@@ -154,6 +154,12 @@ class MapEventPublisherImpl implements MapEventPublisher {
         publishEventInternal(registrations, eventData, partitionId);
     }
 
+    @Override
+    public void hintMapEvent(Address caller, String mapName, EntryEventType eventType,
+                             int numberOfEntriesAffected, int partitionId) {
+        // NOP
+    }
+
     private List<EventRegistration> initRegistrationsWithoutValue(List<EventRegistration> registrationsWithoutValue,
                                                                   Result result) {
         if (registrationsWithoutValue != null) {
@@ -183,8 +189,8 @@ class MapEventPublisherImpl implements MapEventPublisher {
         return !(collection == null || collection.isEmpty());
     }
 
-    private Result applyEventFilter(EventFilter filter, boolean syntheticEvent, Data dataKey,
-                                    Data dataOldValue, Data dataValue, EntryEventType eventType) {
+    protected Result applyEventFilter(EventFilter filter, boolean syntheticEvent, Data dataKey,
+                                      Data dataOldValue, Data dataValue, EntryEventType eventType) {
 
         if (filter instanceof MapPartitionLostEventFilter) {
             return Result.NONE;
@@ -308,7 +314,7 @@ class MapEventPublisherImpl implements MapEventPublisher {
                 dataKey, dataNewValue, dataOldValue, dataMergingValue, eventType);
     }
 
-    private enum Result {
+    protected enum Result {
         VALUE_INCLUDED,
         NO_VALUE_INCLUDED,
         NONE

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ClearOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ClearOperation.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.map.impl.operation;
 
+import com.hazelcast.core.EntryEventType;
+import com.hazelcast.map.impl.MapEventPublisher;
 import com.hazelcast.map.impl.MapServiceContext;
 import com.hazelcast.map.impl.RecordStore;
 import com.hazelcast.spi.BackupAwareOperation;
@@ -54,6 +56,19 @@ public class ClearOperation extends AbstractMapOperation implements BackupAwareO
         }
 
         numberOfClearedEntries = recordStore.clear();
+    }
+
+    @Override
+    public void afterRun() throws Exception {
+        super.afterRun();
+        hintMapEvent();
+    }
+
+    private void hintMapEvent() {
+        MapServiceContext mapServiceContext = mapService.getMapServiceContext();
+        MapEventPublisher mapEventPublisher = mapServiceContext.getMapEventPublisher();
+        mapEventPublisher.hintMapEvent(getCallerAddress(), name, EntryEventType.CLEAR_ALL,
+                numberOfClearedEntries, getPartitionId());
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EvictAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EvictAllOperation.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.map.impl.operation;
 
+import com.hazelcast.core.EntryEventType;
+import com.hazelcast.map.impl.MapEventPublisher;
 import com.hazelcast.map.impl.MapServiceContext;
 import com.hazelcast.map.impl.RecordStore;
 import com.hazelcast.nio.ObjectDataInput;
@@ -24,6 +26,7 @@ import com.hazelcast.spi.BackupAwareOperation;
 import com.hazelcast.spi.impl.MutatingOperation;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.PartitionAwareOperation;
+
 import java.io.IOException;
 
 /**
@@ -56,6 +59,19 @@ public class EvictAllOperation extends AbstractMapOperation implements BackupAwa
         }
         numberOfEvictedEntries = recordStore.evictAll(false);
         shouldRunOnBackup = true;
+    }
+
+    @Override
+    public void afterRun() throws Exception {
+        super.afterRun();
+        hintMapEvent();
+    }
+
+    private void hintMapEvent() {
+        MapServiceContext mapServiceContext = mapService.getMapServiceContext();
+        MapEventPublisher mapEventPublisher = mapServiceContext.getMapEventPublisher();
+        mapEventPublisher.hintMapEvent(getCallerAddress(), name,
+                EntryEventType.EVICT_ALL, numberOfEvictedEntries, getPartitionId());
     }
 
     @Override


### PR DESCRIPTION
- Map wide events are `CLEAR_ALL`, `EVICT_ALL`.
- Currently a map event is published by the end which calls map#clear or map#evictAll and there is no
order guarantee between events fired after the operations, like map#put and map#clear, as a result of that, we may clear a put after a map#clear, to tackle with that kind of possible anomalies, this hint may be used under some conditions internally.