### PR TITLE
Debug logging for slow invocations to deal with OperationTimeout

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/instance/GroupProperties.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/GroupProperties.java
@@ -183,6 +183,18 @@ public class GroupProperties {
     public static final String PROP_SLOW_OPERATION_DETECTOR_THRESHOLD_MILLIS
             = "hazelcast.slow.operation.detector.threshold.millis";
 
+
+    /**
+     * Defines a threshold above which a running invocations in {@link com.hazelcast.spi.OperationService} is considered
+     * to be slow. Any slow invocation will be logged.
+     *
+     * This is an experimental feature and we don't provide any backwards compatibility guarantees on it.
+     *
+     * By default it is -1, to indicate there is no detection.
+     */
+    public static final String PROP_SLOW_INVOCATION_DETECTOR_THRESHOLD_MILLIS
+            = "hazelcast.slow.invocation.detector.threshold.millis";
+
     /**
      * This value defines the retention time of invocations in slow operation logs.
      * <p/>
@@ -538,6 +550,8 @@ public class GroupProperties {
     public final GroupProperty SLOW_OPERATION_DETECTOR_LOG_PURGE_INTERVAL_SECONDS;
     public final GroupProperty SLOW_OPERATION_DETECTOR_STACK_TRACE_LOGGING_ENABLED;
 
+    public final GroupProperty SLOW_INVOCATION_DETECTOR_THRESHOLD_MILLIS;
+
     public final GroupProperty ELASTIC_MEMORY_ENABLED;
 
     public final GroupProperty ELASTIC_MEMORY_TOTAL_SIZE;
@@ -676,6 +690,8 @@ public class GroupProperties {
                 = new GroupProperty(config, PROP_SLOW_OPERATION_DETECTOR_LOG_PURGE_INTERVAL_SECONDS, "300");
         SLOW_OPERATION_DETECTOR_STACK_TRACE_LOGGING_ENABLED
                 = new GroupProperty(config, PROP_SLOW_OPERATION_DETECTOR_STACK_TRACE_LOGGING_ENABLED, "false");
+        SLOW_INVOCATION_DETECTOR_THRESHOLD_MILLIS
+                = new GroupProperty(config, PROP_SLOW_INVOCATION_DETECTOR_THRESHOLD_MILLIS, "-1");
 
         ELASTIC_MEMORY_ENABLED = new GroupProperty(config, PROP_ELASTIC_MEMORY_ENABLED, "false");
         ELASTIC_MEMORY_TOTAL_SIZE = new GroupProperty(config, PROP_ELASTIC_MEMORY_TOTAL_SIZE, "128M");

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationRegistry.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationRegistry.java
@@ -31,6 +31,7 @@ import com.hazelcast.spi.impl.operationservice.impl.responses.CallTimeoutRespons
 import com.hazelcast.spi.impl.operationservice.impl.responses.ErrorResponse;
 import com.hazelcast.spi.impl.operationservice.impl.responses.NormalResponse;
 import com.hazelcast.spi.impl.operationservice.impl.responses.Response;
+import com.hazelcast.util.Clock;
 import com.hazelcast.util.EmptyStatement;
 
 import java.util.concurrent.ConcurrentHashMap;
@@ -69,6 +70,7 @@ public class InvocationRegistry {
     private final ILogger logger;
     private final InspectionThread inspectionThread;
     private final CallIdSequence callIdSequence;
+    private final long slowInvocationThresholdMs;
 
     public InvocationRegistry(OperationServiceImpl operationService, int concurrencyLevel) {
         this.operationService = operationService;
@@ -76,11 +78,21 @@ public class InvocationRegistry {
         this.logger = operationService.logger;
         this.callIdSequence = operationService.backpressureRegulator.newCallIdSequence();
 
+
         GroupProperties props = operationService.nodeEngine.getGroupProperties();
+        this.slowInvocationThresholdMs = initSlowInvocationThresholdMs(props);
         this.backupTimeoutMillis = props.OPERATION_BACKUP_TIMEOUT_MILLIS.getLong();
         this.invocations = new ConcurrentHashMap<Long, Invocation>(INITIAL_CAPACITY, LOAD_FACTOR, concurrencyLevel);
         this.inspectionThread = new InspectionThread();
         inspectionThread.start();
+    }
+
+    private long initSlowInvocationThresholdMs(GroupProperties props) {
+        long thresholdMs = props.SLOW_INVOCATION_DETECTOR_THRESHOLD_MILLIS.getLong();
+        if (thresholdMs > -1) {
+            logger.info("Slow invocation detector enabled, using threshold: " + thresholdMs + " ms");
+        }
+        return thresholdMs;
     }
 
     public long getLastCallId() {
@@ -311,6 +323,8 @@ public class InvocationRegistry {
                 return;
             }
 
+            long now = Clock.currentTimeMillis();
+
             // todo: these 2 measurements should be added to the black-box.
             int backupTimeouts = 0;
             int invocationTimeouts = 0;
@@ -319,26 +333,48 @@ public class InvocationRegistry {
                     return;
                 }
 
-                try {
-                    if (invocation.checkInvocationTimeout()) {
-                        invocationTimeouts++;
-                    }
-                } catch (Throwable t) {
-                    inspectOutputMemoryError(t);
-                    logger.severe("Failed to handle operation timeout of invocation:" + invocation, t);
+                detectSlowInvocation(now, invocation);
+
+                if (checkInvocationTimeout(invocation)) {
+                    invocationTimeouts++;
                 }
 
-                try {
-                    if (invocation.checkBackupTimeout(backupTimeoutMillis)) {
-                        backupTimeouts++;
-                    }
-                } catch (Throwable t) {
-                    inspectOutputMemoryError(t);
-                    logger.severe("Failed to handle backup timeout of invocation:" + invocation, t);
+                if (checkBackupTimeout(invocation)) {
+                    backupTimeouts++;
                 }
             }
 
             log(backupTimeouts, invocationTimeouts);
+        }
+
+        private void detectSlowInvocation(long now, Invocation invocation) {
+            if (slowInvocationThresholdMs > 0) {
+                long durationMs = now - invocation.op.getInvocationTime();
+                if (durationMs > slowInvocationThresholdMs) {
+                    logger.info("Slow invocation: duration=" + durationMs + " ms, operation="
+                            + invocation.op.getClass().getName() + " inv:" + invocation);
+                }
+            }
+        }
+
+        private boolean checkInvocationTimeout(Invocation invocation) {
+            try {
+                return invocation.checkInvocationTimeout();
+            } catch (Throwable t) {
+                inspectOutputMemoryError(t);
+                logger.severe("Failed to handle operation timeout of invocation:" + invocation, t);
+                return false;
+            }
+        }
+
+        private boolean checkBackupTimeout(Invocation invocation) {
+            try {
+                return invocation.checkBackupTimeout(backupTimeoutMillis);
+            } catch (Throwable t) {
+                inspectOutputMemoryError(t);
+                logger.severe("Failed to handle backup timeout of invocation:" + invocation, t);
+                return false;
+            }
         }
 
         private void log(int backupTimeouts, int invocationTimeouts) {


### PR DESCRIPTION
Some logging to detect slow invocations for query op timeout (and anything else that takes time). It does this by lifting on top of the existing periodic scan of all pending invocations and adding some logging if an invocation takes more than a configurable amount of time.

By default it is disabled, but can be enabled by setting a group property. I added it as public property because it is useful for all kinds of problem detection.