### PR TITLE
Reduce transmitted data for cache invalidation message

### DIFF
--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/cache/impl/AbstractClientInternalCacheProxy.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/cache/impl/AbstractClientInternalCacheProxy.java
@@ -385,7 +385,7 @@ abstract class AbstractClientInternalCacheProxy<K, V>
     }
 
     protected void storeInNearCache(Data key, Data valueData, V value) {
-        if (nearCache != null) {
+        if (nearCache != null && valueData != null) {
             Object valueToStore = nearCache.selectToSave(value, valueData);
             nearCache.put(key, valueToStore);
         }

--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/cache/impl/AbstractClientInternalCacheProxy.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/cache/impl/AbstractClientInternalCacheProxy.java
@@ -593,12 +593,18 @@ abstract class AbstractClientInternalCacheProxy<K, V>
 
         @Override
         public void handle(String name, Collection<Data> keys, Collection<String> sourceUuids) {
-            Iterator<Data> keysIt = keys.iterator();
-            Iterator<String> sourceUuidsIt = sourceUuids.iterator();
-            while (keysIt.hasNext() && sourceUuidsIt.hasNext()) {
-                Data key = keysIt.next();
-                String sourceUuid = sourceUuidsIt.next();
-                if (!client.getUuid().equals(sourceUuid)) {
+            if (sourceUuids != null && !sourceUuids.isEmpty()) {
+                Iterator<Data> keysIt = keys.iterator();
+                Iterator<String> sourceUuidsIt = sourceUuids.iterator();
+                while (keysIt.hasNext() && sourceUuidsIt.hasNext()) {
+                    Data key = keysIt.next();
+                    String sourceUuid = sourceUuidsIt.next();
+                    if (!client.getUuid().equals(sourceUuid)) {
+                        nearCache.invalidate(key);
+                    }
+                }
+            } else {
+                for (Data key : keys) {
                     nearCache.invalidate(key);
                 }
             }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/AbstractClientInternalCacheProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/AbstractClientInternalCacheProxy.java
@@ -381,7 +381,7 @@ abstract class AbstractClientInternalCacheProxy<K, V>
     }
 
     protected void storeInNearCache(Data key, Data valueData, V value) {
-        if (nearCache != null) {
+        if (nearCache != null && valueData != null) {
             Object valueToStore = nearCache.selectToSave(value, valueData);
             nearCache.put(key, valueToStore);
         }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/client/CacheInvalidationListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/client/CacheInvalidationListener.java
@@ -19,6 +19,9 @@ package com.hazelcast.cache.impl.client;
 import com.hazelcast.cache.impl.CacheEventListener;
 import com.hazelcast.client.ClientEndpoint;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public final class CacheInvalidationListener implements CacheEventListener {
 
     private final ClientEndpoint endpoint;
@@ -31,10 +34,43 @@ public final class CacheInvalidationListener implements CacheEventListener {
 
     @Override
     public void handleEvent(Object eventObject) {
+        if (!endpoint.isAlive()) {
+            return;
+        }
         if (eventObject instanceof CacheInvalidationMessage) {
-            CacheInvalidationMessage message = (CacheInvalidationMessage) eventObject;
-            if (endpoint.isAlive()) {
-                endpoint.sendEvent(message.getName(), message, callId);
+            String targetUuid = endpoint.getUuid();
+            if (eventObject instanceof CacheSingleInvalidationMessage) {
+                CacheSingleInvalidationMessage message = (CacheSingleInvalidationMessage) eventObject;
+                if (!targetUuid.equals(message.getSourceUuid())) {
+                    // Since we already filtered as source uuid, no need to send source uuid to client
+                    // We don't set it null at here because the same message instance is also used by
+                    // other listeners in this node. So we create a new, fresh and clean message instance.
+                    // TODO Maybe don't send name also to client
+                    endpoint.sendEvent(message.getName(),
+                                       new CacheSingleInvalidationMessage(message.getName(), message.getKey(), null),
+                                       callId);
+                }
+            } else if (eventObject instanceof CacheBatchInvalidationMessage) {
+                CacheBatchInvalidationMessage message = (CacheBatchInvalidationMessage) eventObject;
+                List<CacheSingleInvalidationMessage> invalidationMessages =
+                        message.getInvalidationMessages();
+                List<CacheSingleInvalidationMessage> filteredMessages =
+                        new ArrayList<CacheSingleInvalidationMessage>(invalidationMessages.size());
+                for (CacheSingleInvalidationMessage invalidationMessage : invalidationMessages) {
+                    if (!targetUuid.equals(invalidationMessage.getSourceUuid())) {
+                        // Since we already filtered as source uuid, no need to send source uuid to client
+                        // Also no need to send name to client because single invalidation messages
+                        // are already wrapped by name batch invalidation message. We don't set them null at here
+                        // because the same message instance is also used by other listeners in this node.
+                        // So we create a new, fresh and clean message instance.
+                        filteredMessages.add(
+                                new CacheSingleInvalidationMessage(null, invalidationMessage.getKey(), null));
+                    }
+                }
+                // TODO Maybe don't send name also to client
+                endpoint.sendEvent(message.getName(),
+                                   new CacheBatchInvalidationMessage(message.getName(), filteredMessages),
+                                   callId);
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/nearcache/impl/DefaultNearCache.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/nearcache/impl/DefaultNearCache.java
@@ -31,6 +31,8 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import static com.hazelcast.util.ValidationUtil.checkNotNull;
+
 public class DefaultNearCache<K, V> implements NearCache<K, V> {
 
     protected final String name;
@@ -114,11 +116,16 @@ public class DefaultNearCache<K, V> implements NearCache<K, V> {
 
     @Override
     public V get(K key) {
+        checkNotNull(key, "key cannot be null on get!");
+
         return nearCacheRecordStore.get(key);
     }
 
     @Override
     public void put(K key, V value) {
+        checkNotNull(key, "key cannot be null on put!");
+        checkNotNull(value, "value cannot be null on put");
+
         nearCacheRecordStore.doEvictionIfRequired();
 
         nearCacheRecordStore.put(key, value);
@@ -126,11 +133,15 @@ public class DefaultNearCache<K, V> implements NearCache<K, V> {
 
     @Override
     public boolean remove(K key) {
+        checkNotNull(key, "key cannot be null on remove!");
+
         return nearCacheRecordStore.remove(key);
     }
 
     @Override
     public void invalidate(K key) {
+        checkNotNull(key, "key cannot be null on invalidate!");
+
         nearCacheRecordStore.remove(key);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheAddInvalidationListenerTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheAddInvalidationListenerTask.java
@@ -44,36 +44,61 @@ public class CacheAddInvalidationListenerTask
     protected Object call() {
         final ClientEndpoint endpoint = getEndpoint();
         CacheService cacheService = getService(CacheService.SERVICE_NAME);
-        String registrationId = cacheService.addInvalidationListener(parameters.name, new CacheEventListener() {
-            @Override
-            public void handleEvent(Object eventObject) {
-                if (!endpoint.isAlive()) {
-                    return;
-                }
-                if (eventObject instanceof CacheInvalidationMessage) {
-                    if (eventObject instanceof CacheSingleInvalidationMessage) {
-                        CacheSingleInvalidationMessage message = (CacheSingleInvalidationMessage) eventObject;
-                        ClientMessage eventMessage = CacheAddInvalidationListenerCodec.
-                                    encodeCacheInvalidationEvent(message.getName(), message.getKey(), message.getSourceUuid());
-                        sendClientMessage(message.getName(), eventMessage);
-                    } else if (eventObject instanceof CacheBatchInvalidationMessage) {
-                        CacheBatchInvalidationMessage message = (CacheBatchInvalidationMessage) eventObject;
-                        List<CacheSingleInvalidationMessage> invalidationMessages = message.getInvalidationMessages();
-                        List<Data> keys = new ArrayList<Data>(invalidationMessages.size());
-                        List<String> sourceUuids = new ArrayList<String>(invalidationMessages.size());
-                        for (CacheSingleInvalidationMessage invalidationMessage : invalidationMessages) {
-                            keys.add(invalidationMessage.getKey());
-                            sourceUuids.add(invalidationMessage.getSourceUuid());
-                        }
-                        ClientMessage eventMessage = CacheAddInvalidationListenerCodec.
-                                    encodeCacheBatchInvalidationEvent(message.getName(), keys, sourceUuids);
-                        sendClientMessage(message.getName(), eventMessage);
-                    }
-                }
-            }
-        });
+        String registrationId = cacheService.addInvalidationListener(parameters.name,
+                                                                     new CacheInvalidationEventListener(endpoint));
         endpoint.setListenerRegistration(CacheService.SERVICE_NAME, parameters.name, registrationId);
         return registrationId;
+    }
+
+    private final class CacheInvalidationEventListener implements CacheEventListener {
+
+        private final ClientEndpoint endpoint;
+
+        private CacheInvalidationEventListener(ClientEndpoint endpoint) {
+            this.endpoint = endpoint;
+        }
+
+        @Override
+        public void handleEvent(Object eventObject) {
+            if (!endpoint.isAlive()) {
+                return;
+            }
+            if (eventObject instanceof CacheInvalidationMessage) {
+                String targetUuid = endpoint.getUuid();
+                if (eventObject instanceof CacheSingleInvalidationMessage) {
+                    CacheSingleInvalidationMessage message = (CacheSingleInvalidationMessage) eventObject;
+                    if (!targetUuid.equals(message.getSourceUuid())) {
+                        // Since we already filtered as source uuid, no need to send source uuid to client
+                        // TODO Maybe don't send name also to client
+                        ClientMessage eventMessage =
+                                CacheAddInvalidationListenerCodec
+                                        .encodeCacheInvalidationEvent(message.getName(),
+                                                                      message.getKey(),
+                                                                      null);
+                        sendClientMessage(message.getName(), eventMessage);
+                    }
+                } else if (eventObject instanceof CacheBatchInvalidationMessage) {
+                    CacheBatchInvalidationMessage message = (CacheBatchInvalidationMessage) eventObject;
+                    List<CacheSingleInvalidationMessage> invalidationMessages =
+                            message.getInvalidationMessages();
+                    List<Data> filteredKeys = new ArrayList<Data>(invalidationMessages.size());
+                    for (CacheSingleInvalidationMessage invalidationMessage : invalidationMessages) {
+                        if (!targetUuid.equals(invalidationMessage.getSourceUuid())) {
+                            filteredKeys.add(invalidationMessage.getKey());
+                        }
+                    }
+                    // Since we already filtered keys as source uuid, no need to send source uuid list to client
+                    // TODO Maybe don't send name also to client
+                    ClientMessage eventMessage =
+                            CacheAddInvalidationListenerCodec
+                                .encodeCacheBatchInvalidationEvent(message.getName(),
+                                                                   filteredKeys,
+                                                                   null);
+                    sendClientMessage(message.getName(), eventMessage);
+                }
+            }
+        }
+
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/EventResponseTemplate.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/EventResponseTemplate.java
@@ -62,10 +62,10 @@ public interface EventResponseTemplate {
     void DistributedObject(String name, String serviceName, String eventType);
 
     @EventResponse(EventMessageConst.EVENT_CACHEINVALIDATION)
-    void CacheInvalidation(String name, @Nullable Data key, String sourceUuid);
+    void CacheInvalidation(String name, @Nullable Data key, @Nullable String sourceUuid);
 
     @EventResponse(EventMessageConst.EVENT_CACHEBATCHINVALIDATION)
-    void CacheBatchInvalidation(String name, List<Data> keys, List<String> sourceUuids);
+    void CacheBatchInvalidation(String name, List<Data> keys, @Nullable List<String> sourceUuids);
 
     @EventResponse(EventMessageConst.EVENT_MAPPARTITIONLOST)
     void MapPartitionLost(int partitionId, String uuid);


### PR DESCRIPTION
Filters cache invalidation messages by checking/comparing source uuid and target uuid before sending them. So, 36 length source uuid values are neither serialized to data nor transmitted to client.

P.S: Breaks backward compatibility for new client (not old client). As we talked with @enesakar since it is experimental this is not problem and acceptable.