### PR TITLE
Fixes and enhancements regarding invocation system

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/Operation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/Operation.java
@@ -534,7 +534,7 @@ public abstract class Operation implements DataSerializable {
     @Override
     public String toString() {
         final StringBuilder sb = new StringBuilder(getClass().getName()).append('{');
-        sb.append("serviceName='").append(serviceName).append('\'');
+        sb.append("serviceName='").append(getServiceName()).append('\'');
         sb.append(", partitionId=").append(partitionId);
         sb.append(", callId=").append(callId);
         sb.append(", invocationTime=").append(invocationTime);

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/Invocation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/Invocation.java
@@ -527,7 +527,12 @@ abstract class Invocation implements OperationResponseHandler, Runnable {
             return;
         }
 
-        invocationFuture.set(WAIT_RESPONSE);
+        if (!invocationFuture.set(WAIT_RESPONSE)) {
+            logger.finest("Cannot retry " + toString() + ", because a different response is already set: "
+                    + invocationFuture.response);
+            return;
+        }
+
         ExecutionService ex = nodeEngine.getExecutionService();
         // fast retry for the first few invocations
         if (invokeCount < MAX_FAST_INVOCATION_COUNT) {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationFuture.java
@@ -144,8 +144,11 @@ final class InvocationFuture<E> implements InternalCompletableFuture<E> {
      * 'set' calls are ignored.
      *
      * @param offeredResponse The type of response to offer.
+     * @return <tt>true</tt> if offered response, either a final response or an internal response,
+     * is set/applied, <tt>false</tt> otherwise. If <tt>false</tt> is returned, that means offered response is ignored
+     * because a final response is already set to this future.
      */
-    public void set(Object offeredResponse) {
+    public boolean set(Object offeredResponse) {
         assert !(offeredResponse instanceof Response) : "unexpected response found: " + offeredResponse;
 
         if (offeredResponse == null) {
@@ -167,12 +170,12 @@ final class InvocationFuture<E> implements InternalCompletableFuture<E> {
                 }
 
                 operationService.invocationsRegistry.deregister(invocation);
-                return;
+                return false;
             }
 
             response = offeredResponse;
             if (offeredResponse == WAIT_RESPONSE) {
-                return;
+                return true;
             }
             callbackChain = callbackHead;
             callbackHead = null;
@@ -183,6 +186,7 @@ final class InvocationFuture<E> implements InternalCompletableFuture<E> {
 
 
         notifyCallbacks(callbackChain);
+        return true;
     }
 
     private void notifyCallbacks(ExecutionCallbackNode<E> callbackChain) {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationFuture.java
@@ -165,6 +165,8 @@ final class InvocationFuture<E> implements InternalCompletableFuture<E> {
                     logger.finest("Future response is already set! Current response: "
                             + response + ", Offered response: " + offeredResponse + ", Invocation: " + invocation);
                 }
+
+                operationService.invocationsRegistry.deregister(invocation);
                 return;
             }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationFuture.java
@@ -267,6 +267,9 @@ final class InvocationFuture<E> implements InternalCompletableFuture<E> {
                     boolean executing = operationService.getIsStillRunningService().isOperationExecuting(invocation);
                     if (!executing) {
                         Object operationTimeoutException = invocation.newOperationTimeoutException(pollCount * pollTimeoutMs);
+                        if (response != null) {
+                            continue;
+                        }
                         // tries to set an OperationTimeoutException response if response is not set yet
                         set(operationTimeoutException);
                     }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationBackupHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationBackupHandler.java
@@ -150,6 +150,17 @@ final class OperationBackupHandler {
         InternalPartitionService partitionService = node.getPartitionService();
         InternalPartition partition = partitionService.getPartition(partitionId);
 
+        Operation backupOp = backupAwareOp.getBackupOperation();
+        if (backupOp == null) {
+            throw new IllegalArgumentException("Backup operation should not be null! " + backupAwareOp);
+        }
+        Operation op = (Operation) backupAwareOp;
+        // set service name of backup operation.
+        // if getServiceName() method is overridden to return the same name
+        // then this will have no effect.
+        backupOp.setServiceName(op.getServiceName());
+        Data backupOpData = nodeEngine.getSerializationService().toData(backupOp);
+
         for (int replicaIndex = 1; replicaIndex <= syncBackups + asyncBackups; replicaIndex++) {
             Address target = partition.getReplicaAddress(replicaIndex);
 
@@ -161,7 +172,7 @@ final class OperationBackupHandler {
 
             boolean isSyncBackup = replicaIndex <= syncBackups;
 
-            Backup backup = newBackup(backupAwareOp, replicaVersions, replicaIndex, isSyncBackup);
+            Backup backup = newBackup(backupAwareOp, backupOpData, replicaVersions, replicaIndex, isSyncBackup);
             operationService.send(backup, target);
 
             if (isSyncBackup) {
@@ -172,33 +183,17 @@ final class OperationBackupHandler {
         return sendSyncBackups;
     }
 
-    private Backup newBackup(BackupAwareOperation backupAwareOp, long[] replicaVersions,
-                             int replicaIndex, boolean isSyncBackup) {
-        Operation op = (Operation) backupAwareOp;
-        Operation backupOp = newBackupOperation(backupAwareOp, replicaIndex);
-        Data backupOpData = nodeEngine.getSerializationService().toData(backupOp);
+    private Backup newBackup(BackupAwareOperation backupAwareOp, Data backupOpData, long[] replicaVersions,
+            int replicaIndex, boolean respondBack) {
 
-        Backup backup = new Backup(backupOpData, op.getCallerAddress(), replicaVersions, isSyncBackup);
+        Operation op = (Operation) backupAwareOp;
+        Backup backup = new Backup(backupOpData, op.getCallerAddress(), replicaVersions, respondBack);
         backup.setPartitionId(op.getPartitionId())
                 .setReplicaIndex(replicaIndex)
-                .setServiceName(op.getServiceName())
                 .setCallerUuid(nodeEngine.getLocalMember().getUuid());
         setCallId(backup, op.getCallId());
 
         return backup;
-    }
-
-    private Operation newBackupOperation(BackupAwareOperation backupAwareOp, int replicaIndex) {
-        Operation backupOp = backupAwareOp.getBackupOperation();
-        if (backupOp == null) {
-            throw new IllegalArgumentException("Backup operation should not be null! " + backupAwareOp);
-        }
-
-        Operation op = (Operation) backupAwareOp;
-        backupOp.setPartitionId(op.getPartitionId())
-                .setReplicaIndex(replicaIndex)
-                .setServiceName(op.getServiceName());
-        return backupOp;
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImpl.java
@@ -38,6 +38,7 @@ import com.hazelcast.spi.ReadonlyOperation;
 import com.hazelcast.spi.WaitSupport;
 import com.hazelcast.spi.exception.CallerNotMemberException;
 import com.hazelcast.spi.exception.PartitionMigratingException;
+import com.hazelcast.spi.exception.ResponseAlreadySentException;
 import com.hazelcast.spi.exception.RetryableException;
 import com.hazelcast.spi.exception.WrongTargetException;
 import com.hazelcast.spi.impl.NodeEngineImpl;
@@ -224,7 +225,12 @@ class OperationRunnerImpl extends OperationRunner {
         if (responseHandler == null) {
             throw new IllegalStateException("ResponseHandler should not be null! " + op);
         }
-        responseHandler.sendResponse(op, response);
+
+        try {
+            responseHandler.sendResponse(op, response);
+        } catch (ResponseAlreadySentException e) {
+            logOperationError(op, e);
+        }
     }
 
     private void afterRun(Operation op) {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImpl.java
@@ -201,32 +201,39 @@ class OperationRunnerImpl extends OperationRunner {
 
     private void handleResponse(Operation op) throws Exception {
         boolean returnsResponse = op.returnsResponse();
-        Object response = null;
-        if (op instanceof BackupAwareOperation) {
-            BackupAwareOperation backupAwareOp = (BackupAwareOperation) op;
-            int syncBackupCount = 0;
-            if (backupAwareOp.shouldBackup()) {
-                syncBackupCount = operationService.operationBackupHandler.backup(backupAwareOp);
-            }
-            if (returnsResponse) {
-                response = new NormalResponse(op.getResponse(), op.getCallId(), syncBackupCount, op.isUrgent());
-            }
-        }
+        int syncBackupCount = sendBackup(op);
 
         if (!returnsResponse) {
             return;
         }
 
-        if (response == null) {
-            response = op.getResponse();
+        sendResponse(op, syncBackupCount);
+    }
+
+    private int sendBackup(Operation op) throws Exception {
+        if (!(op instanceof BackupAwareOperation)) {
+            return 0;
         }
 
+        int syncBackupCount = 0;
+        BackupAwareOperation backupAwareOp = (BackupAwareOperation) op;
+        if (backupAwareOp.shouldBackup()) {
+            syncBackupCount = operationService.operationBackupHandler.backup(backupAwareOp);
+        }
+        return syncBackupCount;
+    }
+
+    private void sendResponse(Operation op, int syncBackupCount) {
         OperationResponseHandler responseHandler = op.getOperationResponseHandler();
         if (responseHandler == null) {
             throw new IllegalStateException("ResponseHandler should not be null! " + op);
         }
 
         try {
+            Object response = op.getResponse();
+            if (syncBackupCount > 0) {
+                response = new NormalResponse(response, op.getCallId(), syncBackupCount, op.isUrgent());
+            }
             responseHandler.sendResponse(op, response);
         } catch (ResponseAlreadySentException e) {
             logOperationError(op, e);

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
@@ -332,7 +332,7 @@ public final class OperationServiceImpl implements InternalOperationService, Pac
         long invocationTime = op.getInvocationTime();
         long expireTime = invocationTime + callTimeout;
 
-        if (expireTime <= 0 || expireTime >= Long.MAX_VALUE) {
+        if (expireTime <= 0 || expireTime == Long.MAX_VALUE) {
             return false;
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/ResponsePacketHandlerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/ResponsePacketHandlerImpl.java
@@ -45,7 +45,7 @@ final class ResponsePacketHandlerImpl implements PacketHandler {
         Data data = packet.getData();
         Response response = serializationService.toObject(data);
         try {
-            invocationRegistry.notify(response);
+            invocationRegistry.notify(response, packet.getConn().getEndPoint());
         } catch (Throwable e) {
             logger.severe("While processing response...", e);
         }

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationRegistry_notifyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationRegistry_notifyTest.java
@@ -68,7 +68,7 @@ public class InvocationRegistry_notifyTest extends HazelcastTestSupport {
 
         long callId = invocation.op.getCallId();
         Object value = "foo";
-        invocationRegistry.notify(new NormalResponse(value, callId, 0, false));
+        invocationRegistry.notify(new NormalResponse(value, callId, 0, false), null);
 
         assertEquals(value, invocation.invocationFuture.getSafely());
         assertNull(invocationRegistry.get(callId));
@@ -81,7 +81,7 @@ public class InvocationRegistry_notifyTest extends HazelcastTestSupport {
         long callId = invocation.op.getCallId();
         invocationRegistry.deregister(invocation);
 
-        invocationRegistry.notify(new NormalResponse("foo", callId, 0, false));
+        invocationRegistry.notify(new NormalResponse("foo", callId, 0, false), null);
 
         assertNull(invocationRegistry.get(callId));
     }
@@ -93,11 +93,11 @@ public class InvocationRegistry_notifyTest extends HazelcastTestSupport {
 
         long callId = invocation.op.getCallId();
 
-        invocationRegistry.notify(new BackupResponse(callId, false));
+        invocationRegistry.notify(new BackupResponse(callId, false), null);
         assertSame(invocation, invocationRegistry.get(callId));
 
         Object value = "foo";
-        invocationRegistry.notify(new NormalResponse(value, callId, 1, false));
+        invocationRegistry.notify(new NormalResponse(value, callId, 1, false), null);
         assertNull(invocationRegistry.get(callId));
 
         assertEquals(value, invocation.invocationFuture.getSafely());
@@ -113,7 +113,7 @@ public class InvocationRegistry_notifyTest extends HazelcastTestSupport {
         long callId = invocation.op.getCallId();
 
         String result = "foo";
-        invocationRegistry.notify(new NormalResponse(result, callId, 1, false));
+        invocationRegistry.notify(new NormalResponse(result, callId, 1, false), null);
 
         assertEquals(result, invocation.invocationFuture.get(1, TimeUnit.MINUTES));
         assertNull(invocationRegistry.get(callId));
@@ -134,10 +134,10 @@ public class InvocationRegistry_notifyTest extends HazelcastTestSupport {
 
         long callId = invocation.op.getCallId();
         Object value = "foo";
-        invocationRegistry.notify(new NormalResponse(value, callId, 1, false));
+        invocationRegistry.notify(new NormalResponse(value, callId, 1, false), null);
         assertSame(invocation, invocationRegistry.get(callId));
 
-        invocationRegistry.notify(new BackupResponse(callId, false));
+        invocationRegistry.notify(new BackupResponse(callId, false), null);
         assertNull(invocationRegistry.get(callId));
 
         assertEquals(value, invocation.invocationFuture.getSafely());
@@ -150,7 +150,7 @@ public class InvocationRegistry_notifyTest extends HazelcastTestSupport {
         invocationRegistry.register(invocation);
         invocationRegistry.deregister(invocation);
 
-        invocationRegistry.notify(new BackupResponse(callId, false));
+        invocationRegistry.notify(new BackupResponse(callId, false), null);
         assertNull(invocationRegistry.get(callId));
     }
 
@@ -162,7 +162,8 @@ public class InvocationRegistry_notifyTest extends HazelcastTestSupport {
         invocationRegistry.register(invocation);
 
         long callId = invocation.op.getCallId();
-        invocationRegistry.notify(new ErrorResponse(new ExpectedRuntimeException(), callId, false));
+        invocationRegistry.notify(new ErrorResponse(new ExpectedRuntimeException(), callId, false),
+                null);
 
         try {
             invocation.invocationFuture.getSafely();
@@ -180,7 +181,8 @@ public class InvocationRegistry_notifyTest extends HazelcastTestSupport {
         long callId = invocation.op.getCallId();
         invocationRegistry.deregister(invocation);
 
-        invocationRegistry.notify(new ErrorResponse(new ExpectedRuntimeException(), callId, false));
+        invocationRegistry.notify(new ErrorResponse(new ExpectedRuntimeException(), callId, false),
+                null);
 
         assertNull(invocationRegistry.get(callId));
     }
@@ -193,7 +195,7 @@ public class InvocationRegistry_notifyTest extends HazelcastTestSupport {
         invocationRegistry.register(invocation);
 
         long callId = invocation.op.getCallId();
-        invocationRegistry.notify(new CallTimeoutResponse(callId, false));
+        invocationRegistry.notify(new CallTimeoutResponse(callId, false), null);
 
         assertNull(invocation.invocationFuture.getSafely());
         assertNull(invocationRegistry.get(callId));


### PR DESCRIPTION
- When an invocation timeout is detected (original invocation or its backup), it should be removed from registry. Normally this is done when response is set, but if response is set (either original response just arrives or member left happens) before operation timeout response, invocation can be left in registry.

- Added `response != null` check before throwing operation-timeout-exception to prevent getting a timeout when invocation is just retried.

- `ResponseAlreadySentException` cannot be propagated to the caller, it should be logged on remote side, otherwise this causes error loop.

- Optimized multiple backups to serialize backup operation only once instead of multiple times for all backup replicas.

- Prevent invocation retry if a response is already set to future. This fixes #5261.