### PR TITLE
[Backport] Fixes #4888 - LockStore memory leak on map/multimap destroy 

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockStoreContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockStoreContainer.java
@@ -53,7 +53,7 @@ public final class LockStoreContainer {
     }
 
     void clearLockStore(ObjectNamespace namespace) {
-        LockStoreImpl lockStore = lockStores.get(namespace);
+        LockStoreImpl lockStore = lockStores.remove(namespace);
         if (lockStore != null) {
             lockStore.clear();
         }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/PartitionContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/PartitionContainer.java
@@ -114,6 +114,10 @@ public class PartitionContainer {
         if (recordStore != null) {
             recordStore.clearPartition();
         } else {
+            // It can be that, map is used only for locking,
+            // because of that RecordStore is not created.
+            // We will try to remove/clear LockStore belonging to
+            // this IMap partition.
             clearLockStore(name);
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapPartitionContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapPartitionContainer.java
@@ -16,8 +16,12 @@
 
 package com.hazelcast.multimap.impl;
 
+import com.hazelcast.concurrent.lock.LockService;
+import com.hazelcast.spi.DefaultObjectNamespace;
+import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.util.ConcurrencyUtil;
 import com.hazelcast.util.ConstructorFunction;
+
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
@@ -64,6 +68,21 @@ public class MultiMapPartitionContainer {
         final MultiMapContainer container = containerMap.remove(name);
         if (container != null) {
             container.destroy();
+        } else {
+            // It can be that, multimap is used only for locking,
+            // because of that MultiMapContainer is not created.
+            // We will try to remove/clear LockStore belonging to
+            // this MultiMap partition.
+            clearLockStore(name);
+        }
+    }
+
+    private void clearLockStore(String name) {
+        NodeEngine nodeEngine = service.getNodeEngine();
+        LockService lockService = nodeEngine.getSharedService(LockService.SERVICE_NAME);
+        if (lockService != null) {
+            DefaultObjectNamespace namespace = new DefaultObjectNamespace(MultiMapService.SERVICE_NAME, name);
+            lockService.clearLockStore(partitionId, namespace);
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/map/MapLockTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapLockTest.java
@@ -16,9 +16,13 @@
 
 package com.hazelcast.map;
 
+import com.hazelcast.concurrent.lock.LockService;
+import com.hazelcast.concurrent.lock.LockServiceImpl;
+import com.hazelcast.concurrent.lock.LockStoreContainer;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
+import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
@@ -347,5 +351,26 @@ public class MapLockTest extends HazelcastTestSupport {
 
         assertTrue("a key present in a map, should be locked after map clear", map.isLocked(key));
         assertEquals("unlocked keys not removed", 1, map.size());
+    }
+
+    /**
+     * See issue #4888
+     */
+    @Test
+    public void lockStoreShouldBeRemoved_whenMapIsDestroyed() {
+        HazelcastInstance hz = createHazelcastInstance();
+        IMap map = hz.getMap(randomName());
+        for (int i = 0; i < 1000; i++) {
+            map.lock(i);
+        }
+        map.destroy();
+
+        NodeEngineImpl nodeEngine = getNodeEngineImpl(hz);
+        LockServiceImpl lockService = nodeEngine.getService(LockService.SERVICE_NAME);
+        int partitionCount = nodeEngine.getPartitionService().getPartitionCount();
+        for (int i = 0; i < partitionCount; i++) {
+            LockStoreContainer lockContainer = lockService.getLockContainer(i);
+            Assert.assertEquals("LockStores should be empty", 0, lockContainer.getLockStores().size());
+        }
     }
 }


### PR DESCRIPTION
LockStore should be removed from registry when map/multimap is destroyed. Otherwise it will be a memory leak. 

Backport of #5674
Fixes #4888
