### PR TITLE
Introduces LazyMapEntry. 

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/LazyMapEntry.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/LazyMapEntry.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl;
+
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.nio.serialization.SerializationService;
+
+import java.util.Map;
+
+import static com.hazelcast.util.Preconditions.checkNotNull;
+
+/**
+ * A {@link java.util.Map.Entry Map.Entry} implementation which serializes/de-serializes key and value objects on demand.
+ * It is beneficial when you need to prevent unneeded serialization/de-serialization
+ * when creating a {@link java.util.Map.Entry Map.Entry}. Mainly targeted to supply a lazy entry to
+ * {@link com.hazelcast.map.EntryProcessor#process(Map.Entry)} and
+ * {@link com.hazelcast.map.EntryBackupProcessor#processBackup(Map.Entry)}} methods.
+ * <p/>
+ * <STRONG>Note that this implementation is not synchronized and is not thread-safe.</STRONG>
+ *
+ * @see com.hazelcast.map.impl.operation.EntryOperation#createMapEntry(Data, Object)
+ */
+public class LazyMapEntry implements Map.Entry {
+
+    private Object keyObject;
+    private Object valueObject;
+    private transient Data keyData;
+    private transient Data valueData;
+
+    private transient boolean modified;
+    private transient SerializationService serializationService;
+
+    public LazyMapEntry() {
+    }
+
+    public LazyMapEntry(Object key, Object value, SerializationService serializationService) {
+        init(key, value, serializationService);
+    }
+
+    public void init(Object key, Object value, SerializationService serializationService) {
+        checkNotNull(key, "key cannot be null");
+        checkNotNull(serializationService, "SerializationService cannot be null");
+
+        keyData = null;
+        keyObject = null;
+
+        if (key instanceof Data) {
+            this.keyData = (Data) key;
+        } else {
+            this.keyObject = key;
+        }
+
+        valueData = null;
+        valueObject = null;
+
+        if (value instanceof Data) {
+            this.valueData = (Data) value;
+        } else {
+            this.valueObject = value;
+        }
+
+        this.serializationService = serializationService;
+    }
+
+    @Override
+    public Object getKey() {
+        if (keyObject == null) {
+            keyObject = serializationService.toObject(keyData);
+        }
+        return keyObject;
+    }
+
+
+    @Override
+    public Object getValue() {
+        if (valueObject == null) {
+            valueObject = serializationService.toObject(valueData);
+        }
+        return valueObject;
+    }
+
+    @Override
+    public Object setValue(Object value) {
+        modified = true;
+        Object oldValue = getValue();
+        this.valueObject = value;
+        this.valueData = null;
+        return oldValue;
+    }
+
+    public Object getKeyData() {
+        if (keyData == null) {
+            keyData = serializationService.toData(keyObject);
+        }
+        return keyData;
+    }
+
+    public Object getValueData() {
+        if (valueData == null) {
+            valueData = serializationService.toData(valueObject);
+        }
+        return valueData;
+    }
+
+    public boolean isModified() {
+        return modified;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof Map.Entry)) {
+            return false;
+        }
+        Map.Entry<?, ?> e = (Map.Entry<?, ?>) o;
+        return equals(getKey(), e.getKey()) && equals(getValue(), e.getValue());
+    }
+
+    private static boolean equals(Object o1, Object o2) {
+        return o1 == null ? o2 == null : o1.equals(o2);
+    }
+
+    @Override
+    public int hashCode() {
+        return (getKey() == null ? 0 : getKey().hashCode())
+                ^ (getValue() == null ? 0 : getValue().hashCode());
+    }
+
+    @Override
+    public String toString() {
+        return getKey() + "=" + getValue();
+    }
+}
+

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/AbstractMultipleEntryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/AbstractMultipleEntryOperation.java
@@ -22,10 +22,10 @@ import com.hazelcast.core.EntryEventType;
 import com.hazelcast.core.EntryView;
 import com.hazelcast.map.EntryBackupProcessor;
 import com.hazelcast.map.EntryProcessor;
+import com.hazelcast.map.impl.LazyMapEntry;
 import com.hazelcast.map.impl.LocalMapStatsProvider;
 import com.hazelcast.map.impl.MapContainer;
 import com.hazelcast.map.impl.MapEntrySet;
-import com.hazelcast.map.impl.MapEntrySimple;
 import com.hazelcast.map.impl.MapEventPublisher;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.map.impl.MapServiceContext;
@@ -76,8 +76,8 @@ abstract class AbstractMultipleEntryOperation extends AbstractMapOperation imple
     }
 
 
-    protected Map.Entry createMapEntry(Object key, Object value) {
-        return new MapEntrySimple(key, value);
+    protected Map.Entry createMapEntry(Data key, Object value) {
+        return new LazyMapEntry(key, value, getNodeEngine().getSerializationService());
     }
 
     protected boolean hasRegisteredListenerForThisMap() {
@@ -119,7 +119,7 @@ abstract class AbstractMultipleEntryOperation extends AbstractMapOperation imple
             if (oldValue == null) {
                 return EntryEventType.ADDED;
             }
-            final MapEntrySimple mapEntrySimple = (MapEntrySimple) entry;
+            final LazyMapEntry mapEntrySimple = (LazyMapEntry) entry;
             if (mapEntrySimple.isModified()) {
                 return EntryEventType.UPDATED;
             }
@@ -132,7 +132,7 @@ abstract class AbstractMultipleEntryOperation extends AbstractMapOperation imple
      * Entry has not exist and no add operation has been done.
      */
     protected boolean noOp(Map.Entry entry, Object oldValue) {
-        final MapEntrySimple mapEntrySimple = (MapEntrySimple) entry;
+        final LazyMapEntry mapEntrySimple = (LazyMapEntry) entry;
         return !mapEntrySimple.isModified() || (oldValue == null && entry.getValue() == null);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MultipleEntryBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MultipleEntryBackupOperation.java
@@ -49,10 +49,7 @@ public class MultipleEntryBackupOperation extends AbstractMultipleEntryOperation
             }
             final Object oldValue = getValueFor(dataKey, now);
 
-            final Object key = toObject(dataKey);
-            final Object value = toObject(oldValue);
-
-            final Map.Entry entry = createMapEntry(key, value);
+            final Map.Entry entry = createMapEntry(dataKey, oldValue);
 
             processBackup(entry);
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MultipleEntryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MultipleEntryOperation.java
@@ -25,6 +25,7 @@ import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.SerializationService;
 import com.hazelcast.spi.BackupAwareOperation;
 import com.hazelcast.spi.Operation;
+
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.Map;
@@ -61,10 +62,7 @@ public class MultipleEntryOperation extends AbstractMultipleEntryOperation imple
             }
             final Object oldValue = getValueFor(dataKey, now);
 
-            final Object key = toObject(dataKey);
-            final Object value = toObject(oldValue);
-
-            final Map.Entry entry = createMapEntry(key, value);
+            final Map.Entry entry = createMapEntry(dataKey, oldValue);
 
             final Data response = process(entry);
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryBackupOperation.java
@@ -25,6 +25,7 @@ import com.hazelcast.nio.serialization.SerializationService;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.impl.QueryEntry;
 import com.hazelcast.spi.BackupOperation;
+
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.Map;
@@ -48,13 +49,10 @@ public class PartitionWideEntryBackupOperation extends AbstractMultipleEntryOper
             final Data dataKey = record.getKey();
             final Object oldValue = record.getValue();
 
-            final Object key = toObject(dataKey);
-            final Object value = toObject(oldValue);
-
-            if (!applyPredicate(dataKey, key, value)) {
+            if (!applyPredicate(dataKey, dataKey, oldValue)) {
                 continue;
             }
-            final Map.Entry entry = createMapEntry(key, value);
+            final Map.Entry entry = createMapEntry(dataKey, oldValue);
 
             processBackup(entry);
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryOperation.java
@@ -62,14 +62,11 @@ public class PartitionWideEntryOperation extends AbstractMultipleEntryOperation 
             final Data dataKey = record.getKey();
             final Object oldValue = record.getValue();
 
-            final Object key = toObject(dataKey);
-            final Object value = toObject(oldValue);
-
-            if (!applyPredicate(dataKey, key, value)) {
+            if (!applyPredicate(dataKey, dataKey, oldValue)) {
                 continue;
             }
 
-            final Map.Entry entry = createMapEntry(key, value);
+            final Map.Entry entry = createMapEntry(dataKey, oldValue);
 
             final Data response = process(entry);
 

--- a/hazelcast/src/test/java/com/hazelcast/map/EntryProcessorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/EntryProcessorTest.java
@@ -620,7 +620,7 @@ public class EntryProcessorTest extends HazelcastTestSupport {
 
         public Object process(Map.Entry entry) {
             entry.setValue(null);
-            return entry;
+            return null;
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/LazyMapEntryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/LazyMapEntryTest.java
@@ -1,0 +1,120 @@
+package com.hazelcast.map.impl;
+
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.nio.serialization.DataSerializable;
+import com.hazelcast.nio.serialization.DefaultSerializationServiceBuilder;
+import com.hazelcast.nio.serialization.SerializationService;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.io.IOException;
+import java.io.Serializable;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category(QuickTest.class)
+public class LazyMapEntryTest extends HazelcastTestSupport {
+
+    private LazyMapEntry entry = new LazyMapEntry();
+    private SerializationService serializationService = new DefaultSerializationServiceBuilder().build();
+
+    @Test
+    public void test_init() throws Exception {
+        Data keyData = serializationService.toData("keyData");
+        Data valueData = serializationService.toData("valueData");
+        entry.init(keyData, valueData, serializationService);
+
+        Object valueObject = entry.getValue();
+        Object keyObject = entry.getKey();
+
+        entry.init(keyObject, valueObject, serializationService);
+
+        assertTrue("Old keyData should not be here", keyData != entry.getKeyData());
+        assertTrue("Old valueData should not be here", valueData != entry.getValueData());
+    }
+
+    @Test
+    public void test_init_doesNotSerializeObject() throws Exception {
+        MyObject key = new MyObject();
+        MyObject value = new MyObject();
+
+        entry.init(key, value, serializationService);
+
+        assertEquals(0, key.serializedCount);
+        assertEquals(0, value.serializedCount);
+    }
+
+    @Test
+    public void test_init_doesNotDeserializeObject() throws Exception {
+        MyObject keyObject = new MyObject();
+        MyObject valueObject = new MyObject();
+
+        Data keyData = serializationService.toData(keyObject);
+        Data valueData = serializationService.toData(valueObject);
+
+        entry.init(keyData, valueData, serializationService);
+
+        assertEquals(1, keyObject.serializedCount);
+        assertEquals(1, valueObject.serializedCount);
+        assertEquals(0, keyObject.deserializedCount);
+        assertEquals(0, valueObject.deserializedCount);
+    }
+
+
+    @Test
+    public void testLazyDeserializationWorks() throws Exception {
+        MyObject keyObject = new MyObject();
+        MyObject valueObject = new MyObject();
+
+        Data keyData = serializationService.toData(keyObject);
+        Data valueData = serializationService.toData(valueObject);
+
+        entry.init(keyData, valueData, serializationService);
+
+        Object key = entry.getKey();
+        Object value = entry.getValue();
+
+        assertInstanceOf(MyObject.class, key);
+        assertInstanceOf(MyObject.class, value);
+        assertEquals(1, ((MyObject) key).deserializedCount);
+        assertEquals(1, ((MyObject) value).deserializedCount);
+    }
+
+    private static class MyObject implements DataSerializable, Serializable {
+
+        int serializedCount = 0;
+        int deserializedCount = 0;
+
+        public MyObject() {
+        }
+
+        @Override
+        public void writeData(ObjectDataOutput out) throws IOException {
+            out.writeInt(++serializedCount);
+            out.writeInt(deserializedCount);
+        }
+
+        @Override
+        public void readData(ObjectDataInput in) throws IOException {
+            serializedCount = in.readInt();
+            deserializedCount = in.readInt() + 1;
+        }
+
+        @Override
+        public String toString() {
+            return "MyObject{"
+                    + "deserializedCount=" + deserializedCount
+                    + ", serializedCount=" + serializedCount
+                    + '}';
+        }
+    }
+
+}


### PR DESCRIPTION
It provides on-demand deserialization of key-value pairs for map entry which is passed in `EntryProcessor#process` & `EntryBackupProcessor#processBackup` methods.

closes https://github.com/hazelcast/hazelcast/issues/5301
closes https://github.com/hazelcast/hazelcast/issues/5611