### PR TITLE
Fixes Nested PartitionOperation invocation when mapped to same thread

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/classic/OperationThreadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/classic/OperationThreadTest.java
@@ -7,7 +7,11 @@ import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.impl.operationexecutor.OperationRunner;
 import com.hazelcast.spi.impl.operationexecutor.OperationRunnerFactory;
 import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.anyInt;
@@ -15,6 +19,8 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
 public class OperationThreadTest extends AbstractClassicOperationExecutorTest {
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/classic/RunOnCallingThreadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/classic/RunOnCallingThreadTest.java
@@ -10,7 +10,7 @@ import java.util.concurrent.FutureTask;
 
 import static org.junit.Assert.assertTrue;
 
-public class RunOperationOnCallingThreadTest extends AbstractClassicOperationExecutorTest {
+public class RunOnCallingThreadTest extends AbstractClassicOperationExecutorTest {
 
     @Test(expected = NullPointerException.class)
     public void test_whenNull() {

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationNestedLocalTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationNestedLocalTest.java
@@ -1,0 +1,121 @@
+package com.hazelcast.spi.impl.operationservice.impl;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.spi.InternalCompletableFuture;
+import com.hazelcast.spi.OperationService;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category(QuickTest.class)
+public class InvocationNestedLocalTest extends InvocationNestedTest {
+
+    private final String response = "someresponse";
+
+    @Test
+    public void whenPartition_callsGeneric() {
+        HazelcastInstance hz = createHazelcastInstance();
+        OperationService operationService = getOperationService(hz);
+
+        InnerOperation innerOperation = new InnerOperation(response, -1);
+        OuterOperation outerOperation = new OuterOperation(innerOperation, 0);
+
+        InternalCompletableFuture f = operationService.invokeOnPartition(null, outerOperation, outerOperation.getPartitionId());
+
+        assertEquals(response, f.getSafely());
+    }
+
+    @Test
+    public void whenPartition_callsCorrectPartition() {
+        HazelcastInstance hz = createHazelcastInstance();
+        OperationService operationService = getOperationService(hz);
+
+        int partitionId = 0;
+        InnerOperation innerOperation = new InnerOperation(response, partitionId);
+        OuterOperation outerOperation = new OuterOperation(innerOperation, partitionId);
+
+        InternalCompletableFuture f = operationService.invokeOnPartition(null, outerOperation, outerOperation.getPartitionId());
+
+        assertEquals(response, f.getSafely());
+    }
+
+    @Test
+    public void whenPartition_callsIncorrectPartition() {
+        HazelcastInstance hz = createHazelcastInstance();
+        OperationService operationService = getOperationService(hz);
+
+        int outerPartitionId = 0;
+        int innerPartitionId = 1;
+        for (; innerPartitionId < hz.getPartitionService().getPartitions().size(); innerPartitionId++) {
+            if (!mappedToSameThread(operationService, outerPartitionId, innerPartitionId)) {
+                break;
+            }
+        }
+
+        InnerOperation innerOperation = new InnerOperation(response, innerPartitionId);
+        OuterOperation outerOperation = new OuterOperation(innerOperation, outerPartitionId);
+
+        InternalCompletableFuture f = operationService.invokeOnPartition(null, outerOperation, outerOperation.getPartitionId());
+
+        try {
+            f.getSafely();
+            fail();
+        } catch (IllegalThreadStateException e) {
+        }
+    }
+
+    @Test
+    public void whenPartition_callsDifferentPartition_butMappedToSameThread() throws ExecutionException, InterruptedException {
+        Config config = new Config();
+        config.setProperty(GroupProperties.PROP_PARTITION_COUNT, "2");
+        config.setProperty(GroupProperties.PROP_PARTITION_OPERATION_THREAD_COUNT, "1");
+        HazelcastInstance hz = createHazelcastInstance(config);
+        final OperationService operationService = getOperationService(hz);
+
+        int innerPartitionId = 0;
+        int outerPartitionId = 1;
+        InnerOperation innerOperation = new InnerOperation(response, innerPartitionId);
+        OuterOperation outerOperation = new OuterOperation(innerOperation, outerPartitionId);
+
+        Future f = operationService.invokeOnPartition(null, outerOperation, outerOperation.getPartitionId());
+        assertEquals(response, f.get());
+    }
+
+    @Test
+    public void whenGeneric_callsGeneric() {
+        HazelcastInstance hz = createHazelcastInstance();
+        OperationService operationService = getOperationService(hz);
+
+        InnerOperation innerOperation = new InnerOperation(response, -1);
+        OuterOperation outerOperation = new OuterOperation(innerOperation, -1);
+
+        InternalCompletableFuture f = operationService.invokeOnTarget(null, outerOperation, getAddress(hz));
+
+        assertEquals(response, f.getSafely());
+    }
+
+    @Test
+    public void whenGeneric_callsPartitionSpecific() {
+        HazelcastInstance hz = createHazelcastInstance();
+        OperationService operationService = getOperationService(hz);
+
+        int innerPartitionId = 0;
+        InnerOperation innerOperation = new InnerOperation(response, innerPartitionId);
+        OuterOperation outerOperation = new OuterOperation(innerOperation, -1);
+
+        InternalCompletableFuture f = operationService.invokeOnTarget(null, outerOperation, getAddress(hz));
+
+        assertEquals(response, f.getSafely());
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationNestedRemoteTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationNestedRemoteTest.java
@@ -1,0 +1,139 @@
+package com.hazelcast.spi.impl.operationservice.impl;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.spi.InternalCompletableFuture;
+import com.hazelcast.spi.OperationService;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.ExecutionException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+/**
+ * Test how well HZ deals with nested invocations.
+ */
+@RunWith(HazelcastParallelClassRunner.class)
+@Category(QuickTest.class)
+public class InvocationNestedRemoteTest extends InvocationNestedTest {
+
+    private final String response = "someresponse";
+
+    // ======================= remote invocations ============================================
+
+    @Test
+    public void whenPartition_callsGeneric() {
+        HazelcastInstance[] cluster = createHazelcastInstanceFactory(2).newInstances();
+        HazelcastInstance local = cluster[0];
+        HazelcastInstance remote = cluster[1];
+        OperationService operationService = getOperationService(local);
+
+        InnerOperation innerOperation = new InnerOperation(response, -1);
+        OuterOperation outerOperation = new OuterOperation(innerOperation, getPartitionId(remote));
+
+        InternalCompletableFuture f = operationService.invokeOnPartition(null, outerOperation, outerOperation.getPartitionId());
+
+        assertEquals(response, f.getSafely());
+    }
+
+    @Test
+    public void whenPartition_callsSamePartition() {
+        HazelcastInstance[] cluster = createHazelcastInstanceFactory(2).newInstances();
+        HazelcastInstance local = cluster[0];
+        HazelcastInstance remote = cluster[1];
+        OperationService operationService = getOperationService(local);
+
+        int partitionId = getPartitionId(remote);
+        InnerOperation innerOperation = new InnerOperation(response, partitionId);
+        OuterOperation outerOperation = new OuterOperation(innerOperation, partitionId);
+
+        InternalCompletableFuture f = operationService.invokeOnPartition(null, outerOperation, outerOperation.getPartitionId());
+
+        assertEquals(response, f.getSafely());
+    }
+
+    @Test
+    public void whenPartition_callsDifferentPartition_butMappedToSameThread() throws ExecutionException, InterruptedException {
+        HazelcastInstance[] cluster = createHazelcastInstanceFactory(2).newInstances();
+        HazelcastInstance local = cluster[0];
+        HazelcastInstance remote = cluster[1];
+        OperationService operationService = getOperationService(local);
+
+        int outerPartitionId = getPartitionId(remote);
+        int innerPartitionId = 0;
+        for (; innerPartitionId < remote.getPartitionService().getPartitions().size(); innerPartitionId++) {
+            if (innerPartitionId == outerPartitionId) {
+                continue;
+            }
+
+            if (!getPartitionService(remote).getPartition(innerPartitionId).isLocal()) {
+                continue;
+            }
+
+            if (mappedToSameThread(operationService, outerPartitionId, innerPartitionId)) {
+                break;
+            }
+        }
+        InnerOperation innerOperation = new InnerOperation(response, innerPartitionId);
+        OuterOperation outerOperation = new OuterOperation(innerOperation, outerPartitionId);
+
+        InternalCompletableFuture f = operationService.invokeOnPartition(null, outerOperation, outerOperation.getPartitionId());
+
+        assertEquals(response, f.getSafely());
+    }
+
+    @Test
+    public void whenPartition_callsIncorrectPartition() {
+        HazelcastInstance[] cluster = createHazelcastInstanceFactory(2).newInstances();
+        HazelcastInstance local = cluster[0];
+        HazelcastInstance remote = cluster[1];
+        OperationService operationService = getOperationService(local);
+
+        int outerPartitionId = getPartitionId(remote);
+        int innerPartitionId = getPartitionId(local);
+        InnerOperation innerOperation = new InnerOperation(response, innerPartitionId);
+        OuterOperation outerOperation = new OuterOperation(innerOperation, outerPartitionId);
+
+        InternalCompletableFuture f = operationService.invokeOnPartition(null, outerOperation, outerOperation.getPartitionId());
+
+        try {
+            f.getSafely();
+            fail();
+        } catch (IllegalThreadStateException e) {
+        }
+    }
+
+    @Test
+    public void whenGeneric_callsGeneric() {
+        HazelcastInstance[] cluster = createHazelcastInstanceFactory(2).newInstances();
+        HazelcastInstance local = cluster[0];
+        HazelcastInstance remote = cluster[1];
+        OperationService operationService = getOperationService(local);
+
+        InnerOperation innerOperation = new InnerOperation(response, -1);
+        OuterOperation outerOperation = new OuterOperation(innerOperation, -1);
+
+        InternalCompletableFuture f = operationService.invokeOnTarget(null, outerOperation, getAddress(remote));
+
+        assertEquals(response, f.getSafely());
+    }
+
+    @Test
+    public void whenGeneric_callsPartition() {
+        HazelcastInstance[] cluster = createHazelcastInstanceFactory(2).newInstances();
+        HazelcastInstance local = cluster[0];
+        HazelcastInstance remote = cluster[1];
+        OperationService operationService = getOperationService(local);
+
+        InnerOperation innerOperation = new InnerOperation(response, 0);
+        OuterOperation outerOperation = new OuterOperation(innerOperation, -1);
+
+        InternalCompletableFuture f = operationService.invokeOnTarget(null, outerOperation, getAddress(remote));
+
+        assertEquals(response, f.getSafely());
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationNestedTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationNestedTest.java
@@ -1,229 +1,48 @@
 package com.hazelcast.spi.impl.operationservice.impl;
 
-import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.spi.AbstractOperation;
 import com.hazelcast.spi.InternalCompletableFuture;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.OperationService;
-import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.spi.impl.operationexecutor.classic.ClassicOperationExecutor;
 import com.hazelcast.test.HazelcastTestSupport;
-import com.hazelcast.test.annotation.QuickTest;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
 
 import java.io.IOException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+public abstract class InvocationNestedTest extends HazelcastTestSupport {
 
-/**
- * Test how well HZ deals with nested invocations.
- */
-@RunWith(HazelcastParallelClassRunner.class)
-@Category(QuickTest.class)
-public class InvocationNestedTest extends HazelcastTestSupport {
-
-    // ======================= local invocations ============================================
-
-
-    @Test
-    public void test_whenLocal_andPartitionSpecificCallsGeneric() {
-        HazelcastInstance localHz = createHazelcastInstance();
-
-        String response = "someresponse";
-        DummyOperation nestedOperation = new DummyOperation(response);
-        nestedOperation.setPartitionId(-1);
-        NestedOperation operation = new NestedOperation(nestedOperation);
-        OperationService operationService = getOperationService(localHz);
-        InternalCompletableFuture f = operationService.invokeOnPartition(null, operation, 0);
-
-        assertEquals(response, f.getSafely());
+    public static boolean mappedToSameThread(OperationService operationService, int partitionId1, int partitionId2){
+        OperationServiceImpl operationServiceImpl = (OperationServiceImpl) operationService;
+        ClassicOperationExecutor executor = (ClassicOperationExecutor) operationServiceImpl.getOperationExecutor();
+        int thread1 =  executor.toPartitionThreadIndex(partitionId1);
+        int thread2 =  executor.toPartitionThreadIndex(partitionId2);
+        return thread1 == thread2;
     }
 
-    @Test
-    public void test_whenLocal_andPartitionSpecificCallsCorrectPartitionSpecific() {
-        HazelcastInstance localHz = createHazelcastInstance();
+    public static class OuterOperation extends AbstractOperation {
+        public Operation innerOperation;
+        public Object result;
 
-        String response = "someresponse";
-        DummyOperation nestedOperation = new DummyOperation(response);
-        nestedOperation.setPartitionId(0);
-        NestedOperation operation = new NestedOperation(nestedOperation);
-        OperationService operationService = getOperationService(localHz);
-        InternalCompletableFuture f = operationService.invokeOnPartition(null, operation, nestedOperation.getPartitionId());
-
-        assertEquals(response, f.getSafely());
-    }
-
-    @Test
-    public void test_whenLocal_andPartitionSpecificCallsIncorrectPartitionSpecific() {
-        HazelcastInstance localHz = createHazelcastInstance();
-
-        String response = "someresponse";
-        int outerPartitionId = 0;
-        int nestedPartitionId = 1;
-        DummyOperation nestedOperation = new DummyOperation(response);
-        nestedOperation.setPartitionId(nestedPartitionId);
-        NestedOperation operation = new NestedOperation(nestedOperation);
-        OperationService operationService = getOperationService(localHz);
-
-        InternalCompletableFuture f = operationService.invokeOnPartition(null, operation, outerPartitionId);
-
-        try {
-            f.getSafely();
-            fail();
-        } catch (IllegalThreadStateException e) {
-
-        }
-    }
-
-    @Test
-    public void test_whenLocal_andGenericCallsGeneric() {
-        HazelcastInstance localHz = createHazelcastInstance();
-
-        String response = "someresponse";
-        DummyOperation nestedOperation = new DummyOperation(response);
-        nestedOperation.setPartitionId(-1);
-        NestedOperation operation = new NestedOperation(nestedOperation);
-        OperationService operationService = getOperationService(localHz);
-        InternalCompletableFuture f = operationService.invokeOnTarget(null, operation, getAddress(localHz));
-
-        assertEquals(response, f.getSafely());
-    }
-
-    @Test
-    public void test_whenLocal_andGenericCallsPartitionSpecific() {
-        HazelcastInstance localHz = createHazelcastInstance();
-
-        String response = "someresponse";
-        DummyOperation nestedOperation = new DummyOperation(response);
-        nestedOperation.setPartitionId(0);
-
-        NestedOperation operation = new NestedOperation(nestedOperation);
-        OperationService operationService = getOperationService(localHz);
-        InternalCompletableFuture f = operationService.invokeOnTarget(null, operation, getAddress(localHz));
-
-        assertEquals(response, f.getSafely());
-    }
-
-    // ======================= remote invocations ============================================
-
-    @Test
-    public void test_whenRemote_andPartitionSpecificCallsGeneric() {
-        HazelcastInstance[] cluster = createHazelcastInstanceFactory(2).newInstances();
-        HazelcastInstance local = cluster[0];
-        HazelcastInstance remote = cluster[1];
-
-        String response = "someresponse";
-        DummyOperation nestedOperation = new DummyOperation(response);
-        nestedOperation.setPartitionId(-1);
-        NestedOperation operation = new NestedOperation(nestedOperation);
-        OperationService operationService = getOperationService(local);
-        InternalCompletableFuture f = operationService.invokeOnPartition(null, operation, getPartitionId(remote));
-
-        assertEquals(response, f.getSafely());
-    }
-
-    @Test
-    public void test_whenRemote_andPartitionSpecificCallsCorrectPartitionSpecific() {
-        HazelcastInstance[] cluster = createHazelcastInstanceFactory(2).newInstances();
-        HazelcastInstance local = cluster[0];
-        HazelcastInstance remote = cluster[1];
-
-        String response = "someresponse";
-        int remotePartitionId = getPartitionId(remote);
-
-        DummyOperation nestedOperation = new DummyOperation(response);
-        nestedOperation.setPartitionId(remotePartitionId);
-
-        NestedOperation operation = new NestedOperation(nestedOperation);
-        OperationService operationService = getOperationService(local);
-        InternalCompletableFuture f = operationService.invokeOnPartition(null, operation, remotePartitionId);
-
-        assertEquals(response, f.getSafely());
-    }
-
-    @Test
-    public void test_whenRemote_andPartitionSpecificCallsIncorrectPartitionSpecific() {
-        HazelcastInstance[] cluster = createHazelcastInstanceFactory(2).newInstances();
-        HazelcastInstance local = cluster[0];
-        HazelcastInstance remote = cluster[1];
-
-        String response = "someresponse";
-        int remotePartitionId = getPartitionId(remote);
-        int badPartitionId = (remotePartitionId+1)%getNode(local).partitionService.getPartitionCount();
-
-        DummyOperation nestedOperation = new DummyOperation(response);
-        nestedOperation.setPartitionId(badPartitionId);
-
-        NestedOperation operation = new NestedOperation(nestedOperation);
-        OperationService operationService = getOperationService(local);
-        InternalCompletableFuture f = operationService.invokeOnPartition(null, operation, remotePartitionId);
-
-
-        try {
-            f.getSafely();
-            fail();
-        } catch (IllegalThreadStateException e) {
-
-        }
-    }
-
-    @Test
-    public void test_whenRemote_andGenericCallsGeneric() {
-        HazelcastInstance[] cluster = createHazelcastInstanceFactory(2).newInstances();
-        HazelcastInstance local = cluster[0];
-        HazelcastInstance remote = cluster[1];
-
-        String response = "someresponse";
-        DummyOperation nestedOperation = new DummyOperation(response);
-        nestedOperation.setPartitionId(-1);
-        NestedOperation operation = new NestedOperation(nestedOperation);
-        OperationService operationService = getOperationService(local);
-        InternalCompletableFuture f = operationService.invokeOnTarget(null, operation, getAddress(remote));
-
-        assertEquals(response, f.getSafely());
-    }
-
-    @Test
-    public void test_whenRemote_andGenericCallsPartitionSpecific() {
-        HazelcastInstance[] cluster = createHazelcastInstanceFactory(2).newInstances();
-        HazelcastInstance local = cluster[0];
-        HazelcastInstance remote = cluster[1];
-
-        String response = "someresponse";
-        DummyOperation nestedOperation = new DummyOperation(response);
-        nestedOperation.setPartitionId(0);
-
-        NestedOperation operation = new NestedOperation(nestedOperation);
-        OperationService operationService = getOperationService(local);
-        InternalCompletableFuture f = operationService.invokeOnTarget(null, operation, getAddress(remote));
-
-        assertEquals(response, f.getSafely());
-    }
-
-    public static class NestedOperation extends AbstractOperation {
-        private Operation nestedOperation;
-        private Object result;
-
-        public NestedOperation() {
+        public OuterOperation() {
         }
 
-        public NestedOperation(Operation nestedOperation) {
-            this.nestedOperation = nestedOperation;
+        public OuterOperation(Operation innerOperation, int partitionId) {
+            this.innerOperation = innerOperation;
+            setPartitionId(partitionId);
         }
 
         @Override
         public void run() throws Exception {
-            int partitionId = nestedOperation.getPartitionId();
+            System.out.println(Thread.currentThread());
+            int partitionId = innerOperation.getPartitionId();
             OperationService operationService = getNodeEngine().getOperationService();
             InternalCompletableFuture f;
             if (partitionId >= 0) {
-                f = operationService.invokeOnPartition(null, nestedOperation, partitionId);
+                f = operationService.invokeOnPartition(null, innerOperation, partitionId);
             } else {
-                f = operationService.invokeOnTarget(null, nestedOperation, getNodeEngine().getThisAddress());
+                f = operationService.invokeOnTarget(null, innerOperation, getNodeEngine().getThisAddress());
             }
 
             result = f.getSafely();
@@ -237,30 +56,31 @@ public class InvocationNestedTest extends HazelcastTestSupport {
         @Override
         protected void writeInternal(ObjectDataOutput out) throws IOException {
             super.writeInternal(out);
-            out.writeObject(nestedOperation);
+            out.writeObject(innerOperation);
 
         }
 
         @Override
         protected void readInternal(ObjectDataInput in) throws IOException {
             super.readInternal(in);
-            nestedOperation = in.readObject();
+            innerOperation = in.readObject();
         }
     }
 
-    public static class DummyOperation extends AbstractOperation {
-        private Object value;
+    public static class InnerOperation extends AbstractOperation {
+        public Object value;
 
-        public DummyOperation() {
+        public InnerOperation() {
         }
 
-        public DummyOperation(Object value) {
+        public InnerOperation(Object value, int partitionId) {
             this.value = value;
+            this.setPartitionId(partitionId);
         }
 
         @Override
         public void run() throws Exception {
-
+            System.out.println(Thread.currentThread());
         }
 
         @Override


### PR DESCRIPTION
Fixes #5341

The problem was that the system didn't deal correctly with an inner call for 2 different partitions, but mapped to the same thread. The error was that the OperationRunnerImpl for the inner operation was not obtained using the partition id of the inner operation, but by accessing the OperationThread.currentOperationRunner. So the inner operation would run on the outer OperationRunner and then you get the exception. 

Also tests have been added for local and remote calls where this behaviour is tested.

1 change is ClassicOperationScheduler and 6 changes are in the tests. 