### PR TITLE
code generator dependency moved to hazelcast.pom and annotation processer listed in mvn.compiler.plugin

### DIFF
--- a/hazelcast/pom.xml
+++ b/hazelcast/pom.xml
@@ -39,6 +39,28 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${maven.compiler.plugin.version}</version>
+                <configuration>
+                    <source>${jdk.version}</source>
+                    <target>${jdk.version}</target>
+                    <encoding>${project.build.sourceEncoding}</encoding>
+                    <annotationProcessors>
+                        <annotationProcessor>com.hazelcast.client.protocol.generator.CodecCodeGenerator</annotationProcessor>
+                        <annotationProcessor>com.hazelcast.client.protocol.generator.CodeGeneratorMessageTaskFactory</annotationProcessor>
+                    </annotationProcessors>
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.hazelcast</groupId>
+                        <artifactId>hazelcast-code-generator</artifactId>
+                        <version>${project.version}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+
+            <plugin>
                 <groupId>pl.project13.maven</groupId>
                 <artifactId>git-commit-id-plugin</artifactId>
                 <version>2.1.10</version>
@@ -328,7 +350,7 @@
         <dependency>
             <groupId>com.hazelcast</groupId>
             <artifactId>hazelcast-code-generator</artifactId>
-            <version>${version}</version>
+            <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/hazelcast/src/main/resources/META-INF/services/javax.annotation.processing.Processor
+++ b/hazelcast/src/main/resources/META-INF/services/javax.annotation.processing.Processor
@@ -1,2 +1,0 @@
-com.hazelcast.client.protocol.generator.CodecCodeGenerator
-com.hazelcast.client.protocol.generator.CodeGeneratorMessageTaskFactory

--- a/pom.xml
+++ b/pom.xml
@@ -176,13 +176,6 @@
                     <target>${jdk.version}</target>
                     <encoding>${project.build.sourceEncoding}</encoding>
                 </configuration>
-                <dependencies>
-                    <dependency>
-                        <groupId>com.hazelcast</groupId>
-                        <artifactId>hazelcast-code-generator</artifactId>
-                        <version>${version}</version>
-                    </dependency>
-                </dependencies>
             </plugin>
 
             <plugin>


### PR DESCRIPTION
This fix uses maven-compiler plugin configuration for annotation-processor instead of java service discovery mechanism (via META-INF/services). That way, only hazelcast module will be effected by annotation processor. As a result, hazelcast module will only have provided dependency on code-generator instead of compile scope.

Complements work done by https://github.com/hazelcast/hazelcast/pull/5565