### PR TITLE
Send cache configs to the new node at join 

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheService.java
@@ -53,7 +53,7 @@ import java.util.Collection;
  * using {@link AbstractHazelcastCacheManager#cacheNamePrefix()}.
  * </p>
  */
-public class CacheService extends AbstractCacheService implements ICacheService {
+public class CacheService extends AbstractCacheService {
 
     protected ICacheRecordStore createNewRecordStore(String name, int partitionId) {
         return new CacheRecordStore(name, partitionId, nodeEngine, CacheService.this);
@@ -114,7 +114,7 @@ public class CacheService extends AbstractCacheService implements ICacheService 
         EventService eventService = nodeEngine.getEventService();
         Collection<EventRegistration> registrations = eventService.getRegistrations(SERVICE_NAME, name);
         if (!registrations.isEmpty()) {
-            //TODO : fix below for client protocol
+            // TODO fix below for client protocol
             eventService.publishEvent(SERVICE_NAME, registrations,
                     new CacheInvalidationMessage(name, key, sourceUuid), name.hashCode());
 

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/PostJoinCacheOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/PostJoinCacheOperation.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.cache.impl.operation;
+
+import com.hazelcast.cache.impl.CacheService;
+import com.hazelcast.config.CacheConfig;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.spi.AbstractOperation;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class PostJoinCacheOperation extends AbstractOperation {
+
+    private List<CacheConfig> configs = new ArrayList<CacheConfig>();
+
+    public void addCacheConfig(CacheConfig cacheConfig) {
+        configs.add(cacheConfig);
+    }
+
+    @Override
+    public String getServiceName() {
+        return CacheService.SERVICE_NAME;
+    }
+
+    @Override
+    public void run() throws Exception {
+        CacheService cacheService = getService();
+        for (CacheConfig cacheConfig : configs) {
+            cacheService.createCacheConfigIfAbsent(cacheConfig);
+        }
+    }
+
+    @Override
+    protected void writeInternal(ObjectDataOutput out) throws IOException {
+        super.writeInternal(out);
+        out.writeInt(configs.size());
+        for (CacheConfig config : configs) {
+            out.writeObject(config);
+        }
+    }
+
+    @Override
+    protected void readInternal(ObjectDataInput in) throws IOException {
+        super.readInternal(in);
+        int confSize = in.readInt();
+        for (int i = 0; i < confSize; i++) {
+            CacheConfig config = in.readObject();
+            configs.add(config);
+        }
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/cache/CacheConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CacheConfigTest.java
@@ -17,6 +17,7 @@
 package com.hazelcast.cache;
 
 import com.hazelcast.cache.impl.HazelcastServerCachingProvider;
+import com.hazelcast.cache.impl.ICacheService;
 import com.hazelcast.config.CacheConfig;
 import com.hazelcast.config.EvictionConfig;
 import com.hazelcast.config.CacheSimpleConfig;
@@ -28,6 +29,10 @@ import com.hazelcast.config.XmlConfigBuilder;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.instance.HazelcastInstanceFactory;
+import com.hazelcast.instance.Node;
+import com.hazelcast.instance.TestUtil;
+import com.hazelcast.spi.NodeEngine;
+import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
@@ -299,6 +304,48 @@ public class CacheConfigTest extends HazelcastTestSupport {
         cacheSimpleConfig.addEntryListenerConfig(cacheSimpleEntryListenerConfig);
         config.addCacheConfig(cacheSimpleConfig);
         return config;
+    }
+
+    private ICacheService getCacheService(HazelcastInstance instance) {
+        Node node = TestUtil.getNode(instance);
+        return node.getNodeEngine().getService(ICacheService.SERVICE_NAME);
+    }
+
+    private NodeEngine getNodeEngine(HazelcastInstance instance) {
+        Node node = TestUtil.getNode(instance);
+        return node.getNodeEngine();
+    }
+
+    @Test
+    public void testGetCacheConfigsAtJoin() {
+        final String cacheName = randomString();
+        final String managerPrefix = "hz:";
+        final String fullCacheName = managerPrefix + cacheName;
+        final Config config = new Config();
+        final CacheConfig cacheConfig =
+                new CacheConfig()
+                        .setName(cacheName)
+                        .setManagerPrefix(managerPrefix);
+
+        final TestHazelcastInstanceFactory instanceFactory = createHazelcastInstanceFactory(2);
+        final HazelcastInstance instance1 = instanceFactory.newHazelcastInstance(config);
+        final ICacheService cacheService1 = getCacheService(instance1);
+
+        assertNull(cacheService1.getCacheConfig(fullCacheName));
+
+        cacheService1.createCacheConfigIfAbsent(cacheConfig);
+
+        assertNotNull(cacheService1.getCacheConfig(fullCacheName));
+
+        final HazelcastInstance instance2 = instanceFactory.newHazelcastInstance(config);
+        final ICacheService cacheService2 = getCacheService(instance2);
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertNotNull(cacheService2.getCacheConfig(fullCacheName));
+            }
+        });
     }
 
     public static class EntryListenerFactory implements Factory<EntryListener> {


### PR DESCRIPTION
Fixes #4841

Sends cache configurations to the new node at join via Post-Join operation