### PR TITLE
Fixed a bug in outbound ports parser

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/instance/DefaultNodeContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/DefaultNodeContext.java
@@ -37,7 +37,7 @@ public class DefaultNodeContext implements NodeContext {
 
     @Override
     public ConnectionManager createConnectionManager(Node node, ServerSocketChannel serverSocketChannel) {
-        NodeIOService ioService = new NodeIOService(node);
+        NodeIOService ioService = new NodeIOService(node, node.nodeEngine);
         return new TcpIpConnectionManager(ioService, serverSocketChannel, node.getHazelcastThreadGroup(), node.loggingService);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/nio/NodeIOService.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/NodeIOService.java
@@ -49,9 +49,9 @@ public class NodeIOService implements IOService {
     private final NodeEngineImpl nodeEngine;
     private final PacketTransceiver packetTransceiver;
 
-    public NodeIOService(Node node) {
+    public NodeIOService(Node node, NodeEngineImpl nodeEngine) {
         this.node = node;
-        this.nodeEngine = node.nodeEngine;
+        this.nodeEngine = nodeEngine;
         this.packetTransceiver = nodeEngine.getPacketTransceiver();
     }
 
@@ -321,6 +321,9 @@ public class NodeIOService implements IOService {
             String[] portDefs = portDef.split("[,; ]");
             for (String def : portDefs) {
                 def = def.trim();
+                if (def.isEmpty()) {
+                    continue;
+                }
                 final int dashPos = def.indexOf('-');
                 if (dashPos > 0) {
                     final int start = Integer.parseInt(def.substring(0, dashPos));

--- a/hazelcast/src/test/java/com/hazelcast/cluster/SplitBrainHandlerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/SplitBrainHandlerTest.java
@@ -706,7 +706,7 @@ public class SplitBrainHandlerTest extends HazelcastTestSupport {
     private static class FirewallingNodeContext extends DefaultNodeContext {
         @Override
         public ConnectionManager createConnectionManager(Node node, ServerSocketChannel serverSocketChannel) {
-            NodeIOService ioService = new NodeIOService(node);
+            NodeIOService ioService = new NodeIOService(node, node.nodeEngine);
             return new FirewallingTcpIpConnectionManager(node.loggingService,
                     node.getHazelcastThreadGroup(), ioService, serverSocketChannel);
         }

--- a/hazelcast/src/test/java/com/hazelcast/nio/NodeIOServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/NodeIOServiceTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.hazelcast.nio;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.NetworkConfig;
+import com.hazelcast.instance.Node;
+import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Collection;
+
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@Category(QuickTest.class)
+@RunWith(HazelcastParallelClassRunner.class)
+public class NodeIOServiceTest extends HazelcastTestSupport {
+
+    private NetworkConfig networkConfig;
+    private NodeIOService ioService;
+
+    @Before
+    public void setUp() {
+        Node mockNode = mock(Node.class);
+        NodeEngineImpl mockNodeEngine = mock(NodeEngineImpl.class);
+        ioService = new NodeIOService(mockNode, mockNodeEngine);
+
+        Config config = new Config();
+        networkConfig = config.getNetworkConfig();
+        when(mockNode.getConfig()).thenReturn(config);
+    }
+
+    @Test
+    public void testGetOutboundPorts_zeroTakesPrecedenceInRange() {
+        networkConfig.addOutboundPortDefinition("0-100");
+        Collection<Integer> outboundPorts = ioService.getOutboundPorts();
+        assertEquals(0, outboundPorts.size());
+    }
+
+    @Test
+    public void testGetOutboundPorts_zeroTakesPrecedenceInCSV() {
+        networkConfig.addOutboundPortDefinition("5701, 0, 63");
+        Collection<Integer> outboundPorts = ioService.getOutboundPorts();
+        assertEquals(0, outboundPorts.size());
+    }
+
+    @Test
+    public void testGetOutboundPorts_acceptsZero() {
+        networkConfig.addOutboundPortDefinition("0");
+        Collection<Integer> outboundPorts = ioService.getOutboundPorts();
+        assertEquals(0, outboundPorts.size());
+    }
+
+    @Test
+    public void testGetOutboundPorts_acceptsWildcard() {
+        networkConfig.addOutboundPortDefinition("*");
+        Collection<Integer> outboundPorts = ioService.getOutboundPorts();
+        assertEquals(0, outboundPorts.size());
+    }
+
+    @Test
+    public void testGetOutboundPorts_returnsEmptyCollectionByDefault() {
+        Collection<Integer> outboundPorts = ioService.getOutboundPorts();
+        assertEquals(0, outboundPorts.size());
+    }
+
+    @Test
+    public void testGetOutboundPorts_acceptsRange() {
+        networkConfig.addOutboundPortDefinition("29000-29001");
+        Collection<Integer> outboundPorts = ioService.getOutboundPorts();
+
+        assertThat(outboundPorts, hasSize(2));
+        assertThat(outboundPorts, containsInAnyOrder(29000, 29001));
+    }
+
+    @Test
+    public void testGetOutboundPorts_acceptsSpaceAfterComma() {
+        networkConfig.addOutboundPortDefinition("29000, 29001");
+        Collection<Integer> outboundPorts = ioService.getOutboundPorts();
+
+        assertThat(outboundPorts, hasSize(2));
+        assertThat(outboundPorts, containsInAnyOrder(29000, 29001));
+    }
+
+    @Test
+    public void testGetOutboundPorts_acceptsSpaceAsASeparator() {
+        networkConfig.addOutboundPortDefinition("29000 29001");
+        Collection<Integer> outboundPorts = ioService.getOutboundPorts();
+
+        assertThat(outboundPorts, hasSize(2));
+        assertThat(outboundPorts, containsInAnyOrder(29000, 29001));
+    }
+
+    @Test
+    public void testGetOutboundPorts_acceptsSemicolonAsASeparator() {
+        networkConfig.addOutboundPortDefinition("29000;29001");
+        Collection<Integer> outboundPorts = ioService.getOutboundPorts();
+
+        assertThat(outboundPorts, hasSize(2));
+        assertThat(outboundPorts, containsInAnyOrder(29000, 29001));
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/quorum/PartitionedCluster.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/PartitionedCluster.java
@@ -137,7 +137,7 @@ public class PartitionedCluster {
     private static class FirewallingNodeContext extends DefaultNodeContext {
         @Override
         public ConnectionManager createConnectionManager(Node node, ServerSocketChannel serverSocketChannel) {
-            NodeIOService ioService = new NodeIOService(node);
+            NodeIOService ioService = new NodeIOService(node, node.nodeEngine);
             return new FirewallingTcpIpConnectionManager(node.loggingService,
                     node.getHazelcastThreadGroup(), ioService, serverSocketChannel);
         }


### PR DESCRIPTION
- Fixed a parser bug - when multiple outbound ports are separated by a comma followed by a space. 
- NodeIOService accepts NodeEngineImpl in a constructor instead of touching a field in the Node class.
- Tests for NodeIOServiceTest::getOutboundPorts added

This should be ported to a maintenance branch too.