### PR TITLE
Cleanup of PartitionDistributionTest. Added new failing test cases.

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/partition/PartitionDistributionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/partition/PartitionDistributionTest.java
@@ -17,16 +17,19 @@
 package com.hazelcast.partition;
 
 import com.hazelcast.config.Config;
+import com.hazelcast.config.PartitionGroupConfig;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.Member;
 import com.hazelcast.core.Partition;
 import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.logging.ILogger;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.SlowTest;
 import org.junit.AfterClass;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -40,51 +43,100 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.assertEquals;
+import static java.lang.String.format;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(SlowTest.class)
 public class PartitionDistributionTest extends HazelcastTestSupport {
+
+    private Config hostAwareConfig = new Config();
+
     @BeforeClass
     @AfterClass
     public static void killAllHazelcastInstances() throws IOException {
         Hazelcast.shutdownAll();
     }
 
+    @Before
+    public void setUp() {
+        PartitionGroupConfig partitionGroupConfig = hostAwareConfig.getPartitionGroupConfig();
+        partitionGroupConfig
+                .setEnabled(true)
+                .setGroupType(PartitionGroupConfig.MemberGroupType.HOST_AWARE);
+    }
+
     @Test
-    public void testTwoNodesDefault() throws InterruptedException {
+    public void testTwoNodes_defaultPartitions() throws InterruptedException {
         testPartitionDistribution(271, 2);
     }
 
     @Test
-    public void testTwoNodes1111Partitions() throws InterruptedException {
+    public void testTwoNodes_1111Partitions() throws InterruptedException {
         testPartitionDistribution(1111, 2);
     }
 
     @Test
-    public void testFiveNodesDefault() throws InterruptedException {
+    public void testTwoNodes_defaultPartitions_HostAware() throws InterruptedException {
+        testPartitionDistribution(271, 2, hostAwareConfig);
+    }
+
+    @Test
+    public void testThreeNodes_defaultPartitions() throws InterruptedException {
+        testPartitionDistribution(271, 3);
+    }
+
+    @Test(expected = AssertionError.class)
+    public void testThreeNodes_defaultPartitions_HostAware() throws InterruptedException {
+        testPartitionDistribution(271, 3, hostAwareConfig);
+    }
+
+    @Test
+    public void testFourNodes_defaultPartitions_HostAware() throws InterruptedException {
+        testPartitionDistribution(271, 4, hostAwareConfig);
+    }
+
+    @Test
+    public void testFiveNodes_defaultPartitions() throws InterruptedException {
         testPartitionDistribution(271, 5);
     }
 
     @Test
-    public void testFiveNodes1111Partitions() throws InterruptedException {
+    public void testFiveNodes_1111Partitions() throws InterruptedException {
         testPartitionDistribution(1111, 5);
     }
 
+    @Test(expected = AssertionError.class)
+    public void testFiveNodes_defaultPartitions_HostAware() throws InterruptedException {
+        testPartitionDistribution(271, 5, hostAwareConfig);
+    }
+
     @Test
-    public void testTenNodesDefault() throws InterruptedException {
+    public void testTenNodes_defaultPartitions() throws InterruptedException {
         testPartitionDistribution(271, 10);
     }
 
     @Test
-    public void testTenNodes1111Partitions() throws InterruptedException {
+    public void testTenNodes_1111Partitions() throws InterruptedException {
         testPartitionDistribution(1111, 10);
     }
 
-    private void testPartitionDistribution(final int partitionCount, final int nodeCount) throws InterruptedException {
-        final Config config = new Config();
+    @Test
+    public void testTenNodes_defaultPartitions_HostAware() throws InterruptedException {
+        testPartitionDistribution(271, 10, hostAwareConfig);
+    }
+
+    @Test(expected = AssertionError.class)
+    public void testFifteenNodes_defaultPartitions_HostAware() throws InterruptedException {
+        testPartitionDistribution(271, 15, hostAwareConfig);
+    }
+
+    private void testPartitionDistribution(int partitionCount, int nodeCount) throws InterruptedException {
+        testPartitionDistribution(partitionCount, nodeCount, new Config());
+    }
+
+    private void testPartitionDistribution(int partitionCount, int nodeCount, Config config) throws InterruptedException {
         config.setProperty(GroupProperties.PROP_PARTITION_COUNT, String.valueOf(partitionCount));
         TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(nodeCount);
         final BlockingQueue<Integer> counts = new ArrayBlockingQueue<Integer>(nodeCount);
@@ -94,37 +146,52 @@ public class PartitionDistributionTest extends HazelcastTestSupport {
             instances[i] = factory.newHazelcastInstance(config);
         }
 
-        final ExecutorService ex = Executors.newCachedThreadPool();
+        ExecutorService ex = Executors.newCachedThreadPool();
         try {
-            for (int j = 0; j < nodeCount; j++) {
-                final int instanceIndex = j;
+            for (int i = 0; i < nodeCount; i++) {
+                final int instanceIndex = i;
                 new Thread(new Runnable() {
                     public void run() {
-                        HazelcastInstance h = instances[instanceIndex];
-                        warmUpPartitions(h);
-                        counts.offer(getLocalPartitionsCount(h));
+                        HazelcastInstance instance = instances[instanceIndex];
+                        warmUpPartitions(instance);
+                        counts.offer(getLocalPartitionsCount(instance));
                     }
                 }).start();
             }
 
-            final int average = (partitionCount / nodeCount);
-            int total = 0;
+            ILogger logger = instances[0].getLoggingService().getLogger(getClass());
+            String firstFailureMessage = null;
+
+            int average = (partitionCount / nodeCount);
+            logger.info(format("Partition count: %d, nodes: %d, average: %d", partitionCount, nodeCount, average));
+
+            int totalPartitions = 0;
             for (int i = 0; i < nodeCount; i++) {
-                final Integer c = counts.poll(1, TimeUnit.MINUTES);
-                assertNotNull(c);
-                assertTrue("Partition count is : " + c + ", total partitions: " + partitionCount
-                        + ", nodes: " + nodeCount, c >= average);
-                total += c;
+                Integer localPartitionCount = counts.poll(1, TimeUnit.MINUTES);
+                assertNotNull(localPartitionCount);
+
+                String msg = format("Node: %d, local partition count: %d", i + 1, localPartitionCount);
+                if (firstFailureMessage == null && localPartitionCount < average) {
+                    firstFailureMessage = msg;
+                }
+                logger.info(msg);
+
+                totalPartitions += localPartitionCount;
             }
-            assertEquals(partitionCount, total);
+            assertEqualsStringFormat("Expected sum of local partitions to be %d, but was %d", partitionCount, totalPartitions);
+
+            if (firstFailureMessage != null) {
+                fail(format("%s, partition count: %d, nodes: %d, average: %d",
+                        firstFailureMessage, partitionCount, nodeCount, average));
+            }
         } finally {
             ex.shutdownNow();
         }
     }
 
-    private int getLocalPartitionsCount(HazelcastInstance h) {
-        final Member localMember = h.getCluster().getLocalMember();
-        Set<Partition> partitions = h.getPartitionService().getPartitions();
+    private int getLocalPartitionsCount(HazelcastInstance instance) {
+        Member localMember = instance.getCluster().getLocalMember();
+        Set<Partition> partitions = instance.getPartitionService().getPartitions();
         int count = 0;
         for (Partition partition : partitions) {
             if (localMember.equals(partition.getOwner())) {


### PR DESCRIPTION
* Cleanup of `PartitionDistributionTest`.
* Made logs more verbose (local partition counts are completely logged before failure).
* Added new test cases to `PartitionDistributionTest` with `HOST_AWARE` config.

The new test cases are using a `HOST_AWARE` partition configuration which we use in Simulator. During some runs I noticed a partition imbalance which I could reproduce with these new unit tests. Just clusters with an odd member count seem to fail.