### PR TITLE
Removed deprecated Hz.getLock(Object) method

### DIFF
--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
@@ -328,14 +328,6 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
     }
 
     @Override
-    @Deprecated
-    public ILock getLock(Object key) {
-        //this method will be deleted in the near future.
-        String name = LockProxy.convertToStringKey(key, serializationService);
-        return getDistributedObject(LockServiceImpl.SERVICE_NAME, name);
-    }
-
-    @Override
     public <E> Ringbuffer<E> getRingbuffer(String name) {
         return getDistributedObject(RingbufferService.SERVICE_NAME, name);
     }

--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/impl/HazelcastClientProxy.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/impl/HazelcastClientProxy.java
@@ -129,11 +129,6 @@ public final class HazelcastClientProxy implements HazelcastInstance, Serializat
     }
 
     @Override
-    public ILock getLock(Object key) {
-        return getClient().getLock(key);
-    }
-
-    @Override
     public ILock getLock(String key) {
         return getClient().getLock(key);
     }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
@@ -330,14 +330,6 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
     }
 
     @Override
-    @Deprecated
-    public ILock getLock(Object key) {
-        //this method will be deleted in the near future.
-        String name = LockProxy.convertToStringKey(key, serializationService);
-        return getDistributedObject(LockServiceImpl.SERVICE_NAME, name);
-    }
-
-    @Override
     public Cluster getCluster() {
         return new ClientClusterProxy(clusterService);
     }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientProxy.java
@@ -129,11 +129,6 @@ public final class HazelcastClientProxy implements HazelcastInstance, Serializat
     }
 
     @Override
-    public ILock getLock(Object key) {
-        return getClient().getLock(key);
-    }
-
-    @Override
     public ILock getLock(String key) {
         return getClient().getLock(key);
     }

--- a/hazelcast-ra/hazelcast-jca/src/main/java/com/hazelcast/jca/HazelcastConnectionImpl.java
+++ b/hazelcast-ra/hazelcast-jca/src/main/java/com/hazelcast/jca/HazelcastConnectionImpl.java
@@ -323,12 +323,6 @@ public class HazelcastConnectionImpl implements HazelcastConnection {
         return getHazelcastInstance().getLock(key);
     }
 
-    @Deprecated
-    @Override
-    public ILock getLock(Object key) {
-        return getHazelcastInstance().getLock(key);
-    }
-
     @Override
     public Cluster getCluster() {
         return getHazelcastInstance().getCluster();

--- a/hazelcast/src/main/java/com/hazelcast/core/HazelcastInstance.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/HazelcastInstance.java
@@ -141,12 +141,6 @@ public interface HazelcastInstance {
     ILock getLock(String key);
 
     /**
-     * @deprecated will be removed in Hazelcast 3.2. Use {@link #getLock(String)} instead.
-     */
-    @Deprecated
-    ILock getLock(Object key);
-
-    /**
      * Returns the distributed Ringbuffer instance with the specified name.
      *
      * @param name name of the distributed Ringbuffer

--- a/hazelcast/src/main/java/com/hazelcast/instance/HazelcastInstanceProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/HazelcastInstanceProxy.java
@@ -116,11 +116,6 @@ public final class HazelcastInstanceProxy implements HazelcastInstance, Serializ
     }
 
     @Override
-    public ILock getLock(Object key) {
-        return getOriginal().getLock(key);
-    }
-
-    @Override
     public ILock getLock(String key) {
         return getOriginal().getLock(key);
     }

--- a/hazelcast/src/test/java/com/hazelcast/core/DistributedObjectTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/core/DistributedObjectTest.java
@@ -105,13 +105,6 @@ public class DistributedObjectTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void testLock2() {
-        HazelcastInstance instance = createHazelcastInstance();
-        DistributedObject object = instance.getLock(System.currentTimeMillis());
-        test(instance, object);
-    }
-
-    @Test
     public void testAtomicLong() {
         HazelcastInstance instance = createHazelcastInstance();
         DistributedObject object = instance.getAtomicLong("test");


### PR DESCRIPTION
Since the method was promised to be deleted in 3.2... it is time to keep up this this promise.