### PR TITLE
Make sure hazelcast can be launched from any directory

### DIFF
--- a/hazelcast/src/main/resources/server.bat
+++ b/hazelcast/src/main/resources/server.bat
@@ -23,7 +23,7 @@ if NOT "%MAX_HEAP_SIZE%" == "" (
 	set JAVA_OPTS=%JAVA_OPTS% -Xmx%MAX_HEAP_SIZE%
 )
 
-set CLASSPATH=..\lib\hazelcast-all-${project.version}.jar
+set CLASSPATH=%~dp0..\lib\hazelcast-all-${project.version}.jar
 
 ECHO ########################################
 ECHO # RUN_JAVA=%RUN_JAVA%

--- a/hazelcast/src/main/resources/server.sh
+++ b/hazelcast/src/main/resources/server.sh
@@ -2,7 +2,7 @@
 
 PRG="$0"
 PRGDIR=`dirname "$PRG"`
-HAZELCAST_HOME=../$PRGDIR
+HAZELCAST_HOME=`cd "$PRGDIR/.." >/dev/null; pwd`
 
 if [ $JAVA_HOME ]
 then


### PR DESCRIPTION
Currently, server.sh and server.bat can only be called from HAZELCAST_HOME. This fix allows it to be called from anywhere.