### PR TITLE
Calling InetSocketAddress::getHostName only when the selector hack is enabled.

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnectionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnectionManager.java
@@ -340,8 +340,7 @@ public class TcpIpConnectionManager implements ConnectionManager {
 
     TcpIpConnection assignSocketChannel(SocketChannelWrapper channel, Address endpoint) {
         InetSocketAddress remoteSocketAddress = (InetSocketAddress) channel.socket().getRemoteSocketAddress();
-        String remoteHost = remoteSocketAddress.getHostName();
-        int index = getSelectorIndex(remoteHost);
+        int index = getSelectorIndex(remoteSocketAddress);
 
         final TcpIpConnection connection = new TcpIpConnection(this, inSelectors[index],
                 outSelectors[index], connectionIdGen.incrementAndGet(), channel);
@@ -355,9 +354,10 @@ public class TcpIpConnectionManager implements ConnectionManager {
         return connection;
     }
 
-    private int getSelectorIndex(String remoteHost) {
+    private int getSelectorIndex(InetSocketAddress remoteSocketAddress) {
         Integer index;
         if (selectorImbalanceWorkaroundEnabled) {
+            String remoteHost = remoteSocketAddress.getHostName();
             synchronized (selectorIndexPerHostMap) {
                 index = selectorIndexPerHostMap.get(remoteHost);
                 if (index == null) {


### PR DESCRIPTION
Fixes #5072

In master it's fixed (#5155) by removing the selector hack altogether. We can't do that in 3.4.x as it doesn't have IOBalancer in place. Therefore I'm moving the `getHostName()` call to a branch which is only taken when the selector hack is explicitly enabled. 