### PR TITLE
Moved ServiceInfo from spi to spi.impl.servicemanager

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/partition/impl/MigrationRequestOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/impl/MigrationRequestOperation.java
@@ -32,7 +32,7 @@ import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.PartitionMigrationEvent;
 import com.hazelcast.spi.PartitionReplicationEvent;
 import com.hazelcast.spi.ResponseHandler;
-import com.hazelcast.spi.ServiceInfo;
+import com.hazelcast.spi.impl.servicemanager.ServiceInfo;
 import com.hazelcast.spi.exception.RetryableHazelcastException;
 import com.hazelcast.spi.exception.TargetNotMemberException;
 import com.hazelcast.spi.impl.NodeEngineImpl;

--- a/hazelcast/src/main/java/com/hazelcast/partition/impl/ReplicaSyncRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/impl/ReplicaSyncRequest.java
@@ -30,7 +30,7 @@ import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.OperationService;
 import com.hazelcast.spi.PartitionAwareOperation;
 import com.hazelcast.spi.PartitionReplicationEvent;
-import com.hazelcast.spi.ServiceInfo;
+import com.hazelcast.spi.impl.servicemanager.ServiceInfo;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 
 import java.io.IOException;

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
@@ -33,7 +33,7 @@ import com.hazelcast.quorum.impl.QuorumServiceImpl;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.PostJoinAwareService;
-import com.hazelcast.spi.ServiceInfo;
+import com.hazelcast.spi.impl.servicemanager.ServiceInfo;
 import com.hazelcast.spi.SharedService;
 import com.hazelcast.internal.storage.DataRef;
 import com.hazelcast.internal.storage.Storage;

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/servicemanager/ServiceInfo.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/servicemanager/ServiceInfo.java
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
-package com.hazelcast.spi;
+package com.hazelcast.spi.impl.servicemanager;
+
+import com.hazelcast.spi.ConfigurableService;
+import com.hazelcast.spi.CoreService;
+import com.hazelcast.spi.ManagedService;
 
 /**
  * Contains the name of the service and the actual service.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/servicemanager/ServiceManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/servicemanager/ServiceManager.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.spi.impl.servicemanager;
 
-import com.hazelcast.spi.ServiceInfo;
 import com.hazelcast.spi.SharedService;
 
 import java.util.List;

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/servicemanager/impl/ServiceManagerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/servicemanager/impl/ServiceManagerImpl.java
@@ -47,7 +47,7 @@ import com.hazelcast.ringbuffer.impl.RingbufferService;
 import com.hazelcast.spi.ConfigurableService;
 import com.hazelcast.spi.ManagedService;
 import com.hazelcast.spi.NodeEngine;
-import com.hazelcast.spi.ServiceInfo;
+import com.hazelcast.spi.impl.servicemanager.ServiceInfo;
 import com.hazelcast.spi.SharedService;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.impl.proxyservice.impl.ProxyServiceImpl;

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/servicemanager/impl/ServiceManagerImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/servicemanager/impl/ServiceManagerImplTest.java
@@ -8,7 +8,7 @@ import com.hazelcast.map.impl.MapService;
 import com.hazelcast.spi.ConfigurableService;
 import com.hazelcast.spi.ManagedService;
 import com.hazelcast.spi.NodeEngine;
-import com.hazelcast.spi.ServiceInfo;
+import com.hazelcast.spi.impl.servicemanager.ServiceInfo;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;


### PR DESCRIPTION
Although this class was located in the com.hazelcast.spi package, there is no public API where this is being used. So it isn't exposed in any way apart from being in the spi module. So I consider it safe to
move inside the implementation.