### PR TITLE
Fixed display of system load average in HealthMonitor

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/monitors/HealthMonitor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/monitors/HealthMonitor.java
@@ -39,6 +39,7 @@ import static com.hazelcast.memory.MemoryStatsSupport.freePhysicalMemory;
 import static com.hazelcast.memory.MemoryStatsSupport.freeSwapSpace;
 import static com.hazelcast.memory.MemoryStatsSupport.totalPhysicalMemory;
 import static com.hazelcast.memory.MemoryStatsSupport.totalSwapSpace;
+import static com.hazelcast.util.OperatingSystemMXBeanSupport.getSystemLoadAverage;
 import static com.hazelcast.util.OperatingSystemMXBeanSupport.readLongAttribute;
 import static java.lang.String.format;
 
@@ -182,7 +183,7 @@ public class HealthMonitor extends Thread {
             memoryUsedOfTotalPercentage = PERCENTAGE_MULTIPLIER * memoryUsed / memoryTotal;
             memoryUsedOfMaxPercentage = PERCENTAGE_MULTIPLIER * memoryUsed / memoryMax;
             processCpuLoad = readLongAttribute("ProcessCpuLoad", -1L);
-            systemLoadAverage = readLongAttribute("SystemLoadAverage", -1L);
+            systemLoadAverage = getSystemLoadAverage();
             systemCpuLoad = readLongAttribute("SystemCpuLoad", -1L);
             threadCount = threadMxBean.getThreadCount();
             peakThreadCount = threadMxBean.getPeakThreadCount();
@@ -263,7 +264,7 @@ public class HealthMonitor extends Thread {
 
             sb.append("load.process=").append(format("%.2f", processCpuLoad)).append("%, ");
             sb.append("load.system=").append(format("%.2f", systemCpuLoad)).append("%, ");
-            sb.append("load.systemAverage=").append(format("%.2f", systemLoadAverage)).append("%, ");
+            sb.append("load.systemAverage=").append(systemLoadAverage >= 0 ? format("%.2f, ", systemLoadAverage) : "n/a, ");
             sb.append("thread.count=").append(threadCount).append(", ");
             sb.append("thread.peakCount=").append(peakThreadCount).append(", ");
             sb.append("cluster.timeDiff=").append(clusterTimeDiff).append(", ");

--- a/hazelcast/src/main/java/com/hazelcast/util/OperatingSystemMXBeanSupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/OperatingSystemMXBeanSupport.java
@@ -41,11 +41,11 @@ public final class OperatingSystemMXBeanSupport {
     public static long readLongAttribute(String attributeName, long defaultValue) {
         try {
             String methodName = "get" + attributeName;
-            OperatingSystemMXBean mbean = OPERATING_SYSTEM_MX_BEAN;
-            Method method = mbean.getClass().getMethod(methodName);
+            OperatingSystemMXBean systemMXBean = OPERATING_SYSTEM_MX_BEAN;
+            Method method = systemMXBean.getClass().getMethod(methodName);
             method.setAccessible(true);
 
-            Object value = method.invoke(mbean);
+            Object value = method.invoke(systemMXBean);
             if (value == null) {
                 return defaultValue;
             }
@@ -69,5 +69,14 @@ public final class OperatingSystemMXBeanSupport {
             EmptyStatement.ignore(ignored);
         }
         return defaultValue;
+    }
+
+    /**
+     * Reads the system load average attribute from OperatingSystemMXBean.
+     *
+     * @return system load average or negative value if metric is not available
+     */
+    public static double getSystemLoadAverage() {
+        return OPERATING_SYSTEM_MX_BEAN.getSystemLoadAverage();
     }
 }


### PR DESCRIPTION
Fixed display of system load average in `HealthMonitor`, which is not a percentaged value. Fixed display of negative values, which occurs on OS which don't provide this metric (e.g. Windows).

The load average value cannot be converted to a percentaged value by multiplying with 100. You have to calculate in at least the CPU core count. We should better print the original value.

Before -> After
`load.systemAverage=73.00%` -> `load.systemAverage=0.73`
`load.systemAverage=-100.00%` -> `load.systemAverage=n/a`

For the `SystemCpuLoad` and `ProcessCpuLoad` values the actual approach should be fine:
> The interface `com.sun.management.OperatingSystemMXBean`, has two new methods that easily get this information; `getSystemCpuLoad()` and `getProcessCpuLoad()`. Both methods return the load as a double value in the [0.0,1.0] interval, with 0.0 representing no load to 1.0 representing 100% CPU load for the whole system or the current JVM process respectively.

We can't use those methods since it's Java 7, but both values are percentaged.

Reported via Zendesk ticket 925.