### PR TITLE
Propagate exceptions from map loader to map method caller

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/RecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/RecordStore.java
@@ -265,7 +265,9 @@ public interface RecordStore {
      * @param replaceExistingValues <code>true</code> if need to replace existing values otherwise <code>false</code>
      * @param lastBatch when keys are sent is batches this indicates the last batch. Used to indicate loading is complete.
      */
-    void loadAllFromStore(List<Data> keys, boolean replaceExistingValues, boolean lastBatch);
+    void loadAllFromStore(List<Data> keys, boolean replaceExistingValues);
+
+    void updateLoadStatus(boolean lastBatch, Throwable exception);
 
     MapDataStore<Data, Object> getMapDataStore();
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/LoadAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/LoadAllOperation.java
@@ -22,8 +22,9 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.partition.InternalPartitionService;
-import com.hazelcast.spi.impl.MutatingOperation;
 import com.hazelcast.spi.PartitionAwareOperation;
+import com.hazelcast.spi.impl.MutatingOperation;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -38,7 +39,6 @@ public class LoadAllOperation extends AbstractMapOperation implements PartitionA
     private List<Data> keys;
 
     private boolean replaceExistingValues;
-    private boolean lastBatch = true;
 
     public LoadAllOperation() {
         keys = Collections.emptyList();
@@ -50,20 +50,13 @@ public class LoadAllOperation extends AbstractMapOperation implements PartitionA
         this.replaceExistingValues = replaceExistingValues;
     }
 
-    public LoadAllOperation(String name, List<Data> keys, boolean replaceExistingValues, boolean lastBatch) {
-        super(name);
-        this.keys = keys;
-        this.replaceExistingValues = replaceExistingValues;
-        this.lastBatch = lastBatch;
-    }
-
     @Override
     public void run() throws Exception {
         final int partitionId = getPartitionId();
         MapServiceContext mapServiceContext = mapService.getMapServiceContext();
         final RecordStore recordStore = mapServiceContext.getRecordStore(partitionId, name);
         keys = selectThisPartitionsKeys(this.keys);
-        recordStore.loadAllFromStore(keys, replaceExistingValues, lastBatch);
+        recordStore.loadAllFromStore(keys, replaceExistingValues);
     }
 
     private List<Data> selectThisPartitionsKeys(Collection<Data> keys) {
@@ -94,7 +87,6 @@ public class LoadAllOperation extends AbstractMapOperation implements PartitionA
             out.writeData(key);
         }
         out.writeBoolean(replaceExistingValues);
-        out.writeBoolean(lastBatch);
     }
 
     @Override
@@ -109,6 +101,5 @@ public class LoadAllOperation extends AbstractMapOperation implements PartitionA
             keys.add(data);
         }
         replaceExistingValues = in.readBoolean();
-        lastBatch = in.readBoolean();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/LoadStatusOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/LoadStatusOperation.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.operation;
+
+import com.hazelcast.map.impl.MapServiceContext;
+import com.hazelcast.map.impl.RecordStore;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.spi.PartitionAwareOperation;
+import com.hazelcast.spi.impl.MutatingOperation;
+
+import java.io.IOException;
+
+/**
+ * Notifies RecordStores about completion of loading
+ **/
+public class LoadStatusOperation extends AbstractMapOperation implements PartitionAwareOperation, MutatingOperation {
+
+    private Throwable exception;
+
+    public LoadStatusOperation() {
+    }
+
+    public LoadStatusOperation(String name, Throwable exception) {
+        super(name);
+        this.exception = exception;
+    }
+
+    @Override
+    public void run() throws Exception {
+        final int partitionId = getPartitionId();
+        MapServiceContext mapServiceContext = mapService.getMapServiceContext();
+        RecordStore recordStore = mapServiceContext.getRecordStore(partitionId, name);
+        recordStore.updateLoadStatus(true, exception);
+    }
+
+    @Override
+    protected void writeInternal(ObjectDataOutput out) throws IOException {
+        super.writeInternal(out);
+        out.writeObject(exception);
+    }
+
+    @Override
+    protected void readInternal(ObjectDataInput in) throws IOException {
+        super.readInternal(in);
+        exception = in.readObject();
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/map/mapstore/MapLoaderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/mapstore/MapLoaderTest.java
@@ -17,6 +17,7 @@ import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.test.annotation.Repeat;
 
 import java.io.Serializable;
 import java.util.Arrays;
@@ -38,6 +39,7 @@ import static java.util.Collections.singleton;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -156,8 +158,13 @@ public class MapLoaderTest extends HazelcastTestSupport {
         HazelcastInstance[] hz = createHazelcastInstanceFactory(2).newInstances(config, 2);
         IMap map = hz[0].getMap(mapConfig.getName());
 
-        map.get(generateKeyNotOwnedBy(hz[0]));
-        assertEquals(0, map.size());
+        Throwable exception = null;
+        try {
+            map.get(generateKeyNotOwnedBy(hz[0]));
+        } catch(Throwable e) {
+            exception = e;
+        }
+        assertNotNull("Exception wasn't propagated", exception);
 
         map.loadAll(true);
         assertEquals(1, map.size());
@@ -329,7 +336,7 @@ public class MapLoaderTest extends HazelcastTestSupport {
         public Set loadAllKeys() {
             if (first) {
                 first = false;
-                throw new IllegalStateException();
+                throw new IllegalStateException("Intentional exception");
             }
             return singleton("key");
         }


### PR DESCRIPTION
Calling a map method can trigger map loading. If maploader.loadallkeys throws an exception that exception is now sent back to the caller.
Fixes #5453, #5430
