### PR TITLE
Makes lock operation retries idempotent

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockResourceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockResourceImpl.java
@@ -73,15 +73,11 @@ final class LockResourceImpl implements DataSerializable, LockResource {
         return (this.threadId == threadId && owner != null && owner.equals(this.owner));
     }
 
-    boolean lock(String owner, long threadId, long leaseTime) {
-        return lock(owner, threadId, leaseTime, false);
-    }
-
     boolean lock(String owner, long threadId, long leaseTime, boolean transactional) {
         if (lockCount == 0) {
             this.owner = owner;
             this.threadId = threadId;
-            lockCount++;
+            lockCount = 1;
             acquireTime = Clock.currentTimeMillis();
             setExpirationTime(leaseTime);
             this.transactional = transactional;

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockResourceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockResourceImpl.java
@@ -37,6 +37,7 @@ final class LockResourceImpl implements DataSerializable, LockResource {
     private Data key;
     private String owner;
     private long threadId;
+    private long referenceId;
     private int lockCount;
     private long expirationTime = -1;
     private long acquireTime = -1L;
@@ -73,16 +74,21 @@ final class LockResourceImpl implements DataSerializable, LockResource {
         return (this.threadId == threadId && owner != null && owner.equals(this.owner));
     }
 
-    boolean lock(String owner, long threadId, long leaseTime, boolean transactional) {
+    boolean lock(String owner, long threadId, long referenceId, long leaseTime, boolean transactional) {
         if (lockCount == 0) {
             this.owner = owner;
             this.threadId = threadId;
+            this.referenceId = referenceId;
             lockCount = 1;
             acquireTime = Clock.currentTimeMillis();
             setExpirationTime(leaseTime);
             this.transactional = transactional;
             return true;
         } else if (isLockedBy(owner, threadId)) {
+            if (this.referenceId == referenceId) {
+                return true;
+            }
+            this.referenceId = referenceId;
             lockCount++;
             setExpirationTime(leaseTime);
             this.transactional = transactional;
@@ -119,7 +125,7 @@ final class LockResourceImpl implements DataSerializable, LockResource {
         }
     }
 
-    boolean unlock(String owner, long threadId) {
+    boolean unlock(String owner, long threadId, long referenceId) {
         if (lockCount == 0) {
             return false;
         }
@@ -128,6 +134,11 @@ final class LockResourceImpl implements DataSerializable, LockResource {
             return false;
         }
 
+        if (this.referenceId == referenceId) {
+            return true;
+        }
+
+        this.referenceId = referenceId;
         lockCount--;
         if (lockCount == 0) {
             clear();
@@ -240,6 +251,7 @@ final class LockResourceImpl implements DataSerializable, LockResource {
         threadId = 0;
         lockCount = 0;
         owner = null;
+        referenceId = 0L;
         expirationTime = 0;
         acquireTime = -1L;
         cancelEviction();
@@ -311,6 +323,7 @@ final class LockResourceImpl implements DataSerializable, LockResource {
         out.writeData(key);
         out.writeUTF(owner);
         out.writeLong(threadId);
+        out.writeLong(referenceId);
         out.writeInt(lockCount);
         out.writeLong(expirationTime);
         out.writeLong(acquireTime);
@@ -357,6 +370,7 @@ final class LockResourceImpl implements DataSerializable, LockResource {
         key = in.readData();
         owner = in.readUTF();
         threadId = in.readLong();
+        referenceId = in.readLong();
         lockCount = in.readInt();
         expirationTime = in.readLong();
         acquireTime = in.readLong();

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockServiceImpl.java
@@ -179,14 +179,14 @@ public final class LockServiceImpl implements LockService, ManagedService, Remot
     public void memberRemoved(MembershipServiceEvent event) {
         final MemberImpl member = event.getMember();
         final String uuid = member.getUuid();
-        releaseLocksOf(uuid);
+        releaseLocksOwnedBy(uuid);
     }
 
     @Override
     public void memberAttributeChanged(MemberAttributeServiceEvent event) {
     }
 
-    private void releaseLocksOf(final String uuid) {
+    private void releaseLocksOwnedBy(final String uuid) {
         final InternalOperationService operationService = (InternalOperationService) nodeEngine.getOperationService();
         for (final LockStoreContainer container : containers) {
             operationService.execute(new PartitionSpecificRunnable() {
@@ -319,6 +319,6 @@ public final class LockServiceImpl implements LockService, ManagedService, Remot
 
     @Override
     public void clientDisconnected(String clientUuid) {
-        releaseLocksOf(clientUuid);
+        releaseLocksOwnedBy(clientUuid);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockServiceImpl.java
@@ -32,9 +32,12 @@ import com.hazelcast.spi.MigrationAwareService;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.ObjectNamespace;
 import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.OperationService;
 import com.hazelcast.spi.PartitionMigrationEvent;
 import com.hazelcast.spi.PartitionReplicationEvent;
 import com.hazelcast.spi.RemoteService;
+import com.hazelcast.spi.impl.PartitionSpecificRunnable;
+import com.hazelcast.spi.impl.operationservice.InternalOperationService;
 import com.hazelcast.util.Clock;
 import com.hazelcast.util.ConstructorFunction;
 import com.hazelcast.util.scheduler.EntryTaskScheduler;
@@ -183,34 +186,47 @@ public final class LockServiceImpl implements LockService, ManagedService, Remot
     public void memberAttributeChanged(MemberAttributeServiceEvent event) {
     }
 
-    private void releaseLocksOf(String uuid) {
-        for (LockStoreContainer container : containers) {
-            for (LockStoreImpl lockStore : container.getLockStores()) {
-                releaseLock(uuid, container, lockStore);
-            }
+    private void releaseLocksOf(final String uuid) {
+        final InternalOperationService operationService = (InternalOperationService) nodeEngine.getOperationService();
+        for (final LockStoreContainer container : containers) {
+            operationService.execute(new PartitionSpecificRunnable() {
+                @Override
+                public void run() {
+                    for (LockStoreImpl lockStore : container.getLockStores()) {
+                        releaseLock(operationService, uuid, container.getPartitionId(), lockStore);
+                    }
+                }
+
+                @Override
+                public int getPartitionId() {
+                    return container.getPartitionId();
+                }
+            });
+
         }
     }
 
-    private void releaseLock(String uuid, LockStoreContainer container, LockStoreImpl lockStore) {
+    private void releaseLock(OperationService operationService, String uuid, int partitionId, LockStoreImpl lockStore) {
         Collection<LockResource> locks = lockStore.getLocks();
         for (LockResource lock : locks) {
             Data key = lock.getKey();
             if (uuid.equals(lock.getOwner()) && !lock.isTransactional()) {
-                sendUnlockOperation(container, lockStore, key);
+                UnlockOperation op = createUnlockOperation(partitionId, lockStore.getNamespace(), key, uuid);
+                operationService.runOperationOnCallingThread(op);
             }
         }
     }
 
-    private void sendUnlockOperation(LockStoreContainer container, LockStoreImpl lockStore, Data key) {
-        UnlockOperation op = new LocalLockCleanupOperation(lockStore.getNamespace(), key, -1);
+    private UnlockOperation createUnlockOperation(int partitionId, ObjectNamespace namespace, Data key, String uuid) {
+        UnlockOperation op = new LocalLockCleanupOperation(namespace, key, uuid);
         op.setAsyncBackup(true);
         op.setNodeEngine(nodeEngine);
         op.setServiceName(SERVICE_NAME);
         op.setService(LockServiceImpl.this);
         op.setOperationResponseHandler(createEmptyResponseHandler());
-        op.setPartitionId(container.getPartitionId());
+        op.setPartitionId(partitionId);
         op.setValidateTarget(false);
-        nodeEngine.getOperationService().executeOperation(op);
+        return op;
     }
 
     @Override
@@ -305,5 +321,4 @@ public final class LockServiceImpl implements LockService, ManagedService, Remot
     public void clientDisconnected(String clientUuid) {
         releaseLocksOf(clientUuid);
     }
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockStore.java
@@ -22,13 +22,13 @@ import java.util.Set;
 
 public interface LockStore {
 
-    boolean lock(Data key, String caller, long threadId, long leaseTime);
+    boolean lock(Data key, String caller, long threadId, long referenceId, long leaseTime);
 
-    boolean txnLock(Data key, String caller, long threadId, long leaseTime);
+    boolean txnLock(Data key, String caller, long threadId, long referenceId, long leaseTime);
 
     boolean extendLeaseTime(Data key, String caller, long threadId, long leaseTime);
 
-    boolean unlock(Data key, String caller, long threadId);
+    boolean unlock(Data key, String caller, long threadId, long referenceId);
 
     boolean isLocked(Data key);
 

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockStore.java
@@ -22,11 +22,11 @@ import java.util.Set;
 
 public interface LockStore {
 
-    boolean lock(Data key, String caller, long threadId, long ttl);
+    boolean lock(Data key, String caller, long threadId, long leaseTime);
 
-    boolean txnLock(Data key, String caller, long threadId, long ttl);
+    boolean txnLock(Data key, String caller, long threadId, long leaseTime);
 
-    boolean extendLeaseTime(Data key, String caller, long threadId, long ttl);
+    boolean extendLeaseTime(Data key, String caller, long threadId, long leaseTime);
 
     boolean unlock(Data key, String caller, long threadId);
 

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockStoreImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockStoreImpl.java
@@ -60,14 +60,10 @@ public final class LockStoreImpl implements DataSerializable, LockStore {
         this.lockService = lockService;
     }
 
-    public boolean lock(Data key, String caller, long threadId) {
-        return lock(key, caller, threadId, Long.MAX_VALUE);
-    }
-
     @Override
     public boolean lock(Data key, String caller, long threadId, long leaseTime) {
         LockResourceImpl lock = getLock(key);
-        return lock.lock(caller, threadId, leaseTime);
+        return lock.lock(caller, threadId, leaseTime, false);
     }
 
     @Override
@@ -85,7 +81,7 @@ public final class LockStoreImpl implements DataSerializable, LockStore {
         return lock.extendLeaseTime(caller, threadId, leaseTime);
     }
 
-    private LockResourceImpl getLock(Data key) {
+    public LockResourceImpl getLock(Data key) {
         return ConcurrencyUtil.getOrPutIfAbsent(locks, key, lockConstructor);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockStoreImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockStoreImpl.java
@@ -61,15 +61,15 @@ public final class LockStoreImpl implements DataSerializable, LockStore {
     }
 
     @Override
-    public boolean lock(Data key, String caller, long threadId, long leaseTime) {
+    public boolean lock(Data key, String caller, long threadId, long referenceId, long leaseTime) {
         LockResourceImpl lock = getLock(key);
-        return lock.lock(caller, threadId, leaseTime, false);
+        return lock.lock(caller, threadId, referenceId, leaseTime, false);
     }
 
     @Override
-    public boolean txnLock(Data key, String caller, long threadId, long leaseTime) {
+    public boolean txnLock(Data key, String caller, long threadId, long referenceId, long leaseTime) {
         LockResourceImpl lock = getLock(key);
-        return lock.lock(caller, threadId, leaseTime, true);
+        return lock.lock(caller, threadId, referenceId, leaseTime, true);
     }
 
     @Override
@@ -137,7 +137,7 @@ public final class LockStoreImpl implements DataSerializable, LockStore {
     }
 
     @Override
-    public boolean unlock(Data key, String caller, long threadId) {
+    public boolean unlock(Data key, String caller, long threadId, long referenceId) {
         LockResourceImpl lock = locks.get(key);
         if (lock == null) {
             return false;
@@ -145,7 +145,7 @@ public final class LockStoreImpl implements DataSerializable, LockStore {
 
         boolean result = false;
         if (lock.canAcquireLock(caller, threadId)) {
-            if (lock.unlock(caller, threadId)) {
+            if (lock.unlock(caller, threadId, referenceId)) {
                 result = true;
             }
         }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockStoreProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockStoreProxy.java
@@ -33,15 +33,15 @@ public final class LockStoreProxy implements LockStore {
     }
 
     @Override
-    public boolean lock(Data key, String caller, long threadId, long ttl) {
+    public boolean lock(Data key, String caller, long threadId, long referenceId, long ttl) {
         LockStore lockStore = getLockStoreOrNull();
-        return lockStore != null && lockStore.lock(key, caller, threadId, ttl);
+        return lockStore != null && lockStore.lock(key, caller, threadId, referenceId, ttl);
     }
 
     @Override
-    public boolean txnLock(Data key, String caller, long threadId, long ttl) {
+    public boolean txnLock(Data key, String caller, long threadId, long referenceId, long ttl) {
         LockStore lockStore = getLockStoreOrNull();
-        return lockStore != null && lockStore.txnLock(key, caller, threadId, ttl);
+        return lockStore != null && lockStore.txnLock(key, caller, threadId, referenceId, ttl);
     }
 
     @Override
@@ -51,9 +51,9 @@ public final class LockStoreProxy implements LockStore {
     }
 
     @Override
-    public boolean unlock(Data key, String caller, long threadId) {
+    public boolean unlock(Data key, String caller, long threadId, long referenceId) {
         LockStore lockStore = getLockStoreOrNull();
-        return lockStore != null && lockStore.unlock(key, caller, threadId);
+        return lockStore != null && lockStore.unlock(key, caller, threadId, referenceId);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/AwaitBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/AwaitBackupOperation.java
@@ -46,7 +46,7 @@ public class AwaitBackupOperation extends BaseLockOperation
     @Override
     public void run() throws Exception {
         LockStoreImpl lockStore = getLockStore();
-        lockStore.lock(key, originalCaller, threadId, -1L);
+        lockStore.lock(key, originalCaller, threadId, getReferenceCallId(), -1L);
         ConditionKey conditionKey = new ConditionKey(namespace.getObjectName(), key, conditionId);
         lockStore.removeSignalKey(conditionKey);
         lockStore.removeAwait(key, conditionId, originalCaller, threadId);

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/AwaitBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/AwaitBackupOperation.java
@@ -46,7 +46,7 @@ public class AwaitBackupOperation extends BaseLockOperation
     @Override
     public void run() throws Exception {
         LockStoreImpl lockStore = getLockStore();
-        lockStore.lock(key, originalCaller, threadId);
+        lockStore.lock(key, originalCaller, threadId, -1L);
         ConditionKey conditionKey = new ConditionKey(namespace.getObjectName(), key, conditionId);
         lockStore.removeSignalKey(conditionKey);
         lockStore.removeAwait(key, conditionId, originalCaller, threadId);

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/AwaitOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/AwaitOperation.java
@@ -54,7 +54,7 @@ public class AwaitOperation extends BaseLockOperation
     @Override
     public void run() throws Exception {
         LockStoreImpl lockStore = getLockStore();
-        if (!lockStore.lock(key, getCallerUuid(), threadId, -1L)) {
+        if (!lockStore.lock(key, getCallerUuid(), threadId, getReferenceCallId(), -1L)) {
             throw new IllegalMonitorStateException(
                     "Current thread is not owner of the lock! -> " + lockStore.getOwnerInfo(key));
         }
@@ -108,7 +108,7 @@ public class AwaitOperation extends BaseLockOperation
         lockStore.removeSignalKey(getWaitKey());
         lockStore.removeAwait(key, conditionId, getCallerUuid(), threadId);
 
-        boolean locked = lockStore.lock(key, getCallerUuid(), threadId, -1L);
+        boolean locked = lockStore.lock(key, getCallerUuid(), threadId, getReferenceCallId(), -1L);
         if (locked) {
             // expired & acquired lock, send FALSE
             sendResponse(false);

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/AwaitOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/AwaitOperation.java
@@ -54,7 +54,7 @@ public class AwaitOperation extends BaseLockOperation
     @Override
     public void run() throws Exception {
         LockStoreImpl lockStore = getLockStore();
-        if (!lockStore.lock(key, getCallerUuid(), threadId)) {
+        if (!lockStore.lock(key, getCallerUuid(), threadId, -1L)) {
             throw new IllegalMonitorStateException(
                     "Current thread is not owner of the lock! -> " + lockStore.getOwnerInfo(key));
         }
@@ -108,7 +108,7 @@ public class AwaitOperation extends BaseLockOperation
         lockStore.removeSignalKey(getWaitKey());
         lockStore.removeAwait(key, conditionId, getCallerUuid(), threadId);
 
-        boolean locked = lockStore.lock(key, getCallerUuid(), threadId);
+        boolean locked = lockStore.lock(key, getCallerUuid(), threadId, -1L);
         if (locked) {
             // expired & acquired lock, send FALSE
             sendResponse(false);

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/BeforeAwaitBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/BeforeAwaitBackupOperation.java
@@ -45,7 +45,7 @@ public class BeforeAwaitBackupOperation extends BaseLockOperation implements Bac
     public void run() throws Exception {
         LockStoreImpl lockStore = getLockStore();
         lockStore.addAwait(key, conditionId, originalCaller, threadId);
-        lockStore.unlock(key, originalCaller, threadId);
+        lockStore.unlock(key, originalCaller, threadId, getReferenceCallId());
         response = true;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/BeforeAwaitOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/BeforeAwaitOperation.java
@@ -60,7 +60,7 @@ public class BeforeAwaitOperation extends BaseLockOperation implements Notifier,
     public void run() throws Exception {
         LockStoreImpl lockStore = getLockStore();
         lockStore.addAwait(key, conditionId, getCallerUuid(), threadId);
-        lockStore.unlock(key, getCallerUuid(), threadId);
+        lockStore.unlock(key, getCallerUuid(), threadId, getReferenceCallId());
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/LockBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/LockBackupOperation.java
@@ -41,7 +41,7 @@ public class LockBackupOperation extends BaseLockOperation implements BackupOper
     @Override
     public void run() throws Exception {
         LockStoreImpl lockStore = getLockStore();
-        response = lockStore.lock(key, originalCallerUuid, threadId, ttl);
+        response = lockStore.lock(key, originalCallerUuid, threadId, getReferenceCallId(), ttl);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/LockOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/LockOperation.java
@@ -17,6 +17,7 @@
 package com.hazelcast.concurrent.lock.operations;
 
 import com.hazelcast.concurrent.lock.LockDataSerializerHook;
+import com.hazelcast.concurrent.lock.LockStoreImpl;
 import com.hazelcast.concurrent.lock.LockWaitNotifyKey;
 import com.hazelcast.core.OperationTimeoutException;
 import com.hazelcast.nio.serialization.Data;
@@ -57,7 +58,8 @@ public class LockOperation extends BaseLockOperation implements WaitSupport, Bac
 
     @Override
     public final boolean shouldWait() {
-        return getWaitTimeout() != 0 && !getLockStore().canAcquireLock(key, getCallerUuid(), threadId);
+        LockStoreImpl lockStore = getLockStore();
+        return getWaitTimeout() != 0 && !lockStore.canAcquireLock(key, getCallerUuid(), threadId);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/LockOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/LockOperation.java
@@ -38,12 +38,14 @@ public class LockOperation extends BaseLockOperation implements WaitSupport, Bac
 
     @Override
     public void run() throws Exception {
-        response = getLockStore().lock(key, getCallerUuid(), threadId, ttl);
+        response = getLockStore().lock(key, getCallerUuid(), threadId, getReferenceCallId(), ttl);
     }
 
     @Override
     public Operation getBackupOperation() {
-        return new LockBackupOperation(namespace, key, threadId, getCallerUuid());
+        LockBackupOperation operation = new LockBackupOperation(namespace, key, threadId, getCallerUuid());
+        operation.setReferenceCallId(getReferenceCallId());
+        return operation;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/UnlockBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/UnlockBackupOperation.java
@@ -44,11 +44,14 @@ public class UnlockBackupOperation extends BaseLockOperation implements BackupOp
     @Override
     public void run() throws Exception {
         LockStoreImpl lockStore = getLockStore();
+        boolean unlocked;
         if (force) {
-            response = lockStore.forceUnlock(key);
+            unlocked = lockStore.forceUnlock(key);
         } else {
-            response = lockStore.unlock(key, originalCallerUuid, threadId);
+            unlocked = lockStore.unlock(key, originalCallerUuid, threadId);
         }
+
+        response = unlocked;
         lockStore.pollExpiredAwaitOp(key);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/UnlockBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/UnlockBackupOperation.java
@@ -48,7 +48,7 @@ public class UnlockBackupOperation extends BaseLockOperation implements BackupOp
         if (force) {
             unlocked = lockStore.forceUnlock(key);
         } else {
-            unlocked = lockStore.unlock(key, originalCallerUuid, threadId);
+            unlocked = lockStore.unlock(key, originalCallerUuid, threadId, getReferenceCallId());
         }
 
         response = unlocked;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/DefaultRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/DefaultRecordStore.java
@@ -269,9 +269,9 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore implements 
     }
 
     @Override
-    public boolean txnLock(Data key, String caller, long threadId, long ttl) {
+    public boolean txnLock(Data key, String caller, long threadId, long referenceId, long ttl) {
         checkIfLoaded();
-        return lockStore != null && lockStore.txnLock(key, caller, threadId, ttl);
+        return lockStore != null && lockStore.txnLock(key, caller, threadId, referenceId, ttl);
     }
 
     @Override
@@ -281,9 +281,9 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore implements 
     }
 
     @Override
-    public boolean unlock(Data key, String caller, long threadId) {
+    public boolean unlock(Data key, String caller, long threadId, long referenceId) {
         checkIfLoaded();
-        return lockStore != null && lockStore.unlock(key, caller, threadId);
+        return lockStore != null && lockStore.unlock(key, caller, threadId, referenceId);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/RecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/RecordStore.java
@@ -189,11 +189,11 @@ public interface RecordStore {
 
     int size();
 
-    boolean txnLock(Data key, String caller, long threadId, long ttl);
+    boolean txnLock(Data key, String caller, long threadId, long referenceId, long ttl);
 
     boolean extendLock(Data key, String caller, long threadId, long ttl);
 
-    boolean unlock(Data key, String caller, long threadId);
+    boolean unlock(Data key, String caller, long threadId, long referenceId);
 
     boolean isLocked(Data key);
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnDeleteOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnDeleteOperation.java
@@ -54,7 +54,7 @@ public class TxnDeleteOperation extends BaseRemoveOperation implements MapTxnOpe
 
     @Override
     public void run() {
-        recordStore.unlock(dataKey, ownerUuid, getThreadId());
+        recordStore.unlock(dataKey, ownerUuid, getThreadId(), getCallId());
         Record record = recordStore.getRecord(dataKey);
         if (record == null || version == record.getVersion()) {
             dataOldValue = getNodeEngine().toData(recordStore.remove(dataKey));

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnLockAndGetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnLockAndGetOperation.java
@@ -45,7 +45,7 @@ public class TxnLockAndGetOperation extends LockAwareOperation implements Mutati
 
     @Override
     public void run() throws Exception {
-        if (!recordStore.txnLock(getKey(), ownerUuid, getThreadId(), ttl)) {
+        if (!recordStore.txnLock(getKey(), ownerUuid, getThreadId(), getCallId(), ttl)) {
             throw new TransactionException("Transaction couldn't obtain lock.");
         }
         Record record = recordStore.getRecordOrNull(dataKey);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnPrepareBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnPrepareBackupOperation.java
@@ -45,7 +45,7 @@ public class TxnPrepareBackupOperation extends KeyBasedMapOperation implements B
 
     @Override
     public void run() throws Exception {
-        if (!recordStore.txnLock(getKey(), lockOwner, lockThreadId, LOCK_TTL_MILLIS)) {
+        if (!recordStore.txnLock(getKey(), lockOwner, lockThreadId, getCallId(), LOCK_TTL_MILLIS)) {
             throw new TransactionException("Lock is not owned by the transaction! Caller: " + lockOwner
                     + ", Owner: " + recordStore.getLockOwnerInfo(getKey()));
         }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnRollbackBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnRollbackBackupOperation.java
@@ -43,7 +43,7 @@ public class TxnRollbackBackupOperation extends KeyBasedMapOperation implements 
 
     @Override
     public void run() throws Exception {
-        if (recordStore.isLocked(getKey()) && !recordStore.unlock(getKey(), lockOwner, lockThreadId)) {
+        if (recordStore.isLocked(getKey()) && !recordStore.unlock(getKey(), lockOwner, lockThreadId, getCallId())) {
             throw new TransactionException("Lock is not owned by the transaction! Owner: "
                     + recordStore.getLockOwnerInfo(getKey()));
         }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnRollbackOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnRollbackOperation.java
@@ -47,7 +47,7 @@ public class TxnRollbackOperation extends KeyBasedMapOperation implements Backup
 
     @Override
     public void run() throws Exception {
-        if (recordStore.isLocked(getKey()) && !recordStore.unlock(getKey(), ownerUuid, getThreadId())) {
+        if (recordStore.isLocked(getKey()) && !recordStore.unlock(getKey(), ownerUuid, getThreadId(), getCallId())) {
             throw new TransactionException("Lock is not owned by the transaction! Owner: "
                     + recordStore.getLockOwnerInfo(getKey()));
         }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnSetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnSetOperation.java
@@ -73,7 +73,7 @@ public class TxnSetOperation extends BasePutOperation implements MapTxnOperation
     public void run() {
         final MapServiceContext mapServiceContext = mapService.getMapServiceContext();
         final EventService eventService = getNodeEngine().getEventService();
-        recordStore.unlock(dataKey, ownerUuid, threadId);
+        recordStore.unlock(dataKey, ownerUuid, threadId, getCallId());
         Record record = recordStore.getRecordOrNull(dataKey);
         if (record == null || version == record.getVersion()) {
             if (eventService.hasEventRegistration(MapService.SERVICE_NAME, getName())) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnUnlockBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnUnlockBackupOperation.java
@@ -35,7 +35,7 @@ public class TxnUnlockBackupOperation extends KeyBasedMapOperation implements Ba
 
     @Override
     public void run() {
-        recordStore.unlock(dataKey, getCallerUuid(), getThreadId());
+        recordStore.unlock(dataKey, getCallerUuid(), getThreadId(), getCallId());
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnUnlockOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnUnlockOperation.java
@@ -52,7 +52,7 @@ public class TxnUnlockOperation extends LockAwareOperation implements MapTxnOper
 
     @Override
     public void run() {
-        recordStore.unlock(dataKey, ownerUuid, threadId);
+        recordStore.unlock(dataKey, ownerUuid, threadId, getCallId());
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapContainer.java
@@ -79,12 +79,12 @@ public class MultiMapContainer extends MultiMapContainerSupport {
         return lockStore != null && lockStore.isTransactionallyLocked(key);
     }
 
-    public boolean txnLock(Data key, String caller, long threadId, long ttl) {
-        return lockStore != null && lockStore.txnLock(key, caller, threadId, ttl);
+    public boolean txnLock(Data key, String caller, long threadId, long referenceId, long ttl) {
+        return lockStore != null && lockStore.txnLock(key, caller, threadId, referenceId, ttl);
     }
 
-    public boolean unlock(Data key, String caller, long threadId) {
-        return lockStore != null && lockStore.unlock(key, caller, threadId);
+    public boolean unlock(Data key, String caller, long threadId, long referenceId) {
+        return lockStore != null && lockStore.unlock(key, caller, threadId, referenceId);
     }
 
     public boolean forceUnlock(Data key) {

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnCommitOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnCommitOperation.java
@@ -49,7 +49,7 @@ public class TxnCommitOperation extends MultiMapBackupAwareOperation implements 
             op.run();
             op.afterRun();
         }
-        getOrCreateContainer().unlock(dataKey, getCallerUuid(), threadId);
+        getOrCreateContainer().unlock(dataKey, getCallerUuid(), threadId, getCallId());
     }
 
     public boolean shouldBackup() {

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnLockAndGetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnLockAndGetOperation.java
@@ -51,7 +51,7 @@ public class TxnLockAndGetOperation extends MultiMapKeyBasedOperation implements
     @Override
     public void run() throws Exception {
         MultiMapContainer container = getOrCreateContainer();
-        if (!container.txnLock(dataKey, getCallerUuid(), threadId, ttl)) {
+        if (!container.txnLock(dataKey, getCallerUuid(), threadId, getCallId(), ttl)) {
             throw new TransactionException("Transaction couldn't obtain lock!");
         }
         MultiMapWrapper wrapper = getCollectionWrapper();

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnPrepareBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnPrepareBackupOperation.java
@@ -43,7 +43,7 @@ public class TxnPrepareBackupOperation extends MultiMapKeyBasedOperation impleme
 
     public void run() throws Exception {
         MultiMapContainer container = getOrCreateContainer();
-        if (!container.txnLock(dataKey, caller, threadId, ttl + LOCK_EXTENSION_TIME_IN_MILLIS)) {
+        if (!container.txnLock(dataKey, caller, threadId, getCallId(), ttl + LOCK_EXTENSION_TIME_IN_MILLIS)) {
             throw new TransactionException(
                     "Lock is not owned by the transaction! -> " + container.getLockOwnerInfo(dataKey)
             );

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnRollbackBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnRollbackBackupOperation.java
@@ -41,7 +41,7 @@ public class TxnRollbackBackupOperation extends MultiMapKeyBasedOperation implem
 
     public void run() throws Exception {
         MultiMapContainer container = getOrCreateContainer();
-        if (container.isLocked(dataKey) && !container.unlock(dataKey, caller, threadId)) {
+        if (container.isLocked(dataKey) && !container.unlock(dataKey, caller, threadId, getCallId())) {
             throw new TransactionException(
                     "Lock is not owned by the transaction! -> " + container.getLockOwnerInfo(dataKey)
             );

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnRollbackOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnRollbackOperation.java
@@ -36,7 +36,7 @@ public class TxnRollbackOperation extends MultiMapBackupAwareOperation implement
 
     public void run() throws Exception {
         MultiMapContainer container = getOrCreateContainer();
-        if (container.isLocked(dataKey) && !container.unlock(dataKey, getCallerUuid(), threadId)) {
+        if (container.isLocked(dataKey) && !container.unlock(dataKey, getCallerUuid(), threadId, getCallId())) {
             throw new TransactionException(
                     "Lock is not owned by the transaction! Owner: " + container.getLockOwnerInfo(dataKey)
             );

--- a/hazelcast/src/main/java/com/hazelcast/spi/Operation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/Operation.java
@@ -182,7 +182,11 @@ public abstract class Operation implements DataSerializable {
     // Accessed using OperationAccessor
     final Operation setCallId(long callId) {
         this.callId = callId;
+        onSetCallId();
         return this;
+    }
+
+    protected void onSetCallId() {
     }
 
     public boolean validatesTarget() {

--- a/hazelcast/src/main/java/com/hazelcast/spi/Operation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/Operation.java
@@ -186,6 +186,18 @@ public abstract class Operation implements DataSerializable {
         return this;
     }
 
+    /**
+     * This method is called every time a new <tt>callId</tt> is set to the operation.
+     * A new <tt>callId</tt> is set to an operation before initial invocation
+     * and before every invocation retry.
+     * <p/>
+     * By default this is a no-op method. Operation implementations which are willing to
+     * get notified on <tt>callId</tt> changes can override this method. New <tt>callId</tt>
+     * can be accessed by calling {@link #getCallId()}.
+     * <p/>
+     * For example an operation can distinguish the first invocation and invocation retries by keeping
+     * the initial <tt>callId</tt>.
+     */
     protected void onSetCallId() {
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/lock/LockAdvancedTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/lock/LockAdvancedTest.java
@@ -397,7 +397,7 @@ public class LockAdvancedTest extends HazelcastTestSupport {
         @Override
         public void run() throws Exception {
             LockSupport.parkNanos(TimeUnit.MILLISECONDS.toNanos(1000));
-            getLockStore().lock(key, getCallerUuid(), 1, -1);
+            getLockStore().lock(key, getCallerUuid(), 1, 1, -1);
         }
 
         @Override

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/lock/LockAdvancedTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/lock/LockAdvancedTest.java
@@ -5,6 +5,15 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.HazelcastInstanceNotActiveException;
 import com.hazelcast.core.ILock;
 import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.nio.serialization.impl.DefaultData;
+import com.hazelcast.spi.AbstractOperation;
+import com.hazelcast.spi.ObjectNamespace;
+import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.spi.impl.operationservice.InternalOperationService;
+import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
@@ -13,11 +22,14 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import java.io.IOException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.LockSupport;
 
+import static com.hazelcast.instance.TestUtil.terminateInstance;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -330,6 +342,79 @@ public class LockAdvancedTest extends HazelcastTestSupport {
         sleepMillis(5000);
         t.interrupt();
         assertTrue(latch.await(15, TimeUnit.SECONDS));
+    }
+
+    @Test
+    public void testLockCleanup_whenInvokingMemberDies() {
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(2);
+        HazelcastInstance hz = factory.newHazelcastInstance();
+
+
+        HazelcastInstance hz2 = factory.newHazelcastInstance();
+        NodeEngineImpl nodeEngine = getNodeEngineImpl(hz2);
+        InternalOperationService operationService = getOperationService(hz2);
+        warmUpPartitions(hz2);
+
+        String name = randomNameOwnedBy(hz);
+        Data key = nodeEngine.toData(name);
+        int partitionId = nodeEngine.getPartitionService().getPartitionId(key);
+
+        operationService.invokeOnPartition(LockService.SERVICE_NAME, new SlowLockOperation(name, key, 2000),
+                partitionId);
+
+        sleepMillis(500);
+        terminateInstance(hz2);
+
+        final ILock lock = hz.getLock(name);
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertFalse("Lock owned by dead member should have been released!", lock.isLocked());
+            }
+        }, 30);
+    }
+
+    private static class SlowLockOperation extends AbstractOperation {
+
+        Data key;
+        ObjectNamespace ns;
+        long sleepMillis;
+
+        public SlowLockOperation() {
+        }
+
+        public SlowLockOperation(String name, Data key, long sleepMillis) {
+            this.key = key;
+            this.ns = new InternalLockNamespace(name);
+            this.sleepMillis = sleepMillis;
+        }
+
+        protected final LockStoreImpl getLockStore() {
+            LockServiceImpl service = getService();
+            return service.getLockStore(getPartitionId(), ns);
+        }
+
+        @Override
+        public void run() throws Exception {
+            LockSupport.parkNanos(TimeUnit.MILLISECONDS.toNanos(1000));
+            getLockStore().lock(key, getCallerUuid(), 1, -1);
+        }
+
+        @Override
+        protected void writeInternal(ObjectDataOutput out) throws IOException {
+            super.writeInternal(out);
+            out.writeLong(sleepMillis);
+            out.writeByteArray(key.toByteArray());
+            out.writeUTF(ns.getObjectName());
+        }
+
+        @Override
+        protected void readInternal(ObjectDataInput in) throws IOException {
+            super.readInternal(in);
+            sleepMillis = in.readLong();
+            key = new DefaultData(in.readByteArray());
+            ns = new InternalLockNamespace(in.readUTF());
+        }
     }
 
 }


### PR DESCRIPTION
Added "reference-call-id" to lock operation to provide operation retry idempotence. When a member crashes after processing a lock request and sending its backup, caller will retry the lock operation. If it happens that backup member already processed the lock request, then caller will acquire lock resource 2nd time (because it's reentrant) unintentionally. When it releases the lock only once, lock will hang infinitely. To avoid that, now lock operation and lock service always keep the original/reference call-id for a specific lock resource and if it's tried to be acquired multiple times with the same reference-call-id, lock request will just return success instead of processing it again.

PS: _note that client side requests are not covered here, clients have their own retry logic._

Depends on #5601
Extracted from #5246