### PR TITLE
fix for #5531

### DIFF
--- a/hazelcast-wm/src/main/java/com/hazelcast/web/HazelcastHttpSession.java
+++ b/hazelcast-wm/src/main/java/com/hazelcast/web/HazelcastHttpSession.java
@@ -94,10 +94,12 @@ public class HazelcastHttpSession implements HttpSession {
         entry.setValue(value);
         entry.setDirty(true);
         entry.setRemoved(false);
+        entry.setReload(false);
         if (!deferredWrite && !transientEntry) {
             try {
                 webFilter.getClusteredSessionService().setAttribute(id, name, value);
                 entry.setDirty(false);
+                entry.setReload(true);
             } catch (Exception ignored) {
                 EmptyStatement.ignore(ignored);
             }
@@ -191,6 +193,7 @@ public class HazelcastHttpSession implements HttpSession {
             entry.setValue(null);
             entry.setRemoved(true);
             entry.setDirty(true);
+            entry.setReload(false);
         }
         if (!deferredWrite) {
             try {

--- a/hazelcast-wm/src/test/java/com/hazelcast/wm/test/DeferredWriteClusterTest.java
+++ b/hazelcast-wm/src/test/java/com/hazelcast/wm/test/DeferredWriteClusterTest.java
@@ -127,6 +127,12 @@ public class DeferredWriteClusterTest extends AbstractWebFilterTest {
         assertEquals("value-updated", executeRequest("read", serverPort1, cookieStore));
     }
 
+    @Test(timeout = 20000)
+    public void test_setThenGetAttribute() throws Exception {
+        CookieStore cookieStore = new BasicCookieStore();
+        assertEquals("value",executeRequest("setGet", serverPort1, cookieStore));
+    }
+
     @Override
     protected ServletContainer getServletContainer(int port, String sourceDir, String serverXml) throws Exception {
         return new JettyServer(port, sourceDir, serverXml);

--- a/hazelcast-wm/src/test/java/com/hazelcast/wm/test/TestServlet.java
+++ b/hazelcast-wm/src/test/java/com/hazelcast/wm/test/TestServlet.java
@@ -48,6 +48,10 @@ public class TestServlet extends HttpServlet {
         } else if (req.getRequestURI().endsWith("read")) {
             Object value = session.getAttribute("key");
             resp.getWriter().write(value == null ? "null" : value.toString());
+        } else if (req.getRequestURI().endsWith("setGet")) {
+            session.setAttribute("key","value");
+            Object value = session.getAttribute("key");
+            resp.getWriter().write(value == null ? "null" : value.toString());
         } else if (req.getRequestURI().endsWith("remove")) {
             session.removeAttribute("key");
             resp.getWriter().write("true");


### PR DESCRIPTION
After setting an attribute we need to set reload as false. Because local entry is last value. We shouldn't read from cluster after session.setAttribute().
https://github.com/hazelcast/hazelcast/issues/5531