### PR TITLE
Fixes regarding lock cleanup and lease expiration during member-left (network split)

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientLockProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientLockProxy.java
@@ -83,11 +83,12 @@ public class ClientLockProxy extends ClientProxy implements ILock {
     }
 
     public void lock() {
-        lock(Long.MAX_VALUE, null);
+        LockRequest request = new LockRequest(getKeyData(), ThreadUtil.getThreadId(), -1, -1);
+        invoke(request);
     }
 
     public void lockInterruptibly() throws InterruptedException {
-        LockRequest request = new LockRequest(getKeyData(), ThreadUtil.getThreadId(), Long.MAX_VALUE, -1);
+        LockRequest request = new LockRequest(getKeyData(), ThreadUtil.getThreadId(), -1, -1);
         invokeInterruptibly(request, getKeyData());
     }
 
@@ -101,7 +102,7 @@ public class ClientLockProxy extends ClientProxy implements ILock {
 
     public boolean tryLock(long time, TimeUnit unit) throws InterruptedException {
         LockRequest request = new LockRequest(getKeyData(),
-                ThreadUtil.getThreadId(), Long.MAX_VALUE, getTimeInMillis(time, unit));
+                ThreadUtil.getThreadId(), -1, getTimeInMillis(time, unit));
         Boolean result = invoke(request);
         return result;
     }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
@@ -473,7 +473,7 @@ public class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V> {
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
         final Data keyData = toData(key);
         MapLockRequest request = new MapLockRequest(name, keyData,
-                ThreadUtil.getThreadId(), Long.MAX_VALUE, getTimeInMillis(time, timeunit));
+                ThreadUtil.getThreadId(), -1, getTimeInMillis(time, timeunit));
         Boolean result = invoke(request, keyData);
         return result;
     }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMultiMapProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMultiMapProxy.java
@@ -273,7 +273,7 @@ public class ClientMultiMapProxy<K, V> extends ClientProxy implements MultiMap<K
 
         final Data keyData = toData(key);
         MultiMapLockRequest request = new MultiMapLockRequest(keyData, ThreadUtil.getThreadId(),
-                Long.MAX_VALUE, getTimeInMillis(time, timeunit), name);
+                -1, getTimeInMillis(time, timeunit), name);
         Boolean result = invoke(request, keyData);
         return result;
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/lock/LockLockMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/lock/LockLockMessageTask.java
@@ -16,17 +16,22 @@
 
 package com.hazelcast.client.impl.protocol.task.lock;
 
+import com.hazelcast.client.ClientEndpoint;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.LockLockCodec;
 import com.hazelcast.client.impl.protocol.task.AbstractPartitionMessageTask;
 import com.hazelcast.concurrent.lock.InternalLockNamespace;
 import com.hazelcast.concurrent.lock.LockService;
 import com.hazelcast.concurrent.lock.operations.LockOperation;
+import com.hazelcast.concurrent.lock.operations.UnlockOperation;
+import com.hazelcast.core.OperationTimeoutException;
 import com.hazelcast.instance.Node;
+import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.security.permission.ActionConstants;
 import com.hazelcast.security.permission.LockPermission;
+import com.hazelcast.spi.InvocationBuilder;
 import com.hazelcast.spi.Operation;
 
 import java.security.Permission;
@@ -35,13 +40,15 @@ import java.util.concurrent.TimeUnit;
 public class LockLockMessageTask
         extends AbstractPartitionMessageTask<LockLockCodec.RequestParameters> {
 
+    private Data key;
+
     public LockLockMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);
     }
 
     @Override
     protected Operation prepareOperation() {
-        final Data key = serializationService.toData(parameters.name);
+        key = serializationService.toData(parameters.name);
         return new LockOperation(new InternalLockNamespace(parameters.name)
                 , key, parameters.threadId, parameters.leaseTime, -1);
     }
@@ -54,6 +61,31 @@ public class LockLockMessageTask
     @Override
     protected ClientMessage encodeResponse(Object response) {
         return LockLockCodec.encodeResponse();
+    }
+
+    @Override
+    public void onFailure(Throwable t) {
+        if (t instanceof OperationTimeoutException) {
+            safeUnlock();
+        }
+        super.onFailure(t);
+    }
+
+    private void safeUnlock() {
+        ClientEndpoint endpoint = getEndpoint();
+        Operation op = new UnlockOperation(new InternalLockNamespace(parameters.name), key, parameters.threadId);
+        op.setCallerUuid(endpoint.getUuid());
+        InvocationBuilder builder = nodeEngine.getOperationService()
+                .createInvocationBuilder(getServiceName(), op, getPartitionId())
+                .setResultDeserialized(false);
+        try {
+            builder.invoke();
+        } catch (Throwable e) {
+            ILogger logger = clientEngine.getLogger(getClass());
+            if (logger.isFinestEnabled()) {
+                logger.finest("Error while unlocking because of a lock operation timeout!", e);
+            }
+        }
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapLockMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapLockMessageTask.java
@@ -16,17 +16,22 @@
 
 package com.hazelcast.client.impl.protocol.task.map;
 
+import com.hazelcast.client.ClientEndpoint;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.MapLockCodec;
 import com.hazelcast.client.impl.protocol.task.AbstractPartitionMessageTask;
 import com.hazelcast.concurrent.lock.LockService;
 import com.hazelcast.concurrent.lock.operations.LockOperation;
+import com.hazelcast.concurrent.lock.operations.UnlockOperation;
+import com.hazelcast.core.OperationTimeoutException;
 import com.hazelcast.instance.Node;
+import com.hazelcast.logging.ILogger;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.security.permission.ActionConstants;
 import com.hazelcast.security.permission.MapPermission;
 import com.hazelcast.spi.DefaultObjectNamespace;
+import com.hazelcast.spi.InvocationBuilder;
 import com.hazelcast.spi.ObjectNamespace;
 import com.hazelcast.spi.Operation;
 
@@ -54,6 +59,31 @@ public class MapLockMessageTask
     @Override
     protected ClientMessage encodeResponse(Object response) {
         return MapLockCodec.encodeResponse();
+    }
+
+    @Override
+    public void onFailure(Throwable t) {
+        if (t instanceof OperationTimeoutException) {
+            safeUnlock();
+        }
+        super.onFailure(t);
+    }
+
+    private void safeUnlock() {
+        ClientEndpoint endpoint = getEndpoint();
+        Operation op = new UnlockOperation(getNamespace(), parameters.key, parameters.threadId);
+        op.setCallerUuid(endpoint.getUuid());
+        InvocationBuilder builder = nodeEngine.getOperationService()
+                .createInvocationBuilder(getServiceName(), op, getPartitionId())
+                .setResultDeserialized(false);
+        try {
+            builder.invoke();
+        } catch (Throwable e) {
+            ILogger logger = clientEngine.getLogger(getClass());
+            if (logger.isFinestEnabled()) {
+                logger.finest("Error while unlocking because of a lock operation timeout!", e);
+            }
+        }
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapLockMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapLockMessageTask.java
@@ -16,17 +16,22 @@
 
 package com.hazelcast.client.impl.protocol.task.multimap;
 
+import com.hazelcast.client.ClientEndpoint;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.MultiMapLockCodec;
 import com.hazelcast.client.impl.protocol.task.AbstractPartitionMessageTask;
 import com.hazelcast.concurrent.lock.LockService;
 import com.hazelcast.concurrent.lock.operations.LockOperation;
+import com.hazelcast.concurrent.lock.operations.UnlockOperation;
+import com.hazelcast.core.OperationTimeoutException;
 import com.hazelcast.instance.Node;
+import com.hazelcast.logging.ILogger;
 import com.hazelcast.multimap.impl.MultiMapService;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.security.permission.ActionConstants;
 import com.hazelcast.security.permission.MultiMapPermission;
 import com.hazelcast.spi.DefaultObjectNamespace;
+import com.hazelcast.spi.InvocationBuilder;
 import com.hazelcast.spi.Operation;
 
 import java.security.Permission;
@@ -45,8 +50,12 @@ public class MultiMapLockMessageTask
 
     @Override
     protected Operation prepareOperation() {
-        DefaultObjectNamespace namespace = new DefaultObjectNamespace(MultiMapService.SERVICE_NAME, parameters.name);
+        DefaultObjectNamespace namespace = getNamespace();
         return new LockOperation(namespace, parameters.key, parameters.threadId, parameters.ttl, -1);
+    }
+
+    private DefaultObjectNamespace getNamespace() {
+        return new DefaultObjectNamespace(MultiMapService.SERVICE_NAME, parameters.name);
     }
 
     @Override
@@ -57,6 +66,31 @@ public class MultiMapLockMessageTask
     @Override
     protected MultiMapLockCodec.RequestParameters decodeClientMessage(ClientMessage clientMessage) {
         return MultiMapLockCodec.decodeRequest(clientMessage);
+    }
+
+    @Override
+    public void onFailure(Throwable t) {
+        if (t instanceof OperationTimeoutException) {
+            safeUnlock();
+        }
+        super.onFailure(t);
+    }
+
+    private void safeUnlock() {
+        ClientEndpoint endpoint = getEndpoint();
+        Operation op = new UnlockOperation(getNamespace(), parameters.key, parameters.threadId);
+        op.setCallerUuid(endpoint.getUuid());
+        InvocationBuilder builder = nodeEngine.getOperationService()
+                .createInvocationBuilder(getServiceName(), op, getPartitionId())
+                .setResultDeserialized(false);
+        try {
+            builder.invoke();
+        } catch (Throwable e) {
+            ILogger logger = clientEngine.getLogger(getClass());
+            if (logger.isFinestEnabled()) {
+                logger.finest("Error while unlocking because of a lock operation timeout!", e);
+            }
+        }
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapTryLockMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapTryLockMessageTask.java
@@ -16,17 +16,22 @@
 
 package com.hazelcast.client.impl.protocol.task.multimap;
 
+import com.hazelcast.client.ClientEndpoint;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.MultiMapTryLockCodec;
 import com.hazelcast.client.impl.protocol.task.AbstractPartitionMessageTask;
 import com.hazelcast.concurrent.lock.LockService;
 import com.hazelcast.concurrent.lock.operations.LockOperation;
+import com.hazelcast.concurrent.lock.operations.UnlockOperation;
+import com.hazelcast.core.OperationTimeoutException;
 import com.hazelcast.instance.Node;
+import com.hazelcast.logging.ILogger;
 import com.hazelcast.multimap.impl.MultiMapService;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.security.permission.ActionConstants;
 import com.hazelcast.security.permission.MultiMapPermission;
 import com.hazelcast.spi.DefaultObjectNamespace;
+import com.hazelcast.spi.InvocationBuilder;
 import com.hazelcast.spi.Operation;
 
 import java.security.Permission;
@@ -45,8 +50,12 @@ public class MultiMapTryLockMessageTask
 
     @Override
     protected Operation prepareOperation() {
-        DefaultObjectNamespace namespace = new DefaultObjectNamespace(MultiMapService.SERVICE_NAME, parameters.name);
+        DefaultObjectNamespace namespace = getNamespace();
         return new LockOperation(namespace, parameters.key, parameters.threadId, parameters.timeout);
+    }
+
+    private DefaultObjectNamespace getNamespace() {
+        return new DefaultObjectNamespace(MultiMapService.SERVICE_NAME, parameters.name);
     }
 
     @Override
@@ -57,6 +66,31 @@ public class MultiMapTryLockMessageTask
     @Override
     protected ClientMessage encodeResponse(Object response) {
         return MultiMapTryLockCodec.encodeResponse((Boolean) response);
+    }
+
+    @Override
+    public void onFailure(Throwable t) {
+        if (t instanceof OperationTimeoutException) {
+            safeUnlock();
+        }
+        super.onFailure(t);
+    }
+
+    private void safeUnlock() {
+        ClientEndpoint endpoint = getEndpoint();
+        Operation op = new UnlockOperation(getNamespace(), parameters.key, parameters.threadId);
+        op.setCallerUuid(endpoint.getUuid());
+        InvocationBuilder builder = nodeEngine.getOperationService()
+                .createInvocationBuilder(getServiceName(), op, getPartitionId())
+                .setResultDeserialized(false);
+        try {
+            builder.invoke();
+        } catch (Throwable e) {
+            ILogger logger = clientEngine.getLogger(getClass());
+            if (logger.isFinestEnabled()) {
+                logger.finest("Error while unlocking because of a lock operation timeout!", e);
+            }
+        }
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockProxy.java
@@ -42,7 +42,7 @@ public class LockProxy extends AbstractDistributedObject<LockServiceImpl> implem
         super(nodeEngine, lockService);
         this.name = name;
         this.key = getNameAsPartitionAwareData();
-        this.lockSupport = new LockProxySupport(new InternalLockNamespace(name));
+        this.lockSupport = new LockProxySupport(new InternalLockNamespace(name), lockService.getMaxLeaseTimeInMillis());
         this.partitionId = getNodeEngine().getPartitionService().getPartitionId(key);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockResource.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockResource.java
@@ -39,4 +39,6 @@ public interface LockResource {
     long getRemainingLeaseTime();
 
     long getExpirationTime();
+
+    int getVersion();
 }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockResourceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockResourceImpl.java
@@ -295,7 +295,10 @@ final class LockResourceImpl implements DataSerializable, LockResource {
 
     @Override
     public long getRemainingLeaseTime() {
-        if (expirationTime == Long.MAX_VALUE || expirationTime < 0) {
+        if (!isLocked()) {
+            return -1L;
+        }
+        if (expirationTime < 0) {
             return Long.MAX_VALUE;
         }
         long now = Clock.currentTimeMillis();
@@ -310,7 +313,8 @@ final class LockResourceImpl implements DataSerializable, LockResource {
         return expirationTime;
     }
 
-    int getVersion() {
+    @Override
+    public int getVersion() {
         return version;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockService.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockService.java
@@ -34,4 +34,6 @@ public interface LockService extends SharedService {
     void clearLockStore(int partitionId, ObjectNamespace namespace);
 
     Collection<LockResource> getAllLocks();
+
+    long getMaxLeaseTimeInMillis();
 }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockServiceImpl.java
@@ -32,10 +32,13 @@ import com.hazelcast.spi.MigrationAwareService;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.ObjectNamespace;
 import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.OperationService;
 import com.hazelcast.spi.PartitionMigrationEvent;
 import com.hazelcast.spi.PartitionReplicationEvent;
 import com.hazelcast.spi.RemoteService;
+import com.hazelcast.spi.impl.PartitionSpecificRunnable;
 import com.hazelcast.spi.impl.ResponseHandlerFactory;
+import com.hazelcast.spi.impl.operationservice.InternalOperationService;
 import com.hazelcast.util.Clock;
 import com.hazelcast.util.ConstructorFunction;
 import com.hazelcast.util.scheduler.EntryTaskScheduler;
@@ -183,34 +186,47 @@ public final class LockServiceImpl implements LockService, ManagedService, Remot
     public void memberAttributeChanged(MemberAttributeServiceEvent event) {
     }
 
-    private void releaseLocksOf(String uuid) {
-        for (LockStoreContainer container : containers) {
-            for (LockStoreImpl lockStore : container.getLockStores()) {
-                releaseLock(uuid, container, lockStore);
-            }
+    private void releaseLocksOf(final String uuid) {
+        final InternalOperationService operationService = (InternalOperationService) nodeEngine.getOperationService();
+        for (final LockStoreContainer container : containers) {
+            operationService.execute(new PartitionSpecificRunnable() {
+                @Override
+                public void run() {
+                    for (LockStoreImpl lockStore : container.getLockStores()) {
+                        releaseLock(operationService, uuid, container.getPartitionId(), lockStore);
+                    }
+                }
+
+                @Override
+                public int getPartitionId() {
+                    return container.getPartitionId();
+                }
+            });
+
         }
     }
 
-    private void releaseLock(String uuid, LockStoreContainer container, LockStoreImpl lockStore) {
+    private void releaseLock(OperationService operationService, String uuid, int partitionId, LockStoreImpl lockStore) {
         Collection<LockResource> locks = lockStore.getLocks();
         for (LockResource lock : locks) {
             Data key = lock.getKey();
             if (uuid.equals(lock.getOwner()) && !lock.isTransactional()) {
-                sendUnlockOperation(container, lockStore, key);
+                UnlockOperation op = createUnlockOperation(partitionId, lockStore.getNamespace(), key, uuid);
+                operationService.runOperationOnCallingThread(op);
             }
         }
     }
 
-    private void sendUnlockOperation(LockStoreContainer container, LockStoreImpl lockStore, Data key) {
-        UnlockOperation op = new LocalLockCleanupOperation(lockStore.getNamespace(), key, -1);
+    private UnlockOperation createUnlockOperation(int partitionId, ObjectNamespace namespace, Data key, String uuid) {
+        UnlockOperation op = new LocalLockCleanupOperation(namespace, key, uuid);
         op.setAsyncBackup(true);
         op.setNodeEngine(nodeEngine);
         op.setServiceName(SERVICE_NAME);
         op.setService(LockServiceImpl.this);
         op.setResponseHandler(ResponseHandlerFactory.createEmptyResponseHandler());
-        op.setPartitionId(container.getPartitionId());
+        op.setPartitionId(partitionId);
         op.setValidateTarget(false);
-        nodeEngine.getOperationService().executeOperation(op);
+        return op;
     }
 
     @Override
@@ -305,5 +321,4 @@ public final class LockServiceImpl implements LockService, ManagedService, Remot
     public void clientDisconnected(String clientUuid) {
         releaseLocksOf(clientUuid);
     }
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockStore.java
@@ -22,13 +22,13 @@ import java.util.Set;
 
 public interface LockStore {
 
-    boolean lock(Data key, String caller, long threadId, long ttl);
+    boolean lock(Data key, String caller, long threadId, long referenceId, long leaseTime);
 
-    boolean txnLock(Data key, String caller, long threadId, long ttl);
+    boolean txnLock(Data key, String caller, long threadId, long referenceId, long leaseTime);
 
-    boolean extendLeaseTime(Data key, String caller, long threadId, long ttl);
+    boolean extendLeaseTime(Data key, String caller, long threadId, long leaseTime);
 
-    boolean unlock(Data key, String caller, long threadId);
+    boolean unlock(Data key, String caller, long threadId, long referenceId);
 
     boolean isLocked(Data key);
 

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockStoreImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockStoreImpl.java
@@ -62,8 +62,21 @@ public final class LockStoreImpl implements DataSerializable, LockStore {
 
     @Override
     public boolean lock(Data key, String caller, long threadId, long referenceId, long leaseTime) {
+        leaseTime = getLeaseTime(leaseTime);
         LockResourceImpl lock = getLock(key);
         return lock.lock(caller, threadId, referenceId, leaseTime, false);
+    }
+
+    private long getLeaseTime(long leaseTime) {
+        long maxLeaseTimeInMillis = lockService.getMaxLeaseTimeInMillis();
+        if (leaseTime > maxLeaseTimeInMillis) {
+            throw new IllegalArgumentException("Max allowed lease time: " + maxLeaseTimeInMillis + "ms. "
+                    + "Given lease time: " + leaseTime + "ms.");
+        }
+        if (leaseTime < 0) {
+            leaseTime = maxLeaseTimeInMillis;
+        }
+        return leaseTime;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockStoreImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockStoreImpl.java
@@ -60,20 +60,16 @@ public final class LockStoreImpl implements DataSerializable, LockStore {
         this.lockService = lockService;
     }
 
-    public boolean lock(Data key, String caller, long threadId) {
-        return lock(key, caller, threadId, Long.MAX_VALUE);
+    @Override
+    public boolean lock(Data key, String caller, long threadId, long referenceId, long leaseTime) {
+        LockResourceImpl lock = getLock(key);
+        return lock.lock(caller, threadId, referenceId, leaseTime, false);
     }
 
     @Override
-    public boolean lock(Data key, String caller, long threadId, long leaseTime) {
+    public boolean txnLock(Data key, String caller, long threadId, long referenceId, long leaseTime) {
         LockResourceImpl lock = getLock(key);
-        return lock.lock(caller, threadId, leaseTime);
-    }
-
-    @Override
-    public boolean txnLock(Data key, String caller, long threadId, long leaseTime) {
-        LockResourceImpl lock = getLock(key);
-        return lock.lock(caller, threadId, leaseTime, true);
+        return lock.lock(caller, threadId, referenceId, leaseTime, true);
     }
 
     @Override
@@ -85,7 +81,7 @@ public final class LockStoreImpl implements DataSerializable, LockStore {
         return lock.extendLeaseTime(caller, threadId, leaseTime);
     }
 
-    private LockResourceImpl getLock(Data key) {
+    public LockResourceImpl getLock(Data key) {
         return ConcurrencyUtil.getOrPutIfAbsent(locks, key, lockConstructor);
     }
 
@@ -141,7 +137,7 @@ public final class LockStoreImpl implements DataSerializable, LockStore {
     }
 
     @Override
-    public boolean unlock(Data key, String caller, long threadId) {
+    public boolean unlock(Data key, String caller, long threadId, long referenceId) {
         LockResourceImpl lock = locks.get(key);
         if (lock == null) {
             return false;
@@ -149,7 +145,7 @@ public final class LockStoreImpl implements DataSerializable, LockStore {
 
         boolean result = false;
         if (lock.canAcquireLock(caller, threadId)) {
-            if (lock.unlock(caller, threadId)) {
+            if (lock.unlock(caller, threadId, referenceId)) {
                 result = true;
             }
         }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockStoreProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockStoreProxy.java
@@ -33,15 +33,15 @@ public final class LockStoreProxy implements LockStore {
     }
 
     @Override
-    public boolean lock(Data key, String caller, long threadId, long ttl) {
+    public boolean lock(Data key, String caller, long threadId, long referenceId, long ttl) {
         LockStore lockStore = getLockStoreOrNull();
-        return lockStore != null && lockStore.lock(key, caller, threadId, ttl);
+        return lockStore != null && lockStore.lock(key, caller, threadId, referenceId, ttl);
     }
 
     @Override
-    public boolean txnLock(Data key, String caller, long threadId, long ttl) {
+    public boolean txnLock(Data key, String caller, long threadId, long referenceId, long ttl) {
         LockStore lockStore = getLockStoreOrNull();
-        return lockStore != null && lockStore.txnLock(key, caller, threadId, ttl);
+        return lockStore != null && lockStore.txnLock(key, caller, threadId, referenceId, ttl);
     }
 
     @Override
@@ -51,9 +51,9 @@ public final class LockStoreProxy implements LockStore {
     }
 
     @Override
-    public boolean unlock(Data key, String caller, long threadId) {
+    public boolean unlock(Data key, String caller, long threadId, long referenceId) {
         LockStore lockStore = getLockStoreOrNull();
-        return lockStore != null && lockStore.unlock(key, caller, threadId);
+        return lockStore != null && lockStore.unlock(key, caller, threadId, referenceId);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockStoreProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockStoreProxy.java
@@ -33,21 +33,21 @@ public final class LockStoreProxy implements LockStore {
     }
 
     @Override
-    public boolean lock(Data key, String caller, long threadId, long referenceId, long ttl) {
+    public boolean lock(Data key, String caller, long threadId, long callId, long leaseTime) {
         LockStore lockStore = getLockStoreOrNull();
-        return lockStore != null && lockStore.lock(key, caller, threadId, referenceId, ttl);
+        return lockStore != null && lockStore.lock(key, caller, threadId, callId, leaseTime);
     }
 
     @Override
-    public boolean txnLock(Data key, String caller, long threadId, long referenceId, long ttl) {
+    public boolean txnLock(Data key, String caller, long threadId, long callId, long leaseTime) {
         LockStore lockStore = getLockStoreOrNull();
-        return lockStore != null && lockStore.txnLock(key, caller, threadId, referenceId, ttl);
+        return lockStore != null && lockStore.txnLock(key, caller, threadId, callId, leaseTime);
     }
 
     @Override
-    public boolean extendLeaseTime(Data key, String caller, long threadId, long ttl) {
+    public boolean extendLeaseTime(Data key, String caller, long threadId, long leaseTime) {
         LockStore lockStore = getLockStoreOrNull();
-        return lockStore != null && lockStore.extendLeaseTime(key, caller, threadId, ttl);
+        return lockStore != null && lockStore.extendLeaseTime(key, caller, threadId, leaseTime);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/AwaitBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/AwaitBackupOperation.java
@@ -46,7 +46,7 @@ public class AwaitBackupOperation extends BaseLockOperation
     @Override
     public void run() throws Exception {
         LockStoreImpl lockStore = getLockStore();
-        lockStore.lock(key, originalCaller, threadId, getReferenceCallId(), -1L);
+        lockStore.lock(key, originalCaller, threadId, getReferenceCallId(), leaseTime);
         ConditionKey conditionKey = new ConditionKey(namespace.getObjectName(), key, conditionId);
         lockStore.removeSignalKey(conditionKey);
         lockStore.removeAwait(key, conditionId, originalCaller, threadId);

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/AwaitBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/AwaitBackupOperation.java
@@ -46,7 +46,7 @@ public class AwaitBackupOperation extends BaseLockOperation
     @Override
     public void run() throws Exception {
         LockStoreImpl lockStore = getLockStore();
-        lockStore.lock(key, originalCaller, threadId);
+        lockStore.lock(key, originalCaller, threadId, getReferenceCallId(), -1L);
         ConditionKey conditionKey = new ConditionKey(namespace.getObjectName(), key, conditionId);
         lockStore.removeSignalKey(conditionKey);
         lockStore.removeAwait(key, conditionId, originalCaller, threadId);

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/AwaitOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/AwaitOperation.java
@@ -55,7 +55,7 @@ public class AwaitOperation extends BaseLockOperation
     @Override
     public void run() throws Exception {
         LockStoreImpl lockStore = getLockStore();
-        if (!lockStore.lock(key, getCallerUuid(), threadId, getReferenceCallId(), -1L)) {
+        if (!lockStore.lock(key, getCallerUuid(), threadId, getReferenceCallId(), leaseTime)) {
             throw new IllegalMonitorStateException(
                     "Current thread is not owner of the lock! -> " + lockStore.getOwnerInfo(key));
         }
@@ -109,7 +109,7 @@ public class AwaitOperation extends BaseLockOperation
         lockStore.removeSignalKey(getWaitKey());
         lockStore.removeAwait(key, conditionId, getCallerUuid(), threadId);
 
-        boolean locked = lockStore.lock(key, getCallerUuid(), threadId, getReferenceCallId(), -1L);
+        boolean locked = lockStore.lock(key, getCallerUuid(), threadId, getReferenceCallId(), leaseTime);
         if (locked) {
             ResponseHandler responseHandler = getResponseHandler();
             // expired & acquired lock, send FALSE

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/AwaitOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/AwaitOperation.java
@@ -55,7 +55,7 @@ public class AwaitOperation extends BaseLockOperation
     @Override
     public void run() throws Exception {
         LockStoreImpl lockStore = getLockStore();
-        if (!lockStore.lock(key, getCallerUuid(), threadId)) {
+        if (!lockStore.lock(key, getCallerUuid(), threadId, getReferenceCallId(), -1L)) {
             throw new IllegalMonitorStateException(
                     "Current thread is not owner of the lock! -> " + lockStore.getOwnerInfo(key));
         }
@@ -109,7 +109,7 @@ public class AwaitOperation extends BaseLockOperation
         lockStore.removeSignalKey(getWaitKey());
         lockStore.removeAwait(key, conditionId, getCallerUuid(), threadId);
 
-        boolean locked = lockStore.lock(key, getCallerUuid(), threadId);
+        boolean locked = lockStore.lock(key, getCallerUuid(), threadId, getReferenceCallId(), -1L);
         if (locked) {
             ResponseHandler responseHandler = getResponseHandler();
             // expired & acquired lock, send FALSE

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/BaseLockOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/BaseLockOperation.java
@@ -32,13 +32,12 @@ import java.io.IOException;
 public abstract class BaseLockOperation extends AbstractOperation
         implements PartitionAwareOperation, IdentifiedDataSerializable {
 
-    public static final long DEFAULT_LOCK_TTL = Long.MAX_VALUE;
     public static final int ANY_THREAD = 0;
 
     protected ObjectNamespace namespace;
     protected Data key;
     protected long threadId;
-    protected long ttl = DEFAULT_LOCK_TTL;
+    protected long leaseTime = -1L;
     protected transient Object response;
     private transient boolean asyncBackup;
     private long referenceCallId;
@@ -59,11 +58,11 @@ public abstract class BaseLockOperation extends AbstractOperation
         setWaitTimeout(timeout);
     }
 
-    public BaseLockOperation(ObjectNamespace namespace, Data key, long threadId, long ttl, long timeout) {
+    public BaseLockOperation(ObjectNamespace namespace, Data key, long threadId, long leaseTime, long timeout) {
         this.namespace = namespace;
         this.key = key;
         this.threadId = threadId;
-        this.ttl = ttl;
+        this.leaseTime = leaseTime;
         setWaitTimeout(timeout);
     }
 
@@ -133,7 +132,7 @@ public abstract class BaseLockOperation extends AbstractOperation
         out.writeObject(namespace);
         out.writeData(key);
         out.writeLong(threadId);
-        out.writeLong(ttl);
+        out.writeLong(leaseTime);
         out.writeLong(referenceCallId);
     }
 
@@ -143,7 +142,7 @@ public abstract class BaseLockOperation extends AbstractOperation
         namespace = in.readObject();
         key = in.readData();
         threadId = in.readLong();
-        ttl = in.readLong();
+        leaseTime = in.readLong();
         referenceCallId = in.readLong();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/BeforeAwaitBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/BeforeAwaitBackupOperation.java
@@ -45,7 +45,7 @@ public class BeforeAwaitBackupOperation extends BaseLockOperation implements Bac
     public void run() throws Exception {
         LockStoreImpl lockStore = getLockStore();
         lockStore.addAwait(key, conditionId, originalCaller, threadId);
-        lockStore.unlock(key, originalCaller, threadId);
+        lockStore.unlock(key, originalCaller, threadId, getReferenceCallId());
         response = true;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/BeforeAwaitOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/BeforeAwaitOperation.java
@@ -60,7 +60,7 @@ public class BeforeAwaitOperation extends BaseLockOperation implements Notifier,
     public void run() throws Exception {
         LockStoreImpl lockStore = getLockStore();
         lockStore.addAwait(key, conditionId, getCallerUuid(), threadId);
-        lockStore.unlock(key, getCallerUuid(), threadId);
+        lockStore.unlock(key, getCallerUuid(), threadId, getReferenceCallId());
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/LocalLockCleanupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/LocalLockCleanupOperation.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.concurrent.lock.operations;
 
+import com.hazelcast.concurrent.lock.LockResource;
+import com.hazelcast.concurrent.lock.LockStoreImpl;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -30,11 +32,22 @@ import java.io.IOException;
 
 public class LocalLockCleanupOperation extends UnlockOperation implements Notifier, BackupAwareOperation {
 
-    public LocalLockCleanupOperation() {
+    private final String uuid;
+
+    public LocalLockCleanupOperation(ObjectNamespace namespace, Data key, String uuid) {
+        super(namespace, key, -1, true);
+        this.uuid = uuid;
     }
 
-    public LocalLockCleanupOperation(ObjectNamespace namespace, Data key, long threadId) {
-        super(namespace, key, threadId, true);
+    @Override
+    public void run() throws Exception {
+        LockStoreImpl lockStore = getLockStore();
+        LockResource lock = lockStore.getLock(key);
+        if (uuid.equals(lock.getOwner())) {
+            getLogger().finest("Unlocking lock owned by uuid: " + uuid + ", thread-id: "
+                    + lock.getThreadId() + ", count: " + lock.getLockCount());
+            response = lockStore.forceUnlock(key);
+        }
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/LockBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/LockBackupOperation.java
@@ -33,15 +33,16 @@ public class LockBackupOperation extends BaseLockOperation implements BackupOper
     public LockBackupOperation() {
     }
 
-    public LockBackupOperation(ObjectNamespace namespace, Data key, long threadId, String originalCallerUuid) {
+    public LockBackupOperation(ObjectNamespace namespace, Data key, long threadId, long leaseTime, String originalCallerUuid) {
         super(namespace, key, threadId);
+        this.leaseTime = leaseTime;
         this.originalCallerUuid = originalCallerUuid;
     }
 
     @Override
     public void run() throws Exception {
         LockStoreImpl lockStore = getLockStore();
-        response = lockStore.lock(key, originalCallerUuid, threadId, getReferenceCallId(), ttl);
+        response = lockStore.lock(key, originalCallerUuid, threadId, getReferenceCallId(), leaseTime);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/LockBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/LockBackupOperation.java
@@ -41,7 +41,7 @@ public class LockBackupOperation extends BaseLockOperation implements BackupOper
     @Override
     public void run() throws Exception {
         LockStoreImpl lockStore = getLockStore();
-        response = lockStore.lock(key, originalCallerUuid, threadId, ttl);
+        response = lockStore.lock(key, originalCallerUuid, threadId, getReferenceCallId(), ttl);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/LockOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/LockOperation.java
@@ -17,6 +17,7 @@
 package com.hazelcast.concurrent.lock.operations;
 
 import com.hazelcast.concurrent.lock.LockDataSerializerHook;
+import com.hazelcast.concurrent.lock.LockStoreImpl;
 import com.hazelcast.concurrent.lock.LockWaitNotifyKey;
 import com.hazelcast.core.OperationTimeoutException;
 import com.hazelcast.nio.serialization.Data;
@@ -41,12 +42,14 @@ public class LockOperation extends BaseLockOperation implements WaitSupport, Bac
 
     @Override
     public void run() throws Exception {
-        response = getLockStore().lock(key, getCallerUuid(), threadId, ttl);
+        response = getLockStore().lock(key, getCallerUuid(), threadId, getReferenceCallId(), ttl);
     }
 
     @Override
     public Operation getBackupOperation() {
-        return new LockBackupOperation(namespace, key, threadId, getCallerUuid());
+        LockBackupOperation operation = new LockBackupOperation(namespace, key, threadId, getCallerUuid());
+        operation.setReferenceCallId(getReferenceCallId());
+        return operation;
     }
 
     @Override
@@ -61,7 +64,8 @@ public class LockOperation extends BaseLockOperation implements WaitSupport, Bac
 
     @Override
     public final boolean shouldWait() {
-        return getWaitTimeout() != 0 && !getLockStore().canAcquireLock(key, getCallerUuid(), threadId);
+        LockStoreImpl lockStore = getLockStore();
+        return getWaitTimeout() != 0 && !lockStore.canAcquireLock(key, getCallerUuid(), threadId);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/LockOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/LockOperation.java
@@ -36,18 +36,18 @@ public class LockOperation extends BaseLockOperation implements WaitSupport, Bac
         super(namespace, key, threadId, timeout);
     }
 
-    public LockOperation(ObjectNamespace namespace, Data key, long threadId, long ttl, long timeout) {
-        super(namespace, key, threadId, ttl, timeout);
+    public LockOperation(ObjectNamespace namespace, Data key, long threadId, long leaseTime, long timeout) {
+        super(namespace, key, threadId, leaseTime, timeout);
     }
 
     @Override
     public void run() throws Exception {
-        response = getLockStore().lock(key, getCallerUuid(), threadId, getReferenceCallId(), ttl);
+        response = getLockStore().lock(key, getCallerUuid(), threadId, getReferenceCallId(), leaseTime);
     }
 
     @Override
     public Operation getBackupOperation() {
-        LockBackupOperation operation = new LockBackupOperation(namespace, key, threadId, getCallerUuid());
+        LockBackupOperation operation = new LockBackupOperation(namespace, key, threadId, leaseTime, getCallerUuid());
         operation.setReferenceCallId(getReferenceCallId());
         return operation;
     }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/UnlockBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/UnlockBackupOperation.java
@@ -44,11 +44,14 @@ public class UnlockBackupOperation extends BaseLockOperation implements BackupOp
     @Override
     public void run() throws Exception {
         LockStoreImpl lockStore = getLockStore();
+        boolean unlocked;
         if (force) {
-            response = lockStore.forceUnlock(key);
+            unlocked = lockStore.forceUnlock(key);
         } else {
-            response = lockStore.unlock(key, originalCallerUuid, threadId);
+            unlocked = lockStore.unlock(key, originalCallerUuid, threadId, getReferenceCallId());
         }
+
+        response = unlocked;
         lockStore.pollExpiredAwaitOp(key);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/UnlockIfLeaseExpiredOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/UnlockIfLeaseExpiredOperation.java
@@ -38,10 +38,13 @@ public final class UnlockIfLeaseExpiredOperation extends UnlockOperation {
     public void run() throws Exception {
         LockStoreImpl lockStore = getLockStore();
         int lockVersion = lockStore.getVersion(key);
+        ILogger logger = getLogger();
         if (version == lockVersion) {
+            if (logger.isFinestEnabled()) {
+                logger.finest("Releasing a lock owned by " + lockStore.getOwnerInfo(key) + " after lease timeout!");
+            }
             forceUnlock();
         } else {
-            ILogger logger = getLogger();
             if (logger.isFinestEnabled()) {
                 logger.finest("Won't unlock since lock version is not matching expiration version: "
                         + lockVersion + " vs " + version);

--- a/hazelcast/src/main/java/com/hazelcast/instance/GroupProperties.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/GroupProperties.java
@@ -169,6 +169,7 @@ public class GroupProperties {
     public static final String PROP_PARTITIONING_STRATEGY_CLASS = "hazelcast.partitioning.strategy.class";
     public static final String PROP_GRACEFUL_SHUTDOWN_MAX_WAIT = "hazelcast.graceful.shutdown.max.wait";
     public static final String PROP_SYSTEM_LOG_ENABLED = "hazelcast.system.log.enabled";
+    public static final String PROP_LOCK_MAX_LEASE_TIME_SECONDS = "hazelcast.lock.max.lease.time.seconds";
 
     /**
      * Enables or disables the {@link com.hazelcast.spi.impl.operationexecutor.slowoperationdetector.SlowOperationDetector}.
@@ -551,6 +552,8 @@ public class GroupProperties {
 
     public final GroupProperty SLOW_INVOCATION_DETECTOR_THRESHOLD_MILLIS;
 
+    public final GroupProperty LOCK_MAX_LEASE_TIME_SECONDS;
+
     public final GroupProperty ELASTIC_MEMORY_ENABLED;
 
     public final GroupProperty ELASTIC_MEMORY_TOTAL_SIZE;
@@ -691,6 +694,9 @@ public class GroupProperties {
                 = new GroupProperty(config, PROP_SLOW_OPERATION_DETECTOR_STACK_TRACE_LOGGING_ENABLED, "false");
         SLOW_INVOCATION_DETECTOR_THRESHOLD_MILLIS
                 = new GroupProperty(config, PROP_SLOW_INVOCATION_DETECTOR_THRESHOLD_MILLIS, "-1");
+
+        LOCK_MAX_LEASE_TIME_SECONDS = new GroupProperty(config, PROP_LOCK_MAX_LEASE_TIME_SECONDS,
+                Long.toString(Long.MAX_VALUE));
 
         ELASTIC_MEMORY_ENABLED = new GroupProperty(config, PROP_ELASTIC_MEMORY_ENABLED, "false");
         ELASTIC_MEMORY_TOTAL_SIZE = new GroupProperty(config, PROP_ELASTIC_MEMORY_TOTAL_SIZE, "128M");

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/DefaultRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/DefaultRecordStore.java
@@ -269,9 +269,9 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore implements 
     }
 
     @Override
-    public boolean txnLock(Data key, String caller, long threadId, long ttl) {
+    public boolean txnLock(Data key, String caller, long threadId, long referenceId, long ttl) {
         checkIfLoaded();
-        return lockStore != null && lockStore.txnLock(key, caller, threadId, ttl);
+        return lockStore != null && lockStore.txnLock(key, caller, threadId, referenceId, ttl);
     }
 
     @Override
@@ -281,9 +281,9 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore implements 
     }
 
     @Override
-    public boolean unlock(Data key, String caller, long threadId) {
+    public boolean unlock(Data key, String caller, long threadId, long referenceId) {
         checkIfLoaded();
-        return lockStore != null && lockStore.unlock(key, caller, threadId);
+        return lockStore != null && lockStore.unlock(key, caller, threadId, referenceId);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/RecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/RecordStore.java
@@ -189,11 +189,11 @@ public interface RecordStore {
 
     int size();
 
-    boolean txnLock(Data key, String caller, long threadId, long ttl);
+    boolean txnLock(Data key, String caller, long threadId, long referenceId, long ttl);
 
     boolean extendLock(Data key, String caller, long threadId, long ttl);
 
-    boolean unlock(Data key, String caller, long threadId);
+    boolean unlock(Data key, String caller, long threadId, long referenceId);
 
     boolean isLocked(Data key);
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
@@ -17,6 +17,7 @@
 package com.hazelcast.map.impl.proxy;
 
 import com.hazelcast.concurrent.lock.LockProxySupport;
+import com.hazelcast.concurrent.lock.LockServiceImpl;
 import com.hazelcast.config.EntryListenerConfig;
 import com.hazelcast.config.ListenerConfig;
 import com.hazelcast.config.MapConfig;
@@ -155,7 +156,9 @@ abstract class MapProxySupport extends AbstractDistributedObject<MapService> imp
         partitionStrategy = mapServiceContext.getMapContainer(name).getPartitioningStrategy();
         localMapStats = mapServiceContext.getLocalMapStatsProvider().getLocalMapStatsImpl(name);
         this.partitionService = getNodeEngine().getPartitionService();
-        lockSupport = new LockProxySupport(new DefaultObjectNamespace(MapService.SERVICE_NAME, name));
+
+        lockSupport = new LockProxySupport(new DefaultObjectNamespace(MapService.SERVICE_NAME, name),
+                    LockServiceImpl.getMaxLeaseTimeInMillis(nodeEngine.getGroupProperties()));
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnDeleteOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnDeleteOperation.java
@@ -55,7 +55,7 @@ public class TxnDeleteOperation extends BaseRemoveOperation implements MapTxnOpe
 
     @Override
     public void run() {
-        recordStore.unlock(dataKey, ownerUuid, getThreadId());
+        recordStore.unlock(dataKey, ownerUuid, getThreadId(), getCallId());
         Record record = recordStore.getRecord(dataKey);
         if (record == null || version == record.getVersion()) {
             dataOldValue = getNodeEngine().toData(recordStore.remove(dataKey));

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnLockAndGetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnLockAndGetOperation.java
@@ -45,7 +45,7 @@ public class TxnLockAndGetOperation extends LockAwareOperation implements Mutati
 
     @Override
     public void run() throws Exception {
-        if (!recordStore.txnLock(getKey(), ownerUuid, getThreadId(), ttl)) {
+        if (!recordStore.txnLock(getKey(), ownerUuid, getThreadId(), getCallId(), ttl)) {
             throw new TransactionException("Transaction couldn't obtain lock.");
         }
         Record record = recordStore.getRecordOrNull(dataKey);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnPrepareBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnPrepareBackupOperation.java
@@ -45,7 +45,7 @@ public class TxnPrepareBackupOperation extends KeyBasedMapOperation implements B
 
     @Override
     public void run() throws Exception {
-        if (!recordStore.txnLock(getKey(), lockOwner, lockThreadId, LOCK_TTL_MILLIS)) {
+        if (!recordStore.txnLock(getKey(), lockOwner, lockThreadId, getCallId(), LOCK_TTL_MILLIS)) {
             throw new TransactionException("Lock is not owned by the transaction! Caller: " + lockOwner
                     + ", Owner: " + recordStore.getLockOwnerInfo(getKey()));
         }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnRollbackBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnRollbackBackupOperation.java
@@ -43,7 +43,7 @@ public class TxnRollbackBackupOperation extends KeyBasedMapOperation implements 
 
     @Override
     public void run() throws Exception {
-        if (recordStore.isLocked(getKey()) && !recordStore.unlock(getKey(), lockOwner, lockThreadId)) {
+        if (recordStore.isLocked(getKey()) && !recordStore.unlock(getKey(), lockOwner, lockThreadId, getCallId())) {
             throw new TransactionException("Lock is not owned by the transaction! Owner: "
                     + recordStore.getLockOwnerInfo(getKey()));
         }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnRollbackOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnRollbackOperation.java
@@ -47,7 +47,7 @@ public class TxnRollbackOperation extends KeyBasedMapOperation implements Backup
 
     @Override
     public void run() throws Exception {
-        if (recordStore.isLocked(getKey()) && !recordStore.unlock(getKey(), ownerUuid, getThreadId())) {
+        if (recordStore.isLocked(getKey()) && !recordStore.unlock(getKey(), ownerUuid, getThreadId(), getCallId())) {
             throw new TransactionException("Lock is not owned by the transaction! Owner: "
                     + recordStore.getLockOwnerInfo(getKey()));
         }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnSetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnSetOperation.java
@@ -75,7 +75,7 @@ public class TxnSetOperation extends BasePutOperation implements MapTxnOperation
     public void run() {
         final MapServiceContext mapServiceContext = mapService.getMapServiceContext();
         final EventService eventService = getNodeEngine().getEventService();
-        recordStore.unlock(dataKey, ownerUuid, threadId);
+        recordStore.unlock(dataKey, ownerUuid, threadId, getCallId());
         Record record = recordStore.getRecordOrNull(dataKey);
         if (record == null || version == record.getVersion()) {
             if (eventService.hasEventRegistration(MapService.SERVICE_NAME, getName())) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnUnlockBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnUnlockBackupOperation.java
@@ -35,7 +35,7 @@ public class TxnUnlockBackupOperation extends KeyBasedMapOperation implements Ba
 
     @Override
     public void run() {
-        recordStore.unlock(dataKey, getCallerUuid(), getThreadId());
+        recordStore.unlock(dataKey, getCallerUuid(), getThreadId(), getCallId());
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnUnlockOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnUnlockOperation.java
@@ -53,7 +53,7 @@ public class TxnUnlockOperation extends LockAwareOperation implements MapTxnOper
 
     @Override
     public void run() {
-        recordStore.unlock(dataKey, ownerUuid, threadId);
+        recordStore.unlock(dataKey, ownerUuid, threadId, getCallId());
     }
 
     public boolean shouldWait() {

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapContainer.java
@@ -79,12 +79,12 @@ public class MultiMapContainer extends MultiMapContainerSupport {
         return lockStore != null && lockStore.isTransactionallyLocked(key);
     }
 
-    public boolean txnLock(Data key, String caller, long threadId, long ttl) {
-        return lockStore != null && lockStore.txnLock(key, caller, threadId, ttl);
+    public boolean txnLock(Data key, String caller, long threadId, long referenceId, long ttl) {
+        return lockStore != null && lockStore.txnLock(key, caller, threadId, referenceId, ttl);
     }
 
-    public boolean unlock(Data key, String caller, long threadId) {
-        return lockStore != null && lockStore.unlock(key, caller, threadId);
+    public boolean unlock(Data key, String caller, long threadId, long referenceId) {
+        return lockStore != null && lockStore.unlock(key, caller, threadId, referenceId);
     }
 
     public boolean forceUnlock(Data key) {

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapProxySupport.java
@@ -17,8 +17,10 @@
 package com.hazelcast.multimap.impl;
 
 import com.hazelcast.concurrent.lock.LockProxySupport;
+import com.hazelcast.concurrent.lock.LockServiceImpl;
 import com.hazelcast.config.MultiMapConfig;
 import com.hazelcast.core.EntryEventType;
+import com.hazelcast.map.impl.MapService;
 import com.hazelcast.multimap.impl.operations.CountOperation;
 import com.hazelcast.multimap.impl.operations.GetAllOperation;
 import com.hazelcast.multimap.impl.operations.MultiMapOperationFactory;
@@ -34,6 +36,7 @@ import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.util.ExceptionUtil;
 import com.hazelcast.util.ThreadUtil;
+
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -49,7 +52,9 @@ public abstract class MultiMapProxySupport extends AbstractDistributedObject<Mul
         super(nodeEngine, service);
         this.config = nodeEngine.getConfig().findMultiMapConfig(name);
         this.name = name;
-        lockSupport = new LockProxySupport(new DefaultObjectNamespace(MultiMapService.SERVICE_NAME, name));
+
+        lockSupport = new LockProxySupport(new DefaultObjectNamespace(MapService.SERVICE_NAME, name),
+                LockServiceImpl.getMaxLeaseTimeInMillis(nodeEngine.getGroupProperties()));
     }
 
     protected Boolean putInternal(Data dataKey, Data dataValue, int index) {

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnCommitOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnCommitOperation.java
@@ -49,7 +49,7 @@ public class TxnCommitOperation extends MultiMapBackupAwareOperation implements 
             op.run();
             op.afterRun();
         }
-        getOrCreateContainer().unlock(dataKey, getCallerUuid(), threadId);
+        getOrCreateContainer().unlock(dataKey, getCallerUuid(), threadId, getCallId());
     }
 
     public boolean shouldBackup() {

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnLockAndGetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnLockAndGetOperation.java
@@ -50,7 +50,7 @@ public class TxnLockAndGetOperation extends MultiMapKeyBasedOperation implements
 
     public void run() throws Exception {
         MultiMapContainer container = getOrCreateContainer();
-        if (!container.txnLock(dataKey, getCallerUuid(), threadId, ttl)) {
+        if (!container.txnLock(dataKey, getCallerUuid(), threadId, getCallId(), ttl)) {
             throw new TransactionException("Transaction couldn't obtain lock!");
         }
         MultiMapWrapper wrapper = getCollectionWrapper();

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnPrepareBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnPrepareBackupOperation.java
@@ -43,7 +43,7 @@ public class TxnPrepareBackupOperation extends MultiMapKeyBasedOperation impleme
 
     public void run() throws Exception {
         MultiMapContainer container = getOrCreateContainer();
-        if (!container.txnLock(dataKey, caller, threadId, ttl + LOCK_EXTENSION_TIME_IN_MILLIS)) {
+        if (!container.txnLock(dataKey, caller, threadId, getCallId(), ttl + LOCK_EXTENSION_TIME_IN_MILLIS)) {
             throw new TransactionException(
                     "Lock is not owned by the transaction! -> " + container.getLockOwnerInfo(dataKey)
             );

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnRollbackBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnRollbackBackupOperation.java
@@ -41,7 +41,7 @@ public class TxnRollbackBackupOperation extends MultiMapKeyBasedOperation implem
 
     public void run() throws Exception {
         MultiMapContainer container = getOrCreateContainer();
-        if (container.isLocked(dataKey) && !container.unlock(dataKey, caller, threadId)) {
+        if (container.isLocked(dataKey) && !container.unlock(dataKey, caller, threadId, getCallId())) {
             throw new TransactionException(
                     "Lock is not owned by the transaction! -> " + container.getLockOwnerInfo(dataKey)
             );

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnRollbackOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnRollbackOperation.java
@@ -36,7 +36,7 @@ public class TxnRollbackOperation extends MultiMapBackupAwareOperation implement
 
     public void run() throws Exception {
         MultiMapContainer container = getOrCreateContainer();
-        if (container.isLocked(dataKey) && !container.unlock(dataKey, getCallerUuid(), threadId)) {
+        if (container.isLocked(dataKey) && !container.unlock(dataKey, getCallerUuid(), threadId, getCallId())) {
             throw new TransactionException(
                     "Lock is not owned by the transaction! Owner: " + container.getLockOwnerInfo(dataKey)
             );

--- a/hazelcast/src/main/java/com/hazelcast/spi/Operation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/Operation.java
@@ -182,7 +182,11 @@ public abstract class Operation implements DataSerializable {
     // Accessed using OperationAccessor
     final Operation setCallId(long callId) {
         this.callId = callId;
+        onSetCallId();
         return this;
+    }
+
+    protected void onSetCallId() {
     }
 
     public boolean validatesTarget() {


### PR DESCRIPTION
- Lock cleanup task submitted when a member is left should be executed on related partition threads, otherwise it can miss previously enqueued or being executed lock operations. So, this race can cause infinitely hanging locks.

- Lock cleanup operation should check owner-uuid during its execution in partition thread to avoid race.

- Added "reference-call-id" to lock operation to provide operation retry idempotence. When a member crashes after processing a lock request and sending its backup, caller will retry the lock operation. If it happens that backup member already processed the lock request, then caller will acquire lock resource 2nd time (because it's reentrant) unintentionally. When it releases the lock only once, lock will hang infinitely. To avoid that, now lock operation and lock service always keep the original/reference call-id for a specific lock resource and if it's tried to be acquired multiple times with the same reference-call-id, lock request will just return success instead of processing it again.

- Introduced max-lease-time (default is Integer.MAX seconds) for locks. When lock is acquired without an explicit lease-time then max-lease-time setting will be used. Caller can use a lower value but not a greater one. When a greater lease-time is given, invocation/operation will fail immediately.

- Fixed a bug which lease-time is not set correctly on backups and when backup is promoted, lease handling process doesn't kicks in.

- Added a safety unlock call when a lock invocation timeouts to decrease chance of hanging locks.