### PR TITLE
Queue.take/poll/put/offer should throw InterruptedException directly …

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/QueueAdvancedTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/QueueAdvancedTest.java
@@ -24,6 +24,7 @@ import com.hazelcast.core.IQueue;
 import com.hazelcast.core.MemberAttributeEvent;
 import com.hazelcast.core.MembershipEvent;
 import com.hazelcast.core.MembershipListener;
+import com.hazelcast.instance.GroupProperties;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
@@ -39,6 +40,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -566,6 +568,64 @@ public class QueueAdvancedTest extends HazelcastTestSupport {
         config.getQueueConfig(configName).setMaxSize(100);
         TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(2);
         return factory.newInstances(config);
+    }
+
+    @Test
+    public void testTakeInterruption() throws InterruptedException {
+        Config config = new Config();
+        config.setProperty(GroupProperties.PROP_OPERATION_CALL_TIMEOUT_MILLIS, "1000");
+
+        HazelcastInstance instance = createHazelcastInstance(config);
+        final IQueue<Object> queue = instance.getQueue(randomName());
+
+        final AtomicBoolean interrupted = new AtomicBoolean();
+
+        Thread t = new Thread() {
+            public void run() {
+                try {
+                    queue.take();
+                } catch (InterruptedException e) {
+                    interrupted.set(true);
+                }
+            }
+        };
+        t.start();
+
+        sleepSeconds(1);
+        t.interrupt();
+        t.join(5000);
+
+        assertTrue(interrupted.get());
+    }
+
+    @Test
+    public void testPutInterruption() throws InterruptedException {
+        Config config = new Config();
+        config.setProperty(GroupProperties.PROP_OPERATION_CALL_TIMEOUT_MILLIS, "1000");
+        config.getQueueConfig("default").setMaxSize(1);
+
+        HazelcastInstance instance = createHazelcastInstance(config);
+        final IQueue<Object> queue = instance.getQueue(randomName());
+        final AtomicBoolean interrupted = new AtomicBoolean();
+
+        assertTrue(queue.offer("item"));
+
+        Thread t = new Thread() {
+            public void run() {
+                try {
+                    queue.put("item");
+                } catch (InterruptedException e) {
+                    interrupted.set(true);
+                }
+            }
+        };
+        t.start();
+
+        sleepSeconds(1);
+        t.interrupt();
+        t.join(5000);
+
+        assertTrue(interrupted.get());
     }
 
 }

--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/QueueBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/QueueBasicTest.java
@@ -21,13 +21,9 @@ import com.hazelcast.config.QueueConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IAtomicLong;
 import com.hazelcast.core.IQueue;
-import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
-import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
 
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -304,6 +300,7 @@ public abstract class QueueBasicTest extends HazelcastTestSupport {
         }
     }
 
+    @Test
     public void testContainsAll_whenExists() {
         for (int i = 0; i < 10; i++) {
             queue.offer("item" + i);
@@ -512,7 +509,7 @@ public abstract class QueueBasicTest extends HazelcastTestSupport {
         iterator.remove();
     }
 
-    private class OfferThread extends Thread {
+    private static class OfferThread extends Thread {
         IQueue queue;
 
         OfferThread(IQueue queue) {
@@ -529,7 +526,7 @@ public abstract class QueueBasicTest extends HazelcastTestSupport {
         }
     }
 
-    private class PollThread extends Thread {
+    private static class PollThread extends Thread {
         IQueue queue;
 
         PollThread(IQueue queue) {


### PR DESCRIPTION
…instead of wrapping inside HazelcastException. Partially fixes issue #4143.