### PR TITLE
Balancer improvements

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnectionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnectionManager.java
@@ -144,6 +144,7 @@ public class TcpIpConnectionManager implements ConnectionManager {
         this.loggingService = loggingService;
     }
 
+
     public void interceptSocket(Socket socket, boolean onAccept) throws IOException {
         if (!isSocketInterceptorEnabled()) {
             return;
@@ -173,6 +174,21 @@ public class TcpIpConnectionManager implements ConnectionManager {
 
     public PacketWriter createPacketWriter(TcpIpConnection connection) {
         return ioService.createPacketWriter(connection);
+    }
+
+    // just for testing
+    public Set<TcpIpConnection> getActiveConnections() {
+        return activeConnections;
+    }
+
+    // just for testing
+    public InSelectorImpl[] getInSelectors() {
+        return inSelectors;
+    }
+
+    // just for testing
+    public OutSelectorImpl[] getOutSelectors() {
+        return outSelectors;
     }
 
     @Override
@@ -254,7 +270,6 @@ public class TcpIpConnectionManager implements ConnectionManager {
                 tcpConnection.setMonitor(connectionMonitor);
             }
         }
-        ioBalancer.connectionAdded(connection);
         connectionsMap.put(remoteEndPoint, connection);
         connectionsInProgress.remove(remoteEndPoint);
         ioService.getEventService().executeEventCallback(new StripedRunnable() {
@@ -324,6 +339,7 @@ public class TcpIpConnectionManager implements ConnectionManager {
         acceptedSockets.remove(channel);
 
         connection.start();
+        ioBalancer.connectionAdded(connection);
 
         log(Level.INFO, "Established socket connection between " + channel.socket().getLocalSocketAddress());
 
@@ -359,7 +375,6 @@ public class TcpIpConnectionManager implements ConnectionManager {
         }
         return connection;
     }
-
 
     private TcpIpConnectionMonitor getConnectionMonitor(Address endpoint, boolean reset) {
         TcpIpConnectionMonitor monitor = ConcurrencyUtil.getOrPutIfAbsent(monitors, endpoint, monitorConstructor);


### PR DESCRIPTION
The performance with the io balancer included performance still had dips of 15% once and a while; but performance with these changes is a lot more stable. The cause of the biggest dips is imbalance in the selector load. This is caused by:

1: not all connections were seen by the  IO-Balancer. Some active connections
were not seen, but receive load. Because of these connections being invisible, 
the IO-Balancer doesn't deal with balancing load optimally.

2: if there is 1 selector with a huge number of events, but only a single
handler, this was accepted as a good source selector to move a handler from.
In case of a single handler it doesn't make any sense since you don't want
to move a single handler from an otherwise empty selector.

This is fixed by

1: registering every active connection to the IO-Balancer instead of only the 'registered' ones

2: ignoring selector with a single handler; even though it has a huge number of events

Once merged I'll backport the changes to 3.5 maintenance.