### PR TITLE
Fixed all partial updates on an entry via entry-processor should be r…

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/MapDataStores.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/MapDataStores.java
@@ -16,6 +16,9 @@
 
 package com.hazelcast.map.impl.mapstore;
 
+import com.hazelcast.config.Config;
+import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.config.MapConfig;
 import com.hazelcast.config.MapStoreConfig;
 import com.hazelcast.map.impl.MapServiceContext;
 import com.hazelcast.map.impl.MapStoreWrapper;
@@ -29,8 +32,8 @@ import com.hazelcast.spi.NodeEngine;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static com.hazelcast.map.impl.mapstore.writebehind.WriteBehindQueues.createDefaultWriteBehindQueue;
 import static com.hazelcast.map.impl.mapstore.writebehind.WriteBehindQueues.createBoundedWriteBehindQueue;
+import static com.hazelcast.map.impl.mapstore.writebehind.WriteBehindQueues.createDefaultWriteBehindQueue;
 
 /**
  * Factory class responsible for creating various data store implementations.
@@ -56,17 +59,29 @@ public final class MapDataStores {
                                                                    WriteBehindProcessor writeBehindProcessor) {
         final MapServiceContext mapServiceContext = mapStoreContext.getMapServiceContext();
         final MapStoreWrapper store = mapStoreContext.getMapStoreWrapper();
-        final SerializationService serializationService = mapServiceContext.getNodeEngine().getSerializationService();
+        final NodeEngine nodeEngine = mapServiceContext.getNodeEngine();
+        final SerializationService serializationService = nodeEngine.getSerializationService();
         final MapStoreConfig mapStoreConfig = mapStoreContext.getMapStoreConfig();
         final int writeDelaySeconds = mapStoreConfig.getWriteDelaySeconds();
         final long writeDelayMillis = TimeUnit.SECONDS.toMillis(writeDelaySeconds);
         final boolean writeCoalescing = mapStoreConfig.isWriteCoalescing();
+        final InMemoryFormat inMemoryFormat = getInMemoryFormat(mapStoreContext);
         final WriteBehindStore mapDataStore
-                = new WriteBehindStore(store, serializationService, writeDelayMillis, partitionId);
+                = new WriteBehindStore(store, serializationService, writeDelayMillis, partitionId, inMemoryFormat);
         final WriteBehindQueue writeBehindQueue = newWriteBehindQueue(mapServiceContext, writeCoalescing);
         mapDataStore.setWriteBehindQueue(writeBehindQueue);
         mapDataStore.setWriteBehindProcessor(writeBehindProcessor);
         return (MapDataStore<K, V>) mapDataStore;
+    }
+
+    private static InMemoryFormat getInMemoryFormat(MapStoreContext mapStoreContext) {
+        MapServiceContext mapServiceContext = mapStoreContext.getMapServiceContext();
+        NodeEngine nodeEngine = mapServiceContext.getNodeEngine();
+
+        Config config = nodeEngine.getConfig();
+        String mapName = mapStoreContext.getMapName();
+        MapConfig mapConfig = config.findMapConfig(mapName);
+        return mapConfig.getInMemoryFormat();
     }
 
     private static WriteBehindQueue newWriteBehindQueue(MapServiceContext mapServiceContext, boolean writeCoalescing) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/WriteBehindStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/WriteBehindStore.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.map.impl.mapstore.writebehind;
 
+import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.map.impl.MapStoreWrapper;
 import com.hazelcast.map.impl.mapstore.AbstractMapDataStore;
 import com.hazelcast.map.impl.mapstore.writebehind.entry.DelayedEntries;
@@ -56,6 +57,8 @@ public class WriteBehindStore extends AbstractMapDataStore<Data, Object> {
      */
     private final AtomicInteger flushCounter;
 
+    private final InMemoryFormat inMemoryFormat;
+
     private WriteBehindQueue<DelayedEntry> writeBehindQueue;
 
     private WriteBehindProcessor writeBehindProcessor;
@@ -82,18 +85,25 @@ public class WriteBehindStore extends AbstractMapDataStore<Data, Object> {
     private final ConcurrentMap<Data, DelayedEntry> stagingArea;
 
     public WriteBehindStore(MapStoreWrapper store, SerializationService serializationService,
-                            long writeDelayTime, int partitionId) {
+                            long writeDelayTime, int partitionId, InMemoryFormat inMemoryFormat) {
         super(store, serializationService);
         this.writeDelayTime = writeDelayTime;
         this.partitionId = partitionId;
         this.stagingArea = new ConcurrentHashMap<Data, DelayedEntry>();
         this.flushCounter = new AtomicInteger(0);
+        this.inMemoryFormat = inMemoryFormat;
     }
 
 
-    // TODO when mode is not write-coalescing, clone value objects. this is for EntryProcessors in object memory format.
     @Override
     public Object add(Data key, Object value, long now) {
+
+        // we will be in this `if` only in case of an entry modification via entry-processor.
+        // otherwise this extra serialization of value should not be happen.
+        if (InMemoryFormat.OBJECT.equals(inMemoryFormat)) {
+            value = toData(value);
+        }
+
         long writeDelay = this.writeDelayTime;
         long storeTime = now + writeDelay;
         DelayedEntry<Data, Object> delayedEntry

--- a/hazelcast/src/test/java/com/hazelcast/map/mapstore/writebehind/TestMapUsingMapStoreBuilder.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/mapstore/writebehind/TestMapUsingMapStoreBuilder.java
@@ -15,7 +15,7 @@ public class TestMapUsingMapStoreBuilder<K, V> {
 
     private HazelcastInstance[] nodes;
 
-    private int nodeCount;
+    private int nodeCount = 1;
 
     private int partitionCount = 271;
 


### PR DESCRIPTION
…eflected to map-store when in memory format is OBJECT


closes https://github.com/hazelcast/hazelcast/issues/4957