### PR TITLE
Return value as storage format in Cache

### DIFF
--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/cache/impl/AbstractClientCacheProxy.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/cache/impl/AbstractClientCacheProxy.java
@@ -187,7 +187,7 @@ abstract class AbstractClientCacheProxy<K, V>
     public V get(K key, ExpiryPolicy expiryPolicy) {
         final Future<V> f = getAsync(key, expiryPolicy);
         try {
-            return f.get();
+            return toObject(f.get());
         } catch (Throwable e) {
             throw ExceptionUtil.rethrowAllowedTypeFirst(e, CacheException.class);
         }
@@ -331,6 +331,5 @@ abstract class AbstractClientCacheProxy<K, V>
     }
 
     //endregion ICACHE: JCACHE EXTENSION
-
 
 }

--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/cache/impl/ClientCacheProxy.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/cache/impl/ClientCacheProxy.java
@@ -172,7 +172,7 @@ public class ClientCacheProxy<K, V>
     public V getAndRemove(K key) {
         final ICompletableFuture<V> f = removeAsyncInternal(key, null, false, true, true);
         try {
-            return f.get();
+            return toObject(f.get());
         } catch (Throwable e) {
             throw ExceptionUtil.rethrowAllowedTypeFirst(e, CacheException.class);
         }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/AbstractClientCacheProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/AbstractClientCacheProxy.java
@@ -181,7 +181,7 @@ abstract class AbstractClientCacheProxy<K, V>
     public V get(K key, ExpiryPolicy expiryPolicy) {
         final Future<V> f = getAsync(key, expiryPolicy);
         try {
-            return f.get();
+            return toObject(f.get());
         } catch (Throwable e) {
             throw ExceptionUtil.rethrowAllowedTypeFirst(e, CacheException.class);
         }
@@ -324,6 +324,5 @@ abstract class AbstractClientCacheProxy<K, V>
     }
 
     //endregion ICACHE: JCACHE EXTENSION
-
 
 }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/ClientCacheProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/ClientCacheProxy.java
@@ -173,7 +173,7 @@ public class ClientCacheProxy<K, V>
     public V getAndRemove(K key) {
         final ICompletableFuture<V> f = removeAsyncInternal(key, null, false, true, true);
         try {
-            return f.get();
+            return toObject(f.get());
         } catch (Throwable e) {
             throw ExceptionUtil.rethrowAllowedTypeFirst(e, CacheException.class);
         }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheRecordStore.java
@@ -65,7 +65,7 @@ public class CacheRecordStore
 
     @Override
     protected MaxSizeChecker createCacheMaxSizeChecker(int size,
-                                                            EvictionConfig.MaxSizePolicy maxSizePolicy) {
+                                                       EvictionConfig.MaxSizePolicy maxSizePolicy) {
         if (maxSizePolicy == null) {
             throw new IllegalArgumentException("Max-Size policy cannot be null");
         }
@@ -96,29 +96,37 @@ public class CacheRecordStore
     }
 
     @Override
-    protected <T> CacheRecord createRecord(T value, long creationTime, long expiryTime) {
+    protected CacheRecord createRecord(Object value, long creationTime, long expiryTime) {
         evictIfRequired();
 
         return cacheRecordFactory.newRecordWithExpiry(value, creationTime, expiryTime);
     }
 
     @Override
-    protected <T> Data valueToData(T value) {
+    protected Data valueToData(Object value) {
         return cacheService.toData(value);
     }
 
     @Override
-    protected <T> T dataToValue(Data data) {
-        return (T) serializationService.toObject(data);
+    protected Object dataToValue(Data data) {
+        return serializationService.toObject(data);
     }
 
     @Override
-    protected <T> T recordToValue(CacheRecord record) {
+    protected Object recordToValue(CacheRecord record) {
         Object value = record.getValue();
         if (value instanceof Data) {
-            return dataToValue((Data) value);
+            switch (cacheConfig.getInMemoryFormat()) {
+                case BINARY:
+                    return value;
+                case OBJECT:
+                    return dataToValue((Data) value);
+                default:
+                    throw new IllegalStateException("Unsupported in-memory format: "
+                            + cacheConfig.getInMemoryFormat());
+            }
         } else {
-            return (T) value;
+            return value;
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/cache/recordstore/CacheRecordStoreTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/recordstore/CacheRecordStoreTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.cache.recordstore;
+
+import com.hazelcast.cache.impl.ICacheRecordStore;
+import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class CacheRecordStoreTest
+        extends CacheRecordStoreTestSupport {
+
+    @Test
+    public void putObjectAndGetDataFromCacheRecordStore() {
+        ICacheRecordStore cacheRecordStore = createCacheRecordStore(InMemoryFormat.BINARY);
+        putAndGetFromCacheRecordStore(cacheRecordStore, InMemoryFormat.BINARY);
+    }
+
+    @Test
+    public void putObjectAndGetObjectFromCacheRecordStore() {
+        ICacheRecordStore cacheRecordStore = createCacheRecordStore(InMemoryFormat.OBJECT);
+        putAndGetFromCacheRecordStore(cacheRecordStore, InMemoryFormat.OBJECT);
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/cache/recordstore/CacheRecordStoreTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/recordstore/CacheRecordStoreTestSupport.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.cache.recordstore;
+
+import com.hazelcast.cache.impl.AbstractCacheService;
+import com.hazelcast.cache.impl.CacheRecordStore;
+import com.hazelcast.cache.impl.ICacheRecordStore;
+import com.hazelcast.cache.impl.ICacheService;
+import com.hazelcast.config.CacheConfig;
+import com.hazelcast.config.Config;
+import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.instance.Node;
+import com.hazelcast.instance.TestUtil;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.nio.serialization.DefaultSerializationServiceBuilder;
+import com.hazelcast.nio.serialization.SerializationService;
+import com.hazelcast.spi.NodeEngine;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+
+import org.junit.After;
+import org.junit.Before;
+
+import static junit.framework.Assert.assertTrue;
+
+public abstract class CacheRecordStoreTestSupport
+        extends HazelcastTestSupport {
+
+    protected static final String CACHE_NAME_PREFIX = "hz:";
+    protected static final String DEFAULT_CACHE_NAME = "MyCache";
+    protected static final int DEFAULT_PARTITION_ID = 1;
+    protected static final int CACHE_RECORD_COUNT = 50;
+
+    protected TestHazelcastInstanceFactory factory;
+    protected HazelcastInstance hz;
+
+    @Before
+    public void init() {
+        factory = new TestHazelcastInstanceFactory(1);
+        hz = factory.newHazelcastInstance(createConfig());
+    }
+
+    @After
+    public void tearDown() {
+        factory.shutdownAll();
+    }
+
+    protected Config createConfig() {
+        return new Config();
+    }
+
+    protected CacheConfig createCacheConfig(String cacheName, InMemoryFormat inMemoryFormat) {
+        return new CacheConfig()
+                .setName(cacheName)
+                .setManagerPrefix(CACHE_NAME_PREFIX)
+                .setInMemoryFormat(inMemoryFormat);
+    }
+
+    protected ICacheService getCacheService(HazelcastInstance instance) {
+        Node node = TestUtil.getNode(instance);
+        return node.getNodeEngine().getService(ICacheService.SERVICE_NAME);
+    }
+
+    protected NodeEngine getNodeEngine(HazelcastInstance instance) {
+        Node node = TestUtil.getNode(instance);
+        return node.getNodeEngine();
+    }
+
+    protected ICacheRecordStore createCacheRecordStore(HazelcastInstance instance, String cacheName,
+                                                       int partitionId, InMemoryFormat inMemoryFormat) {
+        NodeEngine nodeEngine = getNodeEngine(instance);
+        ICacheService cacheService = getCacheService(instance);
+        CacheConfig cacheConfig = createCacheConfig(cacheName, inMemoryFormat);
+        cacheService.createCacheConfigIfAbsent(cacheConfig);
+        return new CacheRecordStore(CACHE_NAME_PREFIX + cacheName, partitionId, nodeEngine, (AbstractCacheService) cacheService);
+    }
+
+    protected ICacheRecordStore createCacheRecordStore(HazelcastInstance instance, InMemoryFormat inMemoryFormat) {
+        return createCacheRecordStore(instance, DEFAULT_CACHE_NAME, DEFAULT_PARTITION_ID, inMemoryFormat);
+    }
+
+    protected ICacheRecordStore createCacheRecordStore(InMemoryFormat inMemoryFormat) {
+        return createCacheRecordStore(hz, DEFAULT_CACHE_NAME, DEFAULT_PARTITION_ID, inMemoryFormat);
+    }
+
+    protected void putAndGetFromCacheRecordStore(ICacheRecordStore cacheRecordStore, InMemoryFormat inMemoryFormat) {
+        SerializationService serializationService = new DefaultSerializationServiceBuilder().build();
+
+        for (int i = 0; i < CACHE_RECORD_COUNT; i++) {
+            cacheRecordStore.put(serializationService.toData(i), "value-" + i, null, null, -1);
+        }
+
+        if (inMemoryFormat == InMemoryFormat.BINARY || inMemoryFormat == InMemoryFormat.NATIVE) {
+            for (int i = 0; i < CACHE_RECORD_COUNT; i++) {
+                assertTrue(Data.class.isAssignableFrom(
+                        cacheRecordStore.get(serializationService.toData(i), null).getClass()));
+            }
+        } else if (inMemoryFormat == InMemoryFormat.OBJECT) {
+            for (int i = 0; i < CACHE_RECORD_COUNT; i++) {
+                assertTrue(String.class.isAssignableFrom(
+                        cacheRecordStore.get(serializationService.toData(i), null).getClass()));
+            }
+        } else {
+            throw new IllegalArgumentException("Unsupported in-memory format: " + inMemoryFormat);
+        }
+    }
+
+}


### PR DESCRIPTION
Fixes https://github.com/hazelcast/hazelcast/issues/4632. There is no need for converting stored data to object for `BINARY` storage format. This behaviour is unnecessary and may cause `ClassNotFoundException` if required class is not exist at server but just caller (or client) as seen in this issue https://github.com/hazelcast/hazelcast/issues/4775