### PR TITLE
NamedThreadPoolExecutor removed unused constructors

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/util/executor/NamedThreadPoolExecutor.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/executor/NamedThreadPoolExecutor.java
@@ -17,7 +17,6 @@
 package com.hazelcast.util.executor;
 
 import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.RejectedExecutionHandler;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -27,30 +26,12 @@ public class NamedThreadPoolExecutor extends ThreadPoolExecutor implements Manag
     private final String name;
 
     public NamedThreadPoolExecutor(String name, int corePoolSize, int maximumPoolSize, long keepAliveTime,
-                                   TimeUnit unit, BlockingQueue<Runnable> workQueue) {
-        super(corePoolSize, maximumPoolSize, keepAliveTime, unit, workQueue);
-        this.name = name;
-    }
-
-    public NamedThreadPoolExecutor(String name, int corePoolSize, int maximumPoolSize, long keepAliveTime,
                                    TimeUnit unit, BlockingQueue<Runnable> workQueue, ThreadFactory threadFactory) {
         super(corePoolSize, maximumPoolSize, keepAliveTime, unit, workQueue, threadFactory);
         this.name = name;
     }
 
-    public NamedThreadPoolExecutor(String name, int corePoolSize, int maximumPoolSize, long keepAliveTime,
-                                   TimeUnit unit, BlockingQueue<Runnable> workQueue, RejectedExecutionHandler handler) {
-        super(corePoolSize, maximumPoolSize, keepAliveTime, unit, workQueue, handler);
-        this.name = name;
-    }
-
-    public NamedThreadPoolExecutor(String name, int corePoolSize, int maximumPoolSize, long keepAliveTime,
-                                   TimeUnit unit, BlockingQueue<Runnable> workQueue, ThreadFactory threadFactory,
-                                   RejectedExecutionHandler handler) {
-        super(corePoolSize, maximumPoolSize, keepAliveTime, unit, workQueue, threadFactory, handler);
-        this.name = name;
-    }
-
+    @Override
     public String getName() {
         return name;
     }


### PR DESCRIPTION
Constructors are not used and no tests available as well. So can be deleted.