### PR TITLE
Amount of parallel threads has been reduced to prevent test timeout exceeds

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/mapreduce/MapReduceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/mapreduce/MapReduceTest.java
@@ -14,14 +14,7 @@
 
 package com.hazelcast.mapreduce;
 
-import com.hazelcast.core.ExecutionCallback;
-import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.ICompletableFuture;
-import com.hazelcast.core.IList;
-import com.hazelcast.core.IMap;
-import com.hazelcast.core.ISet;
-import com.hazelcast.core.MultiMap;
-import com.hazelcast.mapreduce.ListSetMapReduceTest.ListSetReducerFactory;
+import com.hazelcast.core.*;
 import com.hazelcast.mapreduce.helpers.Employee;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
@@ -38,66 +31,38 @@ import org.junit.runner.RunWith;
 
 import java.io.IOException;
 import java.math.BigInteger;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Semaphore;
+import java.util.logging.Logger;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category(QuickTest.class)
 @SuppressWarnings("unused")
 public class MapReduceTest
         extends HazelcastTestSupport {
-
+    final static Logger logger = Logger.getLogger("test");
+    
     private static final String MAP_NAME = "default";
 
-    @Test(timeout = 60000)
-    public void test_early_finalization_combiner_github_5283() throws Exception {
-        TestHazelcastInstanceFactory nodeFactory = createHazelcastInstanceFactory(3);
-
-        final HazelcastInstance h1 = nodeFactory.newHazelcastInstance();
-        final HazelcastInstance h2 = nodeFactory.newHazelcastInstance();
-        final HazelcastInstance h3 = nodeFactory.newHazelcastInstance();
-
-        assertClusterSizeEventually(3, h1);
-        assertClusterSizeEventually(3, h2);
-        assertClusterSizeEventually(3, h3);
-
-        IMap<Integer, Integer> m1 = h1.getMap(MAP_NAME);
-        for (int i = 0; i < 100; i++) {
-            m1.put(i, i);
-        }
-
-        JobTracker tracker = h1.getJobTracker("default");
-        KeyValueSource<Integer, Integer> kvs = KeyValueSource.fromMap(m1);
-        KeyValueSource<Integer, Integer> wrapper = new MapKeyValueSourceAdapter<Integer, Integer>(kvs);
-        Job<Integer, Integer> job = tracker.newJob(wrapper);
-
-        ICompletableFuture<Map<String, List<Integer>>> future =
-                job.mapper(new TestMapper())
-                   .combiner(new FinalizingCombinerFactory())
-                   .reducer(new ListBasedReducerFactory()).submit();
-
-        Map<String, List<Integer>> result = future.get();
-
-        assertEquals(100, result.size());
-        for (List<Integer> value : result.values()) {
-            assertEquals(1, value.size());
+    private void tripshutdown(HazelcastInstance h1, HazelcastInstance h2, HazelcastInstance h3) {
+        try {
+            h1.shutdown();
+        } finally {
+            try {
+                h2.shutdown();
+            } finally {
+                h3.shutdown();
+            }
         }
     }
 
     @Test(timeout = 60000)
-    public void test_collide_user_provided_combiner_list_result_github_3614() throws Exception {
+    public void test_early_finalization_combiner_github_5283() throws Exception {
+        logger.info(String.valueOf(Math.max(Runtime.getRuntime().availableProcessors(), 8)));
         TestHazelcastInstanceFactory nodeFactory = createHazelcastInstanceFactory(3);
 
         final HazelcastInstance h1 = nodeFactory.newHazelcastInstance();
@@ -108,25 +73,30 @@ public class MapReduceTest
         assertClusterSizeEventually(3, h2);
         assertClusterSizeEventually(3, h3);
 
-        IMap<Integer, Integer> m1 = h1.getMap(MAP_NAME);
-        for (int i = 0; i < 100; i++) {
-            m1.put(i, i);
-        }
+        try {
+            IMap<Integer, Integer> m1 = h1.getMap(MAP_NAME);
+            for (int i = 0; i < 100; i++) {
+                m1.put(i, i);
+            }
 
-        JobTracker tracker = h1.getJobTracker("default");
-        KeyValueSource<Integer, Integer> kvs = KeyValueSource.fromMap(m1);
-        KeyValueSource<Integer, Integer> wrapper = new MapKeyValueSourceAdapter<Integer, Integer>(kvs);
-        Job<Integer, Integer> job = tracker.newJob(wrapper);
-        ICompletableFuture<Map<String, List<Integer>>> future =
-                job.mapper(new TestMapper())
-                   .combiner(new ListResultingCombinerFactory())
-                   .reducer(new ListBasedReducerFactory()).submit();
+            JobTracker tracker = h1.getJobTracker("default");
+            KeyValueSource<Integer, Integer> kvs = KeyValueSource.fromMap(m1);
+            KeyValueSource<Integer, Integer> wrapper = new MapKeyValueSourceAdapter<Integer, Integer>(kvs);
+            Job<Integer, Integer> job = tracker.newJob(wrapper);
 
-        Map<String, List<Integer>> result = future.get();
+            ICompletableFuture<Map<String, List<Integer>>> future =
+                    job.mapper(new TestMapper())
+                            .combiner(new FinalizingCombinerFactory())
+                            .reducer(new ListBasedReducerFactory()).submit();
 
-        assertEquals(100, result.size());
-        for (List<Integer> value : result.values()) {
-            assertEquals(1, value.size());
+            Map<String, List<Integer>> result = future.get();
+
+            assertEquals(100, result.size());
+            for (List<Integer> value : result.values()) {
+                assertEquals(1, value.size());
+            }
+        } finally {
+            tripshutdown(h1, h2, h3);
         }
     }
 
@@ -143,22 +113,64 @@ public class MapReduceTest
         assertClusterSizeEventually(3, h2);
         assertClusterSizeEventually(3, h3);
 
-        IMap<Integer, Integer> m1 = h1.getMap(MAP_NAME);
-        for (int i = 0; i < 100; i++) {
-            m1.put(i, i);
+        try {
+            IMap<Integer, Integer> m1 = h1.getMap(MAP_NAME);
+            for (int i = 0; i < 100; i++) {
+                m1.put(i, i);
+            }
+
+            JobTracker tracker = h1.getJobTracker("default");
+            KeyValueSource<Integer, Integer> kvs = KeyValueSource.fromMap(m1);
+            KeyValueSource<Integer, Integer> wrapper = new MapKeyValueSourceAdapter<Integer, Integer>(kvs);
+            Job<Integer, Integer> job = tracker.newJob(wrapper);
+            ICompletableFuture<Map<String, List<Integer>>> future = job.mapper(new TestMapper()).submit();
+
+            Map<String, List<Integer>> result = future.get();
+
+            assertEquals(100, result.size());
+            for (List<Integer> value : result.values()) {
+                assertEquals(1, value.size());
+            }
+        } finally {
+            tripshutdown(h1, h2, h3);
         }
+    }
 
-        JobTracker tracker = h1.getJobTracker("default");
-        KeyValueSource<Integer, Integer> kvs = KeyValueSource.fromMap(m1);
-        KeyValueSource<Integer, Integer> wrapper = new MapKeyValueSourceAdapter<Integer, Integer>(kvs);
-        Job<Integer, Integer> job = tracker.newJob(wrapper);
-        ICompletableFuture<Map<String, List<Integer>>> future = job.mapper(new TestMapper()).submit();
+    @Test(timeout = 60000)
+    public void test_collide_user_provided_combiner_list_result_github_3614() throws Exception {
+        TestHazelcastInstanceFactory nodeFactory = createHazelcastInstanceFactory(3);
 
-        Map<String, List<Integer>> result = future.get();
+        final HazelcastInstance h1 = nodeFactory.newHazelcastInstance();
+        final HazelcastInstance h2 = nodeFactory.newHazelcastInstance();
+        final HazelcastInstance h3 = nodeFactory.newHazelcastInstance();
 
-        assertEquals(100, result.size());
-        for (List<Integer> value : result.values()) {
-            assertEquals(1, value.size());
+        assertClusterSizeEventually(3, h1);
+        assertClusterSizeEventually(3, h2);
+        assertClusterSizeEventually(3, h3);
+
+        try {
+            IMap<Integer, Integer> m1 = h1.getMap(MAP_NAME);
+            for (int i = 0; i < 100; i++) {
+                m1.put(i, i);
+            }
+
+            JobTracker tracker = h1.getJobTracker("default");
+            KeyValueSource<Integer, Integer> kvs = KeyValueSource.fromMap(m1);
+            KeyValueSource<Integer, Integer> wrapper = new MapKeyValueSourceAdapter<Integer, Integer>(kvs);
+            Job<Integer, Integer> job = tracker.newJob(wrapper);
+            ICompletableFuture<Map<String, List<Integer>>> future =
+                    job.mapper(new TestMapper())
+                            .combiner(new ListResultingCombinerFactory())
+                            .reducer(new ListBasedReducerFactory()).submit();
+
+            Map<String, List<Integer>> result = future.get();
+
+            assertEquals(100, result.size());
+            for (List<Integer> value : result.values()) {
+                assertEquals(1, value.size());
+            }
+        } finally {
+            tripshutdown(h1, h2, h3);
         }
     }
 
@@ -175,30 +187,34 @@ public class MapReduceTest
         assertClusterSizeEventually(3, h2);
         assertClusterSizeEventually(3, h3);
 
-        IMap<Integer, Integer> m1 = h1.getMap(MAP_NAME);
-        for (int i = 0; i < 100; i++) {
-            m1.put(i, i);
-        }
-
-        JobTracker tracker = h1.getJobTracker("default");
-        Job<Integer, Integer> job = tracker.newJob(KeyValueSource.fromMap(m1));
-        ICompletableFuture<Map<String, List<Integer>>> future = job.mapper(new ExceptionThrowingMapper())
-                                                                   .submit(new Collator<Map.Entry<String, List<Integer>>, Map<String, List<Integer>>>() {
-                                                                       @Override
-                                                                       public Map<String, List<Integer>> collate(
-                                                                               Iterable<Map.Entry<String, List<Integer>>> values) {
-                                                                           return null;
-                                                                       }
-                                                                   });
-
         try {
-            Map<String, List<Integer>> result = future.get();
-            fail();
+            IMap<Integer, Integer> m1 = h1.getMap(MAP_NAME);
+            for (int i = 0; i < 100; i++) {
+                m1.put(i, i);
+            }
 
-        } catch (Exception e) {
-            e.printStackTrace();
-            assertTrue(e.getCause() instanceof NullPointerException);
-            throw e;
+            JobTracker tracker = h1.getJobTracker("default");
+            Job<Integer, Integer> job = tracker.newJob(KeyValueSource.fromMap(m1));
+            ICompletableFuture<Map<String, List<Integer>>> future = job.mapper(new ExceptionThrowingMapper())
+                    .submit(new Collator<Map.Entry<String, List<Integer>>, Map<String, List<Integer>>>() {
+                        @Override
+                        public Map<String, List<Integer>> collate(
+                                Iterable<Map.Entry<String, List<Integer>>> values) {
+                            return null;
+                        }
+                    });
+
+            try {
+                Map<String, List<Integer>> result = future.get();
+                fail();
+
+            } catch (Exception e) {
+                e.printStackTrace();
+                assertTrue(e.getCause() instanceof NullPointerException);
+                throw e;
+            }
+        } finally {
+            tripshutdown(h1, h2, h3);
         }
     }
 
@@ -215,23 +231,27 @@ public class MapReduceTest
         assertClusterSizeEventually(3, h2);
         assertClusterSizeEventually(3, h3);
 
-        IMap<Integer, Integer> m1 = h1.getMap(MAP_NAME);
-        for (int i = 0; i < 100; i++) {
-            m1.put(i, i);
-        }
-
-        JobTracker tracker = h1.getJobTracker("default");
-        Job<Integer, Integer> job = tracker.newJob(KeyValueSource.fromMap(m1));
-        ICompletableFuture<Map<String, List<Integer>>> future = job.mapper(new ExceptionThrowingMapper()).submit();
-
         try {
-            Map<String, List<Integer>> result = future.get();
-            fail();
+            IMap<Integer, Integer> m1 = h1.getMap(MAP_NAME);
+            for (int i = 0; i < 100; i++) {
+                m1.put(i, i);
+            }
 
-        } catch (Exception e) {
-            e.printStackTrace();
-            assertTrue(e.getCause() instanceof NullPointerException);
-            throw e;
+            JobTracker tracker = h1.getJobTracker("default");
+            Job<Integer, Integer> job = tracker.newJob(KeyValueSource.fromMap(m1));
+            ICompletableFuture<Map<String, List<Integer>>> future = job.mapper(new ExceptionThrowingMapper()).submit();
+
+            try {
+                Map<String, List<Integer>> result = future.get();
+                fail();
+
+            } catch (Exception e) {
+                e.printStackTrace();
+                assertTrue(e.getCause() instanceof NullPointerException);
+                throw e;
+            }
+        } finally {
+            tripshutdown(h1, h2, h3);
         }
     }
 
@@ -240,32 +260,48 @@ public class MapReduceTest
             throws Exception {
         TestHazelcastInstanceFactory nodeFactory = createHazelcastInstanceFactory(3);
 
+        logger.info("testInProcessCancellation 1");
         final HazelcastInstance h1 = nodeFactory.newHazelcastInstance();
         final HazelcastInstance h2 = nodeFactory.newHazelcastInstance();
         final HazelcastInstance h3 = nodeFactory.newHazelcastInstance();
+
+        logger.info("testInProcessCancellation 2");
 
         assertClusterSizeEventually(3, h1);
         assertClusterSizeEventually(3, h2);
         assertClusterSizeEventually(3, h3);
 
-        IMap<Integer, Integer> m1 = h1.getMap(MAP_NAME);
-        for (int i = 0; i < 100; i++) {
-            m1.put(i, i);
-        }
-
-        JobTracker tracker = h1.getJobTracker("default");
-        Job<Integer, Integer> job = tracker.newJob(KeyValueSource.fromMap(m1));
-        ICompletableFuture<Map<String, List<Integer>>> future = job.mapper(new TimeConsumingMapper()).submit();
-
-        future.cancel(true);
+        logger.info("testInProcessCancellation 3");
 
         try {
-            Map<String, List<Integer>> result = future.get();
-            fail();
+            logger.info("testInProcessCancellation 4");
+            IMap<Integer, Integer> m1 = h1.getMap(MAP_NAME);
+            for (int i = 0; i < 100; i++) {
+                m1.put(i, i);
+            }
 
-        } catch (Exception e) {
-            e.printStackTrace();
-            throw e;
+            logger.info("testInProcessCancellation 5");
+
+            JobTracker tracker = h1.getJobTracker("default");
+            Job<Integer, Integer> job = tracker.newJob(KeyValueSource.fromMap(m1));
+            ICompletableFuture<Map<String, List<Integer>>> future = job.mapper(new TimeConsumingMapper()).submit();
+
+            logger.info("testInProcessCancellation 6");
+            future.cancel(true);
+
+            logger.info("testInProcessCancellation 7");
+
+            try {
+                Map<String, List<Integer>> result = future.get();
+                fail();
+
+            } catch (Exception e) {
+                e.printStackTrace();
+                throw e;
+            }
+            logger.info("testInProcessCancellation 8");
+        } finally {
+            tripshutdown(h1, h2, h3);
         }
     }
 
@@ -282,20 +318,25 @@ public class MapReduceTest
         assertClusterSizeEventually(3, h2);
         assertClusterSizeEventually(3, h3);
 
-        IMap<Integer, Integer> m1 = h1.getMap(MAP_NAME);
-        for (int i = 0; i < 100; i++) {
-            m1.put(i, i);
-        }
+        try {
 
-        JobTracker tracker = h1.getJobTracker("default");
-        Job<Integer, Integer> job = tracker.newJob(KeyValueSource.fromMap(m1));
-        ICompletableFuture<Map<String, List<Integer>>> future = job.mapper(new TestMapper()).submit();
+            IMap<Integer, Integer> m1 = h1.getMap(MAP_NAME);
+            for (int i = 0; i < 100; i++) {
+                m1.put(i, i);
+            }
 
-        Map<String, List<Integer>> result = future.get();
+            JobTracker tracker = h1.getJobTracker("default");
+            Job<Integer, Integer> job = tracker.newJob(KeyValueSource.fromMap(m1));
+            ICompletableFuture<Map<String, List<Integer>>> future = job.mapper(new TestMapper()).submit();
 
-        assertEquals(100, result.size());
-        for (List<Integer> value : result.values()) {
-            assertEquals(1, value.size());
+            Map<String, List<Integer>> result = future.get();
+
+            assertEquals(100, result.size());
+            for (List<Integer> value : result.values()) {
+                assertEquals(1, value.size());
+            }
+        } finally {
+            tripshutdown(h1, h2, h3);
         }
     }
 
@@ -312,18 +353,23 @@ public class MapReduceTest
         assertClusterSizeEventually(3, h2);
         assertClusterSizeEventually(3, h3);
 
-        IMap<Integer, Integer> m1 = h1.getMap(MAP_NAME);
-        for (int i = 0; i < 10000; i++) {
-            m1.put(i, i);
+        try {
+
+            IMap<Integer, Integer> m1 = h1.getMap(MAP_NAME);
+            for (int i = 0; i < 10000; i++) {
+                m1.put(i, i);
+            }
+
+            JobTracker tracker = h1.getJobTracker("default");
+            Job<Integer, Integer> job = tracker.newJob(KeyValueSource.fromMap(m1));
+            ICompletableFuture<Integer> future = job.onKeys(50).mapper(new TestMapper()).submit(new GroupingTestCollator());
+
+            int result = future.get();
+
+            assertEquals(50, result);
+        } finally {
+            tripshutdown(h1, h2, h3);
         }
-
-        JobTracker tracker = h1.getJobTracker("default");
-        Job<Integer, Integer> job = tracker.newJob(KeyValueSource.fromMap(m1));
-        ICompletableFuture<Integer> future = job.onKeys(50).mapper(new TestMapper()).submit(new GroupingTestCollator());
-
-        int result = future.get();
-
-        assertEquals(50, result);
     }
 
     @Test(timeout = 60000)
@@ -339,19 +385,23 @@ public class MapReduceTest
         assertClusterSizeEventually(3, h2);
         assertClusterSizeEventually(3, h3);
 
-        IMap<Integer, Integer> m1 = h1.getMap(MAP_NAME);
-        for (int i = 0; i < 10000; i++) {
-            m1.put(i, i);
+        try {
+            IMap<Integer, Integer> m1 = h1.getMap(MAP_NAME);
+            for (int i = 0; i < 10000; i++) {
+                m1.put(i, i);
+            }
+
+            JobTracker tracker = h1.getJobTracker("default");
+            Job<Integer, Integer> job = tracker.newJob(KeyValueSource.fromMap(m1));
+            ICompletableFuture<Integer> future = job.keyPredicate(new TestKeyPredicate()).mapper(new TestMapper())
+                    .submit(new GroupingTestCollator());
+
+            int result = future.get();
+
+            assertEquals(50, result);
+        } finally {
+            tripshutdown(h1, h2, h3);
         }
-
-        JobTracker tracker = h1.getJobTracker("default");
-        Job<Integer, Integer> job = tracker.newJob(KeyValueSource.fromMap(m1));
-        ICompletableFuture<Integer> future = job.keyPredicate(new TestKeyPredicate()).mapper(new TestMapper())
-                                                .submit(new GroupingTestCollator());
-
-        int result = future.get();
-
-        assertEquals(50, result);
     }
 
     @Test(timeout = 60000)
@@ -367,19 +417,23 @@ public class MapReduceTest
         assertClusterSizeEventually(3, h2);
         assertClusterSizeEventually(3, h3);
 
-        IMap<Integer, Integer> m1 = h1.getMap(MAP_NAME);
-        for (int i = 0; i < 100; i++) {
-            m1.put(i, i);
+        try {
+            IMap<Integer, Integer> m1 = h1.getMap(MAP_NAME);
+            for (int i = 0; i < 100; i++) {
+                m1.put(i, i);
+            }
+
+            JobTracker tracker = h1.getJobTracker("default");
+            Job<Integer, Integer> job = tracker.newJob(KeyValueSource.fromMap(m1));
+            ICompletableFuture<Map<String, List<Integer>>> future = job.mapper(new GroupingTestMapper(2)).submit();
+
+            Map<String, List<Integer>> result = future.get();
+
+            assertEquals(1, result.size());
+            assertEquals(25, result.values().iterator().next().size());
+        } finally {
+            tripshutdown(h1, h2, h3);
         }
-
-        JobTracker tracker = h1.getJobTracker("default");
-        Job<Integer, Integer> job = tracker.newJob(KeyValueSource.fromMap(m1));
-        ICompletableFuture<Map<String, List<Integer>>> future = job.mapper(new GroupingTestMapper(2)).submit();
-
-        Map<String, List<Integer>> result = future.get();
-
-        assertEquals(1, result.size());
-        assertEquals(25, result.values().iterator().next().size());
     }
 
     @Test(timeout = 60000)
@@ -395,27 +449,32 @@ public class MapReduceTest
         assertClusterSizeEventually(3, h2);
         assertClusterSizeEventually(3, h3);
 
-        IMap<Integer, Integer> m1 = h1.getMap(MAP_NAME);
-        for (int i = 0; i < 100; i++) {
-            m1.put(i, i);
-        }
+        try {
 
-        JobTracker tracker = h1.getJobTracker("default");
-        Job<Integer, Integer> job = tracker.newJob(KeyValueSource.fromMap(m1));
-        ICompletableFuture<Map<String, Integer>> future = job.mapper(new GroupingTestMapper()).reducer(new TestReducerFactory())
-                                                             .submit();
+            IMap<Integer, Integer> m1 = h1.getMap(MAP_NAME);
+            for (int i = 0; i < 100; i++) {
+                m1.put(i, i);
+            }
 
-        Map<String, Integer> result = future.get();
+            JobTracker tracker = h1.getJobTracker("default");
+            Job<Integer, Integer> job = tracker.newJob(KeyValueSource.fromMap(m1));
+            ICompletableFuture<Map<String, Integer>> future = job.mapper(new GroupingTestMapper()).reducer(new TestReducerFactory())
+                    .submit();
 
-        // Precalculate results
-        int[] expectedResults = new int[4];
-        for (int i = 0; i < 100; i++) {
-            int index = i % 4;
-            expectedResults[index] += i;
-        }
+            Map<String, Integer> result = future.get();
 
-        for (int i = 0; i < 4; i++) {
-            assertEquals(expectedResults[i], (int) result.get(String.valueOf(i)));
+            // Precalculate results
+            int[] expectedResults = new int[4];
+            for (int i = 0; i < 100; i++) {
+                int index = i % 4;
+                expectedResults[index] += i;
+            }
+
+            for (int i = 0; i < 4; i++) {
+                assertEquals(expectedResults[i], (int) result.get(String.valueOf(i)));
+            }
+        } finally {
+            tripshutdown(h1, h2, h3);
         }
     }
 
@@ -432,40 +491,45 @@ public class MapReduceTest
         assertClusterSizeEventually(3, h2);
         assertClusterSizeEventually(3, h3);
 
-        final IMap<Integer, Integer> m1 = h1.getMap(MAP_NAME);
-        for (int i = 0; i < 10000; i++) {
-            m1.put(i, i);
-        }
+        try {
 
-        JobTracker tracker = h1.getJobTracker("default");
-        Job<Integer, Integer> job = tracker.newJob(KeyValueSource.fromMap(m1));
-        JobCompletableFuture<Map<String, Integer>> future = job.chunkSize(10).mapper(new GroupingTestMapper())
-                                                               .reducer(new TestReducerFactory()).submit();
-
-        final TrackableJob trackableJob = tracker.getTrackableJob(future.getJobId());
-        final JobProcessInformation processInformation = trackableJob.getJobProcessInformation();
-        Map<String, Integer> result = future.get();
-
-        // Precalculate results
-        int[] expectedResults = new int[4];
-        for (int i = 0; i < 10000; i++) {
-            int index = i % 4;
-            expectedResults[index] += i;
-        }
-
-        for (int i = 0; i < 4; i++) {
-            assertEquals(expectedResults[i], (int) result.get(String.valueOf(i)));
-        }
-
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run() {
-                if (processInformation.getProcessedRecords() < 10000) {
-                    System.err.println(processInformation.getProcessedRecords());
-                }
-                assertEquals(10000, processInformation.getProcessedRecords());
+            final IMap<Integer, Integer> m1 = h1.getMap(MAP_NAME);
+            for (int i = 0; i < 10000; i++) {
+                m1.put(i, i);
             }
-        });
+
+            JobTracker tracker = h1.getJobTracker("default");
+            Job<Integer, Integer> job = tracker.newJob(KeyValueSource.fromMap(m1));
+            JobCompletableFuture<Map<String, Integer>> future = job.chunkSize(10).mapper(new GroupingTestMapper())
+                    .reducer(new TestReducerFactory()).submit();
+
+            final TrackableJob trackableJob = tracker.getTrackableJob(future.getJobId());
+            final JobProcessInformation processInformation = trackableJob.getJobProcessInformation();
+            Map<String, Integer> result = future.get();
+
+            // Precalculate results
+            int[] expectedResults = new int[4];
+            for (int i = 0; i < 10000; i++) {
+                int index = i % 4;
+                expectedResults[index] += i;
+            }
+
+            for (int i = 0; i < 4; i++) {
+                assertEquals(expectedResults[i], (int) result.get(String.valueOf(i)));
+            }
+
+            assertTrueEventually(new AssertTask() {
+                @Override
+                public void run() {
+                    if (processInformation.getProcessedRecords() < 10000) {
+                        System.err.println(processInformation.getProcessedRecords());
+                    }
+                    assertEquals(10000, processInformation.getProcessedRecords());
+                }
+            });
+        } finally {
+            tripshutdown(h1, h2, h3);
+        }
     }
 
     @Test(timeout = 60000)
@@ -481,25 +545,30 @@ public class MapReduceTest
         assertClusterSizeEventually(3, h2);
         assertClusterSizeEventually(3, h3);
 
-        IMap<Integer, Integer> m1 = h1.getMap(MAP_NAME);
-        for (int i = 0; i < 100; i++) {
-            m1.put(i, i);
-        }
+        try {
 
-        JobTracker tracker = h1.getJobTracker("default");
-        Job<Integer, Integer> job = tracker.newJob(KeyValueSource.fromMap(m1));
-        ICompletableFuture<Integer> future = job.mapper(new GroupingTestMapper()).submit(new GroupingTestCollator());
+            IMap<Integer, Integer> m1 = h1.getMap(MAP_NAME);
+            for (int i = 0; i < 100; i++) {
+                m1.put(i, i);
+            }
 
-        int result = future.get();
+            JobTracker tracker = h1.getJobTracker("default");
+            Job<Integer, Integer> job = tracker.newJob(KeyValueSource.fromMap(m1));
+            ICompletableFuture<Integer> future = job.mapper(new GroupingTestMapper()).submit(new GroupingTestCollator());
 
-        // Precalculate result
-        int expectedResult = 0;
-        for (int i = 0; i < 100; i++) {
-            expectedResult += i;
-        }
+            int result = future.get();
 
-        for (int i = 0; i < 4; i++) {
-            assertEquals(expectedResult, result);
+            // Precalculate result
+            int expectedResult = 0;
+            for (int i = 0; i < 100; i++) {
+                expectedResult += i;
+            }
+
+            for (int i = 0; i < 4; i++) {
+                assertEquals(expectedResult, result);
+            }
+        } finally {
+            tripshutdown(h1, h2, h3);
         }
     }
 
@@ -516,34 +585,39 @@ public class MapReduceTest
         assertClusterSizeEventually(3, h2);
         assertClusterSizeEventually(3, h3);
 
-        IMap<Integer, Integer> m1 = h1.getMap(MAP_NAME);
-        for (int i = 0; i < 100; i++) {
-            m1.put(i, i);
-        }
+        try {
+            IMap<Integer, Integer> m1 = h1.getMap(MAP_NAME);
+            for (int i = 0; i < 100; i++) {
+                m1.put(i, i);
+            }
 
-        JobTracker tracker = h1.getJobTracker("default");
-        Job<Integer, Integer> job = tracker.newJob(KeyValueSource.fromMap(m1));
-        ICompletableFuture<Integer> future = job.mapper(new GroupingTestMapper()).reducer(new TestReducerFactory())
-                                                .submit(new TestCollator());
+            JobTracker tracker = h1.getJobTracker("default");
+            Job<Integer, Integer> job = tracker.newJob(KeyValueSource.fromMap(m1));
+            ICompletableFuture<Integer> future = job.mapper(new GroupingTestMapper()).reducer(new TestReducerFactory())
+                    .submit(new TestCollator());
 
-        int result = future.get();
+            int result = future.get();
 
-        // Precalculate result
-        int expectedResult = 0;
-        for (int i = 0; i < 100; i++) {
-            expectedResult += i;
-        }
+            // Precalculate result
+            int expectedResult = 0;
+            for (int i = 0; i < 100; i++) {
+                expectedResult += i;
+            }
 
-        for (int i = 0; i < 4; i++) {
-            assertEquals(expectedResult, result);
+            for (int i = 0; i < 4; i++) {
+                assertEquals(expectedResult, result);
+            }
+        } finally {
+            tripshutdown(h1, h2, h3);
         }
     }
 
     @Test(timeout = 60000)
     public void testAsyncMapper()
             throws Exception {
+        logger.info("testAsyncMapper.1");
         TestHazelcastInstanceFactory nodeFactory = createHazelcastInstanceFactory(3);
-
+        logger.info("testAsyncMapper.2");
         HazelcastInstance h1 = nodeFactory.newHazelcastInstance();
         HazelcastInstance h2 = nodeFactory.newHazelcastInstance();
         HazelcastInstance h3 = nodeFactory.newHazelcastInstance();
@@ -552,40 +626,57 @@ public class MapReduceTest
         assertClusterSizeEventually(3, h2);
         assertClusterSizeEventually(3, h3);
 
-        IMap<Integer, Integer> m1 = h1.getMap(MAP_NAME);
-        for (int i = 0; i < 100; i++) {
-            m1.put(i, i);
-        }
+        logger.info("testAsyncMapper.3");
+        try {
 
-        final Map<String, List<Integer>> listenerResults = new HashMap<String, List<Integer>>();
-        final Semaphore semaphore = new Semaphore(1);
-        semaphore.acquire();
+            IMap<Integer, Integer> m1 = h1.getMap(MAP_NAME);
+            for (int i = 0; i < 100; i++) {
+                m1.put(i, i);
+            }
 
-        JobTracker tracker = h1.getJobTracker("default");
-        Job<Integer, Integer> job = tracker.newJob(KeyValueSource.fromMap(m1));
-        ICompletableFuture<Map<String, List<Integer>>> future = job.mapper(new TestMapper()).submit();
+            logger.info("testAsyncMapper.4");
 
-        future.andThen(new ExecutionCallback<Map<String, List<Integer>>>() {
-            @Override
-            public void onResponse(Map<String, List<Integer>> response) {
-                try {
-                    listenerResults.putAll(response);
-                } finally {
+            final Map<String, List<Integer>> listenerResults = new HashMap<String, List<Integer>>();
+            final Semaphore semaphore = new Semaphore(1);
+            semaphore.acquire();
+
+            JobTracker tracker = h1.getJobTracker("default");
+            Job<Integer, Integer> job = tracker.newJob(KeyValueSource.fromMap(m1));
+            ICompletableFuture<Map<String, List<Integer>>> future = job.mapper(new TestMapper()).submit();
+
+            logger.info("testAsyncMapper.5");
+
+            future.andThen(new ExecutionCallback<Map<String, List<Integer>>>() {
+                @Override
+                public void onResponse(Map<String, List<Integer>> response) {
+                    try {
+                        listenerResults.putAll(response);
+                    } finally {
+                        semaphore.release();
+                    }
+                }
+
+                @Override
+                public void onFailure(Throwable t) {
                     semaphore.release();
                 }
+            });
+
+
+            logger.info("testAsyncMapper.6");
+
+            semaphore.acquire();
+
+            logger.info("testAsyncMapper.7");
+
+            assertEquals(100, listenerResults.size());
+            for (List<Integer> value : listenerResults.values()) {
+                assertEquals(1, value.size());
             }
 
-            @Override
-            public void onFailure(Throwable t) {
-                semaphore.release();
-            }
-        });
-
-        semaphore.acquire();
-
-        assertEquals(100, listenerResults.size());
-        for (List<Integer> value : listenerResults.values()) {
-            assertEquals(1, value.size());
+            logger.info("testAsyncMapper.8");
+        } finally {
+            tripshutdown(h1, h2, h3);
         }
     }
 
@@ -602,40 +693,45 @@ public class MapReduceTest
         assertClusterSizeEventually(3, h2);
         assertClusterSizeEventually(3, h3);
 
-        IMap<Integer, Integer> m1 = h1.getMap(MAP_NAME);
-        for (int i = 0; i < 100; i++) {
-            m1.put(i, i);
-        }
 
-        final Map<String, List<Integer>> listenerResults = new HashMap<String, List<Integer>>();
-        final Semaphore semaphore = new Semaphore(1);
-        semaphore.acquire();
+        try {
+            IMap<Integer, Integer> m1 = h1.getMap(MAP_NAME);
+            for (int i = 0; i < 100; i++) {
+                m1.put(i, i);
+            }
 
-        JobTracker tracker = h1.getJobTracker("default");
-        Job<Integer, Integer> job = tracker.newJob(KeyValueSource.fromMap(m1));
-        ICompletableFuture<Map<String, List<Integer>>> future = job.onKeys(50).mapper(new TestMapper()).submit();
+            final Map<String, List<Integer>> listenerResults = new HashMap<String, List<Integer>>();
+            final Semaphore semaphore = new Semaphore(1);
+            semaphore.acquire();
 
-        future.andThen(new ExecutionCallback<Map<String, List<Integer>>>() {
-            @Override
-            public void onResponse(Map<String, List<Integer>> response) {
-                try {
-                    listenerResults.putAll(response);
-                } finally {
+            JobTracker tracker = h1.getJobTracker("default");
+            Job<Integer, Integer> job = tracker.newJob(KeyValueSource.fromMap(m1));
+            ICompletableFuture<Map<String, List<Integer>>> future = job.onKeys(50).mapper(new TestMapper()).submit();
+
+            future.andThen(new ExecutionCallback<Map<String, List<Integer>>>() {
+                @Override
+                public void onResponse(Map<String, List<Integer>> response) {
+                    try {
+                        listenerResults.putAll(response);
+                    } finally {
+                        semaphore.release();
+                    }
+                }
+
+                @Override
+                public void onFailure(Throwable t) {
                     semaphore.release();
                 }
+            });
+
+            semaphore.acquire();
+
+            assertEquals(1, listenerResults.size());
+            for (List<Integer> value : listenerResults.values()) {
+                assertEquals(1, value.size());
             }
-
-            @Override
-            public void onFailure(Throwable t) {
-                semaphore.release();
-            }
-        });
-
-        semaphore.acquire();
-
-        assertEquals(1, listenerResults.size());
-        for (List<Integer> value : listenerResults.values()) {
-            assertEquals(1, value.size());
+        } finally {
+            tripshutdown(h1, h2, h3);
         }
     }
 
@@ -652,47 +748,52 @@ public class MapReduceTest
         assertClusterSizeEventually(3, h2);
         assertClusterSizeEventually(3, h3);
 
-        IMap<Integer, Integer> m1 = h1.getMap(MAP_NAME);
-        for (int i = 0; i < 100; i++) {
-            m1.put(i, i);
-        }
+        try {
 
-        final Map<String, Integer> listenerResults = new HashMap<String, Integer>();
-        final Semaphore semaphore = new Semaphore(1);
-        semaphore.acquire();
+            IMap<Integer, Integer> m1 = h1.getMap(MAP_NAME);
+            for (int i = 0; i < 100; i++) {
+                m1.put(i, i);
+            }
 
-        JobTracker tracker = h1.getJobTracker("default");
-        Job<Integer, Integer> job = tracker.newJob(KeyValueSource.fromMap(m1));
-        ICompletableFuture<Map<String, Integer>> future = job.mapper(new GroupingTestMapper()).reducer(new TestReducerFactory())//
-                .submit();
+            final Map<String, Integer> listenerResults = new HashMap<String, Integer>();
+            final Semaphore semaphore = new Semaphore(1);
+            semaphore.acquire();
 
-        future.andThen(new ExecutionCallback<Map<String, Integer>>() {
-            @Override
-            public void onResponse(Map<String, Integer> response) {
-                try {
-                    listenerResults.putAll(response);
-                } finally {
+            JobTracker tracker = h1.getJobTracker("default");
+            Job<Integer, Integer> job = tracker.newJob(KeyValueSource.fromMap(m1));
+            ICompletableFuture<Map<String, Integer>> future = job.mapper(new GroupingTestMapper()).reducer(new TestReducerFactory())//
+                    .submit();
+
+            future.andThen(new ExecutionCallback<Map<String, Integer>>() {
+                @Override
+                public void onResponse(Map<String, Integer> response) {
+                    try {
+                        listenerResults.putAll(response);
+                    } finally {
+                        semaphore.release();
+                    }
+                }
+
+                @Override
+                public void onFailure(Throwable t) {
                     semaphore.release();
                 }
+            });
+
+            // Precalculate results
+            int[] expectedResults = new int[4];
+            for (int i = 0; i < 100; i++) {
+                int index = i % 4;
+                expectedResults[index] += i;
             }
 
-            @Override
-            public void onFailure(Throwable t) {
-                semaphore.release();
+            semaphore.acquire();
+
+            for (int i = 0; i < 4; i++) {
+                assertEquals(expectedResults[i], (int) listenerResults.get(String.valueOf(i)));
             }
-        });
-
-        // Precalculate results
-        int[] expectedResults = new int[4];
-        for (int i = 0; i < 100; i++) {
-            int index = i % 4;
-            expectedResults[index] += i;
-        }
-
-        semaphore.acquire();
-
-        for (int i = 0; i < 4; i++) {
-            assertEquals(expectedResults[i], (int) listenerResults.get(String.valueOf(i)));
+        } finally {
+            tripshutdown(h1, h2, h3);
         }
     }
 
@@ -709,45 +810,50 @@ public class MapReduceTest
         assertClusterSizeEventually(3, h2);
         assertClusterSizeEventually(3, h3);
 
-        IMap<Integer, Integer> m1 = h1.getMap(MAP_NAME);
-        for (int i = 0; i < 100; i++) {
-            m1.put(i, i);
-        }
+        try {
 
-        final int[] result = new int[1];
-        final Semaphore semaphore = new Semaphore(1);
-        semaphore.acquire();
+            IMap<Integer, Integer> m1 = h1.getMap(MAP_NAME);
+            for (int i = 0; i < 100; i++) {
+                m1.put(i, i);
+            }
 
-        JobTracker tracker = h1.getJobTracker("default");
-        Job<Integer, Integer> job = tracker.newJob(KeyValueSource.fromMap(m1));
-        ICompletableFuture<Integer> future = job.mapper(new GroupingTestMapper()).submit(new GroupingTestCollator());
+            final int[] result = new int[1];
+            final Semaphore semaphore = new Semaphore(1);
+            semaphore.acquire();
 
-        future.andThen(new ExecutionCallback<Integer>() {
-            @Override
-            public void onResponse(Integer response) {
-                try {
-                    result[0] = response.intValue();
-                } finally {
+            JobTracker tracker = h1.getJobTracker("default");
+            Job<Integer, Integer> job = tracker.newJob(KeyValueSource.fromMap(m1));
+            ICompletableFuture<Integer> future = job.mapper(new GroupingTestMapper()).submit(new GroupingTestCollator());
+
+            future.andThen(new ExecutionCallback<Integer>() {
+                @Override
+                public void onResponse(Integer response) {
+                    try {
+                        result[0] = response.intValue();
+                    } finally {
+                        semaphore.release();
+                    }
+                }
+
+                @Override
+                public void onFailure(Throwable t) {
                     semaphore.release();
                 }
+            });
+
+            // Precalculate result
+            int expectedResult = 0;
+            for (int i = 0; i < 100; i++) {
+                expectedResult += i;
             }
 
-            @Override
-            public void onFailure(Throwable t) {
-                semaphore.release();
+            semaphore.acquire();
+
+            for (int i = 0; i < 4; i++) {
+                assertEquals(expectedResult, result[0]);
             }
-        });
-
-        // Precalculate result
-        int expectedResult = 0;
-        for (int i = 0; i < 100; i++) {
-            expectedResult += i;
-        }
-
-        semaphore.acquire();
-
-        for (int i = 0; i < 4; i++) {
-            assertEquals(expectedResult, result[0]);
+        } finally {
+            tripshutdown(h1, h2, h3);
         }
     }
 
@@ -764,46 +870,51 @@ public class MapReduceTest
         assertClusterSizeEventually(3, h2);
         assertClusterSizeEventually(3, h3);
 
-        IMap<Integer, Integer> m1 = h1.getMap(MAP_NAME);
-        for (int i = 0; i < 100; i++) {
-            m1.put(i, i);
-        }
+        try {
 
-        final int[] result = new int[1];
-        final Semaphore semaphore = new Semaphore(1);
-        semaphore.acquire();
+            IMap<Integer, Integer> m1 = h1.getMap(MAP_NAME);
+            for (int i = 0; i < 100; i++) {
+                m1.put(i, i);
+            }
 
-        JobTracker tracker = h1.getJobTracker("default");
-        Job<Integer, Integer> job = tracker.newJob(KeyValueSource.fromMap(m1));
-        ICompletableFuture<Integer> future = job.mapper(new GroupingTestMapper()).reducer(new TestReducerFactory())
-                                                .submit(new TestCollator());
+            final int[] result = new int[1];
+            final Semaphore semaphore = new Semaphore(1);
+            semaphore.acquire();
 
-        future.andThen(new ExecutionCallback<Integer>() {
-            @Override
-            public void onResponse(Integer response) {
-                try {
-                    result[0] = response.intValue();
-                } finally {
+            JobTracker tracker = h1.getJobTracker("default");
+            Job<Integer, Integer> job = tracker.newJob(KeyValueSource.fromMap(m1));
+            ICompletableFuture<Integer> future = job.mapper(new GroupingTestMapper()).reducer(new TestReducerFactory())
+                    .submit(new TestCollator());
+
+            future.andThen(new ExecutionCallback<Integer>() {
+                @Override
+                public void onResponse(Integer response) {
+                    try {
+                        result[0] = response.intValue();
+                    } finally {
+                        semaphore.release();
+                    }
+                }
+
+                @Override
+                public void onFailure(Throwable t) {
                     semaphore.release();
                 }
+            });
+
+            // Precalculate result
+            int expectedResult = 0;
+            for (int i = 0; i < 100; i++) {
+                expectedResult += i;
             }
 
-            @Override
-            public void onFailure(Throwable t) {
-                semaphore.release();
+            semaphore.acquire();
+
+            for (int i = 0; i < 4; i++) {
+                assertEquals(expectedResult, result[0]);
             }
-        });
-
-        // Precalculate result
-        int expectedResult = 0;
-        for (int i = 0; i < 100; i++) {
-            expectedResult += i;
-        }
-
-        semaphore.acquire();
-
-        for (int i = 0; i < 4; i++) {
-            assertEquals(expectedResult, result[0]);
+        } finally {
+            tripshutdown(h1, h2, h3);
         }
     }
 
@@ -820,26 +931,30 @@ public class MapReduceTest
         assertClusterSizeEventually(3, h2);
         assertClusterSizeEventually(3, h3);
 
-        IMap<Integer, Integer> m1 = h1.getMap(MAP_NAME);
-        for (int i = 0; i < 100; i++) {
-            m1.put(i, i);
-        }
+        try {
+            IMap<Integer, Integer> m1 = h1.getMap(MAP_NAME);
+            for (int i = 0; i < 100; i++) {
+                m1.put(i, i);
+            }
 
-        JobTracker jobTracker = h1.getJobTracker("default");
-        Job<Integer, Integer> job = jobTracker.newJob(KeyValueSource.fromMap(m1));
-        JobCompletableFuture<Map<String, BigInteger>> future = job.chunkSize(10).mapper(new GroupingTestMapper())
-                                                                  .combiner(new ObjectCombinerFactory())
-                                                                  .reducer(new ObjectReducerFactory()).submit();
+            JobTracker jobTracker = h1.getJobTracker("default");
+            Job<Integer, Integer> job = jobTracker.newJob(KeyValueSource.fromMap(m1));
+            JobCompletableFuture<Map<String, BigInteger>> future = job.chunkSize(10).mapper(new GroupingTestMapper())
+                    .combiner(new ObjectCombinerFactory())
+                    .reducer(new ObjectReducerFactory()).submit();
 
-        int[] expectedResults = new int[4];
-        for (int i = 0; i < 100; i++) {
-            int index = i % 4;
-            expectedResults[index] += i;
-        }
+            int[] expectedResults = new int[4];
+            for (int i = 0; i < 100; i++) {
+                int index = i % 4;
+                expectedResults[index] += i;
+            }
 
-        Map<String, BigInteger> map = future.get();
-        for (int i = 0; i < 4; i++) {
-            assertEquals(BigInteger.valueOf(expectedResults[i]), map.get(String.valueOf(i)));
+            Map<String, BigInteger> map = future.get();
+            for (int i = 0; i < 4; i++) {
+                assertEquals(BigInteger.valueOf(expectedResults[i]), map.get(String.valueOf(i)));
+            }
+        } finally {
+            tripshutdown(h1, h2, h3);
         }
     }
 
@@ -852,23 +967,28 @@ public class MapReduceTest
         HazelcastInstance h2 = nodeFactory.newHazelcastInstance();
         HazelcastInstance h3 = nodeFactory.newHazelcastInstance();
 
-        assertClusterSizeEventually(3, h1);
-        assertClusterSizeEventually(3, h2);
-        assertClusterSizeEventually(3, h3);
+        try {
 
-        IMap<Integer, Integer> m1 = h1.getMap(MAP_NAME);
-        for (int i = 0; i < 100; i++) {
-            m1.put(i, i);
+            assertClusterSizeEventually(3, h1);
+            assertClusterSizeEventually(3, h2);
+            assertClusterSizeEventually(3, h3);
+
+            IMap<Integer, Integer> m1 = h1.getMap(MAP_NAME);
+            for (int i = 0; i < 100; i++) {
+                m1.put(i, i);
+            }
+
+            JobTracker jobTracker = h1.getJobTracker("default");
+            Job<Integer, Integer> job = jobTracker.newJob(KeyValueSource.fromMap(m1));
+            JobCompletableFuture<Map<String, BigInteger>> future = job.chunkSize(10).mapper(new GroupingTestMapper())
+                    .combiner(new ObjectCombinerFactory())
+                    .reducer(new NullReducerFactory()).submit();
+
+            Map<String, BigInteger> map = future.get();
+            assertEquals(0, map.size());
+        } finally {
+            tripshutdown(h1, h2, h3);
         }
-
-        JobTracker jobTracker = h1.getJobTracker("default");
-        Job<Integer, Integer> job = jobTracker.newJob(KeyValueSource.fromMap(m1));
-        JobCompletableFuture<Map<String, BigInteger>> future = job.chunkSize(10).mapper(new GroupingTestMapper())
-                                                                  .combiner(new ObjectCombinerFactory())
-                                                                  .reducer(new NullReducerFactory()).submit();
-
-        Map<String, BigInteger> map = future.get();
-        assertEquals(0, map.size());
     }
 
     @Test(timeout = 60000)
@@ -892,9 +1012,9 @@ public class MapReduceTest
         JobTracker jobTracker = h1.getJobTracker("default");
         Job<Integer, Integer> job = jobTracker.newJob(KeyValueSource.fromMap(m1));
         ICompletableFuture<Integer> future = job.mapper(new TestMapper())
-                                                .combiner(new DataSerializableIntermediateCombinerFactory())
-                                                .reducer(new DataSerializableIntermediateReducerFactory())
-                                                .submit(new DataSerializableIntermediateCollator());
+                .combiner(new DataSerializableIntermediateCombinerFactory())
+                .reducer(new DataSerializableIntermediateReducerFactory())
+                .submit(new DataSerializableIntermediateCollator());
 
         // Precalculate result
         int expectedResult = 0;
@@ -907,45 +1027,49 @@ public class MapReduceTest
     }
 
     @Test(timeout = 60000)
-    public void employeeMapReduceTest() throws Exception{
+    public void employeeMapReduceTest() throws Exception {
 
         TestHazelcastInstanceFactory nodeFactory = createHazelcastInstanceFactory(3);
         HazelcastInstance h1 = nodeFactory.newHazelcastInstance();
         HazelcastInstance h2 = nodeFactory.newHazelcastInstance();
         HazelcastInstance h3 = nodeFactory.newHazelcastInstance();
-        final IMap map = h1.getMap(randomString());
 
-        final int keyCount=100;
-        for (int id = 0; id < keyCount; id++) {
-            map.put(id, new Employee(id));
+        try {
+            final IMap map = h1.getMap(randomString());
+
+            final int keyCount = 100;
+            for (int id = 0; id < keyCount; id++) {
+                map.put(id, new Employee(id));
+            }
+
+            JobTracker tracker = h1.getJobTracker(randomString());
+            Job<Integer, Employee> job = tracker.newJob(KeyValueSource.fromMap(map));
+
+            ICompletableFuture<Map<Integer, Set<Employee>>> future = job
+                    .mapper(new ModIdMapper(2))
+                    .combiner(new RangeIdCombinerFactory(10, 30))
+                    .reducer(new IdReducerFactory(10, 20, 30))
+                    .submit();
+
+            Map<Integer, Set<Employee>> result = future.get();
+
+            assertEquals("expected 8 Employees with id's ending 2, 4, 6, 8", 8, result.size());
+        } finally {
+            tripshutdown(h1, h2, h3);
         }
-
-        JobTracker tracker = h1.getJobTracker(randomString());
-        Job<Integer, Employee> job = tracker.newJob(KeyValueSource.fromMap(map));
-
-        ICompletableFuture< Map< Integer, Set<Employee>> > future = job
-                .mapper( new ModIdMapper(2) )
-                .combiner(new RangeIdCombinerFactory(10, 30))
-                .reducer(new IdReducerFactory(10, 20, 30))
-                .submit();
-
-        Map<Integer, Set<Employee>> result = future.get();
-
-        assertEquals("expected 8 Employees with id's ending 2, 4, 6, 8", 8, result.size());
     }
-
 
 
     public static class ModIdMapper implements Mapper<Integer, Employee, Integer, Employee> {
 
-        private int mod=0;
+        private int mod = 0;
 
-        public ModIdMapper(int mod){
-            this.mod=mod;
+        public ModIdMapper(int mod) {
+            this.mod = mod;
         }
 
         public void map(Integer key, Employee e, Context<Integer, Employee> context) {
-            if(e.getId()%mod==0){
+            if (e.getId() % mod == 0) {
                 context.emit(key, e);
             }
         }
@@ -953,28 +1077,28 @@ public class MapReduceTest
 
     public static class RangeIdCombinerFactory implements CombinerFactory<Integer, Employee, Set<Employee>> {
 
-        private int min=0, max=0;
+        private int min = 0, max = 0;
 
-        public RangeIdCombinerFactory(int min, int max){
-            this.min=min;
-            this.max=max;
+        public RangeIdCombinerFactory(int min, int max) {
+            this.min = min;
+            this.max = max;
         }
 
         public Combiner<Employee, Set<Employee>> newCombiner(Integer key) {
-            return new  EmployeeCombiner();
+            return new EmployeeCombiner();
         }
 
-        private class  EmployeeCombiner extends Combiner<Employee, Set<Employee> >{
+        private class EmployeeCombiner extends Combiner<Employee, Set<Employee>> {
             private Set<Employee> passed = new HashSet<Employee>();
 
             public void combine(Employee e) {
-                if(e.getId() >= min && e.getId() <= max){
+                if (e.getId() >= min && e.getId() <= max) {
                     passed.add(e);
                 }
             }
 
             public Set<Employee> finalizeChunk() {
-                if(passed.isEmpty()){
+                if (passed.isEmpty()) {
                     return null;
                 }
                 return passed;
@@ -987,40 +1111,39 @@ public class MapReduceTest
     }
 
 
-
     public static class IdReducerFactory implements ReducerFactory<Integer, Set<Employee>, Set<Employee>> {
 
-        private int[] removeIds=null;
+        private int[] removeIds = null;
 
-        public IdReducerFactory(int... removeIds){
-            this.removeIds=removeIds;
+        public IdReducerFactory(int... removeIds) {
+            this.removeIds = removeIds;
         }
 
         public Reducer<Set<Employee>, Set<Employee>> newReducer(Integer key) {
             return new EmployeeReducer();
         }
 
-        private class EmployeeReducer extends Reducer<Set<Employee>, Set<Employee> >{
+        private class EmployeeReducer extends Reducer<Set<Employee>, Set<Employee>> {
 
             private volatile Set<Employee> passed = new HashSet<Employee>();
 
             public void reduce(Set<Employee> set) {
-                for(Employee e : set){
-                    boolean add=true;
-                    for(int id : removeIds){
-                        if(e.getId()==id){
-                            add=false;
+                for (Employee e : set) {
+                    boolean add = true;
+                    for (int id : removeIds) {
+                        if (e.getId() == id) {
+                            add = false;
                             break;
                         }
                     }
-                    if(add){
+                    if (add) {
                         passed.add(e);
                     }
                 }
             }
 
             public Set<Employee> finalizeReduce() {
-                if(passed.isEmpty()){
+                if (passed.isEmpty()) {
                     return null;
                 }
                 return passed;
@@ -1029,9 +1152,9 @@ public class MapReduceTest
     }
 
 
-    public static class EmployeeCollator implements Collator<Map.Entry<Integer, Set<Employee>>, Map<Integer, Set<Employee>> > {
+    public static class EmployeeCollator implements Collator<Map.Entry<Integer, Set<Employee>>, Map<Integer, Set<Employee>>> {
 
-        public Map<Integer, Set<Employee>> collate( Iterable< Map.Entry<Integer, Set<Employee>> > values) {
+        public Map<Integer, Set<Employee>> collate(Iterable<Map.Entry<Integer, Set<Employee>>> values) {
             Map<Integer, Set<Employee>> result = new HashMap();
             for (Map.Entry<Integer, Set<Employee>> entry : values) {
                 for (Employee e : entry.getValue()) {
@@ -1443,7 +1566,7 @@ public class MapReduceTest
             return new ListResultingCombiner();
         }
 
-        private class ListResultingCombiner extends Combiner<Integer,List<Integer>> {
+        private class ListResultingCombiner extends Combiner<Integer, List<Integer>> {
 
             private final List<Integer> result = new ArrayList<Integer>();
 

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastParallelClassRunner.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastParallelClassRunner.java
@@ -29,7 +29,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class HazelcastParallelClassRunner extends AbstractHazelcastClassRunner {
 
     private static final int MAX_THREADS = !TestEnvironment.isMockNetwork() ? 1
-                : Math.max(Runtime.getRuntime().availableProcessors(), 8);
+                : Math.max(Runtime.getRuntime().availableProcessors()/2, 1);
 
     private final AtomicInteger numThreads = new AtomicInteger(0);
 


### PR DESCRIPTION
MAX_THREADS in the HazelcastParallelClassRunner has been reduced to
Math.min(Runtime.getRuntime().availableProcessors()/2, 1)