### PR TITLE
Cluster uptime and id is sent to call home.

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cluster/ClusterClock.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/ClusterClock.java
@@ -20,12 +20,20 @@ public interface ClusterClock {
 
     /**
      * Returns the cluster-time in milliseconds.
-     *
      * The cluster-time measures elapsed time since the cluster was created. Comparable to the {@link System#nanoTime()}.
-     *
      * @return the cluster-time (elapsed milliseconds since the cluster was created).
      */
     long getClusterTime();
 
     long getClusterTimeDiff();
+
+    /**
+     * Returns the cluster  up-time in milliseconds.
+     * When first node in cluster becomes master, its clusterTime value is saved as
+     * clusterStartTime. Up-time of cluster is calculated as
+     * ClusterClock#getClusterTime - clusterStartTime.
+     *
+     * @return the cluster-up-time
+     */
+     long getClusterUpTime();
 }

--- a/hazelcast/src/main/java/com/hazelcast/cluster/ClusterService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/ClusterService.java
@@ -101,4 +101,12 @@ public interface ClusterService extends CoreService {
      */
     ClusterClock getClusterClock();
 
+    /**
+     * Returns UUID for the cluster.
+     *
+     * @return unique Id for cluster
+     */
+    String getClusterId();
+
+
 }

--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/ClusterClockImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/ClusterClockImpl.java
@@ -20,10 +20,12 @@ import com.hazelcast.cluster.ClusterClock;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.util.Clock;
 
+
 public class ClusterClockImpl implements ClusterClock {
 
     private final ILogger logger;
     private volatile long clusterTimeDiff = Long.MAX_VALUE;
+    private volatile long clusterStartTime = Long.MIN_VALUE;
 
     public ClusterClockImpl(ILogger logger) {
         this.logger = logger;
@@ -46,4 +48,20 @@ public class ClusterClockImpl implements ClusterClock {
     public long getClusterTimeDiff() {
         return (clusterTimeDiff == Long.MAX_VALUE) ? 0 : clusterTimeDiff;
     }
+
+    @Override
+    public long getClusterUpTime() {
+        return Clock.currentTimeMillis() - clusterStartTime;
+    }
+
+    public void setClusterStartTime(long startTime) {
+        if (this.clusterStartTime == Long.MIN_VALUE) {
+            this.clusterStartTime = startTime;
+        }
+    }
+
+    public long getClusterStartTime() {
+       return clusterStartTime;
+    }
+
 }

--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/ClusterServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/ClusterServiceImpl.java
@@ -172,6 +172,8 @@ public final class ClusterServiceImpl implements ClusterService, ConnectionListe
 
     private final ClusterClockImpl clusterClock;
 
+    private String clusterId = null;
+
     public ClusterServiceImpl(final Node node) {
         this.node = node;
         nodeEngine = node.nodeEngine;
@@ -198,6 +200,17 @@ public final class ClusterServiceImpl implements ClusterService, ConnectionListe
     @Override
     public ClusterClockImpl getClusterClock() {
         return clusterClock;
+    }
+
+    @Override
+    public String getClusterId() {
+        return clusterId;
+    }
+
+    public void setClusterId(String clusterId) {
+        if (this.clusterId == null) {
+            this.clusterId = clusterId;
+        }
     }
 
     @Override
@@ -976,7 +989,9 @@ public final class ClusterServiceImpl implements ClusterService, ConnectionListe
                 final int count = members.size() - 1 + setJoins.size();
                 final List<Future> calls = new ArrayList<Future>(count);
                 for (MemberInfo member : setJoins) {
-                    calls.add(invokeClusterOperation(new FinalizeJoinOperation(memberInfos, postJoinOp, time), member.getAddress()));
+                    final long startTime = clusterClock.getClusterStartTime();
+                    calls.add(invokeClusterOperation(new FinalizeJoinOperation(memberInfos, postJoinOp, time,
+                            clusterId, startTime), member.getAddress()));
                 }
                 for (MemberImpl member : members) {
                     if (!member.getAddress().equals(thisAddress)) {

--- a/hazelcast/src/main/java/com/hazelcast/instance/Node.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/Node.java
@@ -576,6 +576,11 @@ public class Node {
         logger.finest("This node is being set as the master");
         masterAddress = address;
         setJoined();
+        this.getClusterService().getClusterClock().
+                setClusterStartTime(Clock.currentTimeMillis());
+        this.getClusterService().setClusterId(
+                UuidUtil.createClusterUuid()
+        );
     }
 
     public Config getConfig() {

--- a/hazelcast/src/main/java/com/hazelcast/util/UuidUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/UuidUtil.java
@@ -55,6 +55,10 @@ public final class UuidUtil {
         }
     }
 
+    public static String createClusterUuid() {
+        return  buildRandomUuidString();
+    }
+
     public static String createMemberUuid(Address endpoint) {
         return buildRandomUUID().toString();
     }

--- a/hazelcast/src/main/java/com/hazelcast/util/VersionCheck.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/VersionCheck.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.util;
 
+import com.hazelcast.cluster.impl.ClusterServiceImpl;
 import com.hazelcast.config.NativeMemoryConfig;
 import com.hazelcast.core.ClientType;
 import com.hazelcast.instance.Node;
@@ -24,8 +25,11 @@ import com.hazelcast.nio.IOUtil;
 import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.management.ManagementFactory;
+import java.lang.management.RuntimeMXBean;
 import java.net.URL;
 import java.net.URLConnection;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
@@ -92,7 +96,8 @@ public final class VersionCheck {
 
     }
 
-    private void doCheck(Node hazelcastNode, String version, boolean isEnterprise) {
+    public Map<String, String> doCheck(Node hazelcastNode, String version, boolean isEnterprise) {
+
         String downloadId = "source";
         InputStream is = null;
         try {
@@ -110,29 +115,36 @@ public final class VersionCheck {
 
         //Calculate native memory usage from native memory config
         NativeMemoryConfig memoryConfig = hazelcastNode.getConfig().getNativeMemoryConfig();
-        long totalNativeMemorySize = hazelcastNode.getClusterService().getSize()
+        final ClusterServiceImpl clusterService = hazelcastNode.getClusterService();
+        long totalNativeMemorySize = clusterService.getSize()
                 * memoryConfig.getSize().bytes();
         String nativeMemoryParameter = (isEnterprise)
                 ? Long.toString(MemoryUnit.BYTES.toGigaBytes(totalNativeMemorySize)) : "0";
         //Calculate connected clients to the cluster.
         Map<ClientType, Integer> clusterClientStats = hazelcastNode.clientEngine.getConnectedClientStats();
+        RuntimeMXBean runtimeMxBean = ManagementFactory.getRuntimeMXBean();
 
-        UrlActionParameterCreator parameterCreator = new UrlActionParameterCreator();
+        Long clusterUpTime = clusterService.getClusterClock().getClusterUpTime();
+
+        VersionCheckParameterCreator parameterCreator = new VersionCheckParameterCreator();
         parameterCreator.addParam("version", version);
         parameterCreator.addParam("m", hazelcastNode.getLocalMember().getUuid());
         parameterCreator.addParam("e", Boolean.toString(isEnterprise));
         parameterCreator.addParam("l", MD5Util.toMD5String(hazelcastNode.getConfig().getLicenseKey()));
         parameterCreator.addParam("p", downloadId);
-        parameterCreator.addParam("c", MD5Util.toMD5String(hazelcastNode.getConfig().getGroupConfig().getName()));
-        parameterCreator.addParam("crsz", convertToLetter(hazelcastNode.getClusterService().getMembers().size()));
+        parameterCreator.addParam("c", clusterService.getClusterId());
+        parameterCreator.addParam("crsz", convertToLetter(clusterService.getMembers().size()));
         parameterCreator.addParam("cssz", convertToLetter(hazelcastNode.clientEngine.getClientEndpointCount()));
         parameterCreator.addParam("hdgb", nativeMemoryParameter);
         parameterCreator.addParam("ccpp", Integer.toString(clusterClientStats.get(ClientType.CPP)));
         parameterCreator.addParam("cdn", Integer.toString(clusterClientStats.get(ClientType.CSHARP)));
         parameterCreator.addParam("cjv", Integer.toString(clusterClientStats.get(ClientType.JAVA)));
-
+        parameterCreator.addParam("cuptm", Long.toString(clusterUpTime));
+        parameterCreator.addParam("nuptm", Long.toString(runtimeMxBean.getUptime()));
         String urlStr = BASE_VERSION_CHECK_URL + parameterCreator.build();
         fetchWebService(urlStr);
+
+        return parameterCreator.getParameters();
     }
 
     private void fetchWebService(String urlStr) {
@@ -151,23 +163,29 @@ public final class VersionCheck {
         }
     }
 
-    private static class UrlActionParameterCreator {
+    private static class VersionCheckParameterCreator {
 
         private final StringBuilder builder;
+        private final Map<String, String> parameters = new HashMap<String, String>();
         private boolean hasParameterBefore;
 
-        public UrlActionParameterCreator() {
+        public VersionCheckParameterCreator() {
             builder = new StringBuilder();
             builder.append("?");
         }
 
-        public UrlActionParameterCreator addParam(String key, String value) {
+        public Map<String, String> getParameters() {
+            return parameters;
+        }
+
+        public VersionCheckParameterCreator addParam(String key, String value) {
             if (hasParameterBefore) {
                 builder.append("&");
             } else {
                 hasParameterBefore = true;
             }
             builder.append(key).append("=").append(value);
+            parameters.put(key, value);
             return this;
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/cluster/ClusterInfoTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/ClusterInfoTest.java
@@ -1,0 +1,121 @@
+package com.hazelcast.cluster;
+
+
+import com.hazelcast.cluster.impl.ClusterServiceImpl;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.instance.Node;
+import com.hazelcast.instance.TestUtil;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class ClusterInfoTest extends HazelcastTestSupport {
+
+
+    private TestHazelcastInstanceFactory factory;
+
+    @Before
+    public void init() {
+        factory = new TestHazelcastInstanceFactory(4);
+    }
+
+    @After
+    public void cleanup() {
+        factory.terminateAll();
+    }
+
+    @Test
+    public void test_start_time_single_node_cluster() throws Exception {
+        HazelcastInstance h1 = factory.newHazelcastInstance();
+        Node node1 = TestUtil.getNode(h1);
+        assertNotEquals(Long.MIN_VALUE, node1.getClusterService().getClusterClock().getClusterStartTime());
+    }
+
+    @Test
+    public void all_nodes_should_have_the_same_cluster_start_time_and_cluster_id() throws Exception {
+
+        HazelcastInstance h1 = factory.newHazelcastInstance();
+        HazelcastInstance h2 = factory.newHazelcastInstance();
+        HazelcastInstance h3 = factory.newHazelcastInstance();
+
+        assertSizeEventually(3, h1.getCluster().getMembers());
+        assertSizeEventually(3, h2.getCluster().getMembers());
+        assertSizeEventually(3, h3.getCluster().getMembers());
+
+        Node node1 = TestUtil.getNode(h1);
+        Node node2 = TestUtil.getNode(h2);
+        Node node3 = TestUtil.getNode(h3);
+
+        //All nodes should have same startTime
+        final ClusterServiceImpl clusterService = node1.getClusterService();
+        long node1ClusterStartTime = clusterService.getClusterClock().getClusterStartTime();
+        long clusterUpTime = clusterService.getClusterClock().getClusterUpTime();
+        String node1ClusterId = clusterService.getClusterId();
+
+        assertTrue(clusterUpTime > 0);
+        assertNotEquals(node1ClusterStartTime, Long.MIN_VALUE);
+        assertEquals(node1ClusterStartTime, node2.getClusterService().getClusterClock().getClusterStartTime());
+        assertEquals(node1ClusterStartTime, node3.getClusterService().getClusterClock().getClusterStartTime());
+
+        //All nodes should have same clusterId
+        assertNotNull(node1ClusterId);
+        assertEquals(node1ClusterId, node2.getClusterService().getClusterId());
+        assertEquals(node1ClusterId, node3.getClusterService().getClusterId());
+
+
+    }
+
+    @Test
+    public void all_nodes_should_have_the_same_cluster_start_time_and_id_after_master_shutdown_and_new_node_join() {
+
+        HazelcastInstance h1 = factory.newHazelcastInstance();
+        HazelcastInstance h2 = factory.newHazelcastInstance();
+        HazelcastInstance h3 = factory.newHazelcastInstance();
+
+        assertSizeEventually(3, h1.getCluster().getMembers());
+        assertSizeEventually(3, h2.getCluster().getMembers());
+        assertSizeEventually(3, h3.getCluster().getMembers());
+
+        Node node1 = TestUtil.getNode(h1);
+        final ClusterServiceImpl clusterService = node1.getClusterService();
+        long node1ClusterStartTime = clusterService.getClusterClock().getClusterStartTime();
+        long clusterUpTime = clusterService.getClusterClock().getClusterUpTime();
+        String node1ClusterId = clusterService.getClusterId();
+
+        assertTrue(clusterUpTime > 0);
+        assertTrue(node1.isMaster());
+        h1.shutdown();
+        assertSizeEventually(2, h2.getCluster().getMembers());
+
+        HazelcastInstance h4 = factory.newHazelcastInstance();
+
+        Node node2 = TestUtil.getNode(h2);
+        Node node3 = TestUtil.getNode(h3);
+        Node node4 = TestUtil.getNode(h4);
+
+        //All nodes should have the same cluster start time
+        assertNotEquals(node1ClusterStartTime, Long.MIN_VALUE);
+        assertEquals(node1ClusterStartTime, node2.getClusterService().getClusterClock().getClusterStartTime());
+        assertEquals(node1ClusterStartTime, node3.getClusterService().getClusterClock().getClusterStartTime());
+        assertEquals(node1ClusterStartTime, node4.getClusterService().getClusterClock().getClusterStartTime());
+
+        //All nodes should have the same clusterId
+        assertEquals(node1ClusterId, node2.getClusterService().getClusterId());
+        assertEquals(node1ClusterId, node3.getClusterService().getClusterId());
+        assertEquals(node1ClusterId, node4.getClusterService().getClusterId());
+
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/TestNodeRegistry.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/TestNodeRegistry.java
@@ -180,6 +180,7 @@ final class TestNodeRegistry {
                 node.setMasterAddress(master);
                 if (node.getMasterAddress().equals(node.getThisAddress())) {
                     node.setJoined();
+                    node.setAsMaster();
                 } else {
                     for (int i = 0; !node.joined() && i < 1000; i++) {
                         try {

--- a/hazelcast/src/test/java/com/hazelcast/util/VersionCheckTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/VersionCheckTest.java
@@ -1,0 +1,62 @@
+package com.hazelcast.util;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.instance.Node;
+import com.hazelcast.instance.TestUtil;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class VersionCheckTest extends HazelcastTestSupport {
+
+
+    private TestHazelcastInstanceFactory factory;
+    private HazelcastInstance hz1;
+
+    @After
+    public void cleanup() {
+        factory.terminateAll();
+    }
+
+    @Before
+    public void init() {
+        factory = new TestHazelcastInstanceFactory(2);
+        hz1 = factory.newHazelcastInstance();
+    }
+
+    @Test
+    public void testVersionCheckParameters() throws Exception {
+
+        Node node1 = TestUtil.getNode(hz1);
+        VersionCheck check = new VersionCheck();
+        Map<String, String> parameters = check.doCheck(node1, "test_version", false);
+
+        assertEquals(parameters.get("version"), "test_version");
+        assertEquals(parameters.get("m"), node1.getLocalMember().getUuid() );
+        assertEquals(parameters.get("e"), "false");
+        assertEquals(parameters.get("l"), "NULL");
+        assertEquals(parameters.get("p"), "source");
+        assertEquals(parameters.get("crsz"), "A");
+        assertEquals(parameters.get("cssz"), "A");
+        assertEquals(parameters.get("hdgb"), "0");
+        assertEquals(parameters.get("ccpp"), "0");
+        assertEquals(parameters.get("cdn"), "0");
+        assertEquals(parameters.get("cjv"), "0");
+        assertNotEquals(parameters.get("cuptm"), "0");
+        assertNotEquals(parameters.get("nuptm"), "0");
+        assertNotEquals(parameters.get("nuptm"), parameters.get("cuptm"));
+    }
+}


### PR DESCRIPTION
This PR adds cluster start time into ClusterClock. Start time of the cluster is set when a master node is assigned in cluster and when a new node makes join request masters start time value is sent to joined node and saved in it ClusterClock. Start time value will be used to calculate uptime of the cluster and will be sent to call home. Also, clusterId sent to call home before was GroupName property and it was not unique value. With this PR clusterId will be concatenation of GroupName and start time. It will provide a pseudo uniqueness since possibility of two clusters starting at the same milliseconds is really low. 