### PR TITLE
fixes #5099. testChangeMemberAttributes

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/parameters/MemberAttributeChangeCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/parameters/MemberAttributeChangeCodec.java
@@ -57,7 +57,8 @@ public final class MemberAttributeChangeCodec {
         }
         int dataSize = ParameterUtil.calculateStringDataSize(memberAttributeChange.getUuid());
         dataSize += ParameterUtil.calculateStringDataSize(memberAttributeChange.getKey());
-        dataSize += Bits.BYTE_SIZE_IN_BYTES;
+        //operation type
+        dataSize += Bits.INT_SIZE_IN_BYTES;
         MemberAttributeOperationType operationType = memberAttributeChange.getOperationType();
         if (operationType == PUT) {
             dataSize += ParameterUtil.calculateStringDataSize(memberAttributeChange.getValue().toString());

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/parameters/MemberAttributeChangeResultParameters.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/parameters/MemberAttributeChangeResultParameters.java
@@ -24,11 +24,9 @@ import com.hazelcast.cluster.client.MemberAttributeChange;
 public class MemberAttributeChangeResultParameters {
     public static final ClientMessageType TYPE = ClientMessageType.MEMBER_ATTRIBUTE_RESULT;
 
-    public com.hazelcast.client.impl.MemberImpl member;
     public MemberAttributeChange memberAttributeChange;
 
     public MemberAttributeChangeResultParameters(ClientMessage clientMessage) {
-        member = MemberCodec.decode(clientMessage);
         memberAttributeChange = MemberAttributeChangeCodec.decode(clientMessage);
     }
 
@@ -36,12 +34,11 @@ public class MemberAttributeChangeResultParameters {
         return new MemberAttributeChangeResultParameters(clientMessage);
     }
 
-    public static ClientMessage encode(com.hazelcast.instance.MemberImpl member, MemberAttributeChange memberAttributeChange) {
-        final int requiredDataSize = calculateDataSize(member, memberAttributeChange);
+    public static ClientMessage encode(MemberAttributeChange memberAttributeChange) {
+        final int requiredDataSize = calculateDataSize(memberAttributeChange);
         ClientMessage clientMessage = ClientMessage.createForEncode(requiredDataSize);
         clientMessage.setMessageType(TYPE.id());
 
-        MemberCodec.encode(member, clientMessage);
         MemberAttributeChangeCodec.encode(memberAttributeChange, clientMessage);
 
         clientMessage.addFlag(ClientMessage.LISTENER_EVENT_FLAG);
@@ -49,9 +46,8 @@ public class MemberAttributeChangeResultParameters {
         return clientMessage;
     }
 
-    public static int calculateDataSize(com.hazelcast.instance.MemberImpl member, MemberAttributeChange memberAttributeChange) {
-        return ClientMessage.HEADER_SIZE//
-                + MemberCodec.calculateDataSize(member)//
+    public static int calculateDataSize(MemberAttributeChange memberAttributeChange) {
+        return ClientMessage.HEADER_SIZE
                 + MemberAttributeChangeCodec.calculateDataSize(memberAttributeChange);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/parameters/MemberCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/parameters/MemberCodec.java
@@ -46,7 +46,7 @@ public final class MemberCodec {
     public static void encode(com.hazelcast.instance.MemberImpl member, ClientMessage clientMessage) {
         AddressCodec.encode(member.getAddress(), clientMessage);
         clientMessage.set(member.getUuid());
-        Map<String, Object> attributes = member.getAttributes();
+        Map<String, Object> attributes = new HashMap<String, Object>(member.getAttributes());
         clientMessage.set(attributes.size());
         for (Map.Entry<String, Object> entry : attributes.entrySet()) {
             clientMessage.set(entry.getKey());

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/RegisterMembershipListenerMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/RegisterMembershipListenerMessageTask.java
@@ -136,7 +136,7 @@ public class RegisterMembershipListenerMessageTask
             String key = memberAttributeEvent.getKey();
             Object value = memberAttributeEvent.getValue();
             MemberAttributeChange memberAttributeChange = new MemberAttributeChange(uuid, op, key, value);
-            ClientMessage eventMessage = MemberAttributeChangeResultParameters.encode(member, memberAttributeChange);
+            ClientMessage eventMessage = MemberAttributeChangeResultParameters.encode(memberAttributeChange);
             sendClientMessage(endpoint.getUuid(), eventMessage);
         }
     }

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/FuzzyClientProtocolBufferTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/FuzzyClientProtocolBufferTest.java
@@ -84,7 +84,7 @@ public class FuzzyClientProtocolBufferTest extends HazelcastTestSupport {
 
     private void testString(ClientProtocolBuffer clientProtocolBuffer) {
         String expected = randomString();
-        int index = pickIndexSuitableForSize(expected.getBytes(Charset.forName("utf-8")).length);
+        int index = pickIndexSuitableForSize(expected.getBytes(Charset.forName("utf-8")).length + Bits.INT_SIZE_IN_BYTES);
         clientProtocolBuffer.putStringUtf8(index, expected);
         int strSize = clientProtocolBuffer.getInt(index);
         assertEquals(expected, clientProtocolBuffer.getStringUtf8(index, strSize));


### PR DESCRIPTION
Problem was concurrent modification of attributes map of member while it is written to buffer. Copying the attributes before writing it to buffer fix the problem. Secondly, member is removed from memberAttributeChangeResultParameters since it is not used.