### PR TITLE
MD5Util test coverage increased

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/util/MD5UtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/MD5UtilTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.util;
+
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+
+import static org.junit.Assert.assertEquals;
+
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class MD5UtilTest {
+
+    @Test
+    public void testToMD5String() {
+        String result = MD5Util.toMD5String("hazelcast");
+        assertEquals("58c304267fc3edac49d35c395f0fbc0f", result);
+    }
+
+    @Test
+    public void testToMD5String_whenNullString() {
+        String str = null;
+        String result = MD5Util.toMD5String(str);
+        assertEquals("NULL", result);
+    }
+
+}


### PR DESCRIPTION
I check `toMD5String` function against a hard coded MD5 String. Let me know if there is a better way.