### PR TITLE
Exception throwing prevented in case of null value addition to index. 

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/query/impl/IndexService.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/IndexService.java
@@ -30,8 +30,9 @@ import java.util.concurrent.atomic.AtomicReference;
  * This class contains methods which manipulate and access index.
  */
 public class IndexService {
+    private static final Index[] EMPTY_INDEX = {};
     private final ConcurrentMap<String, Index> mapIndexes = new ConcurrentHashMap<String, Index>(3);
-    private final AtomicReference<Index[]> indexes = new AtomicReference<Index[]>();
+    private final AtomicReference<Index[]> indexes = new AtomicReference<Index[]>(EMPTY_INDEX);
     private volatile boolean hasIndex;
 
     public synchronized Index destroyIndex(String attribute) {
@@ -60,7 +61,8 @@ public class IndexService {
     }
 
     public void removeEntryIndex(Data indexKey) throws QueryException {
-        for (Index index : indexes.get()) {
+        Index[] indexes = getIndexes();
+        for (Index index : indexes) {
             index.removeEntryIndex(indexKey);
         }
     }
@@ -70,7 +72,8 @@ public class IndexService {
     }
 
     public void saveEntryIndex(QueryableEntry queryableEntry) throws QueryException {
-        for (Index index : indexes.get()) {
+        Index[] indexes = getIndexes();
+        for (Index index : indexes) {
             index.saveEntryIndex(queryableEntry);
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/getters/NullGetter.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/getters/NullGetter.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.query.impl.getters;
+
+/**
+ * Null getter describes neutral behaviour for a {@link Getter}.
+ */
+public final class NullGetter extends Getter {
+
+    /**
+     * Shared singleton instance of this class.
+     */
+    public static final NullGetter NULL_GETTER = new NullGetter();
+
+    private NullGetter() {
+        super(null);
+    }
+
+    @Override
+    Object getValue(Object obj) throws Exception {
+        return null;
+    }
+
+    @Override
+    Class getReturnType() {
+        return null;
+    }
+
+    @Override
+    boolean isCacheable() {
+        return false;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/getters/ReflectionHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/getters/ReflectionHelper.java
@@ -18,6 +18,7 @@ package com.hazelcast.query.impl.getters;
 
 import com.hazelcast.query.QueryException;
 import com.hazelcast.query.impl.AttributeType;
+import com.hazelcast.query.impl.IndexImpl;
 import com.hazelcast.util.ConcurrencyUtil;
 import com.hazelcast.util.ConstructorFunction;
 import com.hazelcast.util.EmptyStatement;
@@ -36,6 +37,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
 import static com.hazelcast.query.QueryConstants.THIS_ATTRIBUTE_NAME;
+import static com.hazelcast.query.impl.getters.NullGetter.NULL_GETTER;
 
 /**
  * Scans your classpath, indexes the metadata, allows you to query it on runtime.
@@ -62,6 +64,10 @@ public final class ReflectionHelper {
     }
 
     public static AttributeType getAttributeType(Class klass) {
+        if (klass == null) {
+            return null;
+        }
+
         if (klass == String.class) {
             return AttributeType.STRING;
         } else if (klass == int.class || klass == Integer.class) {
@@ -123,6 +129,10 @@ public final class ReflectionHelper {
     }
 
     private static Getter createGetter(Object obj, String attribute) {
+        if (obj == null || obj == IndexImpl.NULL) {
+            return NULL_GETTER;
+        }
+
         final Class targetClazz = obj.getClass();
         Class clazz = targetClazz;
         Getter getter = get(clazz, attribute);
@@ -208,5 +218,4 @@ public final class ReflectionHelper {
             throw ExceptionUtil.rethrow(e);
         }
     }
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/getters/NullGetterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/getters/NullGetterTest.java
@@ -1,0 +1,36 @@
+package com.hazelcast.query.impl.getters;
+
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category(QuickTest.class)
+public class NullGetterTest {
+
+    @Test
+    public void test_getValue() throws Exception {
+        Object value = NullGetter.NULL_GETTER.getValue(new Object());
+
+        assertNull(value);
+    }
+
+    @Test
+    public void test_getReturnType() throws Exception {
+        Class returnType = NullGetter.NULL_GETTER.getReturnType();
+
+        assertNull(returnType);
+    }
+
+    @Test
+    public void test_isCacheable() throws Exception {
+        boolean cacheable = NullGetter.NULL_GETTER.isCacheable();
+
+        assertFalse(cacheable);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/getters/ReflectionHelperTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/getters/ReflectionHelperTest.java
@@ -1,0 +1,22 @@
+package com.hazelcast.query.impl.getters;
+
+import com.hazelcast.query.impl.AttributeType;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertNull;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category(QuickTest.class)
+public class ReflectionHelperTest {
+
+    @Test
+    public void test_getAttributeType() throws Exception {
+        AttributeType attributeType = ReflectionHelper.getAttributeType(null, "test");
+
+        assertNull(attributeType);
+    }
+}


### PR DESCRIPTION
This is for the cases which we want to query on keys. If there is no index for keys, querying on keys should silently return null to indicate no result found