### PR TITLE
Added max result size limit for query operations.

### DIFF
--- a/hazelcast-client-new/src/test/java/com/hazelcast/client/map/ClientMapUnboundReturnValuesTestSupport.java
+++ b/hazelcast-client-new/src/test/java/com/hazelcast/client/map/ClientMapUnboundReturnValuesTestSupport.java
@@ -1,0 +1,335 @@
+package com.hazelcast.client.map;
+
+import com.hazelcast.client.HazelcastClient;
+import com.hazelcast.config.Config;
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.core.TransactionalMap;
+import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.map.QueryResultSizeExceededException;
+import com.hazelcast.map.impl.QueryResultSizeLimiter;
+import com.hazelcast.query.TruePredicate;
+import com.hazelcast.transaction.TransactionContext;
+import com.hazelcast.util.EmptyStatement;
+
+import java.util.UUID;
+
+import static java.lang.String.format;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+abstract class ClientMapUnboundReturnValuesTestSupport {
+
+    protected static final int PARTITION_COUNT = 271;
+
+    protected static final int SMALL_LIMIT = QueryResultSizeLimiter.MINIMUM_MAX_RESULT_LIMIT;
+
+    protected static final int PRE_CHECK_TRIGGER_LIMIT_INACTIVE = -1;
+    protected static final int PRE_CHECK_TRIGGER_LIMIT_ACTIVE = Integer.MAX_VALUE;
+
+    private HazelcastInstance instance;
+    private IMap<Integer, Integer> serverMap;
+    private IMap<Integer, Integer> clientMap;
+
+    private int configLimit;
+    private int upperLimit;
+
+    /**
+     * This test calls {@link IMap} methods once which are expected to throw {@link QueryResultSizeExceededException}.
+     * <p/>
+     * This test fills the map to an amount where the exception is safely triggered. Then all {@link IMap} methods are called
+     * which should trigger the exception.
+     * <p/>
+     * This test fails if any of the called methods does not trigger the exception.
+     *
+     * @param partitionCount  number of partitions the created cluster
+     * @param limit           result size limit which will be configured for the cluster
+     * @param preCheckTrigger number of partitions which will be used for local pre-check, <tt>-1</tt> deactivates the pre-check
+     */
+    protected void runClientMapTestWithException(int partitionCount, int limit, int preCheckTrigger) {
+        internalSetUpClient(partitionCount, 1, limit, preCheckTrigger);
+
+        fillToUpperLimit(serverMap, clientMap);
+        internalRunWithException(clientMap);
+
+        shutdown(serverMap);
+    }
+
+    /**
+     * This test calls {@link IMap} methods once which are not expected to throw {@link QueryResultSizeExceededException}.
+     * <p/>
+     * This test fills the map to an amount where the exception is safely triggered. Then all {@link IMap} methods are called
+     * which should not trigger the exception.
+     * <p/>
+     * This methods fails if any of the called methods triggers the exception.
+     *
+     * @param partitionCount  number of partitions the created cluster
+     * @param limit           result size limit which will be configured for the cluster
+     * @param preCheckTrigger number of partitions which will be used for local pre-check, <tt>-1</tt> deactivates the pre-check
+     */
+    protected void runClientMapTestWithoutException(int partitionCount, int limit, int preCheckTrigger) {
+        internalSetUpClient(partitionCount, 1, limit, preCheckTrigger);
+
+        fillToUpperLimit(serverMap, clientMap);
+        internalRunWithoutException(clientMap);
+
+        shutdown(serverMap);
+    }
+
+    /**
+     * This test calls {@link IMap} methods which have to be implemented but are not supported by the client.
+     * <p/>
+     * This methods fails if any of the called methods does not throw a {@link UnsupportedOperationException}.
+     */
+    protected void runClientMapTestCheckUnsupported() {
+        internalSetUpClient(PARTITION_COUNT, 1, 1, PRE_CHECK_TRIGGER_LIMIT_INACTIVE);
+
+        internalRunCheckUnsupported(clientMap);
+    }
+
+    /**
+     * Test which calls {@link TransactionalMap} methods which are expected to throw {@link QueryResultSizeExceededException}.
+     * <p/>
+     * This test fills the map to an amount where the exception is safely triggered. Then all {@link TransactionalMap} methods are
+     * called which should trigger the exception.
+     * <p/>
+     * This test fails if any of the called methods does not trigger the exception.
+     *
+     * @param partitionCount  number of partitions the created cluster
+     * @param limit           result size limit which will be configured for the cluster
+     * @param preCheckTrigger number of partitions which will be used for local pre-check, <tt>-1</tt> deactivates the pre-check
+     */
+    protected void runClientMapTestTxnWithException(int partitionCount, int limit, int preCheckTrigger) {
+        internalSetUpClient(partitionCount, 1, limit, preCheckTrigger);
+
+        fillToUpperLimit(serverMap, clientMap);
+        internalRunTxnWithException(clientMap.getName());
+
+        shutdown(serverMap);
+    }
+
+    /**
+     * Test which calls {@link TransactionalMap} methods which are not expected to throw {@link QueryResultSizeExceededException}.
+     * <p/>
+     * This test fills the map to an amount where the exception is safely triggered. Then all {@link TransactionalMap} methods are
+     * called which should not trigger the exception.
+     * <p/>
+     * This methods fails if any of the called methods triggers the exception.
+     *
+     * @param partitionCount  number of partitions the created cluster
+     * @param limit           result size limit which will be configured for the cluster
+     * @param preCheckTrigger number of partitions which will be used for local pre-check, <tt>-1</tt> deactivates the pre-check
+     */
+    protected void runClientMapTestTxnWithoutException(int partitionCount, int limit, int preCheckTrigger) {
+        internalSetUpClient(partitionCount, 1, limit, preCheckTrigger);
+
+        fillToUpperLimit(serverMap, clientMap);
+        internalRunTxnWithoutException(clientMap.getName());
+
+        shutdown(serverMap);
+    }
+
+    private void internalSetUpClient(int partitionCount, int clusterSize, int limit, int preCheckTrigger) {
+        Config config = createConfig(partitionCount, limit, preCheckTrigger);
+        serverMap = getMapWithNodeCount(clusterSize, config);
+
+        instance = HazelcastClient.newHazelcastClient();
+        clientMap = instance.getMap(serverMap.getName());
+
+        configLimit = limit;
+        upperLimit = Math.round(limit * 1.5f);
+    }
+
+    private Config createConfig(int partitionCount, int limit, int preCheckTrigger) {
+        Config config = new Config();
+        config.setProperty(GroupProperties.PROP_PARTITION_COUNT, String.valueOf(partitionCount));
+        config.setProperty(GroupProperties.PROP_QUERY_RESULT_SIZE_LIMIT, String.valueOf(limit));
+        config.setProperty(GroupProperties.PROP_QUERY_MAX_LOCAL_PARTITION_LIMIT_FOR_PRE_CHECK, String.valueOf(preCheckTrigger));
+        return config;
+    }
+
+    private <K, V> IMap<K, V> getMapWithNodeCount(int nodeCount, Config config) {
+        String mapName = UUID.randomUUID().toString();
+
+        MapConfig mapConfig = new MapConfig();
+        mapConfig.setName(mapName);
+        mapConfig.setAsyncBackupCount(0);
+        mapConfig.setBackupCount(0);
+        config.addMapConfig(mapConfig);
+
+        while (nodeCount > 1) {
+            Hazelcast.newHazelcastInstance(config);
+            nodeCount--;
+        }
+
+        HazelcastInstance node = Hazelcast.newHazelcastInstance(config);
+        return node.getMap(mapName);
+    }
+
+    private void fillToUpperLimit(IMap<Integer, Integer> fillMap, IMap<Integer, Integer> queryMap) {
+        for (int index = 1; index <= upperLimit; index++) {
+            fillMap.put(index, index);
+        }
+        assertEquals("Expected map size of server map to match upperLimit", upperLimit, fillMap.size());
+        assertEquals("Expected map size of client map to match upperLimit", upperLimit, queryMap.size());
+    }
+
+    private void failExpectedException(String methodName) {
+        fail(format("Expected QueryResultSizeExceededException while calling %s with limit %d and upperLimit %d",
+                methodName, configLimit, upperLimit));
+    }
+
+    private void failUnwantedException(String methodName) {
+        fail(format("Unwanted QueryResultSizeExceededException was thrown while calling %s with limit %d and upperLimit %d",
+                methodName, configLimit, upperLimit));
+    }
+
+    /**
+     * Calls {@link IMap} methods once which are expected to throw {@link QueryResultSizeExceededException}.
+     * <p/>
+     * This method requires the map to be filled to an amount where the exception is safely triggered.
+     * <p/>
+     * This methods fails if any of the called methods does not trigger the exception.
+     */
+    private void internalRunWithException(IMap<Integer, Integer> queryMap) {
+        try {
+            queryMap.values(TruePredicate.INSTANCE);
+            failExpectedException("IMap.values(predicate)");
+        } catch (QueryResultSizeExceededException e) {
+            EmptyStatement.ignore(e);
+        }
+
+        try {
+            queryMap.keySet(TruePredicate.INSTANCE);
+            failExpectedException("IMap.keySet(predicate)");
+        } catch (QueryResultSizeExceededException e) {
+            EmptyStatement.ignore(e);
+        }
+
+        try {
+            queryMap.entrySet(TruePredicate.INSTANCE);
+            failExpectedException("IMap.entrySet(predicate)");
+        } catch (QueryResultSizeExceededException e) {
+            EmptyStatement.ignore(e);
+        }
+    }
+
+    /**
+     * Calls {@link IMap} methods once which are not expected to throw a {@link QueryResultSizeExceededException}.
+     * <p/>
+     * This method requires the map to be filled to an amount where the exception is safely triggered.
+     * <p/>
+     * This methods fails if any of the called methods triggers the exception.
+     */
+    private void internalRunWithoutException(IMap<Integer, Integer> queryMap) {
+        try {
+            assertEquals("IMap.values()", upperLimit, queryMap.values().size());
+        } catch (QueryResultSizeExceededException e) {
+            failUnwantedException("IMap.values()");
+        }
+
+        try {
+            assertEquals("IMap.keySet()", upperLimit, queryMap.keySet().size());
+        } catch (QueryResultSizeExceededException e) {
+            failUnwantedException("IMap.keySet()");
+        }
+
+        /*
+        // FIXME: the performance of IMap.entrySet() is too bad to test it with the required number of entries
+        try {
+            assertEquals("IMap.entrySet()", upperLimit, queryMap.entrySet().size());
+        } catch (QueryResultSizeExceededException e) {
+            failUnwantedException("IMap.entrySet()");
+        }
+        */
+    }
+
+    /**
+     * Calls {@link IMap} methods which have to be implemented but are not supported by the client.
+     * <p/>
+     * This methods fails if any of the called methods does not throw a {@link UnsupportedOperationException}.
+     */
+    private void internalRunCheckUnsupported(IMap<Integer, Integer> queryMap) {
+        try {
+            queryMap.localKeySet();
+            failExpectedException("IMap.localKeySet()");
+        } catch (UnsupportedOperationException e) {
+            EmptyStatement.ignore(e);
+        } catch (QueryResultSizeExceededException e) {
+            failUnwantedException("IMap.localKeySet()");
+        }
+
+        try {
+            queryMap.localKeySet(TruePredicate.INSTANCE);
+            failExpectedException("IMap.localKeySet(predicate)");
+        } catch (UnsupportedOperationException e) {
+            EmptyStatement.ignore(e);
+        } catch (QueryResultSizeExceededException e) {
+            failUnwantedException("IMap.localKeySet()");
+        }
+    }
+
+    /**
+     * Calls {@link TransactionalMap} methods once which are expected to throw {@link QueryResultSizeExceededException}.
+     * <p/>
+     * This method requires the map to be filled to an amount where the exception is safely triggered.
+     * <p/>
+     * This methods fails if any of the called methods does not trigger the exception.
+     */
+    private void internalRunTxnWithException(String mapName) {
+        TransactionContext transactionContext = instance.newTransactionContext();
+        transactionContext.beginTransaction();
+        TransactionalMap<Object, Integer> txnMap = transactionContext.getMap(mapName);
+
+        try {
+            txnMap.values(TruePredicate.INSTANCE);
+            failExpectedException("TransactionalMap.values(predicate)");
+        } catch (QueryResultSizeExceededException e) {
+            EmptyStatement.ignore(e);
+        }
+
+        try {
+            txnMap.keySet(TruePredicate.INSTANCE);
+            failExpectedException("TransactionalMap.keySet(predicate)");
+        } catch (QueryResultSizeExceededException e) {
+            EmptyStatement.ignore(e);
+        }
+
+        transactionContext.rollbackTransaction();
+    }
+
+    /**
+     * Calls {@link TransactionalMap} methods once which are not expected to throw a {@link QueryResultSizeExceededException}.
+     * <p/>
+     * This method requires the map to be filled to an amount where the exception is safely triggered.
+     * <p/>
+     * This methods fails if any of the called methods triggers the exception.
+     */
+    private void internalRunTxnWithoutException(String mapName) {
+        TransactionContext transactionContext = instance.newTransactionContext();
+        transactionContext.beginTransaction();
+
+        TransactionalMap<Object, Integer> txnMap = transactionContext.getMap(mapName);
+
+        try {
+            assertEquals("TransactionalMap.values()", upperLimit, txnMap.values().size());
+        } catch (QueryResultSizeExceededException e) {
+            failUnwantedException("TransactionalMap.values()");
+        }
+
+        try {
+            assertEquals("TransactionalMap.keySet()", upperLimit, txnMap.keySet().size());
+        } catch (QueryResultSizeExceededException e) {
+            failUnwantedException("TransactionalMap.keySet()");
+        }
+
+        transactionContext.rollbackTransaction();
+    }
+
+    private void shutdown(IMap map) {
+        map.destroy();
+        Hazelcast.shutdownAll();
+    }
+}

--- a/hazelcast-client-new/src/test/java/com/hazelcast/client/map/ClientMapUnboundReturnValues_BasicTest.java
+++ b/hazelcast-client-new/src/test/java/com/hazelcast/client/map/ClientMapUnboundReturnValues_BasicTest.java
@@ -1,0 +1,37 @@
+package com.hazelcast.client.map;
+
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.NightlyTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(NightlyTest.class)
+public class ClientMapUnboundReturnValues_BasicTest extends ClientMapUnboundReturnValuesTestSupport {
+
+    @Test
+    public void testClientMap_withException_NoPreCheck() {
+        runClientMapTestWithException(PARTITION_COUNT, SMALL_LIMIT, PRE_CHECK_TRIGGER_LIMIT_INACTIVE);
+    }
+
+    @Test
+    public void testClientMap_withException_PreCheck() {
+        runClientMapTestWithException(PARTITION_COUNT, SMALL_LIMIT, PRE_CHECK_TRIGGER_LIMIT_ACTIVE);
+    }
+
+    @Test
+    public void testClientMap_withoutException_NoPreCheck() {
+        runClientMapTestWithoutException(PARTITION_COUNT, SMALL_LIMIT, PRE_CHECK_TRIGGER_LIMIT_INACTIVE);
+    }
+
+    @Test
+    public void testClientMap_withoutException_PreCheck() {
+        runClientMapTestWithoutException(PARTITION_COUNT, SMALL_LIMIT, PRE_CHECK_TRIGGER_LIMIT_ACTIVE);
+    }
+
+    @Test
+    public void testClientMap_checkUnsupported() {
+        runClientMapTestCheckUnsupported();
+    }
+}

--- a/hazelcast-client-new/src/test/java/com/hazelcast/client/map/ClientMapUnboundReturnValues_TxnTest.java
+++ b/hazelcast-client-new/src/test/java/com/hazelcast/client/map/ClientMapUnboundReturnValues_TxnTest.java
@@ -1,0 +1,32 @@
+package com.hazelcast.client.map;
+
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.NightlyTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(NightlyTest.class)
+public class ClientMapUnboundReturnValues_TxnTest extends ClientMapUnboundReturnValuesTestSupport {
+
+    @Test
+    public void testClientTxnMap_withException_NoPreCheck() {
+        runClientMapTestTxnWithException(PARTITION_COUNT, SMALL_LIMIT, PRE_CHECK_TRIGGER_LIMIT_INACTIVE);
+    }
+
+    @Test
+    public void testClientTxnMap_withException_PreCheck() {
+        runClientMapTestTxnWithException(PARTITION_COUNT, SMALL_LIMIT, PRE_CHECK_TRIGGER_LIMIT_ACTIVE);
+    }
+
+    @Test
+    public void testClientTxnMap_withoutException_NoPreCheck() {
+        runClientMapTestTxnWithoutException(PARTITION_COUNT, SMALL_LIMIT, PRE_CHECK_TRIGGER_LIMIT_INACTIVE);
+    }
+
+    @Test
+    public void testClientTxnMap_withoutException_PreCheck() {
+        runClientMapTestTxnWithoutException(PARTITION_COUNT, SMALL_LIMIT, PRE_CHECK_TRIGGER_LIMIT_ACTIVE);
+    }
+}

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
@@ -703,9 +703,10 @@ public final class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public Map<K, V> getAll(Set<K> keys) {
         initNearCache();
-        Set<Data> keySet = new HashSet(keys.size());
+        Set<Data> keySet = new HashSet<Data>(keys.size());
         Map<K, V> result = new HashMap<K, V>();
         for (Object key : keys) {
             keySet.add(toData(key));
@@ -770,6 +771,7 @@ public final class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public Set<K> keySet(Predicate predicate) {
         PagingPredicate pagingPredicate = null;
         if (predicate instanceof PagingPredicate) {
@@ -811,6 +813,7 @@ public final class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public Set<Entry<K, V>> entrySet(Predicate predicate) {
         PagingPredicate pagingPredicate = null;
         if (predicate instanceof PagingPredicate) {

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapUnboundReturnValuesTestSupport.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapUnboundReturnValuesTestSupport.java
@@ -1,0 +1,337 @@
+package com.hazelcast.client.map;
+
+import com.hazelcast.client.HazelcastClient;
+import com.hazelcast.config.Config;
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.core.TransactionalMap;
+import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.map.QueryResultSizeExceededException;
+import com.hazelcast.map.impl.QueryResultSizeLimiter;
+import com.hazelcast.query.TruePredicate;
+import com.hazelcast.transaction.TransactionContext;
+import com.hazelcast.util.EmptyStatement;
+
+import java.util.UUID;
+
+import static java.lang.String.format;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+abstract class ClientMapUnboundReturnValuesTestSupport {
+
+    protected static final int PARTITION_COUNT = 271;
+
+    protected static final int SMALL_LIMIT = QueryResultSizeLimiter.MINIMUM_MAX_RESULT_LIMIT;
+
+    protected static final int PRE_CHECK_TRIGGER_LIMIT_INACTIVE = -1;
+    protected static final int PRE_CHECK_TRIGGER_LIMIT_ACTIVE = Integer.MAX_VALUE;
+
+    private HazelcastInstance instance;
+    private IMap<Integer, Integer> serverMap;
+    private IMap<Integer, Integer> clientMap;
+
+    private int configLimit;
+    private int upperLimit;
+
+    /**
+     * This test calls {@link IMap} methods once which are expected to throw {@link QueryResultSizeExceededException}.
+     * <p/>
+     * This test fills the map to an amount where the exception is safely triggered. Then all {@link IMap} methods are called
+     * which should trigger the exception.
+     * <p/>
+     * This test fails if any of the called methods does not trigger the exception.
+     *
+     * @param partitionCount  number of partitions the created cluster
+     * @param limit           result size limit which will be configured for the cluster
+     * @param preCheckTrigger number of partitions which will be used for local pre-check, <tt>-1</tt> deactivates the pre-check
+     */
+    protected void runClientMapTestWithException(int partitionCount, int limit, int preCheckTrigger) {
+        internalSetUpClient(partitionCount, 1, limit, preCheckTrigger);
+
+        fillToUpperLimit(serverMap, clientMap);
+        internalRunWithException(clientMap);
+
+        shutdown(serverMap);
+    }
+
+    /**
+     * This test calls {@link IMap} methods once which are not expected to throw {@link QueryResultSizeExceededException}.
+     * <p/>
+     * This test fills the map to an amount where the exception is safely triggered. Then all {@link IMap} methods are called
+     * which should not trigger the exception.
+     * <p/>
+     * This methods fails if any of the called methods triggers the exception.
+     *
+     * @param partitionCount  number of partitions the created cluster
+     * @param limit           result size limit which will be configured for the cluster
+     * @param preCheckTrigger number of partitions which will be used for local pre-check, <tt>-1</tt> deactivates the pre-check
+     */
+    protected void runClientMapTestWithoutException(int partitionCount, int limit, int preCheckTrigger) {
+        internalSetUpClient(partitionCount, 1, limit, preCheckTrigger);
+
+        fillToUpperLimit(serverMap, clientMap);
+        internalRunWithoutException(clientMap);
+
+        shutdown(serverMap);
+    }
+
+    /**
+     * This test calls {@link IMap} methods which have to be implemented but are not supported by the client.
+     * <p/>
+     * This methods fails if any of the called methods does not throw a {@link UnsupportedOperationException}.
+     */
+    protected void runClientMapTestCheckUnsupported() {
+        internalSetUpClient(PARTITION_COUNT, 1, 1, PRE_CHECK_TRIGGER_LIMIT_INACTIVE);
+
+        internalRunCheckUnsupported(clientMap);
+
+        shutdown(serverMap);
+    }
+
+    /**
+     * Test which calls {@link TransactionalMap} methods which are expected to throw {@link QueryResultSizeExceededException}.
+     * <p/>
+     * This test fills the map to an amount where the exception is safely triggered. Then all {@link TransactionalMap} methods are
+     * called which should trigger the exception.
+     * <p/>
+     * This test fails if any of the called methods does not trigger the exception.
+     *
+     * @param partitionCount  number of partitions the created cluster
+     * @param limit           result size limit which will be configured for the cluster
+     * @param preCheckTrigger number of partitions which will be used for local pre-check, <tt>-1</tt> deactivates the pre-check
+     */
+    protected void runClientMapTestTxnWithException(int partitionCount, int limit, int preCheckTrigger) {
+        internalSetUpClient(partitionCount, 1, limit, preCheckTrigger);
+
+        fillToUpperLimit(serverMap, clientMap);
+        internalRunTxnWithException(clientMap.getName());
+
+        shutdown(serverMap);
+    }
+
+    /**
+     * Test which calls {@link TransactionalMap} methods which are not expected to throw {@link QueryResultSizeExceededException}.
+     * <p/>
+     * This test fills the map to an amount where the exception is safely triggered. Then all {@link TransactionalMap} methods are
+     * called which should not trigger the exception.
+     * <p/>
+     * This methods fails if any of the called methods triggers the exception.
+     *
+     * @param partitionCount  number of partitions the created cluster
+     * @param limit           result size limit which will be configured for the cluster
+     * @param preCheckTrigger number of partitions which will be used for local pre-check, <tt>-1</tt> deactivates the pre-check
+     */
+    protected void runClientMapTestTxnWithoutException(int partitionCount, int limit, int preCheckTrigger) {
+        internalSetUpClient(partitionCount, 1, limit, preCheckTrigger);
+
+        fillToUpperLimit(serverMap, clientMap);
+        internalRunTxnWithoutException(clientMap.getName());
+
+        shutdown(serverMap);
+    }
+
+    private void internalSetUpClient(int partitionCount, int clusterSize, int limit, int preCheckTrigger) {
+        Config config = createConfig(partitionCount, limit, preCheckTrigger);
+        serverMap = getMapWithNodeCount(clusterSize, config);
+
+        instance = HazelcastClient.newHazelcastClient();
+        clientMap = instance.getMap(serverMap.getName());
+
+        configLimit = limit;
+        upperLimit = Math.round(limit * 1.5f);
+    }
+
+    private Config createConfig(int partitionCount, int limit, int preCheckTrigger) {
+        Config config = new Config();
+        config.setProperty(GroupProperties.PROP_PARTITION_COUNT, String.valueOf(partitionCount));
+        config.setProperty(GroupProperties.PROP_QUERY_RESULT_SIZE_LIMIT, String.valueOf(limit));
+        config.setProperty(GroupProperties.PROP_QUERY_MAX_LOCAL_PARTITION_LIMIT_FOR_PRE_CHECK, String.valueOf(preCheckTrigger));
+        return config;
+    }
+
+    private <K, V> IMap<K, V> getMapWithNodeCount(int nodeCount, Config config) {
+        String mapName = UUID.randomUUID().toString();
+
+        MapConfig mapConfig = new MapConfig();
+        mapConfig.setName(mapName);
+        mapConfig.setAsyncBackupCount(0);
+        mapConfig.setBackupCount(0);
+        config.addMapConfig(mapConfig);
+
+        while (nodeCount > 1) {
+            Hazelcast.newHazelcastInstance(config);
+            nodeCount--;
+        }
+
+        HazelcastInstance node = Hazelcast.newHazelcastInstance(config);
+        return node.getMap(mapName);
+    }
+
+    private void fillToUpperLimit(IMap<Integer, Integer> fillMap, IMap<Integer, Integer> queryMap) {
+        for (int index = 1; index <= upperLimit; index++) {
+            fillMap.put(index, index);
+        }
+        assertEquals("Expected map size of server map to match upperLimit", upperLimit, fillMap.size());
+        assertEquals("Expected map size of client map to match upperLimit", upperLimit, queryMap.size());
+    }
+
+    private void failExpectedException(String methodName) {
+        fail(format("Expected QueryResultSizeExceededException while calling %s with limit %d and upperLimit %d",
+                methodName, configLimit, upperLimit));
+    }
+
+    private void failUnwantedException(String methodName) {
+        fail(format("Unwanted QueryResultSizeExceededException was thrown while calling %s with limit %d and upperLimit %d",
+                methodName, configLimit, upperLimit));
+    }
+
+    /**
+     * Calls {@link IMap} methods once which are expected to throw {@link QueryResultSizeExceededException}.
+     * <p/>
+     * This method requires the map to be filled to an amount where the exception is safely triggered.
+     * <p/>
+     * This methods fails if any of the called methods does not trigger the exception.
+     */
+    private void internalRunWithException(IMap<Integer, Integer> queryMap) {
+        try {
+            queryMap.values(TruePredicate.INSTANCE);
+            failExpectedException("IMap.values(predicate)");
+        } catch (QueryResultSizeExceededException e) {
+            EmptyStatement.ignore(e);
+        }
+
+        try {
+            queryMap.keySet(TruePredicate.INSTANCE);
+            failExpectedException("IMap.keySet(predicate)");
+        } catch (QueryResultSizeExceededException e) {
+            EmptyStatement.ignore(e);
+        }
+
+        try {
+            queryMap.entrySet(TruePredicate.INSTANCE);
+            failExpectedException("IMap.entrySet(predicate)");
+        } catch (QueryResultSizeExceededException e) {
+            EmptyStatement.ignore(e);
+        }
+    }
+
+    /**
+     * Calls {@link IMap} methods once which are not expected to throw a {@link QueryResultSizeExceededException}.
+     * <p/>
+     * This method requires the map to be filled to an amount where the exception is safely triggered.
+     * <p/>
+     * This methods fails if any of the called methods triggers the exception.
+     */
+    private void internalRunWithoutException(IMap<Integer, Integer> queryMap) {
+        try {
+            assertEquals("IMap.values()", upperLimit, queryMap.values().size());
+        } catch (QueryResultSizeExceededException e) {
+            failUnwantedException("IMap.values()");
+        }
+
+        try {
+            assertEquals("IMap.keySet()", upperLimit, queryMap.keySet().size());
+        } catch (QueryResultSizeExceededException e) {
+            failUnwantedException("IMap.keySet()");
+        }
+
+        /*
+        // FIXME: the performance of IMap.entrySet() is too bad to test it with the required number of entries
+        try {
+            assertEquals("IMap.entrySet()", upperLimit, queryMap.entrySet().size());
+        } catch (QueryResultSizeExceededException e) {
+            failUnwantedException("IMap.entrySet()");
+        }
+        */
+    }
+
+    /**
+     * Calls {@link IMap} methods which have to be implemented but are not supported by the client.
+     * <p/>
+     * This methods fails if any of the called methods does not throw a {@link UnsupportedOperationException}.
+     */
+    private void internalRunCheckUnsupported(IMap<Integer, Integer> queryMap) {
+        try {
+            queryMap.localKeySet();
+            failExpectedException("IMap.localKeySet()");
+        } catch (UnsupportedOperationException e) {
+            EmptyStatement.ignore(e);
+        } catch (QueryResultSizeExceededException e) {
+            failUnwantedException("IMap.localKeySet()");
+        }
+
+        try {
+            queryMap.localKeySet(TruePredicate.INSTANCE);
+            failExpectedException("IMap.localKeySet(predicate)");
+        } catch (UnsupportedOperationException e) {
+            EmptyStatement.ignore(e);
+        } catch (QueryResultSizeExceededException e) {
+            failUnwantedException("IMap.localKeySet()");
+        }
+    }
+
+    /**
+     * Calls {@link TransactionalMap} methods once which are expected to throw {@link QueryResultSizeExceededException}.
+     * <p/>
+     * This method requires the map to be filled to an amount where the exception is safely triggered.
+     * <p/>
+     * This methods fails if any of the called methods does not trigger the exception.
+     */
+    private void internalRunTxnWithException(String mapName) {
+        TransactionContext transactionContext = instance.newTransactionContext();
+        transactionContext.beginTransaction();
+        TransactionalMap<Object, Integer> txnMap = transactionContext.getMap(mapName);
+
+        try {
+            txnMap.values(TruePredicate.INSTANCE);
+            failExpectedException("TransactionalMap.values(predicate)");
+        } catch (QueryResultSizeExceededException e) {
+            EmptyStatement.ignore(e);
+        }
+
+        try {
+            txnMap.keySet(TruePredicate.INSTANCE);
+            failExpectedException("TransactionalMap.keySet(predicate)");
+        } catch (QueryResultSizeExceededException e) {
+            EmptyStatement.ignore(e);
+        }
+
+        transactionContext.rollbackTransaction();
+    }
+
+    /**
+     * Calls {@link TransactionalMap} methods once which are not expected to throw a {@link QueryResultSizeExceededException}.
+     * <p/>
+     * This method requires the map to be filled to an amount where the exception is safely triggered.
+     * <p/>
+     * This methods fails if any of the called methods triggers the exception.
+     */
+    private void internalRunTxnWithoutException(String mapName) {
+        TransactionContext transactionContext = instance.newTransactionContext();
+        transactionContext.beginTransaction();
+
+        TransactionalMap<Object, Integer> txnMap = transactionContext.getMap(mapName);
+
+        try {
+            assertEquals("TransactionalMap.values()", upperLimit, txnMap.values().size());
+        } catch (QueryResultSizeExceededException e) {
+            failUnwantedException("TransactionalMap.values()");
+        }
+
+        try {
+            assertEquals("TransactionalMap.keySet()", upperLimit, txnMap.keySet().size());
+        } catch (QueryResultSizeExceededException e) {
+            failUnwantedException("TransactionalMap.keySet()");
+        }
+
+        transactionContext.rollbackTransaction();
+    }
+
+    private void shutdown(IMap map) {
+        map.destroy();
+        Hazelcast.shutdownAll();
+    }
+}

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapUnboundReturnValues_BasicTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapUnboundReturnValues_BasicTest.java
@@ -1,0 +1,37 @@
+package com.hazelcast.client.map;
+
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.NightlyTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(NightlyTest.class)
+public class ClientMapUnboundReturnValues_BasicTest extends ClientMapUnboundReturnValuesTestSupport {
+
+    @Test
+    public void testClientMap_withException_NoPreCheck() {
+        runClientMapTestWithException(PARTITION_COUNT, SMALL_LIMIT, PRE_CHECK_TRIGGER_LIMIT_INACTIVE);
+    }
+
+    @Test
+    public void testClientMap_withException_PreCheck() {
+        runClientMapTestWithException(PARTITION_COUNT, SMALL_LIMIT, PRE_CHECK_TRIGGER_LIMIT_ACTIVE);
+    }
+
+    @Test
+    public void testClientMap_withoutException_NoPreCheck() {
+        runClientMapTestWithoutException(PARTITION_COUNT, SMALL_LIMIT, PRE_CHECK_TRIGGER_LIMIT_INACTIVE);
+    }
+
+    @Test
+    public void testClientMap_withoutException_PreCheck() {
+        runClientMapTestWithoutException(PARTITION_COUNT, SMALL_LIMIT, PRE_CHECK_TRIGGER_LIMIT_ACTIVE);
+    }
+
+    @Test
+    public void testClientMap_checkUnsupported() {
+        runClientMapTestCheckUnsupported();
+    }
+}

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapUnboundReturnValues_TxnTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapUnboundReturnValues_TxnTest.java
@@ -1,0 +1,32 @@
+package com.hazelcast.client.map;
+
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.NightlyTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(NightlyTest.class)
+public class ClientMapUnboundReturnValues_TxnTest extends ClientMapUnboundReturnValuesTestSupport {
+
+    @Test
+    public void testClientTxnMap_withException_NoPreCheck() {
+        runClientMapTestTxnWithException(PARTITION_COUNT, SMALL_LIMIT, PRE_CHECK_TRIGGER_LIMIT_INACTIVE);
+    }
+
+    @Test
+    public void testClientTxnMap_withException_PreCheck() {
+        runClientMapTestTxnWithException(PARTITION_COUNT, SMALL_LIMIT, PRE_CHECK_TRIGGER_LIMIT_ACTIVE);
+    }
+
+    @Test
+    public void testClientTxnMap_withoutException_NoPreCheck() {
+        runClientMapTestTxnWithoutException(PARTITION_COUNT, SMALL_LIMIT, PRE_CHECK_TRIGGER_LIMIT_INACTIVE);
+    }
+
+    @Test
+    public void testClientTxnMap_withoutException_PreCheck() {
+        runClientMapTestTxnWithoutException(PARTITION_COUNT, SMALL_LIMIT, PRE_CHECK_TRIGGER_LIMIT_ACTIVE);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/core/IMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/IMap.java
@@ -16,8 +16,10 @@
 
 package com.hazelcast.core;
 
+import com.hazelcast.instance.GroupProperties;
 import com.hazelcast.map.EntryProcessor;
 import com.hazelcast.map.MapInterceptor;
+import com.hazelcast.map.QueryResultSizeExceededException;
 import com.hazelcast.map.listener.MapListener;
 import com.hazelcast.map.listener.MapPartitionLostListener;
 import com.hazelcast.mapreduce.JobTracker;
@@ -1079,8 +1081,14 @@ public interface IMap<K, V>
      * <p><b>Warning:</b></p>
      * The set is <b>NOT</b> backed by the map,
      * so changes to the map are <b>NOT</b> reflected in the set, and vice-versa.
+     * <p/>
+     * On the server side this method is executed by a distributed query
+     * so it may throw a {@link QueryResultSizeExceededException}
+     * if {@link GroupProperties#PROP_QUERY_RESULT_SIZE_LIMIT} is configured.
      *
      * @return a set clone of the keys contained in this map.
+     * @throws QueryResultSizeExceededException on server side if query result size limit is exceeded
+     * @see GroupProperties#PROP_QUERY_RESULT_SIZE_LIMIT
      */
     Set<K> keySet();
 
@@ -1090,8 +1098,14 @@ public interface IMap<K, V>
      * <p><b>Warning:</b></p>
      * The collection is <b>NOT</b> backed by the map,
      * so changes to the map are <b>NOT</b> reflected in the collection, and vice-versa.
+     * <p/>
+     * On the server side this method is executed by a distributed query
+     * so it may throw a {@link QueryResultSizeExceededException}
+     * if {@link GroupProperties#PROP_QUERY_RESULT_SIZE_LIMIT} is configured.
      *
      * @return a collection clone of the values contained in this map
+     * @throws QueryResultSizeExceededException on server side if query result size limit is exceeded
+     * @see GroupProperties#PROP_QUERY_RESULT_SIZE_LIMIT
      */
     Collection<V> values();
 
@@ -1101,8 +1115,14 @@ public interface IMap<K, V>
      * <p><b>Warning:</b></p>
      * The set is <b>NOT</b> backed by the map,
      * so changes to the map are <b>NOT</b> reflected in the set, and vice-versa.
+     * <p/>
+     * On the server side this method is executed by a distributed query
+     * so it may throw a {@link QueryResultSizeExceededException}
+     * if {@link GroupProperties#PROP_QUERY_RESULT_SIZE_LIMIT} is configured.
      *
      * @return a set clone of the keys mappings in this map
+     * @throws QueryResultSizeExceededException on server side if query result size limit is exceeded
+     * @see GroupProperties#PROP_QUERY_RESULT_SIZE_LIMIT
      */
     Set<Map.Entry<K, V>> entrySet();
 
@@ -1115,9 +1135,15 @@ public interface IMap<K, V>
      * <p><b>Warning:</b></p>
      * The set is <b>NOT</b> backed by the map,
      * so changes to the map are <b>NOT</b> reflected in the set, and vice-versa.
+     * <p/>
+     * This method is always executed by a distributed query
+     * so it may throw a {@link QueryResultSizeExceededException}
+     * if {@link GroupProperties#PROP_QUERY_RESULT_SIZE_LIMIT} is configured.
      *
      * @param predicate specified query criteria.
      * @return result key set of the query.
+     * @throws QueryResultSizeExceededException if query result size limit is exceeded
+     * @see GroupProperties#PROP_QUERY_RESULT_SIZE_LIMIT
      */
     Set<K> keySet(Predicate predicate);
 
@@ -1130,9 +1156,15 @@ public interface IMap<K, V>
      * <p><b>Warning:</b></p>
      * The set is <b>NOT</b> backed by the map,
      * so changes to the map are <b>NOT</b> reflected in the set, and vice-versa.
+     * <p/>
+     * This method is always executed by a distributed query
+     * so it may throw a {@link QueryResultSizeExceededException}
+     * if {@link GroupProperties#PROP_QUERY_RESULT_SIZE_LIMIT} is configured.
      *
      * @param predicate specified query criteria.
      * @return result entry set of the query.
+     * @throws QueryResultSizeExceededException if query result size limit is exceeded
+     * @see GroupProperties#PROP_QUERY_RESULT_SIZE_LIMIT
      */
     Set<Map.Entry<K, V>> entrySet(Predicate predicate);
 
@@ -1145,9 +1177,15 @@ public interface IMap<K, V>
      * <p><b>Warning:</b></p>
      * The collection is <b>NOT</b> backed by the map,
      * so changes to the map are <b>NOT</b> reflected in the collection, and vice-versa.
+     * <p/>
+     * This method is always executed by a distributed query
+     * so it may throw a {@link QueryResultSizeExceededException}
+     * if {@link GroupProperties#PROP_QUERY_RESULT_SIZE_LIMIT} is configured.
      *
      * @param predicate specified query criteria.
      * @return result value collection of the query.
+     * @throws QueryResultSizeExceededException if query result size limit is exceeded
+     * @see GroupProperties#PROP_QUERY_RESULT_SIZE_LIMIT
      */
     Collection<V> values(Predicate predicate);
 
@@ -1164,8 +1202,14 @@ public interface IMap<K, V>
      * <p><b>Warning:</b></p>
      * The set is <b>NOT</b> backed by the map,
      * so changes to the map are <b>NOT</b> reflected in the set, and vice-versa.
+     * <p/>
+     * On the server side this method is executed by a distributed query
+     * so it may throw a {@link QueryResultSizeExceededException}
+     * if {@link GroupProperties#PROP_QUERY_RESULT_SIZE_LIMIT} is configured.
      *
      * @return locally owned keys.
+     * @throws QueryResultSizeExceededException on server side if query result size limit is exceeded
+     * @see GroupProperties#PROP_QUERY_RESULT_SIZE_LIMIT
      */
     Set<K> localKeySet();
 
@@ -1182,9 +1226,15 @@ public interface IMap<K, V>
      * <p><b>Warning:</b></p>
      * The set is <b>NOT</b> backed by the map,
      * so changes to the map are <b>NOT</b> reflected in the set, and vice-versa.
+     * <p/>
+     * This method is always executed by a distributed query
+     * so it may throw a {@link QueryResultSizeExceededException}
+     * if {@link GroupProperties#PROP_QUERY_RESULT_SIZE_LIMIT} is configured.
      *
      * @param predicate specified query criteria.
      * @return keys of matching locally owned entries.
+     * @throws QueryResultSizeExceededException if query result size limit is exceeded
+     * @see GroupProperties#PROP_QUERY_RESULT_SIZE_LIMIT
      */
     Set<K> localKeySet(Predicate predicate);
 

--- a/hazelcast/src/main/java/com/hazelcast/map/QueryResultSizeExceededException.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/QueryResultSizeExceededException.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map;
+
+import com.hazelcast.core.HazelcastException;
+
+import static java.lang.String.format;
+
+/**
+ * This exception is thrown when a query exceeds a configurable result size limit.
+ *
+ * @see com.hazelcast.instance.GroupProperties#PROP_QUERY_RESULT_SIZE_LIMIT
+ */
+public class QueryResultSizeExceededException extends HazelcastException {
+
+    public QueryResultSizeExceededException() {
+        super("This exception has been thrown to prevent an OOME on this Hazelcast instance."
+                + " An OOME might occur when a query collects large data sets from the whole cluster,"
+                + " e.g. by calling IMap.values(), IMap.keySet() or IMap.entrySet()."
+                + " See GroupProperties.PROP_QUERY_RESULT_SIZE_LIMIT for further details.");
+    }
+
+    public QueryResultSizeExceededException(int maxResultLimit, String optionalMessage) {
+        super(format("This exception has been thrown to prevent an OOME on this Hazelcast instance."
+                        + " An OOME might occur when a query collects large data sets from the whole cluster,"
+                        + " e.g. by calling IMap.values(), IMap.keySet() or IMap.entrySet()."
+                        + " See GroupProperties.PROP_QUERY_RESULT_SIZE_LIMIT for further details."
+                        + " The configured query result size limit is %d items.%s",
+                maxResultLimit, optionalMessage));
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapContainerSupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapContainerSupport.java
@@ -26,7 +26,7 @@ import static com.hazelcast.map.impl.ExpirationTimeSetter.calculateTTLMillis;
  *
  * @see MapContainer
  */
-abstract class MapContainerSupport {
+public abstract class MapContainerSupport {
 
     protected volatile MapConfig mapConfig;
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapContextQuerySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapContextQuerySupport.java
@@ -85,4 +85,12 @@ public interface MapContextQuerySupport {
      */
     Set query(String mapName, Predicate predicate,
               IterationType iterationType, boolean dataResult);
+
+    /**
+     * Creates a {@link QueryResult} with configured result limit (according to the number of partitions) if feature is enabled.
+     *
+     * @param numberOfPartitions number of partitions to calculate result limit
+     * @return {@link QueryResult}
+     */
+    QueryResult newQueryResult(int numberOfPartitions);
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/QueryResultSizeLimiter.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/QueryResultSizeLimiter.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl;
+
+import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.map.QueryResultSizeExceededException;
+import com.hazelcast.spi.NodeEngine;
+
+import java.util.Collection;
+
+import static java.lang.Math.ceil;
+import static java.lang.Math.min;
+
+/**
+ * Responsible for limiting result size of queries.
+ * <p/>
+ * This class defines a hard coded minimum {@link #MINIMUM_MAX_RESULT_LIMIT} as well as a factor {@link #MAX_RESULT_LIMIT_FACTOR}
+ * to ensure that the actual result size limit will be a reasonable value. Due to the used hash algorithm the data of a map is not
+ * distributed equally on all partitions in the cluster. Since the decision if the {@link QueryResultSizeExceededException} is
+ * thrown is made on the local number of partition entries we need a reliable distribution of data. The goal is to prevent false
+ * positives, since this may surprise the user. So the exception should never been thrown below the configured limit.
+ * <p/>
+ * The minimum value of {@value #MINIMUM_MAX_RESULT_LIMIT} and the factor of {@value #MAX_RESULT_LIMIT_FACTOR} were determined by
+ * testing on which limit the exception was thrown with different map key types.
+ */
+public class QueryResultSizeLimiter {
+
+    /**
+     * Defines the minimum value for the result size limit to ensure a sufficient distribution of data in the partitions.
+     *
+     * @see QueryResultSizeLimiter
+     */
+    public static final int MINIMUM_MAX_RESULT_LIMIT = 100000;
+
+    /**
+     * Adds a security margin to the configured result size limit to prevent false positives.
+     *
+     * @see QueryResultSizeLimiter
+     */
+    public static final float MAX_RESULT_LIMIT_FACTOR = 1.15f;
+
+    /**
+     * Special value to mark the disabled state.
+     */
+    static final int DISABLED = -1;
+
+    private final MapServiceContext mapServiceContext;
+    private final ILogger log;
+
+    private final int maxResultLimit;
+    private final int maxLocalPartitionsLimitForPreCheck;
+    private final float resultLimitPerPartition;
+
+    private final boolean isQueryResultLimitEnabled;
+    private final boolean isPreCheckEnabled;
+
+    public QueryResultSizeLimiter(MapServiceContext mapServiceContext, ILogger log) {
+        NodeEngine nodeEngine = mapServiceContext.getNodeEngine();
+
+        this.mapServiceContext = mapServiceContext;
+        this.log = log;
+
+        GroupProperties groupProperties = nodeEngine.getGroupProperties();
+        this.maxResultLimit = getMaxResultLimit(groupProperties);
+        this.maxLocalPartitionsLimitForPreCheck = getMaxLocalPartitionsLimitForPreCheck(groupProperties);
+        this.resultLimitPerPartition = maxResultLimit * MAX_RESULT_LIMIT_FACTOR / (float) getPartitionCount(nodeEngine);
+
+        this.isQueryResultLimitEnabled = (maxResultLimit != DISABLED);
+        this.isPreCheckEnabled = (isQueryResultLimitEnabled && maxLocalPartitionsLimitForPreCheck != DISABLED);
+    }
+
+    /**
+     * Just for testing.
+     */
+    boolean isQueryResultLimitEnabled() {
+        return isQueryResultLimitEnabled;
+    }
+
+    /**
+     * Just for testing.
+     */
+    boolean isPreCheckEnabled() {
+        return isPreCheckEnabled;
+    }
+
+    long getNodeResultLimit(int ownedPartitions) {
+        return isQueryResultLimitEnabled ? (long) ceil(resultLimitPerPartition * ownedPartitions) : Long.MAX_VALUE;
+    }
+
+    void checkMaxResultLimitOnLocalPartitions(String mapName) {
+        // check if feature is enabled
+        if (!isPreCheckEnabled) {
+            return;
+        }
+
+        // limit number of local partitions to check to keep runtime constant
+        Collection<Integer> localPartitions = mapServiceContext.getOwnedPartitions();
+        int partitionsToCheck = min(localPartitions.size(), maxLocalPartitionsLimitForPreCheck);
+        if (partitionsToCheck == 0) {
+            return;
+        }
+
+        // calculate size of local partitions
+        int localPartitionSize = getLocalPartitionSize(mapName, localPartitions, partitionsToCheck);
+        if (localPartitionSize == 0) {
+            return;
+        }
+
+        // check local result size
+        long localResultLimit = getNodeResultLimit(partitionsToCheck);
+        if (localPartitionSize > localResultLimit) {
+            throw new QueryResultSizeExceededException(maxResultLimit, " Result size exceeded in local pre-check.");
+        }
+    }
+
+    private int getLocalPartitionSize(String mapName, Collection<Integer> localPartitions, int partitionsToCheck) {
+        int localSize = 0;
+        int partitionsChecked = 0;
+        for (int partitionId : localPartitions) {
+            localSize += mapServiceContext.getRecordStore(partitionId, mapName).size();
+            if (++partitionsChecked == partitionsToCheck) {
+                break;
+            }
+        }
+        return localSize;
+    }
+
+    private int getMaxResultLimit(GroupProperties groupProperties) {
+        int maxResultLimit = groupProperties.QUERY_RESULT_SIZE_LIMIT.getInteger();
+        if (maxResultLimit == -1) {
+            return DISABLED;
+        }
+        if (maxResultLimit <= 0) {
+            throw new IllegalArgumentException(groupProperties.QUERY_RESULT_SIZE_LIMIT.getName()
+                    + " has to be -1 (disabled) or a positive number!");
+        }
+        if (maxResultLimit < MINIMUM_MAX_RESULT_LIMIT) {
+            log.finest("Max result limit was set to minimal value of " + MINIMUM_MAX_RESULT_LIMIT);
+            return MINIMUM_MAX_RESULT_LIMIT;
+        }
+        return maxResultLimit;
+    }
+
+    private int getMaxLocalPartitionsLimitForPreCheck(GroupProperties groupProperties) {
+        int maxLocalPartitionLimitForPreCheck = groupProperties.QUERY_MAX_LOCAL_PARTITION_LIMIT_FOR_PRE_CHECK.getInteger();
+        if (maxLocalPartitionLimitForPreCheck == -1) {
+            return DISABLED;
+        }
+        if (maxLocalPartitionLimitForPreCheck <= 0) {
+            throw new IllegalArgumentException(groupProperties.QUERY_MAX_LOCAL_PARTITION_LIMIT_FOR_PRE_CHECK.getName()
+                    + " has to be -1 (disabled) or a positive number!");
+        }
+        return maxLocalPartitionLimitForPreCheck;
+    }
+
+    private int getPartitionCount(NodeEngine nodeEngine) {
+        return nodeEngine.getPartitionService().getPartitionCount();
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/QueryPartitionOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/QueryPartitionOperation.java
@@ -22,27 +22,25 @@ import com.hazelcast.map.impl.QueryResult;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.query.Predicate;
-import com.hazelcast.query.impl.QueryResultEntryImpl;
 import com.hazelcast.query.impl.QueryableEntry;
 import com.hazelcast.spi.PartitionAwareOperation;
 
 import java.io.IOException;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
+
+import static java.util.Collections.singletonList;
 
 public class QueryPartitionOperation extends AbstractMapOperation implements PartitionAwareOperation {
 
     private Predicate predicate;
     private QueryResult result;
 
+    public QueryPartitionOperation() {
+    }
+
     public QueryPartitionOperation(String mapName, Predicate predicate) {
         super(mapName);
         this.predicate = predicate;
-    }
-
-    @SuppressWarnings("unused")
-    public QueryPartitionOperation() {
     }
 
     @Override
@@ -51,12 +49,9 @@ public class QueryPartitionOperation extends AbstractMapOperation implements Par
         MapContextQuerySupport mapQuerySupport = mapServiceContext.getMapContextQuerySupport();
 
         Collection<QueryableEntry> queryableEntries = mapQuerySupport.queryOnPartition(name, predicate, getPartitionId());
-        result = new QueryResult();
-        for (QueryableEntry entry : queryableEntries) {
-            result.add(new QueryResultEntryImpl(entry.getKeyData(), entry.getIndexKey(), entry.getValueData()));
-        }
-        List<Integer> partitions = Collections.singletonList(getPartitionId());
-        result.setPartitionIds(partitions);
+        result = mapQuerySupport.newQueryResult(1);
+        result.addAll(queryableEntries);
+        result.setPartitionIds(singletonList(getPartitionId()));
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
@@ -641,6 +641,7 @@ public class MapProxyImpl<K, V> extends MapProxySupport implements IMap<K, V>, I
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public Set<K> keySet(final Predicate predicate) {
         if (predicate == null) {
             throw new NullPointerException("Predicate should not be null!");
@@ -657,6 +658,7 @@ public class MapProxyImpl<K, V> extends MapProxySupport implements IMap<K, V>, I
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public Collection<V> values(final Predicate predicate) {
         if (predicate == null) {
             throw new NullPointerException("Predicate should not be null!");
@@ -670,6 +672,7 @@ public class MapProxyImpl<K, V> extends MapProxySupport implements IMap<K, V>, I
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public Set<K> localKeySet(final Predicate predicate) {
         if (predicate == null) {
             throw new NullPointerException("Predicate should not be null!");

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TransactionalMapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TransactionalMapProxySupport.java
@@ -20,6 +20,7 @@ import static com.hazelcast.map.impl.MapService.SERVICE_NAME;
 
 import com.hazelcast.core.PartitioningStrategy;
 import com.hazelcast.instance.MemberImpl;
+import com.hazelcast.map.QueryResultSizeExceededException;
 import com.hazelcast.map.impl.MapEntrySet;
 import com.hazelcast.map.impl.MapKeySet;
 import com.hazelcast.map.impl.MapService;
@@ -295,6 +296,8 @@ public abstract class TransactionalMapProxySupport extends AbstractDistributedOb
             if (partitions.size() == partitionCount) {
                 return result;
             }
+        } catch (QueryResultSizeExceededException e) {
+            throw ExceptionUtil.rethrow(e);
         } catch (Throwable t) {
             EmptyStatement.ignore(t);
         }

--- a/hazelcast/src/test/java/com/hazelcast/map/MapUnboundedReturnValuesTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapUnboundedReturnValuesTestSupport.java
@@ -1,0 +1,401 @@
+package com.hazelcast.map;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.core.TransactionalMap;
+import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.map.impl.QueryResultSizeLimiter;
+import com.hazelcast.query.Predicate;
+import com.hazelcast.query.TruePredicate;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.transaction.TransactionContext;
+import com.hazelcast.util.EmptyStatement;
+
+import java.util.Set;
+
+import static java.lang.String.format;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+abstract class MapUnboundedReturnValuesTestSupport extends HazelcastTestSupport {
+
+    protected static final int CLUSTER_SIZE = 20;
+    protected static final int PARTITION_COUNT = 271;
+
+    protected static final int SMALL_LIMIT = QueryResultSizeLimiter.MINIMUM_MAX_RESULT_LIMIT;
+    protected static final int MEDIUM_LIMIT = (int) (QueryResultSizeLimiter.MINIMUM_MAX_RESULT_LIMIT * 1.5);
+    protected static final int LARGE_LIMIT = QueryResultSizeLimiter.MINIMUM_MAX_RESULT_LIMIT * 2;
+
+    protected static final int PRE_CHECK_TRIGGER_LIMIT_INACTIVE = -1;
+    protected static final int PRE_CHECK_TRIGGER_LIMIT_ACTIVE = Integer.MAX_VALUE;
+
+    protected enum KeyType {
+        STRING,
+        INTEGER
+    }
+
+    private TestHazelcastInstanceFactory factory;
+    private HazelcastInstance instance;
+    private IMap<Object, Integer> map;
+    private ILogger logger;
+
+    private int configLimit;
+    private int lowerLimit;
+    private int upperLimit;
+    private int checkLimitInterval;
+
+    /**
+     * Extensive test which ensures that the {@link QueryResultSizeExceededException} will not be thrown under the configured
+     * limit.
+     * <p/>
+     * This test fills the map below the configured limit to ensure that the exception is not triggered yet. Then it fills up the
+     * map and periodically checks via {@link IMap#keySet()} if the exception is thrown. If the exception is triggered all other
+     * methods from {@link IMap} are executed to ensure they trigger the exception, too.
+     * <p/>
+     * This method fails if the exception is already thrown at {@link #lowerLimit} or if it is not thrown at {@link #upperLimit}.
+     *
+     * @param partitionCount  number of partitions the created cluster
+     * @param clusterSize     number of nodes in the cluster
+     * @param limit           result size limit which will be configured for the cluster
+     * @param preCheckTrigger number of partitions which will be used for local pre-check, <tt>-1</tt> deactivates the pre-check
+     * @param keyType         key type used for the map
+     */
+    protected void runMapFullTest(int partitionCount, int clusterSize, int limit, int preCheckTrigger, KeyType keyType) {
+        internalSetUp(partitionCount, clusterSize, limit, preCheckTrigger);
+
+        fillToLimit(keyType, lowerLimit);
+        internalRunWithLowerBoundCheck(keyType);
+
+        shutdown(factory, map);
+    }
+
+    /**
+     * Quick test which just calls the {@link IMap} methods once and check for the {@link QueryResultSizeExceededException}.
+     * <p/>
+     * This test fills the map to an amount where the exception is safely triggered. Then all {@link IMap} methods are called
+     * and checked if they trigger the exception.
+     * <p/>
+     * This methods fails if any of the called methods does not trigger the exception.
+     *
+     * @param partitionCount  number of partitions the created cluster
+     * @param clusterSize     number of nodes in the cluster
+     * @param limit           result size limit which will be configured for the cluster
+     * @param preCheckTrigger number of partitions which will be used for local pre-check, <tt>-1</tt> deactivates the pre-check
+     * @param keyType         key type used for the map
+     */
+    protected void runMapQuickTest(int partitionCount, int clusterSize, int limit, int preCheckTrigger, KeyType keyType) {
+        internalSetUp(partitionCount, clusterSize, limit, preCheckTrigger);
+
+        fillToLimit(keyType, upperLimit);
+        internalRunQuick();
+        internalRunLocalKeySet();
+        logger.info(format("Limit of %d exceeded at %d (%.2f)", configLimit, upperLimit, (upperLimit * 100f / configLimit)));
+
+        shutdown(factory, map);
+    }
+
+    /**
+     * Test which calls {@link TransactionalMap} methods which are expected to throw {@link QueryResultSizeExceededException}.
+     * <p/>
+     * This test fills the map to an amount where the exception is safely triggered. Then all {@link TransactionalMap} methods are
+     * called which should trigger the exception.
+     * <p/>
+     * This methods fails if any of the called methods does not trigger the exception.
+     *
+     * @param partitionCount  number of partitions the created cluster
+     * @param clusterSize     number of nodes in the cluster
+     * @param limit           result size limit which will be configured for the cluster
+     * @param preCheckTrigger number of partitions which will be used for local pre-check, <tt>-1</tt> deactivates the pre-check
+     */
+    protected void runMapTxnWithExceptionTest(int partitionCount, int clusterSize, int limit, int preCheckTrigger) {
+        internalSetUp(partitionCount, clusterSize, limit, preCheckTrigger);
+
+        fillToLimit(KeyType.INTEGER, upperLimit);
+        internalRunTxnWithException();
+
+        shutdown(factory, map);
+    }
+
+    /**
+     * Test which calls {@link TransactionalMap} methods which are not expected to throw {@link QueryResultSizeExceededException}.
+     * <p/>
+     * This test fills the map to an amount where the exception is safely triggered. Then all {@link TransactionalMap} methods are
+     * called which should not trigger the exception.
+     * <p/>
+     * This methods fails if any of the called methods triggers the exception.
+     *
+     * @param partitionCount  number of partitions the created cluster
+     * @param clusterSize     number of nodes in the cluster
+     * @param limit           result size limit which will be configured for the cluster
+     * @param preCheckTrigger number of partitions which will be used for local pre-check, <tt>-1</tt> deactivates the pre-check
+     */
+    protected void runMapTxnWithoutExceptionTest(int partitionCount, int clusterSize, int limit, int preCheckTrigger) {
+        internalSetUp(partitionCount, clusterSize, limit, preCheckTrigger);
+
+        fillToLimit(KeyType.INTEGER, upperLimit);
+        internalRunTxnWithoutException();
+
+        shutdown(factory, map);
+    }
+
+    private void internalSetUp(int partitionCount, int clusterSize, int limit, int preCheckTrigger) {
+        Config config = createConfig(partitionCount, limit, preCheckTrigger);
+        factory = createTestHazelcastInstanceFactory(clusterSize);
+        map = getMapWithNodeCount(clusterSize, config, factory);
+
+        configLimit = limit;
+        lowerLimit = Math.round(limit * 0.95f);
+        upperLimit = Math.round(limit * 1.5f);
+        checkLimitInterval = limit / 1000;
+    }
+
+    private Config createConfig(int partitionCount, int limit, int preCheckTrigger) {
+        Config config = new Config();
+        config.setProperty(GroupProperties.PROP_PARTITION_COUNT, String.valueOf(partitionCount));
+        config.setProperty(GroupProperties.PROP_QUERY_RESULT_SIZE_LIMIT, String.valueOf(limit));
+        config.setProperty(GroupProperties.PROP_QUERY_MAX_LOCAL_PARTITION_LIMIT_FOR_PRE_CHECK, String.valueOf(preCheckTrigger));
+        return config;
+    }
+
+    private TestHazelcastInstanceFactory createTestHazelcastInstanceFactory(int nodeCount) {
+        if (nodeCount < 1) {
+            throw new IllegalArgumentException("node count < 1");
+        }
+        return createHazelcastInstanceFactory(nodeCount);
+    }
+
+    private <K, V> IMap<K, V> getMapWithNodeCount(int nodeCount, Config config, TestHazelcastInstanceFactory factory) {
+        String mapName = randomMapName();
+
+        MapConfig mapConfig = new MapConfig();
+        mapConfig.setName(mapName);
+        mapConfig.setAsyncBackupCount(0);
+        mapConfig.setBackupCount(0);
+        config.addMapConfig(mapConfig);
+
+        while (nodeCount > 1) {
+            factory.newHazelcastInstance(config);
+            nodeCount--;
+        }
+
+        instance = factory.newHazelcastInstance(config);
+        logger = instance.getLoggingService().getLogger(getClass());
+        return instance.getMap(mapName);
+    }
+
+    private void mapPut(KeyType keyType, int index) {
+        switch (keyType) {
+            case STRING:
+                map.put("key" + index, index);
+                break;
+            case INTEGER:
+                map.put(index, index);
+                break;
+            default:
+                throw new UnsupportedOperationException("Unsupported keyType " + keyType);
+        }
+    }
+
+    private void fillToLimit(KeyType keyType, int limit) {
+        for (int index = 1; index <= limit; index++) {
+            mapPut(keyType, index);
+        }
+        assertEquals("Expected map size of map to match limit " + limit, limit, map.size());
+    }
+
+    private void failExpectedException(String methodName) {
+        fail(format("Expected QueryResultSizeExceededException while calling %s with limit %d and upperLimit %d",
+                methodName, configLimit, upperLimit));
+    }
+
+    private void failUnwantedException(String methodName) {
+        fail(format("Unwanted QueryResultSizeExceededException was thrown while calling %s with limit %d and upperLimit %d",
+                methodName, configLimit, upperLimit));
+    }
+
+    /**
+     * Extensive test which ensures that the {@link QueryResultSizeExceededException} will not be thrown under the configured
+     * limit.
+     * <p/>
+     * This method requires the map to be filled to an amount where the exception is not triggered yet. This method then fills the
+     * map and calls {@link IMap#keySet()} periodically to determine the limit on which the exception is thrown for the first
+     * time. After that it runs {@link #internalRunQuick()} to ensure that all methods will trigger at this limit.
+     * <p/>
+     * This method fails if the exception is already thrown at {@link #lowerLimit} or if it is not thrown at {@link #upperLimit}.
+     */
+    private void internalRunWithLowerBoundCheck(KeyType keyType) {
+        // it should be safe to call IMap.keySet() within lowerLimit
+        try {
+            map.keySet();
+        } catch (QueryResultSizeExceededException e) {
+            fail(format("lowerLimit is too high, already got QueryResultSizeExceededException below %d", lowerLimit));
+        }
+
+        // check up to upperLimit on which index the QueryResultSizeExceededException is thrown by IMap.keySet()
+        int index = lowerLimit;
+        try {
+            int keySetSize = 0;
+            while (++index < upperLimit) {
+                mapPut(keyType, index);
+                if (index % checkLimitInterval == 0) {
+                    Set<Object> keySet = map.keySet();
+                    keySetSize = keySet.size();
+                }
+            }
+            fail(format("Limit should have exceeded, but ran into upperLimit of %d with IMap.keySet() size of %d",
+                    upperLimit, keySetSize));
+        } catch (QueryResultSizeExceededException e) {
+            EmptyStatement.ignore(e);
+        }
+        logger.info(format("Limit of %d exceeded at %d (%.2f)", configLimit, index, (index * 100f / configLimit)));
+
+        assertTrue(format("QueryResultSizeExceededException should not trigger below limit of %d, but was %d (%.2f%%)",
+                configLimit, index, (index * 100f / configLimit)), index > configLimit);
+
+        // do the quick check to ensure that all methods trigger at the actual limit
+        internalRunQuick();
+    }
+
+    /**
+     * Quick run which just executes the {@link IMap} methods once and check for the {@link QueryResultSizeExceededException}.
+     * <p/>
+     * This method requires the map to be filled to an amount where the exception is safely triggered. The local running methods
+     * {@link IMap#localKeySet()} and {@link IMap#localKeySet(Predicate)} are excluded, since they may need a higher fill rate to
+     * succeed.
+     * <p/>
+     * This methods fails if any of the called methods does not trigger the exception.
+     */
+    private void internalRunQuick() {
+        try {
+            map.values(TruePredicate.INSTANCE);
+            failExpectedException("IMap.values(predicate)");
+        } catch (QueryResultSizeExceededException e) {
+            EmptyStatement.ignore(e);
+        }
+
+        try {
+            map.keySet(TruePredicate.INSTANCE);
+            failExpectedException("IMap.keySet(predicate)");
+        } catch (QueryResultSizeExceededException e) {
+            EmptyStatement.ignore(e);
+        }
+
+        try {
+            map.entrySet(TruePredicate.INSTANCE);
+            failExpectedException("IMap.entrySet(predicate)");
+        } catch (QueryResultSizeExceededException e) {
+            EmptyStatement.ignore(e);
+        }
+
+        try {
+            map.values();
+            failExpectedException("IMap.values()");
+        } catch (QueryResultSizeExceededException e) {
+            EmptyStatement.ignore(e);
+        }
+
+        try {
+            map.keySet();
+            failExpectedException("IMap.keySet()");
+        } catch (QueryResultSizeExceededException e) {
+            EmptyStatement.ignore(e);
+        }
+
+        try {
+            map.entrySet();
+            failExpectedException("IMap.entrySet()");
+        } catch (QueryResultSizeExceededException e) {
+            EmptyStatement.ignore(e);
+        }
+    }
+
+    /**
+     * Quick run on the {@link IMap#localKeySet()} and {@link IMap#localKeySet(Predicate)} methods.
+     * <p/>
+     * Requires the map to be filled so the exception is triggered even locally.
+     * <p/>
+     * This methods fails if any of the called methods does not trigger the exception.
+     */
+    private void internalRunLocalKeySet() {
+        try {
+            map.localKeySet();
+            failExpectedException("IMap.localKeySet()");
+        } catch (QueryResultSizeExceededException e) {
+            EmptyStatement.ignore(e);
+        }
+
+        try {
+            map.localKeySet(TruePredicate.INSTANCE);
+            failExpectedException("IMap.localKeySet(predicate)");
+        } catch (QueryResultSizeExceededException e) {
+            EmptyStatement.ignore(e);
+        }
+    }
+
+    /**
+     * Calls {@link TransactionalMap} methods once which are expected to throw {@link QueryResultSizeExceededException}.
+     * <p/>
+     * This method requires the map to be filled to an amount where the exception is safely triggered.
+     * <p/>
+     * This methods fails if any of the called methods does not trigger the exception.
+     */
+    private void internalRunTxnWithException() {
+        TransactionContext transactionContext = instance.newTransactionContext();
+        transactionContext.beginTransaction();
+        TransactionalMap<Object, Integer> txnMap = transactionContext.getMap(map.getName());
+
+        try {
+            txnMap.values(TruePredicate.INSTANCE);
+            failExpectedException("TransactionalMap.values(predicate)");
+        } catch (QueryResultSizeExceededException e) {
+            EmptyStatement.ignore(e);
+        }
+
+        try {
+            txnMap.keySet(TruePredicate.INSTANCE);
+            failExpectedException("TransactionalMap.keySet(predicate)");
+        } catch (QueryResultSizeExceededException e) {
+            EmptyStatement.ignore(e);
+        }
+
+        transactionContext.rollbackTransaction();
+    }
+
+    /**
+     * Calls {@link TransactionalMap} methods once which are not expected to throw a {@link QueryResultSizeExceededException}.
+     * <p/>
+     * This method requires the map to be filled to an amount where the exception is safely triggered.
+     * <p/>
+     * This methods fails if any of the called methods triggers the exception.
+     */
+    private void internalRunTxnWithoutException() {
+        TransactionContext transactionContext = instance.newTransactionContext();
+        transactionContext.beginTransaction();
+
+        TransactionalMap<Object, Integer> txnMap = transactionContext.getMap(map.getName());
+
+        try {
+            assertEquals("TransactionalMap.values()", upperLimit, txnMap.values().size());
+        } catch (QueryResultSizeExceededException e) {
+            failUnwantedException("TransactionalMap.values()");
+        }
+
+        try {
+            assertEquals("TransactionalMap.keySet()", upperLimit, txnMap.keySet().size());
+        } catch (QueryResultSizeExceededException e) {
+            failUnwantedException("TransactionalMap.keySet()");
+        }
+
+        transactionContext.rollbackTransaction();
+    }
+
+    private void shutdown(TestHazelcastInstanceFactory factory, IMap map) {
+        map.destroy();
+        factory.terminateAll();
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/map/MapUnboundedReturnValues_IntKeyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapUnboundedReturnValues_IntKeyTest.java
@@ -1,0 +1,27 @@
+package com.hazelcast.map;
+
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.NightlyTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category(NightlyTest.class)
+public class MapUnboundedReturnValues_IntKeyTest extends MapUnboundedReturnValuesTestSupport {
+
+    @Test
+    public void testMap_SmallLimit_IntKey() {
+        runMapFullTest(PARTITION_COUNT, CLUSTER_SIZE, SMALL_LIMIT, PRE_CHECK_TRIGGER_LIMIT_INACTIVE, KeyType.INTEGER);
+    }
+
+    @Test
+    public void testMap_MediumLimit_IntKey() {
+        runMapFullTest(PARTITION_COUNT, CLUSTER_SIZE, MEDIUM_LIMIT, PRE_CHECK_TRIGGER_LIMIT_INACTIVE, KeyType.INTEGER);
+    }
+
+    @Test
+    public void testMap_LargeLimit_IntKey() {
+        runMapFullTest(PARTITION_COUNT, CLUSTER_SIZE, LARGE_LIMIT, PRE_CHECK_TRIGGER_LIMIT_INACTIVE, KeyType.INTEGER);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/map/MapUnboundedReturnValues_PreCheckTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapUnboundedReturnValues_PreCheckTest.java
@@ -1,0 +1,24 @@
+package com.hazelcast.map;
+
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.NightlyTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category(NightlyTest.class)
+public class MapUnboundedReturnValues_PreCheckTest extends MapUnboundedReturnValuesTestSupport {
+
+    @Test
+    public void testMapKeySet_SmallLimit() {
+        // with a single node we enforce the pre-check to trigger, since all items are on the local node
+        runMapFullTest(PARTITION_COUNT, 1, SMALL_LIMIT, PRE_CHECK_TRIGGER_LIMIT_ACTIVE, KeyType.STRING);
+    }
+
+    @Test
+    public void testMapKeySet_MediumLimit() {
+        // with a single node we enforce the pre-check to trigger, since all items are on the local node
+        runMapFullTest(PARTITION_COUNT, 1, MEDIUM_LIMIT, PRE_CHECK_TRIGGER_LIMIT_ACTIVE, KeyType.INTEGER);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/map/MapUnboundedReturnValues_QuickTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapUnboundedReturnValues_QuickTest.java
@@ -1,0 +1,22 @@
+package com.hazelcast.map;
+
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category(QuickTest.class)
+public class MapUnboundedReturnValues_QuickTest extends MapUnboundedReturnValuesTestSupport {
+
+    @Test
+    public void testMapKeySet_SmallLimit_NoPreCheck() {
+        runMapQuickTest(PARTITION_COUNT, 1, SMALL_LIMIT, PRE_CHECK_TRIGGER_LIMIT_INACTIVE, KeyType.INTEGER);
+    }
+
+    @Test
+    public void testMapKeySet_SmallLimit_PreCheck() {
+        runMapQuickTest(PARTITION_COUNT, 1, SMALL_LIMIT, PRE_CHECK_TRIGGER_LIMIT_ACTIVE, KeyType.INTEGER);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/map/MapUnboundedReturnValues_StringKeyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapUnboundedReturnValues_StringKeyTest.java
@@ -1,0 +1,27 @@
+package com.hazelcast.map;
+
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.NightlyTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category(NightlyTest.class)
+public class MapUnboundedReturnValues_StringKeyTest extends MapUnboundedReturnValuesTestSupport {
+
+    @Test
+    public void testMap_SmallLimit_StringKey() {
+        runMapFullTest(PARTITION_COUNT, CLUSTER_SIZE, SMALL_LIMIT, PRE_CHECK_TRIGGER_LIMIT_INACTIVE, KeyType.STRING);
+    }
+
+    @Test
+    public void testMap_MediumLimit_StringKey() {
+        runMapFullTest(PARTITION_COUNT, CLUSTER_SIZE, MEDIUM_LIMIT, PRE_CHECK_TRIGGER_LIMIT_INACTIVE, KeyType.STRING);
+    }
+
+    @Test
+    public void testMap_LargeLimit_StringKey() {
+        runMapFullTest(PARTITION_COUNT, CLUSTER_SIZE, LARGE_LIMIT, PRE_CHECK_TRIGGER_LIMIT_INACTIVE, KeyType.STRING);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/map/MapUnboundedReturnValues_TxnTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapUnboundedReturnValues_TxnTest.java
@@ -1,0 +1,32 @@
+package com.hazelcast.map;
+
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.NightlyTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category(NightlyTest.class)
+public class MapUnboundedReturnValues_TxnTest extends MapUnboundedReturnValuesTestSupport {
+
+    @Test
+    public void testTxnMap_withException_SmallLimit_NoPrecheck() {
+        runMapTxnWithExceptionTest(PARTITION_COUNT, CLUSTER_SIZE, SMALL_LIMIT, PRE_CHECK_TRIGGER_LIMIT_INACTIVE);
+    }
+
+    @Test
+    public void testTxnMap_withException_SmallLimit_Precheck() {
+        runMapTxnWithExceptionTest(PARTITION_COUNT, CLUSTER_SIZE, SMALL_LIMIT, PRE_CHECK_TRIGGER_LIMIT_ACTIVE);
+    }
+
+    @Test
+    public void testTxnMap_withoutException_SmallLimit_NoPrecheck() {
+        runMapTxnWithoutExceptionTest(PARTITION_COUNT, CLUSTER_SIZE, SMALL_LIMIT, PRE_CHECK_TRIGGER_LIMIT_INACTIVE);
+    }
+
+    @Test
+    public void testTxnMap_withoutException_SmallLimit_Precheck() {
+        runMapTxnWithoutExceptionTest(PARTITION_COUNT, CLUSTER_SIZE, SMALL_LIMIT, PRE_CHECK_TRIGGER_LIMIT_ACTIVE);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/QueryResultSizeLimiterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/QueryResultSizeLimiterTest.java
@@ -1,0 +1,262 @@
+package com.hazelcast.map.impl;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.logging.Logger;
+import com.hazelcast.map.QueryResultSizeExceededException;
+import com.hazelcast.partition.InternalPartitionService;
+import com.hazelcast.spi.NodeEngine;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category(QuickTest.class)
+public class QueryResultSizeLimiterTest {
+
+    private static final String ANY_MAP_NAME = "foobar";
+    private static final int DEFAULT_PARTITION_COUNT = 271;
+
+    private final Map<Integer, Integer> localPartitions = new HashMap<Integer, Integer>();
+
+    private QueryResultSizeLimiter limiter;
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testNodeResultResultSizeLimitNegative() {
+        initMocksWithConfiguration(-2, Integer.MAX_VALUE, Integer.MAX_VALUE);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testNodeResultResultSizeLimitZero() {
+        initMocksWithConfiguration(0, Integer.MAX_VALUE, Integer.MAX_VALUE);
+    }
+
+    @Test
+    public void testNodeResultFeatureDisabled() {
+        initMocksWithConfiguration(-1, Integer.MAX_VALUE, Integer.MAX_VALUE);
+        assertFalse(limiter.isQueryResultLimitEnabled());
+    }
+
+    @Test
+    public void testNodeResultFeatureEnabled() {
+        initMocksWithConfiguration(1, Integer.MAX_VALUE, Integer.MAX_VALUE);
+        assertTrue(limiter.isQueryResultLimitEnabled());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testNodeResultPreCheckLimitNegative() {
+        initMocksWithConfiguration(Integer.MAX_VALUE, -2, Integer.MAX_VALUE);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testNodeResultPreCheckLimitZero() {
+        initMocksWithConfiguration(Integer.MAX_VALUE, 0, Integer.MAX_VALUE);
+    }
+
+    @Test
+    public void testNodeResultPreCheckLimitDisabled() {
+        initMocksWithConfiguration(Integer.MAX_VALUE, -1, Integer.MAX_VALUE);
+        assertTrue(limiter.isQueryResultLimitEnabled());
+        assertFalse(limiter.isPreCheckEnabled());
+    }
+
+    @Test
+    public void testNodeResultPreCheckLimitEnabled() {
+        initMocksWithConfiguration(Integer.MAX_VALUE, 1, Integer.MAX_VALUE);
+        assertTrue(limiter.isQueryResultLimitEnabled());
+        assertTrue(limiter.isPreCheckEnabled());
+    }
+
+    @Test
+    public void testNodeResultLimitMinResultLimit() {
+        initMocksWithConfiguration(QueryResultSizeLimiter.MINIMUM_MAX_RESULT_LIMIT, 3);
+        long nodeResultLimit1 = limiter.getNodeResultLimit(1);
+
+        initMocksWithConfiguration(QueryResultSizeLimiter.MINIMUM_MAX_RESULT_LIMIT / 2, 3);
+        long nodeResultLimit2 = limiter.getNodeResultLimit(1);
+
+        assertEquals(nodeResultLimit1, nodeResultLimit2);
+    }
+
+    @Test
+    public void testNodeResultLimitSinglePartition() {
+        initMocksWithConfiguration(200000, 3);
+
+        assertEquals(849, limiter.getNodeResultLimit(1));
+    }
+
+    @Test
+    public void testNodeResultLimitThreePartitions() {
+        initMocksWithConfiguration(200000, 3);
+
+        assertEquals(2547, limiter.getNodeResultLimit(3));
+    }
+
+    @Test
+    public void testLocalPreCheckDisabled() {
+        initMocksWithConfiguration(200000, QueryResultSizeLimiter.DISABLED);
+
+        limiter.checkMaxResultLimitOnLocalPartitions(ANY_MAP_NAME);
+    }
+
+    @Test
+    public void testLocalPreCheckEnabledWithNoLocalPartitions() {
+        initMocksWithConfiguration(200000, 1);
+
+        limiter.checkMaxResultLimitOnLocalPartitions(ANY_MAP_NAME);
+    }
+
+    @Test
+    public void testLocalPreCheckEnabledWithEmptyPartition() {
+        int[] partitionsSizes = {0};
+        populatePartitions(partitionsSizes);
+        initMocksWithConfiguration(200000, 1);
+
+        limiter.checkMaxResultLimitOnLocalPartitions(ANY_MAP_NAME);
+    }
+
+    @Test
+    public void testLocalPreCheckEnabledWitPartitionBelowLimit() {
+        int[] partitionsSizes = {848};
+        populatePartitions(partitionsSizes);
+        initMocksWithConfiguration(200000, 1);
+
+        limiter.checkMaxResultLimitOnLocalPartitions(ANY_MAP_NAME);
+    }
+
+    @Test(expected = QueryResultSizeExceededException.class)
+    public void testLocalPreCheckEnabledWitPartitionOverLimit() {
+        int[] partitionsSizes = {850};
+        populatePartitions(partitionsSizes);
+        initMocksWithConfiguration(200000, 1);
+
+        limiter.checkMaxResultLimitOnLocalPartitions(ANY_MAP_NAME);
+    }
+
+    @Test
+    public void testLocalPreCheckEnabledWitTwoPartitionsBelowLimit() {
+        int[] partitionsSizes = {849, 849};
+        populatePartitions(partitionsSizes);
+        initMocksWithConfiguration(200000, 2);
+
+        limiter.checkMaxResultLimitOnLocalPartitions(ANY_MAP_NAME);
+    }
+
+    @Test(expected = QueryResultSizeExceededException.class)
+    public void testLocalPreCheckEnabledWitTwoPartitionsOverLimit() {
+        int[] partitionsSizes = {849, 850};
+        populatePartitions(partitionsSizes);
+        initMocksWithConfiguration(200000, 2);
+
+        limiter.checkMaxResultLimitOnLocalPartitions(ANY_MAP_NAME);
+    }
+
+    @Test
+    public void testLocalPreCheckEnabledWitMorePartitionsThanPreCheckThresholdBelowLimit() {
+        int[] partitionSizes = {849, 849, Integer.MAX_VALUE};
+        populatePartitions(partitionSizes);
+        initMocksWithConfiguration(200000, 2);
+
+        limiter.checkMaxResultLimitOnLocalPartitions(ANY_MAP_NAME);
+    }
+
+    @Test(expected = QueryResultSizeExceededException.class)
+    public void testLocalPreCheckEnabledWitMorePartitionsThanPreCheckThresholdOverLimit() {
+        int[] partitionSizes = {849, 850, Integer.MIN_VALUE};
+        populatePartitions(partitionSizes);
+        initMocksWithConfiguration(200000, 2);
+
+        limiter.checkMaxResultLimitOnLocalPartitions(ANY_MAP_NAME);
+    }
+
+    @Test
+    public void testLocalPreCheckEnabledWitDifferentPartitionSizesBelowLimit() {
+        int[] partitionSizes = {566, 1132, Integer.MAX_VALUE};
+        populatePartitions(partitionSizes);
+        initMocksWithConfiguration(200000, 2);
+
+        limiter.checkMaxResultLimitOnLocalPartitions(ANY_MAP_NAME);
+    }
+
+    @Test(expected = QueryResultSizeExceededException.class)
+    public void testLocalPreCheckEnabledWitDifferentPartitionSizesOverLimit() {
+        int[] partitionSizes = {0, 1699, Integer.MIN_VALUE};
+        populatePartitions(partitionSizes);
+        initMocksWithConfiguration(200000, 2);
+
+        limiter.checkMaxResultLimitOnLocalPartitions(ANY_MAP_NAME);
+    }
+
+    private void initMocksWithConfiguration(int maxResultSizeLimit, int maxLocalPartitionLimitForPreCheck) {
+        initMocksWithConfiguration(maxResultSizeLimit, maxLocalPartitionLimitForPreCheck, DEFAULT_PARTITION_COUNT);
+    }
+
+    private void initMocksWithConfiguration(int maxResultSizeLimit, int maxLocalPartitionLimitForPreCheck, int partitionCount) {
+        Config config = new Config();
+        config.setProperty(GroupProperties.PROP_QUERY_RESULT_SIZE_LIMIT, String.valueOf(maxResultSizeLimit));
+        config.setProperty(GroupProperties.PROP_QUERY_MAX_LOCAL_PARTITION_LIMIT_FOR_PRE_CHECK,
+                String.valueOf(maxLocalPartitionLimitForPreCheck));
+        config.setProperty(GroupProperties.PROP_PARTITION_COUNT, String.valueOf(partitionCount));
+
+        GroupProperties groupProperties = new GroupProperties(config);
+
+        InternalPartitionService partitionService = mock(InternalPartitionService.class);
+        when(partitionService.getPartitionCount()).thenReturn(partitionCount);
+
+        NodeEngine nodeEngine = mock(NodeEngine.class);
+        when(nodeEngine.getGroupProperties()).thenReturn(groupProperties);
+        when(nodeEngine.getPartitionService()).thenReturn(partitionService);
+
+        RecordStore recordStore = mock(RecordStore.class);
+        when(recordStore.size()).then(new RecordStoreAnswer(localPartitions.values()));
+
+        MapServiceContext mapServiceContext = mock(MapServiceContext.class);
+        when(mapServiceContext.getNodeEngine()).thenReturn(nodeEngine);
+        when(mapServiceContext.getRecordStore(anyInt(), anyString())).thenReturn(recordStore);
+        when(mapServiceContext.getOwnedPartitions()).thenReturn(localPartitions.keySet());
+
+        limiter = new QueryResultSizeLimiter(mapServiceContext, Logger.getLogger(QueryResultSizeLimiterTest.class));
+    }
+
+    private void populatePartitions(int[] localPartitionSize) {
+        for (int i = 0; i < localPartitionSize.length; i++) {
+            localPartitions.put(i, localPartitionSize[i]);
+        }
+    }
+
+    private static final class RecordStoreAnswer implements Answer<Integer> {
+
+        private final Iterator<Integer> iterator;
+
+        private Integer lastValue = null;
+
+        private RecordStoreAnswer(Collection<Integer> partitionSizes) {
+            this.iterator = partitionSizes.iterator();
+        }
+
+        @Override
+        public Integer answer(InvocationOnMock invocation) throws Throwable {
+            if (iterator.hasNext()) {
+                lastValue = iterator.next();
+            }
+            return lastValue;
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/operation/QueryOperationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/operation/QueryOperationTest.java
@@ -1,0 +1,52 @@
+package com.hazelcast.map.impl.operation;
+
+import com.hazelcast.map.QueryResultSizeExceededException;
+import com.hazelcast.map.impl.QueryResult;
+import com.hazelcast.query.TruePredicate;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class QueryOperationTest extends QueryOperationTestSupport {
+
+    @Override
+    protected AbstractMapOperation createQueryOperation() {
+        return new QueryOperation(MAP_NAME, TruePredicate.INSTANCE);
+    }
+
+    @Test
+    public void testConstructor() {
+        new QueryOperation();
+    }
+
+    @Test
+    public void testRun_resultSizeLimitOff() throws Exception {
+        initMocks(Long.MAX_VALUE, 5);
+
+        QueryResult result = getQueryResult();
+        assertEquals(5, result.getResult().size());
+    }
+
+    @Test
+    public void testRun_resultSizeLimit_notExceeded() throws Exception {
+        initMocks(3, 2);
+
+        QueryResult result = getQueryResult();
+        assertEquals(2, result.getResult().size());
+    }
+
+    @Test
+    public void testRun_resultSizeLimit_equals() throws Exception {
+        initMocks(3, 3);
+
+        QueryResult result = getQueryResult();
+        assertEquals(3, result.getResult().size());
+    }
+
+    @Test(expected = QueryResultSizeExceededException.class)
+    public void testRun_resultSizeLimit_exceeded() throws Exception {
+        initMocks(3, 4);
+
+        getQueryResult();
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/operation/QueryOperationTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/operation/QueryOperationTestSupport.java
@@ -1,0 +1,117 @@
+package com.hazelcast.map.impl.operation;
+
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.map.impl.MapContainer;
+import com.hazelcast.map.impl.MapContextQuerySupport;
+import com.hazelcast.map.impl.MapService;
+import com.hazelcast.map.impl.MapServiceContext;
+import com.hazelcast.map.impl.QueryResult;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.nio.serialization.DefaultData;
+import com.hazelcast.partition.InternalPartitionService;
+import com.hazelcast.query.TruePredicate;
+import com.hazelcast.query.impl.IndexService;
+import com.hazelcast.query.impl.QueryableEntry;
+import com.hazelcast.spi.NodeEngine;
+import com.hazelcast.spi.Operation;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Random;
+import java.util.Set;
+
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public abstract class QueryOperationTestSupport {
+
+    protected static final String MAP_NAME = "mapName";
+
+    private final Answer<Data> randomDataAnswer = new DataAnswer();
+    private final Collection<QueryableEntry> queryEntries = new ArrayList<QueryableEntry>();
+    private final Set<QueryableEntry> queryEntrySet = new HashSet<QueryableEntry>();
+    private final MapContextQuerySupport mapContextQuerySupport = mock(MapContextQuerySupport.class);
+    private AbstractMapOperation queryOperation = createQueryOperation();
+
+    protected abstract AbstractMapOperation createQueryOperation();
+
+    /**
+     * Initializes all mocks needed to execute a query operation.
+     *
+     * @param nodeResultLimit              configures the result size limit, use <code>Long.MAX_VALUE</code> to disable feature
+     * @param numberOfReturnedQueryEntries configures the number of returned entries of the query operation
+     */
+    protected void initMocks(long nodeResultLimit, int numberOfReturnedQueryEntries) {
+        for (int i = 0; i < numberOfReturnedQueryEntries; i++) {
+            QueryableEntry queryableEntry = mock(QueryableEntry.class);
+            when(queryableEntry.getKeyData()).thenAnswer(randomDataAnswer);
+            when(queryableEntry.getIndexKey()).thenAnswer(randomDataAnswer);
+            when(queryableEntry.getValueData()).thenAnswer(randomDataAnswer);
+
+            queryEntries.add(queryableEntry);
+            queryEntrySet.add(queryableEntry);
+        }
+
+        QueryResult queryResult = new QueryResult(nodeResultLimit);
+
+        when(mapContextQuerySupport.newQueryResult(anyInt())).thenReturn(queryResult);
+        when(mapContextQuerySupport.queryOnPartition(MAP_NAME, TruePredicate.INSTANCE, Operation.GENERIC_PARTITION_ID))
+                .thenReturn(queryEntries);
+
+        IndexService indexService = mock(IndexService.class);
+        when(indexService.query(TruePredicate.INSTANCE)).thenReturn(queryEntrySet);
+
+        MapConfig mapConfig = mock(MapConfig.class);
+        when(mapConfig.isStatisticsEnabled()).thenReturn(false);
+
+        MapServiceContext mapServiceContext = mock(MapServiceContext.class);
+        when(mapServiceContext.getMapContextQuerySupport()).thenReturn(mapContextQuerySupport);
+
+        MapService mapService = mock(MapService.class);
+        when(mapService.getMapServiceContext()).thenReturn(mapServiceContext);
+
+        queryOperation.mapService = mapService;
+
+        MapContainer mapContainer = mock(MapContainer.class);
+        when(mapContainer.getIndexService()).thenReturn(indexService);
+        when(mapContainer.getMapConfig()).thenReturn(mapConfig);
+
+        queryOperation.mapContainer = mapContainer;
+
+        InternalPartitionService partitionService = mock(InternalPartitionService.class);
+        when(partitionService.getPartitionStateVersion()).thenReturn(0);
+        when(partitionService.hasOnGoingMigrationLocal()).thenReturn(false);
+
+        NodeEngine nodeEngine = mock(NodeEngine.class);
+        when(nodeEngine.getPartitionService()).thenReturn(partitionService);
+
+        queryOperation.setNodeEngine(nodeEngine);
+    }
+
+    /**
+     * Executes the query operation and returns the {@link QueryResult}.
+     *
+     * @return {@link QueryResult}
+     */
+    protected QueryResult getQueryResult() throws Exception {
+        queryOperation.run();
+        return (QueryResult) queryOperation.getResponse();
+    }
+
+    private static class DataAnswer implements Answer<Data> {
+
+        private static final Random random = new Random();
+
+        @Override
+        public Data answer(InvocationOnMock invocation) throws Throwable {
+            byte[] randomBytes = new byte[20];
+            random.nextBytes(randomBytes);
+
+            return new DefaultData(randomBytes);
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/operation/QueryPartitionOperationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/operation/QueryPartitionOperationTest.java
@@ -1,0 +1,52 @@
+package com.hazelcast.map.impl.operation;
+
+import com.hazelcast.map.QueryResultSizeExceededException;
+import com.hazelcast.map.impl.QueryResult;
+import com.hazelcast.query.TruePredicate;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class QueryPartitionOperationTest extends QueryOperationTestSupport {
+
+    @Override
+    protected AbstractMapOperation createQueryOperation() {
+        return new QueryPartitionOperation(MAP_NAME, TruePredicate.INSTANCE);
+    }
+
+    @Test
+    public void testConstructor() {
+        new QueryPartitionOperation();
+    }
+
+    @Test
+    public void testRun_resultSizeLimitOff() throws Exception {
+        initMocks(Long.MAX_VALUE, 5);
+
+        QueryResult result = getQueryResult();
+        assertEquals(5, result.getResult().size());
+    }
+
+    @Test
+    public void testRun_resultSizeLimit_notExceeded() throws Exception {
+        initMocks(3, 2);
+
+        QueryResult result = getQueryResult();
+        assertEquals(2, result.getResult().size());
+    }
+
+    @Test
+    public void testRun_resultSizeLimit_equals() throws Exception {
+        initMocks(3, 3);
+
+        QueryResult result = getQueryResult();
+        assertEquals(3, result.getResult().size());
+    }
+
+    @Test(expected = QueryResultSizeExceededException.class)
+    public void testRun_resultSizeLimit_exceeded() throws Exception {
+        initMocks(3, 4);
+
+        getQueryResult();
+    }
+}


### PR DESCRIPTION
This is the actual implementation of the "unbounded return values" feature for HZ 3.5.

Most of the code is new test code. I hope I covered all needed classes and scenarios. I have no idea how to test the new client. Maybe we have to do a follow-up PR with some changes if the new client is fully wired and in place.

There is also a big issue with `ClientMapProxy.entrySet()` which seems to have a O(n²) complexity, so it takes too long to test it at the moment. I will create a separate issue for that, please let's not discuss that in this PR. It is not an issue of this feature or these changes. It's most probably a very old problem. Issue: #5130