### PR TITLE
Define "JCache" as Optional at OSGI Bundle Definition

### DIFF
--- a/hazelcast-client-new/pom.xml
+++ b/hazelcast-client-new/pom.xml
@@ -92,6 +92,8 @@
                                 <Import-Package>
                                     !org.junit,
                                     !com.hazelcast.*,
+                                    javax.cache;resolution:=optional,
+                                    javax.cache.*;resolution:=optional,
                                     org.apache.log4j;resolution:=optional,
                                     org.apache.log4j.*;resolution:=optional,
                                     org.apache.logging.log4j;resolution:=optional,

--- a/hazelcast-client/pom.xml
+++ b/hazelcast-client/pom.xml
@@ -92,6 +92,8 @@
                                 <Import-Package>
                                     !org.junit,
                                     !com.hazelcast.*,
+                                    javax.cache;resolution:=optional,
+                                    javax.cache.*;resolution:=optional,
                                     org.apache.log4j;resolution:=optional,
                                     org.apache.log4j.*;resolution:=optional,
                                     org.apache.logging.log4j;resolution:=optional,

--- a/hazelcast/pom.xml
+++ b/hazelcast/pom.xml
@@ -120,6 +120,8 @@
                                     !org.junit,
                                     !com.eclipsesource.json,
                                     sun.misc;resolution:=optional,
+                                    javax.cache;resolution:=optional,
+                                    javax.cache.*;resolution:=optional,
                                     org.apache.log4j;resolution:=optional,
                                     org.apache.logging.log4j;resolution:=optional,
                                     org.apache.logging.log4j.*;resolution:=optional,


### PR DESCRIPTION
Although JCache dependency is defined as `provided` (so it is exported as optional at ` Import-Package` definition in `MANIFEST.MF`) in maven dependencies, it will be nice defining it as optional explicitly in OSGI Bundle definitions also in `pom.xml`