### PR TITLE
ICondition.awaitNanos() should return remaining time not elapsed time…

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientConditionProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientConditionProxy.java
@@ -54,7 +54,7 @@ public class ClientConditionProxy extends ClientProxy implements ICondition {
         long start = System.nanoTime();
         await(nanosTimeout, TimeUnit.NANOSECONDS);
         long end = System.nanoTime();
-        return (end - start);
+        return nanosTimeout - (end - start);
     }
 
     @Override

--- a/hazelcast-client/src/test/java/com/hazelcast/client/lock/ClientConditionTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/lock/ClientConditionTest.java
@@ -16,6 +16,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
@@ -170,5 +171,20 @@ public class ClientConditionTest extends HazelcastTestSupport{
         final ICondition condition = lock.newCondition("condition");
         condition.await(1, TimeUnit.SECONDS);
         lock.unlock();
+    }
+
+    @Test
+    public void testAwaitNanos_remainingTime() throws InterruptedException {
+        ICondition condition = lock.newCondition("condition");
+
+        lock.lock();
+        try {
+            long timeout = 1000L;
+            long remainingTimeout = condition.awaitNanos(timeout);
+            assertTrue("Remaining timeout should be <= 0, but it's = " + remainingTimeout,
+                    remainingTimeout <= 0);
+        } finally {
+            lock.unlock();
+        }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/ConditionImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/ConditionImpl.java
@@ -70,7 +70,7 @@ final class ConditionImpl implements ICondition {
         long start = System.nanoTime();
         await(nanosTimeout, TimeUnit.NANOSECONDS);
         long end = System.nanoTime();
-        return (end - start);
+        return nanosTimeout - (end - start);
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/lock/ConditionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/lock/ConditionTest.java
@@ -55,6 +55,20 @@ public class ConditionTest extends HazelcastTestSupport {
         lock.newCondition(null);
     }
 
+    @Test
+    public void testAwaitNanos_remainingTime() throws InterruptedException {
+        HazelcastInstance instance = createHazelcastInstance();
+        String name = randomString();
+        ILock lock = instance.getLock(name);
+        ICondition condition = lock.newCondition(name);
+
+        lock.lock();
+        long timeout = 1000L;
+        long remainingTimeout = condition.awaitNanos(timeout);
+        assertTrue("Remaining timeout should be <= 0, but it's = " + remainingTimeout,
+                remainingTimeout <= 0);
+    }
+
     @Test(timeout = 60000)
     public void testMultipleConditionsForSameLock() throws InterruptedException {
         HazelcastInstance instance = createHazelcastInstance();


### PR DESCRIPTION
…. Fixes #4603

(cherry picked from commit 218ab9353bd68696ed6021fa1f7bf188ed0da081)