### PR TITLE
Removed all usages of deprecated Callback

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/client/CacheCreateConfigRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/client/CacheCreateConfigRequest.java
@@ -26,9 +26,9 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.PortableReader;
 import com.hazelcast.nio.serialization.PortableWriter;
-import com.hazelcast.spi.Callback;
 import com.hazelcast.spi.InvocationBuilder;
 import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.impl.SimpleExecutionCallback;
 
 import java.io.IOException;
 import java.security.Permission;
@@ -66,11 +66,13 @@ public class CacheCreateConfigRequest
         final Operation op = prepareOperation();
         op.setCallerUuid(endpoint.getUuid());
         final InvocationBuilder builder = operationService.createInvocationBuilder(getServiceName(), op, partitionId);
-        builder.setTryCount(TRY_COUNT).setResultDeserialized(false).setCallback(new Callback<Object>() {
-            public void notify(Object object) {
-                endpoint.sendResponse(object, getCallId());
-            }
-        });
+        builder.setTryCount(TRY_COUNT)
+                .setResultDeserialized(false)
+                .setExecutionCallback(new SimpleExecutionCallback<Object>() {
+                    public void notify(Object object) {
+                        endpoint.sendResponse(object, getCallId());
+                    }
+                });
         builder.invoke();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/client/CacheDestroyRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/client/CacheDestroyRequest.java
@@ -23,9 +23,9 @@ import com.hazelcast.client.ClientEndpoint;
 import com.hazelcast.client.impl.client.ClientRequest;
 import com.hazelcast.nio.serialization.PortableReader;
 import com.hazelcast.nio.serialization.PortableWriter;
-import com.hazelcast.spi.Callback;
 import com.hazelcast.spi.InvocationBuilder;
 import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.impl.SimpleExecutionCallback;
 
 import java.io.IOException;
 import java.security.Permission;
@@ -58,11 +58,13 @@ public class CacheDestroyRequest
         final Operation op = prepareOperation();
         op.setCallerUuid(endpoint.getUuid());
         final InvocationBuilder builder = operationService.createInvocationBuilder(getServiceName(), op, partitionId);
-        builder.setTryCount(TRY_COUNT).setResultDeserialized(false).setCallback(new Callback<Object>() {
-            public void notify(Object object) {
-                endpoint.sendResponse(object, getCallId());
-            }
-        });
+        builder.setTryCount(TRY_COUNT)
+                .setResultDeserialized(false)
+                .setExecutionCallback(new SimpleExecutionCallback<Object>() {
+                    public void notify(Object object) {
+                        endpoint.sendResponse(object, getCallId());
+                    }
+                });
         builder.invoke();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/client/MultiTargetClientRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/client/MultiTargetClientRequest.java
@@ -18,10 +18,10 @@ package com.hazelcast.client.impl.client;
 
 import com.hazelcast.client.ClientEndpoint;
 import com.hazelcast.nio.Address;
-import com.hazelcast.spi.Callback;
 import com.hazelcast.spi.InvocationBuilder;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.OperationFactory;
+import com.hazelcast.spi.impl.SimpleExecutionCallback;
 
 import java.util.Collection;
 import java.util.HashMap;
@@ -53,7 +53,7 @@ public abstract class MultiTargetClientRequest extends ClientRequest {
             op.setCallerUuid(endpoint.getUuid());
             InvocationBuilder builder = operationService.createInvocationBuilder(getServiceName(), op, target)
                     .setResultDeserialized(false)
-                    .setCallback(new SingleTargetCallback(target, callback));
+                    .setExecutionCallback(new SingleTargetCallback(target, callback));
             builder.invoke();
         }
     }
@@ -90,7 +90,7 @@ public abstract class MultiTargetClientRequest extends ClientRequest {
         }
     }
 
-    private static final class SingleTargetCallback implements Callback<Object> {
+    private static final class SingleTargetCallback extends SimpleExecutionCallback<Object> {
 
         final Address target;
         final MultiTargetCallback parent;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractMultiTargetMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractMultiTargetMessageTask.java
@@ -21,10 +21,10 @@ import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.instance.Node;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.Connection;
-import com.hazelcast.spi.Callback;
 import com.hazelcast.spi.InvocationBuilder;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.OperationFactory;
+import com.hazelcast.spi.impl.SimpleExecutionCallback;
 import com.hazelcast.spi.impl.operationservice.InternalOperationService;
 
 import java.util.Collection;
@@ -62,7 +62,7 @@ public abstract class AbstractMultiTargetMessageTask<P> extends AbstractMessageT
             InvocationBuilder builder = operationService.createInvocationBuilder(getServiceName(), op, target)
                     .setTryCount(TRY_COUNT)
                     .setResultDeserialized(false)
-                    .setCallback(new SingleTargetCallback(target, callback));
+                    .setExecutionCallback(new SingleTargetCallback(target, callback));
             builder.invoke();
         }
     }
@@ -108,7 +108,7 @@ public abstract class AbstractMultiTargetMessageTask<P> extends AbstractMessageT
         }
     }
 
-    private final class SingleTargetCallback implements Callback<Object> {
+    private final class SingleTargetCallback extends SimpleExecutionCallback<Object> {
 
         final Address target;
         final MultiTargetCallback parent;

--- a/hazelcast/src/main/java/com/hazelcast/executor/impl/ExecutorServiceProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/executor/impl/ExecutorServiceProxy.java
@@ -39,6 +39,7 @@ import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.OperationService;
 import com.hazelcast.util.Clock;
 import com.hazelcast.util.executor.CompletedFuture;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -366,7 +367,7 @@ public class ExecutorServiceProxy
         CallableTaskOperation op = new CallableTaskOperation(name, null, taskData);
         OperationService operationService = nodeEngine.getOperationService();
         operationService.createInvocationBuilder(DistributedExecutorService.SERVICE_NAME, op, partitionId)
-                .setCallback(new ExecutionCallbackAdapter(callback)).invoke();
+                .setExecutionCallback((ExecutionCallback) callback).invoke();
     }
 
     @Override
@@ -390,8 +391,9 @@ public class ExecutorServiceProxy
         MemberCallableTaskOperation op = new MemberCallableTaskOperation(name, null, taskData);
         OperationService operationService = nodeEngine.getOperationService();
         Address address = ((MemberImpl) member).getAddress();
-        operationService.createInvocationBuilder(DistributedExecutorService.SERVICE_NAME, op, address)
-                .setCallback(new ExecutionCallbackAdapter(callback)).invoke();
+        operationService
+                .createInvocationBuilder(DistributedExecutorService.SERVICE_NAME, op, address)
+                .setExecutionCallback((ExecutionCallback) callback).invoke();
     }
 
     private String getRejectionMessage() {

--- a/hazelcast/src/main/java/com/hazelcast/partition/impl/MigrationRequestOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/impl/MigrationRequestOperation.java
@@ -24,7 +24,6 @@ import com.hazelcast.partition.InternalPartition;
 import com.hazelcast.partition.InternalPartitionService;
 import com.hazelcast.partition.MigrationEndpoint;
 import com.hazelcast.partition.MigrationInfo;
-import com.hazelcast.spi.Callback;
 import com.hazelcast.spi.ExceptionAction;
 import com.hazelcast.spi.MigrationAwareService;
 import com.hazelcast.spi.NodeEngine;
@@ -32,6 +31,7 @@ import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.PartitionMigrationEvent;
 import com.hazelcast.spi.PartitionReplicationEvent;
 import com.hazelcast.spi.ResponseHandler;
+import com.hazelcast.spi.impl.SimpleExecutionCallback;
 import com.hazelcast.spi.impl.servicemanager.ServiceInfo;
 import com.hazelcast.spi.exception.RetryableHazelcastException;
 import com.hazelcast.spi.exception.TargetNotMemberException;
@@ -146,7 +146,7 @@ public final class MigrationRequestOperation extends BaseMigrationOperation {
 
         nodeEngine.getOperationService()
                 .createInvocationBuilder(InternalPartitionService.SERVICE_NAME, operation, destination)
-                .setCallback(new MigrationCallback(migrationInfo, getResponseHandler()))
+                .setExecutionCallback(new MigrationCallback(migrationInfo, getResponseHandler()))
                 .setResultDeserialized(true)
                 .setCallTimeout(partitionService.getPartitionMigrationTimeout())
                 .setTryPauseMillis(TRY_PAUSE_MILLIS)
@@ -208,7 +208,7 @@ public final class MigrationRequestOperation extends BaseMigrationOperation {
         return tasks;
     }
 
-    private static final class MigrationCallback implements Callback<Object> {
+    private static final class MigrationCallback extends SimpleExecutionCallback<Object> {
 
         final MigrationInfo migrationInfo;
         final ResponseHandler responseHandler;

--- a/hazelcast/src/main/java/com/hazelcast/partition/impl/SyncReplicaVersion.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/impl/SyncReplicaVersion.java
@@ -16,13 +16,13 @@
 
 package com.hazelcast.partition.impl;
 
+import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.partition.InternalPartition;
 import com.hazelcast.partition.InternalPartitionService;
 import com.hazelcast.partition.ReplicaErrorLogger;
-import com.hazelcast.spi.Callback;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.OperationService;
@@ -38,10 +38,10 @@ final class SyncReplicaVersion extends Operation implements PartitionAwareOperat
     public static final int OPERATION_TRY_PAUSE_MILLIS = 250;
 
     private final int syncReplicaIndex;
-    private final Callback<Object> callback;
+    private final ExecutionCallback callback;
     private final boolean sync;
 
-    public SyncReplicaVersion(int syncReplicaIndex, Callback<Object> callback) {
+    public SyncReplicaVersion(int syncReplicaIndex, ExecutionCallback callback) {
         if (syncReplicaIndex < 1 || syncReplicaIndex > InternalPartition.MAX_BACKUP_COUNT) {
             throw new IllegalArgumentException("Replica index should be in range [1-"
                     + InternalPartition.MAX_BACKUP_COUNT + "]");
@@ -81,7 +81,7 @@ final class SyncReplicaVersion extends Operation implements PartitionAwareOperat
             OperationService operationService = nodeEngine.getOperationService();
             if (sync) {
                 operationService.createInvocationBuilder(InternalPartitionService.SERVICE_NAME, op, target)
-                        .setCallback(callback)
+                        .setExecutionCallback(callback)
                         .setTryCount(OPERATION_TRY_COUNT)
                         .setTryPauseMillis(OPERATION_TRY_PAUSE_MILLIS)
                         .invoke();
@@ -95,7 +95,7 @@ final class SyncReplicaVersion extends Operation implements PartitionAwareOperat
 
     private void notifyCallback(boolean result) {
         if (callback != null) {
-            callback.notify(result);
+            callback.onResponse(result);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/InvocationBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/InvocationBuilder.java
@@ -265,5 +265,31 @@ public abstract class InvocationBuilder {
         return this;
     }
 
+    protected ExecutionCallback getTargetExecutionCallback() {
+        ExecutionCallback targetCallback = executionCallback;
+        if (callback != null) {
+            targetCallback = new ExecutorCallbackAdapter(callback);
+        }
+        return targetCallback;
+    }
+
+    static final class ExecutorCallbackAdapter<E> implements ExecutionCallback<E> {
+        private final Callback callback;
+
+        private ExecutorCallbackAdapter(Callback callback) {
+            this.callback = callback;
+        }
+
+        @Override
+        public void onResponse(E response) {
+            callback.notify(response);
+        }
+
+        @Override
+        public void onFailure(Throwable t) {
+            callback.notify(t);
+        }
+    }
+
     public abstract <E> InternalCompletableFuture<E> invoke();
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/SimpleExecutionCallback.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/SimpleExecutionCallback.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi.impl;
+
+import com.hazelcast.core.ExecutionCallback;
+
+/**
+ * A ExecutionCallback implementation that simplifies the implementation of the ExecutionCallback by only
+ * needing to implement a single method.
+ *
+ * @param <E>
+ */
+public abstract class SimpleExecutionCallback<E> implements ExecutionCallback<E> {
+
+    public abstract void notify(Object response);
+
+    @Override
+    public final void onResponse(E response) {
+        notify(response);
+    }
+
+    @Override
+    public final void onFailure(Throwable t) {
+        notify(t);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/Invocation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/Invocation.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.spi.impl.operationservice.impl;
 
+import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.core.HazelcastInstanceNotActiveException;
 import com.hazelcast.core.OperationTimeoutException;
 import com.hazelcast.instance.MemberImpl;
@@ -108,7 +109,7 @@ abstract class Invocation implements ResponseHandler, Runnable {
     volatile int invokeCount;
 
     Invocation(NodeEngineImpl nodeEngine, String serviceName, Operation op, int partitionId,
-               int replicaIndex, int tryCount, long tryPauseMillis, long callTimeout, Object callback,
+               int replicaIndex, int tryCount, long tryPauseMillis, long callTimeout, ExecutionCallback callback,
                boolean resultDeserialized) {
         this.operationService = (OperationServiceImpl) nodeEngine.getOperationService();
         this.logger = operationService.invocationLogger;

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationBuilderImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationBuilderImpl.java
@@ -42,17 +42,12 @@ public class InvocationBuilderImpl extends InvocationBuilder {
 
     @Override
     public InternalCompletableFuture invoke() {
-        Object callback = this.callback;
-        if (callback == null) {
-            callback = this.executionCallback;
-        }
-
         if (target == null) {
             return new PartitionInvocation(nodeEngine, serviceName, op, partitionId, replicaIndex,
-                    tryCount, tryPauseMillis, callTimeout, callback, resultDeserialized).invoke();
+                    tryCount, tryPauseMillis, callTimeout, getTargetExecutionCallback(), resultDeserialized).invoke();
         } else {
             return new TargetInvocation(nodeEngine, serviceName, op, target, tryCount, tryPauseMillis,
-                    callTimeout, callback, resultDeserialized).invoke();
+                    callTimeout, getTargetExecutionCallback(), resultDeserialized).invoke();
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationFuture.java
@@ -20,7 +20,6 @@ import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.spi.Callback;
 import com.hazelcast.spi.InternalCompletableFuture;
 import com.hazelcast.spi.impl.operationservice.impl.responses.Response;
 import com.hazelcast.util.Clock;
@@ -67,19 +66,12 @@ final class InvocationFuture<E> implements InternalCompletableFuture<E> {
     private final Invocation invocation;
     private volatile ExecutionCallbackNode<E> callbackHead;
 
-    InvocationFuture(OperationServiceImpl operationService, Invocation invocation, Object callback) {
+    InvocationFuture(OperationServiceImpl operationService, Invocation invocation, ExecutionCallback callback) {
         this.invocation = invocation;
         this.operationService = operationService;
 
         if (callback != null) {
-            ExecutionCallback executionCallback;
-            if (callback instanceof ExecutionCallback) {
-                executionCallback = (ExecutionCallback) callback;
-            } else {
-                executionCallback = new ExecutorCallbackAdapter<E>((Callback) callback);
-            }
-
-            callbackHead = new ExecutionCallbackNode<E>(executionCallback, operationService.asyncExecutor, null);
+            callbackHead = new ExecutionCallbackNode<E>(callback, operationService.asyncExecutor, null);
         }
     }
 
@@ -423,24 +415,6 @@ final class InvocationFuture<E> implements InternalCompletableFuture<E> {
             this.callback = callback;
             this.executor = executor;
             this.next = next;
-        }
-    }
-
-    private static final class ExecutorCallbackAdapter<E> implements ExecutionCallback<E> {
-        private final Callback callback;
-
-        private ExecutorCallbackAdapter(Callback callback) {
-            this.callback = callback;
-        }
-
-        @Override
-        public void onResponse(E response) {
-            callback.notify(response);
-        }
-
-        @Override
-        public void onFailure(Throwable t) {
-            callback.notify(t);
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/PartitionInvocation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/PartitionInvocation.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.spi.impl.operationservice.impl;
 
+import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.nio.Address;
 import com.hazelcast.spi.ExceptionAction;
 import com.hazelcast.spi.Operation;
@@ -29,7 +30,7 @@ public final class PartitionInvocation extends Invocation {
 
     public PartitionInvocation(NodeEngineImpl nodeEngine, String serviceName, Operation op, int partitionId,
                                int replicaIndex, int tryCount, long tryPauseMillis, long callTimeout,
-                               Object callback, boolean resultDeserialized) {
+                               ExecutionCallback callback, boolean resultDeserialized) {
         super(nodeEngine, serviceName, op, partitionId, replicaIndex, tryCount, tryPauseMillis,
                 callTimeout, callback, resultDeserialized);
     }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/TargetInvocation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/TargetInvocation.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.spi.impl.operationservice.impl;
 
+import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.core.MemberLeftException;
 import com.hazelcast.nio.Address;
 import com.hazelcast.spi.ExceptionAction;
@@ -32,7 +33,7 @@ public final class TargetInvocation extends Invocation {
 
     public TargetInvocation(NodeEngineImpl nodeEngine, String serviceName, Operation op,
                             Address target, int tryCount, long tryPauseMillis, long callTimeout,
-                            Object callback, boolean resultDeserialized) {
+                            ExecutionCallback callback, boolean resultDeserialized) {
         super(nodeEngine, serviceName, op, op.getPartitionId(), op.getReplicaIndex(),
                 tryCount, tryPauseMillis, callTimeout, callback, resultDeserialized);
         this.target = target;

--- a/hazelcast/src/test/java/com/hazelcast/spi/InvocationBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/InvocationBuilderTest.java
@@ -1,0 +1,60 @@
+package com.hazelcast.spi;
+
+import com.hazelcast.core.ExecutionCallback;
+import com.hazelcast.nio.Address;
+import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.mockito.Mockito.mock;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category(QuickTest.class)
+public class InvocationBuilderTest extends HazelcastTestSupport {
+
+    @Test
+    public void getTargetExecutionCallback_whenNull() {
+        InvocationBuilder builder = new MockInvocationBuilder(null, null, null, 0, null);
+
+        assertNull(builder.getTargetExecutionCallback());
+    }
+
+    @Test
+    public void getTargetExecutionCallback_whenCallbackInstance() {
+        InvocationBuilder invocationBuilder = new MockInvocationBuilder(null, null, null, 0, null);
+
+        assertNull(invocationBuilder.getTargetExecutionCallback());
+
+        Callback callback = mock(Callback.class);
+        invocationBuilder.setCallback(callback);
+
+        assertInstanceOf(InvocationBuilder.ExecutorCallbackAdapter.class, invocationBuilder.getTargetExecutionCallback());
+    }
+
+    @Test
+    public void getTargetExecutionCallback_whenExecutionCallbackInstance() {
+        InvocationBuilder invocationBuilder = new MockInvocationBuilder(null, null, null, 0, null);
+
+        ExecutionCallback executionCallback = mock(ExecutionCallback.class);
+        invocationBuilder.setExecutionCallback(executionCallback);
+
+        assertSame(executionCallback, invocationBuilder.getTargetExecutionCallback());
+    }
+
+    class MockInvocationBuilder extends InvocationBuilder {
+        public MockInvocationBuilder(NodeEngineImpl nodeEngine, String serviceName, Operation op, int partitionId, Address target) {
+            super(nodeEngine, serviceName, op, partitionId, target);
+        }
+
+        @Override
+        public <E> InternalCompletableFuture<E> invoke() {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
and replaced them by the ExecutionCallback. Also did some simplifications in the InvocationFuture that needed to dealwith 2 types of callbacks. This is now taken care of by the InvocationBuilder that automatically adapts a Callback to an ExecutionCallback.