### PR TITLE
Cleanup of AbstractCompletableFuture (non blocking again) + added tests

### DIFF
--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/proxy/ClientMapReduceProxy.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/proxy/ClientMapReduceProxy.java
@@ -61,7 +61,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
@@ -228,7 +227,7 @@ public class ClientMapReduceProxy
         private volatile boolean cancelled;
 
         protected ClientCompletableFuture(String jobId) {
-            super(null, Logger.getLogger(ClientCompletableFuture.class));
+            super(getContext().getExecutionService().getAsyncExecutor(), Logger.getLogger(ClientCompletableFuture.class));
             this.jobId = jobId;
             this.latch = new CountDownLatch(1);
         }
@@ -268,11 +267,6 @@ public class ClientMapReduceProxy
                 throw new TimeoutException("timeout reached");
             }
             return getResult();
-        }
-
-        @Override
-        protected ExecutorService getAsyncExecutor() {
-            return getContext().getExecutionService().getAsyncExecutor();
         }
     }
 

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapReduceProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapReduceProxy.java
@@ -45,7 +45,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
@@ -171,7 +170,7 @@ public class ClientMapReduceProxy
         private volatile boolean cancelled;
 
         protected ClientCompletableFuture(String jobId) {
-            super(null, Logger.getLogger(ClientCompletableFuture.class));
+            super(getContext().getExecutionService().getAsyncExecutor(), Logger.getLogger(ClientCompletableFuture.class));
             this.jobId = jobId;
             this.latch = new CountDownLatch(1);
         }
@@ -209,11 +208,6 @@ public class ClientMapReduceProxy
                 throw new TimeoutException("timeout reached");
             }
             return getResult();
-        }
-
-        @Override
-        protected ExecutorService getAsyncExecutor() {
-            return getContext().getExecutionService().getAsyncExecutor();
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapKeyLoader.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapKeyLoader.java
@@ -39,6 +39,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -284,15 +285,15 @@ public class MapKeyLoader {
     }
 
     private static final class LoadFinishedFuture extends AbstractCompletableFuture<Boolean>
-        implements ExecutionCallback<Boolean> {
-
-        private LoadFinishedFuture() {
-            super(null, null);
-        }
+            implements ExecutionCallback<Boolean> {
 
         private LoadFinishedFuture(Boolean result) {
-            super(null, null);
+            this();
             setResult(result);
+        }
+
+        private LoadFinishedFuture() {
+            super((Executor) null, null);
         }
 
         @Override
@@ -331,6 +332,4 @@ public class MapKeyLoader {
             return getClass().getSimpleName() + "{done=" + isDone() + "}";
         }
     }
-
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/AbstractCompletableFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/AbstractCompletableFuture.java
@@ -21,28 +21,35 @@ import com.hazelcast.core.ICompletableFuture;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.spi.ExecutionService;
 import com.hazelcast.spi.NodeEngine;
-import com.hazelcast.util.ExceptionUtil;
 
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 
-import static com.hazelcast.util.Preconditions.isNotNull;
+import static com.hazelcast.util.ExceptionUtil.sneakyThrow;
+import static com.hazelcast.util.ValidationUtil.isNotNull;
+import static java.util.concurrent.atomic.AtomicReferenceFieldUpdater.newUpdater;
 
 public abstract class AbstractCompletableFuture<V> implements ICompletableFuture<V> {
 
-    protected static final Object NOT_AVAILABLE_VALUE = new Object();
-    protected final NodeEngine nodeEngine;
+    static final Object INITIAL_STATE = new ExecutionCallbackNode(null, null, null);
 
-    protected volatile Object result = NOT_AVAILABLE_VALUE;
+    private static final AtomicReferenceFieldUpdater<AbstractCompletableFuture, Object> STATE
+            = newUpdater(AbstractCompletableFuture.class, Object.class, "state");
 
-    private final Object completionLock = new Object();
+     protected final NodeEngine nodeEngine;
+    // This field is only assigned by the STATE.
+    // This field encodes an option type of 2 types, an ExecutionCallbackNode or a result.
+    // if the state is an instance of the former, then the future is not done. Otherwise it is.
+    // The reason for this abuse of the type system is to deal with the head node and the result
+    // in a single cas. Using a single cas prevent a thread that calls and then do this concurrently
+    // with a thread that calls setResult.
+    volatile Object state = INITIAL_STATE;
 
     private final ILogger logger;
-    private volatile ExecutionCallbackNode<V> callbackHead;
 
     protected AbstractCompletableFuture(NodeEngine nodeEngine, ILogger logger) {
         this.nodeEngine = nodeEngine;
@@ -59,31 +66,35 @@ public abstract class AbstractCompletableFuture<V> implements ICompletableFuture
         isNotNull(callback, "callback");
         isNotNull(executor, "executor");
 
-        // no need to lock if the future is already completed
-        // isDone() is not called because it can be overridden by subclasses
-        if (isDoneInternal()) {
-            runAsynchronous(callback, executor);
-            return;
-        }
+        for (; ; ) {
+            Object currentState = this.state;
 
-        synchronized (completionLock) {
-            // isDone() is not called because it can be overridden by subclasses
-            if (isDoneInternal()) {
-                runAsynchronous(callback, executor);
+            if (isDone(currentState)) {
+                runAsynchronous(callback, executor, currentState);
                 return;
             }
 
-            this.callbackHead = new ExecutionCallbackNode<V>(callback, executor, callbackHead);
+            ExecutionCallbackNode newState
+                    = new ExecutionCallbackNode<V>(callback, executor, (ExecutionCallbackNode) currentState);
+
+            if (STATE.compareAndSet(this, currentState, newState)) {
+                // we have successfully scheduled the callback.
+                return;
+            }
+
+            // we failed to update the state. This can mean 2 things:
+            // either a result was set, which we'll see when retrying this loop
+            // or a different thread also called andThen, which we'll deal with when we retry the loop.
         }
     }
 
     @Override
     public boolean isDone() {
-        return isDoneInternal();
+        return isDone(state);
     }
 
-    private boolean isDoneInternal() {
-        return result != NOT_AVAILABLE_VALUE;
+    private boolean isDone(Object state) {
+        return !(state instanceof ExecutionCallbackNode);
     }
 
     @Override
@@ -97,72 +108,82 @@ public abstract class AbstractCompletableFuture<V> implements ICompletableFuture
     }
 
     public void setResult(Object result) {
-        ExecutionCallbackNode<V> callbackChain;
-        synchronized (completionLock) {
-            // isDone() is not called because it can be overridden by subclasses
-            if (isDoneInternal()) {
+        for (; ; ) {
+            Object currentState = this.state;
+
+            if (isDone(currentState)) {
                 return;
             }
 
-            this.result = result;
-            callbackChain = callbackHead;
-            callbackHead = null;
+            if (STATE.compareAndSet(this, currentState, result)) {
+                runAsynchronous((ExecutionCallbackNode) currentState, result);
+                break;
+            }
         }
-
-        fireCallbacks(callbackChain);
     }
 
     protected V getResult() {
-        Object result = this.result;
-        if (result instanceof Throwable) {
-            ExceptionUtil.sneakyThrow((Throwable) result);
+        Object state = this.state;
+
+        if (!isDone(state)) {
+            return null;
         }
-        return (V) result;
+
+        if (state instanceof Throwable) {
+            sneakyThrow((Throwable) state);
+        }
+
+        return (V) state;
     }
 
-    protected void fireCallbacks(ExecutionCallbackNode<V> callbackChain) {
-        while (callbackChain != null) {
-            runAsynchronous(callbackChain.callback, callbackChain.executor);
-            callbackChain = callbackChain.next;
+    protected void runAsynchronous(ExecutionCallbackNode head, Object result) {
+        while (head != INITIAL_STATE) {
+            runAsynchronous(head.callback, head.executor, result);
+            head = head.next;
         }
     }
 
-    private void runAsynchronous(final ExecutionCallback<V> callback, final Executor executor) {
-        try {
-            final Object result = this.result;
-            executor.execute(new Runnable() {
-                @Override
-                public void run() {
-                    try {
-                        if (result instanceof Throwable) {
-                            callback.onFailure((Throwable) result);
-                        } else {
-                            callback.onResponse((V) result);
-                        }
-                    } catch (Throwable cause) {
-                        logger.severe("Failed asynchronous execution of execution callback: " + callback
-                                + "for call " + AbstractCompletableFuture.this, cause);
-                    }
-                }
-            });
-        } catch (RejectedExecutionException e) {
-            logger.warning("Execution of callback: " + callback + " is rejected!", e);
-        }
+    private void runAsynchronous(ExecutionCallback<V> callback, Executor executor, Object result) {
+        executor.execute(new ExecutionCallbackRunnable<V>(result, callback));
     }
 
     protected ExecutorService getAsyncExecutor() {
         return nodeEngine.getExecutionService().getExecutor(ExecutionService.ASYNC_EXECUTOR);
     }
 
-    private static final class ExecutionCallbackNode<E> {
-        private final ExecutionCallback<E> callback;
-        private final Executor executor;
-        private final ExecutionCallbackNode<E> next;
+    static final class ExecutionCallbackNode<E> {
+        final ExecutionCallback<E> callback;
+        final Executor executor;
+        final ExecutionCallbackNode<E> next;
 
         private ExecutionCallbackNode(ExecutionCallback<E> callback, Executor executor, ExecutionCallbackNode<E> next) {
             this.callback = callback;
             this.executor = executor;
             this.next = next;
+        }
+    }
+
+    private class ExecutionCallbackRunnable<V> implements Runnable {
+        private final Object result;
+        private final ExecutionCallback<V> callback;
+
+        public ExecutionCallbackRunnable(Object result, ExecutionCallback<V> callback) {
+            this.result = result;
+            this.callback = callback;
+        }
+
+        @Override
+        public void run() {
+            try {
+                if (result instanceof Throwable) {
+                    callback.onFailure((Throwable) result);
+                } else {
+                    callback.onResponse((V) result);
+                }
+            } catch (Throwable cause) {
+                logger.severe("Failed asynchronous execution of execution callback: " + callback
+                        + "for call " + AbstractCompletableFuture.this, cause);
+            }
         }
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/AbstractCompletableFutureTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/AbstractCompletableFutureTest.java
@@ -1,0 +1,326 @@
+package com.hazelcast.spi.impl;
+
+import com.hazelcast.core.ExecutionCallback;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
+import com.hazelcast.spi.NodeEngine;
+import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.util.ExceptionUtil;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static com.hazelcast.spi.impl.AbstractCompletableFuture.ExecutionCallbackNode;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category(QuickTest.class)
+public class AbstractCompletableFutureTest extends HazelcastTestSupport {
+
+    private final static Object FAKE_GET_RESPONSE = "foobar";
+
+    private HazelcastInstance hz;
+    private ILogger logger;
+    private NodeEngineImpl nodeEngine;
+    private Executor executor;
+
+    @Before
+    public void setup() {
+        hz = createHazelcastInstance();
+        nodeEngine = getNodeEngineImpl(hz);
+        logger = Logger.getLogger(AbstractCompletableFutureTest.class);
+        executor = Executors.newFixedThreadPool(1);
+    }
+
+    // ==================== setResult ===========================================
+
+    @Test
+    public void setResult_whenPendingCallback() {
+        setResult_whenPendingCallback(null);
+        setResult_whenPendingCallback("foo");
+        setResult_whenPendingCallback(new Exception());
+    }
+
+    public void setResult_whenPendingCallback(final Object result) {
+        FutureImpl future = new FutureImpl(nodeEngine, logger);
+        final ExecutionCallback callback1 = mock(ExecutionCallback.class);
+        final ExecutionCallback callback2 = mock(ExecutionCallback.class);
+        future.andThen(callback1);
+        future.andThen(callback2);
+
+        future.setResult(result);
+
+        assertSame(result, future.state);
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                if (result instanceof Throwable) {
+                    verify(callback1).onFailure((Throwable) result);
+                } else {
+                    verify(callback1).onResponse(result);
+                }
+            }
+        });
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                if (result instanceof Throwable) {
+                    verify(callback2).onFailure((Throwable) result);
+                } else {
+                    verify(callback2).onResponse(result);
+                }
+            }
+        });
+    }
+
+    @Test
+    public void setResult_whenNoPendingCallback() {
+        setResult_whenNoPendingCallback(null);
+        setResult_whenNoPendingCallback("foo");
+    }
+
+    public void setResult_whenNoPendingCallback(Object result) {
+        FutureImpl future = new FutureImpl(nodeEngine, logger);
+
+        future.setResult(result);
+
+        assertSame(result, future.state);
+    }
+
+
+    @Test
+    public void setResult_whenResultAlreadySet() {
+        FutureImpl future = new FutureImpl(nodeEngine, logger);
+        Object initialResult = "firstresult";
+
+        future.setResult(initialResult);
+
+        future.setResult("secondresult");
+        assertSame(initialResult, future.state);
+    }
+
+    // ==================== get ===========================================
+
+    @Test
+    public void get() throws ExecutionException, InterruptedException {
+        FutureImpl future = new FutureImpl(nodeEngine, logger);
+
+        Object result = future.get();
+
+        assertSame(FAKE_GET_RESPONSE, result);
+        assertEquals(Long.MAX_VALUE, future.timeout);
+        assertEquals(TimeUnit.MILLISECONDS, future.unit);
+    }
+
+    @Test
+    public void get_whenTimeout() throws ExecutionException, InterruptedException {
+        FutureImpl future = new FutureImpl(nodeEngine, logger);
+        future.getException = new TimeoutException();
+        Object result = future.get();
+
+        assertNull(result);
+    }
+
+    // ==================== getResult ===========================================
+
+    @Test
+    public void getResult_whenInitialState() {
+        FutureImpl future = new FutureImpl(nodeEngine, logger);
+
+        Object result = future.getResult();
+
+        assertNull(result);
+    }
+
+    @Test
+    public void getResult_whenPendingCallback() {
+        FutureImpl future = new FutureImpl(nodeEngine, logger);
+        future.andThen(mock(ExecutionCallback.class));
+
+        Object result = future.getResult();
+
+        assertNull(result);
+    }
+
+    @Test
+    public void getResult_whenNullResult() {
+        FutureImpl future = new FutureImpl(nodeEngine, logger);
+        future.setResult(null);
+
+        Object result = future.getResult();
+
+        assertNull(result);
+    }
+
+    @Test
+    public void getResult_whenNoneNullResult() {
+        FutureImpl future = new FutureImpl(nodeEngine, logger);
+        Object expectedResult = "result";
+        future.setResult(expectedResult);
+
+        Object result = future.getResult();
+
+        assertSame(expectedResult, result);
+    }
+
+    // ==================== andThen ===========================================
+
+    @Test(expected = IllegalArgumentException.class)
+    public void andThen_whenNullCallback() {
+        FutureImpl future = new FutureImpl(nodeEngine, logger);
+        future.andThen(null, executor);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void andThen_whenNullExecutor() {
+        FutureImpl future = new FutureImpl(nodeEngine, logger);
+        future.andThen(mock(ExecutionCallback.class), null);
+    }
+
+    @Test
+    public void andThen_whenResultAvailable() {
+        FutureImpl future = new FutureImpl(nodeEngine, logger);
+        final Object result = "result";
+        future.setResult(result);
+
+        final ExecutionCallback callback = mock(ExecutionCallback.class);
+        future.andThen(callback, executor);
+
+        assertSame(result, future.state);
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                verify(callback).onResponse(result);
+            }
+        });
+    }
+
+    @Test
+    public void andThen_whenInitialState() {
+        FutureImpl future = new FutureImpl(nodeEngine, logger);
+
+        ExecutionCallback callback = mock(ExecutionCallback.class);
+        future.andThen(callback, executor);
+
+        ExecutionCallbackNode node = assertInstanceOf(ExecutionCallbackNode.class, future.state);
+        assertSame(node.callback, callback);
+        assertSame(node.executor, executor);
+        assertSame(node.next, AbstractCompletableFuture.INITIAL_STATE);
+        verifyZeroInteractions(callback);
+    }
+
+    @Test
+    public void andThen_whenPendingCallback() {
+        FutureImpl future = new FutureImpl(nodeEngine, logger);
+
+        ExecutionCallback callback1 = mock(ExecutionCallback.class);
+        future.andThen(callback1, executor);
+
+        ExecutionCallback callback2 = mock(ExecutionCallback.class);
+        future.andThen(callback2, executor);
+
+        ExecutionCallbackNode secondNode = assertInstanceOf(ExecutionCallbackNode.class, future.state);
+        assertSame(secondNode.callback, callback2);
+        assertSame(secondNode.executor, executor);
+
+        ExecutionCallbackNode firstNode = secondNode.next;
+        assertSame(firstNode.callback, callback1);
+        assertSame(firstNode.executor, executor);
+        assertSame(firstNode.next, AbstractCompletableFuture.INITIAL_STATE);
+
+        verifyZeroInteractions(callback1);
+        verifyZeroInteractions(callback2);
+    }
+
+    // ==================== isDone ===========================================
+
+    @Test
+    public void isDone_whenInitialState() {
+        FutureImpl future = new FutureImpl(nodeEngine, logger);
+
+        boolean result = future.isDone();
+
+        assertFalse(result);
+    }
+
+    @Test
+    public void isDone_whenCallbackRegistered() {
+        FutureImpl future = new FutureImpl(nodeEngine, logger);
+        future.andThen(mock(ExecutionCallback.class));
+
+        boolean result = future.isDone();
+
+        assertFalse(result);
+    }
+
+    @Test
+    public void isDone_whenNullResultSet() {
+        FutureImpl future = new FutureImpl(nodeEngine, logger);
+        future.setResult(null);
+
+        boolean result = future.isDone();
+
+        assertTrue(result);
+    }
+
+    @Test
+    public void isDone_whenNoneNullResultSet() {
+        FutureImpl future = new FutureImpl(nodeEngine, logger);
+        future.setResult("foo");
+
+        boolean result = future.isDone();
+
+        assertTrue(result);
+    }
+
+    class FutureImpl extends AbstractCompletableFuture {
+
+        private long timeout;
+        private TimeUnit unit;
+        private Exception getException;
+
+        protected FutureImpl(NodeEngine nodeEngine, ILogger logger) {
+            super(nodeEngine, logger);
+        }
+
+        @Override
+        public boolean cancel(boolean mayInterruptIfRunning) {
+            return false;
+        }
+
+        @Override
+        public boolean isCancelled() {
+            return false;
+        }
+
+        @Override
+        public Object get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+            this.timeout = timeout;
+            this.unit = unit;
+            if(getException!=null){
+                ExceptionUtil.sneakyThrow(getException);
+            }
+            return FAKE_GET_RESPONSE;
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/util/FutureUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/FutureUtilTest.java
@@ -23,6 +23,9 @@ import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.transaction.TransactionTimedOutException;
 import com.hazelcast.util.FutureUtil.ExceptionHandler;
 import com.hazelcast.util.executor.CompletedFuture;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -30,6 +33,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -41,14 +45,9 @@ import java.util.logging.Level;
 import static com.hazelcast.util.FutureUtil.logAllExceptions;
 import static com.hazelcast.util.FutureUtil.returnWithDeadline;
 import static com.hazelcast.util.FutureUtil.waitWithDeadline;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category(QuickTest.class)
@@ -311,7 +310,7 @@ public class FutureUtilTest extends HazelcastTestSupport {
     private static class UncancellableFuture<V> extends AbstractCompletableFuture<V> {
 
         public UncancellableFuture() {
-            super(null, null);
+            super((Executor) null, null);
         }
 
         @Override


### PR DESCRIPTION
This is a cleaned up version of the fix from this PR:

https://github.com/hazelcast/hazelcast/pull/5306

So the lock is dropped again and non blocking part is simplified by using a single cas that prevents ending up with a pending callback when a result is set concurrently with an andThen.

This PR also contains tests for the changes.