### PR TITLE
[backport] Fixes Member Update Ordering problem

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/operations/MemberInfoUpdateOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/operations/MemberInfoUpdateOperation.java
@@ -30,9 +30,9 @@ import java.util.Collection;
 
 public class MemberInfoUpdateOperation extends AbstractClusterOperation implements JoinOperation {
 
-    private Collection<MemberInfo> memberInfos;
-    private long masterTime = Clock.currentTimeMillis();
-    private boolean sendResponse;
+    protected Collection<MemberInfo> memberInfos;
+    protected long masterTime = Clock.currentTimeMillis();
+    protected boolean sendResponse;
 
     public MemberInfoUpdateOperation() {
         memberInfos = new ArrayList<MemberInfo>();

--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/operations/TriggerMemberListPublishOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/operations/TriggerMemberListPublishOperation.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.cluster.impl.operations;
+
+import com.hazelcast.cluster.impl.ClusterServiceImpl;
+
+/**
+ * Requests member list publish from master node
+ */
+public class TriggerMemberListPublishOperation extends AbstractClusterOperation {
+
+    public TriggerMemberListPublishOperation() {
+    }
+
+    @Override
+    public void run() throws Exception {
+        final ClusterServiceImpl clusterService = getService();
+        clusterService.sendMemberListToMember(getCallerAddress());
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/SerializationServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/SerializationServiceImpl.java
@@ -50,7 +50,6 @@ import com.hazelcast.nio.serialization.DefaultSerializers.EnumSerializer;
 import com.hazelcast.nio.serialization.DefaultSerializers.Externalizer;
 import com.hazelcast.nio.serialization.DefaultSerializers.ObjectSerializer;
 import com.hazelcast.util.ConcurrentReferenceHashMap;
-
 import java.io.Externalizable;
 import java.io.IOException;
 import java.io.InputStream;
@@ -74,6 +73,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static java.lang.Boolean.parseBoolean;
+
 public class SerializationServiceImpl implements SerializationService {
 
     protected static final PartitioningStrategy EMPTY_PARTITIONING_STRATEGY = new PartitioningStrategy() {
@@ -83,6 +84,7 @@ public class SerializationServiceImpl implements SerializationService {
     };
 
     private static final int CONSTANT_SERIALIZERS_SIZE = SerializationConstants.CONSTANT_SERIALIZERS_LENGTH;
+    private static final String SERIALIZATION_CUSTOM_OVERRIDE = "hazelcast.serialization.custom.override";
 
     protected final ManagedContext managedContext;
     protected final PortableContext portableContext;
@@ -104,6 +106,8 @@ public class SerializationServiceImpl implements SerializationService {
     private final int outputBufferSize;
 
     private volatile boolean active = true;
+    private boolean overrideCustomSerialization;
+
 
     SerializationServiceImpl(InputOutputFactory inputOutputFactory, int version, ClassLoader classLoader,
                              Map<Integer, ? extends DataSerializableFactory> dataSerializableFactories,
@@ -117,6 +121,7 @@ public class SerializationServiceImpl implements SerializationService {
         this.managedContext = managedContext;
         this.globalPartitioningStrategy = partitionStrategy;
         this.outputBufferSize = initialOutputBufferSize;
+        this.overrideCustomSerialization = parseBoolean(System.getProperty(SERIALIZATION_CUSTOM_OVERRIDE, "false"));
 
         dataOutputQueue = new ThreadLocalOutputCache(this);
 
@@ -181,7 +186,7 @@ public class SerializationServiceImpl implements SerializationService {
     }
 
     private void registerClassDefinition(ClassDefinition cd, Map<Integer, ClassDefinition> classDefMap,
-            boolean checkClassDefErrors) {
+                                         boolean checkClassDefErrors) {
         for (int i = 0; i < cd.getFieldCount(); i++) {
             FieldDefinition fd = cd.getField(i);
             if (fd.getType() == FieldType.PORTABLE || fd.getType() == FieldType.PORTABLE_ARRAY) {
@@ -486,17 +491,30 @@ public class SerializationServiceImpl implements SerializationService {
     }
 
     protected final SerializerAdapter serializerFor(final Class type) {
+        SerializerAdapter serializer;
+        if (overrideCustomSerialization) {
+            serializer = lookupSerializer(type);
+            if (serializer != null) {
+                return serializer;
+            }
+        }
         if (DataSerializable.class.isAssignableFrom(type)) {
             return dataSerializerAdapter;
         } else if (Portable.class.isAssignableFrom(type)) {
             return portableSerializerAdapter;
         } else {
-            final SerializerAdapter serializer = constantTypesMap.get(type);
+            serializer = constantTypesMap.get(type);
             if (serializer != null) {
                 return serializer;
             }
         }
-        SerializerAdapter serializer = lookupSerializer(type);
+        serializer = lookupSerializer(type);
+        if (serializer == null) {
+            if (active) {
+                throw new HazelcastSerializationException("There is no suitable serializer for " + type);
+            }
+            throw new HazelcastInstanceNotActiveException();
+        }
         return serializer;
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/cluster/JoinStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/JoinStressTest.java
@@ -16,23 +16,26 @@
 
 package com.hazelcast.cluster;
 
+import com.hazelcast.cluster.impl.operations.MemberInfoUpdateOperation;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.JoinConfig;
 import com.hazelcast.config.MulticastConfig;
 import com.hazelcast.config.NetworkConfig;
+import com.hazelcast.config.SerializationConfig;
+import com.hazelcast.config.SerializerConfig;
 import com.hazelcast.config.TcpIpConfig;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.instance.HazelcastInstanceFactory;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.StreamSerializer;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.NightlyTest;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
-
+import com.hazelcast.test.annotation.Repeat;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -45,6 +48,11 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReferenceArray;
 import java.util.concurrent.locks.LockSupport;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -60,6 +68,7 @@ public class JoinStressTest extends HazelcastTestSupport {
     @Before
     @After
     public void tearDown() {
+        System.clearProperty("hazelcast.serialization.custom.override");
         HazelcastInstanceFactory.terminateAll();
     }
 
@@ -71,6 +80,38 @@ public class JoinStressTest extends HazelcastTestSupport {
     @Test
     public void testMulticastJoinWithManyNodes() throws InterruptedException {
         testJoinWithManyNodes(true);
+    }
+
+    @Repeat(50)
+    @Test
+    public void testJoincompletesCorrectlyWhenMultipleNodesStartedParallel() {
+        int count = 10;
+        final TestHazelcastInstanceFactory factory = new TestHazelcastInstanceFactory(count);
+        final HazelcastInstance[] instances = new HazelcastInstance[count];
+        final CountDownLatch latch = new CountDownLatch(count);
+        final Config config = new Config();
+        final SerializationConfig serializationConfig = new SerializationConfig();
+        final SerializerConfig serializerConfig = new SerializerConfig();
+        serializerConfig.setTypeClassName(MemberInfoUpdateOperation.class.getName());
+        serializerConfig.setImplementation(new MemberInfoUpdateOperationSerializer());
+        serializationConfig.addSerializerConfig(serializerConfig);
+        config.setSerializationConfig(serializationConfig);
+        System.setProperty("hazelcast.serialization.custom.override", "true");
+
+        for (int i = 0; i < count; i++) {
+            final int index = i;
+            new Thread(new Runnable() {
+                @Override
+                public void run() {
+                    instances[index] = factory.newHazelcastInstance(config);
+                    latch.countDown();
+                }
+            }).start();
+        }
+        assertOpenEventually(latch);
+        for (int i = 0; i < count; i++) {
+            assertClusterSize(count, instances[i]);
+        }
     }
 
     public void testJoinWithManyNodes(final boolean multicast) throws InterruptedException {
@@ -176,7 +217,7 @@ public class JoinStressTest extends HazelcastTestSupport {
     }
 
     private void initNetworkConfig(NetworkConfig networkConfig, int basePort, int portSeed,
-            boolean multicast, int nodeCount) {
+                                   boolean multicast, int nodeCount) {
 
         networkConfig.setPortAutoIncrement(false);
         networkConfig.setPort(basePort + portSeed);
@@ -197,6 +238,44 @@ public class JoinStressTest extends HazelcastTestSupport {
         }
         Collections.sort(members);
         tcpIpConfig.setMembers(members);
+    }
+
+    public class MemberInfoUpdateOperationSerializer implements StreamSerializer<MemberInfoUpdateOperation> {
+        @Override
+        public void write(ObjectDataOutput out, MemberInfoUpdateOperation object) throws IOException {
+            object.writeData(out);
+        }
+
+        @Override
+        public MemberInfoUpdateOperation read(ObjectDataInput in) throws IOException {
+            final DelayedMemberInfoUpdateOperation operation = new DelayedMemberInfoUpdateOperation();
+            operation.readData(in);
+            return operation;
+        }
+
+        @Override
+        public int getTypeId() {
+            return 9999;
+        }
+
+        @Override
+        public void destroy() {
+
+        }
+    }
+
+    public static class DelayedMemberInfoUpdateOperation extends MemberInfoUpdateOperation {
+
+        public DelayedMemberInfoUpdateOperation() {
+        }
+
+        @Override
+        public void run() throws Exception {
+            if (memberInfos.size() == 3 && getNodeEngine().getThisAddress().getPort() % 3 == 0) {
+                Thread.sleep(500);
+            }
+            super.run();
+        }
     }
 
 }

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/CustomSerializationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/CustomSerializationTest.java
@@ -22,22 +22,28 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
-
 import java.beans.XMLDecoder;
 import java.beans.XMLEncoder;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteOrder;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import static junit.framework.Assert.assertEquals;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
 public class CustomSerializationTest {
+
+    @After
+    public void cleanup() {
+        System.clearProperty("hazelcast.serialization.custom.override");
+    }
 
     @Test
     public void testSerializer() throws Exception {
@@ -57,6 +63,37 @@ public class CustomSerializationTest {
     @Test
     public void testSerializerNativeOrderUsingUnsafe() throws Exception {
         testSerializer(ByteOrder.nativeOrder(), true);
+    }
+
+    @Test
+    public void testSerializerOverridenHierarchyWhenEnabled() throws Exception {
+        System.setProperty("hazelcast.serialization.custom.override", "true");
+        SerializationConfig config = new SerializationConfig();
+        FooXmlSerializer serializer = new FooXmlSerializer();
+        SerializerConfig sc = new SerializerConfig()
+                .setImplementation(serializer)
+                .setTypeClass(FooDataSerializable.class);
+        config.addSerializerConfig(sc);
+        SerializationService ss = new DefaultSerializationServiceBuilder().setConfig(config).build();
+        FooDataSerializable foo = new FooDataSerializable("foo");
+        ss.toData(foo);
+        assertEquals(0, foo.serializationCount.get());
+        assertEquals(1, serializer.serializationCount.get());
+    }
+
+    @Test
+    public void testSerializerOverridenHierarchyWhenDisabled() throws Exception {
+        SerializationConfig config = new SerializationConfig();
+        FooXmlSerializer serializer = new FooXmlSerializer();
+        SerializerConfig sc = new SerializerConfig()
+                .setImplementation(serializer)
+                .setTypeClass(FooDataSerializable.class);
+        config.addSerializerConfig(sc);
+        SerializationService ss = new DefaultSerializationServiceBuilder().setConfig(config).build();
+        FooDataSerializable foo = new FooDataSerializable("foo");
+        ss.toData(foo);
+        assertEquals(1, foo.serializationCount.get());
+        assertEquals(0, serializer.serializationCount.get());
     }
 
     private void testSerializer(ByteOrder order, boolean allowUnsafe) throws Exception {
@@ -87,7 +124,65 @@ public class CustomSerializationTest {
         }
     }
 
+    public static class FooDataSerializable extends Foo implements DataSerializable {
+
+        AtomicInteger serializationCount = new AtomicInteger();
+        private String foo;
+
+        public FooDataSerializable() {
+        }
+
+        public FooDataSerializable(String foo) {
+            this.foo = foo;
+        }
+
+        public String getFoo() {
+            return foo;
+        }
+
+        public void setFoo(String foo) {
+            this.foo = foo;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            Foo foo1 = (Foo) o;
+
+            return !(foo != null ? !foo.equals(foo1.foo) : foo1.foo != null);
+
+        }
+
+        @Override
+        public int hashCode() {
+            return foo != null ? foo.hashCode() : 0;
+        }
+
+        @Override
+        public void writeData(ObjectDataOutput out) throws IOException {
+            serializationCount.incrementAndGet();
+            out.writeUTF(foo);
+        }
+
+        @Override
+        public void readData(ObjectDataInput in) throws IOException {
+            foo = in.readUTF();
+        }
+
+        @Override
+        public String toString() {
+            return "FooDataSerializable{" +
+                    "foo='" + foo + '\'' +
+                    '}';
+        }
+    }
+
+
     public static class FooXmlSerializer implements StreamSerializer<Foo> {
+
+        AtomicInteger serializationCount = new AtomicInteger();
 
         @Override
         public int getTypeId() {
@@ -96,6 +191,7 @@ public class CustomSerializationTest {
 
         @Override
         public void write(ObjectDataOutput out, Foo object) throws IOException {
+            serializationCount.incrementAndGet();
             ByteArrayOutputStream bos = new ByteArrayOutputStream();
             XMLEncoder encoder = new XMLEncoder(bos);
             encoder.writeObject(object);


### PR DESCRIPTION
Ordering problem solved when receiving member list updates from master node that leads to an inconsistent member-list views across cluster members by ignoring and requesting new member-list from master when an inconsistency happens. Fixes #5393