### PR TITLE
Ensure that the task-to-cancel is not started within ExecutorServiceTest

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/executor/ExecutorServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/executor/ExecutorServiceTest.java
@@ -1337,7 +1337,7 @@ public class ExecutorServiceTest extends ExecutorServiceTestSupport {
 
         IExecutorService executor = hz1.getExecutorService("test");
         Future<Boolean> f = executor
-                .submitToMember(new SleepingTask(TimeUnit.MILLISECONDS.toSeconds(callTimeout) * 3)
+                .submitToMember(new SleepingTask((int) TimeUnit.MILLISECONDS.toSeconds(callTimeout) * 3)
                         , hz2.getCluster().getLocalMember());
 
         Boolean result = f.get(1, TimeUnit.MINUTES);

--- a/hazelcast/src/test/java/com/hazelcast/executor/ExecutorServiceTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/executor/ExecutorServiceTestSupport.java
@@ -27,7 +27,6 @@ import com.hazelcast.test.HazelcastTestSupport;
 import java.io.Serializable;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.fail;
 
@@ -57,14 +56,14 @@ public class ExecutorServiceTestSupport extends HazelcastTestSupport {
     }
 
     static class SleepingTask implements Callable<Boolean>, Serializable, PartitionAware {
-        long sleepSeconds;
+        int sleepSeconds;
 
-        public SleepingTask(long sleepSeconds) {
+        public SleepingTask(int sleepSeconds) {
             this.sleepSeconds = sleepSeconds;
         }
         @Override
         public Boolean call() throws InterruptedException {
-            Thread.sleep(TimeUnit.SECONDS.toMillis(sleepSeconds));
+            sleepAtLeastSeconds(sleepSeconds);
             return true;
         }
         @Override


### PR DESCRIPTION
This change narrows down scope of the test failure #4739.