### PR TITLE
fixes #5473.Fixed via changing the way we register callback for clients

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/client/MultiTargetClientRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/client/MultiTargetClientRequest.java
@@ -37,8 +37,6 @@ import static java.util.Collections.synchronizedSet;
  */
 public abstract class MultiTargetClientRequest extends ClientRequest {
 
-    private static final int TRY_COUNT = 100;
-
     @Override
     public final void process() throws Exception {
         ClientEndpoint endpoint = getEndpoint();
@@ -54,7 +52,6 @@ public abstract class MultiTargetClientRequest extends ClientRequest {
             Operation op = operationFactory.createOperation();
             op.setCallerUuid(endpoint.getUuid());
             InvocationBuilder builder = operationService.createInvocationBuilder(getServiceName(), op, target)
-                    .setTryCount(TRY_COUNT)
                     .setResultDeserialized(false)
                     .setCallback(new SingleTargetCallback(target, callback));
             builder.invoke();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/client/PartitionClientRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/client/PartitionClientRequest.java
@@ -18,7 +18,6 @@ package com.hazelcast.client.impl.client;
 
 import com.hazelcast.client.ClientEndpoint;
 import com.hazelcast.core.ExecutionCallback;
-import com.hazelcast.core.ICompletableFuture;
 import com.hazelcast.spi.InvocationBuilder;
 import com.hazelcast.spi.Operation;
 
@@ -53,10 +52,10 @@ public abstract class PartitionClientRequest extends ClientRequest implements Ex
         op.setCallerUuid(endpoint.getUuid());
         InvocationBuilder builder = operationService.createInvocationBuilder(getServiceName(), op, getPartition())
                 .setReplicaIndex(getReplicaIndex())
+                .setExecutionCallback(this)
                 .setResultDeserialized(false);
 
-        ICompletableFuture future = builder.invoke();
-        future.andThen(this);
+        builder.invoke();
     }
 
     protected abstract Operation prepareOperation();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/client/TargetClientRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/client/TargetClientRequest.java
@@ -18,13 +18,10 @@ package com.hazelcast.client.impl.client;
 
 import com.hazelcast.client.ClientEndpoint;
 import com.hazelcast.core.ExecutionCallback;
-import com.hazelcast.spi.InternalCompletableFuture;
 import com.hazelcast.spi.InvocationBuilder;
 import com.hazelcast.spi.Operation;
 
 public abstract class TargetClientRequest extends ClientRequest implements ExecutionCallback {
-
-    private static final int TRY_COUNT = 100;
 
     @Override
     public final void process() throws Exception {
@@ -33,10 +30,10 @@ public abstract class TargetClientRequest extends ClientRequest implements Execu
         op.setCallerUuid(endpoint.getUuid());
 
         InvocationBuilder builder = getInvocationBuilder(op)
-                .setTryCount(TRY_COUNT)
-                .setResultDeserialized(false);
-        InternalCompletableFuture f = builder.invoke();
-        f.andThen(this);
+                .setResultDeserialized(false)
+                .setExecutionCallback(this);
+
+        builder.invoke();
     }
 
     protected abstract InvocationBuilder getInvocationBuilder(Operation op);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractInvocationMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractInvocationMessageTask.java
@@ -21,15 +21,12 @@ import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.instance.Node;
 import com.hazelcast.nio.Connection;
-import com.hazelcast.spi.InternalCompletableFuture;
 import com.hazelcast.spi.InvocationBuilder;
 import com.hazelcast.spi.Operation;
 
-public abstract class InvocationMessageTask<P> extends AbstractMessageTask<P> implements ExecutionCallback {
+public abstract class AbstractInvocationMessageTask<P> extends AbstractMessageTask<P> implements ExecutionCallback {
 
-    private static final int TRY_COUNT = 100;
-
-    protected InvocationMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
+    protected AbstractInvocationMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);
     }
 
@@ -40,10 +37,9 @@ public abstract class InvocationMessageTask<P> extends AbstractMessageTask<P> im
         op.setCallerUuid(endpoint.getUuid());
 
         InvocationBuilder builder = getInvocationBuilder(op)
-                .setTryCount(TRY_COUNT)
+                .setExecutionCallback(this)
                 .setResultDeserialized(false);
-        InternalCompletableFuture f = builder.invoke();
-        f.andThen(this);
+        builder.invoke();
     }
 
     protected abstract InvocationBuilder getInvocationBuilder(Operation op);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractPartitionMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractPartitionMessageTask.java
@@ -18,7 +18,6 @@ package com.hazelcast.client.impl.protocol.task;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.core.ExecutionCallback;
-import com.hazelcast.core.ICompletableFuture;
 import com.hazelcast.instance.Node;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.spi.InvocationBuilder;
@@ -60,10 +59,10 @@ public abstract class AbstractPartitionMessageTask<P>
         op.setCallerUuid(endpoint.getUuid());
         InvocationBuilder builder = nodeEngine.getOperationService()
                 .createInvocationBuilder(getServiceName(), op, getPartitionId())
+                .setExecutionCallback(this)
                 .setResultDeserialized(false);
 
-        ICompletableFuture future = builder.invoke();
-        future.andThen(this);
+        builder.invoke();
     }
 
     protected abstract Operation prepareOperation();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheListenerRegistrationMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheListenerRegistrationMessageTask.java
@@ -20,7 +20,7 @@ import com.hazelcast.cache.impl.CacheService;
 import com.hazelcast.cache.impl.operation.CacheListenerRegistrationOperation;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.CacheListenerRegistrationCodec;
-import com.hazelcast.client.impl.protocol.task.InvocationMessageTask;
+import com.hazelcast.client.impl.protocol.task.AbstractInvocationMessageTask;
 import com.hazelcast.instance.Node;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.Connection;
@@ -38,7 +38,7 @@ import java.security.Permission;
  * @see CacheListenerRegistrationOperation
  */
 public class CacheListenerRegistrationMessageTask
-        extends InvocationMessageTask<CacheListenerRegistrationCodec.RequestParameters> {
+        extends AbstractInvocationMessageTask<CacheListenerRegistrationCodec.RequestParameters> {
 
     public CacheListenerRegistrationMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheManagementConfigMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheManagementConfigMessageTask.java
@@ -20,7 +20,7 @@ import com.hazelcast.cache.impl.CacheService;
 import com.hazelcast.cache.impl.operation.CacheManagementConfigOperation;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.CacheManagementConfigCodec;
-import com.hazelcast.client.impl.protocol.task.InvocationMessageTask;
+import com.hazelcast.client.impl.protocol.task.AbstractInvocationMessageTask;
 import com.hazelcast.instance.Node;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.Connection;
@@ -37,7 +37,7 @@ import java.security.Permission;
  * @see CacheManagementConfigOperation
  */
 public class CacheManagementConfigMessageTask
-        extends InvocationMessageTask<CacheManagementConfigCodec.RequestParameters> {
+        extends AbstractInvocationMessageTask<CacheManagementConfigCodec.RequestParameters> {
 
     public CacheManagementConfigMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/executorservice/ExecutorServiceSubmitToAddressMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/executorservice/ExecutorServiceSubmitToAddressMessageTask.java
@@ -18,7 +18,7 @@ package com.hazelcast.client.impl.protocol.task.executorservice;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.ExecutorServiceSubmitToAddressCodec;
-import com.hazelcast.client.impl.protocol.task.InvocationMessageTask;
+import com.hazelcast.client.impl.protocol.task.AbstractInvocationMessageTask;
 import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.executor.impl.DistributedExecutorService;
 import com.hazelcast.executor.impl.operations.MemberCallableTaskOperation;
@@ -37,7 +37,7 @@ import java.security.Permission;
 import java.util.concurrent.Callable;
 
 public class ExecutorServiceSubmitToAddressMessageTask
-        extends InvocationMessageTask<ExecutorServiceSubmitToAddressCodec.RequestParameters>
+        extends AbstractInvocationMessageTask<ExecutorServiceSubmitToAddressCodec.RequestParameters>
         implements ExecutionCallback {
 
     public ExecutorServiceSubmitToAddressMessageTask(ClientMessage clientMessage, Node node, Connection connection) {

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/executorservice/ExecutorServiceSubmitToPartitionMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/executorservice/ExecutorServiceSubmitToPartitionMessageTask.java
@@ -18,7 +18,7 @@ package com.hazelcast.client.impl.protocol.task.executorservice;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.ExecutorServiceSubmitToPartitionCodec;
-import com.hazelcast.client.impl.protocol.task.InvocationMessageTask;
+import com.hazelcast.client.impl.protocol.task.AbstractInvocationMessageTask;
 import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.executor.impl.DistributedExecutorService;
 import com.hazelcast.executor.impl.operations.CallableTaskOperation;
@@ -35,7 +35,7 @@ import java.security.Permission;
 import java.util.concurrent.Callable;
 
 public class ExecutorServiceSubmitToPartitionMessageTask
-        extends InvocationMessageTask<ExecutorServiceSubmitToPartitionCodec.RequestParameters>
+        extends AbstractInvocationMessageTask<ExecutorServiceSubmitToPartitionCodec.RequestParameters>
         implements ExecutionCallback {
 
     public ExecutorServiceSubmitToPartitionMessageTask(ClientMessage clientMessage, Node node, Connection connection) {


### PR DESCRIPTION
It is moved from future.andThen to invocation.setExecutionCallback.  Rename InvocationMessageTask to AbstractInvocationMessageTask to make naming consistent.