### PR TITLE
enabled reduced pom generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,5 @@ atlassian-ide-plugin.xml
 hazelcast-ra/*.log
 hazelcast-ra/*.epoch
 hazelcast-all/dependency-reduced-pom.xml
+hazelcast/dependency-reduced-pom.xml
 performance*.log

--- a/hazelcast/pom.xml
+++ b/hazelcast/pom.xml
@@ -223,7 +223,6 @@
                         </goals>
                         <configuration>
                             <finalName>${project.build.finalName}</finalName>
-                            <createDependencyReducedPom>false</createDependencyReducedPom>
                             <createSourcesJar>true</createSourcesJar>
                             <shadeSourcesContent>true</shadeSourcesContent>
                             <artifactSet>
@@ -256,12 +255,6 @@
             <groupId>javax.cache</groupId>
             <artifactId>cache-tests</artifactId>
             <classifier>tests</classifier>
-            <version>1.0.0</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>javax.cache</groupId>
-            <artifactId>cache-tests</artifactId>
             <version>1.0.0</version>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
This PR does enable reduced-dependency-pom.xml generation to remove *minimal-json* from transitive dependency list. reduced-dependency-pom.xml generation was broken because of duplicate JCache test libraries so i removed not-used dependency.