### PR TITLE
Near-cache invalidation event batching implementation

### DIFF
--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/cache/impl/AbstractClientInternalCacheProxy.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/cache/impl/AbstractClientInternalCacheProxy.java
@@ -589,6 +589,19 @@ abstract class AbstractClientInternalCacheProxy<K, V>
         }
 
         @Override
+        public void handle(String name, Collection<Data> keys, Collection<String> sourceUuids) {
+            Iterator<Data> keysIt = keys.iterator();
+            Iterator<String> sourceUuidsIt = sourceUuids.iterator();
+            while (keysIt.hasNext() && sourceUuidsIt.hasNext()) {
+                Data key = keysIt.next();
+                String sourceUuid = sourceUuidsIt.next();
+                if (!client.getUuid().equals(sourceUuid)) {
+                    nearCache.invalidate(key);
+                }
+            }
+        }
+
+        @Override
         public void beforeListenerRegister() {
 
         }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CachePortableHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CachePortableHook.java
@@ -18,6 +18,7 @@ package com.hazelcast.cache.impl;
 
 import com.hazelcast.cache.impl.client.CacheAddEntryListenerRequest;
 import com.hazelcast.cache.impl.client.CacheAddInvalidationListenerRequest;
+import com.hazelcast.cache.impl.client.CacheBatchInvalidationMessage;
 import com.hazelcast.cache.impl.client.CacheClearRequest;
 import com.hazelcast.cache.impl.client.CacheContainsKeyRequest;
 import com.hazelcast.cache.impl.client.CacheCreateConfigRequest;
@@ -28,7 +29,6 @@ import com.hazelcast.cache.impl.client.CacheGetAndRemoveRequest;
 import com.hazelcast.cache.impl.client.CacheGetAndReplaceRequest;
 import com.hazelcast.cache.impl.client.CacheGetConfigRequest;
 import com.hazelcast.cache.impl.client.CacheGetRequest;
-import com.hazelcast.cache.impl.client.CacheInvalidationMessage;
 import com.hazelcast.cache.impl.client.CacheIterateRequest;
 import com.hazelcast.cache.impl.client.CacheListenerRegistrationRequest;
 import com.hazelcast.cache.impl.client.CacheLoadAllRequest;
@@ -39,6 +39,7 @@ import com.hazelcast.cache.impl.client.CacheRemoveEntryListenerRequest;
 import com.hazelcast.cache.impl.client.CacheRemoveInvalidationListenerRequest;
 import com.hazelcast.cache.impl.client.CacheRemoveRequest;
 import com.hazelcast.cache.impl.client.CacheReplaceRequest;
+import com.hazelcast.cache.impl.client.CacheSingleInvalidationMessage;
 import com.hazelcast.cache.impl.client.CacheSizeRequest;
 import com.hazelcast.nio.serialization.ClassDefinition;
 import com.hazelcast.nio.serialization.FactoryIdHelper;
@@ -73,7 +74,7 @@ public class CachePortableHook
     public static final int ADD_INVALIDATION_LISTENER = 12;
     public static final int INVALIDATION_MESSAGE = 13;
     public static final int REMOVE_INVALIDATION_LISTENER = 14;
-    public static final int SEND_STATS = 15;
+    public static final int BATCH_INVALIDATION_MESSAGE = 15;
     public static final int CREATE_CONFIG = 16;
     public static final int GET_CONFIG = 17;
     public static final int GET_ALL = 18;
@@ -158,12 +159,17 @@ public class CachePortableHook
                 };
                 constructors[INVALIDATION_MESSAGE] = new ConstructorFunction<Integer, Portable>() {
                     public Portable createNew(Integer arg) {
-                        return new CacheInvalidationMessage();
+                        return new CacheSingleInvalidationMessage();
                     }
                 };
                 constructors[REMOVE_INVALIDATION_LISTENER] = new ConstructorFunction<Integer, Portable>() {
                     public Portable createNew(Integer arg) {
                         return new CacheRemoveInvalidationListenerRequest();
+                    }
+                };
+                constructors[BATCH_INVALIDATION_MESSAGE] = new ConstructorFunction<Integer, Portable>() {
+                    public Portable createNew(Integer arg) {
+                        return new CacheBatchInvalidationMessage();
                     }
                 };
                 constructors[CREATE_CONFIG] = new ConstructorFunction<Integer, Portable>() {

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheService.java
@@ -16,17 +16,28 @@
 
 package com.hazelcast.cache.impl;
 
+import com.hazelcast.cache.impl.client.CacheBatchInvalidationMessage;
 import com.hazelcast.cache.impl.client.CacheInvalidationListener;
-import com.hazelcast.cache.impl.client.CacheInvalidationMessage;
+import com.hazelcast.cache.impl.client.CacheSingleInvalidationMessage;
 import com.hazelcast.cache.impl.operation.CacheReplicationOperation;
 import com.hazelcast.nio.serialization.Data;
 
 import com.hazelcast.spi.EventRegistration;
 import com.hazelcast.spi.EventService;
+import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.PartitionReplicationEvent;
 
 import java.util.Collection;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Cache Service is the main access point of JCache implementation.
@@ -55,8 +66,35 @@ import java.util.Collection;
  */
 public class CacheService extends AbstractCacheService {
 
+    protected boolean invalidationMessageBatchEnabled;
+    protected int invalidationMessageBatchSize;
+    protected final ConcurrentMap<String, Queue<CacheSingleInvalidationMessage>> invalidationMessageMap =
+            new ConcurrentHashMap<String, Queue<CacheSingleInvalidationMessage>>();
+    protected ScheduledFuture cacheBatchInvalidationMessageSenderScheduler;
+    protected final AtomicBoolean cacheBatchInvalidationMessageSenderInProgress = new AtomicBoolean(false);
+
     protected ICacheRecordStore createNewRecordStore(String name, int partitionId) {
         return new CacheRecordStore(name, partitionId, nodeEngine, CacheService.this);
+    }
+
+    @Override
+    protected void postInit(NodeEngine nodeEngine, Properties properties) {
+        super.postInit(nodeEngine, properties);
+        invalidationMessageBatchEnabled =
+                nodeEngine.getGroupProperties().CACHE_INVALIDATION_MESSAGE_BATCH_ENABLED.getBoolean();
+        if (invalidationMessageBatchEnabled) {
+            invalidationMessageBatchSize =
+                    nodeEngine.getGroupProperties().CACHE_INVALIDATION_MESSAGE_BATCH_SIZE.getInteger();
+            int invalidationMessageBatchFreq =
+                    nodeEngine.getGroupProperties().CACHE_INVALIDATION_MESSAGE_BATCH_FREQUENCY_SECONDS.getInteger();
+            cacheBatchInvalidationMessageSenderScheduler =
+                    nodeEngine.getExecutionService()
+                            .scheduleAtFixedRate(SERVICE_NAME + ":cacheBatchInvalidationMessageSender",
+                                    new CacheBatchInvalidationMessageSender(),
+                                    invalidationMessageBatchFreq,
+                                    invalidationMessageBatchFreq,
+                                    TimeUnit.SECONDS);
+        }
     }
 
     @Override
@@ -75,6 +113,9 @@ public class CacheService extends AbstractCacheService {
     @Override
     public void shutdown(boolean terminate) {
         if (!terminate) {
+            if (cacheBatchInvalidationMessageSenderScheduler != null) {
+                cacheBatchInvalidationMessageSenderScheduler.cancel(true);
+            }
             reset();
         }
     }
@@ -111,14 +152,93 @@ public class CacheService extends AbstractCacheService {
      */
     @Override
     public void sendInvalidationEvent(String name, Data key, String sourceUuid) {
+        if (key == null) {
+            sendSingleInvalidationEvent(name, key, sourceUuid);
+        } else {
+            if (invalidationMessageBatchEnabled) {
+                sendBatchInvalidationEvent(name, key, sourceUuid);
+            } else {
+                sendSingleInvalidationEvent(name, key, sourceUuid);
+            }
+        }
+    }
+
+    protected void sendSingleInvalidationEvent(String name, Data key, String sourceUuid) {
         EventService eventService = nodeEngine.getEventService();
         Collection<EventRegistration> registrations = eventService.getRegistrations(SERVICE_NAME, name);
         if (!registrations.isEmpty()) {
-            // TODO fix below for client protocol
+            //TODO Fix below for client protocol
             eventService.publishEvent(SERVICE_NAME, registrations,
-                    new CacheInvalidationMessage(name, key, sourceUuid), name.hashCode());
+                    new CacheSingleInvalidationMessage(name, key, sourceUuid), name.hashCode());
 
         }
+    }
+
+    protected void sendBatchInvalidationEvent(String name, Data key, String sourceUuid) {
+        EventService eventService = nodeEngine.getEventService();
+        Collection<EventRegistration> registrations = eventService.getRegistrations(SERVICE_NAME, name);
+        if (registrations.isEmpty()) {
+            return;
+        }
+        Queue<CacheSingleInvalidationMessage> invalidationMessageQueue =
+                invalidationMessageMap.get(name);
+        if (invalidationMessageQueue == null) {
+            Queue<CacheSingleInvalidationMessage> newInvalidationMessageQueue =
+                    new ConcurrentLinkedQueue<CacheSingleInvalidationMessage>();
+            invalidationMessageQueue = invalidationMessageMap.putIfAbsent(name, newInvalidationMessageQueue);
+            if (invalidationMessageQueue == null) {
+                invalidationMessageQueue = newInvalidationMessageQueue;
+            }
+        }
+        CacheSingleInvalidationMessage invalidationMessage = new CacheSingleInvalidationMessage(name, key, sourceUuid);
+        invalidationMessageQueue.offer(invalidationMessage);
+        if (invalidationMessageQueue.size() >= invalidationMessageBatchSize) {
+            flushInvalidationMessages(name, invalidationMessageQueue);
+        }
+    }
+
+    protected void flushInvalidationMessages(String cacheName,
+                                             Queue<CacheSingleInvalidationMessage> invalidationMessageQueue) {
+        CacheBatchInvalidationMessage batchInvalidationMessage =
+                new CacheBatchInvalidationMessage(cacheName, invalidationMessageQueue.size());
+        CacheSingleInvalidationMessage invalidationMessage;
+        while ((invalidationMessage = invalidationMessageQueue.poll()) != null) {
+            batchInvalidationMessage.addInvalidationMessage(invalidationMessage);
+        }
+        EventService eventService = nodeEngine.getEventService();
+        Collection<EventRegistration> registrations = eventService.getRegistrations(SERVICE_NAME, cacheName);
+        if (!registrations.isEmpty()) {
+            // TODO fix below for client protocol
+            eventService.publishEvent(SERVICE_NAME, registrations,
+                    batchInvalidationMessage, cacheName.hashCode());
+
+        }
+    }
+
+    protected class CacheBatchInvalidationMessageSender implements Runnable {
+
+        @Override
+        public void run() {
+            // If still in progress, no need to another attempt. So just ignore.
+            if (cacheBatchInvalidationMessageSenderInProgress.compareAndSet(false, true)) {
+                try {
+                    for (Map.Entry<String, Queue<CacheSingleInvalidationMessage>> entry
+                            : invalidationMessageMap.entrySet()) {
+                        if (Thread.currentThread().isInterrupted()) {
+                            break;
+                        }
+                        String cacheName = entry.getKey();
+                        Queue<CacheSingleInvalidationMessage> invalidationMessageQueue = entry.getValue();
+                        if (invalidationMessageQueue.size() > 0) {
+                            flushInvalidationMessages(cacheName, invalidationMessageQueue);
+                        }
+                    }
+                } finally {
+                    cacheBatchInvalidationMessageSenderInProgress.set(false);
+                }
+            }
+        }
+
     }
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/client/CacheBatchInvalidationMessage.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/client/CacheBatchInvalidationMessage.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.cache.impl.client;
+
+import com.hazelcast.cache.impl.CachePortableHook;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.PortableReader;
+import com.hazelcast.nio.serialization.PortableWriter;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class CacheBatchInvalidationMessage extends CacheInvalidationMessage {
+
+    private List<CacheSingleInvalidationMessage> invalidationMessages;
+
+    public CacheBatchInvalidationMessage() {
+
+    }
+
+    public CacheBatchInvalidationMessage(String name) {
+        super(name);
+        this.invalidationMessages = new ArrayList<CacheSingleInvalidationMessage>();
+    }
+
+    public CacheBatchInvalidationMessage(String name, int expectedMessageCount) {
+        super(name);
+        this.invalidationMessages = new ArrayList<CacheSingleInvalidationMessage>(expectedMessageCount);
+    }
+
+    public CacheBatchInvalidationMessage(String name,
+                                         List<CacheSingleInvalidationMessage> invalidationMessages) {
+        super(name);
+        assert invalidationMessages != null : "Invalid invalidation messages: " + invalidationMessages;
+        this.invalidationMessages = invalidationMessages;
+    }
+
+    public CacheBatchInvalidationMessage addInvalidationMessage(CacheSingleInvalidationMessage invalidationMessage) {
+        invalidationMessages.add(invalidationMessage);
+        return this;
+    }
+
+    public List<CacheSingleInvalidationMessage> getInvalidationMessages() {
+        return invalidationMessages;
+    }
+
+    @Override
+    public int getClassId() {
+        return CachePortableHook.BATCH_INVALIDATION_MESSAGE;
+    }
+
+    @Override
+    public void writePortable(PortableWriter writer) throws IOException {
+        super.writePortable(writer);
+        ObjectDataOutput out = writer.getRawDataOutput();
+        boolean hasInvalidationMessages = invalidationMessages != null;
+        out.writeBoolean(hasInvalidationMessages);
+        if (hasInvalidationMessages) {
+            out.writeInt(invalidationMessages.size());
+            for (CacheSingleInvalidationMessage invalidationMessage : invalidationMessages) {
+                out.writeObject(invalidationMessage);
+            }
+        }
+    }
+
+    @Override
+    public void readPortable(PortableReader reader) throws IOException {
+        super.readPortable(reader);
+        ObjectDataInput in = reader.getRawDataInput();
+        if (in.readBoolean()) {
+            int size = in.readInt();
+            invalidationMessages = new ArrayList<CacheSingleInvalidationMessage>(size);
+            for (int i = 0; i < size; i++) {
+                invalidationMessages.add((CacheSingleInvalidationMessage) in.readObject());
+            }
+        }
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder("CacheBatchInvalidationMessage{");
+        sb.append("name='").append(name).append('\'');
+        sb.append(", invalidationMessages=").append(invalidationMessages);
+        sb.append('}');
+        return sb.toString();
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/client/CacheInvalidationListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/client/CacheInvalidationListener.java
@@ -34,8 +34,7 @@ public final class CacheInvalidationListener implements CacheEventListener {
         if (eventObject instanceof CacheInvalidationMessage) {
             CacheInvalidationMessage message = (CacheInvalidationMessage) eventObject;
             if (endpoint.isAlive()) {
-                endpoint.sendEvent(message.getKey(), message, callId);
-
+                endpoint.sendEvent(message.getName(), message, callId);
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/client/CacheInvalidationMessage.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/client/CacheInvalidationMessage.java
@@ -17,8 +17,6 @@
 package com.hazelcast.cache.impl.client;
 
 import com.hazelcast.cache.impl.CachePortableHook;
-import com.hazelcast.nio.ObjectDataInput;
-import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.Portable;
 import com.hazelcast.nio.serialization.PortableReader;
@@ -26,21 +24,16 @@ import com.hazelcast.nio.serialization.PortableWriter;
 
 import java.io.IOException;
 
-public class CacheInvalidationMessage implements Portable {
+public abstract class CacheInvalidationMessage implements Portable {
 
-    private String name;
-    private Data key;
-    private String sourceUuid;
+    protected String name;
 
     public CacheInvalidationMessage() {
 
     }
 
-    public CacheInvalidationMessage(String name, Data key, String sourceUuid) {
-        assert key == null || key.dataSize() > 0 : "Invalid invalidation key: " + key;
+    public CacheInvalidationMessage(String name) {
         this.name = name;
-        this.key = key;
-        this.sourceUuid = sourceUuid;
     }
 
     public String getName() {
@@ -48,11 +41,11 @@ public class CacheInvalidationMessage implements Portable {
     }
 
     public Data getKey() {
-        return key;
+        return null;
     }
 
     public String getSourceUuid() {
-        return sourceUuid;
+        return null;
     }
 
     @Override
@@ -61,40 +54,13 @@ public class CacheInvalidationMessage implements Portable {
     }
 
     @Override
-    public int getClassId() {
-        return CachePortableHook.INVALIDATION_MESSAGE;
-    }
-
-    @Override
     public void writePortable(PortableWriter writer) throws IOException {
         writer.writeUTF("n", name);
-        writer.writeUTF("uuid", sourceUuid);
-        ObjectDataOutput out = writer.getRawDataOutput();
-        boolean hasKey = key != null;
-        out.writeBoolean(hasKey);
-        if (hasKey) {
-            out.writeData(key);
-        }
     }
 
     @Override
     public void readPortable(PortableReader reader) throws IOException {
         name = reader.readUTF("n");
-        sourceUuid = reader.readUTF("uuid");
-        ObjectDataInput in = reader.getRawDataInput();
-        if (in.readBoolean()) {
-            key = in.readData();
-        }
-    }
-
-    @Override
-    public String toString() {
-        final StringBuilder sb = new StringBuilder("CacheInvalidationMessage{");
-        sb.append("name='").append(name).append('\'');
-        sb.append(", key=").append(key);
-        sb.append(", sourceUuid='").append(sourceUuid).append('\'');
-        sb.append('}');
-        return sb.toString();
     }
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/client/CacheSingleInvalidationMessage.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/client/CacheSingleInvalidationMessage.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.cache.impl.client;
+
+import com.hazelcast.cache.impl.CachePortableHook;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.nio.serialization.PortableReader;
+import com.hazelcast.nio.serialization.PortableWriter;
+
+import java.io.IOException;
+
+public class CacheSingleInvalidationMessage extends CacheInvalidationMessage {
+
+    private Data key;
+    private String sourceUuid;
+
+    public CacheSingleInvalidationMessage() {
+
+    }
+
+    public CacheSingleInvalidationMessage(String name, Data key, String sourceUuid) {
+        super(name);
+        assert key == null || key.dataSize() > 0 : "Invalid invalidation key: " + key;
+        assert sourceUuid != null : "Invalid source UUID: " + sourceUuid;
+        this.key = key;
+        this.sourceUuid = sourceUuid;
+    }
+
+    @Override
+    public Data getKey() {
+        return key;
+    }
+
+    public String getSourceUuid() {
+        return sourceUuid;
+    }
+
+    @Override
+    public int getClassId() {
+        return CachePortableHook.INVALIDATION_MESSAGE;
+    }
+
+    @Override
+    public void writePortable(PortableWriter writer) throws IOException {
+        super.writePortable(writer);
+        writer.writeUTF("uuid", sourceUuid);
+        ObjectDataOutput out = writer.getRawDataOutput();
+        boolean hasKey = key != null;
+        out.writeBoolean(hasKey);
+        if (hasKey) {
+            out.writeData(key);
+        }
+    }
+
+    @Override
+    public void readPortable(PortableReader reader) throws IOException {
+        super.readPortable(reader);
+        sourceUuid = reader.readUTF("uuid");
+        ObjectDataInput in = reader.getRawDataInput();
+        if (in.readBoolean()) {
+            key = in.readData();
+        }
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder("CacheSingleInvalidationMessage{");
+        sb.append("name='").append(name).append('\'');
+        sb.append(", key=").append(key);
+        sb.append(", sourceUuid='").append(sourceUuid).append('\'');
+        sb.append('}');
+        return sb.toString();
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/EventMessageConst.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/EventMessageConst.java
@@ -43,4 +43,5 @@ public final class EventMessageConst {
     public static final int EVENT_CACHEINVALIDATION = 208;
     public static final int EVENT_MAPPARTITIONLOST = 209;
     public static final int EVENT_CACHE = 210;
+    public static final int EVENT_CACHEBATCHINVALIDATION = 211;
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/CacheCodecTemplate.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/CacheCodecTemplate.java
@@ -32,8 +32,8 @@ public interface CacheCodecTemplate {
     @Request(id = 1, retryable = true, response = ResponseMessageConst.STRING, event = {EventMessageConst.EVENT_CACHE})
     void addEntryListener(String name);
 
-    @Request(id = 2, retryable = true, response = ResponseMessageConst.STRING,
-            event = {EventMessageConst.EVENT_CACHEINVALIDATION})
+    @Request(id = 2, retryable = false, response = ResponseMessageConst.STRING,
+            event = {EventMessageConst.EVENT_CACHEINVALIDATION, EventMessageConst.EVENT_CACHEBATCHINVALIDATION})
     void addInvalidationListener(String name);
 
     @Request(id = 3, retryable = false, response = ResponseMessageConst.VOID)

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/EventResponseTemplate.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/EventResponseTemplate.java
@@ -27,6 +27,7 @@ import com.hazelcast.nio.Address;
 import com.hazelcast.nio.serialization.Data;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -62,6 +63,9 @@ public interface EventResponseTemplate {
 
     @EventResponse(EventMessageConst.EVENT_CACHEINVALIDATION)
     void CacheInvalidation(String name, @Nullable Data key, String sourceUuid);
+
+    @EventResponse(EventMessageConst.EVENT_CACHEBATCHINVALIDATION)
+    void CacheBatchInvalidation(String name, List<Data> keys, List<String> sourceUuids);
 
     @EventResponse(EventMessageConst.EVENT_MAPPARTITIONLOST)
     void MapPartitionLost(int partitionId, String uuid);

--- a/hazelcast/src/main/java/com/hazelcast/instance/GroupProperties.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/GroupProperties.java
@@ -248,16 +248,37 @@ public class GroupProperties {
             = "hazelcast.enterprise.wanrep.batchfrequency.seconds";
 
     /**
+     * Defines cache invalidation event batch sending is enabled or not.
+     */
+    public static final String PROP_CACHE_INVALIDATION_MESSAGE_BATCH_ENABLED
+            = "hazelcast.cache.invalidation.batch.enabled";
+
+    /**
+     * Defines the maximum number of cache invalidation events to be drained and sent to the event listeners in a batch.
+     */
+    public static final String PROP_CACHE_INVALIDATION_MESSAGE_BATCH_SIZE
+            = "hazelcast.cache.invalidation.batch.size";
+
+    /**
+     * Defines cache invalidation event batch sending frequency in seconds.
+     * When event size does not reach to {@link #PROP_CACHE_INVALIDATION_MESSAGE_BATCH_SIZE} in the given time period
+     * (which is defined by {@link #PROP_CACHE_INVALIDATION_MESSAGE_BATCH_FREQUENCY_SECONDS}),
+     * those events are gathered into a batch and sent to target.
+     */
+    public static final String PROP_CACHE_INVALIDATION_MESSAGE_BATCH_FREQUENCY_SECONDS
+            = "hazelcast.cache.invalidation.batchfrequency.seconds";
+
+    /**
      * Defines timeout duration (in milliseconds) for a WAN replication event before retry.
      * If confirmation is not received in the period of timeout duration, event is resent to target cluster.
      * Only valid for Hazelcast Enterprise
      */
-    public static final String PROP_ENTERPRISE_WAN_REP_OP_TIMEOUT_MILLIS = "hazelcast.enterprise.wanrep.optimeout.millis";
+    public static final String PROP_ENTERPRISE_WAN_REP_OP_TIMEOUT_MILLIS
+            = "hazelcast.enterprise.wanrep.optimeout.millis";
 
     public static final String PROP_CLIENT_MAX_NO_HEARTBEAT_SECONDS = "hazelcast.client.max.no.heartbeat.seconds";
     public static final String PROP_MIGRATION_MIN_DELAY_ON_MEMBER_REMOVED_SECONDS
             = "hazelcast.migration.min.delay.on.member.removed.seconds";
-
 
     /**
      * Using back pressure, you can prevent an overload of pending asynchronous backups. With a map with a
@@ -546,6 +567,10 @@ public class GroupProperties {
     public final GroupProperty ENTERPRISE_WAN_REP_BATCH_FREQUENCY_SECONDS;
     public final GroupProperty ENTERPRISE_WAN_REP_OP_TIMEOUT_MILLIS;
 
+    public final GroupProperty CACHE_INVALIDATION_MESSAGE_BATCH_ENABLED;
+    public final GroupProperty CACHE_INVALIDATION_MESSAGE_BATCH_SIZE;
+    public final GroupProperty CACHE_INVALIDATION_MESSAGE_BATCH_FREQUENCY_SECONDS;
+
     public final GroupProperty CLIENT_HEARTBEAT_TIMEOUT_SECONDS;
 
     public final GroupProperty MIGRATION_MIN_DELAY_ON_MEMBER_REMOVED_SECONDS;
@@ -666,6 +691,13 @@ public class GroupProperties {
         ENTERPRISE_WAN_REP_BATCH_FREQUENCY_SECONDS
                 = new GroupProperty(config, PROP_ENTERPRISE_WAN_REP_BATCH_FREQUENCY_SECONDS, "5");
         ENTERPRISE_WAN_REP_OP_TIMEOUT_MILLIS = new GroupProperty(config, PROP_ENTERPRISE_WAN_REP_OP_TIMEOUT_MILLIS, "60000");
+
+        CACHE_INVALIDATION_MESSAGE_BATCH_ENABLED
+                = new GroupProperty(config, PROP_CACHE_INVALIDATION_MESSAGE_BATCH_ENABLED, "true");
+        CACHE_INVALIDATION_MESSAGE_BATCH_SIZE
+                = new GroupProperty(config, PROP_CACHE_INVALIDATION_MESSAGE_BATCH_SIZE, "100");
+        CACHE_INVALIDATION_MESSAGE_BATCH_FREQUENCY_SECONDS
+                = new GroupProperty(config, PROP_CACHE_INVALIDATION_MESSAGE_BATCH_FREQUENCY_SECONDS, "10");
 
         CLIENT_HEARTBEAT_TIMEOUT_SECONDS = new GroupProperty(config, PROP_CLIENT_MAX_NO_HEARTBEAT_SECONDS, "300");
         MIGRATION_MIN_DELAY_ON_MEMBER_REMOVED_SECONDS


### PR DESCRIPTION
- Sends near-cache invalidation events as batch to client if event batching is enabled (`hazelcast.cache.invalidation.batch.enabled`). 
- Events are sent to client when the event count is reached to max size (`hazelcast.cache.invalidation.batch.size`) or batch event sender tasks flushes the invalidation event queue in its period (`hazelcast.cache.invalidation.batchfrequency.seconds`)