### PR TITLE
Renamed MapEventPublisherSupport to MapEventPublisherImpl

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapEventPublisher.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapEventPublisher.java
@@ -24,7 +24,7 @@ import com.hazelcast.nio.serialization.Data;
 /**
  * Helper methods for publishing events.
  *
- * @see MapEventPublisherSupport
+ * @see MapEventPublisherImpl
  */
 public interface MapEventPublisher {
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapEventPublisherImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapEventPublisherImpl.java
@@ -39,11 +39,11 @@ import java.util.List;
 
 import static com.hazelcast.map.impl.MapService.SERVICE_NAME;
 
-class MapEventPublisherSupport implements MapEventPublisher {
+class MapEventPublisherImpl implements MapEventPublisher {
 
     protected final MapServiceContext mapServiceContext;
 
-    protected MapEventPublisherSupport(MapServiceContext mapServiceContext) {
+    protected MapEventPublisherImpl(MapServiceContext mapServiceContext) {
         this.mapServiceContext = mapServiceContext;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
@@ -96,8 +96,8 @@ class MapServiceContextImpl implements MapServiceContext {
         this.mapContextQuerySupport = new BasicMapContextQuerySupport(this);
     }
 
-    MapEventPublisherSupport createMapEventPublisherSupport() {
-        return new MapEventPublisherSupport(this);
+    MapEventPublisherImpl createMapEventPublisherSupport() {
+        return new MapEventPublisherImpl(this);
     }
 
     @Override


### PR DESCRIPTION
Renamed MapEventPublisherSupport to MapEventPublisherImpl. 

Calling an implementation 'Support' is not a convention in Hazelcast. It is either Default... or ...Impl. 

If there is a support class then it implement some of the methods.. but it isn't a full implementation. Or it contains some reusable methods.

E.g.:
ClientInvocationServiceSupport
ClusterListenerSupport

Within the com.hazelcast.map package support is being used for unexpected reasons. There are also interfaces that contain Support e.g. 

MapServiceContextEventListenerSupport
MapServiceContextInterceptorSupport
MapServiceContextSupport
MapContextQuerySupport

Having a name that doesn't clearly explain its intent makes code hard to understand because you can't guess what it does.


