### PR TITLE
Improved tests for SlowOperationDetector.

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/slowoperationdetector/SlowOperationDetectorAbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/slowoperationdetector/SlowOperationDetectorAbstractTest.java
@@ -25,15 +25,19 @@ import com.hazelcast.instance.GroupProperties;
 import com.hazelcast.internal.management.TimedMemberStateFactory;
 import com.hazelcast.map.EntryBackupProcessor;
 import com.hazelcast.map.EntryProcessor;
+import com.hazelcast.spi.AbstractOperation;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.impl.operationservice.InternalOperationService;
 import com.hazelcast.spi.impl.operationservice.impl.OperationServiceImpl;
-import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.util.EmptyStatement;
 
 import java.lang.reflect.Field;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.instance.TestUtil.getHazelcastInstanceImpl;
@@ -45,6 +49,8 @@ abstract class SlowOperationDetectorAbstractTest extends HazelcastTestSupport {
 
     private static final String DEFAULT_KEY = "key";
     private static final String DEFAULT_VALUE = "value";
+
+    private List<SlowEntryProcessor> entryProcessors = new ArrayList<SlowEntryProcessor>();
 
     HazelcastInstance getSingleNodeCluster(int slowOperationThresholdMillis) {
         Config config = new Config();
@@ -67,17 +73,6 @@ abstract class SlowOperationDetectorAbstractTest extends HazelcastTestSupport {
 
     static void executeEntryProcessor(IMap<String, String> map, EntryProcessor<String, String> entryProcessor) {
         map.executeOnKey(DEFAULT_KEY, entryProcessor);
-    }
-
-    static void waitForAllOperationsToComplete(final HazelcastInstance instance) {
-        sleepSeconds(1);
-        final InternalOperationService operationService = getOperationService(instance);
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run() throws Exception {
-                assertTrue(operationService.getRunningOperationsCount() == 0);
-            }
-        });
     }
 
     static void shutdownOperationService(HazelcastInstance instance) {
@@ -176,7 +171,19 @@ abstract class SlowOperationDetectorAbstractTest extends HazelcastTestSupport {
         }
     }
 
-    static class SlowEntryProcessor implements EntryProcessor<String, String> {
+    SlowEntryProcessor getSlowEntryProcessor(int sleepSeconds) {
+        SlowEntryProcessor entryProcessor = new SlowEntryProcessor(sleepSeconds);
+        entryProcessors.add(entryProcessor);
+        return entryProcessor;
+    }
+
+    void awaitSlowEntryProcessors() {
+        for (SlowEntryProcessor slowEntryProcessor : entryProcessors) {
+            slowEntryProcessor.await();
+        }
+    }
+
+    static class SlowEntryProcessor extends CountDownLatchHolder implements EntryProcessor<String, String> {
 
         final int sleepSeconds;
 
@@ -187,6 +194,7 @@ abstract class SlowOperationDetectorAbstractTest extends HazelcastTestSupport {
         @Override
         public Object process(Map.Entry<String, String> entry) {
             sleepSeconds(sleepSeconds);
+            done();
             return null;
         }
 
@@ -208,7 +216,42 @@ abstract class SlowOperationDetectorAbstractTest extends HazelcastTestSupport {
                 TimeUnit.SECONDS.sleep(sleepSeconds);
             } catch (InterruptedException ignored) {
             }
+            done();
             return null;
+        }
+    }
+
+    static abstract class CountDownLatchOperation extends AbstractOperation {
+
+        private final CountDownLatch latch = new CountDownLatch(1);
+
+        void done() {
+            latch.countDown();
+        }
+
+        void await() {
+            try {
+                latch.await();
+            } catch (InterruptedException e) {
+                EmptyStatement.ignore(e);
+            }
+        }
+    }
+
+    static abstract class CountDownLatchHolder {
+
+        private final CountDownLatch latch = new CountDownLatch(1);
+
+        void done() {
+            latch.countDown();
+        }
+
+        void await() {
+            try {
+                latch.await();
+            } catch (InterruptedException e) {
+                EmptyStatement.ignore(e);
+            }
         }
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/slowoperationdetector/SlowOperationDetector_JsonTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/slowoperationdetector/SlowOperationDetector_JsonTest.java
@@ -98,11 +98,11 @@ public class SlowOperationDetector_JsonTest extends SlowOperationDetectorAbstrac
     @Test
     public void testJSON_SlowEntryProcessor() {
         for (int i = 0; i < 2; i++) {
-            map.executeOnEntries(new SlowEntryProcessor(2));
+            map.executeOnEntries(getSlowEntryProcessor(2));
         }
-        map.executeOnEntries(new SlowEntryProcessor(3));
-        map.executeOnEntries(new SlowEntryProcessor(2));
-        waitForAllOperationsToComplete(instance);
+        map.executeOnEntries(getSlowEntryProcessor(3));
+        map.executeOnEntries(getSlowEntryProcessor(2));
+        awaitSlowEntryProcessors();
 
         logger.finest(getOperationStats(instance).toString());
 
@@ -114,11 +114,14 @@ public class SlowOperationDetector_JsonTest extends SlowOperationDetectorAbstrac
     @Test
     public void testJSON_multipleEntryProcessorClasses() throws InterruptedException {
         for (int i = 0; i < 2; i++) {
-            map.executeOnEntries(new SlowEntryProcessor(2));
+            map.executeOnEntries(getSlowEntryProcessor(2));
         }
-        map.executeOnEntries(new SlowEntryProcessorChild(2));
-        map.executeOnEntries(new SlowEntryProcessor(4));
-        waitForAllOperationsToComplete(instance);
+        SlowEntryProcessorChild entryProcessorChild = new SlowEntryProcessorChild(2);
+        map.executeOnEntries(entryProcessorChild);
+        map.executeOnEntries(getSlowEntryProcessor(4));
+
+        awaitSlowEntryProcessors();
+        entryProcessorChild.await();
 
         logger.finest(getOperationStats(instance).toString());
 

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/slowoperationdetector/SlowOperationDetector_purgeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/slowoperationdetector/SlowOperationDetector_purgeTest.java
@@ -58,13 +58,14 @@ public class SlowOperationDetector_purgeTest extends SlowOperationDetectorAbstra
         setup("3");
 
         // all of these entry processors are executed after each other, not in parallel
-        // so only the last one will survive the purging
         for (int i = 0; i < 2; i++) {
-            map.executeOnEntries(new SlowEntryProcessor(2));
+            map.executeOnEntries(getSlowEntryProcessor(2));
         }
-        map.executeOnEntries(new SlowEntryProcessor(3));
-        map.executeOnEntries(new SlowEntryProcessor(2));
+        map.executeOnEntries(getSlowEntryProcessor(3));
+        map.executeOnEntries(getSlowEntryProcessor(2));
+        awaitSlowEntryProcessors();
 
+        // shutdown to stop purging, so the last entry processor will survive
         shutdownOperationService(instance);
 
         Collection<SlowOperationLog> logs = getSlowOperationLogs(instance);
@@ -87,12 +88,13 @@ public class SlowOperationDetector_purgeTest extends SlowOperationDetectorAbstra
         setup("2");
 
         // all of these entry processors are executed after each other, not in parallel
-        // so none of them will survive the purging
         for (int i = 0; i < 2; i++) {
-            map.executeOnEntries(new SlowEntryProcessor(2));
+            map.executeOnEntries(getSlowEntryProcessor(2));
         }
-        sleepSeconds(3);
+        awaitSlowEntryProcessors();
 
+        // sleep a bit to get the last entry processor purged
+        sleepSeconds(3);
         shutdownOperationService(instance);
 
         Collection<SlowOperationLog> logs = getSlowOperationLogs(instance);


### PR DESCRIPTION
Got rid of `waitForAllOperationsToComplete()` which used a deprecated method. Replaced waiting mechanism with `CountdownLatch` in all used operations.

Should hopefully permanently fix issues like #4719.