### PR TITLE
Closes #5225: `IMap#putTransient` should not store on promoted replica when write-behind is enabled. 

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/DefaultRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/DefaultRecordStore.java
@@ -126,17 +126,12 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore implements 
 
     @Override
     public Record putBackup(Data key, Object value) {
-        return putBackup(key, value, DEFAULT_TTL);
+        return putBackup(key, value, DEFAULT_TTL, false);
     }
 
-    /**
-     * @param key   the key to be processed.
-     * @param value the value to be processed.
-     * @param ttl   milliseconds. Check out {@link com.hazelcast.map.impl.proxy.MapProxySupport#putInternal}
-     * @return previous record if exists otherwise null.
-     */
+
     @Override
-    public Record putBackup(Data key, Object value, long ttl) {
+    public Record putBackup(Data key, Object value, long ttl, boolean putTransient) {
         final long now = getNow();
         markRecordStoreExpirable(ttl);
 
@@ -150,7 +145,11 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore implements 
             updateRecord(record, value, now);
             updateSizeEstimator(calculateRecordHeapCost(record));
         }
-        mapDataStore.addBackup(key, value, now);
+        if (putTransient) {
+            mapDataStore.addTransient(key, now);
+        } else {
+            mapDataStore.addBackup(key, value, now);
+        }
         return record;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/RecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/RecordStore.java
@@ -43,7 +43,14 @@ public interface RecordStore {
 
     Record putBackup(Data key, Object value);
 
-    Record putBackup(Data key, Object value, long ttl);
+    /**
+     * @param key          the key to be processed.
+     * @param value        the value to be processed.
+     * @param ttl          milliseconds. Check out {@link com.hazelcast.map.impl.proxy.MapProxySupport#putInternal}
+     * @param putTransient {@code true} if putting transient entry, otherwise {@code false}
+     * @return previous record if exists otherwise null.
+     */
+    Record putBackup(Data key, Object value, long ttl, boolean putTransient);
 
     boolean tryPut(Data dataKey, Object value, long ttl);
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/BasePutOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/BasePutOperation.java
@@ -26,9 +26,9 @@ import com.hazelcast.map.impl.record.Record;
 import com.hazelcast.map.impl.record.RecordInfo;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.BackupAwareOperation;
-import com.hazelcast.spi.impl.MutatingOperation;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.ResponseHandler;
+import com.hazelcast.spi.impl.MutatingOperation;
 
 import static com.hazelcast.map.impl.record.Records.buildRecordInfo;
 
@@ -36,6 +36,7 @@ public abstract class BasePutOperation extends LockAwareOperation implements Bac
 
     protected transient Data dataOldValue;
     protected transient EntryEventType eventType;
+    protected transient boolean putTransient;
 
     public BasePutOperation(String name, Data dataKey, Data value) {
         super(name, dataKey, value, -1);
@@ -100,7 +101,7 @@ public abstract class BasePutOperation extends LockAwareOperation implements Bac
         if (mapDataStore.isPostProcessingMapStore()) {
             dataValueForBackup = mapService.getMapServiceContext().toData(record.getValue());
         }
-        return new PutBackupOperation(name, dataKey, dataValueForBackup, replicationInfo);
+        return new PutBackupOperation(name, dataKey, dataValueForBackup, replicationInfo, putTransient);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutTransientOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutTransientOperation.java
@@ -30,6 +30,7 @@ public class PutTransientOperation extends BasePutOperation {
     @Override
     public void run() {
         recordStore.putTransient(dataKey, dataValue, ttl);
+        putTransient = true;
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/map/mapstore/writebehind/WriteBehindOnBackupsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/mapstore/writebehind/WriteBehindOnBackupsTest.java
@@ -28,13 +28,17 @@ import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.QuickTest;
-
-import static org.junit.Assert.assertEquals;
-
+import com.hazelcast.test.annotation.SlowTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+
+import java.util.Collection;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category(QuickTest.class)
@@ -66,6 +70,79 @@ public class WriteBehindOnBackupsTest extends HazelcastTestSupport {
         populateMap(map, numberOfItems);
 
         assertWriteBehindQueuesEmptyOnOwnerAndOnBackups(mapName, numberOfItems, mapStore, storeBuilder.getNodes());
+    }
+
+
+    @Test
+    public void testPutTransientDoesNotStoreEntry_onBackupPartition() {
+        String mapName = randomMapName();
+        final MapStoreWithCounter mapStore = new MapStoreWithCounter<Integer, String>();
+        TestMapUsingMapStoreBuilder<Object, Object> storeBuilder = TestMapUsingMapStoreBuilder.create();
+        final IMap<Object, Object> map = storeBuilder
+                .mapName(mapName)
+                .withMapStore(mapStore)
+                .withNodeCount(2)
+                .withNodeFactory(createHazelcastInstanceFactory(2))
+                .withWriteDelaySeconds(1)
+                .withBackupCount(1)
+                .withPartitionCount(1)
+                .withBackupProcessingDelay(1)
+                .build();
+
+
+        map.putTransient(1, 1, 1, TimeUnit.DAYS);
+
+        sleepSeconds(5);
+
+        assertEquals("There should not be any store operation", 0, mapStore.countStore.get());
+    }
+
+
+    @Test
+    @Category(SlowTest.class)
+    public void testPutTransientDoesNotStoreEntry_onPromotedReplica() {
+        String mapName = randomMapName();
+        final MapStoreWithCounter mapStore = new MapStoreWithCounter<Integer, String>();
+        TestMapUsingMapStoreBuilder<String, Object> storeBuilder = TestMapUsingMapStoreBuilder.create();
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(2);
+        final IMap<String, Object> map = storeBuilder
+                .mapName(mapName)
+                .withMapStore(mapStore)
+                .withNodeCount(2)
+                .withNodeFactory(factory)
+                .withWriteDelaySeconds(5)
+                .withBackupCount(1)
+                .withPartitionCount(1)
+                .withBackupProcessingDelay(1)
+                .build();
+
+
+        String key = generateKeyOwnedByFirstNode(factory);
+
+        map.putTransient(key, 1, 1, TimeUnit.DAYS);
+
+        killFirstNode(factory);
+
+        sleepSeconds(10);
+
+        assertEquals("There should not be any store operation on promoted replica", 0, mapStore.countStore.get());
+    }
+
+    private void killFirstNode(TestHazelcastInstanceFactory factory) {
+        Collection<HazelcastInstance> nodes = factory.getAllHazelcastInstances();
+        for (HazelcastInstance node : nodes) {
+            node.shutdown();
+            return;
+        }
+    }
+
+    private String generateKeyOwnedByFirstNode(TestHazelcastInstanceFactory factory) {
+        String key = null;
+        Collection<HazelcastInstance> nodes = factory.getAllHazelcastInstances();
+        for (HazelcastInstance node : nodes) {
+            return HazelcastTestSupport.generateKeyOwnedBy(node);
+        }
+        return key;
     }
 
     private void assertWriteBehindQueuesEmptyOnOwnerAndOnBackups(final String mapName,


### PR DESCRIPTION
Closes https://github.com/hazelcast/hazelcast/issues/5225

- Added `putTransient` flag to `PutBackupOperation`
- Fixed `StoreWorker` problems caused by refactorings for 3.5.