### PR TITLE
Replicatedmap speed improvements backport

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/core/ReplicatedMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/ReplicatedMap.java
@@ -127,24 +127,28 @@ public interface ReplicatedMap<K, V>
     String addEntryListener(EntryListener<K, V> listener, Predicate<K, V> predicate, K key);
 
     /**
-     * Returns a {@link Collection} view of the values contained in this map.
+     * Returns a lazy {@link Collection} view of the values contained in this map.
      * The collection is <b>NOT</b> backed by the map, so changes to the map are
      * <b>NOT</b> reflected in the collection, and vice-versa.<br/>
      * The order of the elements is not guaranteed due to the internal
      * asynchronous replication behavior. If a specific order is needed, use
      * {@link #values(java.util.Comparator)} to force reordering of the
-     * elements before returning.
+     * elements before returning.<br/>
+     * Changes to any returned object are <b>NOT</b> replicated back to other
+     * members.
      *
      * @return a collection view of the values contained in this map
      */
     Collection<V> values();
 
     /**
-     * Returns a {@link Collection} view of the values contained in this map.
+     * Returns a eagerly populated {@link Collection} view of the values contained in this map.
      * The collection is <b>NOT</b> backed by the map, so changes to the map are
      * <b>NOT</b> reflected in the collection, and vice-versa.<br/>
      * The order of the elements is guaranteed by executing the given
-     * {@link java.util.Comparator} before returning the elements.
+     * {@link java.util.Comparator} before returning the elements.<br/>
+     * Changes to any returned object are <b>NOT</b> replicated back to other
+     * members.
      *
      * @param comparator the Comparator to sort the returned elements
      * @return a collection view of the values contained in this map
@@ -152,14 +156,28 @@ public interface ReplicatedMap<K, V>
     Collection<V> values(Comparator<V> comparator);
 
     /**
-     * Returns a {@link Set} view of the mappings contained in this map.
+     * Returns a lazy {@link Set} view of the mappings contained in this map.
      * The set is <b>NOT</b> backed by the map, so changes to the map are
      * <b>NOT</b> reflected in the set, and vice-versa.<br/>
      * The order of the elements is not guaranteed due to the internal
-     * asynchronous replication behavior.
+     * asynchronous replication behavior.<br/>
+     * Changes to any returned object are <b>NOT</b> replicated back to other
+     * members.
      *
      * @return a set view of the mappings contained in this map
      */
     Set<Entry<K, V>> entrySet();
 
+    /**
+     * Returns a lazy {@link Set} view of the key contained in this map.
+     * The set is <b>NOT</b> backed by the map, so changes to the map are
+     * <b>NOT</b> reflected in the set, and vice-versa.<br/>
+     * The order of the elements is not guaranteed due to the internal
+     * asynchronous replication behavior.<br/>
+     * Changes to any returned object are <b>NOT</b> replicated back to other
+     * members.
+     *
+     * @return a collection view of the keys contained in this map
+     */
+    Set<K> keySet();
 }

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/EntrySetIteratorFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/EntrySetIteratorFactory.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.replicatedmap.impl.record;
+
+import com.hazelcast.replicatedmap.impl.record.LazySet.IteratorFactory;
+
+import java.util.AbstractMap;
+import java.util.Iterator;
+import java.util.Map;
+
+class EntrySetIteratorFactory<K, V>
+        implements IteratorFactory<K, V, Map.Entry<K, V>> {
+
+    private final ReplicatedRecordStore recordStore;
+
+    EntrySetIteratorFactory(ReplicatedRecordStore recordStore) {
+        this.recordStore = recordStore;
+    }
+
+    @Override
+    public Iterator<Map.Entry<K, V>> create(final Iterator<Map.Entry<K, ReplicatedRecord<K, V>>> iterator) {
+        return new Iterator<Map.Entry<K, V>>() {
+            private Map.Entry<K, ReplicatedRecord<K, V>> entry;
+
+            @Override
+            public boolean hasNext() {
+                while (iterator.hasNext()) {
+                    entry = iterator.next();
+                    if (!entry.getValue().isTombstone()) {
+                        return true;
+                    }
+                }
+                return false;
+            }
+
+            @Override
+            public Map.Entry<K, V> next() {
+                Object key = recordStore.unmarshallKey(entry.getKey());
+                Object value = recordStore.unmarshallValue(entry.getValue().getValue());
+                return new AbstractMap.SimpleEntry<K, V>((K) key, (V) value);
+            }
+
+            @Override
+            public void remove() {
+                throw new UnsupportedOperationException("Lazy structures are not modifiable");
+            }
+        };
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/KeySetIteratorFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/KeySetIteratorFactory.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.replicatedmap.impl.record;
+
+import com.hazelcast.replicatedmap.impl.record.LazySet.IteratorFactory;
+
+import java.util.Iterator;
+import java.util.Map;
+
+class KeySetIteratorFactory<K, V>
+        implements IteratorFactory<K, V, K> {
+
+    private final ReplicatedRecordStore recordStore;
+
+    KeySetIteratorFactory(ReplicatedRecordStore recordStore) {
+        this.recordStore = recordStore;
+    }
+
+    @Override
+    public Iterator<K> create(final Iterator<Map.Entry<K, ReplicatedRecord<K, V>>> iterator) {
+        return new Iterator<K>() {
+            private Map.Entry<K, ReplicatedRecord<K, V>> entry;
+
+            @Override
+            public boolean hasNext() {
+                while (iterator.hasNext()) {
+                    entry = iterator.next();
+                    if (!entry.getValue().isTombstone()) {
+                        return true;
+                    }
+                }
+                return false;
+            }
+
+            @Override
+            public K next() {
+                Object key = recordStore.unmarshallKey(entry.getKey());
+                return (K) key;
+            }
+
+            @Override
+            public void remove() {
+                throw new UnsupportedOperationException("Lazy structures are not modifiable");
+            }
+        };
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/LazyCollection.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/LazyCollection.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.replicatedmap.impl.record;
+
+import com.hazelcast.replicatedmap.impl.record.LazySet.IteratorFactory;
+
+import java.lang.reflect.Array;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map.Entry;
+
+class LazyCollection<K, V>
+        implements Collection<V> {
+
+    private final InternalReplicatedMapStorage<K, V> storage;
+    private final IteratorFactory<K, V, V> iteratorFactory;
+    private final Collection<ReplicatedRecord<K, V>> values;
+
+    public LazyCollection(IteratorFactory<K, V, V> iteratorFactory, InternalReplicatedMapStorage<K, V> storage) {
+        this.iteratorFactory = iteratorFactory;
+        this.values = storage.values();
+        this.storage = storage;
+    }
+
+    @Override
+    public int size() {
+        return values.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return values.isEmpty();
+    }
+
+    @Override
+    public boolean contains(Object value) {
+        throw new UnsupportedOperationException("LazySet does not support contains requests");
+    }
+
+    @Override
+    public Iterator<V> iterator() {
+        Iterator<Entry<K, ReplicatedRecord<K, V>>> iterator = storage.entrySet().iterator();
+        return iteratorFactory.create(iterator);
+    }
+
+    @Override
+    public Object[] toArray() {
+        List<Object> result = new ArrayList<Object>(storage.values().size());
+        Iterator<V> iterator = iterator();
+        while (iterator.hasNext()) {
+            result.add(iterator.next());
+        }
+        return result.toArray(new Object[result.size()]);
+    }
+
+    @Override
+    public <T> T[] toArray(T[] a) {
+        List<Object> result = new ArrayList<Object>(storage.values().size());
+        Iterator<V> iterator = iterator();
+        while (iterator.hasNext()) {
+            result.add(iterator.next());
+        }
+        if (a.length != result.size()) {
+            a = (T[]) Array.newInstance(a.getClass().getComponentType(), result.size());
+        }
+        for (int i = 0; i < a.length; i++) {
+            a[i] = (T) result.get(i);
+        }
+        return a;
+    }
+
+    @Override
+    public boolean add(V v) {
+        throw new UnsupportedOperationException("LazyList is not modifiable");
+    }
+
+    @Override
+    public boolean remove(Object o) {
+        throw new UnsupportedOperationException("LazyList is not modifiable");
+    }
+
+    @Override
+    public boolean containsAll(Collection<?> c) {
+        throw new UnsupportedOperationException("LazySet does not support contains requests");
+    }
+
+    @Override
+    public boolean addAll(Collection<? extends V> c) {
+        throw new UnsupportedOperationException("LazyList is not modifiable");
+    }
+
+    @Override
+    public boolean removeAll(Collection<?> c) {
+        throw new UnsupportedOperationException("LazyList is not modifiable");
+    }
+
+    @Override
+    public boolean retainAll(Collection<?> c) {
+        throw new UnsupportedOperationException("LazyList is not modifiable");
+    }
+
+    @Override
+    public void clear() {
+        throw new UnsupportedOperationException("LazyList is not modifiable");
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/LazySet.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/LazySet.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.replicatedmap.impl.record;
+
+import java.lang.reflect.Array;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+class LazySet<K, V, R>
+        implements Set<R> {
+
+    private final InternalReplicatedMapStorage<K, V> storage;
+    private final IteratorFactory<K, V, R> iteratorFactory;
+
+    public LazySet(IteratorFactory<K, V, R> iteratorFactory, InternalReplicatedMapStorage<K, V> storage) {
+
+        this.iteratorFactory = iteratorFactory;
+        this.storage = storage;
+    }
+
+    @Override
+    public int size() {
+        return storage.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return storage.isEmpty();
+    }
+
+    @Override
+    public boolean contains(Object o) {
+        throw new UnsupportedOperationException("LazySet does not support contains requests");
+    }
+
+    @Override
+    public Iterator<R> iterator() {
+        final Iterator<Map.Entry<K, ReplicatedRecord<K, V>>> iterator = storage.entrySet().iterator();
+        return iteratorFactory.create(iterator);
+    }
+
+    @Override
+    public Object[] toArray() {
+        List<Object> result = new ArrayList<Object>(storage.values().size());
+        Iterator<R> iterator = iterator();
+        while (iterator.hasNext()) {
+            result.add(iterator.next());
+        }
+        return result.toArray(new Object[result.size()]);
+    }
+
+    @Override
+    public <T> T[] toArray(T[] a) {
+        List<Object> result = new ArrayList<Object>(storage.values().size());
+        Iterator<R> iterator = iterator();
+        while (iterator.hasNext()) {
+            result.add(iterator.next());
+        }
+        if (a.length != result.size()) {
+            a = (T[]) Array.newInstance(a.getClass().getComponentType(), result.size());
+        }
+        for (int i = 0; i < a.length; i++) {
+            a[i] = (T) result.get(i);
+        }
+        return a;
+    }
+
+    @Override
+    public boolean add(R e) {
+        throw new UnsupportedOperationException("LazySet is not modifiable");
+    }
+
+    @Override
+    public boolean remove(Object o) {
+        throw new UnsupportedOperationException("LazySet is not modifiable");
+    }
+
+    @Override
+    public boolean containsAll(Collection<?> c) {
+        throw new UnsupportedOperationException("LazySet does not support contains requests");
+    }
+
+    @Override
+    public boolean addAll(Collection<? extends R> c) {
+        throw new UnsupportedOperationException("LazySet is not modifiable");
+    }
+
+    @Override
+    public boolean retainAll(Collection<?> c) {
+        throw new UnsupportedOperationException("LazySet is not modifiable");
+    }
+
+    @Override
+    public boolean removeAll(Collection<?> c) {
+        throw new UnsupportedOperationException("LazySet is not modifiable");
+    }
+
+    @Override
+    public void clear() {
+        throw new UnsupportedOperationException("LazySet is not modifiable");
+    }
+
+    public interface IteratorFactory<K, V, R> {
+        Iterator<R> create(Iterator<Map.Entry<K, ReplicatedRecord<K, V>>> iterator);
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/ValuesIteratorFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/ValuesIteratorFactory.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.replicatedmap.impl.record;
+
+import com.hazelcast.replicatedmap.impl.record.LazySet.IteratorFactory;
+
+import java.util.Iterator;
+import java.util.Map;
+
+class ValuesIteratorFactory<K, V>
+        implements IteratorFactory<K, V, V> {
+
+    private final ReplicatedRecordStore recordStore;
+
+    ValuesIteratorFactory(ReplicatedRecordStore recordStore) {
+        this.recordStore = recordStore;
+    }
+
+    @Override
+    public Iterator<V> create(final Iterator<Map.Entry<K, ReplicatedRecord<K, V>>> iterator) {
+        return new Iterator<V>() {
+            private Map.Entry<K, ReplicatedRecord<K, V>> entry;
+
+            @Override
+            public boolean hasNext() {
+                while (iterator.hasNext()) {
+                    entry = iterator.next();
+                    if (!entry.getValue().isTombstone()) {
+                        return true;
+                    }
+                }
+                return false;
+            }
+
+            @Override
+            public V next() {
+                Object value = recordStore.unmarshallValue(entry.getValue().getValue());
+                return (V) value;
+            }
+
+            @Override
+            public void remove() {
+                throw new UnsupportedOperationException("Lazy structures are not modifiable");
+            }
+        };
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapTest.java
@@ -38,6 +38,7 @@ import org.junit.runner.RunWith;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -589,32 +590,45 @@ public class ReplicatedMapTest extends ReplicatedMapBaseTest {
     @Test
     public void testKeySet_notIncludes_removedKeys() throws Exception {
         HazelcastInstance node = createHazelcastInstance();
-        ReplicatedMap<Integer, Integer> map = node.getReplicatedMap("default");
+        final ReplicatedMap<Integer, Integer> map = node.getReplicatedMap("default");
         map.put(1, Integer.MAX_VALUE);
         map.put(2, Integer.MIN_VALUE);
 
         map.remove(1);
 
-        Set<Integer> keys = map.keySet();
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run()
+                    throws Exception {
 
-        assertFalse(keys.contains(1));
+                Set<Integer> keys = new HashSet<Integer>(map.keySet());
+                assertFalse(keys.contains(1));
+            }
+        }, 20);
     }
 
     @Test
     public void testEntrySet_notIncludes_removedKeys() throws Exception {
         HazelcastInstance node = createHazelcastInstance();
-        ReplicatedMap<Integer, Integer> map = node.getReplicatedMap("default");
+        final ReplicatedMap<Integer, Integer> map = node.getReplicatedMap("default");
         map.put(1, Integer.MAX_VALUE);
         map.put(2, Integer.MIN_VALUE);
 
         map.remove(1);
 
-        Set<Entry<Integer, Integer>> entries = map.entrySet();
-        for (Entry<Integer, Integer> entry : entries) {
-            if (entry.getKey().equals(1)) {
-                fail(String.format("We do not expect an entry which's key equals to %d in entry set", 1));
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run()
+                    throws Exception {
+
+                Set<Entry<Integer, Integer>> entries = map.entrySet();
+                for (Entry<Integer, Integer> entry : entries) {
+                    if (entry.getKey().equals(1)) {
+                        fail(String.format("We do not expect an entry which's key equals to %d in entry set", 1));
+                    }
+                }
             }
-        }
+        }, 20);
     }
 
     private void testRemove(Config config) throws Exception {


### PR DESCRIPTION
Added all lazy views to ReplicatedMap to prevent copying and re-hashing (HashSet) while retrieving values - speed improvement ~100x