### PR TITLE
AbstractIoSelector + RWHandlers toString

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/AbstractIOSelector.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/AbstractIOSelector.java
@@ -195,4 +195,9 @@ public abstract class AbstractIOSelector extends Thread implements IOSelector {
             Thread.currentThread().interrupt();
         }
     }
+
+    @Override
+    public String toString() {
+        return getName();
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/ReadHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/ReadHandler.java
@@ -178,6 +178,11 @@ public final class ReadHandler extends AbstractSelectionHandler {
         });
     }
 
+    @Override
+    public String toString() {
+        return connection + ".readHandler";
+    }
+
     private class StartMigrationTask implements Runnable {
         private final IOSelector newOwner;
 

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/WriteHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/WriteHandler.java
@@ -285,7 +285,7 @@ public final class WriteHandler extends AbstractSelectionHandler implements Runn
      * @throws Exception
      */
     private void fillOutputBuffer() throws Exception {
-        for (;;) {
+        for (; ; ) {
             if (!outputBuffer.hasRemaining()) {
                 // The buffer is completely filled, we are done.
                 return;
@@ -332,6 +332,11 @@ public final class WriteHandler extends AbstractSelectionHandler implements Runn
     @Override
     public void requestMigration(IOSelector newOwner) {
         offer(new StartMigrationTask(newOwner));
+    }
+
+    @Override
+    public String toString() {
+        return connection + ".writeHandler";
     }
 
     /**


### PR DESCRIPTION
The toString is needed for logging purposes in the iobalancer. Currently
they show the object.toString, which is not very useful.