### PR TITLE
Configurable InvocationFuture's callback-executor 

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/InvocationBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/InvocationBuilder.java
@@ -21,6 +21,8 @@ import com.hazelcast.nio.Address;
 import com.hazelcast.partition.InternalPartition;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 
+import java.util.concurrent.Executor;
+
 /**
  * The InvocationBuilder is responsible for building an invocation of an operation and invoking it.
  * <p/>
@@ -61,6 +63,7 @@ public abstract class InvocationBuilder {
     protected final Address target;
     protected Callback<Object> callback;
     protected ExecutionCallback<Object> executionCallback;
+    protected Executor callbackExecutor;
 
     protected long callTimeout = DEFAULT_CALL_TIMEOUT;
     protected int replicaIndex;
@@ -86,7 +89,7 @@ public abstract class InvocationBuilder {
         this.target = target;
     }
 
-     /**
+    /**
      * Sets the replicaIndex.
      *
      * @param replicaIndex the replica index
@@ -165,6 +168,7 @@ public abstract class InvocationBuilder {
 
     /**
      * Gets the operation to execute.
+     *
      * @return the operation to execute
      */
     public Operation getOp() {
@@ -175,7 +179,7 @@ public abstract class InvocationBuilder {
      * Gets the replicaIndex.
      *
      * @return the replicaIndex
-      */
+     */
 
     public int getReplicaIndex() {
         return replicaIndex;
@@ -202,7 +206,7 @@ public abstract class InvocationBuilder {
     /**
      * Returns the target machine.
      *
-     * @return  the target machine.
+     * @return the target machine.
      */
     public Address getTarget() {
         return target;
@@ -211,7 +215,7 @@ public abstract class InvocationBuilder {
     /**
      * Returns the partition id.
      *
-     * @return  the partition id.
+     * @return the partition id.
      */
     public int getPartitionId() {
         return partitionId;
@@ -262,6 +266,22 @@ public abstract class InvocationBuilder {
             throw new IllegalStateException("Can't set the executionCallback if callback already is set");
         }
         this.executionCallback = executionCallback;
+        return this;
+    }
+
+    /**
+     * Sets the {@code callbackExecutor} in which the {@link #executionCallback} will be run.
+     * If you don't set an executor, default executor will be used.
+     *
+     * @param callbackExecutor the callbackExecutor in which the callback will be run
+     * @return the updated InvocationBuilder.
+     * @throws java.lang.IllegalStateException if an callbackExecutor has already been set.
+     */
+    public InvocationBuilder setCallbackExecutor(Executor callbackExecutor) {
+        if (this.callbackExecutor != null) {
+            throw new IllegalStateException("Can't set the executor if an executor is already set");
+        }
+        this.callbackExecutor = callbackExecutor;
         return this;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/InternalOperationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/InternalOperationService.java
@@ -20,11 +20,15 @@ import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.internal.management.dto.SlowOperationDTO;
 import com.hazelcast.nio.Address;
 import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.OperationFactory;
 import com.hazelcast.spi.OperationService;
 import com.hazelcast.spi.impl.PartitionSpecificRunnable;
 import com.hazelcast.spi.impl.operationexecutor.OperationExecutor;
 
+import java.util.Collection;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Executor;
 
 /**
  * This is the interface that needs to be implemented by actual InternalOperationService. Currently there is a single
@@ -89,4 +93,22 @@ public interface InternalOperationService extends OperationService {
     <V> void asyncInvokeOnPartition(String serviceName, Operation op, int partitionId, ExecutionCallback<V> callback);
 
     <V> void asyncInvokeOnTarget(String serviceName, Operation op, Address target, ExecutionCallback<V> callback);
+
+    /**
+     * Invokes a set of operation on selected set of partitions. Upon finish of operation executions
+     * a given callback in the given executor is run.
+     *
+     * This method blocks until all operations complete.
+     *
+     * @param serviceName      the name of the service
+     * @param operationFactory the factory responsible for creating operations
+     * @param partitions       the partitions the operation should be executed on.
+     * @param callbackExecutor the executor to run the callback
+     * @param callback         the callback which will be run after executions of operations on invoker side.
+     * @return a Map with partitionId as key and the outcome of the operation as value.
+     * @throws Exception
+     */
+    Map<Integer, Object> invokeOnPartitions(String serviceName, OperationFactory operationFactory,
+                                            Collection<Integer> partitions, Executor callbackExecutor,
+                                            ExecutionCallback callback) throws Exception;
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/Invocation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/Invocation.java
@@ -40,6 +40,7 @@ import com.hazelcast.spi.impl.operationservice.impl.responses.NormalResponse;
 import com.hazelcast.util.Clock;
 import com.hazelcast.util.ExceptionUtil;
 
+import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
@@ -48,12 +49,12 @@ import static com.hazelcast.spi.ExecutionService.ASYNC_EXECUTOR;
 import static com.hazelcast.spi.OperationAccessor.setCallTimeout;
 import static com.hazelcast.spi.OperationAccessor.setCallerAddress;
 import static com.hazelcast.spi.OperationAccessor.setInvocationTime;
-import static com.hazelcast.spi.impl.operationutil.Operations.isJoinOperation;
-import static com.hazelcast.spi.impl.operationutil.Operations.isMigrationOperation;
-import static com.hazelcast.spi.impl.operationutil.Operations.isWanReplicationOperation;
 import static com.hazelcast.spi.impl.operationservice.impl.InternalResponse.INTERRUPTED_RESPONSE;
 import static com.hazelcast.spi.impl.operationservice.impl.InternalResponse.NULL_RESPONSE;
 import static com.hazelcast.spi.impl.operationservice.impl.InternalResponse.WAIT_RESPONSE;
+import static com.hazelcast.spi.impl.operationutil.Operations.isJoinOperation;
+import static com.hazelcast.spi.impl.operationutil.Operations.isMigrationOperation;
+import static com.hazelcast.spi.impl.operationutil.Operations.isWanReplicationOperation;
 import static java.lang.Boolean.FALSE;
 import static java.lang.Boolean.TRUE;
 import static java.util.logging.Level.WARNING;
@@ -107,9 +108,10 @@ abstract class Invocation implements ResponseHandler, Runnable {
     // writes to that are normally handled through the INVOKE_COUNT_UPDATER to ensure atomic increments / decrements
     volatile int invokeCount;
 
+    //CHECKSTYLE:OFF
     Invocation(NodeEngineImpl nodeEngine, String serviceName, Operation op, int partitionId,
                int replicaIndex, int tryCount, long tryPauseMillis, long callTimeout, Object callback,
-               boolean resultDeserialized) {
+               Executor callbackExecutor, boolean resultDeserialized) {
         this.operationService = (OperationServiceImpl) nodeEngine.getOperationService();
         this.logger = operationService.invocationLogger;
         this.nodeEngine = nodeEngine;
@@ -120,9 +122,10 @@ abstract class Invocation implements ResponseHandler, Runnable {
         this.tryCount = tryCount;
         this.tryPauseMillis = tryPauseMillis;
         this.callTimeout = getCallTimeout(callTimeout);
-        this.invocationFuture = new InvocationFuture(operationService, this, callback);
+        this.invocationFuture = new InvocationFuture(operationService, this, callback, callbackExecutor);
         this.resultDeserialized = resultDeserialized;
     }
+    //CHECKSTYLE:ON
 
     abstract ExceptionAction onException(Throwable t);
 
@@ -555,7 +558,7 @@ abstract class Invocation implements ResponseHandler, Runnable {
             return false;
         }
 
-         // The backups have not yet completed, but we are going to release the future anyway if a pendingResponse has been set.
+        // The backups have not yet completed, but we are going to release the future anyway if a pendingResponse has been set.
         invocationFuture.set(pendingResponse);
         return true;
     }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationBuilderImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationBuilderImpl.java
@@ -49,10 +49,10 @@ public class InvocationBuilderImpl extends InvocationBuilder {
 
         if (target == null) {
             return new PartitionInvocation(nodeEngine, serviceName, op, partitionId, replicaIndex,
-                    tryCount, tryPauseMillis, callTimeout, callback, resultDeserialized).invoke();
+                    tryCount, tryPauseMillis, callTimeout, callback, callbackExecutor, resultDeserialized).invoke();
         } else {
             return new TargetInvocation(nodeEngine, serviceName, op, target, tryCount, tryPauseMillis,
-                    callTimeout, callback, resultDeserialized).invoke();
+                    callTimeout, callback, callbackExecutor, resultDeserialized).invoke();
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationFuture.java
@@ -67,7 +67,7 @@ final class InvocationFuture<E> implements InternalCompletableFuture<E> {
     private final Invocation invocation;
     private volatile ExecutionCallbackNode<E> callbackHead;
 
-    InvocationFuture(OperationServiceImpl operationService, Invocation invocation, Object callback) {
+    InvocationFuture(OperationServiceImpl operationService, Invocation invocation, Object callback, Executor callbackExecutor) {
         this.invocation = invocation;
         this.operationService = operationService;
 
@@ -79,7 +79,8 @@ final class InvocationFuture<E> implements InternalCompletableFuture<E> {
                 executionCallback = new ExecutorCallbackAdapter<E>((Callback) callback);
             }
 
-            callbackHead = new ExecutionCallbackNode<E>(executionCallback, operationService.asyncExecutor, null);
+            Executor executor = callbackExecutor == null ? operationService.asyncExecutor : callbackExecutor;
+            callbackHead = new ExecutionCallbackNode<E>(executionCallback, executor, null);
         }
     }
 
@@ -401,7 +402,7 @@ final class InvocationFuture<E> implements InternalCompletableFuture<E> {
 
     @Override
     public boolean isDone() {
-         return responseAvailable(response);
+        return responseAvailable(response);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/IsStillRunningService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/IsStillRunningService.java
@@ -63,6 +63,7 @@ public class IsStillRunningService {
 
     /**
      * Checks if an operation is still running.
+     *
      * @param invocation The invocation for this operation.
      * @return true if the operation is running, false otherwise.
      */
@@ -74,7 +75,7 @@ public class IsStillRunningService {
 
             Invocation inv = new TargetInvocation(
                     invocation.nodeEngine, invocation.serviceName, isStillExecuting,
-                    invocation.getTarget(), 0, 0, IS_EXECUTING_CALL_TIMEOUT, null, true);
+                    invocation.getTarget(), 0, 0, IS_EXECUTING_CALL_TIMEOUT, null, null, true);
             Future f = inv.invoke();
             invocation.logger.warning("Asking if operation execution has been started: " + invocation);
             executing = (Boolean) invocation.nodeEngine.toObject(f.get(IS_EXECUTING_CALL_TIMEOUT, TimeUnit.MILLISECONDS));
@@ -245,7 +246,7 @@ public class IsStillRunningService {
         public void run() {
             Invocation inv = new TargetInvocation(
                     invocation.nodeEngine, invocation.serviceName, isStillRunningOperation,
-                    invocation.getTarget(), 0, 0, IS_EXECUTING_CALL_TIMEOUT, callback, true);
+                    invocation.getTarget(), 0, 0, IS_EXECUTING_CALL_TIMEOUT, callback, null, true);
 
             invocation.logger.warning("Asking if operation execution has been started: " + toString());
             inv.invoke();

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
@@ -50,6 +50,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -268,7 +269,7 @@ public final class OperationServiceImpl implements InternalOperationService {
         return new PartitionInvocation(
                 nodeEngine, serviceName, op, partitionId, DEFAULT_REPLICA_INDEX,
                 DEFAULT_TRY_COUNT, DEFAULT_TRY_PAUSE_MILLIS,
-                DEFAULT_CALL_TIMEOUT, null, DEFAULT_DESERIALIZE_RESULT).invoke();
+                DEFAULT_CALL_TIMEOUT, null, null, DEFAULT_DESERIALIZE_RESULT).invoke();
     }
 
     @Override
@@ -276,7 +277,7 @@ public final class OperationServiceImpl implements InternalOperationService {
     public <E> InternalCompletableFuture<E> invokeOnTarget(String serviceName, Operation op, Address target) {
         return new TargetInvocation(nodeEngine, serviceName, op, target, DEFAULT_TRY_COUNT,
                 DEFAULT_TRY_PAUSE_MILLIS,
-                DEFAULT_CALL_TIMEOUT, null, DEFAULT_DESERIALIZE_RESULT).invoke();
+                DEFAULT_CALL_TIMEOUT, null, null, DEFAULT_DESERIALIZE_RESULT).invoke();
     }
 
     @Override
@@ -284,7 +285,7 @@ public final class OperationServiceImpl implements InternalOperationService {
     public <V> void asyncInvokeOnPartition(String serviceName, Operation op, int partitionId, ExecutionCallback<V> callback) {
         new PartitionInvocation(nodeEngine, serviceName, op, partitionId, DEFAULT_REPLICA_INDEX,
                 DEFAULT_TRY_COUNT, DEFAULT_TRY_PAUSE_MILLIS,
-                DEFAULT_CALL_TIMEOUT, callback, DEFAULT_DESERIALIZE_RESULT).invokeAsync();
+                DEFAULT_CALL_TIMEOUT, callback, null, DEFAULT_DESERIALIZE_RESULT).invokeAsync();
     }
 
     @Override
@@ -292,7 +293,7 @@ public final class OperationServiceImpl implements InternalOperationService {
     public <V> void asyncInvokeOnTarget(String serviceName, Operation op, Address target, ExecutionCallback<V> callback) {
         new TargetInvocation(nodeEngine, serviceName, op, target, DEFAULT_TRY_COUNT,
                 DEFAULT_TRY_PAUSE_MILLIS,
-                DEFAULT_CALL_TIMEOUT, callback, DEFAULT_DESERIALIZE_RESULT).invokeAsync();
+                DEFAULT_CALL_TIMEOUT, callback, null, DEFAULT_DESERIALIZE_RESULT).invokeAsync();
     }
 
     // =============================== processing operation  ===============================
@@ -329,6 +330,14 @@ public final class OperationServiceImpl implements InternalOperationService {
     @Override
     public Map<Integer, Object> invokeOnPartitions(String serviceName, OperationFactory operationFactory,
                                                    Collection<Integer> partitions) throws Exception {
+        return invokeOnPartitions(serviceName, operationFactory, partitions, null, null);
+    }
+
+
+    @Override
+    public Map<Integer, Object> invokeOnPartitions(String serviceName, OperationFactory operationFactory,
+                                                   Collection<Integer> partitions, Executor callbackExecutor,
+                                                   ExecutionCallback callback) throws Exception {
         Map<Address, List<Integer>> memberPartitions = new HashMap<Address, List<Integer>>(3);
         InternalPartitionService partitionService = nodeEngine.getPartitionService();
         for (int partition : partitions) {
@@ -340,7 +349,8 @@ public final class OperationServiceImpl implements InternalOperationService {
 
             memberPartitions.get(owner).add(partition);
         }
-        InvokeOnPartitions invokeOnPartitions = new InvokeOnPartitions(this, serviceName, operationFactory, memberPartitions);
+        InvokeOnPartitions invokeOnPartitions = new InvokeOnPartitions(this, serviceName,
+                operationFactory, memberPartitions, callback, callbackExecutor);
         return invokeOnPartitions.invoke();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/PartitionInvocation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/PartitionInvocation.java
@@ -21,6 +21,8 @@ import com.hazelcast.spi.ExceptionAction;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 
+import java.util.concurrent.Executor;
+
 /**
  * A {@link Invocation} evaluates a Operation Invocation for a particular partition running on top of the
  * {@link OperationServiceImpl}.
@@ -29,9 +31,9 @@ public final class PartitionInvocation extends Invocation {
 
     public PartitionInvocation(NodeEngineImpl nodeEngine, String serviceName, Operation op, int partitionId,
                                int replicaIndex, int tryCount, long tryPauseMillis, long callTimeout,
-                               Object callback, boolean resultDeserialized) {
+                               Object callback, Executor callbackExecutor, boolean resultDeserialized) {
         super(nodeEngine, serviceName, op, partitionId, replicaIndex, tryCount, tryPauseMillis,
-                callTimeout, callback, resultDeserialized);
+                callTimeout, callback, callbackExecutor, resultDeserialized);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/TargetInvocation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/TargetInvocation.java
@@ -22,6 +22,8 @@ import com.hazelcast.spi.ExceptionAction;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 
+import java.util.concurrent.Executor;
+
 /**
  * A {@link Invocation} evaluates a Operation Invocation for a particular target running on top of the
  * {@link OperationServiceImpl}.
@@ -32,9 +34,9 @@ public final class TargetInvocation extends Invocation {
 
     public TargetInvocation(NodeEngineImpl nodeEngine, String serviceName, Operation op,
                             Address target, int tryCount, long tryPauseMillis, long callTimeout,
-                            Object callback, boolean resultDeserialized) {
+                            Object callback, Executor callbackExecutor, boolean resultDeserialized) {
         super(nodeEngine, serviceName, op, op.getPartitionId(), op.getReplicaIndex(),
-                tryCount, tryPauseMillis, callTimeout, callback, resultDeserialized);
+                tryCount, tryPauseMillis, callTimeout, callback, callbackExecutor, resultDeserialized);
         this.target = target;
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/spi/InvocationBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/InvocationBuilderTest.java
@@ -1,0 +1,162 @@
+package com.hazelcast.spi;
+
+import com.hazelcast.core.ExecutionCallback;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.map.impl.MapService;
+import com.hazelcast.spi.impl.operationservice.impl.DummyOperation;
+import com.hazelcast.spi.impl.operationservice.impl.InvocationBuilderImpl;
+import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category(QuickTest.class)
+public class InvocationBuilderTest extends HazelcastTestSupport {
+
+    private HazelcastInstance node;
+
+    @Before
+    public void setup() {
+        node = createHazelcastInstance();
+    }
+
+
+    /**
+     * If nothing set to callback-executor, default executor should be used.
+     */
+    @Test
+    public void test_setCallbackExecutor_whenDefault() throws Exception {
+        InvocationBuilder builder = new InvocationBuilderImpl(getNodeEngineImpl(node),
+                MapService.SERVICE_NAME, new DummyOperation("value"), 0);
+
+        final AtomicBoolean executed = new AtomicBoolean(false);
+
+        builder.setExecutionCallback(new ExecutionCallback<Object>() {
+            @Override
+            public void onResponse(Object response) {
+                executed.set(true);
+            }
+
+            @Override
+            public void onFailure(Throwable t) {
+
+            }
+        });
+
+        Future<Object> future = builder.invoke();
+        future.get();
+
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertTrue("Callback should be executed in default executor", executed.get());
+            }
+        });
+    }
+
+
+    /**
+     * When callback-executor is null, default executor should be used.
+     */
+    @Test
+    public void test_setCallbackExecutor_whenNullPassed() throws Exception {
+        InvocationBuilder builder = new InvocationBuilderImpl(getNodeEngineImpl(node),
+                MapService.SERVICE_NAME, new DummyOperation("value"), 0);
+
+        final AtomicBoolean executed = new AtomicBoolean(false);
+
+        builder.setExecutionCallback(new ExecutionCallback<Object>() {
+            @Override
+            public void onResponse(Object response) {
+                executed.set(true);
+            }
+
+            @Override
+            public void onFailure(Throwable t) {
+
+            }
+        }).setCallbackExecutor(null);
+
+        Future<Object> future = builder.invoke();
+        future.get();
+
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertTrue("Callback should be executed in default executor", executed.get());
+            }
+        });
+    }
+
+    /**
+     * When an executor set to callback-executor, callback should be executed in it.
+     */
+    @Test
+    public void test_setCallbackExecutor() throws Exception {
+        InvocationBuilder builder = new InvocationBuilderImpl(getNodeEngineImpl(node),
+                MapService.SERVICE_NAME, new DummyOperation("value"), 0);
+
+        AtomicBoolean executed = new AtomicBoolean(false);
+        final DirectExecutor executor = new DirectExecutor(executed);
+
+        final AtomicBoolean callbackExecuted = new AtomicBoolean(false);
+        builder.setExecutionCallback(new ExecutionCallback<Object>() {
+            @Override
+            public void onResponse(Object response) {
+                callbackExecuted.set(true);
+            }
+
+            @Override
+            public void onFailure(Throwable t) {
+
+            }
+        }).setCallbackExecutor(executor);
+
+        Future<Object> future = builder.invoke();
+        future.get();
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertTrue("Supplied executor should be called", executor.isCalled());
+                assertTrue("Callback should be executed in supplied executor", callbackExecuted.get());
+            }
+        });
+
+    }
+
+    /**
+     * Executes supplied runnable in the caller thread.
+     */
+    private static class DirectExecutor implements Executor {
+
+        private final AtomicBoolean called;
+
+        public DirectExecutor(AtomicBoolean called) {
+            this.called = called;
+        }
+
+        @Override
+        public void execute(Runnable command) {
+            command.run();
+            called.set(true);
+        }
+
+        boolean isCalled() {
+            return called.get();
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/CallIdSequenceWithBackpressureTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/CallIdSequenceWithBackpressureTest.java
@@ -230,6 +230,6 @@ public class CallIdSequenceWithBackpressureTest extends HazelcastTestSupport {
     }
 
     private Invocation newInvocation(Operation op) {
-        return new PartitionInvocation(nodeEngine, null, op, 0, 0, 0, 0, 0, null, false);
+        return new PartitionInvocation(nodeEngine, null, op, 0, 0, 0, 0, 0, null, null, false);
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/CallIdSequenceWithoutBackpressureTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/CallIdSequenceWithoutBackpressureTest.java
@@ -113,6 +113,6 @@ public class CallIdSequenceWithoutBackpressureTest extends HazelcastTestSupport 
     }
 
     private Invocation newInvocation(Operation op) {
-        return new PartitionInvocation(nodeEngine, null, op, 0, 0, 0, 0, 0, null, false);
+        return new PartitionInvocation(nodeEngine, null, op, 0, 0, 0, 0, 0, null, null, false);
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationRegistryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationRegistryTest.java
@@ -10,14 +10,13 @@ import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.util.concurrent.ExecutionException;
 
-import static com.hazelcast.instance.GroupProperties.*;
+import static com.hazelcast.instance.GroupProperties.PROP_BACKPRESSURE_ENABLED;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
@@ -50,7 +49,7 @@ public class InvocationRegistryTest extends HazelcastTestSupport {
     }
 
     private Invocation newInvocation(Operation op) {
-        return new PartitionInvocation(nodeEngine, null, op, op.getPartitionId(), 0, 0, 0, 0, null, false);
+        return new PartitionInvocation(nodeEngine, null, op, op.getPartitionId(), 0, 0, 0, 0, null, null, false);
     }
 
     // ====================== register ===============================

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationRegistry_notifyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationRegistry_notifyTest.java
@@ -18,9 +18,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 import static com.hazelcast.instance.GroupProperties.PROP_BACKPRESSURE_ENABLED;
 import static com.hazelcast.instance.GroupProperties.PROP_OPERATION_CALL_TIMEOUT_MILLIS;
@@ -56,7 +54,7 @@ public class InvocationRegistry_notifyTest extends HazelcastTestSupport {
     }
 
     private Invocation newInvocation(Operation op) {
-        Invocation invocation = new PartitionInvocation(nodeEngine, null, op, op.getPartitionId(), 0, 0, 0, 0, null, false);
+        Invocation invocation = new PartitionInvocation(nodeEngine, null, op, op.getPartitionId(), 0, 0, 0, 0, null, null, false);
         invocation.invTarget = getAddress(local);
         return invocation;
     }
@@ -123,7 +121,7 @@ public class InvocationRegistry_notifyTest extends HazelcastTestSupport {
 
     @Test
     @Ignore
-    public void normalResponse_whenOnlyBackupInThenRetry(){
+    public void normalResponse_whenOnlyBackupInThenRetry() {
 
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/IsStillRunningServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/IsStillRunningServiceTest.java
@@ -53,7 +53,7 @@ public class IsStillRunningServiceTest extends HazelcastTestSupport {
             public void run() throws Exception {
                 int partitionId = operation.getPartitionId();
                 long callId = operation.getCallId();
-                OperationServiceImpl remoteOperationService = (OperationServiceImpl)getOperationService(remoteHz);
+                OperationServiceImpl remoteOperationService = (OperationServiceImpl) getOperationService(remoteHz);
                 IsStillRunningService isStillRunningService = remoteOperationService.getIsStillRunningService();
                 boolean isRunning = isStillRunningService.isOperationExecuting(localAddress, partitionId, callId);
                 assertTrue(isRunning);
@@ -136,7 +136,7 @@ public class IsStillRunningServiceTest extends HazelcastTestSupport {
 
         final TargetInvocation invocation = new TargetInvocation(getNodeEngineImpl(hz1), null,
                 new DummyOperation(callTimeoutMillis * 10), remoteAddress, 0, 0,
-                callTimeoutMillis, null, true);
+                callTimeoutMillis, null, null, true);
         final InvocationFuture future = invocation.invoke();
 
         assertTrueEventually(new AssertTask() {
@@ -175,7 +175,7 @@ public class IsStillRunningServiceTest extends HazelcastTestSupport {
 
         TargetInvocation invocation = new TargetInvocation(getNodeEngineImpl(hz1), null,
                 new DummyOperation(1), remoteAddress, 0, 0,
-                callTimeoutMillis, null, true);
+                callTimeoutMillis, null, null, true);
         final InvocationFuture future = invocation.invoke();
         assertEquals(Boolean.TRUE, future.get());
 


### PR DESCRIPTION
Made InvocationFuture's callback-executor settableso a custom executor can be given to run a callback.

This is first part of the fix of https://github.com/hazelcast/hazelcast/issues/4671