### PR TITLE
Add "CacheEvictionConfig" back - Fix for issue #5180 (Backward compatibility of eviction configuration for cache is broken)

### DIFF
--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/config/XmlClientConfigBuilder.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/config/XmlClientConfigBuilder.java
@@ -273,7 +273,7 @@ public class XmlClientConfigBuilder extends AbstractConfigBuilder {
             evictionConfig.setSize(Integer.parseInt(getTextContent(size)));
         }
         if (maxSizePolicy != null) {
-            evictionConfig.setMaxSizePolicy(
+            evictionConfig.setMaximumSizePolicy(
                     EvictionConfig.MaxSizePolicy.valueOf(
                             upperCaseInternal(getTextContent(maxSizePolicy)))
             );

--- a/hazelcast-client-new/src/test/java/com/hazelcast/client/config/XmlClientConfigBuilderTest.java
+++ b/hazelcast-client-new/src/test/java/com/hazelcast/client/config/XmlClientConfigBuilderTest.java
@@ -247,7 +247,7 @@ public class XmlClientConfigBuilderTest {
 
         assertNotNull(nearCacheConfig.getEvictionConfig());
         assertEquals(100, nearCacheConfig.getEvictionConfig().getSize());
-        assertEquals(EvictionConfig.MaxSizePolicy.ENTRY_COUNT, nearCacheConfig.getEvictionConfig().getMaxSizePolicy());
+        assertEquals(EvictionConfig.MaxSizePolicy.ENTRY_COUNT, nearCacheConfig.getEvictionConfig().getMaximumSizePolicy());
         assertEquals(EvictionPolicy.LFU, nearCacheConfig.getEvictionConfig().getEvictionPolicy());
     }
 

--- a/hazelcast-client/src/main/java/com/hazelcast/client/config/XmlClientConfigBuilder.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/config/XmlClientConfigBuilder.java
@@ -268,7 +268,7 @@ public class XmlClientConfigBuilder extends AbstractConfigBuilder {
             evictionConfig.setSize(Integer.parseInt(getTextContent(size)));
         }
         if (maxSizePolicy != null) {
-            evictionConfig.setMaxSizePolicy(
+            evictionConfig.setMaximumSizePolicy(
                     EvictionConfig.MaxSizePolicy.valueOf(
                             upperCaseInternal(getTextContent(maxSizePolicy)))
             );

--- a/hazelcast-client/src/test/java/com/hazelcast/client/config/XmlClientConfigBuilderTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/config/XmlClientConfigBuilderTest.java
@@ -247,7 +247,7 @@ public class XmlClientConfigBuilderTest {
 
         assertNotNull(nearCacheConfig.getEvictionConfig());
         assertEquals(100, nearCacheConfig.getEvictionConfig().getSize());
-        assertEquals(EvictionConfig.MaxSizePolicy.ENTRY_COUNT, nearCacheConfig.getEvictionConfig().getMaxSizePolicy());
+        assertEquals(EvictionConfig.MaxSizePolicy.ENTRY_COUNT, nearCacheConfig.getEvictionConfig().getMaximumSizePolicy());
         assertEquals(EvictionPolicy.LFU, nearCacheConfig.getEvictionConfig().getEvictionPolicy());
     }
 

--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastConfigBeanDefinitionParser.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastConfigBeanDefinitionParser.java
@@ -679,7 +679,7 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
                 evictionConfig.setSize(Integer.parseInt(getTextContent(size)));
             }
             if (maxSizePolicy != null) {
-                evictionConfig.setMaxSizePolicy(
+                evictionConfig.setMaximumSizePolicy(
                         EvictionConfig.MaxSizePolicy.valueOf(
                                 upperCaseInternal(getTextContent(maxSizePolicy)))
                 );

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/context/TestJCache.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/context/TestJCache.java
@@ -91,7 +91,7 @@ public class TestJCache {
         assertNotNull(simpleConfig.getEvictionConfig());
         assertEquals(50, simpleConfig.getEvictionConfig().getSize());
         assertEquals(EvictionConfig.MaxSizePolicy.ENTRY_COUNT,
-                simpleConfig.getEvictionConfig().getMaxSizePolicy());
+                simpleConfig.getEvictionConfig().getMaximumSizePolicy());
         assertEquals(EvictionPolicy.LRU, simpleConfig.getEvictionConfig().getEvictionPolicy());
 
         NearCacheConfig nearCacheConfig = simpleConfig.getNearCacheConfig();
@@ -106,7 +106,7 @@ public class TestJCache {
 
         assertNotNull(nearCacheConfig.getEvictionConfig());
         assertEquals(100, nearCacheConfig.getEvictionConfig().getSize());
-        assertEquals(EvictionConfig.MaxSizePolicy.ENTRY_COUNT, nearCacheConfig.getEvictionConfig().getMaxSizePolicy());
+        assertEquals(EvictionConfig.MaxSizePolicy.ENTRY_COUNT, nearCacheConfig.getEvictionConfig().getMaximumSizePolicy());
         assertEquals(EvictionPolicy.LFU, nearCacheConfig.getEvictionConfig().getEvictionPolicy());
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheRecordStore.java
@@ -123,7 +123,7 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
         }
         final Factory<ExpiryPolicy> expiryPolicyFactory = cacheConfig.getExpiryPolicyFactory();
         this.defaultExpiryPolicy = expiryPolicyFactory.create();
-        this.maxSizeChecker = createCacheMaxSizeChecker(evictionConfig.getSize(), evictionConfig.getMaxSizePolicy());
+        this.maxSizeChecker = createCacheMaxSizeChecker(evictionConfig.getSize(), evictionConfig.getMaximumSizePolicy());
         this.evictionPolicyEvaluator = createEvictionPolicyEvaluator(evictionConfig);
         this.evictionChecker = createEvictionChecker(evictionConfig);
         this.evictionStrategy = createEvictionStrategy(evictionConfig);

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/nearcache/impl/store/BaseHeapNearCacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/nearcache/impl/store/BaseHeapNearCacheRecordStore.java
@@ -37,7 +37,7 @@ public abstract class BaseHeapNearCacheRecordStore<K, V, R extends NearCacheReco
     protected MaxSizeChecker createNearCacheMaxSizeChecker(EvictionConfig evictionConfig,
                                                            NearCacheConfig nearCacheConfig,
                                                            NearCacheContext nearCacheContext) {
-        EvictionConfig.MaxSizePolicy maxSizePolicy = evictionConfig.getMaxSizePolicy();
+        EvictionConfig.MaxSizePolicy maxSizePolicy = evictionConfig.getMaximumSizePolicy();
         if (maxSizePolicy == null) {
             throw new IllegalArgumentException("Max-Size policy cannot be null");
         }

--- a/hazelcast/src/main/java/com/hazelcast/config/CacheConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CacheConfig.java
@@ -53,7 +53,9 @@ public class CacheConfig<K, V>
     // Default value of eviction config is
     //      * ENTRY_COUNT with 10.000 max entry count
     //      * LRU as eviction policy
-    private EvictionConfig evictionConfig = new EvictionConfig();
+    // TODO Change to "EvictionConfig" instead of "CacheEvictionConfig" in the future
+    // since "CacheEvictionConfig" is deprecated
+    private CacheEvictionConfig evictionConfig = new CacheEvictionConfig();
 
     private NearCacheConfig nearCacheConfig;
 
@@ -78,7 +80,7 @@ public class CacheConfig<K, V>
             this.inMemoryFormat = config.inMemoryFormat;
             // Eviction config cannot be null
             if (config.evictionConfig != null) {
-                this.evictionConfig = new EvictionConfig(config.evictionConfig);
+                this.evictionConfig = new CacheEvictionConfig(config.evictionConfig);
             }
             if (config.nearCacheConfig != null) {
                 this.nearCacheConfig = new NearCacheConfig(config.nearCacheConfig);
@@ -115,7 +117,7 @@ public class CacheConfig<K, V>
         this.inMemoryFormat = simpleConfig.getInMemoryFormat();
         // Eviction config cannot be null
         if (simpleConfig.getEvictionConfig() != null) {
-            this.evictionConfig = new EvictionConfig(simpleConfig.getEvictionConfig());
+            this.evictionConfig = new CacheEvictionConfig(simpleConfig.getEvictionConfig());
         }
         if (simpleConfig.getNearCacheConfig() != null) {
             this.nearCacheConfig = new NearCacheConfig(simpleConfig.getNearCacheConfig());
@@ -285,7 +287,7 @@ public class CacheConfig<K, V>
      *
      * @return the {@link EvictionConfig} instance for eviction configuration
      */
-    public EvictionConfig getEvictionConfig() {
+    public CacheEvictionConfig getEvictionConfig() {
         return evictionConfig;
     }
 
@@ -296,7 +298,15 @@ public class CacheConfig<K, V>
      * @return current cache config instance
      */
     public CacheConfig setEvictionConfig(EvictionConfig evictionConfig) {
-        this.evictionConfig = isNotNull(evictionConfig, "Eviction config cannot be null !");
+        isNotNull(evictionConfig, "Eviction config cannot be null !");
+
+        // TODO Remove this check in the future since "CacheEvictionConfig" is deprecated
+        if (evictionConfig instanceof CacheEvictionConfig) {
+            this.evictionConfig = (CacheEvictionConfig) evictionConfig;
+        } else {
+            this.evictionConfig = new CacheEvictionConfig(evictionConfig);
+        }
+
         return this;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/config/CacheConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CacheConfig.java
@@ -287,6 +287,8 @@ public class CacheConfig<K, V>
      *
      * @return the {@link EvictionConfig} instance for eviction configuration
      */
+    // TODO Change to "EvictionConfig" instead of "CacheEvictionConfig" in the future
+    // since "CacheEvictionConfig" is deprecated
     public CacheEvictionConfig getEvictionConfig() {
         return evictionConfig;
     }

--- a/hazelcast/src/main/java/com/hazelcast/config/CacheConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CacheConfigReadOnly.java
@@ -21,10 +21,10 @@ import java.util.Collections;
 import java.util.Set;
 
 /**
- * Contains the configuration for an {@link com.hazelcast.cache.ICache} (read-only).
+ * Readonly version of {@link com.hazelcast.config.CacheConfig}
  *
- * @param <K>
- * @param <V>
+ * @param <K> type of the key
+ * @param <V> type of the value
  */
 public class CacheConfigReadOnly<K, V> extends CacheConfig<K, V> {
 
@@ -32,13 +32,39 @@ public class CacheConfigReadOnly<K, V> extends CacheConfig<K, V> {
         super(config);
     }
 
+    // TODO Change to "EvictionConfig" instead of "CacheEvictionConfig" in the future
+    // since "CacheEvictionConfig" is deprecated
     @Override
-    public EvictionConfig getEvictionConfig() {
-        final EvictionConfig evictionConfig = super.getEvictionConfig();
+    public CacheEvictionConfig getEvictionConfig() {
+        final CacheEvictionConfig evictionConfig = super.getEvictionConfig();
         if (evictionConfig == null) {
             return null;
         }
-        return evictionConfig.getAsReadOnly();
+        return (CacheEvictionConfig) evictionConfig.getAsReadOnly();
+    }
+
+    @Override
+    public NearCacheConfig getNearCacheConfig() {
+        final NearCacheConfig nearCacheConfig = super.getNearCacheConfig();
+        if (nearCacheConfig == null) {
+            return null;
+        }
+        return nearCacheConfig.getAsReadOnly();
+    }
+
+    @Override
+    public WanReplicationRef getWanReplicationRef() {
+        final WanReplicationRef wanReplicationRef = super.getWanReplicationRef();
+        if (wanReplicationRef == null) {
+            return null;
+        }
+        return wanReplicationRef.getAsReadOnly();
+    }
+
+    @Override
+    public Iterable<CacheEntryListenerConfiguration<K, V>> getCacheEntryListenerConfigurations() {
+        Iterable<CacheEntryListenerConfiguration<K, V>> listenerConfigurations = super.getCacheEntryListenerConfigurations();
+        return Collections.unmodifiableSet((Set<CacheEntryListenerConfiguration<K, V>>) listenerConfigurations);
     }
 
     @Override
@@ -51,12 +77,6 @@ public class CacheConfigReadOnly<K, V> extends CacheConfig<K, V> {
     public CacheConfig<K, V> removeCacheEntryListenerConfiguration(
             CacheEntryListenerConfiguration<K, V> cacheEntryListenerConfiguration) {
         throw new UnsupportedOperationException("This config is read-only cache: " + getName());
-    }
-
-    @Override
-    public Iterable<CacheEntryListenerConfiguration<K, V>> getCacheEntryListenerConfigurations() {
-        Iterable<CacheEntryListenerConfiguration<K, V>> listenerConfigurations = super.getCacheEntryListenerConfigurations();
-        return Collections.unmodifiableSet((Set<CacheEntryListenerConfiguration<K, V>>) listenerConfigurations);
     }
 
     @Override
@@ -119,21 +139,4 @@ public class CacheConfigReadOnly<K, V> extends CacheConfig<K, V> {
         throw new UnsupportedOperationException("This config is read-only cache: " + getName());
     }
 
-    @Override
-    public NearCacheConfig getNearCacheConfig() {
-        final NearCacheConfig nearCacheConfig = super.getNearCacheConfig();
-        if (nearCacheConfig == null) {
-            return null;
-        }
-        return nearCacheConfig.getAsReadOnly();
-    }
-
-    @Override
-    public WanReplicationRef getWanReplicationRef() {
-        final WanReplicationRef wanReplicationRef = super.getWanReplicationRef();
-        if (wanReplicationRef == null) {
-            return null;
-        }
-        return wanReplicationRef.getAsReadOnly();
-    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/CacheEvictionConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CacheEvictionConfig.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+/**
+ * Configuration for cache eviction.
+ *
+ * @see com.hazelcast.config.EvictionConfig
+ *
+ * @deprecated Use {@link com.hazelcast.config.EvictionConfig} instead of this
+ */
+@Deprecated
+public class CacheEvictionConfig
+        extends EvictionConfig {
+
+    public CacheEvictionConfig() {
+    }
+
+    public CacheEvictionConfig(int size, MaxSizePolicy maxSizePolicy, EvictionPolicy evictionPolicy) {
+        super(size, maxSizePolicy, evictionPolicy);
+    }
+
+    public CacheEvictionConfig(EvictionConfig config) {
+        super(config);
+    }
+
+    @Override
+    public EvictionConfig getAsReadOnly() {
+        if (readOnly == null) {
+            readOnly = new CacheEvictionConfigReadOnly(this);
+        }
+        return readOnly;
+    }
+
+    @Override
+    public String toString() {
+        return "CacheEvictionConfig{"
+                + "size=" + size
+                + ", maxSizePolicy=" + maxSizePolicy
+                + ", evictionPolicy=" + evictionPolicy
+                + ", readOnly=" + readOnly
+                + '}';
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/config/CacheEvictionConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CacheEvictionConfig.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.config;
 
+import static com.hazelcast.util.Preconditions.checkNotNull;
+
 /**
  * Configuration for cache eviction.
  *
@@ -34,6 +36,10 @@ public class CacheEvictionConfig
         super(size, maxSizePolicy, evictionPolicy);
     }
 
+    public CacheEvictionConfig(int size, CacheMaxSizePolicy cacheMaxSizePolicy, EvictionPolicy evictionPolicy) {
+        super(size, cacheMaxSizePolicy != null ? cacheMaxSizePolicy.toMaxSizePolicy() : null, evictionPolicy);
+    }
+
     public CacheEvictionConfig(EvictionConfig config) {
         super(config);
     }
@@ -44,6 +50,95 @@ public class CacheEvictionConfig
             readOnly = new CacheEvictionConfigReadOnly(this);
         }
         return readOnly;
+    }
+
+    /**
+     * Cache Maximum Size Policy
+     */
+    public enum CacheMaxSizePolicy {
+        /**
+         * Decide maximum entry count according to node
+         */
+        ENTRY_COUNT,
+        /**
+         * Decide maximum size with use native memory size
+         */
+        USED_NATIVE_MEMORY_SIZE,
+        /**
+         * Decide maximum size with use native memory percentage
+         */
+        USED_NATIVE_MEMORY_PERCENTAGE,
+        /**
+         * Decide minimum free native memory size to trigger cleanup
+         */
+        FREE_NATIVE_MEMORY_SIZE,
+        /**
+         * Decide minimum free native memory percentage to trigger cleanup
+         */
+        FREE_NATIVE_MEMORY_PERCENTAGE;
+
+        public MaxSizePolicy toMaxSizePolicy() {
+            switch (this) {
+                case ENTRY_COUNT:
+                    return MaxSizePolicy.ENTRY_COUNT;
+                case USED_NATIVE_MEMORY_SIZE:
+                    return MaxSizePolicy.USED_NATIVE_MEMORY_SIZE;
+                case USED_NATIVE_MEMORY_PERCENTAGE:
+                    return MaxSizePolicy.USED_NATIVE_MEMORY_PERCENTAGE;
+                case FREE_NATIVE_MEMORY_SIZE:
+                    return MaxSizePolicy.FREE_NATIVE_MEMORY_SIZE;
+                case FREE_NATIVE_MEMORY_PERCENTAGE:
+                    return MaxSizePolicy.FREE_NATIVE_MEMORY_PERCENTAGE;
+                default:
+                    throw new IllegalArgumentException("Invalid Cache Max-Size policy for converting to MaxSizePolicy");
+            }
+        }
+
+        public static CacheMaxSizePolicy fromMaxSizePolicy(MaxSizePolicy maxSizePolicy) {
+            switch (maxSizePolicy) {
+                case ENTRY_COUNT:
+                    return CacheMaxSizePolicy.ENTRY_COUNT;
+                case USED_NATIVE_MEMORY_SIZE:
+                    return CacheMaxSizePolicy.USED_NATIVE_MEMORY_SIZE;
+                case USED_NATIVE_MEMORY_PERCENTAGE:
+                    return CacheMaxSizePolicy.USED_NATIVE_MEMORY_PERCENTAGE;
+                case FREE_NATIVE_MEMORY_SIZE:
+                    return CacheMaxSizePolicy.FREE_NATIVE_MEMORY_SIZE;
+                case FREE_NATIVE_MEMORY_PERCENTAGE:
+                    return CacheMaxSizePolicy.FREE_NATIVE_MEMORY_PERCENTAGE;
+                default:
+                    throw new IllegalArgumentException("Invalid Max-Size policy for converting to CacheMaxSizePolicy");
+            }
+        }
+    }
+
+    /**
+     * Gets the {@link com.hazelcast.config.EvictionConfig.MaxSizePolicy} as
+     * {@link com.hazelcast.config.CacheEvictionConfig.CacheMaxSizePolicy}.
+     *
+     * @return the {@link com.hazelcast.config.EvictionConfig.MaxSizePolicy} as
+     * {@link com.hazelcast.config.CacheEvictionConfig.CacheMaxSizePolicy}
+     *
+     * @deprecated Use {@link com.hazelcast.config.EvictionConfig#getMaximumSizePolicy()} instead of this
+     */
+    public CacheMaxSizePolicy getMaxSizePolicy() {
+        return CacheMaxSizePolicy.fromMaxSizePolicy(getMaximumSizePolicy());
+    }
+
+    /**
+     * Sets the {@link com.hazelcast.config.EvictionConfig.MaxSizePolicy} by using specified
+     * {@link com.hazelcast.config.CacheEvictionConfig.CacheMaxSizePolicy}.
+     *
+     * @param cacheMaxSizePolicy {@link com.hazelcast.config.CacheEvictionConfig.CacheMaxSizePolicy} to be converted
+     *                           and set as {@link com.hazelcast.config.EvictionConfig.MaxSizePolicy}
+     * @return this {@link com.hazelcast.config.CacheEvictionConfig}
+     *
+     * @deprecated Use {@link com.hazelcast.config.EvictionConfig#setMaximumSizePolicy(MaxSizePolicy)} instead of this
+     */
+    public CacheEvictionConfig setMaxSizePolicy(CacheMaxSizePolicy cacheMaxSizePolicy) {
+        checkNotNull(cacheMaxSizePolicy, "Cache Max-Size policy cannot be null !");
+        setMaximumSizePolicy(cacheMaxSizePolicy.toMaxSizePolicy());
+        return this;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/config/CacheEvictionConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CacheEvictionConfigReadOnly.java
@@ -33,7 +33,12 @@ public class CacheEvictionConfigReadOnly
         throw new UnsupportedOperationException("This config is read-only");
     }
 
-    public CacheEvictionConfigReadOnly setMaxSizePolicy(MaxSizePolicy maxSizePolicy) {
+    public CacheEvictionConfigReadOnly setMaximumSizePolicy(MaxSizePolicy maxSizePolicy) {
+        throw new UnsupportedOperationException("This config is read-only");
+    }
+
+    @Override
+    public CacheEvictionConfig setMaxSizePolicy(CacheMaxSizePolicy cacheMaxSizePolicy) {
         throw new UnsupportedOperationException("This config is read-only");
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/config/CacheEvictionConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CacheEvictionConfigReadOnly.java
@@ -17,25 +17,28 @@
 package com.hazelcast.config;
 
 /**
- * Read only version of {@link com.hazelcast.config.EvictionConfig}.
+ * Read only version of {@link CacheEvictionConfig}.
+ *
+ * @deprecated Use {@link com.hazelcast.config.EvictionConfigReadOnly} instead of this
  */
-public class EvictionConfigReadOnly
-        extends EvictionConfig {
+@Deprecated
+public class CacheEvictionConfigReadOnly
+        extends CacheEvictionConfig {
 
-    public EvictionConfigReadOnly(EvictionConfig config) {
+    public CacheEvictionConfigReadOnly(EvictionConfig config) {
         super(config);
     }
 
-    public EvictionConfigReadOnly setSize(int size) {
+    public CacheEvictionConfigReadOnly setSize(int size) {
         throw new UnsupportedOperationException("This config is read-only");
     }
 
-    public EvictionConfigReadOnly setMaxSizePolicy(MaxSizePolicy maxSizePolicy) {
+    public CacheEvictionConfigReadOnly setMaxSizePolicy(MaxSizePolicy maxSizePolicy) {
         throw new UnsupportedOperationException("This config is read-only");
     }
 
     @Override
-    public EvictionConfigReadOnly setEvictionPolicy(EvictionPolicy evictionPolicy) {
+    public CacheEvictionConfigReadOnly setEvictionPolicy(EvictionPolicy evictionPolicy) {
         throw new UnsupportedOperationException("This config is read-only");
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/config/CacheSimpleConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CacheSimpleConfig.java
@@ -277,7 +277,7 @@ public class CacheSimpleConfig {
 
     // TODO Change to "EvictionConfig" instead of "CacheEvictionConfig" in the future
     // since "CacheEvictionConfig" is deprecated
-    public CacheEvictionConfig getEvictionConfig() {
+    public EvictionConfig getEvictionConfig() {
         return evictionConfig;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/config/CacheSimpleConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CacheSimpleConfig.java
@@ -78,9 +78,7 @@ public class CacheSimpleConfig {
     // Default value of eviction config is
     //      * ENTRY_COUNT with 10.000 max entry count
     //      * LRU as eviction policy
-    // TODO Change to "EvictionConfig" instead of "CacheEvictionConfig" in the future
-    // since "CacheEvictionConfig" is deprecated
-    private CacheEvictionConfig evictionConfig = new CacheEvictionConfig();
+    private EvictionConfig evictionConfig = new EvictionConfig();
     private WanReplicationRef wanReplicationRef;
     private NearCacheConfig nearCacheConfig;
 
@@ -269,28 +267,16 @@ public class CacheSimpleConfig {
     }
 
     public CacheSimpleConfig setInMemoryFormat(InMemoryFormat inMemoryFormat) {
-        isNotNull(inMemoryFormat, "In-Memory format cannot be null !");
-
-        this.inMemoryFormat = inMemoryFormat;
+        this.inMemoryFormat = isNotNull(inMemoryFormat, "In-Memory format cannot be null !");
         return this;
     }
 
-    // TODO Change to "EvictionConfig" instead of "CacheEvictionConfig" in the future
-    // since "CacheEvictionConfig" is deprecated
     public EvictionConfig getEvictionConfig() {
         return evictionConfig;
     }
 
     public CacheSimpleConfig setEvictionConfig(EvictionConfig evictionConfig) {
-        isNotNull(evictionConfig, "Eviction config cannot be null !");
-
-        // TODO Remove this check in the future since "CacheEvictionConfig" is deprecated
-        if (evictionConfig instanceof CacheEvictionConfig) {
-            this.evictionConfig = (CacheEvictionConfig) evictionConfig;
-        } else {
-            this.evictionConfig = new CacheEvictionConfig(evictionConfig);
-        }
-
+        this.evictionConfig = isNotNull(evictionConfig, "Eviction config cannot be null !");
         return this;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/config/CacheSimpleConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CacheSimpleConfig.java
@@ -78,7 +78,9 @@ public class CacheSimpleConfig {
     // Default value of eviction config is
     //      * ENTRY_COUNT with 10.000 max entry count
     //      * LRU as eviction policy
-    private EvictionConfig evictionConfig = new EvictionConfig();
+    // TODO Change to "EvictionConfig" instead of "CacheEvictionConfig" in the future
+    // since "CacheEvictionConfig" is deprecated
+    private CacheEvictionConfig evictionConfig = new CacheEvictionConfig();
     private WanReplicationRef wanReplicationRef;
     private NearCacheConfig nearCacheConfig;
 
@@ -273,14 +275,22 @@ public class CacheSimpleConfig {
         return this;
     }
 
-    public EvictionConfig getEvictionConfig() {
+    // TODO Change to "EvictionConfig" instead of "CacheEvictionConfig" in the future
+    // since "CacheEvictionConfig" is deprecated
+    public CacheEvictionConfig getEvictionConfig() {
         return evictionConfig;
     }
 
     public CacheSimpleConfig setEvictionConfig(EvictionConfig evictionConfig) {
         isNotNull(evictionConfig, "Eviction config cannot be null !");
 
-        this.evictionConfig = evictionConfig;
+        // TODO Remove this check in the future since "CacheEvictionConfig" is deprecated
+        if (evictionConfig instanceof CacheEvictionConfig) {
+            this.evictionConfig = (CacheEvictionConfig) evictionConfig;
+        } else {
+            this.evictionConfig = new CacheEvictionConfig(evictionConfig);
+        }
+
         return this;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/config/CacheSimpleConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CacheSimpleConfigReadOnly.java
@@ -21,7 +21,7 @@ import java.util.Collections;
 import java.util.List;
 
 /**
- * Readonly version of CacheSimpleConfig
+ * Readonly version of {@link com.hazelcast.config.CacheSimpleConfig}
  */
 public class CacheSimpleConfigReadOnly
         extends CacheSimpleConfig {
@@ -30,23 +30,15 @@ public class CacheSimpleConfigReadOnly
         super(cacheSimpleConfig);
     }
 
+    // TODO Change to "EvictionConfig" instead of "CacheEvictionConfig" in the future
+    // since "CacheEvictionConfig" is deprecated
     @Override
-    public EvictionConfig getEvictionConfig() {
-        final EvictionConfig evictionConfig = super.getEvictionConfig();
+    public CacheEvictionConfig getEvictionConfig() {
+        final CacheEvictionConfig evictionConfig = super.getEvictionConfig();
         if (evictionConfig == null) {
             return null;
         }
-        return evictionConfig.getAsReadOnly();
-    }
-
-    @Override
-    public CacheSimpleConfig setAsyncBackupCount(int asyncBackupCount) {
-        throw new UnsupportedOperationException("This config is read-only cache: " + getName());
-    }
-
-    @Override
-    public CacheSimpleConfig setBackupCount(int backupCount) {
-        throw new UnsupportedOperationException("This config is read-only cache: " + getName());
+        return (CacheEvictionConfig) evictionConfig.getAsReadOnly();
     }
 
     @Override
@@ -58,6 +50,16 @@ public class CacheSimpleConfigReadOnly
             readOnlyListenerConfigs.add(listenerConfig.getAsReadOnly());
         }
         return Collections.unmodifiableList(readOnlyListenerConfigs);
+    }
+
+    @Override
+    public CacheSimpleConfig setAsyncBackupCount(int asyncBackupCount) {
+        throw new UnsupportedOperationException("This config is read-only cache: " + getName());
+    }
+
+    @Override
+    public CacheSimpleConfig setBackupCount(int backupCount) {
+        throw new UnsupportedOperationException("This config is read-only cache: " + getName());
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/config/CacheSimpleConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CacheSimpleConfigReadOnly.java
@@ -30,15 +30,13 @@ public class CacheSimpleConfigReadOnly
         super(cacheSimpleConfig);
     }
 
-    // TODO Change to "EvictionConfig" instead of "CacheEvictionConfig" in the future
-    // since "CacheEvictionConfig" is deprecated
     @Override
-    public CacheEvictionConfig getEvictionConfig() {
-        final CacheEvictionConfig evictionConfig = super.getEvictionConfig();
+    public EvictionConfig getEvictionConfig() {
+        final EvictionConfig evictionConfig = super.getEvictionConfig();
         if (evictionConfig == null) {
             return null;
         }
-        return (CacheEvictionConfig) evictionConfig.getAsReadOnly();
+        return evictionConfig.getAsReadOnly();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
@@ -470,7 +470,7 @@ public class ConfigXmlGenerator {
         if (e != null) {
             xml.append("<eviction")
                     .append(" size=\"").append(e.getSize()).append("\"")
-                    .append(" max-size-policy=\"").append(e.getMaxSizePolicy()).append("\"")
+                    .append(" max-size-policy=\"").append(e.getMaximumSizePolicy()).append("\"")
                     .append(" eviction-policy=\"").append(e.getEvictionPolicy()).append("\"")
                .append("/>");
         }

--- a/hazelcast/src/main/java/com/hazelcast/config/EvictionConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/EvictionConfig.java
@@ -47,11 +47,11 @@ public class EvictionConfig
      */
     public static final EvictionPolicy DEFAULT_EVICTION_POLICY = EvictionPolicy.LRU;
 
-    private int size = DEFAULT_MAX_ENTRY_COUNT;
-    private MaxSizePolicy maxSizePolicy = MaxSizePolicy.ENTRY_COUNT;
-    private EvictionPolicy evictionPolicy = DEFAULT_EVICTION_POLICY;
+    protected int size = DEFAULT_MAX_ENTRY_COUNT;
+    protected MaxSizePolicy maxSizePolicy = MaxSizePolicy.ENTRY_COUNT;
+    protected EvictionPolicy evictionPolicy = DEFAULT_EVICTION_POLICY;
 
-    private EvictionConfigReadOnly readOnly;
+    protected EvictionConfig readOnly;
 
     public EvictionConfig() {
     }
@@ -126,7 +126,7 @@ public class EvictionConfig
         FREE_NATIVE_MEMORY_PERCENTAGE
     }
 
-    public EvictionConfigReadOnly getAsReadOnly() {
+    public EvictionConfig getAsReadOnly() {
         if (readOnly == null) {
             readOnly = new EvictionConfigReadOnly(this);
         }

--- a/hazelcast/src/main/java/com/hazelcast/config/EvictionConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/EvictionConfig.java
@@ -142,11 +142,11 @@ public class EvictionConfig
         return this;
     }
 
-    public MaxSizePolicy getMaxSizePolicy() {
+    public MaxSizePolicy getMaximumSizePolicy() {
         return maxSizePolicy;
     }
 
-    public EvictionConfig setMaxSizePolicy(MaxSizePolicy maxSizePolicy) {
+    public EvictionConfig setMaximumSizePolicy(MaxSizePolicy maxSizePolicy) {
         this.maxSizePolicy = checkNotNull(maxSizePolicy, "Max-Size policy cannot be null !");
         return this;
     }

--- a/hazelcast/src/main/java/com/hazelcast/config/EvictionConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/EvictionConfigReadOnly.java
@@ -30,7 +30,7 @@ public class EvictionConfigReadOnly
         throw new UnsupportedOperationException("This config is read-only");
     }
 
-    public EvictionConfigReadOnly setMaxSizePolicy(MaxSizePolicy maxSizePolicy) {
+    public EvictionConfigReadOnly setMaximumSizePolicy(MaxSizePolicy maxSizePolicy) {
         throw new UnsupportedOperationException("This config is read-only");
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
@@ -1016,7 +1016,7 @@ public class XmlConfigBuilder extends AbstractConfigBuilder implements ConfigBui
             evictionConfig.setSize(Integer.parseInt(getTextContent(size)));
         }
         if (maxSizePolicy != null) {
-            evictionConfig.setMaxSizePolicy(
+            evictionConfig.setMaximumSizePolicy(
                     EvictionConfig.MaxSizePolicy.valueOf(
                             upperCaseInternal(getTextContent(maxSizePolicy)))
             );

--- a/hazelcast/src/test/java/com/hazelcast/cache/CacheConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CacheConfigTest.java
@@ -98,7 +98,7 @@ public class CacheConfigTest extends HazelcastTestSupport {
         assertNotNull(cacheConfig1.getEvictionConfig());
         assertEquals(50, cacheConfig1.getEvictionConfig().getSize());
         assertEquals(EvictionConfig.MaxSizePolicy.ENTRY_COUNT,
-                cacheConfig1.getEvictionConfig().getMaxSizePolicy());
+                cacheConfig1.getEvictionConfig().getMaximumSizePolicy());
 
         List<CacheSimpleEntryListenerConfig> cacheEntryListeners = cacheConfig1.getCacheEntryListeners();
         assertEquals(2, cacheEntryListeners.size());
@@ -148,7 +148,7 @@ public class CacheConfigTest extends HazelcastTestSupport {
 
         assertNotNull(cacheConfig1.getEvictionConfig());
         assertEquals(50, cacheConfig1.getEvictionConfig().getSize());
-        assertEquals(EvictionConfig.MaxSizePolicy.ENTRY_COUNT, cacheConfig1.getEvictionConfig().getMaxSizePolicy());
+        assertEquals(EvictionConfig.MaxSizePolicy.ENTRY_COUNT, cacheConfig1.getEvictionConfig().getMaximumSizePolicy());
         assertEquals(EvictionPolicy.LFU, cacheConfig1.getEvictionConfig().getEvictionPolicy());
     }
 
@@ -171,7 +171,7 @@ public class CacheConfigTest extends HazelcastTestSupport {
 
         assertNotNull(nearCacheConfig.getEvictionConfig());
         assertEquals(100, nearCacheConfig.getEvictionConfig().getSize());
-        assertEquals(EvictionConfig.MaxSizePolicy.ENTRY_COUNT, nearCacheConfig.getEvictionConfig().getMaxSizePolicy());
+        assertEquals(EvictionConfig.MaxSizePolicy.ENTRY_COUNT, nearCacheConfig.getEvictionConfig().getMaximumSizePolicy());
         assertEquals(EvictionPolicy.LFU, nearCacheConfig.getEvictionConfig().getEvictionPolicy());
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/cache/nearcache/NearCacheRecordStoreTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/nearcache/NearCacheRecordStoreTest.java
@@ -189,7 +189,7 @@ public class NearCacheRecordStoreTest extends NearCacheRecordStoreTestSupport {
             evictionPolicy = EvictionConfig.DEFAULT_EVICTION_POLICY;
         }
         EvictionConfig evictionConfig = new EvictionConfig();
-        evictionConfig.setMaxSizePolicy(EvictionConfig.MaxSizePolicy.ENTRY_COUNT);
+        evictionConfig.setMaximumSizePolicy(EvictionConfig.MaxSizePolicy.ENTRY_COUNT);
         evictionConfig.setSize(MAX_SIZE);
         evictionConfig.setEvictionPolicy(evictionPolicy);
         nearCacheConfig.setEvictionConfig(evictionConfig);

--- a/hazelcast/src/test/java/com/hazelcast/cache/nearcache/NearCacheRecordStoreTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/nearcache/NearCacheRecordStoreTestSupport.java
@@ -2,7 +2,6 @@ package com.hazelcast.cache.nearcache;
 
 import com.hazelcast.cache.impl.nearcache.NearCacheRecordStore;
 import com.hazelcast.config.EvictionConfig;
-import com.hazelcast.config.EvictionPolicy;
 import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.config.NearCacheConfig;
 import com.hazelcast.monitor.NearCacheStats;
@@ -246,7 +245,7 @@ public abstract class NearCacheRecordStoreTestSupport extends CommonNearCacheTes
                 createNearCacheConfig(DEFAULT_NEAR_CACHE_NAME, inMemoryFormat);
 
         EvictionConfig evictionConfig = new EvictionConfig();
-        evictionConfig.setMaxSizePolicy(maxSizePolicy);
+        evictionConfig.setMaximumSizePolicy(maxSizePolicy);
         evictionConfig.setSize(size);
         nearCacheConfig.setEvictionConfig(evictionConfig);
 


### PR DESCRIPTION
Added `CacheEvictionConfig` back and used for eviction configuration of `CacheConfig` for keeping backward compatibility

Fixes #5180 