### PR TITLE
MultiMap tests are opened.

### DIFF
--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/proxy/ClientLockProxy.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/proxy/ClientLockProxy.java
@@ -53,7 +53,7 @@ public class ClientLockProxy extends ClientProxy implements ILock {
     }
 
     public boolean isLocked() {
-        ClientMessage request = LockIsLockedParameters.encode(getName(), ThreadUtil.getThreadId());
+        ClientMessage request = LockIsLockedParameters.encode(getName());
         BooleanResultParameters resultParameters =
                 BooleanResultParameters.decode((ClientMessage) invoke(request));
         return resultParameters.result;

--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/proxy/ClientMultiMapProxy.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/proxy/ClientMultiMapProxy.java
@@ -284,7 +284,12 @@ public class ClientMultiMapProxy<K, V> extends ClientProxy implements MultiMap<K
     }
 
     public void lock(K key) {
-        lock(key, -1, TimeUnit.MILLISECONDS);
+        checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
+
+        final Data keyData = toData(key);
+        ClientMessage request = MultiMapLockParameters.encode(name, keyData,
+                ThreadUtil.getThreadId(), getTimeInMillis(-1, TimeUnit.MILLISECONDS));
+        invoke(request, keyData);
     }
 
     public void lock(K key, long leaseTime, TimeUnit timeUnit) {
@@ -301,7 +306,7 @@ public class ClientMultiMapProxy<K, V> extends ClientProxy implements MultiMap<K
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
 
         final Data keyData = toData(key);
-        ClientMessage request = MultiMapIsLockedParameters.encode(name, keyData, ThreadUtil.getThreadId());
+        ClientMessage request = MultiMapIsLockedParameters.encode(name, keyData);
         ClientMessage response = invoke(request, keyData);
         BooleanResultParameters resultParameters = BooleanResultParameters.decode(response);
         return resultParameters.result;

--- a/hazelcast-client-new/src/test/java/com/hazelcast/client/multimap/ClientMultiMapListenerStressTest.java
+++ b/hazelcast-client-new/src/test/java/com/hazelcast/client/multimap/ClientMultiMapListenerStressTest.java
@@ -26,7 +26,6 @@ import static junit.framework.Assert.assertEquals;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category(NightlyTest.class)
-@Ignore
 public class ClientMultiMapListenerStressTest {
 
     private static final int MAX_SECONDS = 60 * 10;

--- a/hazelcast-client-new/src/test/java/com/hazelcast/client/multimap/ClientMultiMapListenersTest.java
+++ b/hazelcast-client-new/src/test/java/com/hazelcast/client/multimap/ClientMultiMapListenersTest.java
@@ -41,7 +41,6 @@ import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category(QuickTest.class)
-@Ignore
 public class ClientMultiMapListenersTest {
 
     static HazelcastInstance server;

--- a/hazelcast-client-new/src/test/java/com/hazelcast/client/multimap/ClientMultiMapLockTest.java
+++ b/hazelcast-client-new/src/test/java/com/hazelcast/client/multimap/ClientMultiMapLockTest.java
@@ -42,7 +42,6 @@ import static org.junit.Assert.fail;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category(QuickTest.class)
-@Ignore
 public class ClientMultiMapLockTest {
 
     static HazelcastInstance server;

--- a/hazelcast-client-new/src/test/java/com/hazelcast/client/multimap/ClientMultiMapReturnedCollectionTest.java
+++ b/hazelcast-client-new/src/test/java/com/hazelcast/client/multimap/ClientMultiMapReturnedCollectionTest.java
@@ -22,24 +22,22 @@ import com.hazelcast.config.MultiMapConfig;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.MultiMap;
-import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
 import org.junit.AfterClass;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
-import org.junit.Ignore;
 
 import java.util.Collection;
-import java.util.List;
-import java.util.Set;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
 
-@RunWith(HazelcastParallelClassRunner.class)
+@RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-@Ignore
 public class ClientMultiMapReturnedCollectionTest {
 
     static HazelcastInstance server;
@@ -47,6 +45,13 @@ public class ClientMultiMapReturnedCollectionTest {
 
     private static final String SET_MAP = "set-map";
     private static final String LIST_MAP = "list-map";
+
+    @Before
+    @After
+    public void cleanup() {
+        client.getMultiMap(SET_MAP).clear();
+        client.getMultiMap(LIST_MAP).clear();
+    }
 
     @BeforeClass
     public static void init() {
@@ -70,12 +75,12 @@ public class ClientMultiMapReturnedCollectionTest {
         MultiMap<Integer, Integer> multiMap = client.getMultiMap(SET_MAP);
 
         multiMap.put(0, 1);
+        multiMap.put(0, 1);
         multiMap.put(0, 2);
-        multiMap.put(0, 3);
 
         Collection<Integer> collection = multiMap.get(0);
 
-        assertTrue(collection instanceof Set);
+        assertEquals(2, collection.size());
     }
 
     @Test
@@ -83,7 +88,7 @@ public class ClientMultiMapReturnedCollectionTest {
         MultiMap<Integer, Integer> multiMap = client.getMultiMap(SET_MAP);
         Collection<Integer> collection = multiMap.get(0);
 
-        assertTrue(collection instanceof Set);
+        assertEquals(0, collection.size());
     }
 
     @Test
@@ -91,12 +96,12 @@ public class ClientMultiMapReturnedCollectionTest {
         MultiMap<Integer, Integer> multiMap = client.getMultiMap(LIST_MAP);
 
         multiMap.put(0, 1);
+        multiMap.put(0, 1);
         multiMap.put(0, 2);
-        multiMap.put(0, 3);
 
         Collection<Integer> collection = multiMap.get(0);
 
-        assertTrue(collection instanceof List);
+        assertEquals(3, collection.size());
     }
 
     @Test
@@ -104,7 +109,7 @@ public class ClientMultiMapReturnedCollectionTest {
         MultiMap<Integer, Integer> multiMap = client.getMultiMap(LIST_MAP);
         Collection<Integer> collection = multiMap.get(0);
 
-        assertTrue(collection instanceof List);
+        assertEquals(0, collection.size());
     }
 
 
@@ -113,12 +118,12 @@ public class ClientMultiMapReturnedCollectionTest {
         MultiMap<Integer, Integer> multiMap = client.getMultiMap(SET_MAP);
 
         multiMap.put(0, 1);
+        multiMap.put(0, 1);
         multiMap.put(0, 2);
-        multiMap.put(0, 3);
 
         Collection<Integer> collection = multiMap.remove(0);
 
-        assertTrue(collection instanceof Set);
+        assertEquals(2, collection.size());
     }
 
     @Test
@@ -126,7 +131,7 @@ public class ClientMultiMapReturnedCollectionTest {
         MultiMap<Integer, Integer> multiMap = client.getMultiMap(SET_MAP);
         Collection<Integer> collection = multiMap.remove(0);
 
-        assertTrue(collection instanceof Set);
+        assertEquals(0, collection.size());
     }
 
     @Test
@@ -134,12 +139,12 @@ public class ClientMultiMapReturnedCollectionTest {
         MultiMap<Integer, Integer> multiMap = client.getMultiMap(LIST_MAP);
 
         multiMap.put(0, 1);
+        multiMap.put(0, 1);
         multiMap.put(0, 2);
-        multiMap.put(0, 3);
 
         Collection<Integer> collection = multiMap.remove(0);
 
-        assertTrue(collection instanceof List);
+        assertEquals(3, collection.size());
     }
 
     @Test
@@ -147,6 +152,6 @@ public class ClientMultiMapReturnedCollectionTest {
         MultiMap<Integer, Integer> multiMap = client.getMultiMap(LIST_MAP);
         Collection<Integer> collection = multiMap.remove(0);
 
-        assertTrue(collection instanceof List);
+        assertEquals(0, collection.size());
     }
 }

--- a/hazelcast-client-new/src/test/java/com/hazelcast/client/multimap/ClientMultiMapTest.java
+++ b/hazelcast-client-new/src/test/java/com/hazelcast/client/multimap/ClientMultiMapTest.java
@@ -27,7 +27,6 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
-import org.junit.Ignore;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -41,7 +40,6 @@ import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category(QuickTest.class)
-@Ignore
 public class ClientMultiMapTest {
 
     static HazelcastInstance server;
@@ -113,7 +111,6 @@ public class ClientMultiMapTest {
 
     @Test
     public void testValueCount_whenKeyNotThere() {
-        final Object key = "key1";
         final MultiMap mm = client.getMultiMap(randomString());
 
         assertEquals(0, mm.valueCount("NOT_THERE"));
@@ -147,7 +144,7 @@ public class ClientMultiMapTest {
         final MultiMap mm = client.getMultiMap(randomString());
         Collection coll = mm.get("NOT_THERE");
 
-        assertEquals(Collections.EMPTY_SET, coll);
+        assertTrue(coll.isEmpty());
     }
 
     @Test
@@ -172,7 +169,7 @@ public class ClientMultiMapTest {
         final MultiMap mm = client.getMultiMap(randomString());
         Collection coll = mm.remove("NOT_THERE");
 
-        assertEquals(Collections.EMPTY_SET, coll);
+        assertTrue(coll.isEmpty());
     }
 
     @Test

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/parameters/EntryViewParameters.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/parameters/EntryViewParameters.java
@@ -20,76 +20,90 @@ import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.ClientMessageType;
 import com.hazelcast.client.impl.protocol.util.BitUtil;
 import com.hazelcast.client.impl.protocol.util.ParameterUtil;
+import com.hazelcast.map.impl.SimpleEntryView;
 import com.hazelcast.nio.serialization.Data;
 
 @edu.umd.cs.findbugs.annotations.SuppressWarnings({"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"})
 public class EntryViewParameters {
 
-
     /**
      * ClientMessageType of this message
      */
     public static final ClientMessageType TYPE = ClientMessageType.ENTRY_VIEW;
-    public Data key;
-    public Data value;
-    public long cost;
-    public long creationTime;
-    public long expirationTime;
-    public long hits;
-    public long lastAccessTime;
-    public long lastStoredTime;
-    public long lastUpdateTime;
-    public long version;
-    public long evictionCriteriaNumber;
-    public long ttl;
+
+    public SimpleEntryView<Data, Data> dataEntryView;
 
     private EntryViewParameters(ClientMessage flyweight) {
-        key = flyweight.getData();
-        value = flyweight.getData();
-        cost = flyweight.getLong();
-        creationTime = flyweight.getLong();
-        expirationTime = flyweight.getLong();
-        hits = flyweight.getLong();
-        lastAccessTime = flyweight.getLong();
-        lastStoredTime = flyweight.getLong();
-        lastUpdateTime = flyweight.getLong();
-        version = flyweight.getLong();
-        evictionCriteriaNumber = flyweight.getLong();
-        ttl = flyweight.getLong();
+        boolean isNull = flyweight.getBoolean();
+        if (isNull) {
+            return;
+        }
+        dataEntryView = new SimpleEntryView<Data, Data>();
+        dataEntryView.setKey(flyweight.getData());
+        dataEntryView.setValue(flyweight.getData());
+        dataEntryView.setCost(flyweight.getLong());
+        dataEntryView.setCreationTime(flyweight.getLong());
+        dataEntryView.setExpirationTime(flyweight.getLong());
+        dataEntryView.setHits(flyweight.getLong());
+        dataEntryView.setLastAccessTime(flyweight.getLong());
+        dataEntryView.setLastStoredTime(flyweight.getLong());
+        dataEntryView.setLastUpdateTime(flyweight.getLong());
+        dataEntryView.setVersion(flyweight.getLong());
+        dataEntryView.setEvictionCriteriaNumber(flyweight.getLong());
+        dataEntryView.setTtl(flyweight.getLong());
     }
 
     public static EntryViewParameters decode(ClientMessage flyweight) {
         return new EntryViewParameters(flyweight);
     }
 
-    public static ClientMessage encode(Data key, Data value, long cost, long creationTime,
-                                       long expirationTime, long hits, long lastAccessTime,
-                                       long lastStoredTime, long lastUpdateTime, long version,
-                                       long evictionCriteriaNumber, long ttl) {
-        final int requiredDataSize = calculateDataSize(key, value, cost, creationTime,
-                expirationTime, hits, lastAccessTime,
-                lastStoredTime, lastUpdateTime, version,
-                evictionCriteriaNumber, ttl);
+    public static ClientMessage encode(SimpleEntryView<Data, Data> dataEntryView) {
+        final int requiredDataSize = calculateDataSize(dataEntryView);
+
+
         ClientMessage clientMessage = ClientMessage.createForEncode(requiredDataSize);
         clientMessage.ensureCapacity(requiredDataSize);
         clientMessage.setMessageType(TYPE.id());
-        clientMessage.set(key).set(value).set(cost).set(creationTime).set(expirationTime)
+
+        boolean isNull;
+        if (dataEntryView == null) {
+            isNull = true;
+            clientMessage.set(isNull);
+            clientMessage.updateFrameLength();
+            return clientMessage;
+        }
+        isNull = false;
+
+        Data key = dataEntryView.getKey();
+        Data value = dataEntryView.getValue();
+        long cost = dataEntryView.getCost();
+        long creationTime = dataEntryView.getCreationTime();
+        long expirationTime = dataEntryView.getExpirationTime();
+        long hits = dataEntryView.getHits();
+        long lastAccessTime = dataEntryView.getLastAccessTime();
+        long lastStoredTime = dataEntryView.getLastStoredTime();
+        long lastUpdateTime = dataEntryView.getLastUpdateTime();
+        long version = dataEntryView.getVersion();
+        long ttl = dataEntryView.getTtl();
+        long evictionCriteriaNumber = dataEntryView.getEvictionCriteriaNumber();
+
+
+        clientMessage.set(isNull).set(key).set(value).set(cost).set(creationTime).set(expirationTime)
                 .set(hits).set(lastAccessTime).set(lastStoredTime).set(lastUpdateTime)
                 .set(version).set(evictionCriteriaNumber).set(ttl);
         clientMessage.updateFrameLength();
         return clientMessage;
     }
 
-    /**
-     * sample data size estimation
-     *
-     * @return size
-     */
-    public static int calculateDataSize(Data key, Data value, long cost, long creationTime,
-                                        long expirationTime, long hits, long lastAccessTime,
-                                        long lastStoredTime, long lastUpdateTime, long version,
-                                        long evictionCriteriaNumber, long ttl) {
-        return ClientMessage.HEADER_SIZE//
+    public static int calculateDataSize(SimpleEntryView<Data, Data> dataEntryView) {
+        int dataSize = ClientMessage.HEADER_SIZE;
+        dataSize += BitUtil.SIZE_OF_BOOLEAN;
+        if (dataEntryView == null) {
+            return dataSize;
+        }
+        Data key = dataEntryView.getKey();
+        Data value = dataEntryView.getValue();
+        return dataSize
                 + ParameterUtil.calculateDataSize(key)
                 + ParameterUtil.calculateDataSize(value)
                 + BitUtil.SIZE_OF_LONG * 10;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/parameters/LockTemplate.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/parameters/LockTemplate.java
@@ -23,7 +23,7 @@ import com.hazelcast.annotation.GenerateParameters;
 public interface LockTemplate {
 
     @EncodeMethod(id = 1)
-    void isLocked(String name, long threadId);
+    void isLocked(String name);
 
     @EncodeMethod(id = 2)
     void isLockedByCurrentThread(String name, long threadId);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/parameters/MapTemplate.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/parameters/MapTemplate.java
@@ -87,7 +87,7 @@ public interface MapTemplate {
     void tryLock(String name, Data key, long threadId, long timeout);
 
     @EncodeMethod(id = 21)
-    void isLocked(String name, Data key, long threadId);
+    void isLocked(String name, Data key);
 
     @EncodeMethod(id = 22)
     void unlock(String name, Data key, long threadId);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/parameters/MultiMapTemplate.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/parameters/MultiMapTemplate.java
@@ -75,7 +75,7 @@ public interface MultiMapTemplate {
     void tryLock(String name, Data key, long threadId, long timeout);
 
     @EncodeMethod(id = 18)
-    void isLocked(String name, Data key, long threadId);
+    void isLocked(String name, Data key);
 
     @EncodeMethod(id = 19)
     void unlock(String name, Data key, long threadId);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/lock/LockIsLockedMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/lock/LockIsLockedMessageTask.java
@@ -40,7 +40,7 @@ public class LockIsLockedMessageTask extends AbstractPartitionMessageTask<LockIs
     @Override
     protected Operation prepareOperation() {
         final Data key = serializationService.toData(parameters.name);
-        return new IsLockedOperation(new InternalLockNamespace(parameters.name), key, parameters.threadId);
+        return new IsLockedOperation(new InternalLockNamespace(parameters.name), key);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapGetEntryViewMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapGetEntryViewMessageTask.java
@@ -19,7 +19,6 @@ package com.hazelcast.client.impl.protocol.task.map;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.parameters.EntryViewParameters;
 import com.hazelcast.client.impl.protocol.parameters.MapGetEntryViewParameters;
-import com.hazelcast.client.impl.protocol.parameters.VoidResultParameters;
 import com.hazelcast.client.impl.protocol.task.AbstractPartitionMessageTask;
 import com.hazelcast.instance.Node;
 import com.hazelcast.map.impl.MapService;
@@ -30,6 +29,7 @@ import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.security.permission.ActionConstants;
 import com.hazelcast.security.permission.MapPermission;
 import com.hazelcast.spi.Operation;
+
 import java.security.Permission;
 
 public class MapGetEntryViewMessageTask extends AbstractPartitionMessageTask<MapGetEntryViewParameters> {
@@ -52,28 +52,8 @@ public class MapGetEntryViewMessageTask extends AbstractPartitionMessageTask<Map
 
     @Override
     protected ClientMessage encodeResponse(Object response) {
-        if (response == null) {
-            return VoidResultParameters.encode();
-        }
         SimpleEntryView<Data, Data> dataEntryView = (SimpleEntryView<Data, Data>) response;
-        Data key = dataEntryView.getKey();
-        Data value = dataEntryView.getValue();
-        long cost = dataEntryView.getCost();
-        long creationTime = dataEntryView.getCreationTime();
-        long expirationTime = dataEntryView.getExpirationTime();
-        long hits = dataEntryView.getHits();
-        long lastAccessTime = dataEntryView.getLastAccessTime();
-        long lastStoredTime = dataEntryView.getLastStoredTime();
-        long lastUpdateTime = dataEntryView.getLastUpdateTime();
-        long version = dataEntryView.getVersion();
-        long ttl = dataEntryView.getTtl();
-        long evictionCriteriaNumber = dataEntryView.getEvictionCriteriaNumber();
-        ClientMessage clientMessage = EntryViewParameters.encode(key, value,
-                cost, creationTime, expirationTime,
-                hits, lastAccessTime, lastStoredTime,
-                lastUpdateTime, version, evictionCriteriaNumber, ttl);
-        return clientMessage;
-
+        return EntryViewParameters.encode(dataEntryView);
     }
 
     public Permission getRequiredPermission() {

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapIsLockedMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapIsLockedMessageTask.java
@@ -41,7 +41,7 @@ public class MapIsLockedMessageTask extends AbstractPartitionMessageTask<MapIsLo
 
     @Override
     protected Operation prepareOperation() {
-        return new IsLockedOperation(getNamespace(), parameters.key, parameters.threadId);
+        return new IsLockedOperation(getNamespace(), parameters.key);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/AbstractMultiMapAddEntryListenerMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/AbstractMultiMapAddEntryListenerMessageTask.java
@@ -18,8 +18,8 @@ package com.hazelcast.client.impl.protocol.task.multimap;
 
 import com.hazelcast.client.ClientEndpoint;
 import com.hazelcast.client.impl.protocol.ClientMessage;
-import com.hazelcast.client.impl.protocol.parameters.EntryEventParameters;
 import com.hazelcast.client.impl.protocol.parameters.AddListenerResultParameters;
+import com.hazelcast.client.impl.protocol.parameters.EntryEventParameters;
 import com.hazelcast.client.impl.protocol.task.AbstractCallableMessageTask;
 import com.hazelcast.core.EntryAdapter;
 import com.hazelcast.core.EntryEvent;
@@ -33,6 +33,7 @@ import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.DefaultData;
 import com.hazelcast.security.permission.ActionConstants;
 import com.hazelcast.security.permission.MultiMapPermission;
+
 import java.security.Permission;
 
 public abstract class AbstractMultiMapAddEntryListenerMessageTask<P> extends AbstractCallableMessageTask<P> {
@@ -87,8 +88,12 @@ public abstract class AbstractMultiMapAddEntryListenerMessageTask<P> extends Abs
                             + event.getClass().getSimpleName());
                 }
                 DataAwareEntryEvent dataAwareEntryEvent = (DataAwareEntryEvent) event;
-                Data key = dataAwareEntryEvent.getKeyData();
-                Data value = dataAwareEntryEvent.getNewValueData();
+                Data keyData = dataAwareEntryEvent.getKeyData();
+                Data key = keyData == null ? DefaultData.NULL_DATA : keyData;
+
+                Data newValueData = dataAwareEntryEvent.getNewValueData();
+                Data value = newValueData == null ? DefaultData.NULL_DATA : newValueData;
+
                 final EntryEventType type = event.getEventType();
                 final String uuid = event.getMember().getUuid();
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapClearMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapClearMessageTask.java
@@ -60,7 +60,7 @@ public class MultiMapClearMessageTask extends AbstractAllPartitionsMessageTask<M
 
     @Override
     protected MultiMapClearParameters decodeClientMessage(ClientMessage clientMessage) {
-        return null;
+        return MultiMapClearParameters.decode(clientMessage);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapContainsEntryMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapContainsEntryMessageTask.java
@@ -17,6 +17,7 @@
 package com.hazelcast.client.impl.protocol.task.multimap;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
+import com.hazelcast.client.impl.protocol.parameters.BooleanResultParameters;
 import com.hazelcast.client.impl.protocol.parameters.MultiMapContainsEntryParameters;
 import com.hazelcast.client.impl.protocol.task.AbstractPartitionMessageTask;
 import com.hazelcast.instance.Node;
@@ -44,6 +45,11 @@ public class MultiMapContainsEntryMessageTask extends AbstractPartitionMessageTa
         ContainsEntryOperation operation = new ContainsEntryOperation(parameters.name, parameters.key, parameters.value);
         operation.setThreadId(parameters.threadId);
         return operation;
+    }
+
+    @Override
+    protected ClientMessage encodeResponse(Object response) {
+        return BooleanResultParameters.encode((Boolean) response);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapContainsKeyMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapContainsKeyMessageTask.java
@@ -17,6 +17,7 @@
 package com.hazelcast.client.impl.protocol.task.multimap;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
+import com.hazelcast.client.impl.protocol.parameters.BooleanResultParameters;
 import com.hazelcast.client.impl.protocol.parameters.MultiMapContainsKeyParameters;
 import com.hazelcast.client.impl.protocol.task.AbstractPartitionMessageTask;
 import com.hazelcast.instance.Node;
@@ -49,6 +50,11 @@ public class MultiMapContainsKeyMessageTask extends AbstractPartitionMessageTask
     @Override
     protected MultiMapContainsKeyParameters decodeClientMessage(ClientMessage clientMessage) {
         return MultiMapContainsKeyParameters.decode(clientMessage);
+    }
+
+    @Override
+    protected ClientMessage encodeResponse(Object response) {
+        return BooleanResultParameters.encode((Boolean) response);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapForceUnlockMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapForceUnlockMessageTask.java
@@ -18,7 +18,9 @@ package com.hazelcast.client.impl.protocol.task.multimap;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.parameters.MultiMapForceUnlockParameters;
+import com.hazelcast.client.impl.protocol.parameters.VoidResultParameters;
 import com.hazelcast.client.impl.protocol.task.AbstractPartitionMessageTask;
+import com.hazelcast.concurrent.lock.LockService;
 import com.hazelcast.concurrent.lock.operations.UnlockOperation;
 import com.hazelcast.instance.Node;
 import com.hazelcast.multimap.impl.MultiMapService;
@@ -47,13 +49,18 @@ public class MultiMapForceUnlockMessageTask extends AbstractPartitionMessageTask
     }
 
     @Override
+    protected ClientMessage encodeResponse(Object response) {
+        return VoidResultParameters.encode();
+    }
+
+    @Override
     protected MultiMapForceUnlockParameters decodeClientMessage(ClientMessage clientMessage) {
         return MultiMapForceUnlockParameters.decode(clientMessage);
     }
 
     @Override
     public String getServiceName() {
-        return MultiMapService.SERVICE_NAME;
+        return LockService.SERVICE_NAME;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapGetMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapGetMessageTask.java
@@ -61,19 +61,15 @@ public class MultiMapGetMessageTask extends AbstractPartitionMessageTask<MultiMa
 
     @Override
     protected ClientMessage encodeResponse(Object response) {
-        if (response instanceof MultiMapResponse) {
-            Collection<MultiMapRecord> responseCollection = ((MultiMapResponse) response).getCollection();
-            if (responseCollection == null) {
-                return DataCollectionResultParameters.encode(Collections.EMPTY_LIST);
-            }
-            Collection<Data> collection = createCollection(responseCollection);
-            for (MultiMapRecord record : responseCollection) {
-                collection.add(serializationService.toData(record.getObject()));
-            }
-            return DataCollectionResultParameters.encode(collection);
-
+        Collection<MultiMapRecord> responseCollection = ((MultiMapResponse) response).getCollection();
+        if (responseCollection == null) {
+            return DataCollectionResultParameters.encode(Collections.EMPTY_LIST);
         }
-        return super.encodeResponse(response);
+        Collection<Data> collection = createCollection(responseCollection);
+        for (MultiMapRecord record : responseCollection) {
+            collection.add(serializationService.toData(record.getObject()));
+        }
+        return DataCollectionResultParameters.encode(collection);
     }
 
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapIsLockedMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapIsLockedMessageTask.java
@@ -17,8 +17,10 @@
 package com.hazelcast.client.impl.protocol.task.multimap;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
+import com.hazelcast.client.impl.protocol.parameters.BooleanResultParameters;
 import com.hazelcast.client.impl.protocol.parameters.MultiMapIsLockedParameters;
 import com.hazelcast.client.impl.protocol.task.AbstractPartitionMessageTask;
+import com.hazelcast.concurrent.lock.LockService;
 import com.hazelcast.concurrent.lock.operations.IsLockedOperation;
 import com.hazelcast.instance.Node;
 import com.hazelcast.multimap.impl.MultiMapService;
@@ -43,7 +45,7 @@ public class MultiMapIsLockedMessageTask extends AbstractPartitionMessageTask<Mu
     @Override
     protected Operation prepareOperation() {
         DefaultObjectNamespace namespace = new DefaultObjectNamespace(MultiMapService.SERVICE_NAME, parameters.name);
-        return new IsLockedOperation(namespace, parameters.key, parameters.threadId);
+        return new IsLockedOperation(namespace, parameters.key);
     }
 
     @Override
@@ -52,8 +54,13 @@ public class MultiMapIsLockedMessageTask extends AbstractPartitionMessageTask<Mu
     }
 
     @Override
+    protected ClientMessage encodeResponse(Object response) {
+        return BooleanResultParameters.encode((Boolean) response);
+    }
+
+    @Override
     public String getServiceName() {
-        return MultiMapService.SERVICE_NAME;
+        return LockService.SERVICE_NAME;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapLockMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapLockMessageTask.java
@@ -18,7 +18,9 @@ package com.hazelcast.client.impl.protocol.task.multimap;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.parameters.MultiMapLockParameters;
+import com.hazelcast.client.impl.protocol.parameters.VoidResultParameters;
 import com.hazelcast.client.impl.protocol.task.AbstractPartitionMessageTask;
+import com.hazelcast.concurrent.lock.LockService;
 import com.hazelcast.concurrent.lock.operations.LockOperation;
 import com.hazelcast.instance.Node;
 import com.hazelcast.multimap.impl.MultiMapService;
@@ -48,13 +50,18 @@ public class MultiMapLockMessageTask extends AbstractPartitionMessageTask<MultiM
     }
 
     @Override
+    protected ClientMessage encodeResponse(Object response) {
+        return VoidResultParameters.encode();
+    }
+
+    @Override
     protected MultiMapLockParameters decodeClientMessage(ClientMessage clientMessage) {
         return MultiMapLockParameters.decode(clientMessage);
     }
 
     @Override
     public String getServiceName() {
-        return MultiMapService.SERVICE_NAME;
+        return LockService.SERVICE_NAME;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapPutMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapPutMessageTask.java
@@ -17,6 +17,7 @@
 package com.hazelcast.client.impl.protocol.task.multimap;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
+import com.hazelcast.client.impl.protocol.parameters.BooleanResultParameters;
 import com.hazelcast.client.impl.protocol.parameters.MultiMapPutParameters;
 import com.hazelcast.client.impl.protocol.task.AbstractPartitionMessageTask;
 import com.hazelcast.instance.Node;
@@ -47,6 +48,11 @@ public class MultiMapPutMessageTask extends AbstractPartitionMessageTask<MultiMa
     @Override
     protected MultiMapPutParameters decodeClientMessage(ClientMessage clientMessage) {
         return MultiMapPutParameters.decode(clientMessage);
+    }
+
+    @Override
+    protected ClientMessage encodeResponse(Object response) {
+        return BooleanResultParameters.encode((Boolean) response);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapRemoveEntryMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapRemoveEntryMessageTask.java
@@ -17,6 +17,7 @@
 package com.hazelcast.client.impl.protocol.task.multimap;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
+import com.hazelcast.client.impl.protocol.parameters.BooleanResultParameters;
 import com.hazelcast.client.impl.protocol.parameters.MultiMapRemoveEntryParameters;
 import com.hazelcast.client.impl.protocol.task.AbstractPartitionMessageTask;
 import com.hazelcast.instance.Node;
@@ -47,6 +48,11 @@ public class MultiMapRemoveEntryMessageTask extends AbstractPartitionMessageTask
     @Override
     protected MultiMapRemoveEntryParameters decodeClientMessage(ClientMessage clientMessage) {
         return MultiMapRemoveEntryParameters.decode(clientMessage);
+    }
+
+    @Override
+    protected ClientMessage encodeResponse(Object response) {
+        return BooleanResultParameters.encode((Boolean) response);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapRemoveMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapRemoveMessageTask.java
@@ -17,17 +17,23 @@
 package com.hazelcast.client.impl.protocol.task.multimap;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
+import com.hazelcast.client.impl.protocol.parameters.DataCollectionResultParameters;
 import com.hazelcast.client.impl.protocol.parameters.MultiMapRemoveParameters;
 import com.hazelcast.client.impl.protocol.task.AbstractPartitionMessageTask;
 import com.hazelcast.instance.Node;
+import com.hazelcast.multimap.impl.MultiMapRecord;
 import com.hazelcast.multimap.impl.MultiMapService;
+import com.hazelcast.multimap.impl.operations.MultiMapResponse;
 import com.hazelcast.multimap.impl.operations.RemoveAllOperation;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.security.permission.ActionConstants;
 import com.hazelcast.security.permission.MultiMapPermission;
 import com.hazelcast.spi.Operation;
+import com.hazelcast.nio.serialization.Data;
 
 import java.security.Permission;
+import java.util.ArrayList;
+import java.util.Collection;
 
 /**
  * Client Protocol Task for handling messages with type id:
@@ -47,6 +53,17 @@ public class MultiMapRemoveMessageTask extends AbstractPartitionMessageTask<Mult
     @Override
     protected MultiMapRemoveParameters decodeClientMessage(ClientMessage clientMessage) {
         return MultiMapRemoveParameters.decode(clientMessage);
+    }
+
+    @Override
+    protected ClientMessage encodeResponse(Object response) {
+        MultiMapResponse multiMapResponse = (MultiMapResponse) response;
+        Collection<MultiMapRecord> collection = multiMapResponse.getCollection();
+        Collection<Data> resultCollection = new ArrayList<Data>(collection.size());
+        for (MultiMapRecord multiMapRecord : collection) {
+            resultCollection.add(serializationService.toData(multiMapRecord.getObject()));
+        }
+        return DataCollectionResultParameters.encode(resultCollection);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapTryLockMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapTryLockMessageTask.java
@@ -17,8 +17,10 @@
 package com.hazelcast.client.impl.protocol.task.multimap;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
+import com.hazelcast.client.impl.protocol.parameters.BooleanResultParameters;
 import com.hazelcast.client.impl.protocol.parameters.MultiMapTryLockParameters;
 import com.hazelcast.client.impl.protocol.task.AbstractPartitionMessageTask;
+import com.hazelcast.concurrent.lock.LockService;
 import com.hazelcast.concurrent.lock.operations.LockOperation;
 import com.hazelcast.instance.Node;
 import com.hazelcast.multimap.impl.MultiMapService;
@@ -43,7 +45,6 @@ public class MultiMapTryLockMessageTask extends AbstractPartitionMessageTask<Mul
 
     @Override
     protected Operation prepareOperation() {
-
         DefaultObjectNamespace namespace = new DefaultObjectNamespace(MultiMapService.SERVICE_NAME, parameters.name);
         return new LockOperation(namespace, parameters.key, parameters.threadId, parameters.timeout);
     }
@@ -54,8 +55,13 @@ public class MultiMapTryLockMessageTask extends AbstractPartitionMessageTask<Mul
     }
 
     @Override
+    protected ClientMessage encodeResponse(Object response) {
+        return BooleanResultParameters.encode((Boolean) response);
+    }
+
+    @Override
     public String getServiceName() {
-        return MultiMapService.SERVICE_NAME;
+        return LockService.SERVICE_NAME;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapUnlockMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapUnlockMessageTask.java
@@ -18,7 +18,9 @@ package com.hazelcast.client.impl.protocol.task.multimap;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.parameters.MultiMapUnlockParameters;
+import com.hazelcast.client.impl.protocol.parameters.VoidResultParameters;
 import com.hazelcast.client.impl.protocol.task.AbstractPartitionMessageTask;
+import com.hazelcast.concurrent.lock.LockService;
 import com.hazelcast.concurrent.lock.operations.UnlockOperation;
 import com.hazelcast.instance.Node;
 import com.hazelcast.multimap.impl.MultiMapService;
@@ -47,13 +49,18 @@ public class MultiMapUnlockMessageTask extends AbstractPartitionMessageTask<Mult
     }
 
     @Override
+    protected ClientMessage encodeResponse(Object response) {
+        return VoidResultParameters.encode();
+    }
+
+    @Override
     protected MultiMapUnlockParameters decodeClientMessage(ClientMessage clientMessage) {
         return MultiMapUnlockParameters.decode(clientMessage);
     }
 
     @Override
     public String getServiceName() {
-        return MultiMapService.SERVICE_NAME;
+        return LockService.SERVICE_NAME;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapValueCountMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapValueCountMessageTask.java
@@ -17,6 +17,7 @@
 package com.hazelcast.client.impl.protocol.task.multimap;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
+import com.hazelcast.client.impl.protocol.parameters.IntResultParameters;
 import com.hazelcast.client.impl.protocol.parameters.MultiMapValueCountParameters;
 import com.hazelcast.client.impl.protocol.task.AbstractPartitionMessageTask;
 import com.hazelcast.instance.Node;
@@ -49,6 +50,11 @@ public class MultiMapValueCountMessageTask extends AbstractPartitionMessageTask<
     @Override
     protected MultiMapValueCountParameters decodeClientMessage(ClientMessage clientMessage) {
         return MultiMapValueCountParameters.decode(clientMessage);
+    }
+
+    @Override
+    protected ClientMessage encodeResponse(Object response) {
+        return IntResultParameters.encode((Integer) response);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/queue/QueueDrainMaxSizeMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/queue/QueueDrainMaxSizeMessageTask.java
@@ -36,7 +36,6 @@ import java.util.Collection;
 /**
  * Client Protocol Task for handling messages with type id:
  * {@link com.hazelcast.client.impl.protocol.parameters.QueueMessageType#QUEUE_DRAINTOMAXSIZE}
- *
  */
 public class QueueDrainMaxSizeMessageTask
         extends AbstractPartitionMessageTask<QueueDrainToMaxSizeParameters> {
@@ -72,14 +71,9 @@ public class QueueDrainMaxSizeMessageTask
 
     @Override
     protected ClientMessage encodeResponse(Object response) {
-        //TODO do we need this instanceof check???
-        if (response instanceof SerializableCollection) {
-            SerializableCollection serializableCollection = (SerializableCollection) response;
-            Collection<Data> coll = serializableCollection.getCollection();
-            final ClientMessage encode = DataCollectionResultParameters.encode(coll);
-            return encode;
-        }
-        return super.encodeResponse(response);
+        SerializableCollection serializableCollection = (SerializableCollection) response;
+        Collection<Data> coll = serializableCollection.getCollection();
+        return DataCollectionResultParameters.encode(coll);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/queue/QueueDrainMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/queue/QueueDrainMessageTask.java
@@ -72,14 +72,9 @@ public class QueueDrainMessageTask
 
     @Override
     protected ClientMessage encodeResponse(Object response) {
-        //TODO do we need this instanceof check???
-        if (response instanceof SerializableCollection) {
             SerializableCollection serializableCollection = (SerializableCollection) response;
             Collection<Data> coll = serializableCollection.getCollection();
-            final ClientMessage encode = DataCollectionResultParameters.encode(coll);
-            return encode;
-        }
-        return super.encodeResponse(response);
+            return DataCollectionResultParameters.encode(coll);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/queue/QueueIteratorMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/queue/QueueIteratorMessageTask.java
@@ -36,7 +36,6 @@ import java.util.Collection;
 /**
  * Client Protocol Task for handling messages with type id:
  * {@link com.hazelcast.client.impl.protocol.parameters.QueueMessageType#QUEUE_ITERATOR}
- *
  */
 public class QueueIteratorMessageTask
         extends AbstractPartitionMessageTask<QueueIteratorParameters> {
@@ -67,14 +66,9 @@ public class QueueIteratorMessageTask
 
     @Override
     protected ClientMessage encodeResponse(Object response) {
-        //TODO do we need this instanceof check???
-        if (response instanceof SerializableCollection) {
-            SerializableCollection serializableCollection = (SerializableCollection) response;
-            Collection<Data> coll = serializableCollection.getCollection();
-            final ClientMessage encode = DataCollectionResultParameters.encode(coll);
-            return encode;
-        }
-        return super.encodeResponse(response);
+        SerializableCollection serializableCollection = (SerializableCollection) response;
+        Collection<Data> coll = serializableCollection.getCollection();
+        return DataCollectionResultParameters.encode(coll);
     }
 
     @Override


### PR DESCRIPTION
thread id is removed from map , multimap & lock isLocked parameters. 
It is only needed by isLockedByThreadId which is already a different message type and already has threadId as parameter. 
encodeResponse method is added to forgotten MultiMap message tasks . 
MultiMap event return mull data bug is fixed. Instanceof check is removed from encodeResponse methods. 
Some client Multimap tests are opened.