### PR TITLE
Introduced lock max lease time

### DIFF
--- a/hazelcast-client-new/src/test/java/com/hazelcast/client/lock/ClientLockTest.java
+++ b/hazelcast-client-new/src/test/java/com/hazelcast/client/lock/ClientLockTest.java
@@ -17,14 +17,15 @@
 package com.hazelcast.client.lock;
 
 import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.ILock;
+import com.hazelcast.instance.GroupProperties;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -40,24 +41,19 @@ import static org.junit.Assert.assertTrue;
 @Category(QuickTest.class)
 public class ClientLockTest extends HazelcastTestSupport {
 
-    private final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
-    private ILock lock;
-
-    @Before
-    public void setup() {
-        hazelcastFactory.newHazelcastInstance();
-        HazelcastInstance client = hazelcastFactory.newHazelcastClient();
-        lock = client.getLock(randomString());
-    }
+    private TestHazelcastFactory factory = new TestHazelcastFactory();
 
     @After
-    public void tearDown() {
-        lock.forceUnlock();
-        hazelcastFactory.terminateAll();
+    public void teardown() {
+        factory.terminateAll();
     }
 
     @Test
     public void testLock() throws Exception {
+        factory.newHazelcastInstance();
+        HazelcastInstance hz = factory.newHazelcastClient();
+        final ILock lock = hz.getLock(randomName());
+
         lock.lock();
         final CountDownLatch latch = new CountDownLatch(1);
         new Thread() {
@@ -73,6 +69,10 @@ public class ClientLockTest extends HazelcastTestSupport {
 
     @Test
     public void testLockTtl() throws Exception {
+        factory.newHazelcastInstance();
+        HazelcastInstance hz = factory.newHazelcastClient();
+        final ILock lock = hz.getLock(randomName());
+
         lock.lock(3, TimeUnit.SECONDS);
         final CountDownLatch latch = new CountDownLatch(2);
         new Thread() {
@@ -95,6 +95,9 @@ public class ClientLockTest extends HazelcastTestSupport {
 
     @Test
     public void testTryLock() throws Exception {
+        factory.newHazelcastInstance();
+        HazelcastInstance hz = factory.newHazelcastClient();
+        final ILock lock = hz.getLock(randomName());
 
         assertTrue(lock.tryLock(2, TimeUnit.SECONDS));
         final CountDownLatch latch = new CountDownLatch(1);
@@ -135,14 +138,19 @@ public class ClientLockTest extends HazelcastTestSupport {
 
     @Test
     public void testTryLockwithZeroTTL() throws Exception {
+        factory.newHazelcastInstance();
+        HazelcastInstance hz = factory.newHazelcastClient();
+        final ILock lock = hz.getLock(randomName());
 
         boolean lockWithZeroTTL = lock.tryLock(0, TimeUnit.SECONDS);
         assertTrue(lockWithZeroTTL);
-
     }
 
     @Test
     public void testTryLockwithZeroTTLWithExistingLock() throws Exception {
+        factory.newHazelcastInstance();
+        HazelcastInstance hz = factory.newHazelcastClient();
+        final ILock lock = hz.getLock(randomName());
 
         lock.lock();
         final CountDownLatch latch = new CountDownLatch(1);
@@ -158,12 +166,14 @@ public class ClientLockTest extends HazelcastTestSupport {
         }.start();
         assertOpenEventually(latch);
         lock.forceUnlock();
-
     }
-
 
     @Test
     public void testForceUnlock() throws Exception {
+        factory.newHazelcastInstance();
+        HazelcastInstance hz = factory.newHazelcastClient();
+        final ILock lock = hz.getLock(randomName());
+
         lock.lock();
         final CountDownLatch latch = new CountDownLatch(1);
         new Thread() {
@@ -178,6 +188,10 @@ public class ClientLockTest extends HazelcastTestSupport {
 
     @Test
     public void testStats() throws InterruptedException {
+        factory.newHazelcastInstance();
+        HazelcastInstance hz = factory.newHazelcastClient();
+        final ILock lock = hz.getLock(randomName());
+
         lock.lock();
         assertTrue(lock.isLocked());
         assertTrue(lock.isLockedByCurrentThread());
@@ -208,14 +222,16 @@ public class ClientLockTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void testObtainLock_FromDiffClients() throws InterruptedException {
+    public void testObtainLock_FromDifferentClients() throws InterruptedException {
+        factory.newHazelcastInstance();
+        String name = randomName();
 
-        HazelcastInstance clientA = hazelcastFactory.newHazelcastClient();
-        ILock lockA = clientA.getLock(lock.getName());
+        HazelcastInstance clientA = factory.newHazelcastClient();
+        ILock lockA = clientA.getLock(name);
         lockA.lock();
 
-        HazelcastInstance clientB = hazelcastFactory.newHazelcastClient();
-        ILock lockB = clientB.getLock(lock.getName());
+        HazelcastInstance clientB = factory.newHazelcastClient();
+        ILock lockB = clientB.getLock(name);
         boolean lockObtained = lockB.tryLock();
 
         assertFalse("Lock obtained by 2 client ", lockObtained);
@@ -223,12 +239,20 @@ public class ClientLockTest extends HazelcastTestSupport {
 
     @Test(timeout = 60000)
     public void testTryLockLeaseTime_whenLockFree() throws InterruptedException {
+        factory.newHazelcastInstance();
+        HazelcastInstance hz = factory.newHazelcastClient();
+        final ILock lock = hz.getLock(randomName());
+
         boolean isLocked = lock.tryLock(1000, TimeUnit.MILLISECONDS, 1000, TimeUnit.MILLISECONDS);
         assertTrue(isLocked);
     }
 
     @Test(timeout = 60000)
     public void testTryLockLeaseTime_whenLockAcquiredByOther() throws InterruptedException {
+        factory.newHazelcastInstance();
+        HazelcastInstance hz = factory.newHazelcastClient();
+        final ILock lock = hz.getLock(randomName());
+
         Thread thread = new Thread() {
             public void run() {
                 lock.lock();
@@ -243,6 +267,10 @@ public class ClientLockTest extends HazelcastTestSupport {
 
     @Test
     public void testTryLockLeaseTime_lockIsReleasedEventually() throws InterruptedException {
+        factory.newHazelcastInstance();
+        HazelcastInstance hz = factory.newHazelcastClient();
+        final ILock lock = hz.getLock(randomName());
+
         lock.tryLock(1000, TimeUnit.MILLISECONDS, 1000, TimeUnit.MILLISECONDS);
         assertTrueEventually(new AssertTask() {
             @Override
@@ -250,5 +278,38 @@ public class ClientLockTest extends HazelcastTestSupport {
                 assertFalse(lock.isLocked());
             }
         }, 30);
+    }
+
+    @Test
+    public void testMaxLockLeaseTime() {
+        Config config = new Config();
+        config.setProperty(GroupProperties.PROP_LOCK_MAX_LEASE_TIME_SECONDS, "1");
+
+        factory.newHazelcastInstance(config);
+
+        HazelcastInstance hz = factory.newHazelcastClient();
+        final ILock lock = hz.getLock(randomName());
+
+        lock.lock();
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertFalse("Lock should be released after lease expires!", lock.isLocked());
+            }
+        }, 30);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testLockFail_whenGreaterThanMaxLeaseTimeUsed() {
+        Config config = new Config();
+        config.setProperty(GroupProperties.PROP_LOCK_MAX_LEASE_TIME_SECONDS, "1");
+
+        factory.newHazelcastInstance(config);
+
+        HazelcastInstance hz = factory.newHazelcastClient();
+        ILock lock = hz.getLock(randomName());
+
+        lock.lock(10, TimeUnit.SECONDS);
     }
 }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientLockProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientLockProxy.java
@@ -84,11 +84,12 @@ public class ClientLockProxy extends ClientProxy implements ILock {
     }
 
     public void lock() {
-        lock(Long.MAX_VALUE, null);
+        LockRequest request = new LockRequest(getKeyData(), ThreadUtil.getThreadId(), -1, -1);
+        invoke(request);
     }
 
     public void lockInterruptibly() throws InterruptedException {
-        LockRequest request = new LockRequest(getKeyData(), ThreadUtil.getThreadId(), Long.MAX_VALUE, -1);
+        LockRequest request = new LockRequest(getKeyData(), ThreadUtil.getThreadId(), -1, -1);
         invokeInterruptibly(request, getKeyData());
     }
 
@@ -101,7 +102,7 @@ public class ClientLockProxy extends ClientProxy implements ILock {
     }
 
     public boolean tryLock(long timeout, TimeUnit unit) throws InterruptedException {
-        return tryLock(timeout, unit, Long.MAX_VALUE, null);
+        return tryLock(timeout, unit, -1, null);
     }
 
     @Override

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
@@ -470,7 +470,7 @@ public class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V> {
 
     @Override
     public boolean tryLock(K key, long time, TimeUnit timeunit) throws InterruptedException {
-        return tryLock(key, time, timeunit, Long.MAX_VALUE, null);
+        return tryLock(key, time, timeunit, -1, null);
     }
 
     @Override

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMultiMapProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMultiMapProxy.java
@@ -271,7 +271,7 @@ public class ClientMultiMapProxy<K, V> extends ClientProxy implements MultiMap<K
 
     @Override
     public boolean tryLock(K key, long time, TimeUnit timeunit) throws InterruptedException {
-        return tryLock(key, time, timeunit, Long.MAX_VALUE, null);
+        return tryLock(key, time, timeunit, -1, null);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/lock/LockLockMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/lock/LockLockMessageTask.java
@@ -41,7 +41,7 @@ public class LockLockMessageTask
 
     @Override
     protected Operation prepareOperation() {
-        final Data key = serializationService.toData(parameters.name);
+        Data key = serializationService.toData(parameters.name);
         return new LockOperation(new InternalLockNamespace(parameters.name)
                 , key, parameters.threadId, parameters.leaseTime, -1);
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/lock/LockTryLockMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/lock/LockTryLockMessageTask.java
@@ -41,7 +41,7 @@ public class LockTryLockMessageTask
 
     @Override
     protected Operation prepareOperation() {
-        final Data key = serializationService.toData(parameters.name);
+        Data key = serializationService.toData(parameters.name);
         return new LockOperation(new InternalLockNamespace(parameters.name)
                 , key, parameters.threadId, parameters.lease, parameters.timeout);
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapTryLockMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapTryLockMessageTask.java
@@ -56,7 +56,6 @@ public class MapTryLockMessageTask
         return MapTryLockCodec.encodeResponse((Boolean) response);
     }
 
-
     @Override
     public String getServiceName() {
         return LockService.SERVICE_NAME;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapLockMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapLockMessageTask.java
@@ -45,8 +45,12 @@ public class MultiMapLockMessageTask
 
     @Override
     protected Operation prepareOperation() {
-        DefaultObjectNamespace namespace = new DefaultObjectNamespace(MultiMapService.SERVICE_NAME, parameters.name);
+        DefaultObjectNamespace namespace = getNamespace();
         return new LockOperation(namespace, parameters.key, parameters.threadId, parameters.ttl, -1);
+    }
+
+    private DefaultObjectNamespace getNamespace() {
+        return new DefaultObjectNamespace(MultiMapService.SERVICE_NAME, parameters.name);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockProxy.java
@@ -42,7 +42,7 @@ public class LockProxy extends AbstractDistributedObject<LockServiceImpl> implem
         super(nodeEngine, lockService);
         this.name = name;
         this.key = getNameAsPartitionAwareData();
-        this.lockSupport = new LockProxySupport(new InternalLockNamespace(name));
+        this.lockSupport = new LockProxySupport(new InternalLockNamespace(name), lockService.getMaxLeaseTimeInMillis());
         this.partitionId = getNodeEngine().getPartitionService().getPartitionId(key);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockResource.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockResource.java
@@ -39,4 +39,6 @@ public interface LockResource {
     long getRemainingLeaseTime();
 
     long getExpirationTime();
+
+    int getVersion();
 }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockResourceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockResourceImpl.java
@@ -295,7 +295,10 @@ final class LockResourceImpl implements DataSerializable, LockResource {
 
     @Override
     public long getRemainingLeaseTime() {
-        if (expirationTime == Long.MAX_VALUE || expirationTime < 0) {
+        if (!isLocked()) {
+            return -1L;
+        }
+        if (expirationTime < 0) {
             return Long.MAX_VALUE;
         }
         long now = Clock.currentTimeMillis();
@@ -310,7 +313,8 @@ final class LockResourceImpl implements DataSerializable, LockResource {
         return expirationTime;
     }
 
-    int getVersion() {
+    @Override
+    public int getVersion() {
         return version;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockService.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockService.java
@@ -34,4 +34,6 @@ public interface LockService extends SharedService {
     void clearLockStore(int partitionId, ObjectNamespace namespace);
 
     Collection<LockResource> getAllLocks();
+
+    long getMaxLeaseTimeInMillis();
 }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockServiceImpl.java
@@ -20,6 +20,7 @@ import com.hazelcast.concurrent.lock.operations.LocalLockCleanupOperation;
 import com.hazelcast.concurrent.lock.operations.LockReplicationOperation;
 import com.hazelcast.concurrent.lock.operations.UnlockOperation;
 import com.hazelcast.core.DistributedObject;
+import com.hazelcast.instance.GroupProperties;
 import com.hazelcast.instance.MemberImpl;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.partition.MigrationEndpoint;
@@ -50,6 +51,7 @@ import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.spi.impl.OperationResponseHandlerFactory.createEmptyResponseHandler;
 import static com.hazelcast.util.ConcurrencyUtil.getOrPutSynchronized;
@@ -75,12 +77,22 @@ public final class LockServiceImpl implements LockService, ManagedService, Remot
                 }
             };
 
+    private final long maxLeaseTimeInMillis;
+
     public LockServiceImpl(NodeEngine nodeEngine) {
         this.nodeEngine = nodeEngine;
         this.containers = new LockStoreContainer[nodeEngine.getPartitionService().getPartitionCount()];
         for (int i = 0; i < containers.length; i++) {
             containers[i] = new LockStoreContainer(this, i);
         }
+
+        maxLeaseTimeInMillis = getMaxLeaseTimeInMillis(nodeEngine.getGroupProperties());
+    }
+
+    public static long getMaxLeaseTimeInMillis(GroupProperties groupProperties) {
+        long maxLeaseTime = groupProperties.LOCK_MAX_LEASE_TIME_SECONDS.getLong();
+        maxLeaseTime = TimeUnit.SECONDS.toMillis(maxLeaseTime);
+        return maxLeaseTime;
     }
 
     @Override
@@ -116,6 +128,11 @@ public final class LockServiceImpl implements LockService, ManagedService, Remot
         for (LockStoreContainer container : containers) {
             container.clear();
         }
+    }
+
+    @Override
+    public long getMaxLeaseTimeInMillis() {
+        return maxLeaseTimeInMillis;
     }
 
     @Override
@@ -278,7 +295,7 @@ public final class LockServiceImpl implements LockService, ManagedService, Remot
                 }
 
                 long leaseTime = expirationTime - now;
-                scheduleEviction(ls.getNamespace(), lock.getKey(), 0, leaseTime);
+                scheduleEviction(ls.getNamespace(), lock.getKey(), lock.getVersion(), leaseTime);
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockStoreImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockStoreImpl.java
@@ -62,8 +62,21 @@ public final class LockStoreImpl implements DataSerializable, LockStore {
 
     @Override
     public boolean lock(Data key, String caller, long threadId, long referenceId, long leaseTime) {
+        leaseTime = getLeaseTime(leaseTime);
         LockResourceImpl lock = getLock(key);
         return lock.lock(caller, threadId, referenceId, leaseTime, false);
+    }
+
+    private long getLeaseTime(long leaseTime) {
+        long maxLeaseTimeInMillis = lockService.getMaxLeaseTimeInMillis();
+        if (leaseTime > maxLeaseTimeInMillis) {
+            throw new IllegalArgumentException("Max allowed lease time: " + maxLeaseTimeInMillis + "ms. "
+                    + "Given lease time: " + leaseTime + "ms.");
+        }
+        if (leaseTime < 0) {
+            leaseTime = maxLeaseTimeInMillis;
+        }
+        return leaseTime;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockStoreProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockStoreProxy.java
@@ -33,21 +33,21 @@ public final class LockStoreProxy implements LockStore {
     }
 
     @Override
-    public boolean lock(Data key, String caller, long threadId, long referenceId, long ttl) {
+    public boolean lock(Data key, String caller, long threadId, long referenceId, long leaseTime) {
         LockStore lockStore = getLockStoreOrNull();
-        return lockStore != null && lockStore.lock(key, caller, threadId, referenceId, ttl);
+        return lockStore != null && lockStore.lock(key, caller, threadId, referenceId, leaseTime);
     }
 
     @Override
-    public boolean txnLock(Data key, String caller, long threadId, long referenceId, long ttl) {
+    public boolean txnLock(Data key, String caller, long threadId, long referenceId, long leaseTime) {
         LockStore lockStore = getLockStoreOrNull();
-        return lockStore != null && lockStore.txnLock(key, caller, threadId, referenceId, ttl);
+        return lockStore != null && lockStore.txnLock(key, caller, threadId, referenceId, leaseTime);
     }
 
     @Override
-    public boolean extendLeaseTime(Data key, String caller, long threadId, long ttl) {
+    public boolean extendLeaseTime(Data key, String caller, long threadId, long leaseTime) {
         LockStore lockStore = getLockStoreOrNull();
-        return lockStore != null && lockStore.extendLeaseTime(key, caller, threadId, ttl);
+        return lockStore != null && lockStore.extendLeaseTime(key, caller, threadId, leaseTime);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/AwaitBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/AwaitBackupOperation.java
@@ -46,7 +46,7 @@ public class AwaitBackupOperation extends BaseLockOperation
     @Override
     public void run() throws Exception {
         LockStoreImpl lockStore = getLockStore();
-        lockStore.lock(key, originalCaller, threadId, getReferenceCallId(), -1L);
+        lockStore.lock(key, originalCaller, threadId, getReferenceCallId(), leaseTime);
         ConditionKey conditionKey = new ConditionKey(namespace.getObjectName(), key, conditionId);
         lockStore.removeSignalKey(conditionKey);
         lockStore.removeAwait(key, conditionId, originalCaller, threadId);

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/AwaitOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/AwaitOperation.java
@@ -54,7 +54,7 @@ public class AwaitOperation extends BaseLockOperation
     @Override
     public void run() throws Exception {
         LockStoreImpl lockStore = getLockStore();
-        if (!lockStore.lock(key, getCallerUuid(), threadId, getReferenceCallId(), -1L)) {
+        if (!lockStore.lock(key, getCallerUuid(), threadId, getReferenceCallId(), leaseTime)) {
             throw new IllegalMonitorStateException(
                     "Current thread is not owner of the lock! -> " + lockStore.getOwnerInfo(key));
         }
@@ -108,7 +108,7 @@ public class AwaitOperation extends BaseLockOperation
         lockStore.removeSignalKey(getWaitKey());
         lockStore.removeAwait(key, conditionId, getCallerUuid(), threadId);
 
-        boolean locked = lockStore.lock(key, getCallerUuid(), threadId, getReferenceCallId(), -1L);
+        boolean locked = lockStore.lock(key, getCallerUuid(), threadId, getReferenceCallId(), leaseTime);
         if (locked) {
             // expired & acquired lock, send FALSE
             sendResponse(false);

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/BaseLockOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/BaseLockOperation.java
@@ -32,13 +32,12 @@ import java.io.IOException;
 public abstract class BaseLockOperation extends AbstractOperation
         implements PartitionAwareOperation, IdentifiedDataSerializable {
 
-    public static final long DEFAULT_LOCK_TTL = Long.MAX_VALUE;
     public static final int ANY_THREAD = 0;
 
     protected ObjectNamespace namespace;
     protected Data key;
     protected long threadId;
-    protected long ttl = DEFAULT_LOCK_TTL;
+    protected long leaseTime = -1L;
     protected transient Object response;
     private transient boolean asyncBackup;
     private long referenceCallId;
@@ -59,11 +58,11 @@ public abstract class BaseLockOperation extends AbstractOperation
         setWaitTimeout(timeout);
     }
 
-    public BaseLockOperation(ObjectNamespace namespace, Data key, long threadId, long ttl, long timeout) {
+    public BaseLockOperation(ObjectNamespace namespace, Data key, long threadId, long leaseTime, long timeout) {
         this.namespace = namespace;
         this.key = key;
         this.threadId = threadId;
-        this.ttl = ttl;
+        this.leaseTime = leaseTime;
         setWaitTimeout(timeout);
     }
 
@@ -133,7 +132,7 @@ public abstract class BaseLockOperation extends AbstractOperation
         out.writeObject(namespace);
         out.writeData(key);
         out.writeLong(threadId);
-        out.writeLong(ttl);
+        out.writeLong(leaseTime);
         out.writeLong(referenceCallId);
     }
 
@@ -143,7 +142,7 @@ public abstract class BaseLockOperation extends AbstractOperation
         namespace = in.readObject();
         key = in.readData();
         threadId = in.readLong();
-        ttl = in.readLong();
+        leaseTime = in.readLong();
         referenceCallId = in.readLong();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/LockBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/LockBackupOperation.java
@@ -33,15 +33,16 @@ public class LockBackupOperation extends BaseLockOperation implements BackupOper
     public LockBackupOperation() {
     }
 
-    public LockBackupOperation(ObjectNamespace namespace, Data key, long threadId, String originalCallerUuid) {
+    public LockBackupOperation(ObjectNamespace namespace, Data key, long threadId, long leaseTime, String originalCallerUuid) {
         super(namespace, key, threadId);
+        this.leaseTime = leaseTime;
         this.originalCallerUuid = originalCallerUuid;
     }
 
     @Override
     public void run() throws Exception {
         LockStoreImpl lockStore = getLockStore();
-        response = lockStore.lock(key, originalCallerUuid, threadId, getReferenceCallId(), ttl);
+        response = lockStore.lock(key, originalCallerUuid, threadId, getReferenceCallId(), leaseTime);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/LockOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/LockOperation.java
@@ -32,18 +32,18 @@ public class LockOperation extends BaseLockOperation implements WaitSupport, Bac
     public LockOperation() {
     }
 
-    public LockOperation(ObjectNamespace namespace, Data key, long threadId, long ttl, long timeout) {
-        super(namespace, key, threadId, ttl, timeout);
+    public LockOperation(ObjectNamespace namespace, Data key, long threadId, long leaseTime, long timeout) {
+        super(namespace, key, threadId, leaseTime, timeout);
     }
 
     @Override
     public void run() throws Exception {
-        response = getLockStore().lock(key, getCallerUuid(), threadId, getReferenceCallId(), ttl);
+        response = getLockStore().lock(key, getCallerUuid(), threadId, getReferenceCallId(), leaseTime);
     }
 
     @Override
     public Operation getBackupOperation() {
-        LockBackupOperation operation = new LockBackupOperation(namespace, key, threadId, getCallerUuid());
+        LockBackupOperation operation = new LockBackupOperation(namespace, key, threadId, leaseTime, getCallerUuid());
         operation.setReferenceCallId(getReferenceCallId());
         return operation;
     }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/UnlockIfLeaseExpiredOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/UnlockIfLeaseExpiredOperation.java
@@ -38,10 +38,13 @@ public final class UnlockIfLeaseExpiredOperation extends UnlockOperation {
     public void run() throws Exception {
         LockStoreImpl lockStore = getLockStore();
         int lockVersion = lockStore.getVersion(key);
+        ILogger logger = getLogger();
         if (version == lockVersion) {
+            if (logger.isFinestEnabled()) {
+                logger.finest("Releasing a lock owned by " + lockStore.getOwnerInfo(key) + " after lease timeout!");
+            }
             forceUnlock();
         } else {
-            ILogger logger = getLogger();
             if (logger.isFinestEnabled()) {
                 logger.finest("Won't unlock since lock version is not matching expiration version: "
                         + lockVersion + " vs " + version);

--- a/hazelcast/src/main/java/com/hazelcast/instance/GroupProperties.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/GroupProperties.java
@@ -249,6 +249,7 @@ public class GroupProperties {
     public static final String PROP_PARTITIONING_STRATEGY_CLASS = "hazelcast.partitioning.strategy.class";
     public static final String PROP_GRACEFUL_SHUTDOWN_MAX_WAIT = "hazelcast.graceful.shutdown.max.wait";
     public static final String PROP_SYSTEM_LOG_ENABLED = "hazelcast.system.log.enabled";
+    public static final String PROP_LOCK_MAX_LEASE_TIME_SECONDS = "hazelcast.lock.max.lease.time.seconds";
 
     /**
      * Enables or disables the {@link com.hazelcast.spi.impl.operationexecutor.slowoperationdetector.SlowOperationDetector}.
@@ -645,6 +646,8 @@ public class GroupProperties {
 
     public final GroupProperty SLOW_INVOCATION_DETECTOR_THRESHOLD_MILLIS;
 
+    public final GroupProperty LOCK_MAX_LEASE_TIME_SECONDS;
+
     public final GroupProperty ELASTIC_MEMORY_ENABLED;
 
     public final GroupProperty ELASTIC_MEMORY_TOTAL_SIZE;
@@ -798,6 +801,9 @@ public class GroupProperties {
                 = new GroupProperty(config, PROP_SLOW_OPERATION_DETECTOR_STACK_TRACE_LOGGING_ENABLED, "false");
         SLOW_INVOCATION_DETECTOR_THRESHOLD_MILLIS
                 = new GroupProperty(config, PROP_SLOW_INVOCATION_DETECTOR_THRESHOLD_MILLIS, "-1");
+
+        LOCK_MAX_LEASE_TIME_SECONDS = new GroupProperty(config, PROP_LOCK_MAX_LEASE_TIME_SECONDS,
+                Long.toString(Long.MAX_VALUE));
 
         ELASTIC_MEMORY_ENABLED = new GroupProperty(config, PROP_ELASTIC_MEMORY_ENABLED, "false");
         ELASTIC_MEMORY_TOTAL_SIZE = new GroupProperty(config, PROP_ELASTIC_MEMORY_TOTAL_SIZE, "128M");

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
@@ -17,6 +17,7 @@
 package com.hazelcast.map.impl.proxy;
 
 import com.hazelcast.concurrent.lock.LockProxySupport;
+import com.hazelcast.concurrent.lock.LockServiceImpl;
 import com.hazelcast.config.EntryListenerConfig;
 import com.hazelcast.config.ListenerConfig;
 import com.hazelcast.config.MapConfig;
@@ -154,7 +155,9 @@ abstract class MapProxySupport extends AbstractDistributedObject<MapService> imp
         partitionStrategy = mapServiceContext.getMapContainer(name).getPartitioningStrategy();
         localMapStats = mapServiceContext.getLocalMapStatsProvider().getLocalMapStatsImpl(name);
         this.partitionService = getNodeEngine().getPartitionService();
-        lockSupport = new LockProxySupport(new DefaultObjectNamespace(MapService.SERVICE_NAME, name));
+
+        lockSupport = new LockProxySupport(new DefaultObjectNamespace(MapService.SERVICE_NAME, name),
+                    LockServiceImpl.getMaxLeaseTimeInMillis(nodeEngine.getGroupProperties()));
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapProxySupport.java
@@ -17,8 +17,10 @@
 package com.hazelcast.multimap.impl;
 
 import com.hazelcast.concurrent.lock.LockProxySupport;
+import com.hazelcast.concurrent.lock.LockServiceImpl;
 import com.hazelcast.config.MultiMapConfig;
 import com.hazelcast.core.EntryEventType;
+import com.hazelcast.map.impl.MapService;
 import com.hazelcast.multimap.impl.operations.CountOperation;
 import com.hazelcast.multimap.impl.operations.GetAllOperation;
 import com.hazelcast.multimap.impl.operations.MultiMapOperationFactory;
@@ -34,6 +36,7 @@ import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.util.ExceptionUtil;
 import com.hazelcast.util.ThreadUtil;
+
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -49,7 +52,9 @@ public abstract class MultiMapProxySupport extends AbstractDistributedObject<Mul
         super(nodeEngine, service);
         this.config = nodeEngine.getConfig().findMultiMapConfig(name);
         this.name = name;
-        lockSupport = new LockProxySupport(new DefaultObjectNamespace(MultiMapService.SERVICE_NAME, name));
+
+        lockSupport = new LockProxySupport(new DefaultObjectNamespace(MapService.SERVICE_NAME, name),
+                LockServiceImpl.getMaxLeaseTimeInMillis(nodeEngine.getGroupProperties()));
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapProxySupport.java
@@ -20,7 +20,6 @@ import com.hazelcast.concurrent.lock.LockProxySupport;
 import com.hazelcast.concurrent.lock.LockServiceImpl;
 import com.hazelcast.config.MultiMapConfig;
 import com.hazelcast.core.EntryEventType;
-import com.hazelcast.map.impl.MapService;
 import com.hazelcast.multimap.impl.operations.CountOperation;
 import com.hazelcast.multimap.impl.operations.GetAllOperation;
 import com.hazelcast.multimap.impl.operations.MultiMapOperationFactory;
@@ -53,7 +52,7 @@ public abstract class MultiMapProxySupport extends AbstractDistributedObject<Mul
         this.config = nodeEngine.getConfig().findMultiMapConfig(name);
         this.name = name;
 
-        lockSupport = new LockProxySupport(new DefaultObjectNamespace(MapService.SERVICE_NAME, name),
+        lockSupport = new LockProxySupport(new DefaultObjectNamespace(MultiMapService.SERVICE_NAME, name),
                 LockServiceImpl.getMaxLeaseTimeInMillis(nodeEngine.getGroupProperties()));
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/multimap/MultiMapLockTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/multimap/MultiMapLockTest.java
@@ -19,6 +19,7 @@ package com.hazelcast.multimap;
 import com.hazelcast.concurrent.lock.LockService;
 import com.hazelcast.concurrent.lock.LockServiceImpl;
 import com.hazelcast.concurrent.lock.LockStoreContainer;
+import com.hazelcast.concurrent.lock.LockStoreImpl;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.MultiMapConfig;
 import com.hazelcast.core.HazelcastInstance;
@@ -34,6 +35,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import java.util.Collection;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -153,7 +155,8 @@ public class MultiMapLockTest extends HazelcastTestSupport {
         int partitionCount = nodeEngine.getPartitionService().getPartitionCount();
         for (int i = 0; i < partitionCount; i++) {
             LockStoreContainer lockContainer = lockService.getLockContainer(i);
-            assertEquals("LockStores should be empty", 0, lockContainer.getLockStores().size());
+            Collection<LockStoreImpl> lockStores = lockContainer.getLockStores();
+            assertEquals("LockStores should be empty: " + lockStores, 0, lockStores.size());
         }
     }
 


### PR DESCRIPTION
- Introduced max-lease-time (default is Long.MAX_VALUE seconds) for locks. When lock is acquired without an explicit lease-time then max-lease-time setting will be used. Caller can use a lower value but not a greater one. When a greater lease-time is given, invocation/operation will fail immediately.

- Fixed a bug which lease-time is not set correctly on backups and when backup is promoted, lease handling process doesn't kicks in.

Depends on #5601 and #5602
Extracted from #5246