### PR TITLE
Server should reject authentication requests from a client having an unknown owner member

### DIFF
--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/spi/impl/ClientInvocationServiceSupport.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/spi/impl/ClientInvocationServiceSupport.java
@@ -237,6 +237,10 @@ abstract class ClientInvocationServiceSupport implements ClientInvocationService
         }
     }
 
+    public boolean isShutdown() {
+        return isShutdown;
+    }
+
     public void shutdown() {
         isShutdown = true;
         responseThread.interrupt();

--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/spi/impl/ClientMembershipListener.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/spi/impl/ClientMembershipListener.java
@@ -116,7 +116,6 @@ class ClientMembershipListener
 
             Connection connection = connectionManager.getConnection(ownerConnectionAddress);
             if (connection == null) {
-                System.out.println("FATAL connection null " + ownerConnectionAddress);
                 throw new IllegalStateException(
                         "Can not load initial members list because owner connection is null. " + "Address "
                                 + ownerConnectionAddress);

--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/spi/impl/ClientSmartInvocationServiceImpl.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/spi/impl/ClientSmartInvocationServiceImpl.java
@@ -21,23 +21,23 @@ import com.hazelcast.client.connection.nio.ClientConnection;
 import com.hazelcast.client.impl.ClusterAuthenticator;
 import com.hazelcast.client.impl.HazelcastClientInstanceImpl;
 import com.hazelcast.client.impl.MemberImpl;
+import com.hazelcast.client.spi.ClientClusterService;
+import com.hazelcast.core.HazelcastException;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.Connection;
-import com.hazelcast.security.Credentials;
 
 import java.io.IOException;
 
 public final class ClientSmartInvocationServiceImpl extends ClientInvocationServiceSupport {
 
     private final LoadBalancer loadBalancer;
-    private final Credentials credentials;
     private final ClusterAuthenticator authenticator;
 
     public ClientSmartInvocationServiceImpl(HazelcastClientInstanceImpl client, LoadBalancer loadBalancer) {
         super(client);
         this.loadBalancer = loadBalancer;
-        credentials = client.getCredentials();
-        authenticator = new ClusterAuthenticator(client, credentials);
+        authenticator = new ClusterAuthenticator(client, client.getCredentials());
+
     }
 
     public void invokeOnPartitionOwner(ClientInvocation invocation, int partitionId) throws IOException {
@@ -45,10 +45,9 @@ public final class ClientSmartInvocationServiceImpl extends ClientInvocationServ
         if (owner == null) {
             throw new IOException("Partition does not have owner. partitionId : " + partitionId);
         }
-        ClientConnection connection =
-                (ClientConnection) connectionManager.getOrConnect(owner, authenticator);
         invocation.getClientMessage().setPartitionId(partitionId);
-        send(invocation, connection);
+        Connection connection = getConnection(owner);
+        send(invocation, (ClientConnection) connection);
     }
 
     @Override
@@ -57,7 +56,7 @@ public final class ClientSmartInvocationServiceImpl extends ClientInvocationServ
         if (randomAddress == null) {
             throw new IOException("Not address found to invoke ");
         }
-        final Connection connection = connectionManager.getOrConnect(randomAddress, authenticator);
+        final Connection connection = getConnection(randomAddress);
         send(invocation, (ClientConnection) connection);
     }
 
@@ -70,10 +69,29 @@ public final class ClientSmartInvocationServiceImpl extends ClientInvocationServ
         if (!isMember(target)) {
             throw new IOException("Target :  " + target + " is not member. ");
         }
-        final Connection connection = connectionManager.getOrConnect(target, authenticator);
+        final Connection connection = getConnection(target);
         invokeOnConnection(invocation, (ClientConnection) connection);
     }
 
+    private Connection getConnection(Address target) throws IOException {
+        ensureOwnerConnectionAvailable();
+        return connectionManager.getOrConnect(target, authenticator);
+    }
+
+    private void ensureOwnerConnectionAvailable() throws IOException {
+        ClientClusterService clientClusterService = client.getClientClusterService();
+        Address ownerConnectionAddress = clientClusterService.getOwnerConnectionAddress();
+
+        boolean isOwnerConnectionAvailable = ownerConnectionAddress != null
+                && connectionManager.getConnection(ownerConnectionAddress) != null;
+
+        if (!isOwnerConnectionAvailable) {
+            if (isShutdown()) {
+                throw new HazelcastException("ConnectionManager is not active!");
+            }
+            throw new IOException("Not able to setup owner connection!");
+        }
+    }
 
     @Override
     public void invokeOnConnection(ClientInvocation invocation, ClientConnection connection) throws IOException {

--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/spi/impl/ClusterListenerSupport.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/spi/impl/ClusterListenerSupport.java
@@ -175,6 +175,8 @@ public abstract class ClusterListenerSupport implements ConnectionListener, Conn
     }
 
     private void connectToOne() throws Exception {
+        ownerConnectionAddress = null;
+
         final ClientNetworkConfig networkConfig = client.getClientConfig().getNetworkConfig();
         final int connAttemptLimit = networkConfig.getConnectionAttemptLimit();
         final int connectionAttemptPeriod = networkConfig.getConnectionAttemptPeriod();

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocationServiceSupport.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocationServiceSupport.java
@@ -236,6 +236,10 @@ abstract class ClientInvocationServiceSupport implements ClientInvocationService
         }
     }
 
+    public boolean isShutdown() {
+        return isShutdown;
+    }
+
     public void shutdown() {
         isShutdown = true;
         responseThread.interrupt();

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientMembershipListener.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientMembershipListener.java
@@ -95,7 +95,6 @@ class ClientMembershipListener implements EventHandler<ClientInitialMembershipEv
 
             Connection connection = connectionManager.getConnection(ownerConnectionAddress);
             if (connection == null) {
-                System.out.println("FATAL connection null " + ownerConnectionAddress);
                 throw new IllegalStateException("Can not load initial members list because owner connection is null. "
                         + "Address " + ownerConnectionAddress);
             }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientSmartInvocationServiceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientSmartInvocationServiceImpl.java
@@ -20,24 +20,24 @@ import com.hazelcast.client.LoadBalancer;
 import com.hazelcast.client.connection.nio.ClientConnection;
 import com.hazelcast.client.impl.ClusterAuthenticator;
 import com.hazelcast.client.impl.HazelcastClientInstanceImpl;
+import com.hazelcast.client.spi.ClientClusterService;
+import com.hazelcast.core.HazelcastException;
 import com.hazelcast.instance.MemberImpl;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.Connection;
-import com.hazelcast.security.Credentials;
 
 import java.io.IOException;
 
 public final class ClientSmartInvocationServiceImpl extends ClientInvocationServiceSupport {
 
     private final LoadBalancer loadBalancer;
-    private final Credentials credentials;
     private final ClusterAuthenticator authenticator;
 
     public ClientSmartInvocationServiceImpl(HazelcastClientInstanceImpl client, LoadBalancer loadBalancer) {
         super(client);
         this.loadBalancer = loadBalancer;
-        credentials = client.getCredentials();
-        authenticator = new ClusterAuthenticator(client, credentials);
+        authenticator = new ClusterAuthenticator(client, client.getCredentials());
+
     }
 
     public void invokeOnPartitionOwner(ClientInvocation invocation, int partitionId) throws IOException {
@@ -45,9 +45,8 @@ public final class ClientSmartInvocationServiceImpl extends ClientInvocationServ
         if (owner == null) {
             throw new IOException("Partition does not have owner. partitionId : " + partitionId);
         }
-        ClientConnection connection =
-                (ClientConnection) connectionManager.getOrConnect(owner, authenticator);
-        send(invocation, connection);
+        Connection connection = getConnection(owner);
+        send(invocation, (ClientConnection) connection);
     }
 
     @Override
@@ -56,7 +55,7 @@ public final class ClientSmartInvocationServiceImpl extends ClientInvocationServ
         if (randomAddress == null) {
             throw new IOException("Not address found to invoke ");
         }
-        final Connection connection = connectionManager.getOrConnect(randomAddress, authenticator);
+        final Connection connection = getConnection(randomAddress);
         send(invocation, (ClientConnection) connection);
     }
 
@@ -69,8 +68,28 @@ public final class ClientSmartInvocationServiceImpl extends ClientInvocationServ
         if (!isMember(target)) {
             throw new IOException("Target :  " + target + " is not member. ");
         }
-        final Connection connection = connectionManager.getOrConnect(target, authenticator);
+        final Connection connection = getConnection(target);
         invokeOnConnection(invocation, (ClientConnection) connection);
+    }
+
+    private Connection getConnection(Address target) throws IOException {
+        ensureOwnerConnectionAvailable();
+        return connectionManager.getOrConnect(target, authenticator);
+    }
+
+    private void ensureOwnerConnectionAvailable() throws IOException {
+        ClientClusterService clientClusterService = client.getClientClusterService();
+        Address ownerConnectionAddress = clientClusterService.getOwnerConnectionAddress();
+
+        boolean isOwnerConnectionAvailable = ownerConnectionAddress != null
+                && connectionManager.getConnection(ownerConnectionAddress) != null;
+
+        if (!isOwnerConnectionAvailable) {
+            if (isShutdown()) {
+                throw new HazelcastException("ConnectionManager is not active!");
+            }
+            throw new IOException("Not able to setup owner connection!");
+        }
     }
 
     @Override

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClusterListenerSupport.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClusterListenerSupport.java
@@ -160,6 +160,7 @@ public abstract class ClusterListenerSupport implements ConnectionListener, Conn
     }
 
     private void connectToOne() throws Exception {
+        ownerConnectionAddress = null;
         final ClientNetworkConfig networkConfig = client.getClientConfig().getNetworkConfig();
         final int connAttemptLimit = networkConfig.getConnectionAttemptLimit();
         final int connectionAttemptPeriod = networkConfig.getConnectionAttemptPeriod();

--- a/hazelcast/src/main/java/com/hazelcast/client/ClientEndpoint.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/ClientEndpoint.java
@@ -72,4 +72,8 @@ public interface ClientEndpoint {
 
     ClientPrincipal getPrincipal();
 
+    /**
+     * @return true if endpoint is authenticated with valid security credentials, returns false otherwise
+     */
+    boolean isAuthenticated();
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEndpointImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEndpointImpl.java
@@ -118,6 +118,7 @@ public final class ClientEndpointImpl implements Client, ClientEndpoint {
         clientEngine.addOwnershipMapping(principal.getUuid(), principal.getOwnerUuid());
     }
 
+    @Override
     public boolean isAuthenticated() {
         return authenticated;
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/client/AuthenticationRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/client/AuthenticationRequest.java
@@ -146,6 +146,11 @@ public final class AuthenticationRequest extends CallableClientRequest {
             }
         }
 
+        if (clientEngine.getClusterService().getMember(principal.getOwnerUuid()) == null) {
+            return new AuthenticationException("Invalid owner-uuid: " + principal.getOwnerUuid()
+                    + ", it's not member of this cluster!");
+        }
+
         endpoint.authenticated(principal, credentials, ownerConnection);
         clientEngine.getEndpointManager().registerEndpoint(endpoint);
         clientEngine.bind(endpoint);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/client/PartitionClientRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/client/PartitionClientRequest.java
@@ -27,8 +27,6 @@ import com.hazelcast.spi.Operation;
  */
 public abstract class PartitionClientRequest extends ClientRequest implements ExecutionCallback {
 
-    private static final int TRY_COUNT = 100;
-
     /**
      * Called on node side, before starting any operation.
      */
@@ -55,7 +53,6 @@ public abstract class PartitionClientRequest extends ClientRequest implements Ex
         op.setCallerUuid(endpoint.getUuid());
         InvocationBuilder builder = operationService.createInvocationBuilder(getServiceName(), op, getPartition())
                 .setReplicaIndex(getReplicaIndex())
-                .setTryCount(TRY_COUNT)
                 .setResultDeserialized(false);
 
         ICompletableFuture future = builder.invoke();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AuthenticationBaseMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AuthenticationBaseMessageTask.java
@@ -57,6 +57,11 @@ public abstract class AuthenticationBaseMessageTask<P>
         return null;
     }
 
+    @Override
+    protected boolean isAuthenticationMessage() {
+        return true;
+    }
+
     private void handleEndpointNotCreatedConnectionNotAlive() {
         logger.warning("Dropped: " + clientMessage + " -> endpoint not created for AuthenticationRequest, connection not alive");
     }
@@ -93,6 +98,12 @@ public abstract class AuthenticationBaseMessageTask<P>
                     nodeEngine.getOperationService().send(op, member.getAddress());
                 }
             }
+        }
+
+        boolean isMember = clientEngine.getClusterService().getMember(principal.getOwnerUuid()) == null;
+        if (isMember) {
+            throw new AuthenticationException("Invalid owner-uuid: " + principal.getOwnerUuid()
+                    + ", it's not member of this cluster!");
         }
 
         endpoint.authenticated(principal, credentials, isOwnerConnection());


### PR DESCRIPTION
...Otherwise clients can execute illegal operations on cluster and cause infinitely hanging resources (for ex: locks).

When owner connection is lost, client invocations should retry until owner-connection is established or client shutdowns or a timeout happens.

Add  back the missing authenticated check to server for client requests

Changes made both old and new client.

Some of the fixes are ported from @mdogan fixes on a customer branch.