### PR TITLE
WAN replication bug for map entries with a specific TTL

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/AbstractEvictableRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/AbstractEvictableRecordStore.java
@@ -396,7 +396,7 @@ abstract class AbstractEvictableRecordStore extends AbstractRecordStore {
         final long lastUpdateTime = mergingEntry.getLastUpdateTime();
         record.setLastUpdateTime(lastUpdateTime);
 
-        final long maxIdleMillis = mapContainer.getMaxIdleMillis();
+        final long maxIdleMillis = calculateMaxIdleMillis(mapContainer.getMapConfig());
         setExpirationTime(record, maxIdleMillis);
 
         markRecordStoreExpirable(record.getTtl());

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/DefaultRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/DefaultRecordStore.java
@@ -837,6 +837,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore implements 
             }
             newValue = mapDataStore.add(key, newValue, now);
             record = createRecord(key, newValue, now);
+            mergeRecordExpiration(record, mergingEntry);
             records.put(key, record);
             updateSizeEstimator(calculateRecordHeapCost(record));
         } else {
@@ -854,6 +855,9 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore implements 
                 //remove from map & invalidate.
                 deleteRecord(key);
                 return true;
+            }
+            if (newValue == mergingEntry.getValue()) {
+                mergeRecordExpiration(record, mergingEntry);
             }
             // same with the existing entry so no need to map-store etc operations.
             if (mapServiceContext.compare(name, newValue, oldValue)) {


### PR DESCRIPTION
Related to issue #254, but appears that entries with individualised TTLs are not correctly replicated to a remote cluster (hence do not expire, or do so at the default time). Looks like the TTL and ExpirationTime for the merged Record are not being set.

Fix within {Default,AbstractEvictable}RecordStore to set appropriate fields on a synced Record and excluding comparable objects with differing expiry times from being considered equivalent (hence sync skipped).