### PR TITLE
[2.x] - Removed map records should not be purged before they are successfully…

### DIFF
--- a/hazelcast/pom.xml
+++ b/hazelcast/pom.xml
@@ -29,10 +29,6 @@
     <artifactId>hazelcast</artifactId>
     <packaging>jar</packaging>
 
-    <properties>
-        <log4j.version>1.2.12</log4j.version>
-    </properties>
-
     <build>
         <plugins>
             <!--  this create jar file of code from src/test/java so modules with tests can share code -->

--- a/hazelcast/src/main/java/com/hazelcast/impl/CMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/impl/CMap.java
@@ -465,7 +465,7 @@ public class CMap {
 
     public void own(DataRecordEntry dataRecordEntry) {
         Record record = storeDataRecordEntry(dataRecordEntry);
-        if (record != null) {
+        if (record != null && record.isActive()) {
             if (record.valueCount() > 0) {
                 updateIndexes(record);
             }
@@ -510,7 +510,11 @@ public class CMap {
             }
         }
         record.setVersion(dataRecordEntry.getVersion());
-        markAsActive(record);
+        if (dataRecordEntry.isActive()) {
+            markAsActive(record);
+        } else {
+            markAsRemoved(record);
+        }
         return record;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/impl/ConcurrentMapManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/impl/ConcurrentMapManager.java
@@ -3033,7 +3033,14 @@ public class ConcurrentMapManager extends BaseManager {
                 request.value = null;
                 request.response = Boolean.FALSE;
             } else {
-                Record record = ensureRecord(request);
+                Record record = cmap.getRecord(request);
+                if (record != null && !record.isActive() && record.getRemoveTime() > 0) {
+                    request.value = null;
+                    request.response = Boolean.FALSE;
+                    return;
+                }
+
+                record = ensureRecord(request);
                 cmap.put(request);
                 if (record != null) {
                     record.setDirty(false);

--- a/hazelcast/src/main/java/com/hazelcast/impl/PartitionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/impl/PartitionManager.java
@@ -217,7 +217,15 @@ public class PartitionManager {
                     : cmap.getTotalBackupCount() >= replicaIndex;
             if (includeCMap) {
                 for (final Record record : cmap.mapRecords.values()) {
-                    if (record.isActive() && record.isValid(now)) {
+                    if (record.isValid(now)) {
+                        if (!record.isActive() && record.getRemoveTime() == 0L) {
+                            continue;
+                        }
+
+                        if (replicaIndex > 0 && !record.isActive()) {
+                            continue;
+                        }
+
                         if (record.getKeyData() == null || record.getKeyData().size() == 0) {
                             throw new RuntimeException("Record.key is null or empty " + record.getKeyData());
                         }

--- a/hazelcast/src/main/java/com/hazelcast/impl/base/DataRecordEntry.java
+++ b/hazelcast/src/main/java/com/hazelcast/impl/base/DataRecordEntry.java
@@ -41,6 +41,7 @@ public class DataRecordEntry implements DataSerializable, MapEntry {
     private long creationTime = 0;
     private long version = 0;
     private int hits = 0;
+    private boolean active = true;
     private boolean valid = true;
     private boolean dirty = false;
     private String name = null;
@@ -77,6 +78,7 @@ public class DataRecordEntry implements DataSerializable, MapEntry {
         lastStoredTime = record.getLastStoredTime();
         version = record.getVersion();
         hits = record.getHits();
+        active = record.isActive();
         valid = record.isValid();
         dirty = record.isDirty();
         name = record.getName();
@@ -99,6 +101,7 @@ public class DataRecordEntry implements DataSerializable, MapEntry {
 
     public void writeData(DataOutput out) throws IOException {
         long now = Clock.currentTimeMillis();
+        out.writeBoolean(active);
         out.writeBoolean(valid);
         out.writeBoolean(dirty);
         out.writeLong(cost);
@@ -141,6 +144,7 @@ public class DataRecordEntry implements DataSerializable, MapEntry {
 
     public void readData(DataInput in) throws IOException {
         long now = Clock.currentTimeMillis();
+        active = in.readBoolean();
         valid = in.readBoolean();
         dirty = in.readBoolean();
         cost = in.readLong();
@@ -231,6 +235,10 @@ public class DataRecordEntry implements DataSerializable, MapEntry {
 
     public String getName() {
         return name;
+    }
+
+    public boolean isActive() {
+        return active;
     }
 
     public boolean isValid() {

--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,7 @@
 
         <junit.version>4.10</junit.version>
         <mockito.all.version>1.8.2</mockito.all.version>
+        <log4j.version>1.2.12</log4j.version>
         <slf4j.api.version>1.6.0</slf4j.api.version>
     </properties>
     <licenses>
@@ -238,7 +239,13 @@
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>
-
+        <dependency>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+            <version>${log4j.version}</version>
+            <scope>test</scope>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
 
 </project>


### PR DESCRIPTION
… flushed to the write-behind mapstore. Otherwise, a read request can load the entry from map-store before it's deleted and that causes a conflict between map-store and in-memory data.