### PR TITLE
Integrated addTask and wakeup so that there are no races

### DIFF
--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/connection/nio/AbstractClientSelectionHandler.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/connection/nio/AbstractClientSelectionHandler.java
@@ -80,8 +80,7 @@ public abstract class AbstractClientSelectionHandler implements SelectionHandler
     }
 
     public void register() {
-        ioSelector.addTask(this);
-        ioSelector.wakeup();
+        ioSelector.addTaskAndWakeup(this);
     }
 
 }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/AbstractClientSelectionHandler.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/AbstractClientSelectionHandler.java
@@ -80,8 +80,7 @@ public abstract class AbstractClientSelectionHandler implements SelectionHandler
     }
 
     public void register() {
-        ioSelector.addTask(this);
-        ioSelector.wakeup();
+        ioSelector.addTaskAndWakeup(this);
     }
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/AbstractIOSelector.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/AbstractIOSelector.java
@@ -95,6 +95,12 @@ public abstract class AbstractIOSelector extends Thread implements IOSelector {
         selectorQueue.add(runnable);
     }
 
+    @Override
+    public final void addTaskAndWakeup(Runnable runnable) {
+        selectorQueue.add(runnable);
+        selector.wakeup();
+    }
+
     private void processSelectionQueue() {
         //noinspection WhileLoopSpinsOnField
         while (live) {
@@ -191,11 +197,6 @@ public abstract class AbstractIOSelector extends Thread implements IOSelector {
     @Override
     public final Selector getSelector() {
         return selector;
-    }
-
-    @Override
-    public final void wakeup() {
-        selector.wakeup();
     }
 
     private void handleSelectFailure(Throwable e) {

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/AbstractSelectionHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/AbstractSelectionHandler.java
@@ -62,8 +62,7 @@ public abstract class AbstractSelectionHandler implements MigratableHandler {
             return;
         }
 
-        ioSelector.addTask(new MigrationTask(newOwner));
-        ioSelector.wakeup();
+        ioSelector.addTaskAndWakeup(new MigrationTask(newOwner));
     }
 
     protected SelectionKey getSelectionKey() {
@@ -145,7 +144,7 @@ public abstract class AbstractSelectionHandler implements MigratableHandler {
             ioSelector = newOwner;
             selectionKey.cancel();
             selectionKey = null;
-            newOwner.addTask(new Runnable() {
+            newOwner.addTaskAndWakeup(new Runnable() {
                 @Override
                 public void run() {
                     if (!socketChannel.isOpen()) {
@@ -156,7 +155,6 @@ public abstract class AbstractSelectionHandler implements MigratableHandler {
                     registerOp(initialOps);
                 }
             });
-            newOwner.wakeup();
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/IOSelector.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/IOSelector.java
@@ -26,7 +26,13 @@ public interface IOSelector extends OperationHostileThread {
 
     void addTask(Runnable runnable);
 
-    void wakeup();
+    /**
+     * Adds a task to be executed by the IOSelector and wakes up the IOSelector so that it will
+     * eventually pick up the task.
+     *
+     * @param runnable the task to add.
+     */
+    void addTaskAndWakeup(Runnable runnable);
 
     void start();
 

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/ReadHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/ReadHandler.java
@@ -49,15 +49,13 @@ public final class ReadHandler extends AbstractSelectionHandler {
     }
 
     public void start() {
-        ioSelector.addTask(new Runnable() {
+        ioSelector.addTaskAndWakeup(new Runnable() {
             @Override
             public void run() {
                 getSelectionKey();
 
             }
         });
-
-        ioSelector.wakeup();
     }
 
     @Override
@@ -151,7 +149,7 @@ public final class ReadHandler extends AbstractSelectionHandler {
     }
 
     void shutdown() {
-        ioSelector.addTask(new Runnable() {
+        ioSelector.addTaskAndWakeup(new Runnable() {
             @Override
             public void run() {
                 try {
@@ -161,6 +159,5 @@ public final class ReadHandler extends AbstractSelectionHandler {
                 }
             }
         });
-        ioSelector.wakeup();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/WriteHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/WriteHandler.java
@@ -67,13 +67,12 @@ public final class WriteHandler extends AbstractSelectionHandler implements Runn
     // accessed from ReadHandler and SocketConnector
     void setProtocol(final String protocol) {
         final CountDownLatch latch = new CountDownLatch(1);
-        ioSelector.addTask(new Runnable() {
+        ioSelector.addTaskAndWakeup(new Runnable() {
             public void run() {
                 createWriter(protocol);
                 latch.countDown();
             }
         });
-        ioSelector.wakeup();
         try {
             latch.await(TIMEOUT, TimeUnit.SECONDS);
         } catch (InterruptedException e) {
@@ -138,8 +137,7 @@ public final class WriteHandler extends AbstractSelectionHandler implements Runn
 
         // We managed to schedule this WriteHandler. This means we need to add a task to
         // the ioReactor and to give the reactor-thread a kick so that it processes our packets.
-        ioSelector.addTask(this);
-        ioSelector.wakeup();
+        ioSelector.addTaskAndWakeup(this);
     }
 
     /**
@@ -306,7 +304,7 @@ public final class WriteHandler extends AbstractSelectionHandler implements Runn
         urgentWriteQueue.clear();
 
         final CountDownLatch latch = new CountDownLatch(1);
-        ioSelector.addTask(new Runnable() {
+        ioSelector.addTaskAndWakeup(new Runnable() {
             @Override
             public void run() {
                 try {
@@ -318,7 +316,6 @@ public final class WriteHandler extends AbstractSelectionHandler implements Runn
                 }
             }
         });
-        ioSelector.wakeup();
         try {
             latch.await(TIMEOUT, TimeUnit.SECONDS);
         } catch (InterruptedException e) {


### PR DESCRIPTION
Due to migration (a handler moving from one IOSelector to another) it can happen that addTask is called on the old Selector and wakeup called on the new.

This fix prevents this problem.

This is done by replacing:

```
ioSelector.addTask(task)
ioSelector.wakeup
```

with:
```
ioSelector.addTaskAndWakeup(task)
```

I have removed the wakeup method since it isn't used any more. 

We are working on another fix for the IOSelector that prevent adding a task to the wrong selector or adding a task to the new selector when not needed.
