### PR TITLE
Allow to use JDK8 JavaScript scripting engine in OSGi platforms

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/osgi/OSGiScriptEngineManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/osgi/OSGiScriptEngineManager.java
@@ -18,6 +18,7 @@ package com.hazelcast.internal.osgi;
 
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
+import com.hazelcast.nio.ClassLoaderUtil;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 
@@ -245,7 +246,7 @@ public class OSGiScriptEngineManager extends ScriptEngineManager {
     private ClassLoader loadScriptEngineFactoryClassLoader(String factoryName) {
         //We do not really need the class, but we need the classloader
         try {
-            return tryLoadClass(factoryName).getClassLoader();
+            return ClassLoaderUtil.tryLoadClass(factoryName).getClassLoader();
         } catch (ClassNotFoundException cnfe) {
             // may fail if script implementation is not in environment
             logger.warning("Found ScriptEngineFactory candidate for "
@@ -321,43 +322,12 @@ public class OSGiScriptEngineManager extends ScriptEngineManager {
      */
     private void addJavaScriptEngine(List<String> factoryCandidates) {
         //Rhino is available in java < 8, Nashorn is available in java >= 8
-        if (isClassDefined(RHINO_SCRIPT_ENGINE_FACTORY)) {
+        if (ClassLoaderUtil.isClassDefined(RHINO_SCRIPT_ENGINE_FACTORY)) {
             factoryCandidates.add(RHINO_SCRIPT_ENGINE_FACTORY);
-        } else if (isClassDefined(NASHORN_SCRIPT_ENGINE_FACTORY)) {
+        } else if (ClassLoaderUtil.isClassDefined(NASHORN_SCRIPT_ENGINE_FACTORY)) {
             factoryCandidates.add(NASHORN_SCRIPT_ENGINE_FACTORY);
         } else {
             logger.warning("No built-in JavaScript ScriptEngineFactory found.");
-        }
-    }
-
-    /**
-     * Tries to load the given class.
-     *
-     * @param className Name of the class to load
-     * @return Loaded class
-     * @throws ClassNotFoundException when the class is not found
-     */
-    private static Class<?> tryLoadClass(String className) throws ClassNotFoundException {
-        try {
-            return Class.forName(className);
-        } catch (ClassNotFoundException e) {
-            ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
-            return contextClassLoader.loadClass(className);
-        }
-    }
-
-    /**
-     * Indicates whether or not the given class exists
-     *
-     * @param className Name of the class
-     * @return {@code true} if the class exists, {@code false} otherwise
-     */
-    private static boolean isClassDefined(String className) {
-        try {
-            tryLoadClass(className);
-            return true;
-        } catch (ClassNotFoundException e) {
-            return false;
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/osgi/OSGiScriptEngineManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/osgi/OSGiScriptEngineManager.java
@@ -309,6 +309,17 @@ public class OSGiScriptEngineManager extends ScriptEngineManager {
         }
 
         //add java built in JavaScript ScriptEngineFactory's
+        addJavaScriptEngine(factoryCandidates);
+
+        return factoryCandidates;
+    }
+
+    /**
+     * Adds the JDK build-in JavaScript engine into the given list of scripting engine factories.
+     *
+     * @param factoryCandidates List of scripting engine factories
+     */
+    private void addJavaScriptEngine(List<String> factoryCandidates) {
         //Rhino is available in java < 8, Nashorn is available in java >= 8
         if (isClassDefined(RHINO_SCRIPT_ENGINE_FACTORY)) {
             factoryCandidates.add(RHINO_SCRIPT_ENGINE_FACTORY);
@@ -317,7 +328,6 @@ public class OSGiScriptEngineManager extends ScriptEngineManager {
         } else {
             logger.warning("No built-in JavaScript ScriptEngineFactory found.");
         }
-        return factoryCandidates;
     }
 
     /**
@@ -331,7 +341,8 @@ public class OSGiScriptEngineManager extends ScriptEngineManager {
         try {
             return Class.forName(className);
         } catch (ClassNotFoundException e) {
-            return Thread.currentThread().getContextClassLoader().loadClass(className);
+            ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
+            return contextClassLoader.loadClass(className);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/nio/ClassLoaderUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/ClassLoaderUtil.java
@@ -132,6 +132,37 @@ public final class ClassLoaderUtil {
         return type.getClassLoader() == classLoader && name.startsWith(HAZELCAST_BASE_PACKAGE);
     }
 
+    /**
+     * Tries to load the given class.
+     *
+     * @param className Name of the class to load
+     * @return Loaded class
+     * @throws ClassNotFoundException when the class is not found
+     */
+    public static Class<?> tryLoadClass(String className) throws ClassNotFoundException {
+        try {
+            return Class.forName(className);
+        } catch (ClassNotFoundException e) {
+            ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
+            return contextClassLoader.loadClass(className);
+        }
+    }
+
+    /**
+     * Indicates whether or not the given class exists
+     *
+     * @param className Name of the class
+     * @return {@code true} if the class exists, {@code false} otherwise
+     */
+    public static boolean isClassDefined(String className) {
+        try {
+            tryLoadClass(className);
+            return true;
+        } catch (ClassNotFoundException e) {
+            return false;
+        }
+    }
+
     private static final class ConstructorCache {
         private final ConcurrentMap<ClassLoader, ConcurrentMap<String, WeakReference<Constructor>>> cache;
 


### PR DESCRIPTION
This patch allows to use the JavaScript scripting engine of JDK8 (named _Nashorn_). It is still capable of using the one of JDK7 (named _Rhino_).

Without this patch, the following log is displayed when running in JDK8
```
2015-05-12 16:48:06,805 [FelixStartLevel] WARN com.hazelcast.osgi.OSGiScriptEngineManager - Found ScriptEngineFactory candidate for com.sun.script.javascript.RhinoScriptEngineFactory, but cannot load class! -> java.lang.ClassNotFoundException: com.sun.script.javascript.RhinoScriptEngineFactory not found by com.hazelcast [156]
```