### PR TITLE
DefaultScheduledQueue supports Multiple Consumers

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/classic/DefaultScheduleQueue.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/classic/DefaultScheduleQueue.java
@@ -32,7 +32,6 @@ public final class DefaultScheduleQueue implements ScheduleQueue {
 
     private final BlockingQueue normalQueue;
     private final ConcurrentLinkedQueue priorityQueue;
-    private Object pendingNormalItem;
 
     public DefaultScheduleQueue() {
         this(new LinkedBlockingQueue(), new ConcurrentLinkedQueue());
@@ -82,21 +81,9 @@ public final class DefaultScheduleQueue implements ScheduleQueue {
                 return priorityItem;
             }
 
-            if (pendingNormalItem != null) {
-                Object tmp = pendingNormalItem;
-                pendingNormalItem = null;
-                return tmp;
-            }
-
             Object normalItem = normalQueue.take();
             if (normalItem == TRIGGER_TASK) {
                 continue;
-            }
-
-            priorityItem = priorityQueue.poll();
-            if (priorityItem != null) {
-                pendingNormalItem = normalItem;
-                return priorityItem;
             }
 
             return normalItem;

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/classic/ScheduleQueue.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/classic/ScheduleQueue.java
@@ -19,7 +19,8 @@ package com.hazelcast.spi.impl.operationexecutor.classic;
 /**
  * The ScheduleQueue is a kind of priority queue where 'tasks' are queued for scheduling.
  * <p/>
- * ScheduleQueue support concurrent producers but only need to support single consumers.
+ * Implementations must support Multiple-Producer Multiple-Consumers scenario as multiple
+ * {@link GenericOperationThread} share a single queue.
  * <p/>
  * The ScheduledQueue also support priority tasks; so if a task with a priority comes in, than
  * that one is taken before any other normal operation is taken.

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/classic/DefaultScheduleQueueStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/classic/DefaultScheduleQueueStressTest.java
@@ -1,0 +1,89 @@
+package com.hazelcast.spi.impl.operationexecutor.classic;
+
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestThread;
+import com.hazelcast.test.annotation.NightlyTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(NightlyTest.class)
+public class DefaultScheduleQueueStressTest extends HazelcastTestSupport {
+
+    private final DefaultScheduleQueue queue = new DefaultScheduleQueue();
+    private final AtomicBoolean stop = new AtomicBoolean();
+    private final static Object POISON_PILL = new Object();
+
+    @Test
+    public void testMultipleConsumers() {
+        int testDurationSeconds = 10;
+
+        ProducerThread producer = new ProducerThread();
+        ConsumerThread consumer1 = new ConsumerThread(1);
+        ConsumerThread consumer2 = new ConsumerThread(2);
+
+        producer.start();
+        consumer1.start();
+        consumer2.start();
+
+        sleepAndStop(stop, testDurationSeconds);
+
+        producer.assertSucceedsEventually();
+        consumer1.assertSucceedsEventually();
+        consumer2.assertSucceedsEventually();
+
+        long consumed = consumer1.consumed + consumer2.consumed;
+        assertEquals(producer.produced, consumed);
+    }
+
+    private class ProducerThread extends TestThread {
+        private volatile long produced;
+
+        public ProducerThread(){
+            super("ProducerThread");
+        }
+
+        @Override
+        public void doRun() throws Throwable {
+            Random random = new Random();
+            while (!stop.get()) {
+                if (random.nextInt(5) == 0) {
+                    queue.addUrgent("foo");
+                } else {
+                    queue.add("foo");
+                }
+                produced++;
+            }
+
+            for (int k = 0; k < 100; k++) {
+                queue.add(POISON_PILL);
+            }
+        }
+    }
+
+    private class ConsumerThread extends TestThread {
+        volatile long consumed = 0;
+
+        public ConsumerThread(int id){
+            super("ConsumerThread-" + id);
+        }
+
+        @Override
+        public void doRun() throws Throwable {
+            for (; ; ) {
+                Object item = queue.take();
+                if(item == POISON_PILL){
+                    break;
+                }
+                consumed++;
+            }
+        }
+    }
+}


### PR DESCRIPTION
This fixes OperationTimeoutException caused by a lost item when multiple generic operation threads tried to take an item from the queue.

This implementation provides the same guarantee when it comes to priority of urgent tasks as the original MPSC queue.

The stress test was kindly contributed by @pveentjer 

I'll send a PR with a forward port to a master branch once it's reviewed and merged.