### PR TITLE
Fixed all partial updates on an entry via entry-processor should be r…

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/map/mapstore/writebehind/TestMapUsingMapStoreBuilder.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/mapstore/writebehind/TestMapUsingMapStoreBuilder.java
@@ -15,7 +15,7 @@ public class TestMapUsingMapStoreBuilder<K, V> {
 
     private HazelcastInstance[] nodes;
 
-    private int nodeCount;
+    private int nodeCount = 1;
 
     private int partitionCount = 271;
 


### PR DESCRIPTION
…eflected to map-store when in memory format is OBJECT

backport of https://github.com/hazelcast/hazelcast/pull/5403