### PR TITLE
Removed MapServiceContext.getServiceName 

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/AbstractMapServiceContextSupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/AbstractMapServiceContextSupport.java
@@ -28,6 +28,7 @@ import com.hazelcast.util.Clock;
 import java.util.List;
 
 import static com.hazelcast.map.impl.ListenerAdapters.createListenerAdapter;
+import static com.hazelcast.map.impl.MapService.SERVICE_NAME;
 
 abstract class AbstractMapServiceContextSupport implements MapServiceContext {
 
@@ -197,7 +198,7 @@ abstract class AbstractMapServiceContextSupport implements MapServiceContext {
     public String addLocalEventListener(Object listener, String mapName) {
         ListenerAdapter listenerAdaptor = createListenerAdapter(listener);
         EventRegistration registration = nodeEngine.getEventService().
-                registerLocalListener(serviceName(), mapName, listenerAdaptor);
+                registerLocalListener(SERVICE_NAME, mapName, listenerAdaptor);
         return registration.getId();
     }
 
@@ -205,7 +206,7 @@ abstract class AbstractMapServiceContextSupport implements MapServiceContext {
     public String addLocalEventListener(Object listener, EventFilter eventFilter, String mapName) {
         ListenerAdapter listenerAdaptor = createListenerAdapter(listener);
         EventRegistration registration = nodeEngine.getEventService().
-                registerLocalListener(serviceName(), mapName, eventFilter, listenerAdaptor);
+                registerLocalListener(SERVICE_NAME, mapName, eventFilter, listenerAdaptor);
         return registration.getId();
     }
 
@@ -213,7 +214,7 @@ abstract class AbstractMapServiceContextSupport implements MapServiceContext {
     public String addEventListener(Object listener, EventFilter eventFilter, String mapName) {
         ListenerAdapter listenerAdaptor = createListenerAdapter(listener);
         EventRegistration registration = nodeEngine.getEventService().
-                registerListener(serviceName(), mapName, eventFilter, listenerAdaptor);
+                registerListener(SERVICE_NAME, mapName, eventFilter, listenerAdaptor);
         return registration.getId();
     }
 
@@ -221,19 +222,19 @@ abstract class AbstractMapServiceContextSupport implements MapServiceContext {
     public String addPartitionLostListener(MapPartitionLostListener listener, String mapName) {
         final ListenerAdapter listenerAdapter = new InternalMapPartitionLostListenerAdapter(listener);
         final EventFilter filter = new MapPartitionLostEventFilter();
-        final EventRegistration registration = nodeEngine.getEventService().registerListener(serviceName(), mapName, filter,
+        final EventRegistration registration = nodeEngine.getEventService().registerListener(SERVICE_NAME, mapName, filter,
                 listenerAdapter);
         return registration.getId();
     }
 
     @Override
     public boolean removeEventListener(String mapName, String registrationId) {
-        return nodeEngine.getEventService().deregisterListener(serviceName(), mapName, registrationId);
+        return nodeEngine.getEventService().deregisterListener(SERVICE_NAME, mapName, registrationId);
     }
 
     @Override
     public boolean removePartitionLostListener(String mapName, String registrationId) {
-        return nodeEngine.getEventService().deregisterListener(serviceName(), mapName, registrationId);
+        return nodeEngine.getEventService().deregisterListener(SERVICE_NAME, mapName, registrationId);
     }
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/DefaultMapServiceContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/DefaultMapServiceContext.java
@@ -126,11 +126,6 @@ class DefaultMapServiceContext extends AbstractMapServiceContextSupport {
     }
 
     @Override
-    public String serviceName() {
-        return MapService.SERVICE_NAME;
-    }
-
-    @Override
     public MapService getService() {
         return mapService;
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapEventPublisherSupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapEventPublisherSupport.java
@@ -37,6 +37,8 @@ import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
 
+import static com.hazelcast.map.impl.MapService.SERVICE_NAME;
+
 class MapEventPublisherSupport implements MapEventPublisher {
 
     protected final MapServiceContext mapServiceContext;
@@ -50,7 +52,7 @@ class MapEventPublisherSupport implements MapEventPublisher {
         MapContainer mapContainer = mapServiceContext.getMapContainer(mapName);
         MapReplicationUpdate replicationEvent = new MapReplicationUpdate(mapName, mapContainer.getWanMergePolicy(),
                 entryView);
-        mapContainer.getWanReplicationPublisher().publishReplicationEvent(mapServiceContext.serviceName(), replicationEvent);
+        mapContainer.getWanReplicationPublisher().publishReplicationEvent(SERVICE_NAME, replicationEvent);
     }
 
     @Override
@@ -220,9 +222,8 @@ class MapEventPublisherSupport implements MapEventPublisher {
         final MapServiceContext mapServiceContext = this.mapServiceContext;
         final NodeEngine nodeEngine = mapServiceContext.getNodeEngine();
         final EventService eventService = nodeEngine.getEventService();
-        final String serviceName = mapServiceContext.serviceName();
 
-        return eventService.getRegistrations(serviceName, mapName);
+        return eventService.getRegistrations(SERVICE_NAME, mapName);
     }
 
     private int pickOrderKey(Data key) {
@@ -250,9 +251,8 @@ class MapEventPublisherSupport implements MapEventPublisher {
         final MapServiceContext mapServiceContext = this.mapServiceContext;
         final NodeEngine nodeEngine = mapServiceContext.getNodeEngine();
         final EventService eventService = nodeEngine.getEventService();
-        final String serviceName = mapServiceContext.serviceName();
 
-        eventService.publishEvent(serviceName, registrations, eventData, orderKey);
+        eventService.publishEvent(SERVICE_NAME, registrations, eventData, orderKey);
     }
 
     private String getThisNodesAddress() {
@@ -296,9 +296,8 @@ class MapEventPublisherSupport implements MapEventPublisher {
     void publishWanReplicationEventInternal(String mapName, ReplicationEventObject event) {
         final MapServiceContext mapServiceContext = this.mapServiceContext;
         final MapContainer mapContainer = mapServiceContext.getMapContainer(mapName);
-        final String serviceName = mapServiceContext.serviceName();
         final WanReplicationPublisher wanReplicationPublisher = mapContainer.getWanReplicationPublisher();
-        wanReplicationPublisher.publishReplicationEvent(serviceName, event);
+        wanReplicationPublisher.publishReplicationEvent(SERVICE_NAME, event);
     }
 
     private EntryEventData createEntryEventData(String mapName, Address caller,
@@ -309,7 +308,7 @@ class MapEventPublisherSupport implements MapEventPublisher {
                 dataKey, dataNewValue, dataOldValue, dataMergingValue, eventType);
     }
 
-    private static enum Result {
+    private enum Result {
         VALUE_INCLUDED,
         NO_VALUE_INCLUDED,
         NONE

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapManagedService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapManagedService.java
@@ -43,7 +43,7 @@ class MapManagedService implements ManagedService {
         mapServiceContext.initPartitionsContainers();
         final LockService lockService = nodeEngine.getSharedService(LockService.SERVICE_NAME);
         if (lockService != null) {
-            lockService.registerLockStoreConstructor(mapServiceContext.serviceName(),
+            lockService.registerLockStoreConstructor(MapService.SERVICE_NAME,
                     new ConstructorFunction<ObjectNamespace, LockStoreInfo>() {
                         public LockStoreInfo createNew(final ObjectNamespace key) {
                             final MapContainer mapContainer = mapServiceContext.getMapContainer(key.getObjectName());

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapRemoteService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapRemoteService.java
@@ -22,6 +22,8 @@ import com.hazelcast.spi.RemoteService;
 
 import java.util.Map;
 
+import static com.hazelcast.map.impl.MapService.SERVICE_NAME;
+
 /**
  * Defines remote service behavior of map service.
  *
@@ -53,14 +55,10 @@ class MapRemoteService implements RemoteService {
             mapContainer.getMapStoreContext().stop();
         }
         mapServiceContext.destroyMap(name);
-        nodeEngine.getEventService().deregisterAllListeners(mapServiceContext.serviceName(), name);
+        nodeEngine.getEventService().deregisterAllListeners(SERVICE_NAME, name);
     }
 
     MapServiceContext getMapServiceContext() {
         return mapServiceContext;
-    }
-
-    NodeEngine getNodeEngine() {
-        return nodeEngine;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapReplicationSupportingService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapReplicationSupportingService.java
@@ -29,6 +29,8 @@ import com.hazelcast.wan.WanReplicationEvent;
 
 import java.util.concurrent.Future;
 
+import static com.hazelcast.map.impl.MapService.SERVICE_NAME;
+
 class MapReplicationSupportingService implements ReplicationSupportingService {
 
     private final MapServiceContext mapServiceContext;
@@ -53,7 +55,7 @@ class MapReplicationSupportingService implements ReplicationSupportingService {
             try {
                 int partitionId = nodeEngine.getPartitionService().getPartitionId(entryView.getKey());
                 Future f = nodeEngine.getOperationService()
-                        .invokeOnPartition(mapServiceContext.serviceName(), operation, partitionId);
+                        .invokeOnPartition(SERVICE_NAME, operation, partitionId);
                 f.get();
             } catch (Throwable t) {
                 throw ExceptionUtil.rethrow(t);
@@ -65,7 +67,7 @@ class MapReplicationSupportingService implements ReplicationSupportingService {
             try {
                 int partitionId = nodeEngine.getPartitionService().getPartitionId(replicationRemove.getKey());
                 Future f = nodeEngine.getOperationService()
-                        .invokeOnPartition(mapServiceContext.serviceName(), operation, partitionId);
+                        .invokeOnPartition(SERVICE_NAME, operation, partitionId);
                 f.get();
             } catch (Throwable t) {
                 throw ExceptionUtil.rethrow(t);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContext.java
@@ -54,8 +54,6 @@ public interface MapServiceContext extends MapServiceContextSupport,
 
     void clearPartitionData(int partitionId);
 
-    String serviceName();
-
     MapService getService();
 
     void clearPartitions();

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapSplitBrainHandlerService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapSplitBrainHandlerService.java
@@ -38,6 +38,8 @@ import java.util.Map;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 
+import static com.hazelcast.map.impl.MapService.SERVICE_NAME;
+
 class MapSplitBrainHandlerService implements SplitBrainHandlerService {
 
     private final MapServiceContext mapServiceContext;
@@ -129,7 +131,7 @@ class MapSplitBrainHandlerService implements SplitBrainHandlerService {
                     try {
                         int partitionId = nodeEngine.getPartitionService().getPartitionId(record.getKey());
                         ICompletableFuture f = nodeEngine.getOperationService()
-                                .invokeOnPartition(mapServiceContext.serviceName(), operation, partitionId);
+                                .invokeOnPartition(SERVICE_NAME, operation, partitionId);
 
                         f.andThen(mergeCallback);
                     } catch (Throwable t) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/eviction/EvictionOperator.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/eviction/EvictionOperator.java
@@ -33,6 +33,8 @@ import com.hazelcast.util.MemoryInfoAccessor;
 import java.util.Arrays;
 import java.util.Iterator;
 
+import static com.hazelcast.map.impl.MapService.SERVICE_NAME;
+
 /**
  * Eviction helper methods.
  */
@@ -163,9 +165,8 @@ public final class EvictionOperator {
     }
 
     private boolean hasListener(String mapName) {
-        final String serviceName = mapServiceContext.serviceName();
         final EventService eventService = mapServiceContext.getNodeEngine().getEventService();
-        return eventService.hasEventRegistration(serviceName, mapName);
+        return eventService.hasEventRegistration(SERVICE_NAME, mapName);
     }
 
     private boolean evictIfNotLocked(Data key, RecordStore recordStore, boolean backup) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/AbstractMultipleEntryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/AbstractMultipleEntryOperation.java
@@ -42,6 +42,7 @@ import java.util.AbstractMap;
 import java.util.Map;
 
 import static com.hazelcast.map.impl.EntryViews.createSimpleEntryView;
+import static com.hazelcast.map.impl.MapService.SERVICE_NAME;
 
 abstract class AbstractMultipleEntryOperation extends AbstractMapOperation {
 
@@ -80,9 +81,8 @@ abstract class AbstractMultipleEntryOperation extends AbstractMapOperation {
     }
 
     protected boolean hasRegisteredListenerForThisMap() {
-        final String serviceName = mapService.getMapServiceContext().serviceName();
         final EventService eventService = getNodeEngine().getEventService();
-        return eventService.hasEventRegistration(serviceName, name);
+        return eventService.hasEventRegistration(SERVICE_NAME, name);
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOperation.java
@@ -44,6 +44,7 @@ import java.util.AbstractMap;
 import java.util.Map;
 
 import static com.hazelcast.map.impl.EntryViews.createSimpleEntryView;
+import static com.hazelcast.map.impl.MapService.SERVICE_NAME;
 
 /**
  * GOTCHA : This operation LOADS missing keys from map-store, in contrast with PartitionWideEntryOperation.
@@ -239,9 +240,8 @@ public class EntryOperation extends LockAwareOperation implements BackupAwareOpe
     }
 
     private boolean hasRegisteredListenerForThisMap() {
-        final String serviceName = mapService.getMapServiceContext().serviceName();
         final EventService eventService = getNodeEngine().getEventService();
-        return eventService.hasEventRegistration(serviceName, name);
+        return eventService.hasEventRegistration(SERVICE_NAME, name);
     }
 
     /**


### PR DESCRIPTION
and replaced it by MapService.SERVICE_NAME constant.

This is done to reduce complexity. Refering to a constant is less complex than using to a method that refers to a constant.