### PR TITLE
Protocol realated Client Proxies refactored

### DIFF
--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/proxy/ClientAtomicLongProxy.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/proxy/ClientAtomicLongProxy.java
@@ -17,6 +17,8 @@
 package com.hazelcast.client.proxy;
 
 import com.hazelcast.client.impl.client.ClientRequest;
+import com.hazelcast.client.impl.protocol.ClientMessage;
+import com.hazelcast.client.impl.protocol.parameters.*;
 import com.hazelcast.client.spi.ClientProxy;
 import com.hazelcast.concurrent.atomiclong.client.ApplyRequest;
 import com.hazelcast.concurrent.atomiclong.client.AlterRequest;
@@ -47,39 +49,45 @@ public class ClientAtomicLongProxy extends ClientProxy implements IAtomicLong {
     @Override
     public <R> R apply(IFunction<Long, R> function) {
         isNotNull(function, "function");
-        return invoke(new ApplyRequest(name, toData(function)));
+        ClientMessage request = AtomicLongApplyParameters.encode(name, toData(function));
+        return invoke(request);
     }
 
     @Override
     public void alter(IFunction<Long, Long> function) {
         isNotNull(function, "function");
-        invoke(new AlterRequest(name, toData(function)));
+        ClientMessage request = AtomicLongAlterParameters.encode(name, toData(function));
+        invoke(request);
     }
 
     @Override
     public long alterAndGet(IFunction<Long, Long> function) {
         isNotNull(function, "function");
-        return (Long) invoke(new AlterAndGetRequest(name, toData(function)));
+        ClientMessage request = AtomicLongAlterAndGetParameters.encode(name, toData(function));
+        LongResultParameters resultParameters = LongResultParameters.decode((ClientMessage)invoke(request));
+        return resultParameters.result;
     }
 
     @Override
     public long getAndAlter(IFunction<Long, Long> function) {
         isNotNull(function, "function");
-        return (Long) invoke(new GetAndAlterRequest(name, toData(function)));
+        ClientMessage request = AtomicLongGetAndAlterParameters.encode(name, toData(function));
+        LongResultParameters resultParameters = LongResultParameters.decode((ClientMessage)invoke(request));
+        return resultParameters.result;
     }
 
     @Override
     public long addAndGet(long delta) {
-        AddAndGetRequest request = new AddAndGetRequest(name, delta);
-        Long result = invoke(request);
-        return result;
+        ClientMessage request = AtomicLongAddAndGetParameters.encode(name, delta);
+        LongResultParameters resultParameters = LongResultParameters.decode((ClientMessage)invoke(request));
+        return resultParameters.result;
     }
 
     @Override
     public boolean compareAndSet(long expect, long update) {
-        CompareAndSetRequest request = new CompareAndSetRequest(name, expect, update);
-        Boolean result = invoke(request);
-        return result;
+        ClientMessage request = AtomicLongCompareAndSetParameters.encode(name, expect, update);
+        BooleanResultParameters resultParameters = BooleanResultParameters.decode((ClientMessage)invoke(request));
+        return resultParameters.result;
     }
 
     @Override
@@ -94,16 +102,16 @@ public class ClientAtomicLongProxy extends ClientProxy implements IAtomicLong {
 
     @Override
     public long getAndAdd(long delta) {
-        GetAndAddRequest request = new GetAndAddRequest(name, delta);
-        Long result = invoke(request);
-        return result;
+        ClientMessage request  = AtomicLongGetAndAddParameters.encode(name, delta);
+        LongResultParameters resultParameters = LongResultParameters.decode((ClientMessage)invoke(request));
+        return resultParameters.result;
     }
 
     @Override
     public long getAndSet(long newValue) {
-        GetAndSetRequest request = new GetAndSetRequest(name, newValue);
-        Long result = invoke(request);
-        return result;
+        ClientMessage request  = AtomicLongGetAndSetParameters.encode(name, newValue);
+        LongResultParameters resultParameters = LongResultParameters.decode((ClientMessage) invoke(request));
+        return resultParameters.result;
     }
 
     @Override
@@ -118,11 +126,11 @@ public class ClientAtomicLongProxy extends ClientProxy implements IAtomicLong {
 
     @Override
     public void set(long newValue) {
-        SetRequest request = new SetRequest(name, newValue);
+        ClientMessage request = AtomicLongSetParameters.encode(name, newValue);
         invoke(request);
     }
 
-    protected <T> T invoke(ClientRequest req) {
+    protected <T> T invoke(ClientMessage req) {
         return super.invoke(req, getKey());
     }
 

--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/proxy/ClientAtomicReferenceProxy.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/proxy/ClientAtomicReferenceProxy.java
@@ -17,6 +17,8 @@
 package com.hazelcast.client.proxy;
 
 import com.hazelcast.client.impl.client.ClientRequest;
+import com.hazelcast.client.impl.protocol.ClientMessage;
+import com.hazelcast.client.impl.protocol.parameters.*;
 import com.hazelcast.client.spi.ClientProxy;
 import com.hazelcast.concurrent.atomicreference.client.GetRequest;
 import com.hazelcast.concurrent.atomicreference.client.ApplyRequest;
@@ -48,67 +50,86 @@ public class ClientAtomicReferenceProxy<E> extends ClientProxy implements IAtomi
     @Override
     public <R> R apply(IFunction<E, R> function) {
         isNotNull(function, "function");
-        return invoke(new ApplyRequest(name, toData(function)));
+        ClientMessage request = AtomicReferenceApplyParameters.encode(name, toData(function));
+        GenericResultParameters resultParameters = GenericResultParameters.decode((ClientMessage)invoke(request));
+        return toObject(resultParameters.result);
     }
 
     @Override
     public void alter(IFunction<E, E> function) {
         isNotNull(function, "function");
-        invoke(new AlterRequest(name, toData(function)));
+        ClientMessage request = AtomicReferenceAlterParameters.encode(name, toData(function));
+        invoke(request);
     }
 
     @Override
     public E alterAndGet(IFunction<E, E> function) {
         isNotNull(function, "function");
-        return invoke(new AlterAndGetRequest(name, toData(function)));
+        ClientMessage request = AtomicReferenceAlterAndGetParameters.encode(name, toData(function));
+        GenericResultParameters resultParameters = GenericResultParameters.decode((ClientMessage)invoke(request));
+        return toObject(resultParameters.result);
     }
 
     @Override
     public E getAndAlter(IFunction<E, E> function) {
         isNotNull(function, "function");
-        return invoke(new GetAndAlterRequest(name, toData(function)));
+        ClientMessage request = AtomicReferenceGetAndAlterParameters.encode(name, toData(function));
+        GenericResultParameters resultParameters = GenericResultParameters.decode((ClientMessage)invoke(request));
+        return toObject(resultParameters.result);
+
     }
 
     @Override
     public boolean compareAndSet(E expect, E update) {
-        return (Boolean) invoke(new CompareAndSetRequest(name, toData(expect), toData(update)));
+        ClientMessage request = AtomicReferenceCompareAndSetParameters.encode(name, toData(expect), toData(update));
+        BooleanResultParameters resultParameters = BooleanResultParameters.decode((ClientMessage)invoke(request));
+        return resultParameters.result;
     }
 
     @Override
     public boolean contains(E expected) {
-        return (Boolean) invoke(new ContainsRequest(name, toData(expected)));
-    }
+        ClientMessage request = AtomicReferenceContainsParameters.encode(name, toData(expected));
+        BooleanResultParameters resultParameters = BooleanResultParameters.decode((ClientMessage)invoke(request));
+        return resultParameters.result;    }
 
     @Override
     public E get() {
-        return invoke(new GetRequest(name));
+        ClientMessage request = AtomicReferenceGetParameters.encode(name);
+        GenericResultParameters resultParameters = GenericResultParameters.decode((ClientMessage)invoke(request));
+        return toObject(resultParameters.result);
     }
 
     @Override
     public void set(E newValue) {
-        invoke(new SetRequest(name, toData(newValue)));
+        ClientMessage request = AtomicReferenceSetParameters.encode(name, toData(newValue));
+        invoke(request);
     }
 
     @Override
     public void clear() {
-        set(null);
+        ClientMessage request = AtomicReferenceClearParameters.encode(name);
+        invoke(request);
     }
 
     @Override
     public E getAndSet(E newValue) {
-        return invoke(new GetAndSetRequest(name, toData(newValue)));
+        ClientMessage request = AtomicReferenceGetAndSetParameters.encode(name, toData(newValue));
+        GenericResultParameters resultParameters = GenericResultParameters.decode((ClientMessage)invoke(request));
+        return toObject(resultParameters.result);
     }
 
     @Override
     public E setAndGet(E update) {
-        invoke(new SetRequest(name, toData(update)));
-        return update;
+        ClientMessage request = AtomicReferenceSetAndGetParameters.encode(name, toData(update));
+        GenericResultParameters resultParameters = GenericResultParameters.decode((ClientMessage)invoke(request));
+        return toObject(resultParameters.result);
     }
 
     @Override
     public boolean isNull() {
-        return (Boolean) invoke(new IsNullRequest(name));
-    }
+        ClientMessage request = AtomicReferenceIsNullParameters.encode(name);
+        BooleanResultParameters resultParameters = BooleanResultParameters.decode((ClientMessage)invoke(request));
+        return resultParameters.result;    }
 
     protected <T> T invoke(ClientRequest req) {
         return super.invoke(req, getKey());

--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/proxy/ClientCountDownLatchProxy.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/proxy/ClientCountDownLatchProxy.java
@@ -17,6 +17,8 @@
 package com.hazelcast.client.proxy;
 
 import com.hazelcast.client.impl.client.ClientRequest;
+import com.hazelcast.client.impl.protocol.ClientMessage;
+import com.hazelcast.client.impl.protocol.parameters.*;
 import com.hazelcast.client.spi.ClientProxy;
 import com.hazelcast.concurrent.countdownlatch.client.AwaitRequest;
 import com.hazelcast.concurrent.countdownlatch.client.CountDownRequest;
@@ -36,29 +38,29 @@ public class ClientCountDownLatchProxy extends ClientProxy implements ICountDown
     }
 
     public boolean await(long timeout, TimeUnit unit) throws InterruptedException {
-        AwaitRequest request = new AwaitRequest(getName(), getTimeInMillis(timeout, unit));
-        Boolean result = invoke(request);
-        return result;
+        ClientMessage request = CountDownLatchAwaitParameters.encode(getName(), getTimeInMillis(timeout, unit));
+        BooleanResultParameters resultParameters = BooleanResultParameters.decode((ClientMessage) invoke(request));
+        return resultParameters.result;
     }
 
     public void countDown() {
-        CountDownRequest request = new CountDownRequest(getName());
+        ClientMessage request = CountDownLatchCountDownParameters.encode(getName());
         invoke(request);
     }
 
     public int getCount() {
-        GetCountRequest request = new GetCountRequest(getName());
-        Integer result = invoke(request);
-        return result;
+        ClientMessage request = CountDownLatchGetCountParameters.encode(getName());
+        IntResultParameters resultParameters = IntResultParameters.decode((ClientMessage) invoke(request));
+        return resultParameters.result;
     }
 
     public boolean trySetCount(int count) {
         if (count < 0) {
             throw new IllegalArgumentException("count can't be negative");
         }
-        SetCountRequest request = new SetCountRequest(getName(), count);
-        Boolean result = invoke(request);
-        return result;
+        ClientMessage request = CountDownLatchTrySetCountParameters.encode(getName(), count);
+        BooleanResultParameters resultParameters = BooleanResultParameters.decode((ClientMessage) invoke(request));
+        return resultParameters.result;
     }
 
     private Data getKey() {

--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/proxy/ClientSemaphoreProxy.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/proxy/ClientSemaphoreProxy.java
@@ -17,13 +17,9 @@
 package com.hazelcast.client.proxy;
 
 import com.hazelcast.client.impl.client.ClientRequest;
+import com.hazelcast.client.impl.protocol.ClientMessage;
+import com.hazelcast.client.impl.protocol.parameters.*;
 import com.hazelcast.client.spi.ClientProxy;
-import com.hazelcast.concurrent.semaphore.client.InitRequest;
-import com.hazelcast.concurrent.semaphore.client.AcquireRequest;
-import com.hazelcast.concurrent.semaphore.client.AvailableRequest;
-import com.hazelcast.concurrent.semaphore.client.DrainRequest;
-import com.hazelcast.concurrent.semaphore.client.ReleaseRequest;
-import com.hazelcast.concurrent.semaphore.client.ReduceRequest;
 import com.hazelcast.core.ISemaphore;
 import com.hazelcast.nio.serialization.Data;
 
@@ -41,55 +37,56 @@ public class ClientSemaphoreProxy extends ClientProxy implements ISemaphore {
 
     public boolean init(int permits) {
         checkNegative(permits);
-        InitRequest request = new InitRequest(name, permits);
-        Boolean result = invoke(request);
-        return result;
+        ClientMessage request = SemaphoreInitParameters.encode(name, permits);
+        BooleanResultParameters resultParameters = BooleanResultParameters.decode((ClientMessage)invoke(request));
+
+        return resultParameters.result;
     }
 
     public void acquire() throws InterruptedException {
-        AcquireRequest request = new AcquireRequest(name);
+        ClientMessage request = SemaphoreInitParameters.encode(name, 1);
         invoke(request);
     }
 
     public void acquire(int permits) throws InterruptedException {
         checkNegative(permits);
-        AcquireRequest request = new AcquireRequest(name, permits);
+        ClientMessage request = SemaphoreInitParameters.encode(name, 1);
         invoke(request);
     }
 
     public int availablePermits() {
-        AvailableRequest request = new AvailableRequest(name);
-        Integer result = invoke(request);
-        return result;
+        ClientMessage request = SemaphoreAvailablePermitsParameters.encode(name);
+        IntResultParameters resultParameters = IntResultParameters.decode((ClientMessage)invoke(request));
+        return resultParameters.result;
     }
 
     public int drainPermits() {
-        DrainRequest request = new DrainRequest(name);
-        Integer result = invoke(request);
-        return result;
+        ClientMessage request = SemaphoreDrainPermitsParameters.encode(name);
+        IntResultParameters resultParameters = IntResultParameters.decode((ClientMessage) invoke(request));
+        return resultParameters.result;
     }
 
     public void reducePermits(int reduction) {
         checkNegative(reduction);
-        ReduceRequest request = new ReduceRequest(name, reduction);
+        ClientMessage request = SemaphoreReducePermitsParameters.encode(name, reduction);
         invoke(request);
     }
 
     public void release() {
-        ReleaseRequest request = new ReleaseRequest(name, 1);
+        ClientMessage request = SemaphoreReleaseParameters.encode(name, 1);
         invoke(request);
     }
 
     public void release(int permits) {
         checkNegative(permits);
-        ReleaseRequest request = new ReleaseRequest(name, permits);
+        ClientMessage request = SemaphoreReleaseParameters.encode(name, permits);
         invoke(request);
     }
 
     public boolean tryAcquire() {
-        AcquireRequest request = new AcquireRequest(name, 1, 0);
-        Boolean result = invoke(request);
-        return result;
+        ClientMessage request = SemaphoreTryAcquireParameters.encode(name, 1, 0);
+        BooleanResultParameters resultParameters = BooleanResultParameters.decode((ClientMessage) invoke(request));
+        return resultParameters.result;
     }
 
     public boolean tryAcquire(int permits) {
@@ -105,16 +102,17 @@ public class ClientSemaphoreProxy extends ClientProxy implements ISemaphore {
         if (timeout == 0) {
             return tryAcquire();
         }
-        AcquireRequest request = new AcquireRequest(name, 1, unit.toMillis(timeout));
-        Boolean result = invoke(request);
-        return result;
+
+        ClientMessage request = SemaphoreTryAcquireParameters.encode(name, 1, unit.toMillis(timeout));
+        BooleanResultParameters resultParameters = BooleanResultParameters.decode((ClientMessage) invoke(request));
+        return resultParameters.result;
     }
 
     public boolean tryAcquire(int permits, long timeout, TimeUnit unit) throws InterruptedException {
         checkNegative(permits);
-        AcquireRequest request = new AcquireRequest(name, permits, unit.toMillis(timeout));
-        Boolean result = invoke(request);
-        return result;
+        ClientMessage request = SemaphoreTryAcquireParameters.encode(name, permits, unit.toMillis(timeout));
+        BooleanResultParameters resultParameters = BooleanResultParameters.decode((ClientMessage) invoke(request));
+        return resultParameters.result;
     }
 
     protected <T> T invoke(ClientRequest req) {

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/ClientMessageType.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/ClientMessageType.java
@@ -76,7 +76,10 @@ public enum ClientMessageType {
 
     VOID_RESULT(22),
 
-    ENTRY_VIEW(23);
+    ENTRY_VIEW(23),
+
+    LONG_RESULT(24);
+
 
     private final int id;
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/parameters/LongResultParameters.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/parameters/LongResultParameters.java
@@ -1,0 +1,49 @@
+package com.hazelcast.client.impl.protocol.parameters;
+
+import com.hazelcast.client.impl.protocol.ClientMessage;
+import com.hazelcast.client.impl.protocol.ClientMessageType;
+import com.hazelcast.client.impl.protocol.util.BitUtil;
+
+/**
+ * Created by muratayan on 4/22/15.
+ */
+
+@edu.umd.cs.findbugs.annotations.SuppressWarnings({"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"})
+public class LongResultParameters {
+
+    /**
+     * ClientMessageType of this message
+     */
+    public static final ClientMessageType TYPE = ClientMessageType.LONG_RESULT;
+    public long result;
+
+    private LongResultParameters(ClientMessage flyweight) {
+        result = flyweight.getLong();
+    }
+
+    public static LongResultParameters decode(ClientMessage flyweight) {
+        return new LongResultParameters(flyweight);
+    }
+
+    public static ClientMessage encode(long result) {
+        final int requiredDataSize = calculateDataSize(result);
+        ClientMessage clientMessage = ClientMessage.createForEncode(requiredDataSize);
+        clientMessage.ensureCapacity(requiredDataSize);
+        clientMessage.setMessageType(TYPE.id());
+        clientMessage.set(result);
+        clientMessage.updateFrameLength();
+        return clientMessage;
+    }
+
+    /**
+     * sample data size estimation
+     *
+     * @return size
+     */
+    public static int calculateDataSize(long result) {
+        return ClientMessage.HEADER_SIZE
+                + BitUtil.SIZE_OF_LONG;
+    }
+}
+
+


### PR DESCRIPTION
This PR contains protocol related changes in Client Proxies. Changes I made are in:

* hazelcast-client-new/src/main/java/com/hazelcast/client/proxy/ClientAtomicLongProxy.java
* hazelcast-client-new/src/main/java/com/hazelcast/client/proxy/ClientAtomicReferenceProxy.java
* hazelcast-client-new/src/main/java/com/hazelcast/client/proxy/ClientConditionProxy.java
* hazelcast-client-new/src/main/java/com/hazelcast/client/proxy/ClientCountDownLatchProxy.java
* hazelcast-client-new/src/main/java/com/hazelcast/client/proxy/ClientExecutorServiceProxy.java
* hazelcast-client-new/src/main/java/com/hazelcast/client/proxy/ClientLockProxy.java
* hazelcast-client-new/src/main/java/com/hazelcast/client/proxy/ClientSemaphoreProxy.java

Above changes are very similar, I've changed the old `request` based invocations to relevant `ClientMessage` invocations. However, below changes are about a small enhancement. There was no `LongResultParameters` class although we need it. I've added that as well.

* hazelcast/src/main/java/com/hazelcast/client/impl/protocol/ClientMessageType.java
* hazelcast/src/main/java/com/hazelcast/client/impl/protocol/parameters/LongResultParameters.java