### PR TITLE
Fix race in IOBalancer

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/AbstractSelectionHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/AbstractSelectionHandler.java
@@ -47,24 +47,6 @@ public abstract class AbstractSelectionHandler implements MigratableHandler {
         this.initialOps = initialOps;
     }
 
-    /**
-     * Migrates this handler to a new IOSelector thread.
-     * The migration logic is rather simple:
-     * <p><ul>
-     *     <li>Submit a de-registration task to a current IOSelector thread</li>
-     *     <li>The de-registration task submits a registration task to the new IOSelector thread</li>
-     * </ul></p>
-     *
-     * @param newOwner target IOSelector this handler migrates to
-     */
-    public void requestMigration(final IOSelector newOwner) {
-        if (ioSelector == newOwner || !socketChannel.isOpen()) {
-            return;
-        }
-
-        ioSelector.addTaskAndWakeup(new MigrationTask(newOwner));
-    }
-
     protected SelectionKey getSelectionKey() {
         if (selectionKey == null) {
             try {
@@ -128,33 +110,39 @@ public abstract class AbstractSelectionHandler implements MigratableHandler {
         return ioSelector;
     }
 
-    private class MigrationTask implements Runnable {
-        private final IOSelector newOwner;
+    // This method run on the oldOwner IOSelector(thread)
+    void startMigration(final IOSelector newOwner) {
+        assert ioSelector == Thread.currentThread() : "startMigration can only run on the owning IOSelector thread";
+        assert ioSelector != newOwner : "newOwner can't be the same as the existing owner";
 
-        public MigrationTask(IOSelector newOwner) {
-            this.newOwner = newOwner;
+        if (!socketChannel.isOpen()) {
+            // if the channel is closed, we are done.
+            return;
         }
 
-        @Override
-        public void run() {
-            if (!socketChannel.isOpen()) {
-                return;
+        unregisterOp(initialOps);
+        ioSelector = newOwner;
+        selectionKey.cancel();
+        selectionKey = null;
+        selector = null;
+
+        newOwner.addTaskAndWakeup(new Runnable() {
+            @Override
+            public void run() {
+                completeMigration(newOwner);
             }
-            unregisterOp(initialOps);
-            ioSelector = newOwner;
-            selectionKey.cancel();
-            selectionKey = null;
-            newOwner.addTaskAndWakeup(new Runnable() {
-                @Override
-                public void run() {
-                    if (!socketChannel.isOpen()) {
-                        return;
-                    }
-                    selector = newOwner.getSelector();
-                    selectionKey = getSelectionKey();
-                    registerOp(initialOps);
-                }
-            });
+        });
+    }
+
+    private void completeMigration(IOSelector newOwner) {
+        assert ioSelector == newOwner;
+
+        if (!socketChannel.isOpen()) {
+            return;
         }
+
+        selector = newOwner.getSelector();
+        selectionKey = getSelectionKey();
+        registerOp(initialOps);
     }
 }


### PR DESCRIPTION
Fixes an issue with the IOBalancer which can cause OperationTImeoutException.

In short: it can happen that an write handler is migrating and it is going to process a packet on the new IOSelector before it is fully migrated.