### PR TITLE
Document behavior of ICompletableFuture methods

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/core/ICompletableFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/ICompletableFuture.java
@@ -37,7 +37,21 @@ import java.util.concurrent.Future;
 @Beta
 public interface ICompletableFuture<V> extends Future<V> {
 
+    /**
+     * Registers a callback that will run after the future is completed.
+     * Please note that there is no ordering guarantee for running multiple callbacks.
+     * It is also not guaranteed that the callback will run within the same thread that completes the future.
+     *
+     * @param callback the callback to execute
+     */
     void andThen(ExecutionCallback<V> callback);
 
+    /**
+     * Registers a callback that will run with the provided executor after the future is completed.
+     * Please note that there is no ordering guarantee for executing multiple callbacks.
+     *
+     * @param callback the callback to execute
+     * @param executor the executor in which the callback will be run
+     */
     void andThen(ExecutionCallback<V> callback, Executor executor);
 }


### PR DESCRIPTION
This interface provides useful methods to register callbacks for executing after a future is completed but it does not contain any documentation about behaviour or order of the execution. Moreover, all the existing implementations un-intuitively executes subsequently registered callbacks with a random order.

We should start with documenting the methods. We can discuss the execution order and maybe provide an ordering-guarantee afterwards.