### PR TITLE
Declarative configuration support for timed (with duration) "ExpiryPolicyFactory" in JCache

### DIFF
--- a/hazelcast-spring/src/main/resources/hazelcast-spring-3.5.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-3.5.xsd
@@ -434,6 +434,22 @@
                                             </xs:sequence>
                                         </xs:complexType>
                                     </xs:element>
+                                    <xs:element name="expiry-policy-factory" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Defines the expiry policy factory class name or
+                                                defines the expiry policy factory from predefined ones with duration configuration.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                        <xs:complexType>
+                                            <xs:sequence>
+                                                <xs:element name="timed-expiry-policy-factory"
+                                                            type="timed-expiry-policy-factory"
+                                                            minOccurs="0" maxOccurs="1"/>
+                                            </xs:sequence>
+                                            <xs:attribute name="class-name"/>
+                                        </xs:complexType>
+                                    </xs:element>
                                     <xs:element name="wan-replication-ref" type="wan-replication-ref" minOccurs="0"
                                                 maxOccurs="1">
                                         <xs:annotation>
@@ -2100,6 +2116,34 @@
     <xs:simpleType name="in-memory-format">
         <xs:union memberTypes="in-memory-format-enum non-space-string"/>
     </xs:simpleType>
+
+    <xs:simpleType name="time-unit">
+        <xs:restriction base="non-space-string">
+            <xs:enumeration value="NANOSECONDS"/>
+            <xs:enumeration value="MICROSECONDS"/>
+            <xs:enumeration value="MILLISECONDS"/>
+            <xs:enumeration value="SECONDS"/>
+            <xs:enumeration value="MINUTES"/>
+            <xs:enumeration value="HOURS"/>
+            <xs:enumeration value="DAYS"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="expiry-policy-type">
+        <xs:restriction base="non-space-string">
+            <xs:enumeration value="CREATED"/>
+            <xs:enumeration value="ACCESSED"/>
+            <xs:enumeration value="ETERNAL"/>
+            <xs:enumeration value="MODIFIED"/>
+            <xs:enumeration value="TOUCHED"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="timed-expiry-policy-factory">
+        <xs:attribute name="expiry-policy-type" type="expiry-policy-type" use="required"/>
+        <xs:attribute name="duration-amount" type="xs:unsignedLong" use="optional"/>
+        <xs:attribute name="time-unit" type="time-unit" use="optional"/>
+    </xs:complexType>
 
     <xs:simpleType name="concurrency-level">
         <xs:restriction base="xs:int">

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/context/TestJCache.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/context/TestJCache.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.spring.context;
 
+import com.hazelcast.config.Config;
 import com.hazelcast.config.EvictionConfig;
 import com.hazelcast.config.CacheSimpleConfig;
 import com.hazelcast.config.EvictionPolicy;
@@ -24,6 +25,10 @@ import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.spring.CustomSpringJUnit4ClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.config.CacheSimpleConfig.ExpiryPolicyFactoryConfig;
+import com.hazelcast.config.CacheSimpleConfig.ExpiryPolicyFactoryConfig.TimedExpiryPolicyFactoryConfig;
+import com.hazelcast.config.CacheSimpleConfig.ExpiryPolicyFactoryConfig.DurationConfig;
+import com.hazelcast.config.CacheSimpleConfig.ExpiryPolicyFactoryConfig.TimedExpiryPolicyFactoryConfig.ExpiryPolicyType;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -37,8 +42,12 @@ import org.springframework.test.context.ContextConfiguration;
 
 import javax.annotation.Resource;
 
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -84,13 +93,122 @@ public class TestJCache {
         assertTrue(simpleConfig.isWriteThrough());
         assertEquals("com.hazelcast.cache.MyCacheLoaderFactory", simpleConfig.getCacheLoaderFactory());
         assertEquals("com.hazelcast.cache.MyCacheWriterFactory", simpleConfig.getCacheWriterFactory());
-        assertEquals("com.hazelcast.cache.MyExpiryPolicyFactory", simpleConfig.getExpiryPolicyFactory());
+        assertEquals("com.hazelcast.cache.MyExpiryPolicyFactory",
+                simpleConfig.getExpiryPolicyFactoryConfig().getClassName());
         assertEquals(InMemoryFormat.OBJECT, simpleConfig.getInMemoryFormat());
         assertNotNull(simpleConfig.getEvictionConfig());
         assertEquals(50, simpleConfig.getEvictionConfig().getSize());
         assertEquals(EvictionConfig.MaxSizePolicy.ENTRY_COUNT,
                 simpleConfig.getEvictionConfig().getMaximumSizePolicy());
         assertEquals(EvictionPolicy.LRU, simpleConfig.getEvictionConfig().getEvictionPolicy());
+    }
+
+    @Test
+    public void cacheConfigXmlTest_TimedCreatedExpiryPolicyFactory() throws IOException {
+        Config config = instance1.getConfig();
+
+        CacheSimpleConfig cacheWithTimedCreatedExpiryPolicyFactoryConfig =
+                config.getCacheConfig("cacheWithTimedCreatedExpiryPolicyFactory");
+        ExpiryPolicyFactoryConfig expiryPolicyFactoryConfig =
+                cacheWithTimedCreatedExpiryPolicyFactoryConfig.getExpiryPolicyFactoryConfig();
+        ExpiryPolicyFactoryConfig.TimedExpiryPolicyFactoryConfig timedExpiryPolicyFactoryConfig =
+                expiryPolicyFactoryConfig.getTimedExpiryPolicyFactoryConfig();
+        DurationConfig durationConfig = timedExpiryPolicyFactoryConfig.getDurationConfig();
+
+        assertNotNull(expiryPolicyFactoryConfig);
+        assertNotNull(timedExpiryPolicyFactoryConfig);
+        assertNotNull(durationConfig);
+        assertNull(expiryPolicyFactoryConfig.getClassName());
+
+        assertEquals(ExpiryPolicyType.CREATED, timedExpiryPolicyFactoryConfig.getExpiryPolicyType());
+        assertEquals(1, durationConfig.getDurationAmount());
+        assertEquals(TimeUnit.DAYS, durationConfig.getTimeUnit());
+    }
+
+    @Test
+    public void cacheConfigXmlTest_TimedAccessedExpiryPolicyFactory() throws IOException {
+        Config config = instance1.getConfig();
+
+        CacheSimpleConfig cacheWithTimedAccessedExpiryPolicyFactoryConfig =
+                config.getCacheConfig("cacheWithTimedAccessedExpiryPolicyFactory");
+        ExpiryPolicyFactoryConfig expiryPolicyFactoryConfig =
+                cacheWithTimedAccessedExpiryPolicyFactoryConfig.getExpiryPolicyFactoryConfig();
+        TimedExpiryPolicyFactoryConfig timedExpiryPolicyFactoryConfig =
+                expiryPolicyFactoryConfig.getTimedExpiryPolicyFactoryConfig();
+        DurationConfig durationConfig = timedExpiryPolicyFactoryConfig.getDurationConfig();
+
+        assertNotNull(expiryPolicyFactoryConfig);
+        assertNotNull(timedExpiryPolicyFactoryConfig);
+        assertNotNull(durationConfig);
+        assertNull(expiryPolicyFactoryConfig.getClassName());
+
+        assertEquals(ExpiryPolicyType.ACCESSED, timedExpiryPolicyFactoryConfig.getExpiryPolicyType());
+        assertEquals(2, durationConfig.getDurationAmount());
+        assertEquals(TimeUnit.HOURS, durationConfig.getTimeUnit());
+    }
+
+    @Test
+    public void cacheConfigXmlTest_TimedModifiedExpiryPolicyFactory() throws IOException {
+        Config config = instance1.getConfig();
+
+        CacheSimpleConfig cacheWithTimedModifiedExpiryPolicyFactoryConfig =
+                config.getCacheConfig("cacheWithTimedModifiedExpiryPolicyFactory");
+        ExpiryPolicyFactoryConfig expiryPolicyFactoryConfig =
+                cacheWithTimedModifiedExpiryPolicyFactoryConfig.getExpiryPolicyFactoryConfig();
+        TimedExpiryPolicyFactoryConfig timedExpiryPolicyFactoryConfig =
+                expiryPolicyFactoryConfig.getTimedExpiryPolicyFactoryConfig();
+        DurationConfig durationConfig = timedExpiryPolicyFactoryConfig.getDurationConfig();
+
+        assertNotNull(expiryPolicyFactoryConfig);
+        assertNotNull(timedExpiryPolicyFactoryConfig);
+        assertNotNull(durationConfig);
+        assertNull(expiryPolicyFactoryConfig.getClassName());
+
+        assertEquals(ExpiryPolicyType.MODIFIED, timedExpiryPolicyFactoryConfig.getExpiryPolicyType());
+        assertEquals(3, durationConfig.getDurationAmount());
+        assertEquals(TimeUnit.MINUTES, durationConfig.getTimeUnit());
+    }
+
+    @Test
+    public void cacheConfigXmlTest_TimedModifiedTouchedPolicyFactory() throws IOException {
+        Config config = instance1.getConfig();
+
+        CacheSimpleConfig cacheWithTimedTouchedExpiryPolicyFactoryConfig =
+                config.getCacheConfig("cacheWithTimedTouchedExpiryPolicyFactory");
+        ExpiryPolicyFactoryConfig expiryPolicyFactoryConfig =
+                cacheWithTimedTouchedExpiryPolicyFactoryConfig.getExpiryPolicyFactoryConfig();
+        TimedExpiryPolicyFactoryConfig timedExpiryPolicyFactoryConfig =
+                expiryPolicyFactoryConfig.getTimedExpiryPolicyFactoryConfig();
+        DurationConfig durationConfig = timedExpiryPolicyFactoryConfig.getDurationConfig();
+
+        assertNotNull(expiryPolicyFactoryConfig);
+        assertNotNull(timedExpiryPolicyFactoryConfig);
+        assertNotNull(durationConfig);
+        assertNull(expiryPolicyFactoryConfig.getClassName());
+
+        assertEquals(ExpiryPolicyType.TOUCHED, timedExpiryPolicyFactoryConfig.getExpiryPolicyType());
+        assertEquals(4, durationConfig.getDurationAmount());
+        assertEquals(TimeUnit.SECONDS, durationConfig.getTimeUnit());
+    }
+
+    @Test
+    public void cacheConfigXmlTest_TimedEternalTouchedPolicyFactory() throws IOException {
+        Config config = instance1.getConfig();
+
+        CacheSimpleConfig cacheWithTimedEternalExpiryPolicyFactoryConfig =
+                config.getCacheConfig("cacheWithTimedEternalExpiryPolicyFactory");
+        ExpiryPolicyFactoryConfig expiryPolicyFactoryConfig =
+                cacheWithTimedEternalExpiryPolicyFactoryConfig.getExpiryPolicyFactoryConfig();
+        TimedExpiryPolicyFactoryConfig timedExpiryPolicyFactoryConfig =
+                expiryPolicyFactoryConfig.getTimedExpiryPolicyFactoryConfig();
+        DurationConfig durationConfig = timedExpiryPolicyFactoryConfig.getDurationConfig();
+
+        assertNotNull(expiryPolicyFactoryConfig);
+        assertNotNull(timedExpiryPolicyFactoryConfig);
+        assertNull(durationConfig);
+        assertNull(expiryPolicyFactoryConfig.getClassName());
+
+        assertEquals(ExpiryPolicyType.ETERNAL, timedExpiryPolicyFactoryConfig.getExpiryPolicyType());
     }
 
 }

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/context/test-jcache-application-context.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/context/test-jcache-application-context.xml
@@ -69,6 +69,39 @@
                                                  old-value-required="false" synchronous="false"/>
                     </hz:cache-entry-listeners>
             </hz:cache>
+            <hz:cache name="cacheWithTimedCreatedExpiryPolicyFactory">
+                <hz:expiry-policy-factory>
+                    <hz:timed-expiry-policy-factory expiry-policy-type="CREATED"
+                                                    duration-amount="1"
+                                                    time-unit="DAYS"/>
+                </hz:expiry-policy-factory>
+            </hz:cache>
+            <hz:cache name="cacheWithTimedAccessedExpiryPolicyFactory">
+                <hz:expiry-policy-factory>
+                    <hz:timed-expiry-policy-factory expiry-policy-type="ACCESSED"
+                                                    duration-amount="2"
+                                                    time-unit="HOURS"/>
+                </hz:expiry-policy-factory>
+            </hz:cache>
+            <hz:cache name="cacheWithTimedModifiedExpiryPolicyFactory">
+                <hz:expiry-policy-factory>
+                    <hz:timed-expiry-policy-factory expiry-policy-type="MODIFIED"
+                                                    duration-amount="3"
+                                                    time-unit="MINUTES"/>
+                </hz:expiry-policy-factory>
+            </hz:cache>
+            <hz:cache name="cacheWithTimedTouchedExpiryPolicyFactory">
+                <hz:expiry-policy-factory>
+                    <hz:timed-expiry-policy-factory expiry-policy-type="TOUCHED"
+                                                    duration-amount="4"
+                                                    time-unit="SECONDS"/>
+                </hz:expiry-policy-factory>
+            </hz:cache>
+            <hz:cache name="cacheWithTimedEternalExpiryPolicyFactory">
+                <hz:expiry-policy-factory>
+                    <hz:timed-expiry-policy-factory expiry-policy-type="ETERNAL"/>
+                </hz:expiry-policy-factory>
+            </hz:cache>
         </hz:config>
     </hz:hazelcast>
 

--- a/hazelcast/src/main/java/com/hazelcast/config/CacheSimpleConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CacheSimpleConfigReadOnly.java
@@ -81,7 +81,11 @@ public class CacheSimpleConfigReadOnly
     }
 
     @Override
-    public CacheSimpleConfig setExpiryPolicyFactory(String expiryPolicyFactory) {
+    public CacheSimpleConfig setExpiryPolicyFactoryConfig(ExpiryPolicyFactoryConfig expiryPolicyFactoryConfig) {
+        throw new UnsupportedOperationException("This config is read-only cache: " + getName());
+    }
+
+    public CacheSimpleConfig setExpiryPolicyFactory(String className) {
         throw new UnsupportedOperationException("This config is read-only cache: " + getName());
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
@@ -30,6 +30,11 @@ import com.hazelcast.topic.TopicOverloadPolicy;
 import com.hazelcast.util.ExceptionUtil;
 import com.hazelcast.util.StringUtil;
 import com.hazelcast.wan.impl.WanNoDelayReplication;
+import com.hazelcast.config.CacheSimpleConfig.ExpiryPolicyFactoryConfig;
+import com.hazelcast.config.CacheSimpleConfig.ExpiryPolicyFactoryConfig.TimedExpiryPolicyFactoryConfig;
+import com.hazelcast.config.CacheSimpleConfig.ExpiryPolicyFactoryConfig.DurationConfig;
+import com.hazelcast.config.CacheSimpleConfig.ExpiryPolicyFactoryConfig.TimedExpiryPolicyFactoryConfig.ExpiryPolicyType;
+
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NamedNodeMap;
@@ -49,6 +54,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Properties;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.config.MapStoreConfig.InitialLoadMode;
 import static com.hazelcast.config.XmlElements.CACHE;
@@ -1010,7 +1016,7 @@ public class XmlConfigBuilder extends AbstractConfigBuilder implements ConfigBui
             } else if ("cache-writer-factory".equals(nodeName)) {
                 cacheConfig.setCacheWriterFactory(getAttribute(n, "class-name"));
             } else if ("expiry-policy-factory".equals(nodeName)) {
-                cacheConfig.setExpiryPolicyFactory(getAttribute(n, "class-name"));
+                cacheConfig.setExpiryPolicyFactoryConfig(getExpiryPolicyFactoryConfig(n));
             } else if ("cache-entry-listeners".equals(nodeName)) {
                 cacheListenerHandle(n, cacheConfig);
             } else if ("in-memory-format".equals(nodeName)) {
@@ -1026,6 +1032,67 @@ public class XmlConfigBuilder extends AbstractConfigBuilder implements ConfigBui
             }
         }
         this.config.addCacheConfig(cacheConfig);
+    }
+
+    private ExpiryPolicyFactoryConfig getExpiryPolicyFactoryConfig(final org.w3c.dom.Node node) {
+        final String className = getAttribute(node, "class-name");
+        if (!StringUtil.isNullOrEmpty(className)) {
+            return new ExpiryPolicyFactoryConfig(className);
+        } else {
+            TimedExpiryPolicyFactoryConfig timedExpiryPolicyFactoryConfig = null;
+            for (org.w3c.dom.Node n : new IterableNodeList(node.getChildNodes())) {
+                final String nodeName = cleanNodeName(n.getNodeName());
+                if ("timed-expiry-policy-factory".equals(nodeName)) {
+                    timedExpiryPolicyFactoryConfig = getTimedExpiryPolicyFactoryConfig(n);
+                }
+            }
+            if (timedExpiryPolicyFactoryConfig == null) {
+                throw new InvalidConfigurationException(
+                        "One of the \"class-name\" or \"timed-expire-policy-factory\" configuration "
+                                + "is needed for expiry policy factory configuration");
+            } else {
+                return new ExpiryPolicyFactoryConfig(timedExpiryPolicyFactoryConfig);
+            }
+        }
+    }
+
+    private TimedExpiryPolicyFactoryConfig getTimedExpiryPolicyFactoryConfig(final org.w3c.dom.Node node) {
+        final String expiryPolicyTypeStr = getAttribute(node, "expiry-policy-type");
+        final String durationAmountStr = getAttribute(node, "duration-amount");
+        final String timeUnitStr = getAttribute(node, "time-unit");
+        final ExpiryPolicyType expiryPolicyType =
+                ExpiryPolicyType.valueOf(upperCaseInternal(expiryPolicyTypeStr));
+        if (expiryPolicyType != ExpiryPolicyType.ETERNAL
+                && (StringUtil.isNullOrEmpty(durationAmountStr)
+                || StringUtil.isNullOrEmpty(timeUnitStr))) {
+            throw new InvalidConfigurationException(
+                    "Both of the \"duration-amount\" or \"time-unit\" attributes "
+                            + "are required for expiry policy factory configuration "
+                            + "(except \"ETERNAL\" expiry policy type)");
+        }
+        DurationConfig durationConfig = null;
+        if (expiryPolicyType != ExpiryPolicyType.ETERNAL) {
+            long durationAmount;
+            try {
+                durationAmount = Long.parseLong(durationAmountStr);
+            } catch (NumberFormatException e) {
+                throw new InvalidConfigurationException(
+                        "Invalid value for duration amount: " + durationAmountStr, e);
+            }
+            if (durationAmount <= 0) {
+                throw new InvalidConfigurationException(
+                        "Duration amount must be positive: " + durationAmount);
+            }
+            TimeUnit timeUnit;
+            try {
+                timeUnit = TimeUnit.valueOf(upperCaseInternal(timeUnitStr));
+            } catch (IllegalArgumentException e) {
+                throw new InvalidConfigurationException(
+                        "Invalid value for time unit: " + timeUnitStr, e);
+            }
+            durationConfig = new DurationConfig(durationAmount, timeUnit);
+        }
+        return new TimedExpiryPolicyFactoryConfig(expiryPolicyType, durationConfig);
     }
 
     private NearCacheConfig getNearCacheConfig(final org.w3c.dom.Node node) {

--- a/hazelcast/src/main/resources/hazelcast-config-3.5.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-3.5.xsd
@@ -299,12 +299,16 @@
             </xs:element>
             <xs:element name="expiry-policy-factory" minOccurs="0" maxOccurs="1">
                 <xs:complexType>
-                    <xs:annotation>
-                        <xs:documentation>
-                            Defines the expiry policy factory class name.
-                        </xs:documentation>
-                    </xs:annotation>
-                    <xs:attribute name="class-name" use="required"/>
+                    <xs:all>
+                        <xs:annotation>
+                            <xs:documentation>
+                                Defines the expiry policy factory class name or
+                                defines the expiry policy factory from predefined ones with duration configuration.
+                            </xs:documentation>
+                        </xs:annotation>
+                        <xs:element name="timed-expiry-policy-factory" minOccurs="0" maxOccurs="1"/>
+                    </xs:all>
+                    <xs:attribute name="class-name"/>
                 </xs:complexType>
             </xs:element>
             <xs:element name="cache-entry-listeners" type="cache-entry-listeners" minOccurs="0" maxOccurs="1">
@@ -1212,6 +1216,34 @@
             <xs:enumeration value="NATIVE"/>
         </xs:restriction>
     </xs:simpleType>
+
+    <xs:simpleType name="time-unit">
+        <xs:restriction base="non-space-string">
+            <xs:enumeration value="NANOSECONDS"/>
+            <xs:enumeration value="MICROSECONDS"/>
+            <xs:enumeration value="MILLISECONDS"/>
+            <xs:enumeration value="SECONDS"/>
+            <xs:enumeration value="MINUTES"/>
+            <xs:enumeration value="HOURS"/>
+            <xs:enumeration value="DAYS"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="expiry-policy-type">
+        <xs:restriction base="non-space-string">
+            <xs:enumeration value="CREATED"/>
+            <xs:enumeration value="ACCESSED"/>
+            <xs:enumeration value="ETERNAL"/>
+            <xs:enumeration value="MODIFIED"/>
+            <xs:enumeration value="TOUCHED"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="timed-expiry-policy-factory">
+        <xs:attribute name="expiry-policy-type" type="expiry-policy-type" use="required"/>
+        <xs:attribute name="duration-amount" type="xs:unsignedLong" use="optional"/>
+        <xs:attribute name="time-unit" type="time-unit" use="optional"/>
+    </xs:complexType>
 
     <xs:simpleType name="non-space-string">
         <xs:restriction base="xs:string">

--- a/hazelcast/src/test/java/com/hazelcast/cache/CacheConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CacheConfigTest.java
@@ -33,6 +33,10 @@ import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.util.EmptyStatement;
+import com.hazelcast.config.CacheSimpleConfig.ExpiryPolicyFactoryConfig;
+import com.hazelcast.config.CacheSimpleConfig.ExpiryPolicyFactoryConfig.TimedExpiryPolicyFactoryConfig;
+import com.hazelcast.config.CacheSimpleConfig.ExpiryPolicyFactoryConfig.DurationConfig;
+import com.hazelcast.config.CacheSimpleConfig.ExpiryPolicyFactoryConfig.TimedExpiryPolicyFactoryConfig.ExpiryPolicyType;
 
 import org.junit.After;
 import org.junit.Before;
@@ -55,6 +59,7 @@ import java.net.URL;
 import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -85,9 +90,12 @@ public class CacheConfigTest extends HazelcastTestSupport {
         assertEquals("test-pass1", config1.getGroupConfig().getPassword());
 
         CacheSimpleConfig cacheConfig1 = config1.getCacheConfig("cache1");
-        assertEquals("com.hazelcast.cache.CacheConfigTest$MyCacheLoaderFactory", cacheConfig1.getCacheLoaderFactory());
-        assertEquals("com.hazelcast.cache.CacheConfigTest$MyCacheWriterFactory", cacheConfig1.getCacheWriterFactory());
-        assertEquals("com.hazelcast.cache.CacheConfigTest$MyExpirePolicyFactory", cacheConfig1.getExpiryPolicyFactory());
+        assertEquals("com.hazelcast.cache.CacheConfigTest$MyCacheLoaderFactory",
+                cacheConfig1.getCacheLoaderFactory());
+        assertEquals("com.hazelcast.cache.CacheConfigTest$MyCacheWriterFactory",
+                cacheConfig1.getCacheWriterFactory());
+        assertEquals("com.hazelcast.cache.CacheConfigTest$MyExpirePolicyFactory",
+                cacheConfig1.getExpiryPolicyFactoryConfig().getClassName());
         assertTrue(cacheConfig1.isReadThrough());
         assertTrue(cacheConfig1.isWriteThrough());
         assertTrue(cacheConfig1.isStatisticsEnabled());
@@ -125,6 +133,114 @@ public class CacheConfigTest extends HazelcastTestSupport {
         WanReplicationRef wanRefDisabledRepublishingTestCache =
                 config1.getCacheConfig("wanRefDisabledRepublishingTestCache").getWanReplicationRef();
         assertFalse(wanRefDisabledRepublishingTestCache.isRepublishingEnabled());
+    }
+
+    @Test
+    public void cacheConfigXmlTest_TimedCreatedExpiryPolicyFactory() throws IOException {
+        Config config1 = new XmlConfigBuilder(configUrl1).build();
+
+        CacheSimpleConfig cacheWithTimedCreatedExpiryPolicyFactoryConfig =
+                config1.getCacheConfig("cacheWithTimedCreatedExpiryPolicyFactory");
+        ExpiryPolicyFactoryConfig expiryPolicyFactoryConfig =
+                cacheWithTimedCreatedExpiryPolicyFactoryConfig.getExpiryPolicyFactoryConfig();
+        TimedExpiryPolicyFactoryConfig timedExpiryPolicyFactoryConfig =
+                expiryPolicyFactoryConfig.getTimedExpiryPolicyFactoryConfig();
+        DurationConfig durationConfig = timedExpiryPolicyFactoryConfig.getDurationConfig();
+
+        assertNotNull(expiryPolicyFactoryConfig);
+        assertNotNull(timedExpiryPolicyFactoryConfig);
+        assertNotNull(durationConfig);
+        assertNull(expiryPolicyFactoryConfig.getClassName());
+
+        assertEquals(ExpiryPolicyType.CREATED, timedExpiryPolicyFactoryConfig.getExpiryPolicyType());
+        assertEquals(1, durationConfig.getDurationAmount());
+        assertEquals(TimeUnit.DAYS, durationConfig.getTimeUnit());
+    }
+
+    @Test
+    public void cacheConfigXmlTest_TimedAccessedExpiryPolicyFactory() throws IOException {
+        Config config1 = new XmlConfigBuilder(configUrl1).build();
+
+        CacheSimpleConfig cacheWithTimedAccessedExpiryPolicyFactoryConfig =
+                config1.getCacheConfig("cacheWithTimedAccessedExpiryPolicyFactory");
+        ExpiryPolicyFactoryConfig expiryPolicyFactoryConfig =
+                cacheWithTimedAccessedExpiryPolicyFactoryConfig.getExpiryPolicyFactoryConfig();
+        TimedExpiryPolicyFactoryConfig timedExpiryPolicyFactoryConfig =
+                expiryPolicyFactoryConfig.getTimedExpiryPolicyFactoryConfig();
+        DurationConfig durationConfig = timedExpiryPolicyFactoryConfig.getDurationConfig();
+
+        assertNotNull(expiryPolicyFactoryConfig);
+        assertNotNull(timedExpiryPolicyFactoryConfig);
+        assertNotNull(durationConfig);
+        assertNull(expiryPolicyFactoryConfig.getClassName());
+
+        assertEquals(ExpiryPolicyType.ACCESSED, timedExpiryPolicyFactoryConfig.getExpiryPolicyType());
+        assertEquals(2, durationConfig.getDurationAmount());
+        assertEquals(TimeUnit.HOURS, durationConfig.getTimeUnit());
+    }
+
+    @Test
+    public void cacheConfigXmlTest_TimedModifiedExpiryPolicyFactory() throws IOException {
+        Config config1 = new XmlConfigBuilder(configUrl1).build();
+
+        CacheSimpleConfig cacheWithTimedModifiedExpiryPolicyFactoryConfig =
+                config1.getCacheConfig("cacheWithTimedModifiedExpiryPolicyFactory");
+        ExpiryPolicyFactoryConfig expiryPolicyFactoryConfig =
+                cacheWithTimedModifiedExpiryPolicyFactoryConfig.getExpiryPolicyFactoryConfig();
+        TimedExpiryPolicyFactoryConfig timedExpiryPolicyFactoryConfig =
+                expiryPolicyFactoryConfig.getTimedExpiryPolicyFactoryConfig();
+        DurationConfig durationConfig = timedExpiryPolicyFactoryConfig.getDurationConfig();
+
+        assertNotNull(expiryPolicyFactoryConfig);
+        assertNotNull(timedExpiryPolicyFactoryConfig);
+        assertNotNull(durationConfig);
+        assertNull(expiryPolicyFactoryConfig.getClassName());
+
+        assertEquals(ExpiryPolicyType.MODIFIED, timedExpiryPolicyFactoryConfig.getExpiryPolicyType());
+        assertEquals(3, durationConfig.getDurationAmount());
+        assertEquals(TimeUnit.MINUTES, durationConfig.getTimeUnit());
+    }
+
+    @Test
+    public void cacheConfigXmlTest_TimedModifiedTouchedPolicyFactory() throws IOException {
+        Config config1 = new XmlConfigBuilder(configUrl1).build();
+
+        CacheSimpleConfig cacheWithTimedTouchedExpiryPolicyFactoryConfig =
+                config1.getCacheConfig("cacheWithTimedTouchedExpiryPolicyFactory");
+        ExpiryPolicyFactoryConfig expiryPolicyFactoryConfig =
+                cacheWithTimedTouchedExpiryPolicyFactoryConfig.getExpiryPolicyFactoryConfig();
+        TimedExpiryPolicyFactoryConfig timedExpiryPolicyFactoryConfig =
+                expiryPolicyFactoryConfig.getTimedExpiryPolicyFactoryConfig();
+        DurationConfig durationConfig = timedExpiryPolicyFactoryConfig.getDurationConfig();
+
+        assertNotNull(expiryPolicyFactoryConfig);
+        assertNotNull(timedExpiryPolicyFactoryConfig);
+        assertNotNull(durationConfig);
+        assertNull(expiryPolicyFactoryConfig.getClassName());
+
+        assertEquals(ExpiryPolicyType.TOUCHED, timedExpiryPolicyFactoryConfig.getExpiryPolicyType());
+        assertEquals(4, durationConfig.getDurationAmount());
+        assertEquals(TimeUnit.SECONDS, durationConfig.getTimeUnit());
+    }
+
+    @Test
+    public void cacheConfigXmlTest_TimedEternalTouchedPolicyFactory() throws IOException {
+        Config config1 = new XmlConfigBuilder(configUrl1).build();
+
+        CacheSimpleConfig cacheWithTimedEternalExpiryPolicyFactoryConfig =
+                config1.getCacheConfig("cacheWithTimedEternalExpiryPolicyFactory");
+        ExpiryPolicyFactoryConfig expiryPolicyFactoryConfig =
+                cacheWithTimedEternalExpiryPolicyFactoryConfig.getExpiryPolicyFactoryConfig();
+        TimedExpiryPolicyFactoryConfig timedExpiryPolicyFactoryConfig =
+                expiryPolicyFactoryConfig.getTimedExpiryPolicyFactoryConfig();
+        DurationConfig durationConfig = timedExpiryPolicyFactoryConfig.getDurationConfig();
+
+        assertNotNull(expiryPolicyFactoryConfig);
+        assertNotNull(timedExpiryPolicyFactoryConfig);
+        assertNull(durationConfig);
+        assertNull(expiryPolicyFactoryConfig.getClassName());
+
+        assertEquals(ExpiryPolicyType.ETERNAL, timedExpiryPolicyFactoryConfig.getExpiryPolicyType());
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/config/InvalidConfigurationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/InvalidConfigurationTest.java
@@ -252,13 +252,38 @@ public class InvalidConfigurationTest {
     }
 
     @Test
-    public void WhenValid_CacheInMemoryFormat() {
+    public void testWhenValid_CacheInMemoryFormat() {
         buildConfig("cache-in-memory-format", "OBJECT");
     }
 
     @Test(expected = InvalidConfigurationException.class)
-    public void WhenInvalid_CacheInMemoryFormat() {
+    public void testWhenInvalid_CacheInMemoryFormat() {
         buildConfig("cache-in-memory-format", "binaryyy");
+    }
+
+    @Test(expected = InvalidConfigurationException.class)
+    public void testWhenInvalid_EmptyDurationTime() {
+        buildConfig("cache-expiry-policy-duration-amount", "");
+    }
+
+    @Test(expected = InvalidConfigurationException.class)
+    public void testWhenInvalid_InvalidDurationTime() {
+        buildConfig("cache-expiry-policy-duration-amount", "asd");
+    }
+
+    @Test(expected = InvalidConfigurationException.class)
+    public void testWhenInvalid_NegativeDurationTime() {
+        buildConfig("cache-expiry-policy-duration-amount", "-1");
+    }
+
+    @Test(expected = InvalidConfigurationException.class)
+    public void testWhenInvalid_EmptyTimeUnit() {
+        buildConfig("cache-expiry-policy-time-unit", "");
+    }
+
+    @Test(expected = InvalidConfigurationException.class)
+    public void testWhenInvalid_InvalidTimeUnit() {
+        buildConfig("cache-expiry-policy-time-unit", "asd");
     }
 
     @Test(expected = InvalidConfigurationException.class)
@@ -319,6 +344,15 @@ public class InvalidConfigurationTest {
                             " eviction-policy=\"${cache-eviction-policy}\"/>\n" +
                     "</cache>\n" +
 
+                     "<cache name=\"cacheWithTimedExpiryPolicyFactory\">\n" +
+                        "<expiry-policy-factory>\n" +
+                            "<timed-expiry-policy-factory" +
+                                " expiry-policy-type=\"${cache-expiry-policy-type}\"" +
+                                " duration-amount=\"${cache-expiry-policy-duration-amount}\"" +
+                                " time-unit=\"${cache-expiry-policy-time-unit}\"/>" +
+                        "</expiry-policy-factory>\n" +
+                     "</cache>\n" +
+
                     "<multimap name=\"default\">\n" +
                         "<backup-count>${multimap-backup-count}</backup-count>\n" +
                         "<value-collection-type>${multimap-value-collection-type}</value-collection-type>\n" +
@@ -367,6 +401,9 @@ public class InvalidConfigurationTest {
         properties.setProperty("cache-eviction-size", "100");
         properties.setProperty("cache-eviction-max-size-policy", "ENTRY_COUNT");
         properties.setProperty("cache-eviction-policy", "LRU");
+        properties.setProperty("cache-expiry-policy-type", "CREATED");
+        properties.setProperty("cache-expiry-policy-duration-amount", "1");
+        properties.setProperty("cache-expiry-policy-time-unit", "DAYS");
 
         properties.setProperty("multimap-backup-count", "0");
         properties.setProperty("multimap-value-collection-type", "SET");

--- a/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
@@ -629,7 +629,6 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         fail(); //if we, for any reason, we get through the parsing, fail.
     }
 
-
     @Test
     public void setMapStoreConfigImplementationTest() {
         String mapName = "mapStoreImpObjTest";

--- a/hazelcast/src/test/resources/test-hazelcast-jcache.xml
+++ b/hazelcast/src/test/resources/test-hazelcast-jcache.xml
@@ -49,6 +49,44 @@
         <async-backup-count>2</async-backup-count>
     </cache>
 
+    <cache name="cacheWithTimedCreatedExpiryPolicyFactory">
+        <expiry-policy-factory>
+               <timed-expiry-policy-factory expiry-policy-type="CREATED"
+                                            duration-amount="1"
+                                            time-unit="DAYS"/>
+        </expiry-policy-factory>
+    </cache>
+
+    <cache name="cacheWithTimedAccessedExpiryPolicyFactory">
+        <expiry-policy-factory>
+            <timed-expiry-policy-factory expiry-policy-type="ACCESSED"
+                                         duration-amount="2"
+                                         time-unit="HOURS"/>
+        </expiry-policy-factory>
+    </cache>
+
+    <cache name="cacheWithTimedModifiedExpiryPolicyFactory">
+        <expiry-policy-factory>
+            <timed-expiry-policy-factory expiry-policy-type="MODIFIED"
+                                         duration-amount="3"
+                                         time-unit="MINUTES"/>
+        </expiry-policy-factory>
+    </cache>
+
+    <cache name="cacheWithTimedTouchedExpiryPolicyFactory">
+        <expiry-policy-factory>
+            <timed-expiry-policy-factory expiry-policy-type="TOUCHED"
+                                         duration-amount="4"
+                                         time-unit="SECONDS"/>
+        </expiry-policy-factory>
+    </cache>
+
+    <cache name="cacheWithTimedEternalExpiryPolicyFactory">
+        <expiry-policy-factory>
+            <timed-expiry-policy-factory expiry-policy-type="ETERNAL"/>
+        </expiry-policy-factory>
+    </cache>
+
     <cache name="testCache">
         <key-type class-name="java.lang.Integer"/>
         <value-type class-name="java.lang.String"/>


### PR DESCRIPTION
- Fix for issue #5347 (For JCache configuration: duration for ExpiryPolicy can not be set declaratively, but only programmatically)