### PR TITLE
ResponseThread should not eat exception

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/classic/ResponseThread.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/classic/ResponseThread.java
@@ -96,7 +96,7 @@ public final class ResponseThread extends Thread implements OperationHostileThre
             responsePacketHandler.handle(responsePacket);
         } catch (Throwable e) {
             inspectOutputMemoryError(e);
-            logger.severe("Failed to process response: " + responsePacket + " on response thread:" + getName());
+            logger.severe("Failed to process response: " + responsePacket + " on response thread:" + getName(), e);
         }
     }
 


### PR DESCRIPTION
but should log the actual cause.

Fixes #5619