### PR TITLE
XA Transactions end/rollback fix

### DIFF
--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/proxy/txn/xa/XAResourceProxy.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/proxy/txn/xa/XAResourceProxy.java
@@ -23,6 +23,8 @@ import com.hazelcast.client.impl.protocol.codec.XATransactionFinalizeCodec;
 import com.hazelcast.client.spi.ClientContext;
 import com.hazelcast.client.spi.ClientProxy;
 import com.hazelcast.client.spi.ClientTransactionManagerService;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.SerializationService;
 import com.hazelcast.transaction.HazelcastXAResource;
@@ -49,6 +51,8 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 public class XAResourceProxy extends ClientProxy implements HazelcastXAResource {
 
     private static final int DEFAULT_TIMEOUT_SECONDS = (int) MILLISECONDS.toSeconds(TransactionOptions.DEFAULT_TIMEOUT_MILLIS);
+    private static final ILogger LOGGER = Logger.getLogger(XAResourceProxy.class);
+
     private final ConcurrentMap<Long, TransactionContext> threadContextMap = new ConcurrentHashMap<Long, TransactionContext>();
     private final ConcurrentMap<Xid, List<TransactionContext>> xidContextMap
             = new ConcurrentHashMap<Xid, List<TransactionContext>>();
@@ -102,23 +106,12 @@ public class XAResourceProxy extends ClientProxy implements HazelcastXAResource 
     public void end(Xid xid, int flags) throws XAException {
         long threadId = currentThreadId();
         TransactionContext threadContext = threadContextMap.remove(threadId);
-        if (threadContext == null) {
-            throw new XAException("There is no TransactionContext for the current thread: " + threadId);
+        if (threadContext == null && LOGGER.isFinestEnabled()) {
+            LOGGER.finest("There is no TransactionContext for the current thread: " + threadId);
         }
-        switch (flags) {
-            case TMFAIL:
-                List<TransactionContext> contexts = xidContextMap.remove(xid);
-                if (contexts != null) {
-                    for (TransactionContext context : contexts) {
-                        getTransaction(context).rollback();
-                    }
-                }
-                break;
-            case TMSUCCESS:
-            case TMSUSPEND:
-                break;
-            default:
-                throw new XAException("Unknown flag!!! " + flags);
+        List<TransactionContext> contexts = xidContextMap.get(xid);
+        if (contexts == null && LOGGER.isFinestEnabled()) {
+            LOGGER.finest("There is no TransactionContexts for the given xid: " + xid);
         }
     }
 
@@ -157,7 +150,7 @@ public class XAResourceProxy extends ClientProxy implements HazelcastXAResource 
     public void rollback(Xid xid) throws XAException {
         List<TransactionContext> contexts = xidContextMap.remove(xid);
         if (contexts == null) {
-            finalizeTransactionRemotely(xid, true);
+            finalizeTransactionRemotely(xid, false);
             return;
         }
         for (TransactionContext context : contexts) {

--- a/hazelcast-client-new/src/test/java/com/hazelcast/client/txn/ClientXACompatibilityTest.java
+++ b/hazelcast-client-new/src/test/java/com/hazelcast/client/txn/ClientXACompatibilityTest.java
@@ -21,6 +21,8 @@ import javax.transaction.xa.XAResource;
 import javax.transaction.xa.Xid;
 
 
+import java.util.concurrent.CountDownLatch;
+
 import static javax.transaction.xa.XAResource.TMNOFLAGS;
 import static javax.transaction.xa.XAResource.TMSUCCESS;
 import static org.junit.Assert.assertEquals;
@@ -208,4 +210,54 @@ public class ClientXACompatibilityTest extends HazelcastTestSupport {
             assertEquals(XAException.XA_RBTIMEOUT, e.errorCode);
         }
     }
+
+    @Test
+    public void testRollbackWithoutPrepare() throws Exception {
+        doSomeWorkWithXa(xaResource);
+        performRollbackWithXa(xaResource);
+    }
+
+    @Test
+    public void testRollbackWithoutPrepare_EmptyTransactionLog() throws Exception {
+        xaResource.start(xid, XAResource.TMNOFLAGS);
+        xaResource.end(xid, XAResource.TMSUCCESS);
+        performRollbackWithXa(xaResource);
+    }
+
+    @Test
+    public void testRollbackWithoutPrepare_SecondXAResource() throws Exception {
+        doSomeWorkWithXa(xaResource);
+        performRollbackWithXa(secondXaResource);
+    }
+
+    @Test
+    public void testRollbackWithoutPrepare_SecondXAResource_EmptyTransactionLog() throws Exception {
+        xaResource.start(xid, XAResource.TMNOFLAGS);
+        xaResource.end(xid, XAResource.TMSUCCESS);
+        performRollbackWithXa(secondXaResource);
+    }
+
+    @Test
+    public void testEnd_FromDifferentThread() throws Exception {
+        xaResource.start(xid, TMNOFLAGS);
+        TransactionContext context = xaResource.getTransactionContext();
+        TransactionalMap<Object, Object> map = context.getMap("map");
+        map.put("key", "value");
+
+        final CountDownLatch latch = new CountDownLatch(1);
+        new Thread() {
+            @Override
+            public void run() {
+                try {
+                    xaResource.end(xid, XAResource.TMFAIL);
+                    latch.countDown();
+                } catch (XAException e) {
+                    e.printStackTrace();
+                }
+            }
+        }.start();
+
+        assertOpenEventually(latch, 10);
+    }
+
 }

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/ClearRemoteTransactionBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/ClearRemoteTransactionBackupOperation.java
@@ -18,6 +18,7 @@ package com.hazelcast.transaction.impl.xa;
 
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.BackupOperation;
 import com.hazelcast.spi.Operation;
 
@@ -25,18 +26,20 @@ import java.io.IOException;
 
 public class ClearRemoteTransactionBackupOperation extends Operation implements BackupOperation {
 
-    private SerializableXID xid;
+    private Data xidData;
+
+    private transient SerializableXID xid;
 
     public ClearRemoteTransactionBackupOperation() {
     }
 
-    public ClearRemoteTransactionBackupOperation(SerializableXID xid) {
-        this.xid = xid;
+    public ClearRemoteTransactionBackupOperation(Data xidData) {
+        this.xidData = xidData;
     }
 
     @Override
     public void beforeRun() throws Exception {
-
+        xid = getNodeEngine().toObject(xidData);
     }
 
     @Override
@@ -47,7 +50,6 @@ public class ClearRemoteTransactionBackupOperation extends Operation implements 
 
     @Override
     public void afterRun() throws Exception {
-
     }
 
     @Override
@@ -67,11 +69,11 @@ public class ClearRemoteTransactionBackupOperation extends Operation implements 
 
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
-        out.writeObject(xid);
+        out.writeData(xidData);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
-        xid = in.readObject();
+        xidData = in.readData();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/ClearRemoteTransactionOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/ClearRemoteTransactionOperation.java
@@ -82,7 +82,7 @@ public class ClearRemoteTransactionOperation extends Operation implements Backup
 
     @Override
     public Operation getBackupOperation() {
-        return new ClearRemoteTransactionBackupOperation(xid);
+        return new ClearRemoteTransactionBackupOperation(xidData);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/CollectRemoteTransactionsOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/CollectRemoteTransactionsOperation.java
@@ -42,7 +42,7 @@ public class CollectRemoteTransactionsOperation extends Operation {
     public void run() throws Exception {
         XAService xaService = getService();
         NodeEngine nodeEngine = getNodeEngine();
-        Set<SerializableXID> xids = xaService.getXids();
+        Set<SerializableXID> xids = xaService.getPreparedXids();
         HashSet<Data> xidSet = new HashSet<Data>();
         for (SerializableXID xid : xids) {
             xidSet.add(nodeEngine.toData(xid));

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/FinalizeRemoteTransactionBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/FinalizeRemoteTransactionBackupOperation.java
@@ -18,6 +18,7 @@ package com.hazelcast.transaction.impl.xa;
 
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.BackupOperation;
 import com.hazelcast.spi.Operation;
 
@@ -25,18 +26,19 @@ import java.io.IOException;
 
 public class FinalizeRemoteTransactionBackupOperation extends Operation implements BackupOperation {
 
-    private SerializableXID xid;
+    private Data xidData;
+    private transient SerializableXID xid;
 
     public FinalizeRemoteTransactionBackupOperation() {
     }
 
-    public FinalizeRemoteTransactionBackupOperation(SerializableXID xid) {
-        this.xid = xid;
+    public FinalizeRemoteTransactionBackupOperation(Data xidData) {
+        this.xidData = xidData;
     }
 
     @Override
     public void beforeRun() throws Exception {
-
+        xid = getNodeEngine().toObject(xidData);
     }
 
     @Override
@@ -47,7 +49,6 @@ public class FinalizeRemoteTransactionBackupOperation extends Operation implemen
 
     @Override
     public void afterRun() throws Exception {
-
     }
 
     @Override
@@ -67,11 +68,11 @@ public class FinalizeRemoteTransactionBackupOperation extends Operation implemen
 
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
-        out.writeObject(xid);
+        out.writeData(xidData);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
-        xid = in.readObject();
+        xidData = in.readData();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/FinalizeRemoteTransactionOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/FinalizeRemoteTransactionOperation.java
@@ -129,7 +129,7 @@ public class FinalizeRemoteTransactionOperation extends Operation implements Bac
 
     @Override
     public Operation getBackupOperation() {
-        return new FinalizeRemoteTransactionBackupOperation(xid);
+        return new FinalizeRemoteTransactionBackupOperation(xidData);
     }
 
     @Override


### PR DESCRIPTION
remove thread check while ending an xa transaction
removed rollback when 'end' method called with fail flag
fixed finalizing tranasctions remotely 
refactored some backup operations to get rid off an unnecessary serilailization

fixes #5400 
fixes #5401 