### PR TITLE
Fix timeout issue of nightly build

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/AbstractMapQueryMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/AbstractMapQueryMessageTask.java
@@ -63,10 +63,9 @@ public abstract class AbstractMapQueryMessageTask<P> extends AbstractCallableMes
     protected final ClientMessage call() throws Exception {
         Collection<QueryResultEntry> result = new LinkedList<QueryResultEntry>();
 
-        Predicate predicate = getPredicate();
-
         Collection<MemberImpl> members = nodeEngine.getClusterService().getMemberList();
         List<Future> futures = new ArrayList<Future>();
+        Predicate predicate = getPredicate();
         createInvocations(members, futures, predicate);
 
         int partitionCount = nodeEngine.getPartitionService().getPartitionCount();

--- a/hazelcast/src/main/java/com/hazelcast/map/QueryResultSizeExceededException.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/QueryResultSizeExceededException.java
@@ -27,6 +27,10 @@ import static java.lang.String.format;
  */
 public class QueryResultSizeExceededException extends HazelcastException {
 
+    public QueryResultSizeExceededException(String message) {
+        super(message);
+    }
+
     public QueryResultSizeExceededException() {
         super("This exception has been thrown to prevent an OOME on this Hazelcast instance."
                 + " An OOME might occur when a query collects large data sets from the whole cluster,"

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/BasicMapContextQuerySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/BasicMapContextQuerySupport.java
@@ -142,9 +142,10 @@ class BasicMapContextQuerySupport implements MapContextQuerySupport {
             if (partitionIds.isEmpty()) {
                 return result;
             }
-        } catch (QueryResultSizeExceededException e) {
-            throw ExceptionUtil.rethrow(e);
         } catch (Throwable t) {
+            if (t.getCause() instanceof QueryResultSizeExceededException) {
+                throw ExceptionUtil.rethrow(t);
+            }
             logger.warning("Could not get results", t);
         }
 
@@ -182,9 +183,10 @@ class BasicMapContextQuerySupport implements MapContextQuerySupport {
                 PagingPredicateAccessor.setPagingPredicateAnchor(pagingPredicate, ((SortedQueryResultSet) result).last());
                 return result;
             }
-        } catch (QueryResultSizeExceededException e) {
-            throw ExceptionUtil.rethrow(e);
         } catch (Throwable t) {
+            if (t.getCause() instanceof QueryResultSizeExceededException) {
+                throw ExceptionUtil.rethrow(t);
+            }
             logger.warning("Could not get results", t);
         }
 
@@ -219,9 +221,10 @@ class BasicMapContextQuerySupport implements MapContextQuerySupport {
                 PagingPredicateAccessor.setPagingPredicateAnchor(pagingPredicate, ((SortedQueryResultSet) result).last());
                 return result;
             }
-        } catch (QueryResultSizeExceededException e) {
-            throw ExceptionUtil.rethrow(e);
         } catch (Throwable t) {
+            if (t.getCause() instanceof QueryResultSizeExceededException) {
+                throw ExceptionUtil.rethrow(t);
+            }
             logger.warning("Could not get results", t);
         }
 
@@ -263,9 +266,10 @@ class BasicMapContextQuerySupport implements MapContextQuerySupport {
             if (partitionIds.isEmpty()) {
                 return result;
             }
-        } catch (QueryResultSizeExceededException e) {
-            throw ExceptionUtil.rethrow(e);
         } catch (Throwable t) {
+            if (t.getCause() instanceof QueryResultSizeExceededException) {
+                throw ExceptionUtil.rethrow(t);
+            }
             logger.warning("Could not get results", t);
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/client/AbstractMapQueryRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/client/AbstractMapQueryRequest.java
@@ -42,6 +42,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
 import static com.hazelcast.map.impl.MapService.SERVICE_NAME;
@@ -97,8 +98,7 @@ abstract class AbstractMapQueryRequest extends InvocationClientRequest implement
 
     @SuppressWarnings("unchecked")
     private void collectResults(QueryResultSet result, List<Future> futures, Set<Integer> finishedPartitions)
-            throws InterruptedException, java.util.concurrent.ExecutionException {
-
+            throws InterruptedException, ExecutionException {
         for (Future future : futures) {
             QueryResult queryResult = (QueryResult) future.get();
             if (queryResult != null) {
@@ -141,7 +141,7 @@ abstract class AbstractMapQueryRequest extends InvocationClientRequest implement
 
     @SuppressWarnings("unchecked")
     private void collectResultsFromMissingPartitions(QueryResultSet result, List<Future> futures)
-            throws InterruptedException, java.util.concurrent.ExecutionException {
+            throws InterruptedException, ExecutionException {
         for (Future future : futures) {
             QueryResult queryResult = (QueryResult) future.get();
             result.addAll(queryResult.getResult());

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TransactionalMapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TransactionalMapProxySupport.java
@@ -295,9 +295,10 @@ public abstract class TransactionalMapProxySupport extends AbstractDistributedOb
             if (partitions.size() == partitionCount) {
                 return result;
             }
-        } catch (QueryResultSizeExceededException e) {
-            throw ExceptionUtil.rethrow(e);
         } catch (Throwable t) {
+            if (t.getCause() instanceof QueryResultSizeExceededException) {
+                throw ExceptionUtil.rethrow(t);
+            }
             EmptyStatement.ignore(t);
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/map/MapUnboundedReturnValuesTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapUnboundedReturnValuesTestSupport.java
@@ -13,7 +13,7 @@ import com.hazelcast.query.TruePredicate;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.transaction.TransactionContext;
-import com.hazelcast.util.EmptyStatement;
+import com.hazelcast.util.ExceptionUtil;
 
 import java.util.Set;
 
@@ -208,6 +208,13 @@ abstract class MapUnboundedReturnValuesTestSupport extends HazelcastTestSupport 
         assertEquals("Expected map size of map to match limit " + limit, limit, map.size());
     }
 
+    private void checkException(QueryResultSizeExceededException e) {
+        String exception = ExceptionUtil.toString(e);
+        if (exception.contains("QueryPartitionOperation")) {
+            fail("QueryResultSizeExceededException was thrown by QueryPartitionOperation:\n" + exception);
+        }
+    }
+
     private void failExpectedException(String methodName) {
         fail(format("Expected QueryResultSizeExceededException while calling %s with limit %d and upperLimit %d",
                 methodName, configLimit, upperLimit));
@@ -250,7 +257,7 @@ abstract class MapUnboundedReturnValuesTestSupport extends HazelcastTestSupport 
             fail(format("Limit should have exceeded, but ran into upperLimit of %d with IMap.keySet() size of %d",
                     upperLimit, keySetSize));
         } catch (QueryResultSizeExceededException e) {
-            EmptyStatement.ignore(e);
+            checkException(e);
         }
         logger.info(format("Limit of %d exceeded at %d (%.2f)", configLimit, index, (index * 100f / configLimit)));
 
@@ -275,42 +282,42 @@ abstract class MapUnboundedReturnValuesTestSupport extends HazelcastTestSupport 
             map.values(TruePredicate.INSTANCE);
             failExpectedException("IMap.values(predicate)");
         } catch (QueryResultSizeExceededException e) {
-            EmptyStatement.ignore(e);
+            checkException(e);
         }
 
         try {
             map.keySet(TruePredicate.INSTANCE);
             failExpectedException("IMap.keySet(predicate)");
         } catch (QueryResultSizeExceededException e) {
-            EmptyStatement.ignore(e);
+            checkException(e);
         }
 
         try {
             map.entrySet(TruePredicate.INSTANCE);
             failExpectedException("IMap.entrySet(predicate)");
         } catch (QueryResultSizeExceededException e) {
-            EmptyStatement.ignore(e);
+            checkException(e);
         }
 
         try {
             map.values();
             failExpectedException("IMap.values()");
         } catch (QueryResultSizeExceededException e) {
-            EmptyStatement.ignore(e);
+            checkException(e);
         }
 
         try {
             map.keySet();
             failExpectedException("IMap.keySet()");
         } catch (QueryResultSizeExceededException e) {
-            EmptyStatement.ignore(e);
+            checkException(e);
         }
 
         try {
             map.entrySet();
             failExpectedException("IMap.entrySet()");
         } catch (QueryResultSizeExceededException e) {
-            EmptyStatement.ignore(e);
+            checkException(e);
         }
     }
 
@@ -326,14 +333,14 @@ abstract class MapUnboundedReturnValuesTestSupport extends HazelcastTestSupport 
             map.localKeySet();
             failExpectedException("IMap.localKeySet()");
         } catch (QueryResultSizeExceededException e) {
-            EmptyStatement.ignore(e);
+            checkException(e);
         }
 
         try {
             map.localKeySet(TruePredicate.INSTANCE);
             failExpectedException("IMap.localKeySet(predicate)");
         } catch (QueryResultSizeExceededException e) {
-            EmptyStatement.ignore(e);
+            checkException(e);
         }
     }
 
@@ -353,14 +360,14 @@ abstract class MapUnboundedReturnValuesTestSupport extends HazelcastTestSupport 
             txnMap.values(TruePredicate.INSTANCE);
             failExpectedException("TransactionalMap.values(predicate)");
         } catch (QueryResultSizeExceededException e) {
-            EmptyStatement.ignore(e);
+            checkException(e);
         }
 
         try {
             txnMap.keySet(TruePredicate.INSTANCE);
             failExpectedException("TransactionalMap.keySet(predicate)");
         } catch (QueryResultSizeExceededException e) {
-            EmptyStatement.ignore(e);
+            checkException(e);
         }
 
         transactionContext.rollbackTransaction();


### PR DESCRIPTION
* Fixed issue that a `QueryResultSizeExceededException` from a `QueryOperation` was not correctly catched, so the `QueryPartitionOperation` fallback was executed
* Fixed some issues with new tests for unbound return values feature and new client (missing constructor in `QueryResultSizeExceededException`)

There are still tests failing, but they shouldn't timeout anymore. So with this PR the nightly build should finish again. We still have to investigate why some of the tests end up with a `TargetDisconnectedException`.

At least some of the tests are working properly now:
![new-client-tests](https://cloud.githubusercontent.com/assets/4196298/7456729/ff7534f6-f286-11e4-84e6-02648f259adc.png)

Should fix timeout due to https://github.com/hazelcast/hazelcast/issues/5172.