### PR TITLE
Introduce utility and debug methods for partition testing

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/partition/impl/InternalPartitionServiceState.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/impl/InternalPartitionServiceState.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.partition.impl;
+
+/*
+    This enum represents internal state of the com.hazelcast.partition.impl.InternalPartitionServiceImpl over all partitions
+    @see com.hazelcast.partition.impl.InternalPartitionServiceImpl#getMemberState
+ */
+public enum InternalPartitionServiceState {
+
+    /**
+     *  Indicates that there is no migration operation on the system and all first backups are sync for partitions
+     *  owned by this node
+     */
+    SAFE,
+
+    /**
+     *  Indicates that there is a migration operation ongoing on this node
+     */
+    MIGRATION_LOCAL,
+
+    /**
+     *  Indicates that master node manages a migration operation between 2 other nodes
+     */
+    MIGRATION_ON_MASTER,
+
+    /**
+     *  Indicates that there is an not-sync first replica on other nodes for owned partitions of the this node
+     */
+    REPLICA_NOT_SYNC
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/partition/impl/ReplicaSyncInfo.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/impl/ReplicaSyncInfo.java
@@ -18,7 +18,7 @@ package com.hazelcast.partition.impl;
 
 import com.hazelcast.nio.Address;
 
-final class ReplicaSyncInfo {
+public final class ReplicaSyncInfo {
     final int partitionId;
     final int replicaIndex;
     final Address target;

--- a/hazelcast/src/test/java/com/hazelcast/map/MapPartitionLostListenerStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapPartitionLostListenerStressTest.java
@@ -1,11 +1,8 @@
 package com.hazelcast.map;
 
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.instance.Node;
 import com.hazelcast.map.listener.MapPartitionLostListener;
-import com.hazelcast.nio.Address;
 import com.hazelcast.partition.AbstractPartitionLostListenerTest;
-import com.hazelcast.partition.InternalPartition;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.SlowTest;
@@ -15,7 +12,6 @@ import org.junit.runner.RunWith;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -111,7 +107,8 @@ public class MapPartitionLostListenerStressTest
         testMapPartitionLostListener(4, true);
     }
 
-    private void testMapPartitionLostListener(final int numberOfNodesToCrash, final boolean withData) {
+    private void testMapPartitionLostListener(final int numberOfNodesToCrash, final boolean withData)
+            throws InterruptedException {
         final List<HazelcastInstance> instances = getCreatedInstancesShuffledAfterWarmedUp();
 
         List<HazelcastInstance> survivingInstances = new ArrayList<HazelcastInstance>(instances);
@@ -128,7 +125,7 @@ public class MapPartitionLostListenerStressTest
         final Map<Integer, Integer> survivingPartitions = getMinReplicaIndicesByPartitionId(survivingInstances);
 
         terminateInstances(terminatingInstances);
-        waitAllForSafeState(survivingInstances, 300);
+        waitAllForSafeStateAndDumpPartitionServiceOnFailure(survivingInstances, 300);
 
         for (int i = 0; i < getNodeCount(); i++) {
             assertListenerInvocationsEventually(numberOfNodesToCrash, log, survivingPartitions, listeners.get(i), i);
@@ -179,35 +176,6 @@ public class MapPartitionLostListenerStressTest
         }
 
         return listeners;
-    }
-
-    private Map<Integer, Integer> getMinReplicaIndicesByPartitionId(final List<HazelcastInstance> instances) {
-        final Map<Integer, Integer> survivingPartitions = new HashMap<Integer, Integer>();
-
-        for (HazelcastInstance instance : instances) {
-            final Node survivingNode = getNode(instance);
-            final Address survivingNodeAddress = survivingNode.getThisAddress();
-
-            for (InternalPartition partition : survivingNode.getPartitionService().getPartitions()) {
-                if (partition.isOwnerOrBackup(survivingNodeAddress)) {
-                    for (int replicaIndex = 0; replicaIndex < getNodeCount(); replicaIndex++) {
-                        if (survivingNodeAddress.equals(partition.getReplicaAddress(replicaIndex))) {
-                            final Integer replicaIndexOfOtherInstance = survivingPartitions.get(partition.getPartitionId());
-                            if (replicaIndexOfOtherInstance != null) {
-                                survivingPartitions
-                                        .put(partition.getPartitionId(), Math.min(replicaIndex, replicaIndexOfOtherInstance));
-                            } else {
-                                survivingPartitions.put(partition.getPartitionId(), replicaIndex);
-                            }
-
-                            break;
-                        }
-                    }
-                }
-            }
-        }
-
-        return survivingPartitions;
     }
 
 }

--- a/hazelcast/src/test/java/com/hazelcast/test/TestPartitionUtils.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/TestPartitionUtils.java
@@ -1,0 +1,186 @@
+package com.hazelcast.test;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.instance.Node;
+import com.hazelcast.nio.Address;
+import com.hazelcast.partition.InternalPartition;
+import com.hazelcast.partition.InternalPartitionService;
+import com.hazelcast.partition.impl.InternalPartitionServiceState;
+import com.hazelcast.partition.impl.InternalPartitionServiceImpl;
+import com.hazelcast.partition.impl.ReplicaSyncInfo;
+import com.hazelcast.spi.impl.PartitionSpecificRunnable;
+import com.hazelcast.util.scheduler.ScheduledEntry;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static com.hazelcast.instance.TestUtil.getNode;
+import static com.hazelcast.partition.InternalPartition.MAX_REPLICA_COUNT;
+
+public class TestPartitionUtils {
+
+    private TestPartitionUtils() {
+    }
+
+    public static InternalPartitionServiceState getInternalPartitionServiceState(HazelcastInstance instance) {
+        return getInternalPartitionServiceState(getNode(instance));
+    }
+
+    public static InternalPartitionServiceState getInternalPartitionServiceState(Node node) {
+        if (node == null) {
+            return InternalPartitionServiceState.SAFE;
+        }
+        final InternalPartitionServiceImpl partitionService = (InternalPartitionServiceImpl) node.getPartitionService();
+        return partitionService.getMemberState();
+    }
+
+    public static Map<Integer, long[]> getAllReplicaVersions(List<HazelcastInstance> instances)
+            throws InterruptedException {
+        final Map<Integer, long[]> replicaVersions = new HashMap<Integer, long[]>();
+        for (HazelcastInstance instance : instances) {
+            collectOwnedReplicaVersions(getNode(instance), replicaVersions);
+        }
+
+        return replicaVersions;
+    }
+
+    public static Map<Integer, long[]> getOwnedReplicaVersions(HazelcastInstance instance)
+            throws InterruptedException {
+        return getOwnedReplicaVersions(getNode(instance));
+    }
+
+    public static Map<Integer, long[]> getOwnedReplicaVersions(Node node)
+            throws InterruptedException {
+        final Map<Integer, long[]> ownedReplicaVersions = new HashMap<Integer, long[]>();
+        collectOwnedReplicaVersions(node, ownedReplicaVersions);
+        return ownedReplicaVersions;
+    }
+
+    private static void collectOwnedReplicaVersions(Node node, Map<Integer, long[]> replicaVersions)
+            throws InterruptedException {
+        final InternalPartitionService partitionService = node.getPartitionService();
+        final Address nodeAddress = node.getThisAddress();
+        for (InternalPartition partition : partitionService.getPartitions()) {
+            if (nodeAddress.equals(partition.getOwnerOrNull())) {
+                final int partitionId = partition.getPartitionId();
+                replicaVersions.put(partitionId, getReplicaVersions(node, partitionId));
+            }
+        }
+    }
+
+    public static long[] getReplicaVersions(HazelcastInstance instance, int partitionId)
+            throws InterruptedException {
+        return getReplicaVersions(getNode(instance), partitionId);
+    }
+
+    public static long[] getReplicaVersions(Node node, int partitionId)
+            throws InterruptedException {
+        final GetReplicaVersionsRunnable runnable = new GetReplicaVersionsRunnable(node, partitionId);
+        node.getNodeEngine().getOperationService().execute(runnable);
+        return runnable.getReplicaVersions();
+    }
+
+    public static List<ReplicaSyncInfo> getOngoingReplicaSyncRequests(HazelcastInstance instance) {
+        return getOngoingReplicaSyncRequests(getNode(instance));
+    }
+
+    public static List<ReplicaSyncInfo> getOngoingReplicaSyncRequests(Node node) {
+        final InternalPartitionServiceImpl partitionService = (InternalPartitionServiceImpl) node.getPartitionService();
+        return partitionService.getOngoingReplicaSyncRequests();
+    }
+
+    public static List<ScheduledEntry<Integer, ReplicaSyncInfo>> getScheduledReplicaSyncRequests(HazelcastInstance instance) {
+        return getScheduledReplicaSyncRequests(getNode(instance));
+    }
+
+    public static List<ScheduledEntry<Integer, ReplicaSyncInfo>> getScheduledReplicaSyncRequests(Node node) {
+        final InternalPartitionServiceImpl partitionService = (InternalPartitionServiceImpl) node.getPartitionService();
+        return partitionService.getScheduledReplicaSyncRequests();
+    }
+
+    public static Map<Integer, List<Address>> getAllReplicaAddresses(List<HazelcastInstance> instances) {
+        if (instances.isEmpty()) {
+            return Collections.emptyMap();
+        }
+
+        for (HazelcastInstance instance : instances) {
+            final Node node = getNode(instance);
+            if (node.isMaster()) {
+                return getAllReplicaAddresses(node);
+            }
+        }
+
+        return Collections.emptyMap();
+    }
+
+    public static Map<Integer, List<Address>> getAllReplicaAddresses(HazelcastInstance instance) {
+        return getAllReplicaAddresses(getNode(instance));
+    }
+
+    public static Map<Integer, List<Address>> getAllReplicaAddresses(Node node) {
+        final Map<Integer, List<Address>> allReplicaAddresses = new HashMap<Integer, List<Address>>();
+        final InternalPartitionService partitionService = node.getPartitionService();
+        for (int partitionId = 0; partitionId < partitionService.getPartitionCount(); partitionId++) {
+            allReplicaAddresses.put(partitionId, getReplicaAddresses(node, partitionId));
+        }
+
+        return allReplicaAddresses;
+    }
+
+    public static List<Address> getReplicaAddresses(HazelcastInstance instance, int partitionId) {
+        return getReplicaAddresses(getNode(instance), partitionId);
+    }
+
+    public static List<Address> getReplicaAddresses(Node node, int partitionId) {
+        final List<Address> replicaAddresses = new ArrayList<Address>();
+        final InternalPartitionService partitionService = node.getPartitionService();
+        final InternalPartition partition = partitionService.getPartition(partitionId);
+        for (int i = 0; i < MAX_REPLICA_COUNT; i++) {
+            replicaAddresses.add(partition.getReplicaAddress(i));
+        }
+        return replicaAddresses;
+    }
+
+    private static class GetReplicaVersionsRunnable
+            implements PartitionSpecificRunnable {
+
+        private final Node node;
+
+        private final int partitionId;
+
+        private final CountDownLatch latch = new CountDownLatch(1);
+
+        private long[] replicaVersions;
+
+        public GetReplicaVersionsRunnable(Node node, int partitionId) {
+            this.node = node;
+            this.partitionId = partitionId;
+        }
+
+        @Override
+        public int getPartitionId() {
+            return partitionId;
+        }
+
+        @Override
+        public void run() {
+            final InternalPartitionService partitionService = node.nodeEngine.getPartitionService();
+            final long[] replicaVersions = partitionService.getPartitionReplicaVersions(partitionId);
+            this.replicaVersions = Arrays.copyOf(replicaVersions, replicaVersions.length);
+            latch.countDown();
+        }
+
+        public long[] getReplicaVersions()
+                throws InterruptedException {
+            latch.await(30, TimeUnit.SECONDS);
+            return replicaVersions;
+        }
+    }
+
+}


### PR DESCRIPTION
* Introduce many utility methods for accessing to partition-related information via TestPartitionUtils
* Add methods to InternalPartitionServiceImpl to return internal state for debugging purposes
* Refactor waitAllForSafeState utility method in HazelcastTestSupport so that it can report failed nodes
* Refactor partition lost listener tests to use these newly introduced utility methods

This PR emerged from the logging needs of partition lost listener stress tests. Some failures occur when system runs very fast and enabling debug logs causes them to disappear. So I use these utility methods to log internal state of the partition service just like a thread dump.