### PR TITLE
Lock resource cleanup on member left

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockResourceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockResourceImpl.java
@@ -73,15 +73,11 @@ final class LockResourceImpl implements DataSerializable, LockResource {
         return (this.threadId == threadId && owner != null && owner.equals(this.owner));
     }
 
-    boolean lock(String owner, long threadId, long leaseTime) {
-        return lock(owner, threadId, leaseTime, false);
-    }
-
     boolean lock(String owner, long threadId, long leaseTime, boolean transactional) {
         if (lockCount == 0) {
             this.owner = owner;
             this.threadId = threadId;
-            lockCount++;
+            lockCount = 1;
             acquireTime = Clock.currentTimeMillis();
             setExpirationTime(leaseTime);
             this.transactional = transactional;

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockServiceImpl.java
@@ -179,14 +179,14 @@ public final class LockServiceImpl implements LockService, ManagedService, Remot
     public void memberRemoved(MembershipServiceEvent event) {
         final MemberImpl member = event.getMember();
         final String uuid = member.getUuid();
-        releaseLocksOf(uuid);
+        releaseLocksOwnedBy(uuid);
     }
 
     @Override
     public void memberAttributeChanged(MemberAttributeServiceEvent event) {
     }
 
-    private void releaseLocksOf(final String uuid) {
+    private void releaseLocksOwnedBy(final String uuid) {
         final InternalOperationService operationService = (InternalOperationService) nodeEngine.getOperationService();
         for (final LockStoreContainer container : containers) {
             operationService.execute(new PartitionSpecificRunnable() {
@@ -319,6 +319,6 @@ public final class LockServiceImpl implements LockService, ManagedService, Remot
 
     @Override
     public void clientDisconnected(String clientUuid) {
-        releaseLocksOf(clientUuid);
+        releaseLocksOwnedBy(clientUuid);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockServiceImpl.java
@@ -32,9 +32,12 @@ import com.hazelcast.spi.MigrationAwareService;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.ObjectNamespace;
 import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.OperationService;
 import com.hazelcast.spi.PartitionMigrationEvent;
 import com.hazelcast.spi.PartitionReplicationEvent;
 import com.hazelcast.spi.RemoteService;
+import com.hazelcast.spi.impl.PartitionSpecificRunnable;
+import com.hazelcast.spi.impl.operationservice.InternalOperationService;
 import com.hazelcast.util.Clock;
 import com.hazelcast.util.ConstructorFunction;
 import com.hazelcast.util.scheduler.EntryTaskScheduler;
@@ -183,34 +186,47 @@ public final class LockServiceImpl implements LockService, ManagedService, Remot
     public void memberAttributeChanged(MemberAttributeServiceEvent event) {
     }
 
-    private void releaseLocksOf(String uuid) {
-        for (LockStoreContainer container : containers) {
-            for (LockStoreImpl lockStore : container.getLockStores()) {
-                releaseLock(uuid, container, lockStore);
-            }
+    private void releaseLocksOf(final String uuid) {
+        final InternalOperationService operationService = (InternalOperationService) nodeEngine.getOperationService();
+        for (final LockStoreContainer container : containers) {
+            operationService.execute(new PartitionSpecificRunnable() {
+                @Override
+                public void run() {
+                    for (LockStoreImpl lockStore : container.getLockStores()) {
+                        releaseLock(operationService, uuid, container.getPartitionId(), lockStore);
+                    }
+                }
+
+                @Override
+                public int getPartitionId() {
+                    return container.getPartitionId();
+                }
+            });
+
         }
     }
 
-    private void releaseLock(String uuid, LockStoreContainer container, LockStoreImpl lockStore) {
+    private void releaseLock(OperationService operationService, String uuid, int partitionId, LockStoreImpl lockStore) {
         Collection<LockResource> locks = lockStore.getLocks();
         for (LockResource lock : locks) {
             Data key = lock.getKey();
             if (uuid.equals(lock.getOwner()) && !lock.isTransactional()) {
-                sendUnlockOperation(container, lockStore, key);
+                UnlockOperation op = createUnlockOperation(partitionId, lockStore.getNamespace(), key, uuid);
+                operationService.runOperationOnCallingThread(op);
             }
         }
     }
 
-    private void sendUnlockOperation(LockStoreContainer container, LockStoreImpl lockStore, Data key) {
-        UnlockOperation op = new LocalLockCleanupOperation(lockStore.getNamespace(), key, -1);
+    private UnlockOperation createUnlockOperation(int partitionId, ObjectNamespace namespace, Data key, String uuid) {
+        UnlockOperation op = new LocalLockCleanupOperation(namespace, key, uuid);
         op.setAsyncBackup(true);
         op.setNodeEngine(nodeEngine);
         op.setServiceName(SERVICE_NAME);
         op.setService(LockServiceImpl.this);
         op.setOperationResponseHandler(createEmptyResponseHandler());
-        op.setPartitionId(container.getPartitionId());
+        op.setPartitionId(partitionId);
         op.setValidateTarget(false);
-        nodeEngine.getOperationService().executeOperation(op);
+        return op;
     }
 
     @Override
@@ -305,5 +321,4 @@ public final class LockServiceImpl implements LockService, ManagedService, Remot
     public void clientDisconnected(String clientUuid) {
         releaseLocksOf(clientUuid);
     }
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockStore.java
@@ -22,11 +22,11 @@ import java.util.Set;
 
 public interface LockStore {
 
-    boolean lock(Data key, String caller, long threadId, long ttl);
+    boolean lock(Data key, String caller, long threadId, long leaseTime);
 
-    boolean txnLock(Data key, String caller, long threadId, long ttl);
+    boolean txnLock(Data key, String caller, long threadId, long leaseTime);
 
-    boolean extendLeaseTime(Data key, String caller, long threadId, long ttl);
+    boolean extendLeaseTime(Data key, String caller, long threadId, long leaseTime);
 
     boolean unlock(Data key, String caller, long threadId);
 

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockStoreImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockStoreImpl.java
@@ -60,14 +60,10 @@ public final class LockStoreImpl implements DataSerializable, LockStore {
         this.lockService = lockService;
     }
 
-    public boolean lock(Data key, String caller, long threadId) {
-        return lock(key, caller, threadId, Long.MAX_VALUE);
-    }
-
     @Override
     public boolean lock(Data key, String caller, long threadId, long leaseTime) {
         LockResourceImpl lock = getLock(key);
-        return lock.lock(caller, threadId, leaseTime);
+        return lock.lock(caller, threadId, leaseTime, false);
     }
 
     @Override
@@ -85,7 +81,7 @@ public final class LockStoreImpl implements DataSerializable, LockStore {
         return lock.extendLeaseTime(caller, threadId, leaseTime);
     }
 
-    private LockResourceImpl getLock(Data key) {
+    public LockResourceImpl getLock(Data key) {
         return ConcurrencyUtil.getOrPutIfAbsent(locks, key, lockConstructor);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/AwaitBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/AwaitBackupOperation.java
@@ -46,7 +46,7 @@ public class AwaitBackupOperation extends BaseLockOperation
     @Override
     public void run() throws Exception {
         LockStoreImpl lockStore = getLockStore();
-        lockStore.lock(key, originalCaller, threadId);
+        lockStore.lock(key, originalCaller, threadId, -1L);
         ConditionKey conditionKey = new ConditionKey(namespace.getObjectName(), key, conditionId);
         lockStore.removeSignalKey(conditionKey);
         lockStore.removeAwait(key, conditionId, originalCaller, threadId);

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/AwaitOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/AwaitOperation.java
@@ -54,7 +54,7 @@ public class AwaitOperation extends BaseLockOperation
     @Override
     public void run() throws Exception {
         LockStoreImpl lockStore = getLockStore();
-        if (!lockStore.lock(key, getCallerUuid(), threadId)) {
+        if (!lockStore.lock(key, getCallerUuid(), threadId, -1L)) {
             throw new IllegalMonitorStateException(
                     "Current thread is not owner of the lock! -> " + lockStore.getOwnerInfo(key));
         }
@@ -108,7 +108,7 @@ public class AwaitOperation extends BaseLockOperation
         lockStore.removeSignalKey(getWaitKey());
         lockStore.removeAwait(key, conditionId, getCallerUuid(), threadId);
 
-        boolean locked = lockStore.lock(key, getCallerUuid(), threadId);
+        boolean locked = lockStore.lock(key, getCallerUuid(), threadId, -1L);
         if (locked) {
             // expired & acquired lock, send FALSE
             sendResponse(false);

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/LockOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/LockOperation.java
@@ -17,6 +17,7 @@
 package com.hazelcast.concurrent.lock.operations;
 
 import com.hazelcast.concurrent.lock.LockDataSerializerHook;
+import com.hazelcast.concurrent.lock.LockStoreImpl;
 import com.hazelcast.concurrent.lock.LockWaitNotifyKey;
 import com.hazelcast.core.OperationTimeoutException;
 import com.hazelcast.nio.serialization.Data;
@@ -57,7 +58,8 @@ public class LockOperation extends BaseLockOperation implements WaitSupport, Bac
 
     @Override
     public final boolean shouldWait() {
-        return getWaitTimeout() != 0 && !getLockStore().canAcquireLock(key, getCallerUuid(), threadId);
+        LockStoreImpl lockStore = getLockStore();
+        return getWaitTimeout() != 0 && !lockStore.canAcquireLock(key, getCallerUuid(), threadId);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/UnlockBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/UnlockBackupOperation.java
@@ -44,11 +44,14 @@ public class UnlockBackupOperation extends BaseLockOperation implements BackupOp
     @Override
     public void run() throws Exception {
         LockStoreImpl lockStore = getLockStore();
+        boolean unlocked;
         if (force) {
-            response = lockStore.forceUnlock(key);
+            unlocked = lockStore.forceUnlock(key);
         } else {
-            response = lockStore.unlock(key, originalCallerUuid, threadId);
+            unlocked = lockStore.unlock(key, originalCallerUuid, threadId);
         }
+
+        response = unlocked;
         lockStore.pollExpiredAwaitOp(key);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/lock/LockAdvancedTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/lock/LockAdvancedTest.java
@@ -5,6 +5,15 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.HazelcastInstanceNotActiveException;
 import com.hazelcast.core.ILock;
 import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.nio.serialization.impl.DefaultData;
+import com.hazelcast.spi.AbstractOperation;
+import com.hazelcast.spi.ObjectNamespace;
+import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.spi.impl.operationservice.InternalOperationService;
+import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
@@ -13,11 +22,14 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import java.io.IOException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.LockSupport;
 
+import static com.hazelcast.instance.TestUtil.terminateInstance;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -330,6 +342,79 @@ public class LockAdvancedTest extends HazelcastTestSupport {
         sleepMillis(5000);
         t.interrupt();
         assertTrue(latch.await(15, TimeUnit.SECONDS));
+    }
+
+    @Test
+    public void testLockCleanup_whenInvokingMemberDies() {
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(2);
+        HazelcastInstance hz = factory.newHazelcastInstance();
+
+
+        HazelcastInstance hz2 = factory.newHazelcastInstance();
+        NodeEngineImpl nodeEngine = getNodeEngineImpl(hz2);
+        InternalOperationService operationService = getOperationService(hz2);
+        warmUpPartitions(hz2);
+
+        String name = randomNameOwnedBy(hz);
+        Data key = nodeEngine.toData(name);
+        int partitionId = nodeEngine.getPartitionService().getPartitionId(key);
+
+        operationService.invokeOnPartition(LockService.SERVICE_NAME, new SlowLockOperation(name, key, 2000),
+                partitionId);
+
+        sleepMillis(500);
+        terminateInstance(hz2);
+
+        final ILock lock = hz.getLock(name);
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertFalse("Lock owned by dead member should have been released!", lock.isLocked());
+            }
+        }, 30);
+    }
+
+    private static class SlowLockOperation extends AbstractOperation {
+
+        Data key;
+        ObjectNamespace ns;
+        long sleepMillis;
+
+        public SlowLockOperation() {
+        }
+
+        public SlowLockOperation(String name, Data key, long sleepMillis) {
+            this.key = key;
+            this.ns = new InternalLockNamespace(name);
+            this.sleepMillis = sleepMillis;
+        }
+
+        protected final LockStoreImpl getLockStore() {
+            LockServiceImpl service = getService();
+            return service.getLockStore(getPartitionId(), ns);
+        }
+
+        @Override
+        public void run() throws Exception {
+            LockSupport.parkNanos(TimeUnit.MILLISECONDS.toNanos(1000));
+            getLockStore().lock(key, getCallerUuid(), 1, -1);
+        }
+
+        @Override
+        protected void writeInternal(ObjectDataOutput out) throws IOException {
+            super.writeInternal(out);
+            out.writeLong(sleepMillis);
+            out.writeByteArray(key.toByteArray());
+            out.writeUTF(ns.getObjectName());
+        }
+
+        @Override
+        protected void readInternal(ObjectDataInput in) throws IOException {
+            super.readInternal(in);
+            sleepMillis = in.readLong();
+            key = new DefaultData(in.readByteArray());
+            ns = new InternalLockNamespace(in.readUTF());
+        }
     }
 
 }


### PR DESCRIPTION
- Lock cleanup task submitted when a member is left should be executed on related partition threads, otherwise it can miss previously enqueued or being executed lock operations. So, this race can cause infinitely hanging locks.

- Lock cleanup operation should check owner-uuid during its execution in partition thread to avoid race.

Extracted from #5246