### PR TITLE
Avoiding sleep when loading empty maps in eager mode

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/DefaultRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/DefaultRecordStore.java
@@ -20,6 +20,7 @@ package com.hazelcast.map.impl;
 import com.hazelcast.concurrent.lock.LockService;
 import com.hazelcast.concurrent.lock.LockStore;
 import com.hazelcast.core.EntryView;
+import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.map.impl.mapstore.MapDataStore;
 import com.hazelcast.map.impl.mapstore.MapStoreContext;
@@ -117,6 +118,11 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore implements 
         if (keyLoader.shouldDoInitialLoad()) {
             loadAll(false);
         }
+    }
+
+    @Override
+    public void onKeyLoad(ExecutionCallback<Boolean> callback) {
+        keyLoader.onKeyLoad(callback);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/RecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/RecordStore.java
@@ -17,6 +17,7 @@
 package com.hazelcast.map.impl;
 
 import com.hazelcast.core.EntryView;
+import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.map.impl.mapstore.MapDataStore;
 import com.hazelcast.map.impl.record.Record;
 import com.hazelcast.map.merge.MapMergePolicy;
@@ -293,4 +294,7 @@ public interface RecordStore {
 
     /** Performs initial loading from a MapLoader if it has not been done before  **/
     void maybeDoInitialLoad();
+
+    /** Register a callback for when key loading is complete **/
+    void onKeyLoad(ExecutionCallback<Boolean> callback);
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/LoadStatusOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/LoadStatusOperationFactory.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.operation;
+
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.OperationFactory;
+
+import java.io.IOException;
+
+/**
+ *    Factory for {@link LoadStatusOperation}
+ **/
+public class LoadStatusOperationFactory implements OperationFactory  {
+
+    private Throwable exception;
+    private String name;
+
+    public LoadStatusOperationFactory() {
+    }
+
+    public LoadStatusOperationFactory(String name, Throwable exception) {
+        this.name = name;
+        this.exception = exception;
+    }
+
+    @Override
+    public Operation createOperation() {
+        return new LoadStatusOperation(name, exception);
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
+        out.writeUTF(name);
+        out.writeObject(exception);
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) throws IOException {
+        name = in.readUTF();
+        exception = in.readObject();
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
@@ -68,6 +68,7 @@ import com.hazelcast.map.impl.operation.LoadMapOperation;
 import com.hazelcast.map.impl.operation.MapFlushOperation;
 import com.hazelcast.map.impl.operation.MapGetAllOperationFactory;
 import com.hazelcast.map.impl.operation.MultipleEntryOperationFactory;
+import com.hazelcast.map.impl.operation.PartitionCheckIfLoadedOperation;
 import com.hazelcast.map.impl.operation.PartitionCheckIfLoadedOperationFactory;
 import com.hazelcast.map.impl.operation.PartitionWideEntryWithPredicateOperationFactory;
 import com.hazelcast.map.impl.operation.PutAllOperation;
@@ -109,6 +110,7 @@ import com.hazelcast.spi.OperationFactory;
 import com.hazelcast.spi.OperationService;
 import com.hazelcast.spi.impl.BinaryOperationFactory;
 import com.hazelcast.util.ExceptionUtil;
+import com.hazelcast.util.FutureUtil;
 import com.hazelcast.util.IterableUtil;
 import com.hazelcast.util.IterationType;
 import com.hazelcast.util.ThreadUtil;
@@ -131,9 +133,12 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.map.impl.MapService.SERVICE_NAME;
+import static com.hazelcast.util.FutureUtil.logAllExceptions;
 import static com.hazelcast.util.IterableUtil.nullToEmpty;
 import static com.hazelcast.util.Preconditions.checkNotNull;
 import static java.util.Collections.singleton;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static java.util.logging.Level.WARNING;
 
 abstract class MapProxySupport extends AbstractDistributedObject<MapService> implements InitializingObject {
 
@@ -633,15 +638,15 @@ abstract class MapProxySupport extends AbstractDistributedObject<MapService> imp
         final NodeEngine nodeEngine = getNodeEngine();
         try {
             OperationService operationService = nodeEngine.getOperationService();
+            int mapNamePartition = partitionService.getPartitionId(name);
+
+            Operation op = new PartitionCheckIfLoadedOperation(name, false, true);
+            Future loadingFuture = operationService.invokeOnPartition(SERVICE_NAME, op, mapNamePartition);
+            // wait for keys to be loaded
+            FutureUtil.waitWithDeadline(singleton(loadingFuture), 1, SECONDS, logAllExceptions(WARNING));
+
             OperationFactory opFactory = new PartitionCheckIfLoadedOperationFactory(name);
-
-            Map<Integer, Object> results;
-            Collection<Integer> mapNamePartition = getPartitionsForKeys(singleton(toData(name)));
-
-            results = operationService.invokeOnPartitions(SERVICE_NAME, opFactory, mapNamePartition);
-            waitAllTrue(results);
-
-            results = operationService.invokeOnAllPartitions(SERVICE_NAME, opFactory);
+            Map<Integer, Object> results = operationService.invokeOnAllPartitions(SERVICE_NAME, opFactory);
             waitAllTrue(results);
 
         } catch (Throwable t) {

--- a/hazelcast/src/test/java/com/hazelcast/map/mapstore/MapStoreTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/mapstore/MapStoreTest.java
@@ -510,35 +510,6 @@ public class MapStoreTest extends HazelcastTestSupport {
         assertEquals(1000, map2.size());
     }
 
-    private boolean checkIfMapLoaded(String mapName, HazelcastInstance instance) throws InterruptedException {
-        NodeEngineImpl nodeEngine = TestUtil.getNode(instance).nodeEngine;
-        int partitionCount = nodeEngine.getPartitionService().getPartitionCount();
-        MapService service = nodeEngine.getService(MapService.SERVICE_NAME);
-        boolean loaded = false;
-
-        final long end = System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(1);
-
-        while (!loaded) {
-            for (int i = 0; i < partitionCount; i++) {
-                final RecordStore recordStore = service.getMapServiceContext()
-                        .getPartitionContainer(i).getRecordStore(mapName);
-                if (recordStore != null) {
-                    loaded = recordStore.isLoaded();
-                    if (!loaded) {
-                        break;
-                    }
-                }
-            }
-            if (System.currentTimeMillis() >= end) {
-                break;
-            }
-            //give a rest to cpu.
-            Thread.sleep(10);
-        }
-
-        return loaded;
-    }
-
     /*
      * Test for Issue 572
     */


### PR DESCRIPTION
Instead of checking for load status every second now delaying response from PartitionCheckIfLoadedOperation until keys are loaded. 
Issue #5349
