### PR TITLE
Prevents unnecessary calculation of stats

### DIFF
--- a/hazelcast/pom.xml
+++ b/hazelcast/pom.xml
@@ -34,6 +34,8 @@
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.basedir}</main.basedir>
         <atomikos-version>3.9.3</atomikos-version>
+        <jsp.api.version>2.2.1</jsp.api.version>
+        <servlet.api.version>3.0.1</servlet.api.version>
     </properties>
 
     <build>
@@ -358,6 +360,38 @@
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
+
+        <dependency>
+            <groupId>javax.servlet.jsp</groupId>
+            <artifactId>javax.servlet.jsp-api</artifactId>
+            <version>${jsp.api.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <version>${servlet.api.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-server</artifactId>
+            <version>8.1.16.v20140903</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-webapp</artifactId>
+            <version>8.1.16.v20140903</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.3.1</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
 </project>

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/ManagementCenterService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/ManagementCenterService.java
@@ -296,10 +296,10 @@ public class ManagementCenterService {
         public void run() {
             try {
                 while (isRunning()) {
-                    long start = Clock.currentTimeMillis();
+                    long startMs = Clock.currentTimeMillis();
                     sendState();
-                    long end = Clock.currentTimeMillis();
-                    sleepIfPossible(end - start);
+                    long endMs = Clock.currentTimeMillis();
+                    sleepIfPossible(endMs - startMs);
                 }
             } catch (Throwable throwable) {
                 inspectOutputMemoryError(throwable);
@@ -310,10 +310,10 @@ public class ManagementCenterService {
             }
         }
 
-        private void sleepIfPossible(long elapsed) throws InterruptedException {
-            long sleepTime = updateIntervalMs - elapsed;
-            if (sleepTime > 0) {
-                Thread.sleep(sleepTime);
+        private void sleepIfPossible(long elapsedMs) throws InterruptedException {
+            long sleepTimeMs = updateIntervalMs - elapsedMs;
+            if (sleepTimeMs > 0) {
+                Thread.sleep(sleepTimeMs);
             }
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/JettyServer.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/JettyServer.java
@@ -1,0 +1,53 @@
+package com.hazelcast.internal.management;
+
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.nio.SelectChannelConnector;
+import org.eclipse.jetty.webapp.WebAppContext;
+
+public class JettyServer {
+
+    Server server;
+
+    public JettyServer(int port, String sourceDir, String serverXml) throws Exception {
+        buildJetty(port, sourceDir, serverXml);
+    }
+
+    public void stop() throws Exception {
+        server.stop();
+    }
+
+    public void start() throws Exception {
+        server.start();
+    }
+
+    public void restart() throws Exception {
+        server.stop();
+        server.start();
+    }
+
+    public void buildJetty(int port, String sourceDir, String webXmlFile) throws Exception {
+        server = new Server();
+
+        SelectChannelConnector connector = new SelectChannelConnector();
+        connector.setPort(port);
+        server.addConnector(connector);
+        WebAppContext context = new WebAppContext();
+        context.setResourceBase(sourceDir);
+        context.setDescriptor(sourceDir + "/WEB-INF/" + webXmlFile);
+        context.setLogUrlOnStart(true);
+        context.setContextPath("/");
+        context.setParentLoaderPriority(true);
+
+        server.setHandler(context);
+
+        server.start();
+    }
+
+    public boolean isRunning() {
+        if (server == null) {
+            return false;
+        } else {
+            return server.isRunning();
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/ManagementCenterServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/ManagementCenterServiceTest.java
@@ -1,0 +1,101 @@
+package com.hazelcast.internal.management;
+
+import com.eclipsesource.json.JsonObject;
+import com.hazelcast.config.Config;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.monitor.TimedMemberState;
+import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.NightlyTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.util.EntityUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.net.URL;
+
+import static java.lang.String.format;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+@Category(NightlyTest.class)
+public class ManagementCenterServiceTest extends HazelcastTestSupport {
+
+    private JettyServer jettyServer;
+    private HazelcastInstance hazelcastInstance;
+    private int portNum;
+
+    @Before
+    public void setUp() throws Exception {
+        URL root = new URL(MancenterServlet.class.getResource("/"), "../test-classes");
+        String baseDir = new File(root.getFile().replaceAll("%20", " ")).toString();
+        String sourceDir = baseDir + "/../../src/test/webapp";
+        String sourceName = "server_config.xml";
+        portNum = availablePort();
+        jettyServer = new JettyServer(portNum, sourceDir, sourceName);
+
+        hazelcastInstance = Hazelcast.newHazelcastInstance(makeConfig());
+    }
+
+    @Test
+    public void testTimedMemberStateNotNull() throws Exception {
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                CloseableHttpClient client = HttpClientBuilder.create().disableRedirectHandling().build();
+                HttpUriRequest request;
+                request = new HttpGet("http://localhost:" + portNum + "/mancen/memberStateCheck");
+                HttpResponse response = client.execute(request);
+                HttpEntity entity = response.getEntity();
+                String responseString = EntityUtils.toString(entity);
+                assertNotEquals("", responseString);
+                JsonObject object = JsonObject.readFrom(responseString);
+                TimedMemberState memberState = new TimedMemberState();
+                memberState.fromJson(object);
+                assertEquals("dev", memberState.getClusterName());
+            }
+        });
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        hazelcastInstance.shutdown();
+        jettyServer.stop();
+    }
+
+    private Config makeConfig() {
+        Config config = new Config();
+        return addManagementCenter(config);
+    }
+
+    private Config addManagementCenter(Config config) {
+        config.getManagementCenterConfig().setEnabled(true);
+        config.getManagementCenterConfig().setUrl(format("http://localhost:%d%s/", portNum, "/mancen"));
+        return config;
+    }
+
+    private int availablePort() throws IOException {
+        while (true) {
+            int port = (int) (65536 * Math.random());
+            try {
+                ServerSocket socket = new ServerSocket(port);
+                socket.close();
+                return port;
+            } catch (Exception ignore) {
+                // try next port
+            }
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/MancenterServlet.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/MancenterServlet.java
@@ -1,0 +1,48 @@
+package com.hazelcast.internal.management;
+
+import com.eclipsesource.json.JsonObject;
+import com.hazelcast.monitor.TimedMemberState;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.BufferedReader;
+import java.io.IOException;
+
+public class MancenterServlet extends HttpServlet {
+
+    private volatile TimedMemberState memberState = null;
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        if(req.getPathInfo().contains("memberStateCheck")) {
+            if(memberState != null) {
+                resp.getWriter().write(memberState.toJson().toString());
+            } else {
+                resp.getWriter().write("");
+            }
+        }
+    }
+
+    @Override
+    protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        BufferedReader br = req.getReader();
+        StringBuilder sb = new StringBuilder();
+        String str;
+        while ((str = br.readLine()) != null) {
+            sb.append(str);
+        }
+        final String json = sb.toString();
+        final JsonObject object = JsonObject.readFrom(json);
+        process(object);
+    }
+
+    public void process(JsonObject json) {
+        ManagementCenterIdentifier identifier = new ManagementCenterIdentifier();
+        identifier.fromJson(json.get("identifier").asObject());
+        memberState = new TimedMemberState();
+        memberState.fromJson(json.get("timedMemberState").asObject());
+    }
+
+}

--- a/hazelcast/src/test/webapp/WEB-INF/server_config.xml
+++ b/hazelcast/src/test/webapp/WEB-INF/server_config.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="ISO-8859-1" standalone="no"?>
+<!--
+  ~ Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<web-app xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="2.5"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd">
+
+    <display-name>demo</display-name>
+    <servlet>
+        <servlet-name>test-servlet</servlet-name>
+        <servlet-class>com.hazelcast.internal.management.MancenterServlet</servlet-class>
+        <load-on-startup>1</load-on-startup>
+    </servlet>
+
+    <servlet-mapping>
+        <servlet-name>test-servlet</servlet-name>
+        <url-pattern>/mancen/*</url-pattern>
+    </servlet-mapping>
+
+</web-app>


### PR DESCRIPTION
fixes #4895, Stats were being calculated twice just to collect data structure names.
Also `StateSendThread` sleep time is now calculated depending on the elapsed time on stat gathering.