### PR TITLE
Fixes/Improvements in ClusterServiceImpl.merge()

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/instance/Node.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/Node.java
@@ -36,7 +36,6 @@ import com.hazelcast.core.HazelcastInstanceAware;
 import com.hazelcast.core.LifecycleListener;
 import com.hazelcast.core.MembershipListener;
 import com.hazelcast.core.MigrationListener;
-import com.hazelcast.partition.PartitionLostListener;
 import com.hazelcast.internal.ascii.TextCommandService;
 import com.hazelcast.internal.ascii.TextCommandServiceImpl;
 import com.hazelcast.internal.management.ManagementCenterService;
@@ -48,6 +47,7 @@ import com.hazelcast.nio.ConnectionManager;
 import com.hazelcast.nio.Packet;
 import com.hazelcast.nio.serialization.SerializationService;
 import com.hazelcast.partition.InternalPartitionService;
+import com.hazelcast.partition.PartitionLostListener;
 import com.hazelcast.partition.impl.InternalPartitionServiceImpl;
 import com.hazelcast.security.Credentials;
 import com.hazelcast.security.SecurityContext;
@@ -378,7 +378,15 @@ public class Node {
         }
     }
 
-    public void onRestart() {
+    /**
+     * Resets the internal cluster-state of the Node to be able to make it ready to join a new cluster.
+     * After this method is called,
+     * a new join process can be triggered by calling {@link #rejoin()}.
+     * <p/>
+     * This method is called during merge process after a split-brain is detected.
+     */
+    public void reset() {
+        setMasterAddress(null);
         joined.set(false);
         joiner.reset();
         final String uuid = createMemberUuid(address);

--- a/hazelcast/src/main/java/com/hazelcast/nio/ConnectionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/ConnectionManager.java
@@ -39,11 +39,35 @@ public interface ConnectionManager {
 
     void destroyConnection(Connection conn);
 
-    void shutdown();
-
+    /**
+     * Starts ConnectionManager, initializes its resources, starts threads etc.
+     * After start ConnectionManager becomes fully operational.
+     * <p/>
+     * If it's already started, then this method has no effect.
+     *
+     * @throws IllegalStateException if ConnectionManager is shutdown
+     */
     void start();
 
-    void restart();
+    /**
+     * Stops ConnectionManager, releases its resources, stops threads etc.
+     * When stopped ConnectionManager can be started again using {@link #start()}.
+     * <p/>
+     * This method has no effect if it's already stopped or shutdown.
+     * <p/>
+     * Currently <tt>stop</tt> is called during merge process
+     * to detach node from current cluster. After node becomes ready to join to
+     * the new cluster, <tt>start</tt> is called to re-initialize the ConnectionManager.
+     */
+    void stop();
+
+    /**
+     * Shutdowns ConnectionManager completely. ConnectionManager won't be operational anymore and
+     * cannot be restarted.
+     * <p/>
+     * This method has no effect if it's already shutdown.
+     */
+    void shutdown();
 
     void addConnectionListener(ConnectionListener connectionListener);
 }

--- a/hazelcast/src/main/java/com/hazelcast/nio/NodeIOService.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/NodeIOService.java
@@ -17,7 +17,6 @@
 package com.hazelcast.nio;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
-import com.hazelcast.internal.ascii.TextCommandService;
 import com.hazelcast.config.NetworkConfig;
 import com.hazelcast.config.SSLConfig;
 import com.hazelcast.config.SocketInterceptorConfig;
@@ -27,6 +26,7 @@ import com.hazelcast.instance.MemberImpl;
 import com.hazelcast.instance.Node;
 import com.hazelcast.instance.OutOfMemoryErrorDispatcher;
 import com.hazelcast.internal.metrics.MetricsRegistry;
+import com.hazelcast.internal.ascii.TextCommandService;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.SerializationService;

--- a/hazelcast/src/test/java/com/hazelcast/test/TestNodeRegistry.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/TestNodeRegistry.java
@@ -251,7 +251,8 @@ public final class TestNodeRegistry {
             }
         }
 
-        public Connection getConnection(Address address) {
+      @Override
+      public Connection getConnection(Address address) {
             MockConnection conn = mapConnections.get(address);
             if (conn == null) {
                 NodeEngineImpl nodeEngine = nodes.get(address);
@@ -264,14 +265,17 @@ public final class TestNodeRegistry {
             return conn;
         }
 
+        @Override
         public Connection getOrConnect(Address address) {
             return getConnection(address);
         }
 
+        @Override
         public Connection getOrConnect(Address address, boolean silent) {
             return getConnection(address);
         }
 
+        @Override
         public void shutdown() {
             for (Address address : nodes.keySet()) {
                 if (address.equals(node.getThisAddress())) continue;
@@ -307,9 +311,11 @@ public final class TestNodeRegistry {
             return true;
         }
 
+        @Override
         public void start() {
         }
 
+        @Override
         public void addConnectionListener(ConnectionListener connectionListener) {
             connectionListeners.add(connectionListener);
         }
@@ -331,8 +337,8 @@ public final class TestNodeRegistry {
             });
         }
 
-
-        public void restart() {
+        @Override
+        public void stop() {
         }
 
         @Override
@@ -340,6 +346,7 @@ public final class TestNodeRegistry {
             return 0;
         }
 
+        @Override
         public int getCurrentClientConnections() {
             return 0;
         }
@@ -349,6 +356,7 @@ public final class TestNodeRegistry {
             return 0;
         }
 
+        @Override
         public int getAllTextConnections() {
             return 0;
         }


### PR DESCRIPTION
- During split-brain merge process "ClusterServiceImpl.merge()", cluster state should be reset, all connections should be closed and all invocations from current member should be notified to retry. Then after gathering merge-tasks from related services, all services also should be reset. After that connection manager will be started and node will join target cluster. This will make invocations race free during merge process.

- Improved (TCPIP)ConnectionManager to support start and stop instead of one-shot restart and added some javadocs.

Extracted from #5247