### PR TITLE
[DONT MERGE] Pulled out the IOSelectorThread

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/IOSelector.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/IOSelector.java
@@ -16,11 +16,9 @@
 
 package com.hazelcast.nio.tcp;
 
-import com.hazelcast.spi.impl.operationexecutor.OperationHostileThread;
-
 import java.nio.channels.Selector;
 
-public interface IOSelector extends OperationHostileThread {
+public interface IOSelector {
 
     Selector getSelector();
 


### PR DESCRIPTION
Pulled out the IOSelectorThread from the IOSelector. The IOSelectorThread is now
an inner class of the IOSelector; so from the outside nothing has changed.

The meaning of the IOSelector was overloaded due to too many responsibilities.
It acts like a selector, it also acts like a thread. Now these responsibilities
have separated.