### PR TITLE
Fixed tests for SlowOperationDetector

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/slowoperationdetector/SlowOperationDetectorAbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/slowoperationdetector/SlowOperationDetectorAbstractTest.java
@@ -29,7 +29,6 @@ import com.hazelcast.spi.AbstractOperation;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.impl.operationservice.InternalOperationService;
 import com.hazelcast.spi.impl.operationservice.impl.OperationServiceImpl;
-import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.util.EmptyStatement;
 
@@ -47,8 +46,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 abstract class SlowOperationDetectorAbstractTest extends HazelcastTestSupport {
-
-    static final long ASSERT_TRUE_TIMEOUT = 10;
 
     private static final String DEFAULT_KEY = "key";
     private static final String DEFAULT_VALUE = "value";
@@ -113,22 +110,12 @@ abstract class SlowOperationDetectorAbstractTest extends HazelcastTestSupport {
     }
 
     static void assertNumberOfSlowOperationLogs(final Collection<SlowOperationLog> logs, final int expected) {
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run() throws Exception {
-                assertEqualsStringFormat("Expected %d slow operation logs, but was %d.", expected, logs.size());
-            }
-        }, ASSERT_TRUE_TIMEOUT);
+        assertEqualsStringFormat("Expected %d slow operation logs, but was %d.", expected, logs.size());
     }
 
     static void assertTotalInvocations(final SlowOperationLog log, final int totalInvocations) {
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run() throws Exception {
-                assertEqualsStringFormat("Expected %d total invocations, but was %d. Log: " + log.createDTO().toJson(),
-                        totalInvocations, log.totalInvocations.get());
-            }
-        }, ASSERT_TRUE_TIMEOUT);
+        assertEqualsStringFormat("Expected %d total invocations, but was %d. Log: " + log.createDTO().toJson(),
+                totalInvocations, log.totalInvocations.get());
     }
 
     static void assertEntryProcessorOperation(SlowOperationLog log) {

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/slowoperationdetector/SlowOperationDetectorBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/slowoperationdetector/SlowOperationDetectorBasicTest.java
@@ -100,7 +100,7 @@ public class SlowOperationDetectorBasicTest extends SlowOperationDetectorAbstrac
     public void testSlowOperationOnGenericOperationThread() {
         instance = getSingleNodeCluster(1000);
 
-        SlowOperation operation = new SlowOperation(2);
+        SlowOperation operation = new SlowOperation(3);
         executeOperation(instance, operation);
         operation.await();
 
@@ -117,7 +117,7 @@ public class SlowOperationDetectorBasicTest extends SlowOperationDetectorAbstrac
     public void testSlowOperationOnPartitionOperationThread() {
         instance = getSingleNodeCluster(1000);
 
-        SlowOperation operation = new SlowOperation(4, 1);
+        SlowOperation operation = new SlowOperation(4, 2);
         executeOperation(instance, operation);
         operation.await();
 
@@ -171,13 +171,13 @@ public class SlowOperationDetectorBasicTest extends SlowOperationDetectorAbstrac
     @Test
     public void testSlowRecursiveOperation() {
         int partitionThreads = 32;
-        int numberOfOperations = 50;
-        int recursionDepth = 20;
+        int numberOfOperations = 40;
+        int recursionDepth = 15;
 
         Config config = new Config();
         config.setProperty(GroupProperties.PROP_SLOW_OPERATION_DETECTOR_THRESHOLD_MILLIS, "1000");
+        config.setProperty(GroupProperties.PROP_SLOW_OPERATION_DETECTOR_LOG_RETENTION_SECONDS, String.valueOf(Integer.MAX_VALUE));
         config.setProperty(GroupProperties.PROP_PARTITION_OPERATION_THREAD_COUNT, String.valueOf(partitionThreads));
-
         instance = createHazelcastInstance(config);
 
         List<SlowRecursiveOperation> operations = new ArrayList<SlowRecursiveOperation>(numberOfOperations);
@@ -186,7 +186,7 @@ public class SlowOperationDetectorBasicTest extends SlowOperationDetectorAbstrac
         int partitionIndex = 1;
         for (int i = 0; i < numberOfOperations; i++) {
             int partitionId = partitionIndex % partitionCount;
-            SlowRecursiveOperation operation = new SlowRecursiveOperation(partitionId, recursionDepth, 3);
+            SlowRecursiveOperation operation = new SlowRecursiveOperation(partitionId, recursionDepth, 4);
             operations.add(operation);
             executeOperation(instance, operation);
             partitionIndex += partitionCount / partitionThreads + 1;

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/slowoperationdetector/SlowOperationDetector_JsonTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/slowoperationdetector/SlowOperationDetector_JsonTest.java
@@ -98,10 +98,10 @@ public class SlowOperationDetector_JsonTest extends SlowOperationDetectorAbstrac
     @Test
     public void testJSON_SlowEntryProcessor() {
         for (int i = 0; i < 2; i++) {
-            map.executeOnEntries(getSlowEntryProcessor(2));
+            map.executeOnEntries(getSlowEntryProcessor(3));
         }
+        map.executeOnEntries(getSlowEntryProcessor(4));
         map.executeOnEntries(getSlowEntryProcessor(3));
-        map.executeOnEntries(getSlowEntryProcessor(2));
         awaitSlowEntryProcessors();
 
         logger.finest(getOperationStats(instance).toString());
@@ -114,9 +114,9 @@ public class SlowOperationDetector_JsonTest extends SlowOperationDetectorAbstrac
     @Test
     public void testJSON_multipleEntryProcessorClasses() throws InterruptedException {
         for (int i = 0; i < 2; i++) {
-            map.executeOnEntries(getSlowEntryProcessor(2));
+            map.executeOnEntries(getSlowEntryProcessor(3));
         }
-        SlowEntryProcessorChild entryProcessorChild = new SlowEntryProcessorChild(2);
+        SlowEntryProcessorChild entryProcessorChild = new SlowEntryProcessorChild(3);
         map.executeOnEntries(entryProcessorChild);
         map.executeOnEntries(getSlowEntryProcessor(4));
 


### PR DESCRIPTION
Fixed tests for SlowOperationDetector.

I finally could reproduce the problems locally. The solution was to use `@Repeat(value = 100)` on the test class, not method and let the whole test class run. The fixed tests were all run during the night on my machine and produced no errors.

The originate problem is the accuracy of the SlowOperationDetector, which has to determine the runtime of an operation completely on its own. So the detected runtime of a 3 second sleep may vary between 1001 and 3001 milliseconds. Tests were adapted to cover that range of measured results.

Should hopefully fix #5169 and #4719.