### PR TITLE
Serialization ByteArrayObjectDataInput pooling

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/AtomicLongBaseOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/AtomicLongBaseOperation.java
@@ -74,7 +74,7 @@ public abstract class AtomicLongBaseOperation extends Operation
 
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
-        out.writeUTF(name);
+       out.writeUTF(name);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/nio/BufferObjectDataInput.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/BufferObjectDataInput.java
@@ -67,4 +67,8 @@ public interface BufferObjectDataInput extends ObjectDataInput, Closeable {
     void position(int newPos);
 
     void reset();
+
+    void clear();
+
+    void init(byte[] data, int offset);
 }

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/ByteArrayObjectDataInput.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/ByteArrayObjectDataInput.java
@@ -34,7 +34,7 @@ class ByteArrayObjectDataInput extends InputStream implements BufferObjectDataIn
 
     byte[] data;
 
-    final int size;
+    int size;
 
     int pos;
 
@@ -51,12 +51,25 @@ class ByteArrayObjectDataInput extends InputStream implements BufferObjectDataIn
     }
 
     ByteArrayObjectDataInput(byte[] data, int offset, SerializationService service, ByteOrder byteOrder) {
-        super();
         this.data = data;
         this.size = data != null ? data.length : 0;
         this.service = service;
-        pos = offset;
-        bigEndian = byteOrder == ByteOrder.BIG_ENDIAN;
+        this.pos = offset;
+        this.bigEndian = byteOrder == ByteOrder.BIG_ENDIAN;
+    }
+   @Override
+    public void init(byte[] data, int offset) {
+        this.data = data;
+        this.size = data != null ? data.length : 0;
+        this.pos = offset;
+    }
+
+    @Override
+    public void clear() {
+        this.data = null;
+        this.pos = 0;
+        this.size = 0;
+        this.mark = 0;
     }
 
     public int read() throws IOException {

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/DefaultData.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/DefaultData.java
@@ -23,12 +23,11 @@ import java.util.Arrays;
 
 @edu.umd.cs.findbugs.annotations.SuppressWarnings("EI_EXPOSE_REP")
 public final class DefaultData implements Data {
-
-    // type and partition_hash are always written with BIG_ENDIAN byte-order
-    static final int TYPE_OFFSET = 0;
+  // type and partition_hash are always written with BIG_ENDIAN byte-order
+    public static final int TYPE_OFFSET = 0;
     // will use a byte to store partition_hash bit
-    static final int PARTITION_HASH_BIT_OFFSET = 4;
-    static final int DATA_OFFSET = 5;
+    public static final int PARTITION_HASH_BIT_OFFSET = 4;
+    public static final int DATA_OFFSET = 5;
 
     // array (12: array header, 4: length)
     private static final int ARRAY_HEADER_SIZE_IN_BYTES = 16;

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/DefaultSerializationServiceBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/DefaultSerializationServiceBuilder.java
@@ -24,6 +24,7 @@ import com.hazelcast.core.ManagedContext;
 import com.hazelcast.core.PartitioningStrategy;
 import com.hazelcast.nio.ClassLoaderUtil;
 import com.hazelcast.nio.UnsafeHelper;
+import com.hazelcast.nio.serialization.bufferpool.BufferPoolFactoryImpl;
 
 import java.nio.ByteOrder;
 import java.util.HashMap;
@@ -221,7 +222,7 @@ public class DefaultSerializationServiceBuilder implements SerializationServiceB
         return new SerializationServiceImpl(inputOutputFactory, version,
                     classLoader, dataSerializableFactories,
                     portableFactories, classDefinitions, checkClassDefErrors, managedContext, partitioningStrategy,
-                    initialOutputBufferSize, enableCompression, enableSharedObject);
+                    initialOutputBufferSize, enableCompression, enableSharedObject, new BufferPoolFactoryImpl());
     }
 
     private void registerSerializerHooks(SerializationServiceImpl ss) {

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/SerializationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/SerializationService.java
@@ -52,6 +52,8 @@ public interface SerializationService {
 
     BufferObjectDataOutput createObjectDataOutput(int size);
 
+    BufferObjectDataOutput createObjectDataOutput();
+
     ObjectDataOutputStream createObjectDataOutputStream(OutputStream out);
 
     ObjectDataInputStream createObjectDataInputStream(InputStream in);
@@ -69,10 +71,6 @@ public interface SerializationService {
     ManagedContext getManagedContext();
 
     ByteOrder getByteOrder();
-
-//    BufferObjectDataOutput pop();
-//
-//    void push(BufferObjectDataOutput out);
 
     void destroy();
 }

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/bufferpool/BufferPool.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/bufferpool/BufferPool.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.nio.serialization.bufferpool;
+
+import com.hazelcast.nio.BufferObjectDataInput;
+import com.hazelcast.nio.BufferObjectDataOutput;
+import com.hazelcast.nio.serialization.Data;
+
+/**
+ * The BufferPool allows the pooling of the {@link BufferObjectDataInput} and {@link BufferObjectDataOutput} instances.
+ *
+ * The BufferPool is accessed using the {@link BufferPoolThreadLocal} So each thread gets its own instance and therefore
+ * it doesn't need to be thread-safe.
+ */
+public interface BufferPool {
+
+    /**
+     * Takes an BufferObjectDataOutput from the pool.
+     *
+     * @return the taken BufferObjectDataOutput.
+     */
+    BufferObjectDataOutput takeOutputBuffer();
+
+    /**
+     * Returns a BufferObjectDataOutput back to the pool.
+     *
+     * The implementation is free to not return the instance to the pool but just close it.
+     *
+     * @param out the BufferObjectDataOutput.
+     */
+    void returnOutputBuffer(BufferObjectDataOutput out);
+
+    /**
+     * Takes an BufferObjectDataInput from the pool and initializes it with the given data.
+     *
+     * The reason that Data is passed as argument, is that for HazelcastEnterprise different
+     * BufferObjectDataInput can be returned based on the type of Data.
+     *
+     * @param data
+     * @return the taken BufferObjectDataInput
+     */
+    BufferObjectDataInput takeInputBuffer(Data data);
+
+    /**
+     * Returns a BufferObjectDataInput back to the pool.
+     *
+     * The implementation is free to not return the instance to the pool but just close it.
+     *
+     * @param in the BufferObjectDataInput.
+     */
+    void returnInputBuffer(BufferObjectDataInput in);
+}

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/bufferpool/BufferPoolFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/bufferpool/BufferPoolFactory.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.nio.serialization.bufferpool;
+
+import com.hazelcast.nio.serialization.SerializationService;
+
+/**
+ * A factory for creating {@link BufferPool} instances.
+ *
+ * The reason this complexity exists, is that in Hazelcast Enterprise the pooling mechanism needs to
+ * deal with different types of buffers (e.g. offheap).
+ */
+public interface BufferPoolFactory {
+
+    BufferPool create(SerializationService serializationService);
+}

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/bufferpool/BufferPoolFactoryImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/bufferpool/BufferPoolFactoryImpl.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.nio.serialization.bufferpool;
+
+import com.hazelcast.nio.serialization.SerializationService;
+
+/**
+ * Default {@link BufferPoolFactory} implementation. Creates {@link BufferPoolImpl} instances.
+ */
+public class BufferPoolFactoryImpl implements BufferPoolFactory {
+
+    @Override
+    public BufferPool create(SerializationService serializationService) {
+        return new BufferPoolImpl(serializationService);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/bufferpool/BufferPoolImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/bufferpool/BufferPoolImpl.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.nio.serialization.bufferpool;
+
+import com.hazelcast.nio.BufferObjectDataInput;
+import com.hazelcast.nio.BufferObjectDataOutput;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.nio.serialization.DefaultData;
+import com.hazelcast.nio.serialization.SerializationService;
+
+import java.io.Closeable;
+import java.util.ArrayDeque;
+import java.util.Queue;
+
+import static com.hazelcast.nio.IOUtil.closeResource;
+
+/**
+ * Default {BufferPool} implementation.
+ *
+ * This class is designed to that a subclass can be made. This is done for the Enterprise version.
+ */
+public class BufferPoolImpl implements BufferPool {
+    static final int MAX_POOLED_ITEMS = 3;
+
+    protected final SerializationService serializationService;
+
+    // accessible for testing.
+    final Queue<BufferObjectDataOutput> outputQueue = new ArrayDeque<BufferObjectDataOutput>(MAX_POOLED_ITEMS);
+    final Queue<BufferObjectDataInput> inputQueue = new ArrayDeque<BufferObjectDataInput>(MAX_POOLED_ITEMS);
+
+    public BufferPoolImpl(SerializationService serializationService) {
+        this.serializationService = serializationService;
+    }
+
+    @Override
+    public BufferObjectDataOutput takeOutputBuffer() {
+        BufferObjectDataOutput out = outputQueue.poll();
+        if (out == null) {
+            out = serializationService.createObjectDataOutput();
+        }
+        return out;
+    }
+
+    @Override
+    public void returnOutputBuffer(BufferObjectDataOutput out) {
+        if (out == null) {
+            return;
+        }
+
+        out.clear();
+
+        offerOrClose(outputQueue, out);
+    }
+
+    @Override
+    public BufferObjectDataInput takeInputBuffer(Data data) {
+        BufferObjectDataInput in = inputQueue.poll();
+        if (in == null) {
+            in = serializationService.createObjectDataInput((byte[]) null);
+        }
+        in.init(data.toByteArray(), DefaultData.DATA_OFFSET);
+        return in;
+    }
+
+    @Override
+    public void returnInputBuffer(BufferObjectDataInput in) {
+        if (in == null) {
+            return;
+        }
+
+        in.clear();
+
+        offerOrClose(inputQueue, in);
+    }
+
+    private static <C extends Closeable> void offerOrClose(Queue<C> queue, C item) {
+        if (queue.size() == MAX_POOLED_ITEMS) {
+            closeResource(item);
+            return;
+        }
+
+        queue.offer(item);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/bufferpool/BufferPoolThreadLocal.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/bufferpool/BufferPoolThreadLocal.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.nio.serialization.bufferpool;
+
+import com.hazelcast.nio.serialization.SerializationService;
+import com.hazelcast.util.ConcurrentReferenceHashMap;
+
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * A thread-local like structure for {@link BufferPoolImpl}.
+ *
+ * The reason not a regular ThreadLocal is being used is that the pooled instances should be
+ * pooled per HZ instance because:
+ * - buffers can contain references to hz instance specifics
+ * - buffers for a given hz instance should be cleanable when the instance shuts down and we don't
+ * want to have memory leaks.
+ */
+public final class BufferPoolThreadLocal {
+
+    private static final float LOAD_FACTOR = 0.91f;
+
+    private final ConcurrentMap<Thread, BufferPool> pools;
+    private final SerializationService serializationService;
+    private final BufferPoolFactory bufferPoolFactory;
+
+    public BufferPoolThreadLocal(SerializationService serializationService, BufferPoolFactory bufferPoolFactory) {
+        this.serializationService = serializationService;
+        this.bufferPoolFactory = bufferPoolFactory;
+        int initialCapacity = Runtime.getRuntime().availableProcessors();
+        this.pools = new ConcurrentReferenceHashMap<Thread, BufferPool>(initialCapacity, LOAD_FACTOR, 1);
+    }
+
+    public BufferPool get() {
+        Thread t = Thread.currentThread();
+        BufferPool pool = pools.get(t);
+        if (pool == null) {
+            pool = bufferPoolFactory.create(serializationService);
+            pools.put(t, pool);
+        }
+
+        return pool;
+    }
+
+    public void clear() {
+        pools.clear();
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/bufferpool/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/bufferpool/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Contains the logic for the BufferPool.
+ */
+package com.hazelcast.nio.serialization.bufferpool;

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/bufferpool/BufferPoolTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/bufferpool/BufferPoolTest.java
@@ -1,0 +1,142 @@
+package com.hazelcast.nio.serialization.bufferpool;
+
+import com.hazelcast.nio.BufferObjectDataInput;
+import com.hazelcast.nio.BufferObjectDataOutput;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.nio.serialization.DefaultData;
+import com.hazelcast.nio.serialization.DefaultSerializationServiceBuilder;
+import com.hazelcast.nio.serialization.SerializationService;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category(QuickTest.class)
+public class BufferPoolTest extends HazelcastTestSupport {
+
+    private SerializationService serializationService;
+    private BufferPoolImpl bufferPool;
+
+    @Before
+    public void setup() {
+        serializationService = new DefaultSerializationServiceBuilder().build();
+        bufferPool = new BufferPoolImpl(serializationService);
+    }
+
+    // ======================= out ==========================================
+
+    @Test
+    public void takeOutputBuffer_whenPooledInstance() {
+        BufferObjectDataOutput found1 = bufferPool.takeOutputBuffer();
+        bufferPool.returnOutputBuffer(found1);
+        BufferObjectDataOutput found2 = bufferPool.takeOutputBuffer();
+
+        assertSame(found1, found2);
+    }
+
+    @Test
+    public void takeOutputBuffer_whenNestedInstance() {
+        BufferObjectDataOutput found1 = bufferPool.takeOutputBuffer();
+        BufferObjectDataOutput found2 = bufferPool.takeOutputBuffer();
+
+        assertNotSame(found1, found2);
+    }
+
+    @Test
+    public void returnOutputBuffer_whenNull() {
+        bufferPool.returnOutputBuffer(null);
+        assertEquals(0, bufferPool.outputQueue.size());
+    }
+
+    @Test
+    public void returnOutputBuffer() {
+        BufferObjectDataOutput out = mock(BufferObjectDataOutput.class);
+
+        bufferPool.returnOutputBuffer(out);
+
+        // lets see if the item was pushed on the queue
+        assertEquals(1, bufferPool.outputQueue.size());
+        // we need to make sure clear was called
+        verify(out, times(1)).clear();
+    }
+
+    @Test
+    public void returnOutputBuffer_whenOverflowing() throws IOException {
+        for (int k = 0; k < BufferPoolImpl.MAX_POOLED_ITEMS; k++) {
+            bufferPool.returnOutputBuffer(mock(BufferObjectDataOutput.class));
+        }
+        BufferObjectDataOutput out = mock(BufferObjectDataOutput.class);
+
+        bufferPool.returnOutputBuffer(out);
+
+        assertEquals(BufferPoolImpl.MAX_POOLED_ITEMS, bufferPool.outputQueue.size());
+        // we need to make sure that the out was closed since we are not going to pool it.
+        verify(out, times(1)).close();
+    }
+
+    // ======================= in ==========================================
+
+    @Test
+    public void takeInputBuffer_whenPooledInstance() {
+        Data data = new DefaultData(new byte[]{});
+        BufferObjectDataInput found1 = bufferPool.takeInputBuffer(data);
+        bufferPool.returnInputBuffer(found1);
+        BufferObjectDataInput found2 = bufferPool.takeInputBuffer(data);
+
+        assertSame(found1, found2);
+    }
+
+    @Test
+    public void takeInputBuffer_whenNestedInstance() {
+        Data data = new DefaultData(new byte[]{});
+        BufferObjectDataInput found1 = bufferPool.takeInputBuffer(data);
+        BufferObjectDataInput found2 = bufferPool.takeInputBuffer(data);
+
+        assertNotSame(found1, found2);
+    }
+
+    @Test
+    public void returnInputBuffer() {
+        BufferObjectDataInput in = mock(BufferObjectDataInput.class);
+
+        bufferPool.returnInputBuffer(in);
+
+        // lets see if the item was pushed on the queue
+        assertEquals(1, bufferPool.inputQueue.size());
+        // we need to make sure clear was called
+        verify(in, times(1)).clear();
+    }
+
+    @Test
+    public void returnInputBuffer_whenOverflowing() throws IOException {
+        for (int k = 0; k < BufferPoolImpl.MAX_POOLED_ITEMS; k++) {
+            bufferPool.returnInputBuffer(mock(BufferObjectDataInput.class));
+        }
+        BufferObjectDataInput in = mock(BufferObjectDataInput.class);
+
+        bufferPool.returnInputBuffer(in);
+
+        assertEquals(BufferPoolImpl.MAX_POOLED_ITEMS, bufferPool.inputQueue.size());
+        // we need to make sure that the in was closed since we are not going to pool it.
+        verify(in, times(1)).close();
+    }
+
+    @Test
+    public void returnInputBuffer_whenNull() {
+        bufferPool.returnInputBuffer(null);
+        assertEquals(0, bufferPool.inputQueue.size());
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/bufferpool/BufferPoolThreadLocalTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/bufferpool/BufferPoolThreadLocalTest.java
@@ -1,0 +1,58 @@
+package com.hazelcast.nio.serialization.bufferpool;
+
+import com.hazelcast.nio.serialization.SerializationService;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.Callable;
+
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+import static org.mockito.Mockito.mock;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category(QuickTest.class)
+public class BufferPoolThreadLocalTest extends HazelcastTestSupport {
+
+    private SerializationService serializationService;
+    private BufferPoolThreadLocal bufferPoolThreadLocal;
+
+    @Before
+    public void setup() {
+        serializationService = mock(SerializationService.class);
+        bufferPoolThreadLocal = new BufferPoolThreadLocal(serializationService, new BufferPoolFactoryImpl());
+    }
+
+    @Test
+    public void get_whenSameThread_samePoolInstance() {
+        BufferPool pool1 = bufferPoolThreadLocal.get();
+        BufferPool pool2 = bufferPoolThreadLocal.get();
+        assertSame(pool1, pool2);
+    }
+
+    @Test
+    public void get_whenDifferentThreads_thenDifferentInstances() throws Exception {
+        BufferPool pool1 = bufferPoolThreadLocal.get();
+        BufferPool pool2 = spawn(new Callable<BufferPool>() {
+            @Override
+            public BufferPool call() throws Exception {
+                return bufferPoolThreadLocal.get();
+            }
+        }).get();
+
+        assertNotSame(pool1, pool2);
+    }
+
+    @Test
+    public void clear() {
+        BufferPool pool1 = bufferPoolThreadLocal.get();
+        bufferPoolThreadLocal.clear();
+        BufferPool pool2 = bufferPoolThreadLocal.get();
+        assertNotSame(pool1, pool2);
+    }
+}


### PR DESCRIPTION
Currently the ByteArrayObjectDataInput is not pooled in the SerializationServiceImpl; unlike the ByteArrayObjectDataOutput. This PR fixes this problem, this means that for every deserialization one object less is created.

This means that for a remote executed operation, there are at least 2 objects less being created. A deserialization of the operation and a deserialization of the response. In practice the number could be even higher, if there is nested deserialization. 

Another minor improvement are:
* for every deserialization 2 ConcurrentHashMap accessed were done; now only 1.
* with the old approach there we no bound on the size of the pooled inputs due to a programming mistake. With the new approach there is a cap of 3 (which was the original intent.. as discussed with Mehmet).