### PR TITLE
Backport of Agrona collections

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,6 @@
+The package com.hazelcast.util.collection and the classes:
+com.hazelcast.util.QuickMath
+com.hazelcast.client.impl.protocol.util.UnsafeBuffer
+com.hazelcast.client.impl.protocol.util.BufferBuilder
+contain code originating from the Agrona project
+(https://github.com/real-logic/Agrona).

--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -213,10 +213,8 @@
     <suppress checks="JavadocMethod" files="com.hazelcast.client.impl[\\/]"/>
 
     <!--CLIENT PROTOCOL-->
-    <!--TODO: we will refactor these External utils-->
-    <suppress checks="" files="com.hazelcast.client.impl.protocol.util[\\/]"/>
-    <!--TODO we will refactor these encode-decode code-->
-    <!--Parameters class are gonna be auto generated-->
+    <suppress checks="IllegalImport" files="com/hazelcast/client/impl/protocol/util/UnsafeBuffer"/>
+    <!--Parameters classes are auto-generated-->
     <suppress checks="" files="com.hazelcast.client.impl.protocol.map.*Parameters"/>
     <suppress checks="" files="com.hazelcast.client.impl.protocol.*Parameters"/>
     <suppress checks="" files="com.hazelcast.client.impl.protocol.*Codec"/>
@@ -554,6 +552,10 @@
     <suppress checks="JavadocVariable" files="com.hazelcast.internal.management.request.ConsoleRequestConstants"/>
     <suppress checks="JavadocVariable|VisibilityModifier" files="com.hazelcast.internal.management.dto.*"/>
 
+    <!-- Agrona backport -->
+    <suppress checks="MagicNumber" files="com/hazelcast/util/collection/" />
+    <suppress checks="JavadocType" files="com/hazelcast/util/collection/.*2ObjectHashMap" />
+    <suppress checks="MethodCount" files="com/hazelcast/util/collection/.*HashSet" />
 
     <!-- Map -->
     <suppress checks="JavadocMethod" files="com.hazelcast.map[\\/]"/>

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/util/BufferBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/util/BufferBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 - 2015 Real Logic Ltd.
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package com.hazelcast.client.impl.protocol.util;
 
 import com.hazelcast.util.QuickMath;
@@ -23,6 +24,7 @@ import java.util.Arrays;
  * Builder for appending buffers that grows capacity as necessary.
  */
 public class BufferBuilder {
+    /** Buffer's default initial capacity */
     public static final int INITIAL_CAPACITY = 4096;
 
     private static final String PROP_HAZELCAST_PROTOCOL_UNSAFE = "hazelcast.protocol.unsafe.enabled";

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/util/ClientMessageBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/util/ClientMessageBuilder.java
@@ -1,5 +1,22 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.client.impl.protocol.util;
 
+import com.hazelcast.util.collection.Int2ObjectHashMap;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 
 import java.nio.ByteBuffer;
@@ -37,7 +54,8 @@ public class ClientMessageBuilder {
                 continue;
             }
 
-            if (message.isFlagSet(BEGIN_FLAG)) {     // first fragment
+            // first fragment
+            if (message.isFlagSet(BEGIN_FLAG)) {
                 final BufferBuilder builder = new BufferBuilder();
                 builderBySessionIdMap.put(message.getCorrelationId(), builder);
                 builder.append(message.buffer(), 0, message.getFrameLength());

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/util/MessageFlyweight.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/util/MessageFlyweight.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.client.impl.protocol.util;
 
 import com.hazelcast.nio.Bits;
@@ -27,9 +43,11 @@ public class MessageFlyweight {
      */
     private static final short SHORT_MASK = 0x00FF;
 
-    private int offset; //initialized in wrap method by user , does not change.
-    private int index; //starts from zero, incremented each tome something set to buffer
     protected ClientProtocolBuffer buffer;
+    //initialized in wrap method by user , does not change.
+    private int offset;
+    //starts from zero, incremented each tome something set to buffer
+    private int index;
 
 
     public MessageFlyweight() {

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/util/SafeBuffer.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/util/SafeBuffer.java
@@ -20,7 +20,6 @@ import com.hazelcast.nio.Bits;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
-import java.nio.charset.Charset;
 
 /**
  * Implementation of ClientProtocolBuffer that is used by default in clients.
@@ -29,7 +28,6 @@ import java.nio.charset.Charset;
  */
 public class SafeBuffer implements ClientProtocolBuffer {
 
-    public static final Charset UTF_8 = Charset.forName("utf-8");
     private ByteBuffer byteBuffer;
 
     public SafeBuffer(byte[] buffer) {
@@ -74,7 +72,7 @@ public class SafeBuffer implements ClientProtocolBuffer {
 
     @Override
     public int putStringUtf8(int index, String value, int maxEncodedSize) {
-        final byte[] bytes = value.getBytes(UTF_8);
+        final byte[] bytes = value.getBytes(Bits.UTF_8);
         if (bytes.length > maxEncodedSize) {
             throw new IllegalArgumentException("Encoded string larger than maximum size: " + maxEncodedSize);
         }
@@ -138,7 +136,7 @@ public class SafeBuffer implements ClientProtocolBuffer {
         final byte[] stringInBytes = new byte[length];
         getBytes(offset + Bits.INT_SIZE_IN_BYTES, stringInBytes);
 
-        return new String(stringInBytes, UTF_8);
+        return new String(stringInBytes, Bits.UTF_8);
     }
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/util/UnsafeBuffer.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/util/UnsafeBuffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 Real Logic Ltd.
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package com.hazelcast.client.impl.protocol.util;
 
 import com.hazelcast.nio.Bits;
@@ -20,20 +21,12 @@ import com.hazelcast.nio.UnsafeHelper;
 import sun.misc.Unsafe;
 
 import java.nio.ByteOrder;
-import java.nio.charset.Charset;
-
-;
 
 /**
  * Supports regular, byte ordered, access to an underlying buffer.
  */
-@edu.umd.cs.findbugs.annotations.SuppressWarnings({"EI_EXPOSE_REP", "EI_EXPOSE_REP2"})
+@edu.umd.cs.findbugs.annotations.SuppressWarnings({ "EI_EXPOSE_REP", "EI_EXPOSE_REP2" })
 public class UnsafeBuffer implements ClientProtocolBuffer {
-    /**
-     * UTF-8 charset
-     */
-    public static final Charset UTF_8 = Charset.forName("utf-8");
-
     private static final String DISABLE_BOUNDS_CHECKS_PROP_NAME = "hazelcast.disable.bounds.checks";
     private static final boolean SHOULD_BOUNDS_CHECK = !Boolean.getBoolean(DISABLE_BOUNDS_CHECKS_PROP_NAME);
 
@@ -197,7 +190,7 @@ public class UnsafeBuffer implements ClientProtocolBuffer {
         final byte[] stringInBytes = new byte[length];
         getBytes(offset + Bits.INT_SIZE_IN_BYTES, stringInBytes);
 
-        return new String(stringInBytes, UTF_8);
+        return new String(stringInBytes, Bits.UTF_8);
     }
 
     @Override
@@ -207,7 +200,7 @@ public class UnsafeBuffer implements ClientProtocolBuffer {
 
     @Override
     public int putStringUtf8(final int index, final String value, final int maxEncodedSize) {
-        final byte[] bytes = value.getBytes(UTF_8);
+        final byte[] bytes = value.getBytes(Bits.UTF_8);
         if (bytes.length > maxEncodedSize) {
             throw new IllegalArgumentException("Encoded string larger than maximum size: " + maxEncodedSize);
         }

--- a/hazelcast/src/main/java/com/hazelcast/nio/Bits.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/Bits.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.nio;
 
+import java.nio.charset.Charset;
+
 /**
  * Access and manipulate bits, bytes, primitives ...
  */
@@ -57,6 +59,15 @@ public final class Bits {
      * Length of the data blocks used by the CPU cache sub-system in bytes.
      */
     public static final int CACHE_LINE_LENGTH = 64;
+
+    /**
+     * A reusable instance of the UTF-8 charset
+     * */
+    public static final Charset UTF_8 = Charset.forName("UTF-8");
+    /**
+     * A reusable instance of the ISO Latin-1 charset
+     * */
+    public static final Charset ISO_8859_1 = Charset.forName("ISO-8859-1");
 
     private Bits() {
     }

--- a/hazelcast/src/main/java/com/hazelcast/util/Preconditions.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/Preconditions.java
@@ -29,6 +29,22 @@ public final class Preconditions {
 
 
     /**
+     * Tests if a string contains text.
+     *
+     * @param argument     the string tested to see if it contains text.
+     * @param errorMessage the errorMessage
+     * @return the string argument that was tested.
+     * @throws java.lang.IllegalArgumentException if the string is empty
+     */
+    public static String checkHasText(String argument, String errorMessage) {
+        if (argument == null || argument.isEmpty()) {
+            throw new IllegalArgumentException(errorMessage);
+        }
+
+        return argument;
+    }
+
+    /**
      * Tests if an argument is not null.
      *
      * @param argument     the argument tested to see if it is not null.
@@ -44,18 +60,16 @@ public final class Preconditions {
     }
 
     /**
-     * Tests if a string contains text.
+     * Tests if an argument is not null.
      *
-     * @param argument     the string tested to see if it contains text.
-     * @param errorMessage the errorMessage
-     * @return the string argument that was tested.
-     * @throws java.lang.IllegalArgumentException if the string is empty
+     * @param argument     the argument tested to see if it is not null.
+     * @return the argument that was tested.
+     * @throws java.lang.NullPointerException if argument is null
      */
-    public static String checkHasText(String argument, String errorMessage) {
-        if (argument == null || argument.isEmpty()) {
-            throw new IllegalArgumentException(errorMessage);
+    public static <T> T checkNotNull(T argument) {
+        if (argument == null) {
+            throw new NullPointerException();
         }
-
         return argument;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/util/QuickMath.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/QuickMath.java
@@ -67,42 +67,31 @@ public final class QuickMath {
     }
 
     /**
-     * Returns the next power of two that is larger than the specified int value.
+     * Fast method of finding the next power of 2 greater than or equal to the supplied value.
+     * <p/>
+     * If the value is &lt;= 0 then 1 will be returned.
+     * <p/>
+     * This method is not suitable for {@link Integer#MIN_VALUE} or numbers greater than 2^30.
      *
-     * @param value the int value
-     * @return the next power of two that is larger than the specified int value.
+     * @param value from which to search for next power of 2
+     * @return The next power of 2 or the value itself if it is a power of 2
      */
-    public static int nextPowerOfTwo(int value) {
-        if (!isPowerOfTwo(value)) {
-            value--;
-            value |= value >> 1;
-            value |= value >> 2;
-            value |= value >> 4;
-            value |= value >> 8;
-            value |= value >> 16;
-            value++;
-        }
-        return value;
+    public static int nextPowerOfTwo(final int value) {
+        return 1 << (32 - Integer.numberOfLeadingZeros(value - 1));
     }
 
     /**
-     * Returns the next power of two that is larger than the specified long value.
+     * Fast method of finding the next power of 2 greater than or equal to the supplied value.
+     * <p/>
+     * If the value is &lt;= 0 then 1 will be returned.
+     * <p/>
+     * This method is not suitable for {@link Long#MIN_VALUE} or numbers greater than 2^62.
      *
-     * @param value the long value
-     * @return the next power of two that is larger than the specified long value
+     * @param value from which to search for next power of 2
+     * @return The next power of 2 or the value itself if it is a power of 2
      */
-    public static long nextPowerOfTwo(long value) {
-        if (!isPowerOfTwo(value)) {
-            value--;
-            value |= value >> 1;
-            value |= value >> 2;
-            value |= value >> 4;
-            value |= value >> 8;
-            value |= value >> 16;
-            value |= value >> 32;
-            value++;
-        }
-        return value;
+    public static long nextPowerOfTwo(final long value) {
+        return 1L << (64 - Long.numberOfLeadingZeros(value - 1));
     }
 
     /**
@@ -238,5 +227,4 @@ public final class QuickMath {
             return 0;
         }
     }
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/util/collection/BiInt2ObjectMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/collection/BiInt2ObjectMap.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.util.collection;
+
+
+import com.hazelcast.util.function.Consumer;
+
+import java.util.Map;
+
+/**
+ * Map that takes two part int key and associates with an object.
+ * <p/>
+ * The underlying implementation use as {@link Long2ObjectHashMap} and combines both int keys into a long key.
+ *
+ * @param <V> type of the object stored in the map.
+ */
+public class BiInt2ObjectMap<V> {
+    /**
+     * Handler for a map entry
+     *
+     * @param <V> type of the value
+     */
+    public interface EntryConsumer<V> {
+        /**
+         * A map entry
+         *
+         * @param keyPartA for the key
+         * @param keyPartB for the key
+         * @param value    for the entry
+         */
+        void accept(int keyPartA, int keyPartB, V value);
+    }
+
+    private final Long2ObjectHashMap<V> map;
+
+    /**
+     * Construct an empty map
+     */
+    public BiInt2ObjectMap() {
+        map = new Long2ObjectHashMap<V>();
+    }
+
+    /**
+     * See {@link Long2ObjectHashMap#Long2ObjectHashMap(int, double)}.
+     *
+     * @param initialCapacity for the underlying hash map
+     * @param loadFactor      for the underlying hash map
+     */
+    public BiInt2ObjectMap(final int initialCapacity, final double loadFactor) {
+        map = new Long2ObjectHashMap<V>(initialCapacity, loadFactor);
+    }
+
+    /**
+     * Get the total capacity for the map to which the load factor with be a fraction of.
+     *
+     * @return the total capacity for the map.
+     */
+    public int capacity() {
+        return map.capacity();
+    }
+
+    /**
+     * Get the load factor beyond which the map will increase size.
+     *
+     * @return load factor for when the map should increase size.
+     */
+    public double loadFactor() {
+        return map.loadFactor();
+    }
+
+    /**
+     * Put a value into the map.
+     *
+     * @param keyPartA for the key
+     * @param keyPartB for the key
+     * @param value    to put into the map
+     * @return the previous value if found otherwise null
+     */
+    public V put(final int keyPartA, final int keyPartB, final V value) {
+        final long key = compoundKey(keyPartA, keyPartB);
+
+        return map.put(key, value);
+    }
+
+    /**
+     * Retrieve a value from the map.
+     *
+     * @param keyPartA for the key
+     * @param keyPartB for the key
+     * @return value matching the key if found or null if not found.
+     */
+    public V get(final int keyPartA, final int keyPartB) {
+        final long key = compoundKey(keyPartA, keyPartB);
+
+        return map.get(key);
+    }
+
+    /**
+     * Remove a value from the map and return the value.
+     *
+     * @param keyPartA for the key
+     * @param keyPartB for the key
+     * @return the previous value if found otherwise null
+     */
+    public V remove(final int keyPartA, final int keyPartB) {
+        final long key = compoundKey(keyPartA, keyPartB);
+
+        return map.remove(key);
+    }
+
+    /**
+     * Iterate over the entries of the map
+     *
+     * @param consumer to apply to each entry in the map
+     */
+    public void forEach(final EntryConsumer<V> consumer) {
+        for (Map.Entry<Long, V> entry : map.entrySet()) {
+            Long compoundKey = entry.getKey();
+            final int keyPartA = (int) (compoundKey >>> 32);
+            final int keyPartB = (int) (compoundKey & 0xFFFFFFFFL);
+            consumer.accept(keyPartA, keyPartB, entry.getValue());
+        }
+    }
+
+    /**
+     * Iterate over the values in the map
+     *
+     * @param consumer to apply to each value in the map
+     */
+    public void forEach(final Consumer<V> consumer) {
+        for (Map.Entry<Long, V> entry : map.entrySet()) {
+            consumer.accept(entry.getValue());
+        }
+    }
+
+    /**
+     * Return the number of unique entries in the map.
+     *
+     * @return number of unique entries in the map.
+     */
+    public int size() {
+        return map.size();
+    }
+
+    /**
+     * Is map empty or not.
+     *
+     * @return boolean indicating empty map or not
+     */
+    public boolean isEmpty() {
+        return map.isEmpty();
+    }
+
+    private static long compoundKey(final int keyPartA, final int keyPartB) {
+        return ((long) keyPartA << 32) | keyPartB;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/util/collection/Hashing.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/collection/Hashing.java
@@ -14,26 +14,23 @@
  * limitations under the License.
  */
 
-package com.hazelcast.client.impl.protocol.util;
+package com.hazelcast.util.collection;
 
-import com.hazelcast.nio.Bits;
-import com.hazelcast.nio.serialization.Data;
+/**
+ * Hashcode calculation.
+ */
+public final class Hashing {
+    private Hashing() { }
 
-public final class ParameterUtil {
-
-    private static final int UTF8_MAX_BYTES_PER_CHAR = 4;
-
-    private ParameterUtil() { }
-
-    public static int calculateStringDataSize(String string) {
-        return Bits.INT_SIZE_IN_BYTES + string.length() * UTF8_MAX_BYTES_PER_CHAR;
+    public static int intHash(final int value, final int mask) {
+        final int hash = (value << 1) - (value << 8);
+        return hash & mask;
     }
 
-    public static int calculateByteArrayDataSize(byte[] bytes) {
-        return Bits.INT_SIZE_IN_BYTES + bytes.length;
+    public static int longHash(final long value, final int mask) {
+        int hash = (int) value ^ (int) (value >>> 32);
+        hash = (hash << 1) - (hash << 8);
+        return hash & mask;
     }
 
-    public static int calculateDataSize(Data key) {
-        return calculateByteArrayDataSize(key.toByteArray());
-    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/util/collection/IntHashSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/collection/IntHashSet.java
@@ -1,0 +1,380 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.util.collection;
+
+import com.hazelcast.util.QuickMath;
+import com.hazelcast.util.function.Predicate;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Set;
+
+import static com.hazelcast.util.Preconditions.checkNotNull;
+
+/**
+ * Simple fixed-size int hashset for validating tags.
+ */
+public final class IntHashSet implements Set<Integer> {
+    private final int[] values;
+    private final IntIterator iterator;
+    private final int mask;
+    private final int missingValue;
+
+    private int size;
+
+    public IntHashSet(final int proposedCapacity, final int missingValue) {
+        size = 0;
+        this.missingValue = missingValue;
+        final int capacity = QuickMath.nextPowerOfTwo(proposedCapacity);
+        mask = capacity - 1;
+        values = new int[capacity];
+        Arrays.fill(values, missingValue);
+
+        // NB: references values in the constructor, so must be assigned after values
+        iterator = new IntIterator(missingValue, values);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public boolean add(final Integer value) {
+        return add(value.intValue());
+    }
+
+    /**
+     * Primitive specialised overload of {this#add(Integer)}
+     *
+     * @param value the value to add
+     * @return true if the collection has changed, false otherwise
+     */
+    public boolean add(final int value) {
+        int index = Hashing.intHash(value, mask);
+
+        while (values[index] != missingValue) {
+            if (values[index] == value) {
+                return false;
+            }
+
+            index = next(index);
+        }
+
+        values[index] = value;
+        size++;
+
+        return true;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public boolean remove(final Object value) {
+        return value instanceof Integer && remove(((Integer) value).intValue());
+    }
+
+    /**
+     * An int specialised version of {this#remove(Object)}.
+     *
+     * @param value the value to remove
+     * @return true if the value was present, false otherwise
+     */
+    public boolean remove(final int value) {
+        int index = Hashing.intHash(value, mask);
+
+        while (values[index] != missingValue) {
+            if (values[index] == value) {
+                values[index] = missingValue;
+                compactChain(index);
+                return true;
+            }
+
+            index = next(index);
+        }
+
+        return false;
+    }
+
+    private int next(int index) {
+        index = ++index & mask;
+        return index;
+    }
+
+    private void compactChain(final int deleteIndex) {
+        final int[] values = this.values;
+
+        int index = deleteIndex;
+        while (true) {
+            final int previousIndex = index;
+            index = next(index);
+            if (values[index] == missingValue) {
+                return;
+            }
+
+            values[previousIndex] = values[index];
+            values[index] = missingValue;
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public boolean contains(final Object value) {
+        return value instanceof Integer && contains(((Integer) value).intValue());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public boolean contains(final int value) {
+        int index = Hashing.intHash(value, mask);
+
+        while (values[index] != missingValue) {
+            if (values[index] == value) {
+                return true;
+            }
+
+            index = next(index);
+        }
+
+        return false;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public int size() {
+        return size;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public boolean isEmpty() {
+        return size() == 0;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public void clear() {
+        final int[] values = this.values;
+        final int length = values.length;
+        for (int i = 0; i < length; i++) {
+            values[i] = missingValue;
+        }
+        size = 0;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @SuppressWarnings("unchecked")
+    public <T> T[] toArray(final T[] ignore) {
+        return (T[]) (Object) Arrays.copyOf(values, values.length);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public boolean addAll(final Collection<? extends Integer> coll) {
+        return addAllCapture(coll);
+    }
+
+    private <E extends Integer> boolean addAllCapture(final Collection<E> coll) {
+        final Predicate<E> p = new Predicate<E>() {
+            @Override
+            public boolean test(E x) {
+                return add(x);
+            }
+        };
+        return conjunction(coll, p);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public boolean containsAll(final Collection<?> coll) {
+        return containsAllCapture(coll);
+    }
+
+    private <E> boolean containsAllCapture(Collection<E> coll) {
+        return conjunction(coll, new Predicate<E>() {
+            @Override
+            public boolean test(E value) {
+                return contains(value);
+            }
+        });
+    }
+
+    /**
+     * IntHashSet specialised variant of {this#containsAll(Collection)}.
+     *
+     * @param other the int hashset to compare against.
+     * @return true if every element in other is in this.
+     */
+    public boolean containsAll(final IntHashSet other) {
+        final IntIterator iterator = other.iterator();
+        while (iterator.hasNext()) {
+            if (!contains(iterator.nextValue())) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Fast Path set difference for comparison with another IntHashSet.
+     * <p/>
+     * NB: garbage free in the identical case, allocates otherwise.
+     *
+     * @param collection the other set to subtract
+     * @return null if identical, otherwise the set of differences
+     */
+    public IntHashSet difference(final IntHashSet collection) {
+        checkNotNull(collection, "Collection must not be null");
+
+        IntHashSet difference = null;
+
+        final IntIterator it = iterator();
+
+        while (it.hasNext()) {
+            final int value = it.nextValue();
+            if (!collection.contains(value)) {
+                if (difference == null) {
+                    difference = new IntHashSet(size, missingValue);
+                }
+
+                difference.add(value);
+            }
+        }
+
+        return difference;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public boolean removeAll(final Collection<?> coll) {
+        return removeAllCapture(coll);
+    }
+
+    private <E> boolean removeAllCapture(final Collection<E> coll) {
+        return conjunction(coll, new Predicate<E>() {
+            @Override
+            public boolean test(E value) {
+                return remove(value);
+            }
+        });
+    }
+
+    private static <E> boolean conjunction(final Collection<E> collection, final Predicate<E> predicate) {
+        checkNotNull(collection);
+
+        boolean acc = false;
+        for (final E e : collection) {
+            // Deliberate strict evaluation
+            acc |= predicate.test(e);
+        }
+
+        return acc;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public IntIterator iterator() {
+        iterator.reset();
+        return iterator;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public void copy(final IntHashSet obj) {
+        // NB: mask also implies the length is the same
+        if (this.mask != obj.mask) {
+            throw new IllegalArgumentException("Cannot copy object: masks not equal");
+        }
+
+        if (this.missingValue != obj.missingValue) {
+            throw new IllegalArgumentException("Cannot copy object: missingValues not equal");
+        }
+
+        System.arraycopy(obj.values, 0, this.values, 0, this.values.length);
+        this.size = obj.size;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public String toString() {
+        final StringBuilder b = new StringBuilder(size() * 3 + 2);
+        b.append('{');
+        String separator = "";
+        for (int i : values) {
+            b.append(i).append(separator);
+            separator = ",";
+        }
+        return b.append('}').toString();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public Object[] toArray() {
+        final int[] values = this.values;
+        final Object[] array = new Object[values.length];
+        for (int i = 0; i < values.length; i++) {
+            array[i] = values[i];
+        }
+        return array;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public boolean equals(final Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (other instanceof IntHashSet) {
+            final IntHashSet otherSet = (IntHashSet) other;
+            return otherSet.missingValue == missingValue && otherSet.size() == size() && containsAll(otherSet);
+        }
+
+        return false;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public int hashCode() {
+        final IntIterator iterator = iterator();
+        int total = 0;
+        while (iterator.hasNext()) {
+            // Cast exists for substitutions
+            total += (int) iterator.nextValue();
+        }
+        return total;
+    }
+
+    // --- Unimplemented below here
+
+    public boolean retainAll(final Collection<?> coll) {
+        throw new UnsupportedOperationException("Not implemented");
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/util/collection/IntIterator.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/collection/IntIterator.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.util.collection;
+
+import java.util.Iterator;
+
+/**
+ * An iterator for a sequence of primitive integers.
+ */
+public class IntIterator implements Iterator<Integer> {
+    private final int missingValue;
+    private final int[] values;
+
+    private int position;
+
+    /**
+     * Construct an {@link Iterator} over an array of primitives ints.
+     *
+     * @param missingValue to indicate the value is missing, i.e. not present or null.
+     * @param values       to iterate over.
+     */
+    public IntIterator(final int missingValue, final int[] values) {
+        this.missingValue = missingValue;
+        this.values = values;
+    }
+
+    public boolean hasNext() {
+        final int[] values = this.values;
+        while (position < values.length) {
+            if (values[position] != missingValue) {
+                return true;
+            }
+
+            position++;
+        }
+
+        return false;
+    }
+
+    public Integer next() {
+        return nextValue();
+    }
+
+    public void remove() {
+        throw new UnsupportedOperationException("remove");
+    }
+
+    /**
+     * Strongly typed alternative of {@link Iterator#next()} to avoid boxing.
+     *
+     * @return the next int value.
+     */
+    public int nextValue() {
+        final int value = values[position];
+        position++;
+        return value;
+    }
+
+    void reset() {
+        position = 0;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/util/collection/Long2LongHashMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/collection/Long2LongHashMap.java
@@ -1,0 +1,463 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.util.collection;
+
+import com.hazelcast.util.QuickMath;
+import com.hazelcast.util.function.BiConsumer;
+import com.hazelcast.util.function.LongLongConsumer;
+import com.hazelcast.util.function.Predicate;
+import com.hazelcast.util.function.Supplier;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * A Probing hashmap specialised for long key and value pairs.
+ */
+public class Long2LongHashMap implements Map<Long, Long> {
+    private final Set<Long> keySet;
+    private final LongIterator valueIterator = new LongIterator(1);
+    private final Collection<Long> values;
+    private final Set<Entry<Long, Long>> entrySet;
+
+    private final double loadFactor;
+    private final long missingValue;
+
+    private long[] entries;
+    private int capacity;
+    private int mask;
+    private int resizeThreshold;
+    private int size;
+
+    public Long2LongHashMap(final long missingValue) {
+        this(16, 0.6, missingValue);
+    }
+
+    @SuppressWarnings("unchecked")
+    public Long2LongHashMap(final int initialCapacity, final double loadFactor, final long missingValue) {
+        this.loadFactor = loadFactor;
+        this.missingValue = missingValue;
+        capacity(QuickMath.nextPowerOfTwo(initialCapacity));
+        final LongIterator keyIterator = new LongIterator(0);
+        keySet = new MapDelegatingSet<Long>(this, new IteratorSupplier(keyIterator), new Predicate() {
+            @Override public boolean test(Object value) {
+                return containsValue(value);
+            }
+        });
+        values = new MapDelegatingSet<Long>(this, new Supplier<Iterator<Long>>() {
+            @Override public Iterator<Long> get() {
+                return valueIterator.reset();
+            }
+        }, new Predicate() {
+            @Override
+            public boolean test(Object key) {
+                return containsKey(key);
+            }
+        });
+        final EntryIterator entryIterator = new EntryIterator();
+        entrySet = new MapDelegatingSet<Entry<Long, Long>>(this, new EntryIteratorSupplier(entryIterator), new
+                Predicate() {
+            @Override
+            public boolean test(Object e) {
+                return Long2LongHashMap.this.containsKey(((Entry<Long, Long>) e).getKey());
+            }
+        });
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public int size() {
+        return size;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public boolean isEmpty() {
+        return size() == 0;
+    }
+
+    public long get(final long key) {
+        final long[] entries = this.entries;
+        int index = hash(key);
+        long candidateKey;
+        while ((candidateKey = entries[index]) != missingValue) {
+            if (candidateKey == key) {
+                return entries[index + 1];
+            }
+            index = next(index);
+        }
+        return missingValue;
+    }
+
+    public long put(final long key, final long value) {
+        long oldValue = missingValue;
+        int index = hash(key);
+        long candidateKey;
+        while ((candidateKey = entries[index]) != missingValue) {
+            if (candidateKey == key) {
+                oldValue = entries[index + 1];
+                break;
+            }
+            index = next(index);
+        }
+        if (oldValue == missingValue) {
+            ++size;
+            entries[index] = key;
+        }
+        entries[index + 1] = value;
+        checkResize();
+        return oldValue;
+    }
+
+    private void checkResize() {
+        if (size > resizeThreshold) {
+            final int newCapacity = capacity << 1;
+            if (newCapacity < 0) {
+                throw new IllegalStateException("Max capacity reached at size=" + size);
+            }
+            rehash(newCapacity);
+        }
+    }
+
+    private void rehash(final int newCapacity) {
+        final long[] oldEntries = entries;
+        capacity(newCapacity);
+        for (int i = 0; i < oldEntries.length; i += 2) {
+            final long key = oldEntries[i];
+            if (key != missingValue) {
+                put(key, oldEntries[i + 1]);
+            }
+        }
+    }
+
+    private int hash(final long key) {
+        int hash = (int) key ^ (int) (key >>> 32);
+        hash = (hash << 1) - (hash << 8);
+        return hash & mask;
+    }
+
+    /**
+     * Primitive specialised forEach implementation.
+     * <p/>
+     * NB: Renamed from forEach to avoid overloading on parameter types of lambda
+     * expression, which doesn't interplay well with type inference in lambda expressions.
+     *
+     * @param consumer a callback called for each key/value pair in the map.
+     */
+    public void longForEach(final LongLongConsumer consumer) {
+        final long[] entries = this.entries;
+        for (int i = 0; i < entries.length; i += 2) {
+            final long key = entries[i];
+            if (key != missingValue) {
+                consumer.accept(entries[i], entries[i + 1]);
+            }
+        }
+    }
+
+    /**
+     * Long primitive specialised containsKey.
+     *
+     * @param key the key to check.
+     * @return true if the map contains key as a key, false otherwise.
+     */
+    public boolean containsKey(final long key) {
+        return get(key) != missingValue;
+    }
+
+    public boolean containsValue(final long value) {
+        final long[] entries = this.entries;
+        for (int i = 1; i < entries.length; i += 2) {
+            final long entryValue = entries[i];
+            if (entryValue == value) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public void clear() {
+        Arrays.fill(entries, missingValue);
+        size = 0;
+    }
+
+    // ---------------- Boxed Versions Below ----------------
+
+    /**
+     * {@inheritDoc}
+     */
+    public Long get(final Object key) {
+        return get((long) (Long) key);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public Long put(final Long key, final Long value) {
+        return put(key.longValue(), value.longValue());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public void forEach(final BiConsumer<? super Long, ? super Long> action) {
+        longForEach(new UnboxingBiConsumer(action));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public boolean containsKey(final Object key) {
+        return containsKey((long) (Long) key);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public boolean containsValue(final Object value) {
+        return containsValue((long) (Long) value);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public void putAll(final Map<? extends Long, ? extends Long> map) {
+        for (final Entry<? extends Long, ? extends Long> entry : map.entrySet()) {
+            put(entry.getKey(), entry.getValue());
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public Set<Long> keySet() {
+        return keySet;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public Collection<Long> values() {
+        return values;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public Set<Entry<Long, Long>> entrySet() {
+        return entrySet;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public Long remove(final Object key) {
+        return remove((long) (Long) key);
+    }
+
+    public long remove(final long key) {
+        final long[] entries = this.entries;
+        int index = hash(key);
+        long candidateKey;
+        while ((candidateKey = entries[index]) != missingValue) {
+            if (candidateKey == key) {
+                final int valueIndex = index + 1;
+                final long oldValue = entries[valueIndex];
+                entries[index] = missingValue;
+                entries[valueIndex] = missingValue;
+                size--;
+                compactChain(index);
+                return oldValue;
+            }
+            index = next(index);
+        }
+        return missingValue;
+    }
+
+    private void compactChain(int deleteIndex) {
+        final long[] entries = this.entries;
+        int index = deleteIndex;
+        while (true) {
+            index = next(index);
+            if (entries[index] == missingValue) {
+                return;
+            }
+            final int hash = hash(entries[index]);
+            if ((index < hash && (hash <= deleteIndex || deleteIndex <= index))
+                    || (hash <= deleteIndex && deleteIndex <= index)) {
+                entries[deleteIndex] = entries[index];
+                entries[deleteIndex + 1] = entries[index + 1];
+                entries[index] = missingValue;
+                entries[index + 1] = missingValue;
+                deleteIndex = index;
+            }
+        }
+    }
+
+    public long minValue() {
+        long min = Long.MAX_VALUE;
+        final LongIterator iterator = valueIterator.reset();
+        while (iterator.hasNext()) {
+            min = Math.min(min, iterator.nextValue());
+        }
+        return min;
+    }
+
+    private static class IteratorSupplier implements Supplier<Iterator<Long>> {
+        private final LongIterator keyIterator;
+
+        public IteratorSupplier(LongIterator keyIterator) {
+            this.keyIterator = keyIterator;
+        }
+
+        @Override
+        public Iterator<Long> get() {
+            return keyIterator.reset();
+        }
+    }
+
+    private static class EntryIteratorSupplier implements Supplier<Iterator<Entry<Long, Long>>> {
+        private final EntryIterator entryIterator;
+
+        public EntryIteratorSupplier(EntryIterator entryIterator) {
+            this.entryIterator = entryIterator;
+        }
+
+        @Override
+        public Iterator<Entry<Long, Long>> get() {
+            return entryIterator.reset();
+        }
+    }
+
+    private static class UnboxingBiConsumer implements LongLongConsumer {
+        private final BiConsumer<? super Long, ? super Long> action;
+
+        public UnboxingBiConsumer(BiConsumer<? super Long, ? super Long> action) {
+            this.action = action;
+        }
+
+        @Override
+        public void accept(long t, long u) {
+            action.accept(t, u);
+        }
+    }
+
+    // ---------------- Utility Classes ----------------
+
+    private abstract class AbstractIterator {
+        protected final int startIndex;
+
+        protected int index;
+
+        protected AbstractIterator(final int startIndex) {
+            this.startIndex = startIndex;
+            index = startIndex;
+        }
+
+        public boolean hasNext() {
+            while (entries[index] == missingValue) {
+                nextIndex();
+                if (index == startIndex) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        public void remove() {
+            throw new UnsupportedOperationException("remove");
+        }
+
+        protected void nextIndex() {
+            index = next(index);
+        }
+    }
+
+    private final class LongIterator extends AbstractIterator implements Iterator<Long> {
+        private LongIterator(final int startIndex) {
+            super(startIndex);
+        }
+
+        private LongIterator reset() {
+            index = startIndex;
+            return this;
+        }
+
+        public Long next() {
+            return nextValue();
+        }
+
+        public long nextValue() {
+            final long entry = entries[index];
+            nextIndex();
+            return entry;
+        }
+    }
+
+    private final class EntryIterator extends AbstractIterator implements Iterator<Entry<Long, Long>>, Entry<Long,
+            Long> {
+        private long key;
+        private long value;
+
+        private EntryIterator() {
+            super(0);
+        }
+
+        private EntryIterator reset() {
+            index = startIndex;
+            return this;
+        }
+
+        public Long getKey() {
+            return key;
+        }
+
+        public Long getValue() {
+            return value;
+        }
+
+        public Long setValue(final Long value) {
+            throw new UnsupportedOperationException();
+        }
+
+        public Entry<Long, Long> next() {
+            key = entries[index];
+            value = entries[index + 1];
+            nextIndex();
+            return this;
+        }
+    }
+
+    private int next(final int index) {
+        return (index + 2) & mask;
+    }
+
+    private void capacity(final int newCapacity) {
+        capacity = newCapacity;
+        resizeThreshold = (int) (newCapacity * loadFactor);
+        mask = (newCapacity * 2) - 1;
+        entries = new long[newCapacity * 2];
+        Arrays.fill(entries, missingValue);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/util/collection/Long2ObjectHashMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/collection/Long2ObjectHashMap.java
@@ -1,0 +1,579 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.util.collection;
+
+import com.hazelcast.util.QuickMath;
+import com.hazelcast.util.function.LongFunction;
+
+import java.util.AbstractCollection;
+import java.util.AbstractSet;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Set;
+
+import static com.hazelcast.util.Preconditions.checkNotNull;
+
+/**
+ * {@link java.util.Map} implementation specialised for long keys using open addressing and
+ * linear probing for cache efficient access.
+ *
+ * @param <V> values stored in the {@link java.util.Map}
+ */
+public class Long2ObjectHashMap<V> implements Map<Long, V> {
+    private final double loadFactor;
+    private int resizeThreshold;
+    private int capacity;
+    private int mask;
+    private int size;
+
+    private long[] keys;
+    private Object[] values;
+
+    // Cached to avoid allocation.
+    private final ValueCollection<V> valueCollection = new ValueCollection<V>();
+    private final KeySet keySet = new KeySet();
+    private final EntrySet<V> entrySet = new EntrySet<V>();
+
+    public Long2ObjectHashMap() {
+        this(8, 0.6);
+    }
+
+    /**
+     * Construct a new map allowing a configuration for initial capacity and load factor.
+     *
+     * @param initialCapacity for the backing array
+     * @param loadFactor      limit for resizing on puts
+     */
+    public Long2ObjectHashMap(final int initialCapacity, final double loadFactor) {
+        this.loadFactor = loadFactor;
+        capacity = QuickMath.nextPowerOfTwo(initialCapacity);
+        mask = capacity - 1;
+        resizeThreshold = (int) (capacity * loadFactor);
+
+        keys = new long[capacity];
+        values = new Object[capacity];
+    }
+
+    /**
+     * Get the load factor beyond which the map will increase size.
+     *
+     * @return load factor for when the map should increase size.
+     */
+    public double loadFactor() {
+        return loadFactor;
+    }
+
+    /**
+     * Get the total capacity for the map to which the load factor with be a fraction of.
+     *
+     * @return the total capacity for the map.
+     */
+    public int capacity() {
+        return capacity;
+    }
+
+    /**
+     * Get the actual threshold which when reached the map resize.
+     * This is a function of the current capacity and load factor.
+     *
+     * @return the threshold when the map will resize.
+     */
+    public int resizeThreshold() {
+        return resizeThreshold;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public int size() {
+        return size;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public boolean isEmpty() {
+        return 0 == size;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public boolean containsKey(final Object key) {
+        checkNotNull(key, "Null keys are not permitted");
+        return containsKey(((Long) key).longValue());
+    }
+
+    /**
+     * Overloaded version of {@link Map#containsKey(Object)} that takes a primitive long key.
+     *
+     * @param key for indexing the {@link Map}
+     * @return true if the key is found otherwise false.
+     */
+    public boolean containsKey(final long key) {
+        int index = hash(key);
+        while (null != values[index]) {
+            if (key == keys[index]) {
+                return true;
+            }
+            index = ++index & mask;
+        }
+        return false;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public boolean containsValue(final Object value) {
+        checkNotNull(value, "Null values are not permitted");
+        for (final Object v : values) {
+            if (null != v && value.equals(v)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public V get(final Object key) {
+        return get(((Long) key).longValue());
+    }
+
+    /**
+     * Overloaded version of {@link Map#get(Object)} that takes a primitive long key.
+     *
+     * @param key for indexing the {@link Map}
+     * @return the value if found otherwise null
+     */
+    @SuppressWarnings("unchecked")
+    public V get(final long key) {
+        int index = hash(key);
+        Object value;
+        while (null != (value = values[index])) {
+            if (key == keys[index]) {
+                return (V) value;
+            }
+            index = ++index & mask;
+        }
+        return null;
+    }
+
+    /**
+     * Get a value for a given key, or if it does ot exist then default the value via a {@link LongFunction}
+     * and put it in the map.
+     * <p/>
+     * Primitive specialized version of {@link java.util.Map#computeIfAbsent}.
+     *
+     * @param key             to search on.
+     * @param mappingFunction to provide a value if the get returns null.
+     * @return the value if found otherwise the default.
+     */
+    public V computeIfAbsent(final long key, final LongFunction<? extends V> mappingFunction) {
+        checkNotNull(mappingFunction, "mappingFunction cannot be null");
+        V value = get(key);
+        if (value == null) {
+            value = mappingFunction.apply(key);
+            if (value != null) {
+                put(key, value);
+            }
+        }
+        return value;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public V put(final Long key, final V value) {
+        return put(key.longValue(), value);
+    }
+
+    /**
+     * Overloaded version of {@link Map#put(Object, Object)} that takes a primitive int key.
+     *
+     * @param key   for indexing the {@link Map}
+     * @param value to be inserted in the {@link Map}
+     * @return the previous value if found otherwise null
+     */
+    @SuppressWarnings("unchecked")
+    public V put(final long key, final V value) {
+        checkNotNull(value, "Value cannot be null");
+        V oldValue = null;
+        int index = hash(key);
+        while (null != values[index]) {
+            if (key == keys[index]) {
+                oldValue = (V) values[index];
+                break;
+            }
+            index = ++index & mask;
+        }
+        if (null == oldValue) {
+            ++size;
+            keys[index] = key;
+        }
+        values[index] = value;
+        if (size > resizeThreshold) {
+            increaseCapacity();
+        }
+        return oldValue;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public V remove(final Object key) {
+        return remove(((Long) key).longValue());
+    }
+
+    /**
+     * Overloaded version of {@link Map#remove(Object)} that takes a primitive int key.
+     *
+     * @param key for indexing the {@link Map}
+     * @return the value if found otherwise null
+     */
+    @SuppressWarnings("unchecked")
+    public V remove(final long key) {
+        int index = hash(key);
+        Object value;
+        while (null != (value = values[index])) {
+            if (key == keys[index]) {
+                values[index] = null;
+                --size;
+                compactChain(index);
+                return (V) value;
+            }
+            index = ++index & mask;
+        }
+        return null;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public void clear() {
+        size = 0;
+        Arrays.fill(values, null);
+    }
+
+    /**
+     * Compact the {@link Map} backing arrays by rehashing with a capacity just larger than current size
+     * and giving consideration to the load factor.
+     */
+    public void compact() {
+        final int idealCapacity = (int) Math.round(size() * (1.0d / loadFactor));
+        rehash(QuickMath.nextPowerOfTwo(idealCapacity));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public void putAll(final Map<? extends Long, ? extends V> map) {
+        for (final Entry<? extends Long, ? extends V> entry : map.entrySet()) {
+            put(entry.getKey(), entry.getValue());
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public KeySet keySet() {
+        return keySet;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public Collection<V> values() {
+        return valueCollection;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public Set<Entry<Long, V>> entrySet() {
+        return entrySet;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public String toString() {
+        final StringBuilder sb = new StringBuilder();
+        sb.append('{');
+        for (final Map.Entry<Long, V> entry : entrySet()) {
+            sb.append(entry.getKey().longValue());
+            sb.append('=');
+            sb.append(entry.getValue());
+            sb.append(", ");
+        }
+        if (sb.length() > 1) {
+            sb.setLength(sb.length() - 2);
+        }
+        sb.append('}');
+        return sb.toString();
+    }
+
+    private void increaseCapacity() {
+        final int newCapacity = capacity << 1;
+        if (newCapacity < 0) {
+            throw new IllegalStateException("Max capacity reached at size=" + size);
+        }
+        rehash(newCapacity);
+    }
+
+    private void rehash(final int newCapacity) {
+        if (1 != Integer.bitCount(newCapacity)) {
+            throw new IllegalStateException("New capacity must be a power of two");
+        }
+        capacity = newCapacity;
+        mask = newCapacity - 1;
+        resizeThreshold = (int) (newCapacity * loadFactor);
+        final long[] tempKeys = new long[capacity];
+        final Object[] tempValues = new Object[capacity];
+        for (int i = 0, size = values.length; i < size; i++) {
+            final Object value = values[i];
+            if (null != value) {
+                final long key = keys[i];
+                int newHash = hash(key);
+                while (null != tempValues[newHash]) {
+                    newHash = ++newHash & mask;
+                }
+                tempKeys[newHash] = key;
+                tempValues[newHash] = value;
+            }
+        }
+        keys = tempKeys;
+        values = tempValues;
+    }
+
+    private void compactChain(int deleteIndex) {
+        int index = deleteIndex;
+        while (true) {
+            index = ++index & mask;
+            if (null == values[index]) {
+                return;
+            }
+            final int hash = hash(keys[index]);
+            if ((index < hash && (hash <= deleteIndex || deleteIndex <= index))
+                    || (hash <= deleteIndex && deleteIndex <= index)) {
+                keys[deleteIndex] = keys[index];
+                values[deleteIndex] = values[index];
+                values[index] = null;
+                deleteIndex = index;
+            }
+        }
+    }
+
+    private int hash(final long key) {
+        int hash = (int) key ^ (int) (key >>> 32);
+        hash = (hash << 1) - (hash << 8);
+        return hash & mask;
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////////////////////
+    // Internal Sets and Collections
+    ///////////////////////////////////////////////////////////////////////////////////////////////
+
+    public class KeySet extends AbstractSet<Long> {
+        public int size() {
+            return Long2ObjectHashMap.this.size();
+        }
+
+        public boolean isEmpty() {
+            return Long2ObjectHashMap.this.isEmpty();
+        }
+
+        public boolean contains(final Object o) {
+            return Long2ObjectHashMap.this.containsKey(o);
+        }
+
+        public boolean contains(final long key) {
+            return Long2ObjectHashMap.this.containsKey(key);
+        }
+
+        public KeyIterator iterator() {
+            return new KeyIterator();
+        }
+
+        public boolean remove(final Object o) {
+            return null != Long2ObjectHashMap.this.remove(o);
+        }
+
+        public boolean remove(final long key) {
+            return null != Long2ObjectHashMap.this.remove(key);
+        }
+
+        public void clear() {
+            Long2ObjectHashMap.this.clear();
+        }
+    }
+
+    private class ValueCollection<V> extends AbstractCollection<V> {
+        public int size() {
+            return Long2ObjectHashMap.this.size();
+        }
+
+        public boolean isEmpty() {
+            return Long2ObjectHashMap.this.isEmpty();
+        }
+
+        public boolean contains(final Object o) {
+            return Long2ObjectHashMap.this.containsValue(o);
+        }
+
+        public ValueIterator<V> iterator() {
+            return new ValueIterator<V>();
+        }
+
+        public void clear() {
+            Long2ObjectHashMap.this.clear();
+        }
+    }
+
+    private class EntrySet<V> extends AbstractSet<Map.Entry<Long, V>> {
+        public int size() {
+            return Long2ObjectHashMap.this.size();
+        }
+
+        public boolean isEmpty() {
+            return Long2ObjectHashMap.this.isEmpty();
+        }
+
+        public Iterator<Map.Entry<Long, V>> iterator() {
+            return new EntryIterator<V>();
+        }
+
+        public void clear() {
+            Long2ObjectHashMap.this.clear();
+        }
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////////////////////
+    // Iterators
+    ///////////////////////////////////////////////////////////////////////////////////////////////
+
+    private abstract class AbstractIterator<T> implements Iterator<T> {
+        protected final long[] keys = Long2ObjectHashMap.this.keys;
+        protected final Object[] values = Long2ObjectHashMap.this.values;
+        private int posCounter;
+        private int stopCounter;
+        private boolean isPositionValid;
+
+        protected AbstractIterator() {
+            int i = capacity;
+            if (null != values[capacity - 1]) {
+                i = 0;
+                for (int size = capacity; i < size; i++) {
+                    if (null == values[i]) {
+                        break;
+                    }
+                }
+            }
+            stopCounter = i;
+            posCounter = i + capacity;
+        }
+
+        protected int getPosition() {
+            return posCounter & mask;
+        }
+
+        public boolean hasNext() {
+            for (int i = posCounter - 1; i >= stopCounter; i--) {
+                final int index = i & mask;
+                if (null != values[index]) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        protected void findNext() {
+            isPositionValid = false;
+            for (int i = posCounter - 1; i >= stopCounter; i--) {
+                final int index = i & mask;
+                if (null != values[index]) {
+                    posCounter = i;
+                    isPositionValid = true;
+                    return;
+                }
+            }
+            throw new NoSuchElementException();
+        }
+
+        public abstract T next();
+
+        public void remove() {
+            if (isPositionValid) {
+                final int position = getPosition();
+                values[position] = null;
+                --size;
+                compactChain(position);
+                isPositionValid = false;
+            } else {
+                throw new IllegalStateException();
+            }
+        }
+    }
+
+    public class ValueIterator<T> extends AbstractIterator<T> {
+        @SuppressWarnings("unchecked")
+        public T next() {
+            findNext();
+            return (T) values[getPosition()];
+        }
+    }
+
+    public class KeyIterator extends AbstractIterator<Long> {
+        public Long next() {
+            return nextLong();
+        }
+
+        public long nextLong() {
+            findNext();
+
+            return keys[getPosition()];
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public class EntryIterator<V> extends AbstractIterator<Entry<Long, V>> implements Entry<Long, V> {
+        public Entry<Long, V> next() {
+            findNext();
+            return this;
+        }
+
+        public Long getKey() {
+            return keys[getPosition()];
+        }
+
+        public V getValue() {
+            return (V) values[getPosition()];
+        }
+
+        public V setValue(final V value) {
+            checkNotNull(value);
+            final int pos = getPosition();
+            final Object oldValue = values[pos];
+            values[pos] = value;
+            return (V) oldValue;
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/util/collection/LongHashSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/collection/LongHashSet.java
@@ -1,0 +1,380 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.util.collection;
+
+import com.hazelcast.util.QuickMath;
+import com.hazelcast.util.function.Predicate;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Set;
+
+import static com.hazelcast.util.Preconditions.checkNotNull;
+
+/**
+ * Simple fixed-size long hashset for validating tags.
+ */
+public final class LongHashSet implements Set<Long> {
+    private final long[] values;
+    private final LongIterator iterator;
+    private final int mask;
+    private final long missingValue;
+
+    private int size;
+
+    public LongHashSet(final int proposedCapacity, final long missingValue) {
+        size = 0;
+        this.missingValue = missingValue;
+        final int capacity = QuickMath.nextPowerOfTwo(proposedCapacity);
+        mask = capacity - 1;
+        values = new long[capacity];
+        Arrays.fill(values, missingValue);
+
+        // NB: references values in the constructor, so must be assigned after values
+        iterator = new LongIterator(missingValue, values);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public boolean add(final Long value) {
+        return add(value.longValue());
+    }
+
+    /**
+     * Primitive specialised overload of {this#add(Long)}
+     *
+     * @param value the value to add
+     * @return true if the collection has changed, false otherwise
+     */
+    public boolean add(final long value) {
+        int index = Hashing.longHash(value, mask);
+
+        while (values[index] != missingValue) {
+            if (values[index] == value) {
+                return false;
+            }
+
+            index = next(index);
+        }
+
+        values[index] = value;
+        size++;
+
+        return true;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public boolean remove(final Object value) {
+        return value instanceof Long && remove(((Long) value).longValue());
+    }
+
+    /**
+     * An long specialised version of {this#remove(Object)}.
+     *
+     * @param value the value to remove
+     * @return true if the value was present, false otherwise
+     */
+    public boolean remove(final long value) {
+        int index = Hashing.longHash(value, mask);
+
+        while (values[index] != missingValue) {
+            if (values[index] == value) {
+                values[index] = missingValue;
+                compactChain(index);
+                return true;
+            }
+
+            index = next(index);
+        }
+
+        return false;
+    }
+
+    private int next(int index) {
+        index = ++index & mask;
+        return index;
+    }
+
+    private void compactChain(final int deleteIndex) {
+        final long[] values = this.values;
+
+        int index = deleteIndex;
+        while (true) {
+            final int previousIndex = index;
+            index = next(index);
+            if (values[index] == missingValue) {
+                return;
+            }
+
+            values[previousIndex] = values[index];
+            values[index] = missingValue;
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public boolean contains(final Object value) {
+        return value instanceof Long && contains(((Long) value).longValue());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public boolean contains(final long value) {
+        int index = Hashing.longHash(value, mask);
+
+        while (values[index] != missingValue) {
+            if (values[index] == value) {
+                return true;
+            }
+
+            index = next(index);
+        }
+
+        return false;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public int size() {
+        return size;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public boolean isEmpty() {
+        return size() == 0;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public void clear() {
+        final long[] values = this.values;
+        final int length = values.length;
+        for (int i = 0; i < length; i++) {
+            values[i] = missingValue;
+        }
+        size = 0;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @SuppressWarnings("unchecked")
+    public <T> T[] toArray(final T[] ignore) {
+        return (T[]) (Object) Arrays.copyOf(values, values.length);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public boolean addAll(final Collection<? extends Long> coll) {
+        return addAllCapture(coll);
+    }
+
+    private <E extends Long> boolean addAllCapture(final Collection<E> coll) {
+        final Predicate<E> p = new Predicate<E>() {
+            @Override
+            public boolean test(E x) {
+                return add(x);
+            }
+        };
+        return conjunction(coll, p);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public boolean containsAll(final Collection<?> coll) {
+        return containsAllCapture(coll);
+    }
+
+    private <E> boolean containsAllCapture(Collection<E> coll) {
+        return conjunction(coll, new Predicate<E>() {
+            @Override
+            public boolean test(E value) {
+                return contains(value);
+            }
+        });
+    }
+
+    /**
+     * LongHashSet specialised variant of {this#containsAll(Collection)}.
+     *
+     * @param other the long hashset to compare against.
+     * @return true if every element in other is in this.
+     */
+    public boolean containsAll(final LongHashSet other) {
+        final LongIterator iterator = other.iterator();
+        while (iterator.hasNext()) {
+            if (!contains(iterator.nextValue())) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Fast Path set difference for comparison with another LongHashSet.
+     * <p/>
+     * NB: garbage free in the identical case, allocates otherwise.
+     *
+     * @param collection the other set to subtract
+     * @return null if identical, otherwise the set of differences
+     */
+    public LongHashSet difference(final LongHashSet collection) {
+        checkNotNull(collection);
+
+        LongHashSet difference = null;
+
+        final LongIterator it = iterator();
+
+        while (it.hasNext()) {
+            final long value = it.nextValue();
+            if (!collection.contains(value)) {
+                if (difference == null) {
+                    difference = new LongHashSet(size, missingValue);
+                }
+
+                difference.add(value);
+            }
+        }
+
+        return difference;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public boolean removeAll(final Collection<?> coll) {
+        return removeAllCapture(coll);
+    }
+
+    private <E> boolean removeAllCapture(final Collection<E> coll) {
+        return conjunction(coll, new Predicate<E>() {
+            @Override
+            public boolean test(E value) {
+                return remove(value);
+            }
+        });
+    }
+
+    private static <T> boolean conjunction(final Collection<T> collection, final Predicate<T> predicate) {
+        checkNotNull(collection);
+
+        boolean acc = false;
+        for (final T t : collection) {
+            // Deliberate strict evaluation
+            acc |= predicate.test(t);
+        }
+
+        return acc;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public LongIterator iterator() {
+        iterator.reset();
+        return iterator;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public void copy(final LongHashSet obj) {
+        // NB: mask also implies the length is the same
+        if (this.mask != obj.mask) {
+            throw new IllegalArgumentException("Cannot copy object: masks not equal");
+        }
+
+        if (this.missingValue != obj.missingValue) {
+            throw new IllegalArgumentException("Cannot copy object: missingValues not equal");
+        }
+
+        System.arraycopy(obj.values, 0, this.values, 0, this.values.length);
+        this.size = obj.size;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public String toString() {
+        final StringBuilder b = new StringBuilder(size() * 3 + 2);
+        b.append('{');
+        String separator = "";
+        for (long i : values) {
+            b.append(i).append(separator);
+            separator = ",";
+        }
+        return b.append('}').toString();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public Object[] toArray() {
+        final long[] values = this.values;
+        final Object[] array = new Object[values.length];
+        for (int i = 0; i < values.length; i++) {
+            array[i] = values[i];
+        }
+        return array;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public boolean equals(final Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (other instanceof LongHashSet) {
+            final LongHashSet otherSet = (LongHashSet) other;
+            return otherSet.missingValue == missingValue && otherSet.size() == size() && containsAll(otherSet);
+        }
+
+        return false;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public int hashCode() {
+        final LongIterator iterator = iterator();
+        int total = 0;
+        while (iterator.hasNext()) {
+            // Cast exists for substitutions
+            total += (long) iterator.nextValue();
+        }
+        return total;
+    }
+
+    // --- Unimplemented below here
+
+    public boolean retainAll(final Collection<?> coll) {
+        throw new UnsupportedOperationException("Not implemented");
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/util/collection/LongIterator.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/collection/LongIterator.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.util.collection;
+
+import java.util.Iterator;
+
+/**
+ * An iterator for a sequence of primitive integers.
+ */
+public class LongIterator implements Iterator<Long> {
+    private final long missingValue;
+    private final long[] values;
+
+    private int position;
+
+    /**
+     * Construct an {@link Iterator} over an array of primitives longs.
+     *
+     * @param missingValue to indicate the value is missing, i.e. not present or null.
+     * @param values       to iterate over.
+     */
+    public LongIterator(final long missingValue, final long[] values) {
+        this.missingValue = missingValue;
+        this.values = values;
+    }
+
+    public boolean hasNext() {
+        final long[] values = this.values;
+        while (position < values.length) {
+            if (values[position] != missingValue) {
+                return true;
+            }
+
+            position++;
+        }
+
+        return false;
+    }
+
+    public Long next() {
+        return nextValue();
+    }
+
+    public void remove() {
+        throw new UnsupportedOperationException("remove");
+    }
+
+    /**
+     * Strongly typed alternative of {@link Iterator#next()} not to avoid boxing.
+     *
+     * @return the next long value.
+     */
+    public long nextValue() {
+        final long value = values[position];
+        position++;
+        return value;
+    }
+
+    void reset() {
+        position = 0;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/util/collection/MapDelegatingSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/collection/MapDelegatingSet.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.util.collection;
+
+import com.hazelcast.util.function.Predicate;
+import com.hazelcast.util.function.Supplier;
+
+import java.util.AbstractSet;
+import java.util.Iterator;
+import java.util.Map;
+
+/**
+ * Read-only collection which delegates its operations to an underlying map and a couple of functions. Designed
+ * to easily implement keyset() and values() methods in a map.
+ *
+ * @param <V> The generic type of the set.
+ */
+public final class MapDelegatingSet<V> extends AbstractSet<V> {
+    private final Map<?, ?> delegate;
+    private final Supplier<Iterator<V>> iterator;
+    private final Predicate contains;
+
+    public MapDelegatingSet(final Map<?, ?> delegate, final Supplier<Iterator<V>> iterator, final Predicate contains) {
+        this.delegate = delegate;
+        this.iterator = iterator;
+        this.contains = contains;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public int size() {
+        return delegate.size();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public boolean isEmpty() {
+        return delegate.isEmpty();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @SuppressWarnings("unchecked")
+    public boolean contains(final Object o) {
+        return contains.test(o);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public Iterator<V> iterator() {
+        return iterator.get();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public void clear() {
+        delegate.clear();
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/util/collection/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/collection/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * The Agrona project backport: collections.
+ */
+package com.hazelcast.util.collection;

--- a/hazelcast/src/main/java/com/hazelcast/util/function/BiConsumer.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/function/BiConsumer.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.util.function;
+
+/**
+ * Represents an operation that accepts two input arguments and returns no
+ * result.  This is the two-arity specialization of {@link Consumer}.
+ * Unlike most other functional interfaces, {@code BiConsumer} is expected
+ * to operate via side-effects.
+ *
+ * @param <T> the type of the first argument to the operation
+ * @param <U> the type of the second argument to the operation
+ */
+public interface BiConsumer<T, U> {
+
+    /**
+     * Performs this operation on the given arguments.
+     *
+     * @param t the first input argument
+     * @param u the second input argument
+     */
+    void accept(T t, U u);
+}

--- a/hazelcast/src/main/java/com/hazelcast/util/function/Consumer.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/function/Consumer.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.util.function;
+
+/**
+ * Represents an operation that accepts a single input argument and returns no
+ * result. Unlike most other functional interfaces, {@code Consumer} is expected
+ * to operate via side-effects.
+ *
+ * @param <T> the type of the input to the operation
+ */
+public interface Consumer<T> {
+
+    /**
+     * Performs this operation on the given argument.
+     *
+     * @param t the input argument
+     */
+    void accept(T t);
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/util/function/IntFunction.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/function/IntFunction.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.util.function;
+
+/**
+ * Represents a function that accepts an int-valued argument and produces a
+ * result.  This is the {@code int}-consuming primitive specialization for
+ * {@link Function}.
+ *
+ * @param <R> the type of the result of the function
+ */
+public interface IntFunction<R> {
+
+    /**
+     * Applies this function to the given argument.
+     *
+     * @param value the function argument
+     * @return the function result
+     */
+    R apply(int value);
+}

--- a/hazelcast/src/main/java/com/hazelcast/util/function/LongFunction.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/function/LongFunction.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.util.function;
+
+/**
+ * Represents a function that accepts a long-valued argument and produces a
+ * result.
+ *
+ * @param <R> the type of the result of the function
+ */
+public interface LongFunction<R> {
+
+    /**
+     * Applies this function to the given argument.
+     *
+     * @param value the function argument
+     * @return the function result
+     */
+    R apply(long value);
+}

--- a/hazelcast/src/main/java/com/hazelcast/util/function/LongLongConsumer.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/function/LongLongConsumer.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.util.function;
+
+/**
+ * This is a (long,long) primitive specialisation of a BiConsumer
+ */
+public interface LongLongConsumer {
+    /**
+     * Accept a key and value that comes as a tuple of longs.
+     *
+     * @param key   for the tuple.
+     * @param value for the tuple.
+     */
+    void accept(long key, long value);
+}

--- a/hazelcast/src/main/java/com/hazelcast/util/function/Predicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/function/Predicate.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.util.function;
+
+/**
+ * Represents a predicate (boolean-valued function) of one argument.
+ *
+ * @param <T> the type of the input to the predicate
+ */
+public interface Predicate<T> {
+
+    /**
+     * Evaluates this predicate on the given argument.
+     *
+     * @param t the input argument
+     * @return {@code true} if the input argument matches the predicate,
+     * otherwise {@code false}
+     */
+    boolean test(T t);
+}

--- a/hazelcast/src/main/java/com/hazelcast/util/function/Supplier.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/function/Supplier.java
@@ -14,7 +14,16 @@
  * limitations under the License.
  */
 
+package com.hazelcast.util.function;
+
 /**
- * This package is currently a dummy package for collections. There is nothing interesting to find here.
+ * Represents a supplier of results.
+ *
+ * <p>There is no requirement that a new or distinct result be returned each
+ * time the supplier is invoked.
+ *
+ * @param <T> the type of results supplied by this supplier
  */
-package com.hazelcast.collection;
+public interface Supplier<T> {
+    T get();
+}

--- a/hazelcast/src/main/java/com/hazelcast/util/function/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/function/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Backport of Java 8 functional interfaces which Agrona depends on.
+ */
+package com.hazelcast.util.function;

--- a/hazelcast/src/test/java/com/hazelcast/util/QuickMathTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/QuickMathTest.java
@@ -48,6 +48,10 @@ public class QuickMathTest {
 
     @Test
     public void testNextPowerOfTwo() {
+        assertEquals(1, QuickMath.nextPowerOfTwo(-9999999));
+        assertEquals(1, QuickMath.nextPowerOfTwo(-1));
+        assertEquals(1, QuickMath.nextPowerOfTwo(0));
+        assertEquals(1, QuickMath.nextPowerOfTwo(1));
         assertEquals(2, QuickMath.nextPowerOfTwo(2));
         assertEquals(1024, QuickMath.nextPowerOfTwo(999));
         assertEquals(1 << 23, QuickMath.nextPowerOfTwo((1 << 23) - 1));
@@ -56,6 +60,17 @@ public class QuickMathTest {
         assertEquals(2048L, QuickMath.nextPowerOfTwo(2000L));
         assertEquals(1L << 33, QuickMath.nextPowerOfTwo((1L << 33) - 3));
         assertEquals(1L << 43, QuickMath.nextPowerOfTwo((1L << 43)));
+    }
+
+    @Test
+    public void testNextLongPowerOfTwo() {
+        assertEquals(1L, QuickMath.nextPowerOfTwo(-9999999L));
+        assertEquals(1L, QuickMath.nextPowerOfTwo(-1L));
+        assertEquals(1L, QuickMath.nextPowerOfTwo(0L));
+        assertEquals(1L, QuickMath.nextPowerOfTwo(1L));
+        assertEquals(2L, QuickMath.nextPowerOfTwo(2L));
+        assertEquals(4L, QuickMath.nextPowerOfTwo(3L));
+        assertEquals(1L << 62, QuickMath.nextPowerOfTwo((1L << 61) + 1));
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/util/collection/BiInt2ObjectMapTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/collection/BiInt2ObjectMapTest.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2014 Real Logic Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.util.collection;
+
+import com.hazelcast.util.collection.BiInt2ObjectMap.EntryConsumer;
+import com.hazelcast.util.function.Consumer;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.hamcrest.CoreMatchers.either;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class BiInt2ObjectMapTest {
+    private final BiInt2ObjectMap<String> map = new BiInt2ObjectMap<String>();
+
+    @Test public void shouldInitialiseUnderlyingImplementation() {
+        final int initialCapacity = 10;
+        final double loadFactor = 0.6;
+        final BiInt2ObjectMap<String> map = new BiInt2ObjectMap<String>(initialCapacity, loadFactor);
+
+        assertThat(map.capacity(), either(is(initialCapacity)).or(greaterThan(initialCapacity)));
+        assertThat(map.loadFactor(), is(loadFactor));
+    }
+
+    @Test public void shouldReportEmpty() {
+        assertThat(map.isEmpty(), is(true));
+    }
+
+    @Test public void shouldPutItem() {
+        final String testValue = "Test";
+        final int keyPartA = 3;
+        final int keyPartB = 7;
+
+        assertNull(map.put(keyPartA, keyPartB, testValue));
+        assertThat(map.size(), is(1));
+    }
+
+    @Test public void shouldPutAndGetItem() {
+        final String testValue = "Test";
+        final int keyPartA = 3;
+        final int keyPartB = 7;
+
+        assertNull(map.put(keyPartA, keyPartB, testValue));
+        assertThat(map.get(keyPartA, keyPartB), is(testValue));
+    }
+
+    @Test public void shouldReturnNullWhenNotFoundItem() {
+        final int keyPartA = 3;
+        final int keyPartB = 7;
+
+        assertNull(map.get(keyPartA, keyPartB));
+    }
+
+    @Test public void shouldRemoveItem() {
+        final String testValue = "Test";
+        final int keyPartA = 3;
+        final int keyPartB = 7;
+
+        map.put(keyPartA, keyPartB, testValue);
+        assertThat(map.remove(keyPartA, keyPartB), is(testValue));
+        assertNull(map.get(keyPartA, keyPartB));
+    }
+
+    @Test public void shouldIterateValues() {
+        final Set<String> expectedSet = new HashSet<String>();
+        final int count = 7;
+
+        for (int i = 0; i < count; i++) {
+            final String value = String.valueOf(i);
+            expectedSet.add(value);
+            map.put(i, i + 97, value);
+        }
+
+        final Set<String> actualSet = new HashSet<String>();
+
+        map.forEach(new Consumer<String>() {
+            @Override public void accept(String s) {
+                actualSet.add(s);
+            }
+        });
+
+        assertThat(actualSet, equalTo(expectedSet));
+    }
+
+    @Test public void shouldIterateEntries() {
+        final Set<EntryCapture<String>> expectedSet = new HashSet<EntryCapture<String>>();
+        final int count = 7;
+
+        for (int i = 0; i < count; i++) {
+            final String value = String.valueOf(i);
+            expectedSet.add(new EntryCapture<String>(i, i + 97, value));
+            map.put(i, i + 97, value);
+        }
+
+        final Set<EntryCapture<String>> actualSet = new HashSet<EntryCapture<String>>();
+
+        map.forEach(new EntryConsumer<String>() {
+            @Override public void accept(int keyPartA, int keyPartB, String value) {
+                actualSet.add(new EntryCapture<String>(keyPartA, keyPartB, value));
+            }
+        });
+
+        assertThat(actualSet, equalTo(expectedSet));
+    }
+
+    public static class EntryCapture<V> {
+        public final int keyPartA;
+        public final int keyPartB;
+        public final V value;
+
+        public EntryCapture(final int keyPartA, final int keyPartB, final V value) {
+            this.keyPartA = keyPartA;
+            this.keyPartB = keyPartB;
+            this.value = value;
+        }
+
+        public boolean equals(final Object o) {
+            if (this == o) {
+                return true;
+            }
+
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            final EntryCapture that = (EntryCapture) o;
+
+            return keyPartA == that.keyPartA && keyPartB == that.keyPartB && value.equals(that.value);
+
+        }
+
+        public int hashCode() {
+            int result = keyPartA;
+            result = 31 * result + keyPartB;
+            result = 31 * result + value.hashCode();
+
+            return result;
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/util/collection/Int2ObjectHashMapTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/collection/Int2ObjectHashMapTest.java
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.hazelcast.client.protocol;
 
-import com.hazelcast.client.impl.protocol.util.Int2ObjectHashMap;
+package com.hazelcast.util.collection;
+
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Assert;
@@ -37,22 +37,17 @@ import static org.junit.Assert.assertThat;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class Int2ObjectHashMapTest
-{
+public class Int2ObjectHashMapTest {
     private final Int2ObjectHashMap<String> intToObjectMap = new Int2ObjectHashMap<String>();
 
-    @Test
-    public void shouldDoPutAndThenGet()
-    {
+    @Test public void shouldDoPutAndThenGet() {
         final String value = "Seven";
         intToObjectMap.put(7, value);
 
         assertThat(intToObjectMap.get(7), is(value));
     }
 
-    @Test
-    public void shouldReplaceExistingValueForTheSameKey()
-    {
+    @Test public void shouldReplaceExistingValueForTheSameKey() {
         final int key = 7;
         final String value = "Seven";
         intToObjectMap.put(key, value);
@@ -65,13 +60,10 @@ public class Int2ObjectHashMapTest
         assertThat(valueOf(intToObjectMap.size()), is(valueOf(1)));
     }
 
-    @Test
-    public void shouldGrowWhenThresholdExceeded()
-    {
+    @Test public void shouldGrowWhenThresholdExceeded() {
         final double loadFactor = 0.5d;
         final Int2ObjectHashMap<String> map = new Int2ObjectHashMap<String>(32, loadFactor);
-        for (int i = 0; i < 16; i++)
-        {
+        for (int i = 0; i < 16; i++) {
             map.put(i, Integer.toString(i));
         }
 
@@ -89,9 +81,7 @@ public class Int2ObjectHashMapTest
         assertThat(loadFactor, closeTo(map.loadFactor(), 0.0));
     }
 
-    @Test
-    public void shouldHandleCollisionAndThenLinearProbe()
-    {
+    @Test public void shouldHandleCollisionAndThenLinearProbe() {
         final double loadFactor = 0.5d;
         final Int2ObjectHashMap<String> map = new Int2ObjectHashMap<String>(32, loadFactor);
         final int key = 7;
@@ -107,11 +97,8 @@ public class Int2ObjectHashMapTest
         assertThat(loadFactor, closeTo(map.loadFactor(), 0.0));
     }
 
-    @Test
-    public void shouldClearCollection()
-    {
-        for (int i = 0; i < 15; i++)
-        {
+    @Test public void shouldClearCollection() {
+        for (int i = 0; i < 15; i++) {
             intToObjectMap.put(i, Integer.toString(i));
         }
 
@@ -124,17 +111,13 @@ public class Int2ObjectHashMapTest
         Assert.assertNull(intToObjectMap.get(1));
     }
 
-    @Test
-    public void shouldCompactCollection()
-    {
+    @Test public void shouldCompactCollection() {
         final int totalItems = 50;
-        for (int i = 0; i < totalItems; i++)
-        {
+        for (int i = 0; i < totalItems; i++) {
             intToObjectMap.put(i, Integer.toString(i));
         }
 
-        for (int i = 0, limit = totalItems - 4; i < limit; i++)
-        {
+        for (int i = 0, limit = totalItems - 4; i < limit; i++) {
             intToObjectMap.remove(i);
         }
 
@@ -144,9 +127,7 @@ public class Int2ObjectHashMapTest
         assertThat(valueOf(intToObjectMap.capacity()), lessThan(valueOf(capacityBeforeCompaction)));
     }
 
-    @Test
-    public void shouldContainValue()
-    {
+    @Test public void shouldContainValue() {
         final int key = 7;
         final String value = "Seven";
 
@@ -156,9 +137,7 @@ public class Int2ObjectHashMapTest
         Assert.assertFalse(intToObjectMap.containsValue("NoKey"));
     }
 
-    @Test
-    public void shouldContainKey()
-    {
+    @Test public void shouldContainKey() {
         final int key = 7;
         final String value = "Seven";
 
@@ -168,9 +147,7 @@ public class Int2ObjectHashMapTest
         Assert.assertFalse(intToObjectMap.containsKey(0));
     }
 
-    @Test
-    public void shouldRemoveEntry()
-    {
+    @Test public void shouldRemoveEntry() {
         final int key = 7;
         final String value = "Seven";
 
@@ -183,9 +160,7 @@ public class Int2ObjectHashMapTest
         Assert.assertFalse(intToObjectMap.containsKey(key));
     }
 
-    @Test
-    public void shouldRemoveEntryAndCompactCollisionChain()
-    {
+    @Test public void shouldRemoveEntryAndCompactCollisionChain() {
         final int key = 12;
         final String value = "12";
 
@@ -201,13 +176,10 @@ public class Int2ObjectHashMapTest
         assertThat(intToObjectMap.remove(key), is(value));
     }
 
-    @Test
-    public void shouldIterateValues()
-    {
+    @Test public void shouldIterateValues() {
         final Collection<String> initialSet = new HashSet<String>();
 
-        for (int i = 0; i < 11; i++)
-        {
+        for (int i = 0; i < 11; i++) {
             final String value = Integer.toString(i);
             intToObjectMap.put(i, value);
             initialSet.add(value);
@@ -215,21 +187,17 @@ public class Int2ObjectHashMapTest
 
         final Collection<String> copyToSet = new HashSet<String>();
 
-        for (final String s : intToObjectMap.values())
-        {
+        for (final String s : intToObjectMap.values()) {
             copyToSet.add(s);
         }
 
         assertThat(copyToSet, is(initialSet));
     }
 
-    @Test
-    public void shouldIterateKeysGettingIntAsPrimitive()
-    {
+    @Test public void shouldIterateKeysGettingIntAsPrimitive() {
         final Collection<Integer> initialSet = new HashSet<Integer>();
 
-        for (int i = 0; i < 11; i++)
-        {
+        for (int i = 0; i < 11; i++) {
             final String value = Integer.toString(i);
             intToObjectMap.put(i, value);
             initialSet.add(valueOf(i));
@@ -237,21 +205,17 @@ public class Int2ObjectHashMapTest
 
         final Collection<Integer> copyToSet = new HashSet<Integer>();
 
-        for (final Int2ObjectHashMap.KeyIterator iter = intToObjectMap.keySet().iterator(); iter.hasNext();)
-        {
+        for (final Int2ObjectHashMap.KeyIterator iter = intToObjectMap.keySet().iterator(); iter.hasNext(); ) {
             copyToSet.add(valueOf(iter.nextInt()));
         }
 
         assertThat(copyToSet, is(initialSet));
     }
 
-    @Test
-    public void shouldIterateKeys()
-    {
+    @Test public void shouldIterateKeys() {
         final Collection<Integer> initialSet = new HashSet<Integer>();
 
-        for (int i = 0; i < 11; i++)
-        {
+        for (int i = 0; i < 11; i++) {
             final String value = Integer.toString(i);
             intToObjectMap.put(i, value);
             initialSet.add(valueOf(i));
@@ -259,22 +223,18 @@ public class Int2ObjectHashMapTest
 
         final Collection<Integer> copyToSet = new HashSet<Integer>();
 
-        for (final Integer aInteger : intToObjectMap.keySet())
-        {
+        for (final Integer aInteger : intToObjectMap.keySet()) {
             copyToSet.add(aInteger);
         }
 
         assertThat(copyToSet, is(initialSet));
     }
 
-    @Test
-    public void shouldIterateAndHandleRemove()
-    {
+    @Test public void shouldIterateAndHandleRemove() {
         final Collection<Integer> initialSet = new HashSet<Integer>();
 
         final int count = 11;
-        for (int i = 0; i < count; i++)
-        {
+        for (int i = 0; i < count; i++) {
             final String value = Integer.toString(i);
             intToObjectMap.put(i, value);
             initialSet.add(valueOf(i));
@@ -283,15 +243,11 @@ public class Int2ObjectHashMapTest
         final Collection<Integer> copyOfSet = new HashSet<Integer>();
 
         int i = 0;
-        for (final Iterator<Integer> iter = intToObjectMap.keySet().iterator(); iter.hasNext();)
-        {
+        for (final Iterator<Integer> iter = intToObjectMap.keySet().iterator(); iter.hasNext(); ) {
             final Integer item = iter.next();
-            if (i++ == 7)
-            {
+            if (i++ == 7) {
                 iter.remove();
-            }
-            else
-            {
+            } else {
                 copyOfSet.add(item);
             }
         }
@@ -302,23 +258,18 @@ public class Int2ObjectHashMapTest
         assertThat(valueOf(copyOfSet.size()), is(valueOf(reducedSetSize)));
     }
 
-    @Test
-    public void shouldIterateEntries()
-    {
+    @Test public void shouldIterateEntries() {
         final int count = 11;
-        for (int i = 0; i < count; i++)
-        {
+        for (int i = 0; i < count; i++) {
             final String value = Integer.toString(i);
             intToObjectMap.put(i, value);
         }
 
         final String testValue = "Wibble";
-        for (final Map.Entry<Integer, String> entry : intToObjectMap.entrySet())
-        {
+        for (final Map.Entry<Integer, String> entry : intToObjectMap.entrySet()) {
             assertThat(entry.getKey(), equalTo(valueOf(entry.getValue())));
 
-            if (entry.getKey() == 7)
-            {
+            if (entry.getKey() == 7) {
                 entry.setValue(testValue);
             }
         }
@@ -326,13 +277,10 @@ public class Int2ObjectHashMapTest
         assertThat(intToObjectMap.get(7), equalTo(testValue));
     }
 
-    @Test
-    public void shouldGenerateStringRepresentation()
-    {
+    @Test public void shouldGenerateStringRepresentation() {
         final int[] testEntries = {3, 1, 19, 7, 11, 12, 7};
 
-        for (final int testEntry : testEntries)
-        {
+        for (final int testEntry : testEntries) {
             intToObjectMap.put(testEntry, String.valueOf(testEntry));
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/util/collection/IntHashSetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/collection/IntHashSetTest.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright 2015 Real Logic Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.util.collection;
+
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Iterator;
+
+import static org.hamcrest.Matchers.contains;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class IntHashSetTest {
+    private final IntHashSet obj = new IntHashSet(100, -1);
+
+    @Test public void initiallyContainsNoElements() throws Exception {
+        for (int i = 0; i < 10000; i++) {
+            assertFalse(obj.contains(i));
+        }
+    }
+
+    @Test public void initiallyContainsNoBoxedElements() {
+        for (int i = 0; i < 10000; i++) {
+            assertFalse(obj.contains(Integer.valueOf(i)));
+        }
+    }
+
+    @Test public void containsAddedBoxedElement() {
+        assertTrue(obj.add(1));
+
+        assertTrue(obj.contains(1));
+    }
+
+    @Test public void addingAnElementTwiceDoesNothing() {
+        assertTrue(obj.add(1));
+
+        assertFalse(obj.add(1));
+    }
+
+    @Test public void containsAddedBoxedElements() {
+        assertTrue(obj.add(1));
+        assertTrue(obj.add(Integer.valueOf(2)));
+
+        assertTrue(obj.contains(Integer.valueOf(1)));
+        assertTrue(obj.contains(2));
+    }
+
+    @Test public void removingAnElementFromAnEmptyListDoesNothing() {
+        assertFalse(obj.remove(0));
+    }
+
+    @Test public void removingAPresentElementRemovesIt() {
+        assertTrue(obj.add(1));
+
+        assertTrue(obj.remove(1));
+
+        assertFalse(obj.contains(1));
+    }
+
+    @Test public void sizeIsInitiallyZero() {
+        assertEquals(0, obj.size());
+    }
+
+    @Test public void sizeIncrementsWithNumberOfAddedElements() {
+        obj.add(1);
+        obj.add(2);
+
+        assertEquals(2, obj.size());
+    }
+
+    @Test public void sizeContainsNumberOfNewElements() {
+        obj.add(1);
+        obj.add(1);
+
+        assertEquals(1, obj.size());
+    }
+
+    @Test public void iteratorsListElements() {
+        obj.add(1);
+        obj.add(2);
+
+        assertIteratorHasElements();
+    }
+
+    @Test public void iteratorsStartFromTheBeginningEveryTime() {
+        iteratorsListElements();
+
+        assertIteratorHasElements();
+    }
+
+    @Test public void clearRemovesAllElementsOfTheSet() {
+        obj.add(1);
+        obj.add(2);
+
+        obj.clear();
+
+        assertEquals(0, obj.size());
+        assertFalse(obj.contains(1));
+        assertFalse(obj.contains(2));
+    }
+
+    @Test public void differenceReturnsNullIfBothSetsEqual() {
+        obj.add(1);
+        obj.add(2);
+
+        final IntHashSet other = new IntHashSet(100, -1);
+        other.add(1);
+        other.add(2);
+
+        assertNull(obj.difference(other));
+    }
+
+    @Test public void differenceReturnsSetDifference() {
+        obj.add(1);
+        obj.add(2);
+
+        final IntHashSet other = new IntHashSet(100, -1);
+        other.add(1);
+
+        final IntHashSet diff = obj.difference(other);
+        assertEquals(1, diff.size());
+        assertTrue(diff.contains(2));
+    }
+
+    @Test public void copiesOtherIntHashSet() {
+        obj.add(1);
+        obj.add(2);
+
+        final IntHashSet other = new IntHashSet(100, -1);
+        other.copy(obj);
+
+        assertThat(other, contains(1, 2));
+    }
+
+    @Test public void twoEmptySetsAreEqual() {
+        final IntHashSet other = new IntHashSet(100, -1);
+        assertEquals(obj, other);
+    }
+
+    @Test public void equalityRequiresTheSameMissingValue() {
+        final IntHashSet other = new IntHashSet(100, 1);
+        assertNotEquals(obj, other);
+    }
+
+    @Test public void setsWithTheSameValuesAreEqual() {
+        final IntHashSet other = new IntHashSet(100, -1);
+
+        obj.add(1);
+        obj.add(1001);
+
+        other.add(1);
+        other.add(1001);
+
+        assertEquals(obj, other);
+    }
+
+    @Test public void setsWithTheDifferentSizesAreNotEqual() {
+        final IntHashSet other = new IntHashSet(100, -1);
+
+        obj.add(1);
+        obj.add(1001);
+
+        other.add(1001);
+
+        assertNotEquals(obj, other);
+    }
+
+    @Test public void setsWithTheDifferentValuesAreNotEqual() {
+        final IntHashSet other = new IntHashSet(100, -1);
+
+        obj.add(1);
+        obj.add(1001);
+
+        other.add(2);
+        other.add(1001);
+
+        assertNotEquals(obj, other);
+    }
+
+    @Test public void twoEmptySetsHaveTheSameHashcode() {
+        final IntHashSet other = new IntHashSet(100, -1);
+        assertEquals(obj.hashCode(), other.hashCode());
+    }
+
+    @Test public void setsWithTheSameValuesHaveTheSameHashcode() {
+        final IntHashSet other = new IntHashSet(100, -1);
+
+        obj.add(1);
+        obj.add(1001);
+
+        other.add(1);
+        other.add(1001);
+
+        assertEquals(obj.hashCode(), other.hashCode());
+    }
+
+    private void assertIteratorHasElements() {
+        final Iterator<Integer> iter = obj.iterator();
+
+        assertTrue(iter.hasNext());
+        assertEquals(Integer.valueOf(1), iter.next());
+        assertTrue(iter.hasNext());
+        assertEquals(Integer.valueOf(2), iter.next());
+        assertFalse(iter.hasNext());
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/util/collection/Long2LongHashMapTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/collection/Long2LongHashMapTest.java
@@ -1,0 +1,248 @@
+/*
+ * Copyright 2015 Real Logic Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.util.collection;
+
+import com.hazelcast.util.function.LongLongConsumer;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.mockito.InOrder;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+
+import static java.lang.Long.MAX_VALUE;
+import static org.hamcrest.Matchers.hasItems;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class Long2LongHashMapTest {
+    public static final long MISSING_VALUE = -1L;
+
+    private Long2LongHashMap map = new Long2LongHashMap(MISSING_VALUE);
+
+    @Test public void shouldInitiallyBeEmpty() {
+        assertEquals(0, map.size());
+        assertTrue(map.isEmpty());
+    }
+
+    @Test public void getShouldReturnMissingValueWhenEmpty() {
+        assertEquals(MISSING_VALUE, map.get(1L));
+    }
+
+    @Test public void getShouldReturnMissingValueWhenThereIsNoElement() {
+        map.put(1L, 1L);
+
+        assertEquals(MISSING_VALUE, map.get(2L));
+    }
+
+    @Test public void getShouldReturnPutValues() {
+        map.put(1L, 1L);
+
+        assertEquals(1L, map.get(1L));
+    }
+
+    @Test public void putShouldReturnOldValue() {
+        map.put(1L, 1L);
+
+        assertEquals(1L, map.put(1L, 2L));
+    }
+
+    @Test public void clearShouldResetSize() {
+        map.put(1L, 1L);
+        map.put(100L, 100L);
+
+        map.clear();
+
+        assertEquals(0, map.size());
+        assertTrue(map.isEmpty());
+    }
+
+    @Test public void clearShouldRemoveValues() {
+        map.put(1L, 1L);
+        map.put(100L, 100L);
+
+        map.clear();
+
+        assertEquals(MISSING_VALUE, map.get(1L));
+        assertEquals(MISSING_VALUE, map.get(100L));
+    }
+
+    @Test public void forEachShouldLoopOverEveryElement() {
+        map.put(1L, 1L);
+        map.put(100L, 100L);
+
+        final LongLongConsumer mockConsumer = mock(LongLongConsumer.class);
+        map.longForEach(mockConsumer);
+
+        final InOrder inOrder = inOrder(mockConsumer);
+        inOrder.verify(mockConsumer).accept(1L, 1L);
+        inOrder.verify(mockConsumer).accept(100L, 100L);
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    @Test public void shouldNotContainKeyOfAMissingKey() {
+        assertFalse(map.containsKey(1L));
+    }
+
+    @Test public void shouldContainKeyOfAPresentKey() {
+        map.put(1L, 1L);
+
+        assertTrue(map.containsKey(1L));
+    }
+
+    @Test public void shouldNotContainValueForAMissingEntry() {
+        assertFalse(map.containsValue(1L));
+    }
+
+    @Test public void shouldContainValueForAPresentEntry() {
+        map.put(1L, 1L);
+
+        assertTrue(map.containsValue(1L));
+    }
+
+    @Test public void shouldExposeValidKeySet() {
+        map.put(1L, 1L);
+        map.put(2L, 2L);
+
+        assertCollectionContainsElements(map.keySet());
+    }
+
+    @Test public void shouldExposeValidValueSet() {
+        map.put(1L, 1L);
+        map.put(2L, 2L);
+
+        assertCollectionContainsElements(map.values());
+    }
+
+    @Test public void shouldPutAllMembersOfAnotherHashMap() {
+        map.put(1L, 1L);
+        map.put(2L, 3L);
+
+        final Map<Long, Long> other = new HashMap<Long, Long>();
+        other.put(1L, 2L);
+        other.put(3L, 4L);
+
+        map.putAll(other);
+
+        assertEquals(3, map.size());
+
+        assertEquals(2, map.get(1L));
+        assertEquals(3, map.get(2L));
+        assertEquals(4, map.get(3L));
+    }
+
+    @Test public void entrySetShouldContainEntries() {
+        map.put(1L, 1L);
+        map.put(2L, 3L);
+
+        final Set<Entry<Long, Long>> entrySet = map.entrySet();
+        assertEquals(2, entrySet.size());
+        assertFalse(entrySet.isEmpty());
+
+        final Iterator<Entry<Long, Long>> it = entrySet.iterator();
+        assertTrue(it.hasNext());
+        assertEntryIs(it.next(), 1L, 1L);
+        assertTrue(it.hasNext());
+        assertEntryIs(it.next(), 2L, 3L);
+        assertFalse(it.hasNext());
+    }
+
+    @Test public void removeShouldReturnMissing() {
+        assertEquals(MISSING_VALUE, map.remove(1L));
+    }
+
+    @Test public void removeShouldReturnValueRemoved() {
+        map.put(1L, 2L);
+
+        assertEquals(2L, map.remove(1L));
+    }
+
+    @Test public void removeShouldRemoveEntry() {
+        map.put(1L, 2L);
+
+        map.remove(1L);
+
+        assertTrue(map.isEmpty());
+        assertFalse(map.containsKey(1L));
+        assertFalse(map.containsValue(2L));
+    }
+
+    @Test public void shouldOnlyRemoveTheSpecifiedEntry() {
+        for (int i = 0; i < 8; i++) {
+            map.put(i, i * 2);
+        }
+
+        map.remove(5L);
+
+        for (int i = 0; i < 8; i++) {
+            if (i != 5) {
+                assertTrue(map.containsKey(i));
+                assertTrue(map.containsValue(2 * i));
+            }
+        }
+    }
+
+    @Test public void shouldResizeWhenMoreElementsAreAdded() {
+        for (int key = 0; key < 100; key++) {
+            final int value = key * 2;
+            assertEquals(MISSING_VALUE, map.put(key, value));
+            assertEquals(value, map.get(key));
+        }
+    }
+
+    @Test public void shouldHaveNoMinValueForEmptyCollection() {
+        assertEquals(MAX_VALUE, map.minValue());
+    }
+
+    @Test public void shouldFindMinValue() {
+        map.put(1, 2);
+        map.put(2, 10);
+        map.put(3, -5);
+
+        assertEquals(-5, map.minValue());
+    }
+
+    private static void assertEntryIs(final Entry<Long, Long> entry, final long expectedKey, final long expectedValue) {
+        assertEquals(expectedKey, entry.getKey().longValue());
+        assertEquals(expectedValue, entry.getValue().longValue());
+    }
+
+    private static void assertCollectionContainsElements(final Collection<Long> keys) {
+        assertEquals(2, keys.size());
+        assertFalse(keys.isEmpty());
+        assertTrue(keys.contains(1L));
+        assertTrue(keys.contains(2L));
+        assertFalse(keys.contains(3L));
+        assertThat(keys, hasItems(1L, 2L));
+
+        assertThat("iterator has failed to be reset", keys, hasItems(1L, 2L));
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/util/collection/Long2ObjectHashMapTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/collection/Long2ObjectHashMapTest.java
@@ -1,0 +1,285 @@
+/*
+ * Copyright 2014 Real Logic Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.util.collection;
+
+
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Map;
+
+import static java.lang.Long.valueOf;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.hamcrest.number.IsCloseTo.closeTo;
+import static org.hamcrest.number.OrderingComparison.lessThan;
+import static org.junit.Assert.assertThat;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class Long2ObjectHashMapTest {
+    private final Long2ObjectHashMap<String> longToObjectMap = new Long2ObjectHashMap<String>();
+
+    @Test public void shouldDoPutAndThenGet() {
+        final String value = "Seven";
+        longToObjectMap.put(7, value);
+
+        assertThat(longToObjectMap.get(7), is(value));
+    }
+
+    @Test public void shouldReplaceExistingValueForTheSameKey() {
+        final long key = 7;
+        final String value = "Seven";
+        longToObjectMap.put(key, value);
+
+        final String newValue = "New Seven";
+        final String oldValue = longToObjectMap.put(key, newValue);
+
+        assertThat(longToObjectMap.get(key), is(newValue));
+        assertThat(oldValue, is(value));
+        assertThat(valueOf(longToObjectMap.size()), is(valueOf(1)));
+    }
+
+    @Test public void shouldGrowWhenThresholdExceeded() {
+        final double loadFactor = 0.5d;
+        final Long2ObjectHashMap<String> map = new Long2ObjectHashMap<String>(32, loadFactor);
+        for (int i = 0; i < 16; i++) {
+            map.put(i, Long.toString(i));
+        }
+
+        assertThat(valueOf(map.resizeThreshold()), is(valueOf(16)));
+        assertThat(valueOf(map.capacity()), is(valueOf(32)));
+        assertThat(valueOf(map.size()), is(valueOf(16)));
+
+        map.put(16, "16");
+
+        assertThat(valueOf(map.resizeThreshold()), is(valueOf(32)));
+        assertThat(valueOf(map.capacity()), is(valueOf(64)));
+        assertThat(valueOf(map.size()), is(valueOf(17)));
+
+        assertThat(map.get(16), equalTo("16"));
+        assertThat(loadFactor, closeTo(map.loadFactor(), 0.0));
+
+    }
+
+    @Test public void shouldHandleCollisionAndThenLinearProbe() {
+        final double loadFactor = 0.5d;
+        final Long2ObjectHashMap<String> map = new Long2ObjectHashMap<String>(32, loadFactor);
+        final long key = 7;
+        final String value = "Seven";
+        map.put(key, value);
+
+        final long collisionKey = key + map.capacity();
+        final String collisionValue = Long.toString(collisionKey);
+        map.put(collisionKey, collisionValue);
+
+        assertThat(map.get(key), is(value));
+        assertThat(map.get(collisionKey), is(collisionValue));
+        assertThat(loadFactor, closeTo(map.loadFactor(), 0.0));
+    }
+
+    @Test public void shouldClearCollection() {
+        for (int i = 0; i < 15; i++) {
+            longToObjectMap.put(i, Long.toString(i));
+        }
+
+        assertThat(valueOf(longToObjectMap.size()), is(valueOf(15)));
+        assertThat(longToObjectMap.get(1), is("1"));
+
+        longToObjectMap.clear();
+
+        assertThat(valueOf(longToObjectMap.size()), is(valueOf(0)));
+        Assert.assertNull(longToObjectMap.get(1));
+    }
+
+    @Test public void shouldCompactCollection() {
+        final int totalItems = 50;
+        for (int i = 0; i < totalItems; i++) {
+            longToObjectMap.put(i, Long.toString(i));
+        }
+
+        for (int i = 0, limit = totalItems - 4; i < limit; i++) {
+            longToObjectMap.remove(i);
+        }
+
+        final int capacityBeforeCompaction = longToObjectMap.capacity();
+        longToObjectMap.compact();
+
+        assertThat(valueOf(longToObjectMap.capacity()), lessThan(valueOf(capacityBeforeCompaction)));
+    }
+
+    @Test public void shouldContainValue() {
+        final long key = 7;
+        final String value = "Seven";
+
+        longToObjectMap.put(key, value);
+
+        Assert.assertTrue(longToObjectMap.containsValue(value));
+        Assert.assertFalse(longToObjectMap.containsValue("NoKey"));
+    }
+
+    @Test public void shouldContainKey() {
+        final long key = 7;
+        final String value = "Seven";
+
+        longToObjectMap.put(key, value);
+
+        Assert.assertTrue(longToObjectMap.containsKey(key));
+        Assert.assertFalse(longToObjectMap.containsKey(0));
+    }
+
+    @Test public void shouldRemoveEntry() {
+        final long key = 7;
+        final String value = "Seven";
+
+        longToObjectMap.put(key, value);
+
+        Assert.assertTrue(longToObjectMap.containsKey(key));
+
+        longToObjectMap.remove(key);
+
+        Assert.assertFalse(longToObjectMap.containsKey(key));
+    }
+
+    @Test public void shouldRemoveEntryAndCompactCollisionChain() {
+        final long key = 12;
+        final String value = "12";
+
+        longToObjectMap.put(key, value);
+        longToObjectMap.put(13, "13");
+
+        final long collisionKey = key + longToObjectMap.capacity();
+        final String collisionValue = Long.toString(collisionKey);
+
+        longToObjectMap.put(collisionKey, collisionValue);
+        longToObjectMap.put(14, "14");
+
+        assertThat(longToObjectMap.remove(key), is(value));
+    }
+
+    @Test public void shouldIterateValues() {
+        final Collection<String> initialSet = new HashSet<String>();
+
+        for (int i = 0; i < 11; i++) {
+            final String value = Long.toString(i);
+            longToObjectMap.put(i, value);
+            initialSet.add(value);
+        }
+
+        final Collection<String> copyToSet = new HashSet<String>(longToObjectMap.values());
+
+        assertThat(copyToSet, is(initialSet));
+    }
+
+    @Test public void shouldIterateKeysGettingLongAsPrimitive() {
+        final Collection<Long> initialSet = new HashSet<Long>();
+
+        for (int i = 0; i < 11; i++) {
+            final String value = Long.toString(i);
+            longToObjectMap.put(i, value);
+            initialSet.add(valueOf(i));
+        }
+
+        final Collection<Long> copyToSet = new HashSet<Long>();
+
+        for (final Long2ObjectHashMap.KeyIterator iter = longToObjectMap.keySet().iterator(); iter.hasNext(); ) {
+            copyToSet.add(valueOf(iter.nextLong()));
+        }
+
+        assertThat(copyToSet, is(initialSet));
+    }
+
+    @Test public void shouldIterateKeys() {
+        final Collection<Long> initialSet = new HashSet<Long>();
+
+        for (int i = 0; i < 11; i++) {
+            final String value = Long.toString(i);
+            longToObjectMap.put(i, value);
+            initialSet.add(valueOf(i));
+        }
+
+        final Collection<Long> copyToSet = new HashSet<Long>(longToObjectMap.keySet());
+
+        assertThat(copyToSet, is(initialSet));
+    }
+
+    @Test public void shouldIterateAndHandleRemove() {
+        final Collection<Long> initialSet = new HashSet<Long>();
+
+        final int count = 11;
+        for (int i = 0; i < count; i++) {
+            final String value = Long.toString(i);
+            longToObjectMap.put(i, value);
+            initialSet.add(valueOf(i));
+        }
+
+        final Collection<Long> copyOfSet = new HashSet<Long>();
+
+        int i = 0;
+        for (final Iterator<Long> iter = longToObjectMap.keySet().iterator(); iter.hasNext(); ) {
+            final Long item = iter.next();
+            if (i++ == 7) {
+                iter.remove();
+            } else {
+                copyOfSet.add(item);
+            }
+        }
+
+        assertThat(valueOf(initialSet.size()), is(valueOf(count)));
+        final int reducedSetSize = count - 1;
+        assertThat(valueOf(longToObjectMap.size()), is(valueOf(reducedSetSize)));
+        assertThat(valueOf(copyOfSet.size()), is(valueOf(reducedSetSize)));
+    }
+
+    @Test public void shouldIterateEntries() {
+        final int count = 11;
+        for (int i = 0; i < count; i++) {
+            final String value = Long.toString(i);
+            longToObjectMap.put(i, value);
+        }
+
+        final String testValue = "Wibble";
+        for (final Map.Entry<Long, String> entry : longToObjectMap.entrySet()) {
+            assertThat(entry.getKey(), equalTo(valueOf(entry.getValue())));
+
+            if (entry.getKey().intValue() == 7) {
+                entry.setValue(testValue);
+            }
+        }
+
+        assertThat(longToObjectMap.get(7), equalTo(testValue));
+    }
+
+    @Test public void shouldGenerateStringRepresentation() {
+        final int[] testEntries = {3, 1, 19, 7, 11, 12, 7};
+
+        for (final int testEntry : testEntries) {
+            longToObjectMap.put(testEntry, String.valueOf(testEntry));
+        }
+
+        final String mapAsAString = "{7=7, 12=12, 19=19, 3=3, 11=11, 1=1}";
+        assertThat(longToObjectMap.toString(), equalTo(mapAsAString));
+    }
+}
+

--- a/pom.xml
+++ b/pom.xml
@@ -221,7 +221,7 @@
                 <version>${maven.surefire.plugin.version}</version>
                 <configuration combine.self="override">
                     <redirectTestOutputToFile>true</redirectTestOutputToFile>
-
+                    <runOrder>failedfirst</runOrder>
 
                     <!-- 1C means 1 process per cpu core -->
                     <!-- forkCount>1C</forkCount>


### PR DESCRIPTION
Contributes a subset of Agrona collections to Hazelcast codebase:

1. `BiInt2ObjectMap`
2. `Int2ObjectHashMap`
3. `IntHashSet`
4. `Long2LongHashMap`
5. `Long2ObjectHashMap`
6. `LongHashSet`

`Int2ObjectHashMap` is already used by the `client` code and `Long2ObjectHashMap` will be used in a feature planned for 3.6. There are probably more target usages around the current codebase where their application would save memory and increase performance.