### PR TITLE
DelegatingFuture should deserialize value passed into ExecutionCallback if required

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/util/executor/CompletedFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/executor/CompletedFuture.java
@@ -87,10 +87,15 @@ public final class CompletedFuture<V> implements ICompletableFuture<V> {
         executor.execute(new Runnable() {
             @Override
             public void run() {
-                if (value instanceof Throwable) {
-                    callback.onFailure((Throwable) value);
+                Object object = value;
+                if (object instanceof Data) {
+                    object = serializationService.toObject(object);
+                }
+
+                if (object instanceof Throwable) {
+                    callback.onFailure((Throwable) object);
                 } else {
-                    callback.onResponse((V) value);
+                    callback.onResponse((V) object);
                 }
             }
         });

--- a/hazelcast/src/main/java/com/hazelcast/util/executor/DelegatingFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/executor/DelegatingFuture.java
@@ -34,6 +34,7 @@ public class DelegatingFuture<V> implements ICompletableFuture<V> {
     private final SerializationService serializationService;
     private final V defaultValue;
     private final boolean hasDefaultValue;
+    private final Object mutex = new Object();
     private V value;
     private Throwable error;
     private volatile boolean done;
@@ -64,7 +65,7 @@ public class DelegatingFuture<V> implements ICompletableFuture<V> {
     @Override
     public final V get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
         if (!done) {
-            synchronized (this) {
+            synchronized (mutex) {
                 if (!done) {
                     try {
                         value = getResult(future.get(timeout, unit));
@@ -135,12 +136,47 @@ public class DelegatingFuture<V> implements ICompletableFuture<V> {
     }
 
     @Override
-    public void andThen(ExecutionCallback<V> callback) {
-        future.andThen(callback);
+    public void andThen(final ExecutionCallback<V> callback) {
+        future.andThen(new DelegatingExecutionCallback<V>(callback));
     }
 
     @Override
-    public void andThen(ExecutionCallback<V> callback, Executor executor) {
-        future.andThen(callback, executor);
+    public void andThen(final ExecutionCallback<V> callback, Executor executor) {
+        future.andThen(new DelegatingExecutionCallback<V>(callback), executor);
+    }
+
+    private class DelegatingExecutionCallback<T> implements ExecutionCallback {
+
+        private final ExecutionCallback<T> callback;
+
+        DelegatingExecutionCallback(ExecutionCallback<T> callback) {
+            this.callback = callback;
+        }
+
+        @Override
+        public void onResponse(Object response) {
+            if (!done) {
+                synchronized (mutex) {
+                    if (!done) {
+                        value = getResult(response);
+                        done = true;
+                    }
+                }
+            }
+            callback.onResponse((T) value);
+        }
+
+        @Override
+        public void onFailure(Throwable t) {
+            if (!done) {
+                synchronized (mutex) {
+                    if (!done) {
+                        error = t;
+                        done = true;
+                    }
+                }
+            }
+            callback.onFailure(t);
+        }
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/executor/CompletableFutureTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/executor/CompletableFutureTest.java
@@ -17,8 +17,6 @@ package com.hazelcast.executor;
 
 import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.core.ICompletableFuture;
-import com.hazelcast.instance.HazelcastInstanceImpl;
-import com.hazelcast.instance.HazelcastInstanceProxy;
 import com.hazelcast.spi.ExecutionService;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.test.HazelcastParallelClassRunner;
@@ -31,16 +29,11 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import java.lang.reflect.Field;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static java.util.Arrays.asList;
-import static org.hamcrest.Matchers.*;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
@@ -53,7 +46,6 @@ public class CompletableFutureTest extends HazelcastTestSupport {
 
     private ExecutionService executionService;
     private CountDownLatch startLatch, doneLatch;
-    private ExecutorService executorService;
     private AtomicReference<Object> ref1, ref2;
 
     @Before
@@ -61,14 +53,12 @@ public class CompletableFutureTest extends HazelcastTestSupport {
         NodeEngine nodeEngine = getNode(createHazelcastInstance()).getNodeEngine();
         executionService = nodeEngine.getExecutionService();
         startLatch = new CountDownLatch(1);
-        executorService = Executors.newSingleThreadExecutor();
         ref1 = new AtomicReference<Object>();
         ref2 = new AtomicReference<Object>();
     }
 
     @After
     public void tearDown() {
-        executorService.shutdown();
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/util/executor/CallerRunsExecutor.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/executor/CallerRunsExecutor.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.util.executor;
+
+import java.util.concurrent.Executor;
+
+class CallerRunsExecutor implements Executor {
+    @Override
+    public void execute(Runnable command) {
+        command.run();
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/util/executor/CompletedFutureTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/executor/CompletedFutureTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.util.executor;
+
+import com.hazelcast.core.ICompletableFuture;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.nio.serialization.DefaultSerializationServiceBuilder;
+import com.hazelcast.nio.serialization.SerializationService;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category(QuickTest.class)
+public class CompletedFutureTest {
+
+    private final SerializationService serializationService
+            = new DefaultSerializationServiceBuilder().build();
+
+    @Test
+    public void test_get_Object() throws ExecutionException, InterruptedException {
+        Object value = "value";
+        Future future = new CompletedFuture(null, value, null);
+        assertEquals(value, future.get());
+    }
+
+    @Test
+    public void test_get_Data() throws ExecutionException, InterruptedException {
+        Object value = "value";
+        Data data = serializationService.toData(value);
+        Future future = new CompletedFuture(serializationService, data, null);
+        assertEquals(value, future.get());
+    }
+
+    @Test
+    public void test_get_Object_withTimeout() throws ExecutionException, InterruptedException, TimeoutException {
+        Object value = "value";
+        Future future = new CompletedFuture(null, value, null);
+        assertEquals(value, future.get(1, TimeUnit.MILLISECONDS));
+    }
+
+    @Test
+    public void test_get_Data_withTimeout() throws ExecutionException, InterruptedException, TimeoutException {
+        Object value = "value";
+        Data data = serializationService.toData(value);
+        Future future = new CompletedFuture(serializationService, data, null);
+        assertEquals(value, future.get(1, TimeUnit.MILLISECONDS));
+    }
+
+    @Test(expected = ExecutionException.class)
+    public void test_get_Exception() throws ExecutionException, InterruptedException {
+        Throwable error = new Throwable();
+        Future future = new CompletedFuture(null, error, null);
+        future.get();
+    }
+
+    @Test(expected = ExecutionException.class)
+    public void test_get_Exception_Data() throws ExecutionException, InterruptedException {
+        Throwable error = new Throwable();
+        Data data = serializationService.toData(error);
+        Future future = new CompletedFuture(serializationService, data, null);
+        future.get();
+    }
+
+    @Test
+    public void test_cancel() {
+        Future future = new CompletedFuture(null, null, null);
+        assertFalse(future.cancel(true));
+        assertFalse(future.isCancelled());
+    }
+
+    @Test
+    public void test_isDone() {
+        Future future = new CompletedFuture(null, null, null);
+        assertTrue(future.isDone());
+    }
+
+    @Test
+    public void test_andThen_Object() {
+        Object value = "value";
+        ICompletableFuture future = new CompletedFuture(null, value, null);
+        TestExecutionCallback callback = new TestExecutionCallback();
+        future.andThen(callback, new CallerRunsExecutor());
+        assertEquals(value, callback.value);
+    }
+
+    @Test
+    public void test_andThen_Data() {
+        Object value = "value";
+        Data data = serializationService.toData(value);
+        ICompletableFuture future = new CompletedFuture(serializationService, data, null);
+        TestExecutionCallback callback = new TestExecutionCallback();
+        future.andThen(callback, new CallerRunsExecutor());
+        assertEquals(value, callback.value);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void test_andThen_Exception() {
+        Throwable error = new RuntimeException();
+        ICompletableFuture future = new CompletedFuture(null, error, null);
+        TestExecutionCallback callback = new TestExecutionCallback();
+        future.andThen(callback, new CallerRunsExecutor());
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void test_andThen_Exception_Data() {
+        Throwable error = new RuntimeException();
+        Data data = serializationService.toData(error);
+        ICompletableFuture future = new CompletedFuture(serializationService, data, null);
+        TestExecutionCallback callback = new TestExecutionCallback();
+        future.andThen(callback, new CallerRunsExecutor());
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/util/executor/DelegatingFutureTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/executor/DelegatingFutureTest.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.util.executor;
+
+import com.hazelcast.core.ExecutionCallback;
+import com.hazelcast.core.ICompletableFuture;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.nio.serialization.DefaultSerializationServiceBuilder;
+import com.hazelcast.nio.serialization.SerializationService;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category(QuickTest.class)
+public class DelegatingFutureTest {
+
+    private final SerializationService serializationService
+            = new DefaultSerializationServiceBuilder().build();
+
+    @Test
+    public void test_get_Object() throws ExecutionException, InterruptedException {
+        Object value = "value";
+        Future future = new DelegatingFuture(new FakeCompletableFuture(value), null);
+        assertEquals(value, future.get());
+    }
+
+    @Test
+    public void test_get_Data() throws ExecutionException, InterruptedException {
+        Object value = "value";
+        Data data = serializationService.toData(value);
+        Future future = new DelegatingFuture(new FakeCompletableFuture(data), serializationService);
+        assertEquals(value, future.get());
+    }
+
+    @Test
+    public void test_get_Object_withTimeout() throws ExecutionException, InterruptedException, TimeoutException {
+        Object value = "value";
+        Future future = new DelegatingFuture(new FakeCompletableFuture(value), null);
+        assertEquals(value, future.get(1, TimeUnit.MILLISECONDS));
+    }
+
+    @Test
+    public void test_get_Data_withTimeout() throws ExecutionException, InterruptedException, TimeoutException {
+        Object value = "value";
+        Data data = serializationService.toData(value);
+        Future future = new DelegatingFuture(new FakeCompletableFuture(data), serializationService);
+        assertEquals(value, future.get(1, TimeUnit.MILLISECONDS));
+    }
+
+    @Test(expected = ExecutionException.class)
+    public void test_get_Exception() throws ExecutionException, InterruptedException {
+        Throwable error = new Throwable();
+        Future future = new DelegatingFuture(new FakeCompletableFuture(error), null);
+        future.get();
+    }
+
+    @Test
+    public void test_cancel() {
+        Future future = new DelegatingFuture(new FakeCompletableFuture(null), null);
+        assertFalse(future.cancel(true));
+        assertFalse(future.isCancelled());
+    }
+
+    @Test
+    public void test_isDone() {
+        Future future = new DelegatingFuture(new FakeCompletableFuture("value"), null);
+        assertTrue(future.isDone());
+    }
+
+    @Test
+    public void test_andThen_Object() {
+        Object value = "value";
+        ICompletableFuture future = new DelegatingFuture(new FakeCompletableFuture(value), null);
+        TestExecutionCallback callback = new TestExecutionCallback();
+        future.andThen(callback, new CallerRunsExecutor());
+        assertEquals(value, callback.value);
+    }
+
+    @Test
+    public void test_andThen_Data() {
+        Object value = "value";
+        Data data = serializationService.toData(value);
+        ICompletableFuture future = new DelegatingFuture(new FakeCompletableFuture(data), serializationService);
+        TestExecutionCallback callback = new TestExecutionCallback();
+        future.andThen(callback, new CallerRunsExecutor());
+        assertEquals(value, callback.value);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void test_andThen_Exception() {
+        Throwable error = new RuntimeException();
+        ICompletableFuture future = new DelegatingFuture(new FakeCompletableFuture(error), null);
+        TestExecutionCallback callback = new TestExecutionCallback();
+        future.andThen(callback, new CallerRunsExecutor());
+    }
+
+    private static class FakeCompletableFuture<V> implements ICompletableFuture<V> {
+        private final Object value;
+
+        private FakeCompletableFuture(Object value) {
+            this.value = value;
+        }
+
+        @Override
+        public void andThen(ExecutionCallback<V> callback) {
+            if (value instanceof Throwable) {
+                callback.onFailure((Throwable) value);
+            } else {
+                callback.onResponse((V) value);
+            }
+        }
+
+        @Override
+        public void andThen(ExecutionCallback<V> callback, Executor executor) {
+            andThen(callback);
+        }
+
+        @Override
+        public boolean cancel(boolean mayInterruptIfRunning) {
+            return false;
+        }
+
+        @Override
+        public boolean isCancelled() {
+            return false;
+        }
+
+        @Override
+        public boolean isDone() {
+            return value != null;
+        }
+
+        @Override
+        public V get() throws InterruptedException, ExecutionException {
+            if (value instanceof ExecutionException) {
+                throw (ExecutionException) value;
+            }
+            if (value instanceof CancellationException) {
+                throw (CancellationException) value;
+            }
+            if (value instanceof InterruptedException) {
+                throw (InterruptedException) value;
+            }
+            if (value instanceof Throwable) {
+                throw new ExecutionException((Throwable) value);
+            }
+            return (V) value;
+        }
+
+        @Override
+        public V get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+            return get();
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/util/executor/TestExecutionCallback.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/executor/TestExecutionCallback.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.util.executor;
+
+import com.hazelcast.core.ExecutionCallback;
+import com.hazelcast.util.ExceptionUtil;
+
+class TestExecutionCallback implements ExecutionCallback {
+    volatile Object value;
+
+    @Override
+    public void onResponse(Object response) {
+        value = response;
+    }
+
+    @Override
+    public void onFailure(Throwable t) {
+        throw ExceptionUtil.rethrow(t);
+    }
+}


### PR DESCRIPTION
- DelegatingFuture should deserialize value passed into ExecutionCallback if required.
- Added tests for DelegatingFuture and CompletedFuture.
- Fixes #5158