### PR TITLE
Small improvements for SlowOperationDetector

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/slowoperationdetector/SlowOperationDetector_purgeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/slowoperationdetector/SlowOperationDetector_purgeTest.java
@@ -41,8 +41,9 @@ public class SlowOperationDetector_purgeTest extends SlowOperationDetectorAbstra
         config.setProperty(GroupProperties.PROP_SLOW_OPERATION_DETECTOR_THRESHOLD_MILLIS, "1000");
         config.setProperty(GroupProperties.PROP_SLOW_OPERATION_DETECTOR_LOG_RETENTION_SECONDS, logRetentionSeconds);
         config.setProperty(GroupProperties.PROP_SLOW_OPERATION_DETECTOR_LOG_PURGE_INTERVAL_SECONDS, "1");
+        config.setProperty(GroupProperties.PROP_SLOW_OPERATION_DETECTOR_STACK_TRACE_LOGGING_ENABLED, "true");
 
-        instance = getSingleNodeCluster(config);
+        instance = createHazelcastInstance(config);
         map = getMapWithSingleElement(instance);
     }
 


### PR DESCRIPTION
Added hint in first log of SlowOperationDetector.
Added a missing test for the property to disable the feature.
Added the stack trace config property to some tests to increase code coverage.

Fixes #5043.