### PR TITLE
Enabled thread dump on test failure

### DIFF
--- a/hazelcast-ra/hazelcast-jca/pom.xml
+++ b/hazelcast-ra/hazelcast-jca/pom.xml
@@ -100,12 +100,6 @@
     </dependencyManagement>
     <dependencies>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.8.1</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.jboss.arquillian.junit</groupId>
             <artifactId>arquillian-junit-container</artifactId>
             <scope>test</scope>

--- a/hazelcast-ra/hazelcast-jca/src/test/java/com/hazelcast/jca/XATestWithJCA.java
+++ b/hazelcast-ra/hazelcast-jca/src/test/java/com/hazelcast/jca/XATestWithJCA.java
@@ -20,12 +20,11 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.core.TransactionalMap;
 import com.hazelcast.test.HazelcastParallelClassRunner;
-import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.QuickTest;
-import com.hazelcast.test.annotation.SlowTest;
 import com.hazelcast.transaction.impl.xa.SerializableXID;
 import com.hazelcast.util.ExceptionUtil;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -142,6 +141,5 @@ public class XATestWithJCA extends HazelcastTestSupport {
 
         }
     }
-
 
 }

--- a/hazelcast/src/test/java/com/hazelcast/test/AbstractHazelcastClassRunner.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/AbstractHazelcastClassRunner.java
@@ -40,7 +40,8 @@ import org.junit.runners.model.Statement;
  */
 public abstract class AbstractHazelcastClassRunner extends AbstractParameterizedHazelcastClassRunner {
 
-    protected static final boolean DISABLE_THREAD_DUMP_ON_FAILURE = true;
+    protected static final boolean DISABLE_THREAD_DUMP_ON_FAILURE =
+            Boolean.getBoolean("hazelcast.test.disableThreadDumpOnFailure");
 
     static {
         final String logging = "hazelcast.logging.type";


### PR DESCRIPTION
- Enabled thread dump on test failure by default and it can be disabled by   
`-Dhazelcast.test.disableThreadDumpOnFailure=true`
- Removed junit dependency from jca module since its version was different from parent