### PR TITLE
Moved version check after node starts.

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/instance/Node.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/Node.java
@@ -166,7 +166,6 @@ public class Node {
             clusterService = new ClusterServiceImpl(this);
             textCommandService = new TextCommandServiceImpl(this);
             nodeExtension.printNodeInfo(this);
-            versionCheck.check(this, getBuildInfo().getVersion(), buildInfo.isEnterprise());
             this.multicastService = createMulticastService(addressPicker);
             initializeListeners(config);
             joiner = nodeContext.createJoiner(this);
@@ -358,6 +357,7 @@ public class Node {
             logger.warning("ManagementCenterService could not be constructed!", e);
         }
         nodeExtension.afterStart(this);
+        versionCheck.check(this, getBuildInfo().getVersion(), buildInfo.isEnterprise());
     }
 
     public void shutdown(final boolean terminate) {


### PR DESCRIPTION
Version checking operation is done after node start completes and active, because we are collecting connected client information and node has to be active first.