### PR TITLE
Fix update/invalidate race in NearCache

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,2 @@
+The package com.hazelcast.agrona contains code originating
+from the Agrona project (https://github.com/real-logic/Agrona).

--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -551,6 +551,12 @@
     <suppress checks="JavadocVariable" files="com.hazelcast.internal.management.request.ConsoleRequestConstants"/>
     <suppress checks="JavadocVariable|VisibilityModifier" files="com.hazelcast.internal.management.dto.*"/>
 
+    <!-- Agrona backport -->
+    <suppress checks="MagicNumber" files="com/hazelcast/agrona/" />
+    <suppress checks="ExecutableStatementCount" files="com/hazelcast/agrona/BitUtil" />
+    <suppress checks="JavadocType" files="com/hazelcast/agrona/collections/.*2ObjectHashMap" />
+    <suppress checks="MethodCount" files="com/hazelcast/agrona/collections/.*HashSet" />
+    <suppress checks="VisibilityModifier|JavadocVariable" files="com/hazelcast/agrona/collections/MutableInteger" />
 
     <!-- Map -->
     <suppress checks="JavadocMethod" files="com.hazelcast.map[\\/]"/>

--- a/hazelcast/src/main/java/com/hazelcast/agrona/BitUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/agrona/BitUtil.java
@@ -1,0 +1,237 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.agrona;
+
+import java.nio.charset.Charset;
+
+/**
+ * Miscellaneous useful functions for dealing with low level bits and bytes.
+ */
+public final class BitUtil {
+    private static final byte[] HEX_DIGIT_TABLE = {
+            '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f',
+    };
+
+    private static final byte[] FROM_HEX_DIGIT_TABLE;
+
+    static {
+        FROM_HEX_DIGIT_TABLE = new byte[128];
+        FROM_HEX_DIGIT_TABLE['0'] = 0x00;
+        FROM_HEX_DIGIT_TABLE['1'] = 0x01;
+        FROM_HEX_DIGIT_TABLE['2'] = 0x02;
+        FROM_HEX_DIGIT_TABLE['3'] = 0x03;
+        FROM_HEX_DIGIT_TABLE['4'] = 0x04;
+        FROM_HEX_DIGIT_TABLE['5'] = 0x05;
+        FROM_HEX_DIGIT_TABLE['6'] = 0x06;
+        FROM_HEX_DIGIT_TABLE['7'] = 0x07;
+        FROM_HEX_DIGIT_TABLE['8'] = 0x08;
+        FROM_HEX_DIGIT_TABLE['9'] = 0x09;
+        FROM_HEX_DIGIT_TABLE['a'] = 0x0a;
+        FROM_HEX_DIGIT_TABLE['A'] = 0x0a;
+        FROM_HEX_DIGIT_TABLE['b'] = 0x0b;
+        FROM_HEX_DIGIT_TABLE['B'] = 0x0b;
+        FROM_HEX_DIGIT_TABLE['c'] = 0x0c;
+        FROM_HEX_DIGIT_TABLE['C'] = 0x0c;
+        FROM_HEX_DIGIT_TABLE['d'] = 0x0d;
+        FROM_HEX_DIGIT_TABLE['D'] = 0x0d;
+        FROM_HEX_DIGIT_TABLE['e'] = 0x0e;
+        FROM_HEX_DIGIT_TABLE['E'] = 0x0e;
+        FROM_HEX_DIGIT_TABLE['f'] = 0x0f;
+        FROM_HEX_DIGIT_TABLE['F'] = 0x0f;
+    }
+
+    private static final int LAST_DIGIT_MASK = 0x1;
+
+    private static final Charset UTF8_CHARSET = Charset.forName("UTF-8");
+
+    private BitUtil() { }
+
+    /**
+     * Fast method of finding the next power of 2 greater than or equal to the supplied value.
+     * <p/>
+     * If the value is &lt;= 0 then 1 will be returned.
+     * <p/>
+     * This method is not suitable for {@link Integer#MIN_VALUE} or numbers greater than 2^30.
+     *
+     * @param value from which to search for next power of 2
+     * @return The next power of 2 or the value itself if it is a power of 2
+     */
+    public static int findNextPositivePowerOfTwo(final int value) {
+        return 1 << (32 - Integer.numberOfLeadingZeros(value - 1));
+    }
+
+    /**
+     * Align a value to the next multiple up of alignment.
+     * If the value equals an alignment multiple then it is returned unchanged.
+     * <p/>
+     * This method executes without branching.
+     *
+     * @param value     to be aligned up.
+     * @param alignment to be used.
+     * @return the value aligned to the next boundary.
+     */
+    public static int align(final int value, final int alignment) {
+        return (value + (alignment - 1)) & ~(alignment - 1);
+    }
+
+    /**
+     * Generate a byte array from the hex representation of the given byte array.
+     *
+     * @param buffer to convert from a hex representation (in Big Endian)
+     * @return new byte array that is decimal representation of the passed array
+     */
+    public static byte[] fromHexByteArray(final byte[] buffer) {
+        final byte[] outputBuffer = new byte[buffer.length >> 1];
+
+        for (int i = 0; i < buffer.length; i += 2) {
+            outputBuffer[i >> 1] = (byte)
+                    ((FROM_HEX_DIGIT_TABLE[buffer[i]] << 4) | FROM_HEX_DIGIT_TABLE[buffer[i + 1]]);
+        }
+
+        return outputBuffer;
+    }
+
+    /**
+     * Generate a byte array that is a hex representation of a given byte array.
+     *
+     * @param buffer to convert to a hex representation
+     * @return new byte array that is hex representation (in Big Endian) of the passed array
+     */
+    public static byte[] toHexByteArray(final byte[] buffer) {
+        return toHexByteArray(buffer, 0, buffer.length);
+    }
+
+    /**
+     * Generate a byte array that is a hex representation of a given byte array.
+     *
+     * @param buffer to convert to a hex representation
+     * @param offset the offset into the buffer
+     * @param length the number of bytes to convert
+     * @return new byte array that is hex representation (in Big Endian) of the passed array
+     */
+    public static byte[] toHexByteArray(final byte[] buffer, int offset, int length) {
+        final byte[] outputBuffer = new byte[length << 1];
+
+        for (int i = 0; i < (length << 1); i += 2) {
+            final byte b = buffer[offset + (i >> 1)];
+
+            outputBuffer[i] = HEX_DIGIT_TABLE[(b >> 4) & 0x0F];
+            outputBuffer[i + 1] = HEX_DIGIT_TABLE[b & 0x0F];
+        }
+
+        return outputBuffer;
+    }
+
+    /**
+     * Generate a byte array from a string that is the hex representation of the given byte array.
+     *
+     * @param string to convert from a hex representation (in Big Endian)
+     * @return new byte array holding the decimal representation of the passed array
+     */
+    public static byte[] fromHex(final String string) {
+        return fromHexByteArray(string.getBytes(UTF8_CHARSET));
+    }
+
+    /**
+     * Generate a string that is the hex representation of a given byte array.
+     *
+     * @param buffer to convert to a hex representation
+     * @param offset the offset into the buffer
+     * @param length the number of bytes to convert
+     * @return new String holding the hex representation (in Big Endian) of the passed array
+     */
+    public static String toHex(final byte[] buffer, int offset, int length) {
+        return new String(toHexByteArray(buffer, offset, length), UTF8_CHARSET);
+    }
+
+    /**
+     * Generate a string that is the hex representation of a given byte array.
+     *
+     * @param buffer to convert to a hex representation
+     * @return new String holding the hex representation (in Big Endian) of the passed array
+     */
+    public static String toHex(final byte[] buffer) {
+        return new String(toHexByteArray(buffer), UTF8_CHARSET);
+    }
+
+    /**
+     * Is a number even.
+     *
+     * @param value to check.
+     * @return true if the number is even otherwise false.
+     */
+    public static boolean isEven(final int value) {
+        return (value & LAST_DIGIT_MASK) == 0;
+    }
+
+    /**
+     * Is a value a positive power of two.
+     *
+     * @param value to be checked.
+     * @return true if the number is a positive power of two otherwise false.
+     */
+    public static boolean isPowerOfTwo(final int value) {
+        return value > 0 && ((value & (~value + 1)) == value);
+    }
+
+    /**
+     * Cycles indices of an array one at a time in a forward fashion
+     *
+     * @param current value to be incremented.
+     * @param max     value for the cycle.
+     * @return the next value, or zero if max is reached.
+     */
+    public static int next(final int current, final int max) {
+        int next = current + 1;
+        if (next == max) {
+            next = 0;
+        }
+
+        return next;
+    }
+
+    /**
+     * Cycles indices of an array one at a time in a backwards fashion
+     *
+     * @param current value to be decremented.
+     * @param max     value of the cycle.
+     * @return the next value, or max - 1 if current is zero
+     */
+    public static int previous(final int current, final int max) {
+        if (0 == current) {
+            return max - 1;
+        }
+
+        return current - 1;
+    }
+
+    /**
+     * Calculate the shift value to scale a number based on how refs are compressed or not.
+     *
+     * @param scale of the number reported by Unsafe.
+     * @return how many times the number needs to be shifted to the left.
+     */
+    public static int calculateShiftForScale(final int scale) {
+        if (4 == scale) {
+            return 2;
+        } else if (8 == scale) {
+            return 3;
+        } else {
+            throw new IllegalArgumentException("Unknown pointer size");
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/agrona/collections/BiInt2ObjectMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/agrona/collections/BiInt2ObjectMap.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.agrona.collections;
+
+
+import java.util.Map;
+
+/**
+ * Map that takes two part int key and associates with an object.
+ * <p/>
+ * The underlying implementation use as {@link Long2ObjectHashMap} and combines both int keys into a long key.
+ *
+ * @param <V> type of the object stored in the map.
+ */
+public class BiInt2ObjectMap<V> {
+    /**
+     * Handler for a map entry
+     *
+     * @param <V> type of the value
+     */
+    public interface EntryConsumer<V> {
+        /**
+         * A map entry
+         *
+         * @param keyPartA for the key
+         * @param keyPartB for the key
+         * @param value    for the entry
+         */
+        void accept(int keyPartA, int keyPartB, V value);
+    }
+
+    private final Long2ObjectHashMap<V> map;
+
+    /**
+     * Construct an empty map
+     */
+    public BiInt2ObjectMap() {
+        map = new Long2ObjectHashMap<V>();
+    }
+
+    /**
+     * See {@link Long2ObjectHashMap#Long2ObjectHashMap(int, double)}.
+     *
+     * @param initialCapacity for the underlying hash map
+     * @param loadFactor      for the underlying hash map
+     */
+    public BiInt2ObjectMap(final int initialCapacity, final double loadFactor) {
+        map = new Long2ObjectHashMap<V>(initialCapacity, loadFactor);
+    }
+
+    /**
+     * Get the total capacity for the map to which the load factor with be a fraction of.
+     *
+     * @return the total capacity for the map.
+     */
+    public int capacity() {
+        return map.capacity();
+    }
+
+    /**
+     * Get the load factor beyond which the map will increase size.
+     *
+     * @return load factor for when the map should increase size.
+     */
+    public double loadFactor() {
+        return map.loadFactor();
+    }
+
+    /**
+     * Put a value into the map.
+     *
+     * @param keyPartA for the key
+     * @param keyPartB for the key
+     * @param value    to put into the map
+     * @return the previous value if found otherwise null
+     */
+    public V put(final int keyPartA, final int keyPartB, final V value) {
+        final long key = compoundKey(keyPartA, keyPartB);
+
+        return map.put(key, value);
+    }
+
+    /**
+     * Retrieve a value from the map.
+     *
+     * @param keyPartA for the key
+     * @param keyPartB for the key
+     * @return value matching the key if found or null if not found.
+     */
+    public V get(final int keyPartA, final int keyPartB) {
+        final long key = compoundKey(keyPartA, keyPartB);
+
+        return map.get(key);
+    }
+
+    /**
+     * Remove a value from the map and return the value.
+     *
+     * @param keyPartA for the key
+     * @param keyPartB for the key
+     * @return the previous value if found otherwise null
+     */
+    public V remove(final int keyPartA, final int keyPartB) {
+        final long key = compoundKey(keyPartA, keyPartB);
+
+        return map.remove(key);
+    }
+
+    /**
+     * Iterate over the contents of the map
+     *
+     * @param consumer to apply to each value in the map
+     */
+    public void forEach(final EntryConsumer<V> consumer) {
+        for (Map.Entry<Long, V> entry : map.entrySet()) {
+            Long compoundKey = entry.getKey();
+            final int keyPartA = (int) (compoundKey >>> 32);
+            final int keyPartB = (int) (compoundKey & 0xFFFFFFFFL);
+            consumer.accept(keyPartA, keyPartB, entry.getValue());
+        }
+    }
+
+    /**
+     * Return the number of unique entries in the map.
+     *
+     * @return number of unique entries in the map.
+     */
+    public int size() {
+        return map.size();
+    }
+
+    /**
+     * Is map empty or not.
+     *
+     * @return boolean indicating empty map or not
+     */
+    public boolean isEmpty() {
+        return map.isEmpty();
+    }
+
+    private static long compoundKey(final int keyPartA, final int keyPartB) {
+        return ((long) keyPartA << 32) | keyPartB;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/agrona/collections/Hashing.java
+++ b/hazelcast/src/main/java/com/hazelcast/agrona/collections/Hashing.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.agrona.collections;
+
+/**
+ * Hashcode calculation.
+ */
+public final class Hashing {
+    private Hashing() { }
+
+    public static int intHash(final int value, final int mask) {
+        final int hash = (value << 1) - (value << 8);
+        return hash & mask;
+    }
+
+    public static int longHash(final long value, final int mask) {
+        int hash = (int) value ^ (int) (value >>> 32);
+        hash = (hash << 1) - (hash << 8);
+        return hash & mask;
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/agrona/collections/Int2ObjectHashMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/agrona/collections/Int2ObjectHashMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 Real Logic Ltd.
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,9 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.hazelcast.client.impl.protocol.util;
 
-import com.hazelcast.util.QuickMath;
+package com.hazelcast.agrona.collections;
+
+
+import com.hazelcast.agrona.BitUtil;
+import com.hazelcast.agrona.function.IntFunction;
 
 import java.util.AbstractCollection;
 import java.util.AbstractSet;
@@ -34,9 +37,8 @@ import static com.hazelcast.util.Preconditions.checkNotNull;
  *
  * @param <V> values stored in the {@link java.util.Map}
  */
-@edu.umd.cs.findbugs.annotations.SuppressWarnings({"PZ_DONT_REUSE_ENTRY_OBJECTS_IN_ITERATORS"})
-public class Int2ObjectHashMap<V>
-        implements Map<Integer, V> {
+@edu.umd.cs.findbugs.annotations.SuppressWarnings("PZ_DONT_REUSE_ENTRY_OBJECTS_IN_ITERATORS")
+public class Int2ObjectHashMap<V> implements Map<Integer, V> {
     private final double loadFactor;
     private int resizeThreshold;
     private int capacity;
@@ -47,9 +49,9 @@ public class Int2ObjectHashMap<V>
     private Object[] values;
 
     // Cached to avoid allocation.
-    private final ValueCollection<V> valueCollection = new ValueCollection<V>();
+    private final ValueCollection valueCollection = new ValueCollection();
     private final KeySet keySet = new KeySet();
-    private final EntrySet<V> entrySet = new EntrySet<V>();
+    private final EntrySet entrySet = new EntrySet();
 
     public Int2ObjectHashMap() {
         this(8, 0.6);
@@ -63,7 +65,7 @@ public class Int2ObjectHashMap<V>
      */
     public Int2ObjectHashMap(final int initialCapacity, final double loadFactor) {
         this.loadFactor = loadFactor;
-        capacity = QuickMath.nextPowerOfTwo(initialCapacity);
+        capacity = BitUtil.findNextPositivePowerOfTwo(initialCapacity);
         mask = capacity - 1;
         resizeThreshold = (int) (capacity * loadFactor);
 
@@ -186,24 +188,29 @@ public class Int2ObjectHashMap<V>
         return null;
     }
 
+
     /**
-     * Get a value for a given key, or if it does ot exist then default the value via a {@link Supplier}
+     * Get a value for a given key, or if it does ot exist then default the value via a {@link IntFunction}
      * and put it in the map.
+     * <p/>
+     * Primitive specialized version of {@link java.util.Map#computeIfAbsent}.
      *
-     * @param key      to search on.
-     * @param supplier to provide a default if the get returns null.
+     * @param key             to search on.
+     * @param mappingFunction to provide a value if the get returns null.
      * @return the value if found otherwise the default.
      */
-    public V getOrDefault(final int key, final Supplier<V> supplier) {
+    public V computeIfAbsent(final int key, final IntFunction<? extends V> mappingFunction) {
+        checkNotNull(mappingFunction, "mappingFunction cannot be null");
         V value = get(key);
         if (value == null) {
-            value = supplier.get();
-            put(key, value);
+            value = mappingFunction.apply(key);
+            if (value != null) {
+                put(key, value);
+            }
         }
 
         return value;
     }
-
 
     /**
      * {@inheritDoc}
@@ -297,7 +304,7 @@ public class Int2ObjectHashMap<V>
      */
     public void compact() {
         final int idealCapacity = (int) Math.round(size() * (1.0d / loadFactor));
-        rehash(QuickMath.nextPowerOfTwo(idealCapacity));
+        rehash(BitUtil.findNextPositivePowerOfTwo(idealCapacity));
     }
 
     /**
@@ -402,8 +409,8 @@ public class Int2ObjectHashMap<V>
 
             final int hash = hash(keys[index]);
 
-            if ((index < hash && (hash <= deleteIndex || deleteIndex <= index)) || (hash <= deleteIndex
-                    && deleteIndex <= index)) {
+            if ((index < hash && (hash <= deleteIndex || deleteIndex <= index))
+                    || (hash <= deleteIndex && deleteIndex <= index)) {
                 keys[deleteIndex] = keys[index];
                 values[deleteIndex] = values[index];
 
@@ -422,8 +429,7 @@ public class Int2ObjectHashMap<V>
     // Internal Sets and Collections
     ///////////////////////////////////////////////////////////////////////////////////////////////
 
-    public class KeySet
-            extends AbstractSet<Integer> {
+    public class KeySet extends AbstractSet<Integer> {
         public int size() {
             return Int2ObjectHashMap.this.size();
         }
@@ -457,8 +463,7 @@ public class Int2ObjectHashMap<V>
         }
     }
 
-    private class ValueCollection<V>
-            extends AbstractCollection<V> {
+    private class ValueCollection extends AbstractCollection<V> {
         public int size() {
             return Int2ObjectHashMap.this.size();
         }
@@ -480,8 +485,7 @@ public class Int2ObjectHashMap<V>
         }
     }
 
-    private class EntrySet<V>
-            extends AbstractSet<Entry<Integer, V>> {
+    private class EntrySet extends AbstractSet<Entry<Integer, V>> {
         public int size() {
             return Int2ObjectHashMap.this.size();
         }
@@ -503,13 +507,12 @@ public class Int2ObjectHashMap<V>
     // Iterators
     ///////////////////////////////////////////////////////////////////////////////////////////////
 
-    private abstract class AbstractIterator<T>
-            implements Iterator<T> {
-        private int posCounter;
-        private int stopCounter;
-        private boolean isPositionValid = false;
+    private abstract class AbstractIterator<T> implements Iterator<T> {
         protected final int[] keys = Int2ObjectHashMap.this.keys;
         protected final Object[] values = Int2ObjectHashMap.this.values;
+        private int posCounter;
+        private int stopCounter;
+        private boolean isPositionValid;
 
         protected AbstractIterator() {
             int i = capacity;
@@ -573,8 +576,7 @@ public class Int2ObjectHashMap<V>
         }
     }
 
-    public class ValueIterator<T>
-            extends AbstractIterator<T> {
+    public class ValueIterator<T> extends AbstractIterator<T> {
         @SuppressWarnings("unchecked")
         public T next() {
             findNext();
@@ -583,8 +585,7 @@ public class Int2ObjectHashMap<V>
         }
     }
 
-    public class KeyIterator
-            extends AbstractIterator<Integer> {
+    public class KeyIterator extends AbstractIterator<Integer> {
         public Integer next() {
             return nextInt();
         }
@@ -597,9 +598,7 @@ public class Int2ObjectHashMap<V>
     }
 
     @SuppressWarnings("unchecked")
-    public class EntryIterator<V>
-            extends AbstractIterator<Entry<Integer, V>>
-            implements Entry<Integer, V> {
+    public class EntryIterator<V> extends AbstractIterator<Entry<Integer, V>> implements Entry<Integer, V> {
         public Entry<Integer, V> next() {
             findNext();
 
@@ -615,7 +614,7 @@ public class Int2ObjectHashMap<V>
         }
 
         public V setValue(final V value) {
-            checkNotNull(value, "value cannot be null");
+            checkNotNull(value, "Value must not be null");
 
             final int pos = getPosition();
             final Object oldValue = values[pos];
@@ -624,15 +623,4 @@ public class Int2ObjectHashMap<V>
             return (V) oldValue;
         }
     }
-
-    public interface Supplier<T> {
-
-        /**
-         * Gets a result.
-         *
-         * @return a result
-         */
-        T get();
-    }
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/agrona/collections/IntHashSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/agrona/collections/IntHashSet.java
@@ -1,0 +1,380 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.agrona.collections;
+
+import com.hazelcast.agrona.BitUtil;
+import com.hazelcast.agrona.function.Predicate;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Set;
+
+import static com.hazelcast.util.Preconditions.checkNotNull;
+
+/**
+ * Simple fixed-size int hashset for validating tags.
+ */
+public final class IntHashSet implements Set<Integer> {
+    private final int[] values;
+    private final IntIterator iterator;
+    private final int mask;
+    private final int missingValue;
+
+    private int size;
+
+    public IntHashSet(final int proposedCapacity, final int missingValue) {
+        size = 0;
+        this.missingValue = missingValue;
+        final int capacity = BitUtil.findNextPositivePowerOfTwo(proposedCapacity);
+        mask = capacity - 1;
+        values = new int[capacity];
+        Arrays.fill(values, missingValue);
+
+        // NB: references values in the constructor, so must be assigned after values
+        iterator = new IntIterator(missingValue, values);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public boolean add(final Integer value) {
+        return add(value.intValue());
+    }
+
+    /**
+     * Primitive specialised overload of {this#add(Integer)}
+     *
+     * @param value the value to add
+     * @return true if the collection has changed, false otherwise
+     */
+    public boolean add(final int value) {
+        int index = Hashing.intHash(value, mask);
+
+        while (values[index] != missingValue) {
+            if (values[index] == value) {
+                return false;
+            }
+
+            index = next(index);
+        }
+
+        values[index] = value;
+        size++;
+
+        return true;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public boolean remove(final Object value) {
+        return value instanceof Integer && remove(((Integer) value).intValue());
+    }
+
+    /**
+     * An int specialised version of {this#remove(Object)}.
+     *
+     * @param value the value to remove
+     * @return true if the value was present, false otherwise
+     */
+    public boolean remove(final int value) {
+        int index = Hashing.intHash(value, mask);
+
+        while (values[index] != missingValue) {
+            if (values[index] == value) {
+                values[index] = missingValue;
+                compactChain(index);
+                return true;
+            }
+
+            index = next(index);
+        }
+
+        return false;
+    }
+
+    private int next(int index) {
+        index = ++index & mask;
+        return index;
+    }
+
+    private void compactChain(final int deleteIndex) {
+        final int[] values = this.values;
+
+        int index = deleteIndex;
+        while (true) {
+            final int previousIndex = index;
+            index = next(index);
+            if (values[index] == missingValue) {
+                return;
+            }
+
+            values[previousIndex] = values[index];
+            values[index] = missingValue;
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public boolean contains(final Object value) {
+        return value instanceof Integer && contains(((Integer) value).intValue());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public boolean contains(final int value) {
+        int index = Hashing.intHash(value, mask);
+
+        while (values[index] != missingValue) {
+            if (values[index] == value) {
+                return true;
+            }
+
+            index = next(index);
+        }
+
+        return false;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public int size() {
+        return size;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public boolean isEmpty() {
+        return size() == 0;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public void clear() {
+        final int[] values = this.values;
+        final int length = values.length;
+        for (int i = 0; i < length; i++) {
+            values[i] = missingValue;
+        }
+        size = 0;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @SuppressWarnings("unchecked")
+    public <T> T[] toArray(final T[] ignore) {
+        return (T[]) (Object) Arrays.copyOf(values, values.length);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public boolean addAll(final Collection<? extends Integer> coll) {
+        return addAllCapture(coll);
+    }
+
+    private <E extends Integer> boolean addAllCapture(final Collection<E> coll) {
+        final Predicate<E> p = new Predicate<E>() {
+            @Override
+            public boolean test(E x) {
+                return add(x);
+            }
+        };
+        return conjunction(coll, p);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public boolean containsAll(final Collection<?> coll) {
+        return containsAllCapture(coll);
+    }
+
+    private <E> boolean containsAllCapture(Collection<E> coll) {
+        return conjunction(coll, new Predicate<E>() {
+            @Override
+            public boolean test(E value) {
+                return contains(value);
+            }
+        });
+    }
+
+    /**
+     * IntHashSet specialised variant of {this#containsAll(Collection)}.
+     *
+     * @param other the int hashset to compare against.
+     * @return true if every element in other is in this.
+     */
+    public boolean containsAll(final IntHashSet other) {
+        final IntIterator iterator = other.iterator();
+        while (iterator.hasNext()) {
+            if (!contains(iterator.nextValue())) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Fast Path set difference for comparison with another IntHashSet.
+     * <p/>
+     * NB: garbage free in the identical case, allocates otherwise.
+     *
+     * @param collection the other set to subtract
+     * @return null if identical, otherwise the set of differences
+     */
+    public IntHashSet difference(final IntHashSet collection) {
+        checkNotNull(collection, "Collection must not be null");
+
+        IntHashSet difference = null;
+
+        final IntIterator it = iterator();
+
+        while (it.hasNext()) {
+            final int value = it.nextValue();
+            if (!collection.contains(value)) {
+                if (difference == null) {
+                    difference = new IntHashSet(size, missingValue);
+                }
+
+                difference.add(value);
+            }
+        }
+
+        return difference;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public boolean removeAll(final Collection<?> coll) {
+        return removeAllCapture(coll);
+    }
+
+    private <E> boolean removeAllCapture(final Collection<E> coll) {
+        return conjunction(coll, new Predicate<E>() {
+            @Override
+            public boolean test(E value) {
+                return remove(value);
+            }
+        });
+    }
+
+    private static <E> boolean conjunction(final Collection<E> collection, final Predicate<E> predicate) {
+        checkNotNull(collection);
+
+        boolean acc = false;
+        for (final E e : collection) {
+            // Deliberate strict evaluation
+            acc |= predicate.test(e);
+        }
+
+        return acc;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public IntIterator iterator() {
+        iterator.reset();
+        return iterator;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public void copy(final IntHashSet obj) {
+        // NB: mask also implies the length is the same
+        if (this.mask != obj.mask) {
+            throw new IllegalArgumentException("Cannot copy object: masks not equal");
+        }
+
+        if (this.missingValue != obj.missingValue) {
+            throw new IllegalArgumentException("Cannot copy object: missingValues not equal");
+        }
+
+        System.arraycopy(obj.values, 0, this.values, 0, this.values.length);
+        this.size = obj.size;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public String toString() {
+        final StringBuilder b = new StringBuilder(size() * 3 + 2);
+        b.append('{');
+        String separator = "";
+        for (int i : values) {
+            b.append(i).append(separator);
+            separator = ",";
+        }
+        return b.append('}').toString();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public Object[] toArray() {
+        final int[] values = this.values;
+        final Object[] array = new Object[values.length];
+        for (int i = 0; i < values.length; i++) {
+            array[i] = values[i];
+        }
+        return array;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public boolean equals(final Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (other instanceof IntHashSet) {
+            final IntHashSet otherSet = (IntHashSet) other;
+            return otherSet.missingValue == missingValue && otherSet.size() == size() && containsAll(otherSet);
+        }
+
+        return false;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public int hashCode() {
+        final IntIterator iterator = iterator();
+        int total = 0;
+        while (iterator.hasNext()) {
+            // Cast exists for substitutions
+            total += (int) iterator.nextValue();
+        }
+        return total;
+    }
+
+    // --- Unimplemented below here
+
+    public boolean retainAll(final Collection<?> coll) {
+        throw new UnsupportedOperationException("Not implemented");
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/agrona/collections/IntIterator.java
+++ b/hazelcast/src/main/java/com/hazelcast/agrona/collections/IntIterator.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.agrona.collections;
+
+import java.util.Iterator;
+
+/**
+ * An iterator for a sequence of primitive integers.
+ */
+public class IntIterator implements Iterator<Integer> {
+    private final int missingValue;
+    private final int[] values;
+
+    private int position;
+
+    /**
+     * Construct an {@link Iterator} over an array of primitives ints.
+     *
+     * @param missingValue to indicate the value is missing, i.e. not present or null.
+     * @param values       to iterate over.
+     */
+    public IntIterator(final int missingValue, final int[] values) {
+        this.missingValue = missingValue;
+        this.values = values;
+    }
+
+    public boolean hasNext() {
+        final int[] values = this.values;
+        while (position < values.length) {
+            if (values[position] != missingValue) {
+                return true;
+            }
+
+            position++;
+        }
+
+        return false;
+    }
+
+    public Integer next() {
+        return nextValue();
+    }
+
+    public void remove() {
+        throw new UnsupportedOperationException("remove");
+    }
+
+    /**
+     * Strongly typed alternative of {@link Iterator#next()} to avoid boxing.
+     *
+     * @return the next int value.
+     */
+    public int nextValue() {
+        final int value = values[position];
+        position++;
+        return value;
+    }
+
+    void reset() {
+        position = 0;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/agrona/collections/Long2LongHashMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/agrona/collections/Long2LongHashMap.java
@@ -1,0 +1,463 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.agrona.collections;
+
+import com.hazelcast.agrona.BitUtil;
+import com.hazelcast.agrona.function.BiConsumer;
+import com.hazelcast.agrona.function.LongLongConsumer;
+import com.hazelcast.agrona.function.Predicate;
+import com.hazelcast.agrona.function.Supplier;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * A Probing hashmap specialised for long key and value pairs.
+ */
+public class Long2LongHashMap implements Map<Long, Long> {
+    private final Set<Long> keySet;
+    private final LongIterator valueIterator = new LongIterator(1);
+    private final Collection<Long> values;
+    private final Set<Entry<Long, Long>> entrySet;
+
+    private final double loadFactor;
+    private final long missingValue;
+
+    private long[] entries;
+    private int capacity;
+    private int mask;
+    private int resizeThreshold;
+    private int size;
+
+    public Long2LongHashMap(final long missingValue) {
+        this(16, 0.6, missingValue);
+    }
+
+    @SuppressWarnings("unchecked")
+    public Long2LongHashMap(final int initialCapacity, final double loadFactor, final long missingValue) {
+        this.loadFactor = loadFactor;
+        this.missingValue = missingValue;
+        capacity(BitUtil.findNextPositivePowerOfTwo(initialCapacity));
+        final LongIterator keyIterator = new LongIterator(0);
+        keySet = new MapDelegatingSet<Long>(this, new IteratorSupplier(keyIterator), new Predicate() {
+            @Override public boolean test(Object value) {
+                return containsValue(value);
+            }
+        });
+        values = new MapDelegatingSet<Long>(this, new Supplier<Iterator<Long>>() {
+            @Override public Iterator<Long> get() {
+                return valueIterator.reset();
+            }
+        }, new Predicate() {
+            @Override
+            public boolean test(Object key) {
+                return containsKey(key);
+            }
+        });
+        final EntryIterator entryIterator = new EntryIterator();
+        entrySet = new MapDelegatingSet<Entry<Long, Long>>(this, new EntryIteratorSupplier(entryIterator), new
+                Predicate() {
+            @Override
+            public boolean test(Object e) {
+                return Long2LongHashMap.this.containsKey(((Entry<Long, Long>) e).getKey());
+            }
+        });
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public int size() {
+        return size;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public boolean isEmpty() {
+        return size() == 0;
+    }
+
+    public long get(final long key) {
+        final long[] entries = this.entries;
+        int index = hash(key);
+        long candidateKey;
+        while ((candidateKey = entries[index]) != missingValue) {
+            if (candidateKey == key) {
+                return entries[index + 1];
+            }
+            index = next(index);
+        }
+        return missingValue;
+    }
+
+    public long put(final long key, final long value) {
+        long oldValue = missingValue;
+        int index = hash(key);
+        long candidateKey;
+        while ((candidateKey = entries[index]) != missingValue) {
+            if (candidateKey == key) {
+                oldValue = entries[index + 1];
+                break;
+            }
+            index = next(index);
+        }
+        if (oldValue == missingValue) {
+            ++size;
+            entries[index] = key;
+        }
+        entries[index + 1] = value;
+        checkResize();
+        return oldValue;
+    }
+
+    private void checkResize() {
+        if (size > resizeThreshold) {
+            final int newCapacity = capacity << 1;
+            if (newCapacity < 0) {
+                throw new IllegalStateException("Max capacity reached at size=" + size);
+            }
+            rehash(newCapacity);
+        }
+    }
+
+    private void rehash(final int newCapacity) {
+        final long[] oldEntries = entries;
+        capacity(newCapacity);
+        for (int i = 0; i < oldEntries.length; i += 2) {
+            final long key = oldEntries[i];
+            if (key != missingValue) {
+                put(key, oldEntries[i + 1]);
+            }
+        }
+    }
+
+    private int hash(final long key) {
+        int hash = (int) key ^ (int) (key >>> 32);
+        hash = (hash << 1) - (hash << 8);
+        return hash & mask;
+    }
+
+    /**
+     * Primitive specialised forEach implementation.
+     * <p/>
+     * NB: Renamed from forEach to avoid overloading on parameter types of lambda
+     * expression, which doesn't interplay well with type inference in lambda expressions.
+     *
+     * @param consumer a callback called for each key/value pair in the map.
+     */
+    public void longForEach(final LongLongConsumer consumer) {
+        final long[] entries = this.entries;
+        for (int i = 0; i < entries.length; i += 2) {
+            final long key = entries[i];
+            if (key != missingValue) {
+                consumer.accept(entries[i], entries[i + 1]);
+            }
+        }
+    }
+
+    /**
+     * Long primitive specialised containsKey.
+     *
+     * @param key the key to check.
+     * @return true if the map contains key as a key, false otherwise.
+     */
+    public boolean containsKey(final long key) {
+        return get(key) != missingValue;
+    }
+
+    public boolean containsValue(final long value) {
+        final long[] entries = this.entries;
+        for (int i = 1; i < entries.length; i += 2) {
+            final long entryValue = entries[i];
+            if (entryValue == value) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public void clear() {
+        Arrays.fill(entries, missingValue);
+        size = 0;
+    }
+
+    // ---------------- Boxed Versions Below ----------------
+
+    /**
+     * {@inheritDoc}
+     */
+    public Long get(final Object key) {
+        return get((long) (Long) key);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public Long put(final Long key, final Long value) {
+        return put(key.longValue(), value.longValue());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public void forEach(final BiConsumer<? super Long, ? super Long> action) {
+        longForEach(new UnboxingBiConsumer(action));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public boolean containsKey(final Object key) {
+        return containsKey((long) (Long) key);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public boolean containsValue(final Object value) {
+        return containsValue((long) (Long) value);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public void putAll(final Map<? extends Long, ? extends Long> map) {
+        for (final Entry<? extends Long, ? extends Long> entry : map.entrySet()) {
+            put(entry.getKey(), entry.getValue());
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public Set<Long> keySet() {
+        return keySet;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public Collection<Long> values() {
+        return values;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public Set<Entry<Long, Long>> entrySet() {
+        return entrySet;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public Long remove(final Object key) {
+        return remove((long) (Long) key);
+    }
+
+    public long remove(final long key) {
+        final long[] entries = this.entries;
+        int index = hash(key);
+        long candidateKey;
+        while ((candidateKey = entries[index]) != missingValue) {
+            if (candidateKey == key) {
+                final int valueIndex = index + 1;
+                final long oldValue = entries[valueIndex];
+                entries[index] = missingValue;
+                entries[valueIndex] = missingValue;
+                size--;
+                compactChain(index);
+                return oldValue;
+            }
+            index = next(index);
+        }
+        return missingValue;
+    }
+
+    private void compactChain(int deleteIndex) {
+        final long[] entries = this.entries;
+        int index = deleteIndex;
+        while (true) {
+            index = next(index);
+            if (entries[index] == missingValue) {
+                return;
+            }
+            final int hash = hash(entries[index]);
+            if ((index < hash && (hash <= deleteIndex || deleteIndex <= index))
+                    || (hash <= deleteIndex && deleteIndex <= index)) {
+                entries[deleteIndex] = entries[index];
+                entries[deleteIndex + 1] = entries[index + 1];
+                entries[index] = missingValue;
+                entries[index + 1] = missingValue;
+                deleteIndex = index;
+            }
+        }
+    }
+
+    public long minValue() {
+        long min = Long.MAX_VALUE;
+        final LongIterator iterator = valueIterator.reset();
+        while (iterator.hasNext()) {
+            min = Math.min(min, iterator.nextValue());
+        }
+        return min;
+    }
+
+    private static class IteratorSupplier implements Supplier<Iterator<Long>> {
+        private final LongIterator keyIterator;
+
+        public IteratorSupplier(LongIterator keyIterator) {
+            this.keyIterator = keyIterator;
+        }
+
+        @Override
+        public Iterator<Long> get() {
+            return keyIterator.reset();
+        }
+    }
+
+    private static class EntryIteratorSupplier implements Supplier<Iterator<Entry<Long, Long>>> {
+        private final EntryIterator entryIterator;
+
+        public EntryIteratorSupplier(EntryIterator entryIterator) {
+            this.entryIterator = entryIterator;
+        }
+
+        @Override
+        public Iterator<Entry<Long, Long>> get() {
+            return entryIterator.reset();
+        }
+    }
+
+    private static class UnboxingBiConsumer implements LongLongConsumer {
+        private final BiConsumer<? super Long, ? super Long> action;
+
+        public UnboxingBiConsumer(BiConsumer<? super Long, ? super Long> action) {
+            this.action = action;
+        }
+
+        @Override
+        public void accept(long t, long u) {
+            action.accept(t, u);
+        }
+    }
+
+    // ---------------- Utility Classes ----------------
+
+    private abstract class AbstractIterator {
+        protected final int startIndex;
+
+        protected int index;
+
+        protected AbstractIterator(final int startIndex) {
+            this.startIndex = startIndex;
+            index = startIndex;
+        }
+
+        public boolean hasNext() {
+            while (entries[index] == missingValue) {
+                nextIndex();
+                if (index == startIndex) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        public void remove() {
+            throw new UnsupportedOperationException("remove");
+        }
+
+        protected void nextIndex() {
+            index = next(index);
+        }
+    }
+
+    private final class LongIterator extends AbstractIterator implements Iterator<Long> {
+        private LongIterator(final int startIndex) {
+            super(startIndex);
+        }
+
+        private LongIterator reset() {
+            index = startIndex;
+            return this;
+        }
+
+        public Long next() {
+            return nextValue();
+        }
+
+        public long nextValue() {
+            final long entry = entries[index];
+            nextIndex();
+            return entry;
+        }
+    }
+
+    private final class EntryIterator extends AbstractIterator implements Iterator<Entry<Long, Long>>, Entry<Long,
+            Long> {
+        private long key;
+        private long value;
+
+        private EntryIterator() {
+            super(0);
+        }
+
+        private EntryIterator reset() {
+            index = startIndex;
+            return this;
+        }
+
+        public Long getKey() {
+            return key;
+        }
+
+        public Long getValue() {
+            return value;
+        }
+
+        public Long setValue(final Long value) {
+            throw new UnsupportedOperationException();
+        }
+
+        public Entry<Long, Long> next() {
+            key = entries[index];
+            value = entries[index + 1];
+            nextIndex();
+            return this;
+        }
+    }
+
+    private int next(final int index) {
+        return (index + 2) & mask;
+    }
+
+    private void capacity(final int newCapacity) {
+        capacity = newCapacity;
+        resizeThreshold = (int) (newCapacity * loadFactor);
+        mask = (newCapacity * 2) - 1;
+        entries = new long[newCapacity * 2];
+        Arrays.fill(entries, missingValue);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/agrona/collections/Long2ObjectHashMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/agrona/collections/Long2ObjectHashMap.java
@@ -1,0 +1,579 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.agrona.collections;
+
+import com.hazelcast.agrona.BitUtil;
+import com.hazelcast.agrona.function.LongFunction;
+
+import java.util.AbstractCollection;
+import java.util.AbstractSet;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Set;
+
+import static com.hazelcast.util.Preconditions.checkNotNull;
+
+/**
+ * {@link java.util.Map} implementation specialised for long keys using open addressing and
+ * linear probing for cache efficient access.
+ *
+ * @param <V> values stored in the {@link java.util.Map}
+ */
+public class Long2ObjectHashMap<V> implements Map<Long, V> {
+    private final double loadFactor;
+    private int resizeThreshold;
+    private int capacity;
+    private int mask;
+    private int size;
+
+    private long[] keys;
+    private Object[] values;
+
+    // Cached to avoid allocation.
+    private final ValueCollection<V> valueCollection = new ValueCollection<V>();
+    private final KeySet keySet = new KeySet();
+    private final EntrySet<V> entrySet = new EntrySet<V>();
+
+    public Long2ObjectHashMap() {
+        this(8, 0.6);
+    }
+
+    /**
+     * Construct a new map allowing a configuration for initial capacity and load factor.
+     *
+     * @param initialCapacity for the backing array
+     * @param loadFactor      limit for resizing on puts
+     */
+    public Long2ObjectHashMap(final int initialCapacity, final double loadFactor) {
+        this.loadFactor = loadFactor;
+        capacity = BitUtil.findNextPositivePowerOfTwo(initialCapacity);
+        mask = capacity - 1;
+        resizeThreshold = (int) (capacity * loadFactor);
+
+        keys = new long[capacity];
+        values = new Object[capacity];
+    }
+
+    /**
+     * Get the load factor beyond which the map will increase size.
+     *
+     * @return load factor for when the map should increase size.
+     */
+    public double loadFactor() {
+        return loadFactor;
+    }
+
+    /**
+     * Get the total capacity for the map to which the load factor with be a fraction of.
+     *
+     * @return the total capacity for the map.
+     */
+    public int capacity() {
+        return capacity;
+    }
+
+    /**
+     * Get the actual threshold which when reached the map resize.
+     * This is a function of the current capacity and load factor.
+     *
+     * @return the threshold when the map will resize.
+     */
+    public int resizeThreshold() {
+        return resizeThreshold;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public int size() {
+        return size;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public boolean isEmpty() {
+        return 0 == size;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public boolean containsKey(final Object key) {
+        checkNotNull(key, "Null keys are not permitted");
+        return containsKey(((Long) key).longValue());
+    }
+
+    /**
+     * Overloaded version of {@link Map#containsKey(Object)} that takes a primitive long key.
+     *
+     * @param key for indexing the {@link Map}
+     * @return true if the key is found otherwise false.
+     */
+    public boolean containsKey(final long key) {
+        int index = hash(key);
+        while (null != values[index]) {
+            if (key == keys[index]) {
+                return true;
+            }
+            index = ++index & mask;
+        }
+        return false;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public boolean containsValue(final Object value) {
+        checkNotNull(value, "Null values are not permitted");
+        for (final Object v : values) {
+            if (null != v && value.equals(v)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public V get(final Object key) {
+        return get(((Long) key).longValue());
+    }
+
+    /**
+     * Overloaded version of {@link Map#get(Object)} that takes a primitive long key.
+     *
+     * @param key for indexing the {@link Map}
+     * @return the value if found otherwise null
+     */
+    @SuppressWarnings("unchecked")
+    public V get(final long key) {
+        int index = hash(key);
+        Object value;
+        while (null != (value = values[index])) {
+            if (key == keys[index]) {
+                return (V) value;
+            }
+            index = ++index & mask;
+        }
+        return null;
+    }
+
+    /**
+     * Get a value for a given key, or if it does ot exist then default the value via a {@link LongFunction}
+     * and put it in the map.
+     * <p/>
+     * Primitive specialized version of {@link java.util.Map#computeIfAbsent}.
+     *
+     * @param key             to search on.
+     * @param mappingFunction to provide a value if the get returns null.
+     * @return the value if found otherwise the default.
+     */
+    public V computeIfAbsent(final long key, final LongFunction<? extends V> mappingFunction) {
+        checkNotNull(mappingFunction, "mappingFunction cannot be null");
+        V value = get(key);
+        if (value == null) {
+            value = mappingFunction.apply(key);
+            if (value != null) {
+                put(key, value);
+            }
+        }
+        return value;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public V put(final Long key, final V value) {
+        return put(key.longValue(), value);
+    }
+
+    /**
+     * Overloaded version of {@link Map#put(Object, Object)} that takes a primitive int key.
+     *
+     * @param key   for indexing the {@link Map}
+     * @param value to be inserted in the {@link Map}
+     * @return the previous value if found otherwise null
+     */
+    @SuppressWarnings("unchecked")
+    public V put(final long key, final V value) {
+        checkNotNull(value, "Value cannot be null");
+        V oldValue = null;
+        int index = hash(key);
+        while (null != values[index]) {
+            if (key == keys[index]) {
+                oldValue = (V) values[index];
+                break;
+            }
+            index = ++index & mask;
+        }
+        if (null == oldValue) {
+            ++size;
+            keys[index] = key;
+        }
+        values[index] = value;
+        if (size > resizeThreshold) {
+            increaseCapacity();
+        }
+        return oldValue;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public V remove(final Object key) {
+        return remove(((Long) key).longValue());
+    }
+
+    /**
+     * Overloaded version of {@link Map#remove(Object)} that takes a primitive int key.
+     *
+     * @param key for indexing the {@link Map}
+     * @return the value if found otherwise null
+     */
+    @SuppressWarnings("unchecked")
+    public V remove(final long key) {
+        int index = hash(key);
+        Object value;
+        while (null != (value = values[index])) {
+            if (key == keys[index]) {
+                values[index] = null;
+                --size;
+                compactChain(index);
+                return (V) value;
+            }
+            index = ++index & mask;
+        }
+        return null;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public void clear() {
+        size = 0;
+        Arrays.fill(values, null);
+    }
+
+    /**
+     * Compact the {@link Map} backing arrays by rehashing with a capacity just larger than current size
+     * and giving consideration to the load factor.
+     */
+    public void compact() {
+        final int idealCapacity = (int) Math.round(size() * (1.0d / loadFactor));
+        rehash(BitUtil.findNextPositivePowerOfTwo(idealCapacity));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public void putAll(final Map<? extends Long, ? extends V> map) {
+        for (final Entry<? extends Long, ? extends V> entry : map.entrySet()) {
+            put(entry.getKey(), entry.getValue());
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public KeySet keySet() {
+        return keySet;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public Collection<V> values() {
+        return valueCollection;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public Set<Entry<Long, V>> entrySet() {
+        return entrySet;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public String toString() {
+        final StringBuilder sb = new StringBuilder();
+        sb.append('{');
+        for (final Map.Entry<Long, V> entry : entrySet()) {
+            sb.append(entry.getKey().longValue());
+            sb.append('=');
+            sb.append(entry.getValue());
+            sb.append(", ");
+        }
+        if (sb.length() > 1) {
+            sb.setLength(sb.length() - 2);
+        }
+        sb.append('}');
+        return sb.toString();
+    }
+
+    private void increaseCapacity() {
+        final int newCapacity = capacity << 1;
+        if (newCapacity < 0) {
+            throw new IllegalStateException("Max capacity reached at size=" + size);
+        }
+        rehash(newCapacity);
+    }
+
+    private void rehash(final int newCapacity) {
+        if (1 != Integer.bitCount(newCapacity)) {
+            throw new IllegalStateException("New capacity must be a power of two");
+        }
+        capacity = newCapacity;
+        mask = newCapacity - 1;
+        resizeThreshold = (int) (newCapacity * loadFactor);
+        final long[] tempKeys = new long[capacity];
+        final Object[] tempValues = new Object[capacity];
+        for (int i = 0, size = values.length; i < size; i++) {
+            final Object value = values[i];
+            if (null != value) {
+                final long key = keys[i];
+                int newHash = hash(key);
+                while (null != tempValues[newHash]) {
+                    newHash = ++newHash & mask;
+                }
+                tempKeys[newHash] = key;
+                tempValues[newHash] = value;
+            }
+        }
+        keys = tempKeys;
+        values = tempValues;
+    }
+
+    private void compactChain(int deleteIndex) {
+        int index = deleteIndex;
+        while (true) {
+            index = ++index & mask;
+            if (null == values[index]) {
+                return;
+            }
+            final int hash = hash(keys[index]);
+            if ((index < hash && (hash <= deleteIndex || deleteIndex <= index))
+                    || (hash <= deleteIndex && deleteIndex <= index)) {
+                keys[deleteIndex] = keys[index];
+                values[deleteIndex] = values[index];
+                values[index] = null;
+                deleteIndex = index;
+            }
+        }
+    }
+
+    private int hash(final long key) {
+        int hash = (int) key ^ (int) (key >>> 32);
+        hash = (hash << 1) - (hash << 8);
+        return hash & mask;
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////////////////////
+    // Internal Sets and Collections
+    ///////////////////////////////////////////////////////////////////////////////////////////////
+
+    public class KeySet extends AbstractSet<Long> {
+        public int size() {
+            return Long2ObjectHashMap.this.size();
+        }
+
+        public boolean isEmpty() {
+            return Long2ObjectHashMap.this.isEmpty();
+        }
+
+        public boolean contains(final Object o) {
+            return Long2ObjectHashMap.this.containsKey(o);
+        }
+
+        public boolean contains(final long key) {
+            return Long2ObjectHashMap.this.containsKey(key);
+        }
+
+        public KeyIterator iterator() {
+            return new KeyIterator();
+        }
+
+        public boolean remove(final Object o) {
+            return null != Long2ObjectHashMap.this.remove(o);
+        }
+
+        public boolean remove(final long key) {
+            return null != Long2ObjectHashMap.this.remove(key);
+        }
+
+        public void clear() {
+            Long2ObjectHashMap.this.clear();
+        }
+    }
+
+    private class ValueCollection<V> extends AbstractCollection<V> {
+        public int size() {
+            return Long2ObjectHashMap.this.size();
+        }
+
+        public boolean isEmpty() {
+            return Long2ObjectHashMap.this.isEmpty();
+        }
+
+        public boolean contains(final Object o) {
+            return Long2ObjectHashMap.this.containsValue(o);
+        }
+
+        public ValueIterator<V> iterator() {
+            return new ValueIterator<V>();
+        }
+
+        public void clear() {
+            Long2ObjectHashMap.this.clear();
+        }
+    }
+
+    private class EntrySet<V> extends AbstractSet<Map.Entry<Long, V>> {
+        public int size() {
+            return Long2ObjectHashMap.this.size();
+        }
+
+        public boolean isEmpty() {
+            return Long2ObjectHashMap.this.isEmpty();
+        }
+
+        public Iterator<Map.Entry<Long, V>> iterator() {
+            return new EntryIterator<V>();
+        }
+
+        public void clear() {
+            Long2ObjectHashMap.this.clear();
+        }
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////////////////////
+    // Iterators
+    ///////////////////////////////////////////////////////////////////////////////////////////////
+
+    private abstract class AbstractIterator<T> implements Iterator<T> {
+        protected final long[] keys = Long2ObjectHashMap.this.keys;
+        protected final Object[] values = Long2ObjectHashMap.this.values;
+        private int posCounter;
+        private int stopCounter;
+        private boolean isPositionValid;
+
+        protected AbstractIterator() {
+            int i = capacity;
+            if (null != values[capacity - 1]) {
+                i = 0;
+                for (int size = capacity; i < size; i++) {
+                    if (null == values[i]) {
+                        break;
+                    }
+                }
+            }
+            stopCounter = i;
+            posCounter = i + capacity;
+        }
+
+        protected int getPosition() {
+            return posCounter & mask;
+        }
+
+        public boolean hasNext() {
+            for (int i = posCounter - 1; i >= stopCounter; i--) {
+                final int index = i & mask;
+                if (null != values[index]) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        protected void findNext() {
+            isPositionValid = false;
+            for (int i = posCounter - 1; i >= stopCounter; i--) {
+                final int index = i & mask;
+                if (null != values[index]) {
+                    posCounter = i;
+                    isPositionValid = true;
+                    return;
+                }
+            }
+            throw new NoSuchElementException();
+        }
+
+        public abstract T next();
+
+        public void remove() {
+            if (isPositionValid) {
+                final int position = getPosition();
+                values[position] = null;
+                --size;
+                compactChain(position);
+                isPositionValid = false;
+            } else {
+                throw new IllegalStateException();
+            }
+        }
+    }
+
+    public class ValueIterator<T> extends AbstractIterator<T> {
+        @SuppressWarnings("unchecked")
+        public T next() {
+            findNext();
+            return (T) values[getPosition()];
+        }
+    }
+
+    public class KeyIterator extends AbstractIterator<Long> {
+        public Long next() {
+            return nextLong();
+        }
+
+        public long nextLong() {
+            findNext();
+
+            return keys[getPosition()];
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public class EntryIterator<V> extends AbstractIterator<Entry<Long, V>> implements Entry<Long, V> {
+        public Entry<Long, V> next() {
+            findNext();
+            return this;
+        }
+
+        public Long getKey() {
+            return keys[getPosition()];
+        }
+
+        public V getValue() {
+            return (V) values[getPosition()];
+        }
+
+        public V setValue(final V value) {
+            checkNotNull(value);
+            final int pos = getPosition();
+            final Object oldValue = values[pos];
+            values[pos] = value;
+            return (V) oldValue;
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/agrona/collections/LongHashSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/agrona/collections/LongHashSet.java
@@ -1,0 +1,380 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.agrona.collections;
+
+import com.hazelcast.agrona.BitUtil;
+import com.hazelcast.agrona.function.Predicate;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Set;
+
+import static com.hazelcast.util.Preconditions.checkNotNull;
+
+/**
+ * Simple fixed-size long hashset for validating tags.
+ */
+public final class LongHashSet implements Set<Long> {
+    private final long[] values;
+    private final LongIterator iterator;
+    private final int mask;
+    private final long missingValue;
+
+    private int size;
+
+    public LongHashSet(final int proposedCapacity, final long missingValue) {
+        size = 0;
+        this.missingValue = missingValue;
+        final int capacity = BitUtil.findNextPositivePowerOfTwo(proposedCapacity);
+        mask = capacity - 1;
+        values = new long[capacity];
+        Arrays.fill(values, missingValue);
+
+        // NB: references values in the constructor, so must be assigned after values
+        iterator = new LongIterator(missingValue, values);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public boolean add(final Long value) {
+        return add(value.longValue());
+    }
+
+    /**
+     * Primitive specialised overload of {this#add(Long)}
+     *
+     * @param value the value to add
+     * @return true if the collection has changed, false otherwise
+     */
+    public boolean add(final long value) {
+        int index = Hashing.longHash(value, mask);
+
+        while (values[index] != missingValue) {
+            if (values[index] == value) {
+                return false;
+            }
+
+            index = next(index);
+        }
+
+        values[index] = value;
+        size++;
+
+        return true;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public boolean remove(final Object value) {
+        return value instanceof Long && remove(((Long) value).longValue());
+    }
+
+    /**
+     * An long specialised version of {this#remove(Object)}.
+     *
+     * @param value the value to remove
+     * @return true if the value was present, false otherwise
+     */
+    public boolean remove(final long value) {
+        int index = Hashing.longHash(value, mask);
+
+        while (values[index] != missingValue) {
+            if (values[index] == value) {
+                values[index] = missingValue;
+                compactChain(index);
+                return true;
+            }
+
+            index = next(index);
+        }
+
+        return false;
+    }
+
+    private int next(int index) {
+        index = ++index & mask;
+        return index;
+    }
+
+    private void compactChain(final int deleteIndex) {
+        final long[] values = this.values;
+
+        int index = deleteIndex;
+        while (true) {
+            final int previousIndex = index;
+            index = next(index);
+            if (values[index] == missingValue) {
+                return;
+            }
+
+            values[previousIndex] = values[index];
+            values[index] = missingValue;
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public boolean contains(final Object value) {
+        return value instanceof Long && contains(((Long) value).longValue());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public boolean contains(final long value) {
+        int index = Hashing.longHash(value, mask);
+
+        while (values[index] != missingValue) {
+            if (values[index] == value) {
+                return true;
+            }
+
+            index = next(index);
+        }
+
+        return false;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public int size() {
+        return size;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public boolean isEmpty() {
+        return size() == 0;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public void clear() {
+        final long[] values = this.values;
+        final int length = values.length;
+        for (int i = 0; i < length; i++) {
+            values[i] = missingValue;
+        }
+        size = 0;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @SuppressWarnings("unchecked")
+    public <T> T[] toArray(final T[] ignore) {
+        return (T[]) (Object) Arrays.copyOf(values, values.length);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public boolean addAll(final Collection<? extends Long> coll) {
+        return addAllCapture(coll);
+    }
+
+    private <E extends Long> boolean addAllCapture(final Collection<E> coll) {
+        final Predicate<E> p = new Predicate<E>() {
+            @Override
+            public boolean test(E x) {
+                return add(x);
+            }
+        };
+        return conjunction(coll, p);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public boolean containsAll(final Collection<?> coll) {
+        return containsAllCapture(coll);
+    }
+
+    private <E> boolean containsAllCapture(Collection<E> coll) {
+        return conjunction(coll, new Predicate<E>() {
+            @Override
+            public boolean test(E value) {
+                return contains(value);
+            }
+        });
+    }
+
+    /**
+     * LongHashSet specialised variant of {this#containsAll(Collection)}.
+     *
+     * @param other the long hashset to compare against.
+     * @return true if every element in other is in this.
+     */
+    public boolean containsAll(final LongHashSet other) {
+        final LongIterator iterator = other.iterator();
+        while (iterator.hasNext()) {
+            if (!contains(iterator.nextValue())) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Fast Path set difference for comparison with another LongHashSet.
+     * <p/>
+     * NB: garbage free in the identical case, allocates otherwise.
+     *
+     * @param collection the other set to subtract
+     * @return null if identical, otherwise the set of differences
+     */
+    public LongHashSet difference(final LongHashSet collection) {
+        checkNotNull(collection);
+
+        LongHashSet difference = null;
+
+        final LongIterator it = iterator();
+
+        while (it.hasNext()) {
+            final long value = it.nextValue();
+            if (!collection.contains(value)) {
+                if (difference == null) {
+                    difference = new LongHashSet(size, missingValue);
+                }
+
+                difference.add(value);
+            }
+        }
+
+        return difference;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public boolean removeAll(final Collection<?> coll) {
+        return removeAllCapture(coll);
+    }
+
+    private <E> boolean removeAllCapture(final Collection<E> coll) {
+        return conjunction(coll, new Predicate<E>() {
+            @Override
+            public boolean test(E value) {
+                return remove(value);
+            }
+        });
+    }
+
+    private static <T> boolean conjunction(final Collection<T> collection, final Predicate<T> predicate) {
+        checkNotNull(collection);
+
+        boolean acc = false;
+        for (final T t : collection) {
+            // Deliberate strict evaluation
+            acc |= predicate.test(t);
+        }
+
+        return acc;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public LongIterator iterator() {
+        iterator.reset();
+        return iterator;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public void copy(final LongHashSet obj) {
+        // NB: mask also implies the length is the same
+        if (this.mask != obj.mask) {
+            throw new IllegalArgumentException("Cannot copy object: masks not equal");
+        }
+
+        if (this.missingValue != obj.missingValue) {
+            throw new IllegalArgumentException("Cannot copy object: missingValues not equal");
+        }
+
+        System.arraycopy(obj.values, 0, this.values, 0, this.values.length);
+        this.size = obj.size;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public String toString() {
+        final StringBuilder b = new StringBuilder(size() * 3 + 2);
+        b.append('{');
+        String separator = "";
+        for (long i : values) {
+            b.append(i).append(separator);
+            separator = ",";
+        }
+        return b.append('}').toString();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public Object[] toArray() {
+        final long[] values = this.values;
+        final Object[] array = new Object[values.length];
+        for (int i = 0; i < values.length; i++) {
+            array[i] = values[i];
+        }
+        return array;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public boolean equals(final Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (other instanceof LongHashSet) {
+            final LongHashSet otherSet = (LongHashSet) other;
+            return otherSet.missingValue == missingValue && otherSet.size() == size() && containsAll(otherSet);
+        }
+
+        return false;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public int hashCode() {
+        final LongIterator iterator = iterator();
+        int total = 0;
+        while (iterator.hasNext()) {
+            // Cast exists for substitutions
+            total += (long) iterator.nextValue();
+        }
+        return total;
+    }
+
+    // --- Unimplemented below here
+
+    public boolean retainAll(final Collection<?> coll) {
+        throw new UnsupportedOperationException("Not implemented");
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/agrona/collections/LongIterator.java
+++ b/hazelcast/src/main/java/com/hazelcast/agrona/collections/LongIterator.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.agrona.collections;
+
+import java.util.Iterator;
+
+/**
+ * An iterator for a sequence of primitive integers.
+ */
+public class LongIterator implements Iterator<Long> {
+    private final long missingValue;
+    private final long[] values;
+
+    private int position;
+
+    /**
+     * Construct an {@link Iterator} over an array of primitives longs.
+     *
+     * @param missingValue to indicate the value is missing, i.e. not present or null.
+     * @param values       to iterate over.
+     */
+    public LongIterator(final long missingValue, final long[] values) {
+        this.missingValue = missingValue;
+        this.values = values;
+    }
+
+    public boolean hasNext() {
+        final long[] values = this.values;
+        while (position < values.length) {
+            if (values[position] != missingValue) {
+                return true;
+            }
+
+            position++;
+        }
+
+        return false;
+    }
+
+    public Long next() {
+        return nextValue();
+    }
+
+    public void remove() {
+        throw new UnsupportedOperationException("remove");
+    }
+
+    /**
+     * Strongly typed alternative of {@link Iterator#next()} not to avoid boxing.
+     *
+     * @return the next long value.
+     */
+    public long nextValue() {
+        final long value = values[position];
+        position++;
+        return value;
+    }
+
+    void reset() {
+        position = 0;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/agrona/collections/MapDelegatingSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/agrona/collections/MapDelegatingSet.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.agrona.collections;
+
+import com.hazelcast.agrona.function.Predicate;
+import com.hazelcast.agrona.function.Supplier;
+
+import java.util.AbstractSet;
+import java.util.Iterator;
+import java.util.Map;
+
+/**
+ * Read-only collection which delegates its operations to an underlying map and a couple of functions. Designed
+ * to easily implement keyset() and values() methods in a map.
+ *
+ * @param <V> The generic type of the set.
+ */
+public final class MapDelegatingSet<V> extends AbstractSet<V> {
+    private final Map<?, ?> delegate;
+    private final Supplier<Iterator<V>> iterator;
+    private final Predicate contains;
+
+    public MapDelegatingSet(final Map<?, ?> delegate, final Supplier<Iterator<V>> iterator, final Predicate contains) {
+        this.delegate = delegate;
+        this.iterator = iterator;
+        this.contains = contains;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public int size() {
+        return delegate.size();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public boolean isEmpty() {
+        return delegate.isEmpty();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @SuppressWarnings("unchecked")
+    public boolean contains(final Object o) {
+        return contains.test(o);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public Iterator<V> iterator() {
+        return iterator.get();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public void clear() {
+        delegate.clear();
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/agrona/collections/MutableInteger.java
+++ b/hazelcast/src/main/java/com/hazelcast/agrona/collections/MutableInteger.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.agrona.collections;
+
+/**
+ * Holder for an int value that is mutable. Useful for being a counter in a {@link java.util.Map}
+ */
+public class MutableInteger {
+    public int value;
+}

--- a/hazelcast/src/main/java/com/hazelcast/agrona/collections/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/agrona/collections/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * The Agrona project backport: collections.
+ */
+package com.hazelcast.agrona.collections;

--- a/hazelcast/src/main/java/com/hazelcast/agrona/function/BiConsumer.java
+++ b/hazelcast/src/main/java/com/hazelcast/agrona/function/BiConsumer.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.agrona.function;
+
+/**
+ * Represents an operation that accepts two input arguments and returns no
+ * result.  This is the two-arity specialization of {@link Consumer}.
+ * Unlike most other functional interfaces, {@code BiConsumer} is expected
+ * to operate via side-effects.
+ *
+ * @param <T> the type of the first argument to the operation
+ * @param <U> the type of the second argument to the operation
+ */
+public interface BiConsumer<T, U> {
+
+    /**
+     * Performs this operation on the given arguments.
+     *
+     * @param t the first input argument
+     * @param u the second input argument
+     */
+    void accept(T t, U u);
+}

--- a/hazelcast/src/main/java/com/hazelcast/agrona/function/Consumer.java
+++ b/hazelcast/src/main/java/com/hazelcast/agrona/function/Consumer.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.agrona.function;
+
+/**
+ * Represents an operation that accepts a single input argument and returns no
+ * result. Unlike most other functional interfaces, {@code Consumer} is expected
+ * to operate via side-effects.
+ *
+ * @param <T> the type of the input to the operation
+ */
+public interface Consumer<T> {
+
+    /**
+     * Performs this operation on the given argument.
+     *
+     * @param t the input argument
+     */
+    void accept(T t);
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/agrona/function/IntFunction.java
+++ b/hazelcast/src/main/java/com/hazelcast/agrona/function/IntFunction.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.agrona.function;
+
+/**
+ * Represents a function that accepts an int-valued argument and produces a
+ * result.  This is the {@code int}-consuming primitive specialization for
+ * {@link Function}.
+ *
+ * @param <R> the type of the result of the function
+ */
+public interface IntFunction<R> {
+
+    /**
+     * Applies this function to the given argument.
+     *
+     * @param value the function argument
+     * @return the function result
+     */
+    R apply(int value);
+}

--- a/hazelcast/src/main/java/com/hazelcast/agrona/function/LongFunction.java
+++ b/hazelcast/src/main/java/com/hazelcast/agrona/function/LongFunction.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.agrona.function;
+
+/**
+ * Represents a function that accepts a long-valued argument and produces a
+ * result.
+ *
+ * @param <R> the type of the result of the function
+ */
+public interface LongFunction<R> {
+
+    /**
+     * Applies this function to the given argument.
+     *
+     * @param value the function argument
+     * @return the function result
+     */
+    R apply(long value);
+}

--- a/hazelcast/src/main/java/com/hazelcast/agrona/function/LongLongConsumer.java
+++ b/hazelcast/src/main/java/com/hazelcast/agrona/function/LongLongConsumer.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.agrona.function;
+
+/**
+ * This is a (long,long) primitive specialisation of a BiConsumer
+ */
+public interface LongLongConsumer {
+    /**
+     * Accept a key and value that comes as a tuple of longs.
+     *
+     * @param key   for the tuple.
+     * @param value for the tuple.
+     */
+    void accept(long key, long value);
+}

--- a/hazelcast/src/main/java/com/hazelcast/agrona/function/Predicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/agrona/function/Predicate.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.agrona.function;
+
+/**
+ * Represents a predicate (boolean-valued function) of one argument.
+ *
+ * @param <T> the type of the input to the predicate
+ */
+public interface Predicate<T> {
+
+    /**
+     * Evaluates this predicate on the given argument.
+     *
+     * @param t the input argument
+     * @return {@code true} if the input argument matches the predicate,
+     * otherwise {@code false}
+     */
+    boolean test(T t);
+}

--- a/hazelcast/src/main/java/com/hazelcast/agrona/function/Supplier.java
+++ b/hazelcast/src/main/java/com/hazelcast/agrona/function/Supplier.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.agrona.function;
+
+/**
+ * Represents a supplier of results.
+ *
+ * <p>There is no requirement that a new or distinct result be returned each
+ * time the supplier is invoked.
+ *
+ * @param <T> the type of results supplied by this supplier
+ */
+public interface Supplier<T> {
+    T get();
+}

--- a/hazelcast/src/main/java/com/hazelcast/agrona/function/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/agrona/function/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Backport of Java 8 functional interfaces which Agrona depends on.
+ */
+package com.hazelcast.agrona.function;

--- a/hazelcast/src/main/java/com/hazelcast/agrona/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/agrona/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * The Agrona project backport.
+ */
+package com.hazelcast.agrona;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/util/ClientMessageBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/util/ClientMessageBuilder.java
@@ -1,5 +1,6 @@
 package com.hazelcast.client.impl.protocol.util;
 
+import com.hazelcast.agrona.collections.Int2ObjectHashMap;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 
 import java.nio.ByteBuffer;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/NearCacheConcurrentMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/NearCacheConcurrentMap.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl;
+
+import com.hazelcast.nio.serialization.Data;
+
+import java.util.AbstractCollection;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Specialization of ConcurrethHashMap for the near cache. Masks out the
+ * <code>PendingValue</code> sentinel records from results.
+ */
+public class NearCacheConcurrentMap extends ConcurrentHashMap<Data, NearCacheRecord>
+{
+    @Override
+    public NearCacheRecord get(Object key) {
+        final NearCacheRecord rec = super.get(key);
+        return rec.isPending()? null : rec;
+    }
+
+    @Override
+    public Collection<NearCacheRecord> values() {
+        return null;
+    }
+
+    @Override
+    public Set<Entry<Data, NearCacheRecord>> entrySet() {
+        return null;
+    }
+
+    @Override
+    public NearCacheRecord putIfAbsent(Data key, NearCacheRecord value) {
+        NearCacheRecord prev = super.putIfAbsent(key, value);
+        while (prev != null && prev.isPending() && !super.replace(key, prev, value)) {
+            prev = super.get(key);
+        }
+        return prev;
+    }
+
+    final class Values extends AbstractCollection<NearCacheRecord> {
+        Values() {
+        }
+
+        public Iterator<NearCacheRecord> iterator() {
+            return new ValueIterator();
+        }
+
+        public int size() {
+            return NearCacheConcurrentMap.this.size();
+        }
+
+        public boolean contains(Object var1) {
+            return NearCacheConcurrentMap.this.containsValue(var1);
+        }
+
+        public void clear() {
+            NearCacheConcurrentMap.this.clear();
+        }
+    }
+
+    final class ValueIterator implements Iterator<NearCacheRecord> {
+        ValueIterator() {
+            this.wrapped = null;
+        }
+
+        public NearCacheRecord next() {
+            return super.nextEntry().value;
+        }
+
+        public V nextElement() {
+            return super.nextEntry().value;
+        }
+    }
+
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/NearCacheProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/NearCacheProvider.java
@@ -74,31 +74,44 @@ public class NearCacheProvider {
         }
     }
 
+    public long announcePutNearCache(String mapName, Data key) {
+        assertNearCacheEnabled(mapName);
+        return getNearCache(mapName).announcePut(key);
+    }
+
+    public Object putNearCacheAnnounced(String mapName, long permit, Data key, Data value) {
+        assertNearCacheEnabled(mapName);
+        return getNearCache(mapName).putAnnounced(permit, key, value);
+    }
+
+    public void cancelAnnouncement(String mapName, long permit, Data key) {
+        assertNearCacheEnabled(mapName);
+        getNearCache(mapName).cancelAnnouncement(permit, key);
+    }
+
+    private void assertNearCacheEnabled(String mapName) {
+        if (!isNearCacheEnabled(mapName)) {
+            throw new IllegalArgumentException("Near cache is not enabled on " + mapName);
+        }
+    }
+
     // this operation returns the given value in near-cache memory format (data or object)
     // if near-cache is not enabled, it returns null
     public Object putNearCache(String mapName, Data key, Data value) {
         // todo assert near-cache is enabled might be better
-        if (!isNearCacheEnabled(mapName)) {
-            return null;
-        }
-        NearCache nearCache = getNearCache(mapName);
-        return nearCache.put(key, value);
+        return isNearCacheEnabled(mapName) ? getNearCache(mapName).put(key, value) : null;
     }
 
     public void invalidateNearCache(String mapName, Data key) {
-        if (!isNearCacheEnabled(mapName)) {
-            return;
+        if (isNearCacheEnabled(mapName)) {
+            getNearCache(mapName).invalidate(key);
         }
-        NearCache nearCache = getNearCache(mapName);
-        nearCache.invalidate(key);
     }
 
     public void invalidateNearCache(String mapName, Collection<Data> keys) {
-        if (!isNearCacheEnabled(mapName)) {
-            return;
+        if (isNearCacheEnabled(mapName)) {
+            getNearCache(mapName).invalidate(keys);
         }
-        NearCache nearCache = getNearCache(mapName);
-        nearCache.invalidate(keys);
     }
 
     public void clearNearCache(String mapName) {
@@ -139,15 +152,11 @@ public class NearCacheProvider {
     }
 
     public boolean isNearCacheEnabled(String mapName) {
-        final MapContainer mapContainer = mapServiceContext.getMapContainer(mapName);
-        return mapContainer.isNearCacheEnabled();
+        return mapServiceContext.getMapContainer(mapName).isNearCacheEnabled();
     }
 
     public void invalidateAllNearCaches(String mapName, Set<Data> keys) {
-        if (!isNearCacheEnabled(mapName)) {
-            return;
-        }
-        if (keys == null || keys.isEmpty()) {
+        if (!isNearCacheEnabled(mapName) || keys == null || keys.isEmpty()) {
             return;
         }
         //send operation.
@@ -171,11 +180,7 @@ public class NearCacheProvider {
     }
 
     public Object getFromNearCache(String mapName, Data key) {
-        if (!isNearCacheEnabled(mapName)) {
-            return null;
-        }
-        NearCache nearCache = getNearCache(mapName);
-        return nearCache.get(key);
+        return isNearCacheEnabled(mapName) ? getNearCache(mapName).get(key) : null;
     }
 }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/NearCacheRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/NearCacheRecord.java
@@ -61,12 +61,24 @@ public class NearCacheRecord {
     private volatile long lastAccessTime;
 
     public NearCacheRecord(Object key, Object value) {
+        this(key, value, new AtomicLong());
+    }
+
+    private NearCacheRecord(Object key, Object value, AtomicLong hit) {
         this.key = key;
         this.value = value;
         long time = Clock.currentTimeMillis();
         this.lastAccessTime = time;
         this.creationTime = time;
         this.hit = new AtomicLong();
+    }
+
+    private NearCacheRecord(Object key) {
+        this(key, null, null);
+    }
+
+    public NearCacheRecord pendingValue(Object key) {
+        return new NearCacheRecord(key);
     }
 
     public Object getKey() {
@@ -104,6 +116,10 @@ public class NearCacheRecord {
         long time = Clock.currentTimeMillis();
         return (maxIdleMillis > 0 && time > lastAccessTime + maxIdleMillis)
                 || (timeToLiveMillis > 0 && time > creationTime + timeToLiveMillis);
+    }
+
+    public boolean isPending() {
+        return hit == null;
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/util/Preconditions.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/Preconditions.java
@@ -29,6 +29,22 @@ public final class Preconditions {
 
 
     /**
+     * Tests if a string contains text.
+     *
+     * @param argument     the string tested to see if it contains text.
+     * @param errorMessage the errorMessage
+     * @return the string argument that was tested.
+     * @throws java.lang.IllegalArgumentException if the string is empty
+     */
+    public static String checkHasText(String argument, String errorMessage) {
+        if (argument == null || argument.isEmpty()) {
+            throw new IllegalArgumentException(errorMessage);
+        }
+
+        return argument;
+    }
+
+    /**
      * Tests if an argument is not null.
      *
      * @param argument     the argument tested to see if it is not null.
@@ -44,18 +60,16 @@ public final class Preconditions {
     }
 
     /**
-     * Tests if a string contains text.
+     * Tests if an argument is not null.
      *
-     * @param argument     the string tested to see if it contains text.
-     * @param errorMessage the errorMessage
-     * @return the string argument that was tested.
-     * @throws java.lang.IllegalArgumentException if the string is empty
+     * @param argument     the argument tested to see if it is not null.
+     * @return the argument that was tested.
+     * @throws java.lang.NullPointerException if argument is null
      */
-    public static String checkHasText(String argument, String errorMessage) {
-        if (argument == null || argument.isEmpty()) {
-            throw new IllegalArgumentException(errorMessage);
+    public static <T> T checkNotNull(T argument) {
+        if (argument == null) {
+            throw new NullPointerException();
         }
-
         return argument;
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/cache/nearcache/NearCacheTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/nearcache/NearCacheTestSupport.java
@@ -17,18 +17,18 @@ import static org.junit.Assert.assertTrue;
 
 public abstract class NearCacheTestSupport extends CommonNearCacheTestSupport {
 
-    protected abstract NearCache<Integer, String> createNearCache(String name,
-                                                                  NearCacheConfig nearCacheConfig,
-                                                                  ManagedNearCacheRecordStore nearCacheRecordStore);
+    protected abstract NearCache<Integer, String> createNearCache(
+            String name, NearCacheConfig nearCacheConfig, ManagedNearCacheRecordStore nearCacheRecordStore);
 
-    protected NearCache<Integer, String> createNearCache(String name,
-                                                         ManagedNearCacheRecordStore nearCacheRecordStore) {
+    protected NearCache<Integer, String> createNearCache(
+            String name, ManagedNearCacheRecordStore nearCacheRecordStore)
+    {
         return createNearCache(name,
                                createNearCacheConfig(name, NearCacheConfig.DEFAULT_MEMORY_FORMAT),
                                nearCacheRecordStore);
     }
 
-    protected class ManagedNearCacheRecordStore implements NearCacheRecordStore<Integer, String> {
+    protected static class ManagedNearCacheRecordStore implements NearCacheRecordStore<Integer, String> {
 
         protected final NearCacheStats nearCacheStats = new NearCacheStatsImpl();
 
@@ -140,7 +140,7 @@ public abstract class NearCacheTestSupport extends CommonNearCacheTestSupport {
 
     }
 
-    protected Map<Integer, String> generateRandomKeyValueMappings() {
+    protected static Map<Integer, String> generateRandomKeyValueMappings() {
         Map<Integer, String> expectedKeyValueMappings = new HashMap<Integer, String>();
         for (int i = 0; i < DEFAULT_RECORD_COUNT; i++) {
             expectedKeyValueMappings.put(i, "Record-" + i);
@@ -148,12 +148,12 @@ public abstract class NearCacheTestSupport extends CommonNearCacheTestSupport {
         return expectedKeyValueMappings;
     }
 
-    protected ManagedNearCacheRecordStore createManagedNearCacheRecordStore(
+    protected static ManagedNearCacheRecordStore createManagedNearCacheRecordStore(
             Map<Integer, String> expectedKeyValueMappings) {
         return new ManagedNearCacheRecordStore(expectedKeyValueMappings);
     }
 
-    protected ManagedNearCacheRecordStore createManagedNearCacheRecordStore() {
+    protected static ManagedNearCacheRecordStore createManagedNearCacheRecordStore() {
         return new ManagedNearCacheRecordStore(generateRandomKeyValueMappings());
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/Int2ObjectHashMapTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/Int2ObjectHashMapTest.java
@@ -15,7 +15,7 @@
  */
 package com.hazelcast.client.protocol;
 
-import com.hazelcast.client.impl.protocol.util.Int2ObjectHashMap;
+import com.hazelcast.agrona.collections.Int2ObjectHashMap;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Assert;

--- a/hazelcast/src/test/java/com/hazelcast/map/nearcache/NearCacheConcurrentInvalidationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/nearcache/NearCacheConcurrentInvalidationTest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.nearcache;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.config.NearCacheConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.map.impl.MapService;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.LockSupport;
+
+import static java.lang.Runtime.getRuntime;
+import static org.junit.Assert.fail;
+
+@RunWith(HazelcastSerialClassRunner.class)
+public class NearCacheConcurrentInvalidationTest extends HazelcastTestSupport {
+    private static final int numGetters = getRuntime().availableProcessors() - 1;
+    private static final int maxRuntime = 10;
+    private static final String mapName = "testMap" + NearCacheConcurrentInvalidationTest.class.getSimpleName();
+    private static final String key = "key123";
+
+    private ConcurrentMap<String, String> map;
+    private HazelcastInstance hz;
+
+    private final CountDownLatch problemDetectedLatch = new CountDownLatch(1);
+    private volatile int lastPut;
+    private volatile boolean keepGoing = true;
+
+    @Before public void setUp() {
+        final Config config = new Config();
+        final NearCacheConfig nearCacheConfig = new NearCacheConfig();
+        nearCacheConfig.setCacheLocalEntries(true); // needed because we test with single node
+        nearCacheConfig.setInMemoryFormat(InMemoryFormat.OBJECT);
+        final MapConfig mapConfig = config.getMapConfig(mapName);
+        mapConfig.setNearCacheConfig(nearCacheConfig);
+        hz = createHazelcastInstance(config);
+        map = hz.getMap(mapName);
+    }
+
+    // Reproduces https://github.com/hazelcast/hazelcast/issues/4671
+    @Test
+    public void putThenGet_withConcurrentGetting() throws Exception {
+        workTheMap();
+        assertCorrectness();
+    }
+
+    private void workTheMap() throws Exception {
+        final ExecutorService threadPool = Executors.newFixedThreadPool(1 + numGetters);
+        threadPool.submit(new Putter());
+        for (int i = 0; i < numGetters; i++) {
+            threadPool.submit(new Getter());
+        }
+        if (!problemDetectedLatch.await(maxRuntime, TimeUnit.SECONDS)) {
+            System.out.println("Problem did not occur within " + maxRuntime + "s.");
+        }
+        keepGoing = false;
+        threadPool.shutdown();
+        threadPool.awaitTermination(10, TimeUnit.SECONDS);
+    }
+
+    private void assertCorrectness() throws Exception {
+        final int expected = lastPut;
+        final int actual = Integer.parseInt(map.get(key));
+        if (actual < expected) {
+            flushNearCache();
+            final int actual2 = Integer.parseInt(map.get(key));
+            fail(String.format(
+                    "Near cache failed to become consistent: actual = %d, expected = %d." +
+                    " Flushing the near cache %s: actual2 = %d.",
+                    actual, expected,
+                    actual2 < expected ? "didn't help" : "cleared the inconsistency",
+                    actual2));
+        }
+    }
+
+    private class Putter implements Runnable {
+        @Override public void run() {
+            for (int i = 0; keepGoing; i++) {
+                map.put(key, String.valueOf(i));
+                lastPut = i;
+                int actual = Integer.parseInt(map.get(key));
+                if (actual != i) {
+                    System.err.format("Assertion failed: actual = %d, expected = %d\n", actual, i);
+                    // sleep to ensure near cache invalidation is really lost
+                    sleepMillis(100);
+                    // test again and stop if really lost
+                    actual = Integer.parseInt(map.get(key));
+                    if (actual != i) {
+                        System.err.format("Near cache invalidation lost: actual = %d, expected = %d\n", actual, i);
+                        problemDetectedLatch.countDown();
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    private class Getter implements Runnable {
+        @Override public void run() {
+            while (keepGoing) {
+                map.get(key);
+                LockSupport.parkNanos(1);
+            }
+        }
+    }
+
+    private void flushNearCache() throws Exception {
+        final MapService mapService = getNodeEngineImpl(hz).getService(MapService.SERVICE_NAME);
+        mapService.getMapServiceContext().getNearCacheProvider().clearNearCache(mapName);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/map/nearcache/NearCacheTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/nearcache/NearCacheTest.java
@@ -36,6 +36,7 @@ import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.test.annotation.Repeat;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -619,7 +620,7 @@ public class NearCacheTest extends HazelcastTestSupport {
         final CountDownLatch latch = new CountDownLatch(mapSize);
 
         addListener(map, latch);
-        populateMapWithExpirableEntries(map, mapSize, 3, TimeUnit.SECONDS);
+        populateMapWithExpirableEntries(map, mapSize, 3000, TimeUnit.MILLISECONDS);
         pullEntriesToNearCache(map, mapSize);
 
         waitUntilEvictionEventsReceived(latch);
@@ -640,8 +641,8 @@ public class NearCacheTest extends HazelcastTestSupport {
     }
 
     private void pullEntriesToNearCache(IMap<Integer, Integer> map, int mapSize) {
-        for (int i = 0; i < mapSize; i++) {
-            map.get(i);
+        for (int i = 0; i < mapSize * 100; i++) {
+            map.get(i % mapSize);
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
@@ -83,16 +83,16 @@ public abstract class HazelcastTestSupport {
 
     public static void assertUtilityConstructor(Class clazz) {
         Constructor[] constructors = clazz.getDeclaredConstructors();
-        assertEquals("there are more than 1 constructors", 1, constructors.length);
+        assertEquals("There is more than one constructor in "+clazz, 1, constructors.length);
 
         Constructor constructor = constructors[0];
         int modifiers = constructor.getModifiers();
-        assertTrue("access modifier is not private", Modifier.isPrivate(modifiers));
+        assertTrue("Constructor is not private in"+clazz, Modifier.isPrivate(modifiers));
 
         constructor.setAccessible(true);
         try {
             constructor.newInstance();
-        } catch (Exception e) {
+        } catch (Exception ignored) {
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -221,7 +221,7 @@
                 <version>${maven.surefire.plugin.version}</version>
                 <configuration combine.self="override">
                     <redirectTestOutputToFile>true</redirectTestOutputToFile>
-
+                    <runOrder>failedfirst</runOrder>
 
                     <!-- 1C means 1 process per cpu core -->
                     <!-- forkCount>1C</forkCount>


### PR DESCRIPTION
Fix for #4671. Also contributes Agrona collections backport, which is used in the fix.

Statement of issue:

Currently `NearCache` has a race condition between the methods `get`, `put` and `invalidate`. In outline, this interleaving is possible (all operations on the same key):

1. *threadA*: `get` from near cache -> cache miss;
2. *threadA*: fetch from source of truth;
3. *threadB*: update source of truth;
4. *threadB*: `invalidate` in near cache;
5. *threadA*: `put` to near cache.

The value that was put in step 5 is stale, having been replaced in step 3 by a newer value. Cache invalidation in step 4 is overridden by the put in step 5. Now the cache is permanently inconsistent.

Fix: introduce the methods `announcePut` and `putAnnounced` to allow the following workflow:

1. `get` from near cache -> miss;
2. announce to update a cache key, obtain a _permit_ (an integer from an atomic sequence);
3. fetch from source of truth;
4. execute announced put, providing the permit;
5. if the permit checks out, near cache accepts the value and dismisses the permit.

In step 2, near cache remembers your permit and associates it with the key. In step 4 it checks that your permit is not stale.

The `invalidate` operation revokes any permit it finds.

Permit is accepted by `putAnnounced` if it is greater than or equal to the stored permit.

Synchronization had to be introduced because `announcePut`, `putAnnounced`, and `invalidate` must be mutually linearizable and they all maintain a complex invariant. Several update operations must be kept atomic by the lock.