### PR TITLE
MapService refactoring. Make partition destroy to be called from the partition thread.

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/DefaultRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/DefaultRecordStore.java
@@ -637,6 +637,11 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore implements 
         final long now = getNow();
 
         final Record record = getRecord(key);
+
+        if (record == null) {
+            return null;
+        }
+
         // expiration has delay on backups, but reading backup data should not be affected by this delay.
         // this is the reason why we are passing `false` to isExpired() method.
         final boolean expired = isExpired(record, now, false);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapService.java
@@ -38,7 +38,6 @@ import com.hazelcast.spi.TransactionalService;
 import com.hazelcast.transaction.TransactionalObject;
 import com.hazelcast.transaction.impl.TransactionSupport;
 import com.hazelcast.wan.WanReplicationEvent;
-
 import java.util.Map;
 import java.util.Properties;
 
@@ -190,5 +189,4 @@ public class MapService implements ManagedService, MigrationAwareService,
     public void clientDisconnected(String clientUuid) {
         clientAwareService.clientDisconnected(clientUuid);
     }
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/PartitionContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/PartitionContainer.java
@@ -78,7 +78,7 @@ public class PartitionContainer {
     /**
      * Used when sorting partition containers in {@link com.hazelcast.map.impl.eviction.ExpirationManager}
      * A non-volatile copy of lastCleanupTime is used with two reasons.
-     * <p/>
+     * <p>
      * 1. We need an un-modified field during sorting.
      * 2. Decrease number of volatile reads.
      */
@@ -109,7 +109,7 @@ public class PartitionContainer {
         return maps.get(mapName);
     }
 
-    void destroyMap(String name) {
+    public void destroyMap(String name) {
         RecordStore recordStore = maps.remove(name);
         if (recordStore != null) {
             recordStore.clearPartition();

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/BasePutOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/BasePutOperation.java
@@ -84,10 +84,7 @@ public abstract class BasePutOperation extends LockAwareOperation implements Bac
     @Override
     public boolean shouldBackup() {
         Record record = recordStore.getRecord(dataKey);
-        if (record == null) {
-            return false;
-        }
-        return true;
+        return record != null;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/KeyBasedMapOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/KeyBasedMapOperation.java
@@ -19,7 +19,6 @@ package com.hazelcast.map.impl.operation;
 import com.hazelcast.map.impl.MapContainer;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.map.impl.NearCacheProvider;
-import com.hazelcast.map.impl.PartitionContainer;
 import com.hazelcast.map.impl.RecordStore;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
@@ -28,6 +27,7 @@ import com.hazelcast.spi.NamedOperation;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.PartitionAwareOperation;
 import com.hazelcast.util.Clock;
+
 import java.io.IOException;
 
 public abstract class KeyBasedMapOperation extends Operation implements PartitionAwareOperation, NamedOperation {
@@ -40,7 +40,6 @@ public abstract class KeyBasedMapOperation extends Operation implements Partitio
 
     protected transient MapService mapService;
     protected transient MapContainer mapContainer;
-    protected transient PartitionContainer partitionContainer;
     protected transient RecordStore recordStore;
 
     public KeyBasedMapOperation() {
@@ -103,8 +102,7 @@ public abstract class KeyBasedMapOperation extends Operation implements Partitio
     public final void beforeRun() throws Exception {
         mapService = getService();
         mapContainer = mapService.getMapServiceContext().getMapContainer(name);
-        partitionContainer = mapService.getMapServiceContext().getPartitionContainer(getPartitionId());
-        recordStore = partitionContainer.getRecordStore(name);
+        recordStore = mapService.getMapServiceContext().getPartitionContainer(getPartitionId()).getRecordStore(name);
         innerBeforeRun();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapPartitionDestroyOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapPartitionDestroyOperation.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.operation;
+
+
+import java.io.IOException;
+import com.hazelcast.map.impl.PartitionContainer;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.PartitionAwareOperation;
+
+public class MapPartitionDestroyOperation extends Operation implements PartitionAwareOperation {
+    private final PartitionContainer partitionContainer;
+    private final String mapName;
+
+    public MapPartitionDestroyOperation(PartitionContainer partitionContainer, String mapName) {
+        this.partitionContainer = partitionContainer;
+        this.mapName = mapName;
+        this.setPartitionId(partitionContainer.getPartitionId());
+    }
+
+    @Override
+    public void beforeRun() throws Exception {
+
+    }
+
+    @Override
+    public void run() throws Exception {
+        this.partitionContainer.destroyMap(mapName);
+    }
+
+    @Override
+    public void afterRun() throws Exception {
+
+    }
+
+    @Override
+    public boolean returnsResponse() {
+        return true;
+    }
+
+    @Override
+    public Object getResponse() {
+        return partitionContainer.getPartitionId();
+    }
+
+    @Override
+    protected void writeInternal(ObjectDataOutput out) throws IOException {
+        /*
+        * It is local only operation and will never be serialized
+        * */
+    }
+
+    @Override
+    protected void readInternal(ObjectDataInput in) throws IOException {
+        /*
+        * It is local only operation and will never be serialized
+        * */
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MergeOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MergeOperation.java
@@ -93,7 +93,7 @@ public class MergeOperation extends BasePutOperation {
             return new RemoveBackupOperation(name, dataKey);
         } else {
             final Record record = recordStore.getRecord(dataKey);
-            final RecordInfo replicationInfo = Records.buildRecordInfo(record);
+            final RecordInfo replicationInfo = record != null ? Records.buildRecordInfo(record) : null;
             return new PutBackupOperation(name, dataKey, dataValue, replicationInfo);
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutBackupOperation.java
@@ -72,7 +72,9 @@ public final class PutBackupOperation extends KeyBasedMapOperation implements Ba
 
     @Override
     public void afterRun() throws Exception {
-        evict(true);
+        if (recordInfo != null) {
+            evict(true);
+        }
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnSetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnSetOperation.java
@@ -111,7 +111,7 @@ public class TxnSetOperation extends BasePutOperation implements MapTxnOperation
 
     public Operation getBackupOperation() {
         final Record record = recordStore.getRecord(dataKey);
-        final RecordInfo replicationInfo = Records.buildRecordInfo(record);
+        final RecordInfo replicationInfo = record != null ? Records.buildRecordInfo(record) : null;
         return new PutBackupOperation(name, dataKey, dataValue, replicationInfo, true, false);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/map/MapPutDestroyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapPutDestroyTest.java
@@ -1,0 +1,89 @@
+package com.hazelcast.map;
+
+
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.NightlyTest;
+import org.junit.Test;
+import com.hazelcast.core.IMap;
+import org.junit.runner.RunWith;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.test.HazelcastTestSupport;
+import org.junit.experimental.categories.Category;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import com.hazelcast.test.HazelcastParallelClassRunner;
+
+import static junit.framework.TestCase.fail;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category(NightlyTest.class)
+public class MapPutDestroyTest extends HazelcastTestSupport {
+    @Test
+    public void testConcurrentPutDestroy_doesNotCauseNPE() {
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(3);
+        final HazelcastInstance instance = factory.newHazelcastInstance();
+        final String mapName = randomString();
+        final AtomicReference<Throwable> error = new AtomicReference<Throwable>(null);
+
+        final AtomicBoolean stop = new AtomicBoolean();
+
+        Thread t1 = new Thread(
+                new Runnable() {
+                    @Override
+                    public void run() {
+                        try {
+                            while (!stop.get()) {
+                                IMap<Object, Object> map = instance.getMap(mapName);
+                                map.put(System.currentTimeMillis(), Boolean.TRUE);
+                            }
+                        } catch (Throwable e) {
+                            error.set(e);
+                        }
+                    }
+                }
+        );
+
+        Thread t2 = new Thread(
+                new Runnable() {
+                    @Override
+                    public void run() {
+                        try {
+                            while (!stop.get()) {
+                                IMap<Object, Object> map = instance.getMap(mapName);
+                                map.destroy();
+                            }
+                        } catch (Throwable e) {
+                            error.set(e);
+                        }
+                    }
+                }
+        );
+
+        t1.start();
+        t2.start();
+
+        sleepSeconds(10);
+        stop.set(true);
+
+        try {
+            t1.join();
+        } catch (Throwable e) {
+            e.printStackTrace();
+        }
+
+        try {
+            t2.join();
+        } catch (Throwable e) {
+            e.printStackTrace();
+        }
+
+        Throwable object = error.get();
+
+        if (object != null) {
+            object.printStackTrace(System.out);
+            fail(object.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
To be done:

1) Some refactoring
2) Make CleanPartitions in map.Destory to be called from the PartitionThread.
Issue:
#4331
