### PR TITLE
I/O scheduling bug fixed

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/WriteHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/WriteHandler.java
@@ -157,7 +157,7 @@ public final class WriteHandler extends AbstractSelectionHandler implements Runn
      * This call is only made by the IO thread.
      */
     private void unschedule() {
-        if (dirtyOutputBuffer()) {
+        if (dirtyOutputBuffer() || currentPacket != null) {
             // Because not all data was written to the socket, we need to register for OP_WRITE so we get
             // notified when the socketChannel is ready for more data.
             registerOp(SelectionKey.OP_WRITE);


### PR DESCRIPTION
When a last packet doesn't fully fit the outputBuffer then we have to re-schedule writeHandler again
otherwise there is a risk of a dangling packet - a packet which is partially written.

This is very visible in queries - a packet with QueryResult can easily exceed a size of the outputBuffer.