### PR TITLE
Clean up ExecutorService tests

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/executor/ExecutorServiceCancelTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/executor/ExecutorServiceCancelTest.java
@@ -1,15 +1,12 @@
 package com.hazelcast.executor;
 
-import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IExecutorService;
 import com.hazelcast.core.Member;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.QuickTest;
-import org.junit.AfterClass;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -18,6 +15,8 @@ import org.junit.runner.RunWith;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import static org.junit.Assert.assertTrue;
 
@@ -30,16 +29,8 @@ import static org.junit.Assert.assertTrue;
  */
 public class ExecutorServiceCancelTest extends ExecutorServiceTestSupport {
 
-    public static final int SLEEP_TIME_SECONDS = 1000;
-
     private HazelcastInstance server1;
     private HazelcastInstance server2;
-
-    @BeforeClass
-    @AfterClass
-    public static void cleanup() {
-        Hazelcast.shutdownAll();
-    }
 
     @Before
     public void setup() {
@@ -48,43 +39,74 @@ public class ExecutorServiceCancelTest extends ExecutorServiceTestSupport {
         server2 = factory.newHazelcastInstance();
     }
 
-
-    @Test(expected = CancellationException.class)
+    @Test
     public void testCancel_submitRandom() throws ExecutionException, InterruptedException {
         IExecutorService executorService = server1.getExecutorService(randomString());
-        Future<Boolean> future = executorService.submit(new SleepingTask(SLEEP_TIME_SECONDS));
-        boolean cancelled = future.cancel(true);
-        assertTrue(cancelled);
-        future.get();
+        Future<Boolean> future = executorService.submit(new SleepingTask(Integer.MAX_VALUE));
+        assertTrue(future.cancel(true));
     }
 
     @Test(expected = CancellationException.class)
+    public void testGetValueAfterCancel_submitRandom()
+            throws ExecutionException, InterruptedException, TimeoutException {
+        IExecutorService executorService = server1.getExecutorService(randomString());
+        Future<Boolean> future = executorService.submit(new SleepingTask(Integer.MAX_VALUE));
+        future.cancel(true);
+        future.get(10, TimeUnit.SECONDS);
+    }
+
+    @Test
     public void testCancel_submitToLocalMember() throws ExecutionException, InterruptedException {
         testCancel_submitToMember(server1, server1.getCluster().getLocalMember());
     }
 
-    @Test(expected = CancellationException.class)
+    @Test
     public void testCancel_submitToRemoteMember() throws ExecutionException, InterruptedException {
         testCancel_submitToMember(server1, server2.getCluster().getLocalMember());
     }
 
+    @Test(expected = CancellationException.class)
+    public void testGetValueAfterCancel_submitToLocalMember()
+            throws ExecutionException, InterruptedException, TimeoutException {
+        testGetValueAfterCancel_submitToMember(server1, server1.getCluster().getLocalMember());
+    }
+
+    @Test(expected = CancellationException.class)
+    public void testGetValueAfterCancel_submitToRemoteMember()
+            throws ExecutionException, InterruptedException, TimeoutException {
+        testGetValueAfterCancel_submitToMember(server1, server2.getCluster().getLocalMember());
+    }
 
     private void testCancel_submitToMember(HazelcastInstance instance, Member member)
             throws ExecutionException, InterruptedException {
         IExecutorService executorService = instance.getExecutorService(randomString());
-        Future<Boolean> future = executorService.submitToMember(new SleepingTask(SLEEP_TIME_SECONDS), member);
+        Future<Boolean> future = executorService.submitToMember(new SleepingTask(Integer.MAX_VALUE), member);
+        assertTrue(future.cancel(true));
+    }
+
+    private void testGetValueAfterCancel_submitToMember(HazelcastInstance instance, Member member)
+            throws ExecutionException, InterruptedException, TimeoutException {
+        IExecutorService executorService = instance.getExecutorService(randomString());
+        Future<Boolean> future = executorService.submitToMember(new SleepingTask(Integer.MAX_VALUE), member);
+        future.cancel(true);
+        future.get(10, TimeUnit.SECONDS);
+    }
+
+    @Test
+    public void testCancel_submitToKeyOwner() throws ExecutionException, InterruptedException {
+        IExecutorService executorService = server1.getExecutorService(randomString());
+        Future<Boolean> future = executorService.submitToKeyOwner(new SleepingTask(Integer.MAX_VALUE), randomString());
         boolean cancelled = future.cancel(true);
         assertTrue(cancelled);
-        future.get();
     }
 
     @Test(expected = CancellationException.class)
-    public void testCancel_submitToKeyOwner() throws ExecutionException, InterruptedException {
+    public void testGetValueAfterCancel_submitToKeyOwner()
+            throws ExecutionException, InterruptedException, TimeoutException {
         IExecutorService executorService = server1.getExecutorService(randomString());
-        Future<Boolean> future = executorService.submitToKeyOwner(new SleepingTask(SLEEP_TIME_SECONDS), randomString());
-        boolean cancelled = future.cancel(true);
-        assertTrue(cancelled);
-        future.get();
+        Future<Boolean> future = executorService.submitToKeyOwner(new SleepingTask(Integer.MAX_VALUE), randomString());
+        future.cancel(true);
+        future.get(10, TimeUnit.SECONDS);
     }
 
 }

--- a/hazelcast/src/test/java/com/hazelcast/executor/ExecutorServiceTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/executor/ExecutorServiceTestSupport.java
@@ -17,16 +17,24 @@ package com.hazelcast.executor;
 
 import com.hazelcast.config.Config;
 import com.hazelcast.config.ExecutorConfig;
+import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.HazelcastInstanceAware;
 import com.hazelcast.core.IExecutorService;
 import com.hazelcast.core.Member;
+import com.hazelcast.core.MultiExecutionCallback;
 import com.hazelcast.core.PartitionAware;
+import com.hazelcast.spi.impl.executionservice.InternalExecutionService;
 import com.hazelcast.test.HazelcastTestSupport;
 
 import java.io.Serializable;
+import java.util.Map;
 import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.Assert.fail;
 
@@ -42,7 +50,76 @@ public class ExecutorServiceTestSupport extends HazelcastTestSupport {
         return instance.getExecutorService(name);
     }
 
-    static class BasicTestTask implements Callable<String>, Serializable, PartitionAware {
+    int findNextKeyForMember(HazelcastInstance instance, Member localMember) {
+        int key = 0;
+        while (!localMember.equals(instance.getPartitionService().getPartition(++key).getOwner())) ;
+        return key;
+    }
+
+    InternalExecutionService getExecutionService(HazelcastInstance instance) {
+        return getNode(instance).getNodeEngine().getExecutionService();
+    }
+
+    static class CountDownLatchAwaitingCallable
+            implements Callable<String> {
+
+        public static String RESULT = "Success";
+
+        private final CountDownLatch latch;
+
+        public CountDownLatchAwaitingCallable(CountDownLatch latch) {
+            this.latch = latch;
+        }
+
+        @Override
+        public String call()
+                throws Exception {
+            latch.await(30, TimeUnit.SECONDS);
+            return RESULT;
+        }
+    }
+
+    static class CountingDownExecutionCallback<T> implements ExecutionCallback<T> {
+
+        private final CountDownLatch latch;
+
+        private final AtomicReference<Object> result = new AtomicReference<Object>();
+
+        public CountingDownExecutionCallback(int count) {
+            this.latch = new CountDownLatch(count);
+        }
+
+        public CountingDownExecutionCallback(CountDownLatch latch) {
+            this.latch = latch;
+        }
+
+        @Override
+        public void onResponse(T response) {
+            if (!result.compareAndSet(null, response)) {
+                System.out.println("New response received after result is set. Response: " + response +  " Resuilt: " + result.get());
+            }
+            latch.countDown();
+        }
+
+        @Override
+        public void onFailure(Throwable t) {
+            if (!result.compareAndSet(null, t)) {
+                System.out.println("Failure received after result is set. Failure: " + t +  " Resuilt: " + result.get());
+            }
+            latch.countDown();
+        }
+
+        public CountDownLatch getLatch() {
+            return latch;
+        }
+
+        public Object getResult() {
+            return result.get();
+        }
+    }
+
+    static class BasicTestCallable
+            implements Callable<String>, Serializable, PartitionAware {
         public static String RESULT = "Task completed";
 
         @Override public String call() {
@@ -55,15 +132,16 @@ public class ExecutorServiceTestSupport extends HazelcastTestSupport {
         }
     }
 
-    static class SleepingTask implements Callable<Boolean>, Serializable, PartitionAware {
-        int sleepSeconds;
+    static class SleepingTask
+            implements Callable<Boolean>, Serializable, PartitionAware {
+        long sleepSeconds;
 
-        public SleepingTask(int sleepSeconds) {
+        public SleepingTask(long sleepSeconds) {
             this.sleepSeconds = sleepSeconds;
         }
         @Override
         public Boolean call() throws InterruptedException {
-            sleepAtLeastSeconds(sleepSeconds);
+            sleepAtLeastSeconds((int) sleepSeconds);
             return true;
         }
         @Override
@@ -77,7 +155,7 @@ public class ExecutorServiceTestSupport extends HazelcastTestSupport {
 
         @Override
         public String call() throws Exception {
-            Future future = instance.getExecutorService("NestedExecutorTask").submit(new BasicTestTask());
+            Future future = instance.getExecutorService("NestedExecutorTask").submit(new BasicTestCallable());
             return (String) future.get();
         }
         @Override
@@ -118,6 +196,198 @@ public class ExecutorServiceTestSupport extends HazelcastTestSupport {
         @Override
         public void setHazelcastInstance(HazelcastInstance hazelcastInstance) {
             initializeCalled = true;
+        }
+    }
+
+    static class IncrementAtomicLongIfMemberUUIDNotMatchRunnable implements Runnable, Serializable, HazelcastInstanceAware {
+
+        private final String uuid;
+        private final String name;
+
+        private HazelcastInstance instance;
+
+        public IncrementAtomicLongIfMemberUUIDNotMatchRunnable(String uuid, String name) {
+            this.uuid = uuid;
+            this.name = name;
+        }
+
+        @Override
+        public void setHazelcastInstance(HazelcastInstance instance) {
+            this.instance = instance;
+        }
+
+        @Override
+        public void run() {
+            if(!instance.getCluster().getLocalMember().getUuid().equals(uuid)) {
+                instance.getAtomicLong(name).incrementAndGet();
+            }
+        }
+    }
+
+    static class NullResponseCountingCallback<T> implements ExecutionCallback<T> {
+
+        private final AtomicInteger nullResponseCount = new AtomicInteger(0);
+
+        private final CountDownLatch responseLatch;
+
+        public NullResponseCountingCallback(int count) {
+            this.responseLatch = new CountDownLatch(count);
+        }
+
+        @Override
+        public void onResponse(T response) {
+            if (response == null) {
+                nullResponseCount.incrementAndGet();
+            }
+
+            responseLatch.countDown();
+        }
+
+        @Override
+        public void onFailure(Throwable t) {
+            System.out.println("Exception received: " + t);
+        }
+
+        public int getNullResponseCount() {
+            return nullResponseCount.get();
+        }
+
+        public boolean awaitResponseLatch(int seconds)
+                throws InterruptedException {
+            return responseLatch.await(seconds, TimeUnit.SECONDS);
+        }
+
+        public CountDownLatch getResponseLatch() {
+            return responseLatch;
+        }
+    }
+
+    static class ResponseCountingMultiExecutionCallback implements MultiExecutionCallback {
+
+        private final AtomicInteger count = new AtomicInteger();
+
+        private final CountDownLatch latch;
+
+        public ResponseCountingMultiExecutionCallback(int count) {
+            this.latch = new CountDownLatch(count);
+        }
+
+        public void onResponse(Member member, Object value) {
+            count.incrementAndGet();
+        }
+
+        public void onComplete(Map<Member, Object> values) {
+            latch.countDown();
+        }
+
+        public int getCount() {
+            return count.get();
+        }
+
+        public CountDownLatch getLatch() {
+            return latch;
+        }
+    };
+
+    static class BooleanSuccessResponseCountingCallback
+            implements ExecutionCallback<Boolean> {
+
+        private final AtomicInteger successResponseCount = new AtomicInteger(0);
+
+        private final CountDownLatch responseLatch;
+
+        public BooleanSuccessResponseCountingCallback(int count) {
+            this.responseLatch = new CountDownLatch(count);
+        }
+
+        @Override
+        public void onResponse(Boolean response) {
+            if (response) {
+                successResponseCount.incrementAndGet();
+            }
+            responseLatch.countDown();
+        }
+
+        @Override
+        public void onFailure(Throwable t) {
+
+        }
+
+        public int getSuccessResponseCount() {
+            return successResponseCount.get();
+        }
+
+        public CountDownLatch getResponseLatch() {
+            return responseLatch;
+        }
+    }
+
+    static class IncrementAtomicLongRunnable implements Runnable, Serializable, HazelcastInstanceAware {
+
+        private final String name;
+
+        private HazelcastInstance instance;
+
+        public IncrementAtomicLongRunnable(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public void setHazelcastInstance(HazelcastInstance instance) {
+            this.instance = instance;
+        }
+
+        @Override
+        public void run() {
+            instance.getAtomicLong(name).incrementAndGet();
+        }
+    }
+
+    static class IncrementAtomicLongCallable implements Callable<Long>, Serializable, HazelcastInstanceAware {
+
+        private final String name;
+
+        private HazelcastInstance instance;
+
+        public IncrementAtomicLongCallable(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public void setHazelcastInstance(HazelcastInstance instance) {
+            this.instance = instance;
+        }
+
+        public void run() {
+            instance.getAtomicLong(name).incrementAndGet();
+        }
+
+        @Override
+        public Long call()
+                throws Exception {
+            return instance.getAtomicLong(name).incrementAndGet();
+        }
+    }
+
+    static class MemberUUIDCheckCallable implements Callable<Boolean>, HazelcastInstanceAware, Serializable {
+
+        private final String uuid;
+
+        public MemberUUIDCheckCallable(String uuid) {
+            this.uuid = uuid;
+        }
+
+        private HazelcastInstance instance;
+
+        @Override
+        public Boolean call()
+                throws Exception {
+            return instance.getCluster().getLocalMember().getUuid().equals(uuid);
+        }
+
+        @Override
+        public void setHazelcastInstance(HazelcastInstance instance) {
+            this.instance = instance;
         }
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/executor/SingleNodeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/executor/SingleNodeTest.java
@@ -77,9 +77,9 @@ public class SingleNodeTest extends ExecutorServiceTestSupport {
 
     @Test
     public void submitBasicTask() throws Exception {
-        Callable<String> task = new BasicTestTask();
+        Callable<String> task = new BasicTestCallable();
         Future future = executor.submit(task);
-        assertEquals(future.get(), BasicTestTask.RESULT);
+        assertEquals(future.get(), BasicTestCallable.RESULT);
     }
 
     @Test(expected = RejectedExecutionException.class)
@@ -95,7 +95,7 @@ public class SingleNodeTest extends ExecutorServiceTestSupport {
 
     @Test
     public void executionCallback_notifiedOnSuccess() throws Exception {
-        Callable<String> task = new BasicTestTask();
+        Callable<String> task = new BasicTestCallable();
         final CountDownLatch latch = new CountDownLatch(1);
         final ExecutionCallback<String> executionCallback = new ExecutionCallback<String>() {
             public void onResponse(String response) {
@@ -145,7 +145,7 @@ public class SingleNodeTest extends ExecutorServiceTestSupport {
         Callable task1 = new SleepingTask(100);
         Future inProgFuture = executor.submit(task1);
 
-        Callable task2 = new BasicTestTask();
+        Callable task2 = new BasicTestCallable();
         /* This future should not be an instance of CompletedFuture
          * Because even if we get an exception, isDone is returning true */
         Future queuedFuture = executor.submit(task2);
@@ -167,9 +167,9 @@ public class SingleNodeTest extends ExecutorServiceTestSupport {
 
     @Test
     public void isDoneAfterGet() throws Exception {
-        Callable<String> task = new BasicTestTask();
+        Callable<String> task = new BasicTestCallable();
         Future future = executor.submit(task);
-        assertEquals(future.get(), BasicTestTask.RESULT);
+        assertEquals(future.get(), BasicTestCallable.RESULT);
         assertTrue(future.isDone());
     }
 
@@ -177,14 +177,14 @@ public class SingleNodeTest extends ExecutorServiceTestSupport {
     public void issue129() throws Exception {
         for (int i = 0; i < 1000; i++) {
             Callable<String>
-                    task1 = new BasicTestTask(),
-                    task2 = new BasicTestTask();
+                    task1 = new BasicTestCallable(),
+                    task2 = new BasicTestCallable();
             Future<String>
                     future1 = executor.submit(task1),
                     future2 = executor.submit(task2);
-            assertEquals(future2.get(), BasicTestTask.RESULT);
+            assertEquals(future2.get(), BasicTestCallable.RESULT);
             assertTrue(future2.isDone());
-            assertEquals(future1.get(), BasicTestTask.RESULT);
+            assertEquals(future1.get(), BasicTestCallable.RESULT);
             assertTrue(future1.isDone());
         }
     }
@@ -209,10 +209,10 @@ public class SingleNodeTest extends ExecutorServiceTestSupport {
 
     @Test
     public void getManyTimesFromSameFuture() throws Exception {
-        Callable<String> task = new BasicTestTask();
+        Callable<String> task = new BasicTestCallable();
         Future<String> future = executor.submit(task);
         for (int i = 0; i < 4; i++) {
-            assertEquals(future.get(), BasicTestTask.RESULT);
+            assertEquals(future.get(), BasicTestCallable.RESULT);
             assertTrue(future.isDone());
         }
     }
@@ -221,19 +221,19 @@ public class SingleNodeTest extends ExecutorServiceTestSupport {
     public void invokeAll() throws Exception {
         // Only one task
         ArrayList<Callable<String>> tasks = new ArrayList<Callable<String>>();
-        tasks.add(new BasicTestTask());
+        tasks.add(new BasicTestCallable());
         List<Future<String>> futures = executor.invokeAll(tasks);
         assertEquals(futures.size(), 1);
-        assertEquals(futures.get(0).get(), BasicTestTask.RESULT);
+        assertEquals(futures.get(0).get(), BasicTestCallable.RESULT);
         // More tasks
         tasks.clear();
         for (int i = 0; i < 1000; i++) {
-            tasks.add(new BasicTestTask());
+            tasks.add(new BasicTestCallable());
         }
         futures = executor.invokeAll(tasks);
         assertEquals(futures.size(), 1000);
         for (int i = 0; i < 1000; i++) {
-            assertEquals(futures.get(i).get(), BasicTestTask.RESULT);
+            assertEquals(futures.get(i).get(), BasicTestCallable.RESULT);
         }
     }
 
@@ -267,19 +267,19 @@ public class SingleNodeTest extends ExecutorServiceTestSupport {
     public void invokeAllTimeoutSuccess() throws Exception {
         // Only one task
         ArrayList<Callable<String>> tasks = new ArrayList<Callable<String>>();
-        tasks.add(new BasicTestTask());
+        tasks.add(new BasicTestCallable());
         List<Future<String>> futures = executor.invokeAll(tasks, 5, TimeUnit.SECONDS);
         assertEquals(futures.size(), 1);
-        assertEquals(futures.get(0).get(), BasicTestTask.RESULT);
+        assertEquals(futures.get(0).get(), BasicTestCallable.RESULT);
         // More tasks
         tasks.clear();
         for (int i = 0; i < 1000; i++) {
-            tasks.add(new BasicTestTask());
+            tasks.add(new BasicTestCallable());
         }
         futures = executor.invokeAll(tasks, 5, TimeUnit.SECONDS);
         assertEquals(futures.size(), 1000);
         for (int i = 0; i < 1000; i++) {
-            assertEquals(futures.get(i).get(), BasicTestTask.RESULT);
+            assertEquals(futures.get(i).get(), BasicTestCallable.RESULT);
         }
     }
 
@@ -323,7 +323,7 @@ public class SingleNodeTest extends ExecutorServiceTestSupport {
         assertTrue(executor.isTerminated());
 
         // New tasks must be rejected
-        Callable<String> task = new BasicTestTask();
+        Callable<String> task = new BasicTestCallable();
         executor.submit(task);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/executor/SpecificSetupTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/executor/SpecificSetupTest.java
@@ -18,12 +18,10 @@ package com.hazelcast.executor;
 
 import com.hazelcast.config.Config;
 import com.hazelcast.config.ExecutorConfig;
-import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IExecutorService;
 import com.hazelcast.core.ManagedContext;
 import com.hazelcast.core.PartitionAware;
-import com.hazelcast.instance.GroupProperties;
 import com.hazelcast.monitor.LocalExecutorStats;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
@@ -34,15 +32,11 @@ import org.junit.runner.RunWith;
 
 import java.io.Serializable;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static com.hazelcast.instance.GroupProperties.PROP_OPERATION_CALL_TIMEOUT_MILLIS;
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.Assert.assertEquals;

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
@@ -253,7 +253,7 @@ public abstract class HazelcastTestSupport {
         stop.set(true);
     }
 
-    public static void sleepAtLeastMillis(int sleepFor) {
+    public static void sleepAtLeastMillis(long sleepFor) {
        boolean interrupted = false;
        try {
            long remainingNanos = MILLISECONDS.toNanos(sleepFor);
@@ -274,7 +274,7 @@ public abstract class HazelcastTestSupport {
        }
     }
 
-    public static void sleepAtLeastSeconds(int seconds) {
+    public static void sleepAtLeastSeconds(long seconds) {
         sleepAtLeastMillis(seconds * 1000);
     }
 


### PR DESCRIPTION
* Split test methods that verify multiple things
* Remove ScriptRunnable usage and related code duplications
* Refactor test methods