### PR TITLE
findbugs and hazelcast-code-generator scope made provided

### DIFF
--- a/hazelcast/pom.xml
+++ b/hazelcast/pom.xml
@@ -319,13 +319,6 @@
         </dependency>
 
         <dependency>
-            <groupId>net.sourceforge.findbugs</groupId>
-            <artifactId>annotations</artifactId>
-            <version>1.3.2</version>
-            <scope>compile</scope>
-        </dependency>
-
-        <dependency>
             <groupId>com.eclipsesource.minimal-json</groupId>
             <artifactId>minimal-json</artifactId>
             <version>0.9.2</version>
@@ -336,6 +329,7 @@
             <groupId>com.hazelcast</groupId>
             <artifactId>hazelcast-code-generator</artifactId>
             <version>${version}</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -867,6 +867,12 @@
             <scope>test</scope>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>net.sourceforge.findbugs</groupId>
+            <artifactId>annotations</artifactId>
+            <version>1.3.2</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
 </project>


### PR DESCRIPTION
**findbugs:** I have moved up the findbugs dependency and made it provided. That way all dependent modules will get the dependency. Previously it was through hazelcast module.
**hazelcast-code-generator:** it is provided now. 
**minimal-json:** I could not find any solution for minimal-json. 