### PR TITLE
Fixes Member Update Ordering problem

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/ClusterServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/ClusterServiceImpl.java
@@ -33,6 +33,7 @@ import com.hazelcast.cluster.impl.operations.MemberInfoUpdateOperation;
 import com.hazelcast.cluster.impl.operations.MemberRemoveOperation;
 import com.hazelcast.cluster.impl.operations.PostJoinOperation;
 import com.hazelcast.cluster.impl.operations.SetMasterOperation;
+import com.hazelcast.cluster.impl.operations.TriggerMemberListPublishOperation;
 import com.hazelcast.core.Cluster;
 import com.hazelcast.core.HazelcastException;
 import com.hazelcast.core.HazelcastInstanceNotActiveException;
@@ -79,6 +80,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -502,13 +504,27 @@ public final class ClusterServiceImpl implements ClusterService, ConnectionListe
         }
     }
 
+
+    public void sendMemberListToMember(Address target) {
+        if (!isMaster()) {
+            return;
+        }
+        if (thisAddress.equals(target)) {
+            return;
+        }
+        final Collection<MemberImpl> members = getMemberList();
+        MemberInfoUpdateOperation op = new MemberInfoUpdateOperation(
+                createMemberInfoList(members), clusterClock.getClusterTime(), false);
+        nodeEngine.getOperationService().send(op, target);
+    }
+
     private void sendMemberListToOthers() {
         if (!isMaster()) {
             return;
         }
         final Collection<MemberImpl> members = getMemberList();
         MemberInfoUpdateOperation op = new MemberInfoUpdateOperation(
-                createMemberInfos(members), clusterClock.getClusterTime(), false);
+                createMemberInfoList(members), clusterClock.getClusterTime(), false);
         for (MemberImpl member : members) {
             if (member.equals(thisMember)) {
                 continue;
@@ -757,7 +773,7 @@ public final class ClusterServiceImpl implements ClusterService, ConnectionListe
                 final PostJoinOperation postJoinOp = postJoinOps != null && postJoinOps.length > 0
                         ? new PostJoinOperation(postJoinOps) : null;
 
-                Operation op = new FinalizeJoinOperation(createMemberInfos(getMemberList()), postJoinOp,
+                Operation op = new FinalizeJoinOperation(createMemberInfoList(getMemberList()), postJoinOp,
                         clusterClock.getClusterTime(), false);
                 nodeEngine.getOperationService().send(op, target);
             } else {
@@ -976,7 +992,7 @@ public final class ClusterServiceImpl implements ClusterService, ConnectionListe
                 // pause migrations until join, member-update and post-join operations are completed.
                 node.getPartitionService().pauseMigration();
                 final Collection<MemberImpl> members = getMemberList();
-                final Collection<MemberInfo> memberInfos = createMemberInfos(members);
+                final Collection<MemberInfo> memberInfos = createMemberInfoList(members);
                 for (MemberInfo memberJoining : setJoins) {
                     memberInfos.add(memberJoining);
                 }
@@ -1009,8 +1025,16 @@ public final class ClusterServiceImpl implements ClusterService, ConnectionListe
         }
     }
 
-    private static Collection<MemberInfo> createMemberInfos(Collection<MemberImpl> members) {
-        final Collection<MemberInfo> memberInfos = new LinkedList<MemberInfo>();
+    private static List<MemberInfo> createMemberInfoList(Collection<MemberImpl> members) {
+        final List<MemberInfo> memberInfos = new LinkedList<MemberInfo>();
+        for (MemberImpl member : members) {
+            memberInfos.add(new MemberInfo(member));
+        }
+        return memberInfos;
+    }
+
+    private static Set<MemberInfo> createMemberInfoSet(Collection<MemberImpl> members) {
+        final Set<MemberInfo> memberInfos = new HashSet<MemberInfo>();
         for (MemberImpl member : members) {
             memberInfos.add(new MemberInfo(member));
         }
@@ -1020,26 +1044,16 @@ public final class ClusterServiceImpl implements ClusterService, ConnectionListe
     public void updateMembers(Collection<MemberInfo> members) {
         lock.lock();
         try {
-            Map<Address, MemberImpl> oldMemberMap = membersMapRef.get();
+            Map<Address, MemberImpl> currentMemberMap = membersMapRef.get();
 
-            if (oldMemberMap.size() == members.size()) {
-                boolean same = true;
-                for (MemberInfo memberInfo : members) {
-                    MemberImpl member = oldMemberMap.get(memberInfo.getAddress());
-                    if (member == null || !member.getUuid().equals(memberInfo.getUuid())) {
-                        same = false;
-                        break;
-                    }
-                }
-                if (same) {
-                    logger.finest("No need to process member update...");
-                    return;
-                }
+            if (!shouldProcessMemberUpdate(currentMemberMap, members)) {
+                return;
             }
+
             MemberImpl[] newMembers = new MemberImpl[members.size()];
             int k = 0;
             for (MemberInfo memberInfo : members) {
-                MemberImpl member = oldMemberMap.get(memberInfo.getAddress());
+                MemberImpl member = currentMemberMap.get(memberInfo.getAddress());
                 if (member == null) {
                     member = createMember(memberInfo.getAddress(), memberInfo.getUuid(),
                             thisAddress.getScopeId(), memberInfo.getAttributes());
@@ -1057,6 +1071,45 @@ public final class ClusterServiceImpl implements ClusterService, ConnectionListe
             logger.info(membersString());
         } finally {
             lock.unlock();
+        }
+    }
+
+    private boolean shouldProcessMemberUpdate(Map<Address, MemberImpl> currentMembers,
+                                              Collection<MemberInfo> newMemberInfos) {
+
+        int currentMembersSize = currentMembers.size();
+        int newMembersSize = newMemberInfos.size();
+
+        if (currentMembersSize > newMembersSize) {
+            logger.warning("Received an older member update, no need to process...");
+            nodeEngine.getOperationService().send(new TriggerMemberListPublishOperation(), getMasterAddress());
+            return false;
+        }
+
+        // member-update process only accepts new member updates
+        if (currentMembersSize == newMembersSize) {
+            Set<MemberInfo> currentMemberInfos = createMemberInfoSet(currentMembers.values());
+            if (currentMemberInfos.containsAll(newMemberInfos)) {
+                logger.finest("Received a periodic member update, no need to process...");
+            } else {
+                logger.warning("Received an inconsistent member update "
+                        + "which contains new members and removes some of the current members! "
+                        + "Ignoring and requesting a new member update...");
+                nodeEngine.getOperationService().send(new TriggerMemberListPublishOperation(), getMasterAddress());
+            }
+            return false;
+        }
+
+        Set<MemberInfo> currentMemberInfos = createMemberInfoSet(currentMembers.values());
+        currentMemberInfos.removeAll(newMemberInfos);
+        if (currentMemberInfos.isEmpty()) {
+            return true;
+        } else {
+            logger.warning("Received an inconsistent member update, it has more members but "
+                    + "but also removes some of the current members! "
+                    + "Ignoring and requesting a new member update...");
+            nodeEngine.getOperationService().send(new TriggerMemberListPublishOperation(), getMasterAddress());
+            return false;
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/operations/MemberInfoUpdateOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/operations/MemberInfoUpdateOperation.java
@@ -30,9 +30,9 @@ import java.util.Collection;
 
 public class MemberInfoUpdateOperation extends AbstractClusterOperation implements JoinOperation {
 
-    private Collection<MemberInfo> memberInfos;
-    private long masterTime = Clock.currentTimeMillis();
-    private boolean sendResponse;
+    protected Collection<MemberInfo> memberInfos;
+    protected long masterTime = Clock.currentTimeMillis();
+    protected boolean sendResponse;
 
     public MemberInfoUpdateOperation() {
         memberInfos = new ArrayList<MemberInfo>();

--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/operations/TriggerMemberListPublishOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/operations/TriggerMemberListPublishOperation.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.cluster.impl.operations;
+
+import com.hazelcast.cluster.impl.ClusterServiceImpl;
+
+/**
+ * Requests member list publish from master node
+ */
+public class TriggerMemberListPublishOperation extends AbstractClusterOperation {
+
+    public TriggerMemberListPublishOperation() {
+    }
+
+    @Override
+    public void run() throws Exception {
+        final ClusterServiceImpl clusterService = getService();
+        clusterService.sendMemberListToMember(getCallerAddress());
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/CustomSerializationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/CustomSerializationTest.java
@@ -22,22 +22,28 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
-
 import java.beans.XMLDecoder;
 import java.beans.XMLEncoder;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteOrder;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import static junit.framework.Assert.assertEquals;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
 public class CustomSerializationTest {
+
+    @After
+    public void cleanup() {
+        System.clearProperty("hazelcast.serialization.custom.override");
+    }
 
     @Test
     public void testSerializer() throws Exception {
@@ -57,6 +63,37 @@ public class CustomSerializationTest {
     @Test
     public void testSerializerNativeOrderUsingUnsafe() throws Exception {
         testSerializer(ByteOrder.nativeOrder(), true);
+    }
+
+    @Test
+    public void testSerializerOverridenHierarchyWhenEnabled() throws Exception {
+        System.setProperty("hazelcast.serialization.custom.override", "true");
+        SerializationConfig config = new SerializationConfig();
+        FooXmlSerializer serializer = new FooXmlSerializer();
+        SerializerConfig sc = new SerializerConfig()
+                .setImplementation(serializer)
+                .setTypeClass(FooDataSerializable.class);
+        config.addSerializerConfig(sc);
+        SerializationService ss = new DefaultSerializationServiceBuilder().setConfig(config).build();
+        FooDataSerializable foo = new FooDataSerializable("foo");
+        ss.toData(foo);
+        assertEquals(0, foo.serializationCount.get());
+        assertEquals(1, serializer.serializationCount.get());
+    }
+
+    @Test
+    public void testSerializerOverridenHierarchyWhenDisabled() throws Exception {
+        SerializationConfig config = new SerializationConfig();
+        FooXmlSerializer serializer = new FooXmlSerializer();
+        SerializerConfig sc = new SerializerConfig()
+                .setImplementation(serializer)
+                .setTypeClass(FooDataSerializable.class);
+        config.addSerializerConfig(sc);
+        SerializationService ss = new DefaultSerializationServiceBuilder().setConfig(config).build();
+        FooDataSerializable foo = new FooDataSerializable("foo");
+        ss.toData(foo);
+        assertEquals(1, foo.serializationCount.get());
+        assertEquals(0, serializer.serializationCount.get());
     }
 
     private void testSerializer(ByteOrder order, boolean allowUnsafe) throws Exception {
@@ -109,7 +146,65 @@ public class CustomSerializationTest {
         }
     }
 
+    public static class FooDataSerializable extends Foo implements DataSerializable {
+
+        AtomicInteger serializationCount = new AtomicInteger();
+        private String foo;
+
+        public FooDataSerializable() {
+        }
+
+        public FooDataSerializable(String foo) {
+            this.foo = foo;
+        }
+
+        public String getFoo() {
+            return foo;
+        }
+
+        public void setFoo(String foo) {
+            this.foo = foo;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            Foo foo1 = (Foo) o;
+
+            return !(foo != null ? !foo.equals(foo1.foo) : foo1.foo != null);
+
+        }
+
+        @Override
+        public int hashCode() {
+            return foo != null ? foo.hashCode() : 0;
+        }
+
+        @Override
+        public void writeData(ObjectDataOutput out) throws IOException {
+            serializationCount.incrementAndGet();
+            out.writeUTF(foo);
+        }
+
+        @Override
+        public void readData(ObjectDataInput in) throws IOException {
+            foo = in.readUTF();
+        }
+
+        @Override
+        public String toString() {
+            return "FooDataSerializable{" +
+                    "foo='" + foo + '\'' +
+                    '}';
+        }
+    }
+
+
     public static class FooXmlSerializer implements StreamSerializer<Foo> {
+
+        AtomicInteger serializationCount = new AtomicInteger();
 
         @Override
         public int getTypeId() {
@@ -118,6 +213,7 @@ public class CustomSerializationTest {
 
         @Override
         public void write(ObjectDataOutput out, Foo object) throws IOException {
+            serializationCount.incrementAndGet();
             ByteArrayOutputStream bos = new ByteArrayOutputStream();
             XMLEncoder encoder = new XMLEncoder(bos);
             encoder.writeObject(object);


### PR DESCRIPTION
Member update ordering problem solved when receiving member list updates from master node that leads to an inconsistent member-list views across cluster members by ignoring and requesting new member-list from master when an inconsistency happens. Fixes #5393.

Thanks @mdogan for his time on providing a base fix for this pull request. 