### PR TITLE
fixed MAX_HEAP_SIZE env variable to set jvm's -Xmx option 

### DIFF
--- a/hazelcast/src/main/resources/server.bat
+++ b/hazelcast/src/main/resources/server.bat
@@ -20,7 +20,7 @@ if NOT "%MIN_HEAP_SIZE%" == "" (
 )
 
 if NOT "%MAX_HEAP_SIZE%" == "" (
-	set JAVA_OPTS=%JAVA_OPTS% -Xms%MAX_HEAP_SIZE%
+	set JAVA_OPTS=%JAVA_OPTS% -Xmx%MAX_HEAP_SIZE%
 )
 
 set CLASSPATH=..\lib\hazelcast-${project.version}.jar

--- a/hazelcast/src/main/resources/server.sh
+++ b/hazelcast/src/main/resources/server.sh
@@ -36,7 +36,7 @@ if [ "x$MIN_HEAP_SIZE" != "x" ]; then
 fi
 
 if [ "x$MAX_HEAP_SIZE" != "x" ]; then
-	JAVA_OPTS="$JAVA_OPTS -Xms${MAX_HEAP_SIZE}"
+	JAVA_OPTS="$JAVA_OPTS -Xmx${MAX_HEAP_SIZE}"
 fi
 
 export CLASSPATH=$HAZELCAST_HOME/lib/hazelcast-${project.version}.jar


### PR DESCRIPTION
Hi, I've come across a simple mistake in the server launch script that `MAX_HEAP_SIZE` environment variable is adding `-Xms` instead of `-Xmx` of `JAVA_OPTS`.

I'm assuming this is not intentional, but might have been hard to notice because the JVM heap size will be set to MAX_HEAP_SIZE anyway.

PS. I'd love to sign the Contributor Agreement Form, but it wouldn't let me login with my Atlassian Cloud account. I'll try again soon.