### PR TITLE
AtomicReference serialization fix backport

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/AbstractAlterOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/AbstractAlterOperation.java
@@ -58,13 +58,13 @@ public abstract class AbstractAlterOperation extends AtomicReferenceBackupAwareO
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
-        out.writeObject(function);
+        out.writeData(function);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
-        function = in.readObject();
+        function = in.readData();
     }
 
     @Override


### PR DESCRIPTION
Bug is fixed in 3.5 (#4652) but missing in 3.4 maintenance branch, issue #5265