### PR TITLE
Avoiding sleep when loading empty maps in eager mode (forward port)

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapKeyLoader.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapKeyLoader.java
@@ -22,6 +22,7 @@ import com.hazelcast.core.MapLoader;
 import com.hazelcast.map.impl.mapstore.MapStoreContext;
 import com.hazelcast.map.impl.operation.LoadAllOperation;
 import com.hazelcast.map.impl.operation.LoadStatusOperation;
+import com.hazelcast.map.impl.operation.LoadStatusOperationFactory;
 import com.hazelcast.map.impl.operation.PartitionCheckIfLoadedOperation;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.partition.InternalPartitionService;
@@ -236,7 +237,7 @@ public class MapKeyLoader {
         return state.is(State.NOT_LOADED);
     }
 
-    private void sendKeysInBatches(MapStoreContext mapStoreContext, boolean replaceExistingValues) {
+    private void sendKeysInBatches(MapStoreContext mapStoreContext, boolean replaceExistingValues) throws Exception {
 
         int clusterSize = partitionService.getMemberPartitionsMap().size();
         Iterator<Object> keys = null;
@@ -267,6 +268,7 @@ public class MapKeyLoader {
             // for all LoadAllOperation(s) to be ACKed by receivers and only then we send them the LoadStatusOperation
             // See https://github.com/hazelcast/hazelcast/issues/4024 for additional details
             FutureUtil.waitWithDeadline(futures, KEY_DISTRIBUTION_TIMEOUT_MINUTES, TimeUnit.MINUTES);
+
         } catch (Exception caught) {
             loadError = caught;
         } finally {
@@ -292,18 +294,16 @@ public class MapKeyLoader {
     }
 
     private void sendLoadCompleted(int clusterSize, int partitions,
-            boolean replaceExistingValues, Throwable exception) {
-        for (int partitionId = 0; partitionId < partitions; partitionId++) {
-            Operation op = new LoadStatusOperation(mapName, exception);
-            opService.invokeOnPartition(SERVICE_NAME, op, partitionId);
-        }
+            boolean replaceExistingValues, Throwable exception) throws Exception {
+
+        // notify all partitions about loading status: finished or exception encountered
+        opService.invokeOnAllPartitions(SERVICE_NAME, new LoadStatusOperationFactory(mapName, exception));
 
         // notify SENDER_BACKUP
         if (hasBackup && clusterSize > 1) {
             Operation op = new LoadStatusOperation(mapName, exception);
             opService.createInvocationBuilder(SERVICE_NAME, op, mapNamePartition).setReplicaIndex(1).invoke();
         }
-
     }
 
     public void setMaxBatch(int maxBatch) {
@@ -382,5 +382,9 @@ public class MapKeyLoader {
         public String toString() {
             return getClass().getSimpleName() + "{done=" + isDone() + "}";
         }
+    }
+
+    public void onKeyLoad(ExecutionCallback<Boolean> callback) {
+        loadFinished.andThen(callback, execService.getExecutor(MAP_LOAD_ALL_KEYS_EXECUTOR));
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/LoadStatusOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/LoadStatusOperationFactory.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.operation;
+
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.OperationFactory;
+
+import java.io.IOException;
+
+/**
+ *    Factory for {@link LoadStatusOperation}
+ **/
+public class LoadStatusOperationFactory implements OperationFactory  {
+
+    private Throwable exception;
+    private String name;
+
+    public LoadStatusOperationFactory() {
+    }
+
+    public LoadStatusOperationFactory(String name, Throwable exception) {
+        this.name = name;
+        this.exception = exception;
+    }
+
+    @Override
+    public Operation createOperation() {
+        return new LoadStatusOperation(name, exception);
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
+        out.writeUTF(name);
+        out.writeObject(exception);
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) throws IOException {
+        name = in.readUTF();
+        exception = in.readObject();
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionCheckIfLoadedOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionCheckIfLoadedOperation.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.map.impl.operation;
 
+import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.map.impl.MapServiceContext;
 import com.hazelcast.map.impl.recordstore.RecordStore;
 import com.hazelcast.nio.ObjectDataInput;
@@ -29,6 +30,7 @@ public class PartitionCheckIfLoadedOperation extends AbstractMapOperation implem
 
     private boolean isFinished;
     private boolean doLoad;
+    private boolean waitForKeyLoad;
 
     public PartitionCheckIfLoadedOperation() {
     }
@@ -42,13 +44,25 @@ public class PartitionCheckIfLoadedOperation extends AbstractMapOperation implem
         this.doLoad = doLoad;
     }
 
+    public PartitionCheckIfLoadedOperation(String name, boolean doLoad, boolean waitForKeyLoad) {
+        super(name);
+        this.doLoad = doLoad;
+        this.waitForKeyLoad = waitForKeyLoad;
+    }
+
     @Override
     public void run() {
         MapServiceContext mapServiceContext = mapService.getMapServiceContext();
         RecordStore recordStore = mapServiceContext.getRecordStore(getPartitionId(), name);
+
         isFinished = recordStore.isLoaded();
+
         if (doLoad) {
             recordStore.maybeDoInitialLoad();
+        }
+
+        if (waitForKeyLoad) {
+           recordStore.onKeyLoad(new CallbackResponseSender());
         }
     }
 
@@ -58,14 +72,34 @@ public class PartitionCheckIfLoadedOperation extends AbstractMapOperation implem
     }
 
     @Override
+    public boolean returnsResponse() {
+        return !waitForKeyLoad;
+    }
+
+    @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
         out.writeBoolean(doLoad);
+        out.writeBoolean(waitForKeyLoad);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
         doLoad = in.readBoolean();
+        waitForKeyLoad = in.readBoolean();
+    }
+
+    private class CallbackResponseSender implements ExecutionCallback<Boolean> {
+
+        @Override
+        public void onResponse(Boolean response) {
+            sendResponse(response);
+        }
+
+        @Override
+        public void onFailure(Throwable error) {
+            sendResponse(error);
+        }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
@@ -20,6 +20,7 @@ package com.hazelcast.map.impl.recordstore;
 import com.hazelcast.concurrent.lock.LockService;
 import com.hazelcast.concurrent.lock.LockStore;
 import com.hazelcast.core.EntryView;
+import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.map.impl.EntryViews;
 import com.hazelcast.map.impl.MapContainer;
@@ -123,6 +124,11 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore implements 
         if (keyLoader.shouldDoInitialLoad()) {
             loadAll(false);
         }
+    }
+
+    @Override
+    public void onKeyLoad(ExecutionCallback<Boolean> callback) {
+        keyLoader.onKeyLoad(callback);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStore.java
@@ -17,6 +17,7 @@
 package com.hazelcast.map.impl.recordstore;
 
 import com.hazelcast.core.EntryView;
+import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.map.impl.MapContainer;
 import com.hazelcast.map.impl.MapEntrySet;
 import com.hazelcast.map.impl.mapstore.MapDataStore;
@@ -296,4 +297,7 @@ public interface RecordStore {
      * Performs initial loading from a MapLoader if it has not been done before
      **/
     void maybeDoInitialLoad();
+
+    /** Register a callback for when key loading is complete **/
+    void onKeyLoad(ExecutionCallback<Boolean> callback);
 }

--- a/hazelcast/src/test/java/com/hazelcast/map/mapstore/MapStoreTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/mapstore/MapStoreTest.java
@@ -510,35 +510,6 @@ public class MapStoreTest extends HazelcastTestSupport {
         assertEquals(1000, map2.size());
     }
 
-    private boolean checkIfMapLoaded(String mapName, HazelcastInstance instance) throws InterruptedException {
-        NodeEngineImpl nodeEngine = TestUtil.getNode(instance).nodeEngine;
-        int partitionCount = nodeEngine.getPartitionService().getPartitionCount();
-        MapService service = nodeEngine.getService(MapService.SERVICE_NAME);
-        boolean loaded = false;
-
-        final long end = System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(1);
-
-        while (!loaded) {
-            for (int i = 0; i < partitionCount; i++) {
-                final RecordStore recordStore = service.getMapServiceContext()
-                        .getPartitionContainer(i).getRecordStore(mapName);
-                if (recordStore != null) {
-                    loaded = recordStore.isLoaded();
-                    if (!loaded) {
-                        break;
-                    }
-                }
-            }
-            if (System.currentTimeMillis() >= end) {
-                break;
-            }
-            //give a rest to cpu.
-            Thread.sleep(10);
-        }
-
-        return loaded;
-    }
-
     /*
      * Test for Issue 572
     */


### PR DESCRIPTION
Instead of checking for load status every second now delaying response from PartitionCheckIfLoadedOperation until keys are loaded. 
Issue #5349
