### PR TITLE
Fixed shift of lastUpdateTime after getAll. 

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/DefaultRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/DefaultRecordStore.java
@@ -63,7 +63,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore implements 
     private final Collection<Future> loadingFutures = new ArrayList<Future>();
 
     public DefaultRecordStore(MapContainer mapContainer, int partitionId,
-            MapKeyLoader keyLoader, ILogger logger) {
+                              MapKeyLoader keyLoader, ILogger logger) {
         super(mapContainer, partitionId);
 
         this.logger = logger;
@@ -657,17 +657,25 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore implements 
                 iterator.remove();
             }
         }
-        final Map entriesLoaded = mapDataStore.loadAll(keys);
-        addMapEntrySet(entriesLoaded, mapEntrySet);
 
-        // add loaded key-value pairs to this record-store.
-        Set<Map.Entry<Data, Data>> entrySet = mapEntrySet.getEntrySet();
-        for (Map.Entry<Data, Data> entry : entrySet) {
-            // correct TTL will be set in the put method below, when creating record.
-            // use putTransient since we already fetched entries from map-loader.
-            putTransient(entry.getKey(), entry.getValue(), DEFAULT_TTL);
-        }
+        Map loadedEntries = loadEntries(keys);
+        addMapEntrySet(loadedEntries, mapEntrySet);
+
         return mapEntrySet;
+    }
+
+    private Map loadEntries(Set<Data> keys) {
+        Map loadedEntries = mapDataStore.loadAll(keys);
+        if (loadedEntries == null || loadedEntries.isEmpty()) {
+            return Collections.emptyMap();
+        }
+        // add loaded key-value pairs to this record-store.
+        Set entrySet = loadedEntries.entrySet();
+        for (Object object : entrySet) {
+            Map.Entry entry = (Map.Entry) object;
+            putFromLoad(toData(entry.getKey()), entry.getValue());
+        }
+        return loadedEntries;
     }
 
     private void addMapEntrySet(Object key, Object value, MapEntrySet mapEntrySet) {

--- a/hazelcast/src/test/java/com/hazelcast/map/EvictionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/EvictionTest.java
@@ -1097,5 +1097,27 @@ public class EvictionTest extends HazelcastTestSupport {
         assertNull("value of expired key should be null on a replicated partition", value);
     }
 
+
+    @Test
+    public void testGetAll_doesNotShiftLastUpdateTimeOfEntry() throws Exception {
+        HazelcastInstance node = createHazelcastInstance();
+        IMap<Integer, Integer> map = node.getMap(randomMapName());
+
+        int key = 1;
+        map.put(key, 0, 1, TimeUnit.MINUTES);
+
+        EntryView<Integer, Integer> entryView = map.getEntryView(key);
+        long lastUpdateTimeBeforeGetAll = entryView.getLastUpdateTime();
+
+        Set<Integer> keys = Collections.singleton(key);
+        map.getAll(keys);
+
+        entryView = map.getEntryView(key);
+        long lastUpdateTimeAfterGetAll = entryView.getLastUpdateTime();
+
+        assertEquals("getAll should not shift lastUpdateTime of the entry",
+                lastUpdateTimeBeforeGetAll, lastUpdateTimeAfterGetAll);
+
+    }
 }
 


### PR DESCRIPTION
Last update time of an entry should not be changed after getAll.
Forward port of https://github.com/hazelcast/hazelcast/pull/5343