### PR TITLE
SingleNodeTest.cancelWhileQueued fix - BasicTestTask is now PartitionAware

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/executor/ExecutorServiceTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/executor/ExecutorServiceTestSupport.java
@@ -43,11 +43,16 @@ public class ExecutorServiceTestSupport extends HazelcastTestSupport {
         return instance.getExecutorService(name);
     }
 
-    static class BasicTestTask implements Callable<String>, Serializable {
+    static class BasicTestTask implements Callable<String>, Serializable, PartitionAware {
         public static String RESULT = "Task completed";
 
         @Override public String call() {
             return RESULT;
+        }
+
+        @Override
+        public Object getPartitionKey() {
+            return "key";
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/executor/SingleNodeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/executor/SingleNodeTest.java
@@ -23,7 +23,6 @@ import com.hazelcast.monitor.LocalExecutorStats;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
-import com.hazelcast.test.annotation.Repeat;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;


### PR DESCRIPTION
After #5022 is merged, issue #4915 is reopened. I've tracked down the issue and saw that while `SleepingTask` is *PartitionAware* `BasicTestTask` is not, and assigned to a random partition each time the test runs. Thus, in some rare occasions this causes `BasicTestTask` to be executed before `SleepingTask`. The way it should be can be seen below:

```java
Callable task1 = new SleepingTask(100);
Future inProgFuture = executor.submit(task1);
Callable task2 = new BasicTestTask();
Future queuedFuture = executor.submit(task2);

assertFalse(queuedFuture.isDone());
assertTrue(queuedFuture.cancel(true));
assertTrue(queuedFuture.isCancelled());
assertTrue(queuedFuture.isDone());
```
Sometimes `queuedFuture` is mysteriously finishing before `inProgFuture` operation.

In theory it should remain in the queue while first task is still running.

Right now I made the `BasicTestTask` *PartitionAware* as well, so that it gets send to same partition thread with the `SleepingTask`. Hence, we guarantee ordering for the test.

fixes #4915 