### PR TITLE
Client partition refresh should only done over owner connection and s…

### DIFF
--- a/hazelcast-client-new/src/test/java/com/hazelcast/client/txn/ClientTxnTest.java
+++ b/hazelcast-client-new/src/test/java/com/hazelcast/client/txn/ClientTxnTest.java
@@ -35,7 +35,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
-import org.junit.Ignore;
 
 import java.util.concurrent.CountDownLatch;
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/GetPartitionsMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/GetPartitionsMessageTask.java
@@ -35,9 +35,6 @@ import java.util.Map;
 
 public class GetPartitionsMessageTask extends AbstractCallableMessageTask<GetPartitionsParameters> {
 
-    private static final ClientMessage EMPTY_PARTITIONS
-            = GetPartitionsResultParameters.encode(new Address[0], new int[0]);
-
     public GetPartitionsMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);
     }
@@ -63,7 +60,7 @@ public class GetPartitionsMessageTask extends AbstractCallableMessageTask<GetPar
             Address owner = partitions[i].getOwnerOrNull();
             int index = -1;
             if (owner == null) {
-                return EMPTY_PARTITIONS;
+                return GetPartitionsResultParameters.encode(new Address[0], new int[0]);
             }
 
             final Integer idx = addressMap.get(owner);


### PR DESCRIPTION
…hould not block/retry if connection fails. Otherwise a newly submitted/scheduled partition table refresh task cannot be executed and invocations fails after timeout.

see failure: https://hazelcast-l337.ci.cloudbees.com/job/Hazelcast-3.x-pr-builder/13477/