### PR TITLE
Wait for LoadMapOperation to return during IMap.loadAll

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
@@ -523,7 +523,13 @@ abstract class MapProxySupport extends AbstractDistributedObject<MapService> imp
         int mapNamePartition = partitionService.getPartitionId(name);
 
         Operation operation = new LoadMapOperation(name, replaceExistingValues);
-        operationService.invokeOnPartition(MapService.SERVICE_NAME, operation, mapNamePartition);
+        Future loadMapFuture = operationService.invokeOnPartition(MapService.SERVICE_NAME, operation, mapNamePartition);
+
+        try {
+            loadMapFuture.get();
+        } catch (Throwable t) {
+            throw ExceptionUtil.rethrow(t);
+        }
 
         waitUntilLoaded();
     }


### PR DESCRIPTION
Otherwise seeing other operations sneaking in before LoadMapOperation and causing the map to load twice as in: #5282
