### PR TITLE
Transiently put entries should not be reached after eviction when map…

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/WriteBehindStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/WriteBehindStore.java
@@ -64,6 +64,14 @@ public class WriteBehindStore extends AbstractMapDataStore<Data, Object> {
      */
     private final Set<Data> writeBehindWaitingDeletions;
 
+    /**
+     * To look up entries which are put with {@link com.hazelcast.core.IMap#putTransient}.
+     * This lookup is needed when write-behind and eviction are used together. During eviction
+     * of an entry normally we are flushing evicted entry to the {@link #stagingArea} to get rid of any stale read
+     * but transient entries should not be flushed there because they don't exist in data stores.
+     */
+    private final Set<Data> transients;
+
     public WriteBehindStore(MapStoreWrapper store, SerializationService serializationService,
                             long writeDelayTime, int partitionId) {
         super(store, serializationService);
@@ -72,6 +80,7 @@ public class WriteBehindStore extends AbstractMapDataStore<Data, Object> {
         this.stagingArea = createStagingArea();
         this.flushCounter = new AtomicInteger(0);
         this.writeBehindWaitingDeletions = new HashSet<Data>();
+        this.transients = new HashSet<Data>();
     }
 
     private ConcurrentHashMap<Data, DelayedEntry> createStagingArea() {
@@ -92,6 +101,7 @@ public class WriteBehindStore extends AbstractMapDataStore<Data, Object> {
 
         writeBehindQueue.offer(delayedEntry);
         removeFromWaitingDeletions(key);
+        transients.remove(key);
 
         return value;
     }
@@ -99,6 +109,7 @@ public class WriteBehindStore extends AbstractMapDataStore<Data, Object> {
     @Override
     public void addTransient(Data key, long now) {
         removeFromWaitingDeletions(key);
+        transients.add(key);
     }
 
     @Override
@@ -114,6 +125,7 @@ public class WriteBehindStore extends AbstractMapDataStore<Data, Object> {
                 DelayedEntry.createWithNullValue(key, storeTime, partitionId);
         addToWaitingDeletions(key);
         removeFromStagingArea(key);
+        transients.remove(key);
 
         writeBehindQueue.offer(delayedEntry);
     }
@@ -127,6 +139,7 @@ public class WriteBehindStore extends AbstractMapDataStore<Data, Object> {
     public void clear() {
         writeBehindQueue.clear();
         writeBehindWaitingDeletions.clear();
+        transients.clear();
         stagingArea.clear();
         flushCounter.set(0);
     }
@@ -197,9 +210,14 @@ public class WriteBehindStore extends AbstractMapDataStore<Data, Object> {
 
     @Override
     public Object flush(Data key, Object value, long now, boolean backup) {
+        if (transients.remove(key)) {
+            return null;
+        }
+
         if (writeBehindQueue.size() == 0) {
             return null;
         }
+
         long storeTime = now + writeDelayTime;
         DelayedEntry<Void, Object> delayedEntry = createWithNullKey(value, storeTime);
         stagingArea.put(key, delayedEntry);


### PR DESCRIPTION
… is backed by a write behond store

backport of #5302