### PR TITLE
Moved com.hazelcast.wan to com.hazelcast.internal.wan

### DIFF
--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/DummyWanReplication.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/DummyWanReplication.java
@@ -18,8 +18,8 @@ package com.hazelcast.spring;
 
 import com.hazelcast.instance.Node;
 import com.hazelcast.map.impl.record.Record;
-import com.hazelcast.wan.ReplicationEventObject;
-import com.hazelcast.wan.WanReplicationEndpoint;
+import com.hazelcast.internal.wan.ReplicationEventObject;
+import com.hazelcast.internal.wan.WanReplicationEndpoint;
 
 public class DummyWanReplication implements WanReplicationEndpoint {
 

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
@@ -85,7 +85,7 @@ import com.hazelcast.quorum.QuorumType;
 import com.hazelcast.spring.serialization.DummyDataSerializableFactory;
 import com.hazelcast.spring.serialization.DummyPortableFactory;
 import com.hazelcast.test.annotation.QuickTest;
-import com.hazelcast.wan.WanReplicationEndpoint;
+import com.hazelcast.internal.wan.WanReplicationEndpoint;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullcacheconfig-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullcacheconfig-applicationContext-hazelcast.xml
@@ -51,7 +51,7 @@
             </hz:properties>
             <hz:wan-replication name="testWan" snapshot-enabled="false">
                 <hz:target-cluster group-name="tokyo" group-password="tokyo-pass">
-                    <hz:replication-impl>com.hazelcast.wan.impl.WanNoDelayReplication</hz:replication-impl>
+                    <hz:replication-impl>com.hazelcast.internal.wan.impl.WanNoDelayReplication</hz:replication-impl>
                     <hz:end-points>
                         <hz:address>10.2.1.1:5701</hz:address>
                         <hz:address>10.2.1.2:5701</hz:address>

--- a/hazelcast/src/main/java/com/hazelcast/config/WanReplicationConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/WanReplicationConfig.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.config;
 
+import com.hazelcast.internal.wan.WanReplicationEvent;
+
 import java.util.ArrayList;
 import java.util.List;
 /**
@@ -27,7 +29,7 @@ public class WanReplicationConfig {
     List<WanTargetClusterConfig> targetClusterConfigs;
     /**
      * This property is only valid when used with WAN Batch replication, Enterprise Only
-     * When enabled, only the latest {@link com.hazelcast.wan.WanReplicationEvent} of a key is sent to target
+     * When enabled, only the latest {@link WanReplicationEvent} of a key is sent to target
      */
     boolean snapshotEnabled;
 

--- a/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
@@ -29,7 +29,7 @@ import com.hazelcast.spi.ServiceConfigurationParser;
 import com.hazelcast.topic.TopicOverloadPolicy;
 import com.hazelcast.util.ExceptionUtil;
 import com.hazelcast.util.StringUtil;
-import com.hazelcast.wan.impl.WanNoDelayReplication;
+import com.hazelcast.internal.wan.impl.WanNoDelayReplication;
 import com.hazelcast.config.CacheSimpleConfig.ExpiryPolicyFactoryConfig;
 import com.hazelcast.config.CacheSimpleConfig.ExpiryPolicyFactoryConfig.TimedExpiryPolicyFactoryConfig;
 import com.hazelcast.config.CacheSimpleConfig.ExpiryPolicyFactoryConfig.DurationConfig;

--- a/hazelcast/src/main/java/com/hazelcast/instance/DefaultNodeExtension.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/DefaultNodeExtension.java
@@ -48,8 +48,8 @@ import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.util.ConstructorFunction;
 import com.hazelcast.util.ExceptionUtil;
-import com.hazelcast.wan.WanReplicationService;
-import com.hazelcast.wan.impl.WanReplicationServiceImpl;
+import com.hazelcast.internal.wan.WanReplicationService;
+import com.hazelcast.internal.wan.impl.WanReplicationServiceImpl;
 
 import static com.hazelcast.map.impl.MapServiceConstructor.getDefaultMapServiceConstructor;
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/wan/ReplicationEventObject.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/wan/ReplicationEventObject.java
@@ -14,14 +14,10 @@
  * limitations under the License.
  */
 
-package com.hazelcast.wan;
+package com.hazelcast.internal.wan;
 
 /**
- * This interface offers the implementation of different kinds of replication techniques like
- * TCP, UDP or maybe even an JMS based service
+ * Marker interface for WAN replication messages
  */
-public interface WanReplicationPublisher {
-
-    void publishReplicationEvent(String serviceName, ReplicationEventObject eventObject);
-
+public interface ReplicationEventObject {
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/wan/WanReplicationEndpoint.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/wan/WanReplicationEndpoint.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.hazelcast.wan;
+package com.hazelcast.internal.wan;
 
 import com.hazelcast.instance.Node;
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/wan/WanReplicationEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/wan/WanReplicationEvent.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.hazelcast.wan;
+package com.hazelcast.internal.wan;
 
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;

--- a/hazelcast/src/main/java/com/hazelcast/internal/wan/WanReplicationPublisher.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/wan/WanReplicationPublisher.java
@@ -14,10 +14,14 @@
  * limitations under the License.
  */
 
-package com.hazelcast.wan;
+package com.hazelcast.internal.wan;
 
 /**
- * Marker interface for WAN replication messages
+ * This interface offers the implementation of different kinds of replication techniques like
+ * TCP, UDP or maybe even an JMS based service
  */
-public interface ReplicationEventObject {
+public interface WanReplicationPublisher {
+
+    void publishReplicationEvent(String serviceName, ReplicationEventObject eventObject);
+
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/wan/WanReplicationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/wan/WanReplicationService.java
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-package com.hazelcast.wan;
+package com.hazelcast.internal.wan;
 
 import com.hazelcast.nio.Packet;
 import com.hazelcast.spi.CoreService;
 
 /**
  * This is the WAN replications service API core interface. The WanReplicationService needs to
- * be capable of creating the actual {@link com.hazelcast.wan.WanReplicationPublisher} instances
+ * be capable of creating the actual {@link WanReplicationPublisher} instances
  * to replicate values to other clusters over the wide area network, so it has to deal with long
  * delays, slow uploads and higher latencies.
  */
@@ -34,7 +34,7 @@ public interface WanReplicationService
     String SERVICE_NAME = "hz:core:wanReplicationService";
 
     /**
-     * Creates a new {@link com.hazelcast.wan.WanReplicationPublisher} by the given name. If
+     * Creates a new {@link WanReplicationPublisher} by the given name. If
      * the name already exists, returns the previous instance.
      *
      * @param name name of the WAN replication configuration

--- a/hazelcast/src/main/java/com/hazelcast/internal/wan/impl/WanNoDelayReplication.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/wan/impl/WanNoDelayReplication.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.hazelcast.wan.impl;
+package com.hazelcast.internal.wan.impl;
 
 import com.hazelcast.cluster.impl.operations.AuthorizationOperation;
 import com.hazelcast.instance.Node;
@@ -29,10 +29,10 @@ import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.OperationService;
 import com.hazelcast.util.AddressUtil;
 import com.hazelcast.util.AddressUtil.AddressHolder;
-import com.hazelcast.wan.ReplicationEventObject;
-import com.hazelcast.wan.WanReplicationEndpoint;
-import com.hazelcast.wan.WanReplicationEvent;
-import com.hazelcast.wan.WanReplicationService;
+import com.hazelcast.internal.wan.ReplicationEventObject;
+import com.hazelcast.internal.wan.WanReplicationEndpoint;
+import com.hazelcast.internal.wan.WanReplicationEvent;
+import com.hazelcast.internal.wan.WanReplicationService;
 
 import java.util.Arrays;
 import java.util.LinkedList;

--- a/hazelcast/src/main/java/com/hazelcast/internal/wan/impl/WanReplicationPublisherDelegate.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/wan/impl/WanReplicationPublisherDelegate.java
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-package com.hazelcast.wan.impl;
+package com.hazelcast.internal.wan.impl;
 
-import com.hazelcast.wan.ReplicationEventObject;
-import com.hazelcast.wan.WanReplicationEndpoint;
-import com.hazelcast.wan.WanReplicationPublisher;
+import com.hazelcast.internal.wan.ReplicationEventObject;
+import com.hazelcast.internal.wan.WanReplicationEndpoint;
+import com.hazelcast.internal.wan.WanReplicationPublisher;
 
 /**
  * Delegating replication publisher implementation

--- a/hazelcast/src/main/java/com/hazelcast/internal/wan/impl/WanReplicationServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/wan/impl/WanReplicationServiceImpl.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.hazelcast.wan.impl;
+package com.hazelcast.internal.wan.impl;
 
 import com.hazelcast.config.ExecutorConfig;
 import com.hazelcast.config.WanReplicationConfig;
@@ -29,17 +29,17 @@ import com.hazelcast.spi.ReplicationSupportingService;
 import com.hazelcast.util.ExceptionUtil;
 import com.hazelcast.util.executor.StripedExecutor;
 import com.hazelcast.util.executor.StripedRunnable;
-import com.hazelcast.wan.WanReplicationEndpoint;
-import com.hazelcast.wan.WanReplicationEvent;
-import com.hazelcast.wan.WanReplicationPublisher;
-import com.hazelcast.wan.WanReplicationService;
+import com.hazelcast.internal.wan.WanReplicationEndpoint;
+import com.hazelcast.internal.wan.WanReplicationEvent;
+import com.hazelcast.internal.wan.WanReplicationPublisher;
+import com.hazelcast.internal.wan.WanReplicationService;
 
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
- * Open source implementation of the {@link com.hazelcast.wan.WanReplicationService}
+ * Open source implementation of the {@link WanReplicationService}
  */
 public class WanReplicationServiceImpl implements WanReplicationService {
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/wan/impl/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/wan/impl/package-info.java
@@ -15,6 +15,6 @@
  */
 
 /**
- * This package contains the WAN replication API
+ * This package contains the opensource implementation of WAN replication
  */
-package com.hazelcast.wan;
+package com.hazelcast.internal.wan.impl;

--- a/hazelcast/src/main/java/com/hazelcast/internal/wan/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/wan/package-info.java
@@ -15,6 +15,6 @@
  */
 
 /**
- * This package contains the opensource implementation of WAN replication
+ * This package contains the WAN replication API
  */
-package com.hazelcast.wan.impl;
+package com.hazelcast.internal.wan;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapContainer.java
@@ -35,8 +35,8 @@ import com.hazelcast.nio.serialization.SerializationService;
 import com.hazelcast.query.impl.IndexService;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.util.ExceptionUtil;
-import com.hazelcast.wan.WanReplicationPublisher;
-import com.hazelcast.wan.WanReplicationService;
+import com.hazelcast.internal.wan.WanReplicationPublisher;
+import com.hazelcast.internal.wan.WanReplicationService;
 
 import java.util.List;
 import java.util.Map;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapEventPublisherImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapEventPublisherImpl.java
@@ -29,8 +29,8 @@ import com.hazelcast.spi.EventRegistration;
 import com.hazelcast.spi.EventService;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.impl.eventservice.impl.EmptyFilter;
-import com.hazelcast.wan.ReplicationEventObject;
-import com.hazelcast.wan.WanReplicationPublisher;
+import com.hazelcast.internal.wan.ReplicationEventObject;
+import com.hazelcast.internal.wan.WanReplicationPublisher;
 
 import java.util.ArrayList;
 import java.util.Collection;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapReplicationSupportingService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapReplicationSupportingService.java
@@ -25,7 +25,7 @@ import com.hazelcast.map.impl.wan.MapReplicationUpdate;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.ReplicationSupportingService;
 import com.hazelcast.util.ExceptionUtil;
-import com.hazelcast.wan.WanReplicationEvent;
+import com.hazelcast.internal.wan.WanReplicationEvent;
 
 import java.util.concurrent.Future;
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapService.java
@@ -37,7 +37,7 @@ import com.hazelcast.spi.StatisticsAwareService;
 import com.hazelcast.spi.TransactionalService;
 import com.hazelcast.transaction.TransactionalObject;
 import com.hazelcast.transaction.impl.TransactionSupport;
-import com.hazelcast.wan.WanReplicationEvent;
+import com.hazelcast.internal.wan.WanReplicationEvent;
 
 import java.util.Map;
 import java.util.Properties;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/wan/MapReplicationRemove.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/wan/MapReplicationRemove.java
@@ -20,7 +20,7 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.DataSerializable;
-import com.hazelcast.wan.ReplicationEventObject;
+import com.hazelcast.internal.wan.ReplicationEventObject;
 import java.io.IOException;
 
 public class MapReplicationRemove implements ReplicationEventObject, DataSerializable {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/wan/MapReplicationUpdate.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/wan/MapReplicationUpdate.java
@@ -21,7 +21,7 @@ import com.hazelcast.map.merge.MapMergePolicy;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.DataSerializable;
-import com.hazelcast.wan.ReplicationEventObject;
+import com.hazelcast.internal.wan.ReplicationEventObject;
 import java.io.IOException;
 
 public class MapReplicationUpdate implements ReplicationEventObject, DataSerializable {

--- a/hazelcast/src/main/java/com/hazelcast/spi/NodeEngine.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/NodeEngine.java
@@ -30,7 +30,7 @@ import com.hazelcast.internal.storage.DataRef;
 import com.hazelcast.internal.storage.Storage;
 import com.hazelcast.quorum.impl.QuorumServiceImpl;
 import com.hazelcast.transaction.TransactionManagerService;
-import com.hazelcast.wan.WanReplicationService;
+import com.hazelcast.internal.wan.WanReplicationService;
 
 /**
  * The NodeEngine is the 'umbrella' of services/service-method that gets injected into a {@link ManagedService}.

--- a/hazelcast/src/main/java/com/hazelcast/spi/ReplicationSupportingService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/ReplicationSupportingService.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.spi;
 
-import com.hazelcast.wan.WanReplicationEvent;
+import com.hazelcast.internal.wan.WanReplicationEvent;
 
 /**
  * An interface that can be implemented by SPI services to give them the ability to listen to

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
@@ -52,7 +52,7 @@ import com.hazelcast.spi.impl.executionservice.InternalExecutionService;
 import com.hazelcast.spi.impl.executionservice.impl.ExecutionServiceImpl;
 import com.hazelcast.transaction.TransactionManagerService;
 import com.hazelcast.transaction.impl.TransactionManagerServiceImpl;
-import com.hazelcast.wan.WanReplicationService;
+import com.hazelcast.internal.wan.WanReplicationService;
 
 import java.util.Collection;
 import java.util.LinkedList;

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/transceiver/impl/PacketTransceiverImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/transceiver/impl/PacketTransceiverImpl.java
@@ -28,7 +28,7 @@ import com.hazelcast.spi.impl.operationservice.InternalOperationService;
 import com.hazelcast.spi.impl.eventservice.InternalEventService;
 import com.hazelcast.spi.impl.operationexecutor.OperationExecutor;
 import com.hazelcast.spi.impl.transceiver.PacketTransceiver;
-import com.hazelcast.wan.WanReplicationService;
+import com.hazelcast.internal.wan.WanReplicationService;
 
 import java.util.concurrent.TimeUnit;
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/wan/WanReplicationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/wan/WanReplicationTest.java
@@ -1,4 +1,4 @@
-package com.hazelcast.wan;
+package com.hazelcast.internal.wan;
 
 import com.hazelcast.config.Config;
 import com.hazelcast.config.WanReplicationConfig;
@@ -17,7 +17,7 @@ import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.NightlyTest;
-import com.hazelcast.wan.impl.WanNoDelayReplication;
+import com.hazelcast.internal.wan.impl.WanNoDelayReplication;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;

--- a/hazelcast/src/test/resources/hazelcast-fullconfig.xml
+++ b/hazelcast/src/test/resources/hazelcast-fullconfig.xml
@@ -44,14 +44,14 @@
     <management-center enabled="true" update-interval="5">http://mywebserver:8080</management-center>
     <wan-replication name="my-wan-cluster">
         <target-cluster group-name="tokyo" group-password="tokyo-pass">
-            <replication-impl>com.hazelcast.wan.impl.WanNoDelayReplication</replication-impl>
+            <replication-impl>com.hazelcast.internal.wan.impl.WanNoDelayReplication</replication-impl>
             <end-points>
                 <address>10.2.1.1:5701</address>
                 <address>10.2.1.2:5701</address>
             </end-points>
         </target-cluster>
         <target-cluster group-name="london" group-password="london-pass">
-            <replication-impl>com.hazelcast.wan.impl.WanNoDelayReplication</replication-impl>
+            <replication-impl>com.hazelcast.internal.wan.impl.WanNoDelayReplication</replication-impl>
             <end-points>
                 <address>10.3.5.1:5701</address>
                 <address>10.3.5.2:5701</address>


### PR DESCRIPTION
This module is purely internal and not a public API; so it belongs in the com.hazelcast.internal. 

Thanks for helping out Emrah.

I'll take care of Enterprise as soon as this is merged.