### PR TITLE
Longer timeout of DistributedObjectDestroyOperation

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/ProxyServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/ProxyServiceImpl.java
@@ -58,10 +58,10 @@ public class ProxyServiceImpl
 
     public static final String SERVICE_NAME = "hz:core:proxyService";
 
-    private static final FutureUtil.ExceptionHandler DESTROY_PROXY_EXCEPTION_HANDLER = FutureUtil.logAllExceptions(Level.FINEST);
+    private static final FutureUtil.ExceptionHandler DESTROY_PROXY_EXCEPTION_HANDLER = FutureUtil.logAllExceptions(Level.WARNING);
 
     private static final int TRY_COUNT = 10;
-    private static final long TIME = 3;
+    private static final long DESTROY_TIMEOUT_SECONDS = 30;
 
     final NodeEngineImpl nodeEngine;
     final ILogger logger;
@@ -140,7 +140,7 @@ public class ProxyServiceImpl
 
         destroyLocalDistributedObject(serviceName, name, true);
 
-        waitWithDeadline(calls, TIME, TimeUnit.SECONDS, DESTROY_PROXY_EXCEPTION_HANDLER);
+        waitWithDeadline(calls, DESTROY_TIMEOUT_SECONDS, TimeUnit.SECONDS, DESTROY_PROXY_EXCEPTION_HANDLER);
     }
 
     public void destroyLocalDistributedObject(String serviceName, String name, boolean fireEvent) {


### PR DESCRIPTION
Forward fix for #5035
See 8dad05f3dd4d8e539d606809acdda15c2e874007 for a reproducer.

In a nutshell:
The test destroys a map, creates it again an expects each member will call loadAllKeys on a MapLoader.

However it waits just 3 seconds for a response of DistributedObjectDestroyOperation. If the response is slower
then it carries on -> it means the test will work with the old map which has not been destroyed yet
-> the getAllKeys won't be called -> assertion failure.

The  3 seconds timeout seems to really short to me. I'm increasing it to 30 seconds.
Moreover I'm increasing a log level as I don't think a missing response is a business as usual.