### PR TITLE
Improved logging in tests for SlowOperationDetector.

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryWithPredicateOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryWithPredicateOperation.java
@@ -53,7 +53,11 @@ public class PartitionWideEntryWithPredicateOperation extends PartitionWideEntry
 
     @Override
     public String toString() {
-        return "PartitionWideEntryWithPredicateOperation{}";
+        return "PartitionWideEntryWithPredicateOperation{"
+                + "name='" + name
+                + "', entryProcessor='" + entryProcessor.toString()
+                + "', predicate='" + predicate.toString()
+                + "'}";
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/query/TruePredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/TruePredicate.java
@@ -45,4 +45,9 @@ public class TruePredicate implements DataSerializable, Predicate {
     public boolean apply(Map.Entry mapEntry) {
         return true;
     }
+
+    @Override
+    public String toString() {
+        return "TruePredicate{}";
+    }
 }


### PR DESCRIPTION
* Improved logging in tests for `SlowOperationDetector`
* Made use of `assertTrueEventually()` to give `SlowOperationDetector` enough time to scan for slow operations
* Implemented `toString()` methods for `PartitionWideEntryWithPredicateOperation` and `TruePredicate`

There are still tests failing and I have no idea why exactly. So I improved the logging to gather more information if tests fail again.