### PR TITLE
Fixed a race condition in join mechanism where both member-map and membe...

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/ClusterServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/ClusterServiceImpl.java
@@ -564,10 +564,6 @@ public final class ClusterServiceImpl implements ClusterService, ConnectionListe
             return;
         }
 
-        if (isJoinRequestFromAnExistingMember(joinRequest, connection)) {
-            return;
-        }
-
         if (!node.isMaster()) {
             sendMasterAnswer(joinRequest.getAddress());
             return;
@@ -583,6 +579,10 @@ public final class ClusterServiceImpl implements ClusterService, ConnectionListe
 
         lock.lock();
         try {
+            if (isJoinRequestFromAnExistingMember(joinRequest, connection)) {
+                return;
+            }
+
             long now = Clock.currentTimeMillis();
             if (logger.isFinestEnabled()) {
                 String msg = "Handling join from " + joinRequest.getAddress() + ", inProgress: " + joinInProgress
@@ -695,26 +695,21 @@ public final class ClusterServiceImpl implements ClusterService, ConnectionListe
             return true;
         }
 
-        lock.lock();
-        try {
-            // If this node is master then remove old member and process join request.
-            // If requesting address is equal to master node's address, that means master node
-            // somehow disconnected and wants to join back.
-            // So drop old member and process join request if this node becomes master.
-            if (node.isMaster() || target.equals(node.getMasterAddress())) {
-                logger.warning("New join request has been received from an existing endpoint! => " + member
-                        + " Removing old member and processing join request...");
+        // If this node is master then remove old member and process join request.
+        // If requesting address is equal to master node's address, that means master node
+        // somehow disconnected and wants to join back.
+        // So drop old member and process join request if this node becomes master.
+        if (node.isMaster() || target.equals(node.getMasterAddress())) {
+            logger.warning("New join request has been received from an existing endpoint! => " + member
+                    + " Removing old member and processing join request...");
 
-                doRemoveAddress(target, false);
-                Connection existing = node.connectionManager.getConnection(target);
-                if (existing != connection) {
-                    node.connectionManager.destroyConnection(existing);
-                    node.connectionManager.registerConnection(target, connection);
-                }
-                return false;
+            doRemoveAddress(target, false);
+            Connection existing = node.connectionManager.getConnection(target);
+            if (existing != connection) {
+                node.connectionManager.destroyConnection(existing);
+                node.connectionManager.registerConnection(target, connection);
             }
-        } finally {
-            lock.unlock();
+            return false;
         }
         return true;
     }
@@ -813,7 +808,8 @@ public final class ClusterServiceImpl implements ClusterService, ConnectionListe
                 public void run() {
                     lifecycleService.fireLifecycleEvent(MERGING);
                     final NodeEngineImpl nodeEngine = node.nodeEngine;
-                    final Collection<SplitBrainHandlerService> services = nodeEngine.getServices(SplitBrainHandlerService.class);
+                    final Collection<SplitBrainHandlerService> services = nodeEngine
+                            .getServices(SplitBrainHandlerService.class);
                     final Collection<Runnable> tasks = new LinkedList<Runnable>();
                     for (SplitBrainHandlerService service : services) {
                         final Runnable runnable = service.prepareMergeRunnable();


### PR DESCRIPTION
...r-list references are read together without synchronization. While master node handling a join request from an endpoint, it can happen that a new join request is received from the same endpoint and master returns success response immediately when endpoint is found in member-map. But problem is, update of member-map and member-list references is not atomic, one should not read both references and expect them to be consistent without proper synchronization.

- Moved `isJoinRequestFromAnExistingMember()` method inside the lock block.

Fixes #5129

ps: Thanks @eminn for finding the root cause