### PR TITLE
FactoryIdHelper cleanup

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheDataSerializerHook.java
@@ -19,7 +19,6 @@ package com.hazelcast.cache.impl;
 import com.hazelcast.cache.HazelcastExpiryPolicy;
 import com.hazelcast.cache.impl.operation.CacheBackupEntryProcessorOperation;
 import com.hazelcast.cache.impl.operation.CacheClearBackupOperation;
-import com.hazelcast.cache.impl.operation.CacheRemoveAllBackupOperation;
 import com.hazelcast.cache.impl.operation.CacheClearOperation;
 import com.hazelcast.cache.impl.operation.CacheClearOperationFactory;
 import com.hazelcast.cache.impl.operation.CacheContainsKeyOperation;
@@ -41,6 +40,7 @@ import com.hazelcast.cache.impl.operation.CachePutAllBackupOperation;
 import com.hazelcast.cache.impl.operation.CachePutBackupOperation;
 import com.hazelcast.cache.impl.operation.CachePutIfAbsentOperation;
 import com.hazelcast.cache.impl.operation.CachePutOperation;
+import com.hazelcast.cache.impl.operation.CacheRemoveAllBackupOperation;
 import com.hazelcast.cache.impl.operation.CacheRemoveAllOperation;
 import com.hazelcast.cache.impl.operation.CacheRemoveAllOperationFactory;
 import com.hazelcast.cache.impl.operation.CacheRemoveBackupOperation;
@@ -48,12 +48,15 @@ import com.hazelcast.cache.impl.operation.CacheRemoveOperation;
 import com.hazelcast.cache.impl.operation.CacheReplaceOperation;
 import com.hazelcast.cache.impl.operation.CacheSizeOperation;
 import com.hazelcast.cache.impl.operation.CacheSizeOperationFactory;
-import com.hazelcast.nio.serialization.impl.ArrayDataSerializableFactory;
 import com.hazelcast.nio.serialization.DataSerializableFactory;
 import com.hazelcast.nio.serialization.DataSerializerHook;
-import com.hazelcast.nio.serialization.impl.FactoryIdHelper;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.nio.serialization.impl.ArrayDataSerializableFactory;
+import com.hazelcast.nio.serialization.impl.FactoryIdHelper;
 import com.hazelcast.util.ConstructorFunction;
+
+import static com.hazelcast.nio.serialization.impl.FactoryIdHelper.CACHE_DS_FACTORY;
+import static com.hazelcast.nio.serialization.impl.FactoryIdHelper.CACHE_DS_FACTORY_ID;
 
 /**
  * {@link CacheDataSerializerHook} contains all the ID hooks for {@link IdentifiedDataSerializable} classes used
@@ -64,7 +67,7 @@ import com.hazelcast.util.ConstructorFunction;
 public final class CacheDataSerializerHook
         implements DataSerializerHook {
 
-    public static final int F_ID = FactoryIdHelper.getFactoryId(FactoryIdHelper.CACHE_DS_FACTORY, -25);
+    public static final int F_ID = FactoryIdHelper.getFactoryId(CACHE_DS_FACTORY, CACHE_DS_FACTORY_ID);
     public static final short GET = 1;
     public static final short CONTAINS_KEY = 2;
     public static final short PUT = 3;

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CachePortableHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CachePortableHook.java
@@ -42,13 +42,16 @@ import com.hazelcast.cache.impl.client.CacheReplaceRequest;
 import com.hazelcast.cache.impl.client.CacheSingleInvalidationMessage;
 import com.hazelcast.cache.impl.client.CacheSizeRequest;
 import com.hazelcast.nio.serialization.ClassDefinition;
-import com.hazelcast.nio.serialization.impl.FactoryIdHelper;
 import com.hazelcast.nio.serialization.Portable;
 import com.hazelcast.nio.serialization.PortableFactory;
 import com.hazelcast.nio.serialization.PortableHook;
+import com.hazelcast.nio.serialization.impl.FactoryIdHelper;
 import com.hazelcast.util.ConstructorFunction;
 
 import java.util.Collection;
+
+import static com.hazelcast.nio.serialization.impl.FactoryIdHelper.CACHE_PORTABLE_FACTORY;
+import static com.hazelcast.nio.serialization.impl.FactoryIdHelper.CACHE_PORTABLE_FACTORY_ID;
 
 /**
  * {@link CachePortableHook} contains all the ID hooks for classes used inside the JCache framework which implement
@@ -59,7 +62,7 @@ import java.util.Collection;
 public class CachePortableHook
         implements PortableHook {
 
-    public static final int F_ID = FactoryIdHelper.getFactoryId(FactoryIdHelper.CACHE_PORTABLE_FACTORY, -24);
+    public static final int F_ID = FactoryIdHelper.getFactoryId(CACHE_PORTABLE_FACTORY, CACHE_PORTABLE_FACTORY_ID);
     public static final int GET = 1;
     public static final int PUT = 2;
     public static final int PUT_IF_ABSENT = 3;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientDataSerializerHook.java
@@ -19,8 +19,11 @@ package com.hazelcast.client.impl;
 import com.hazelcast.client.impl.client.ClientResponse;
 import com.hazelcast.nio.serialization.DataSerializableFactory;
 import com.hazelcast.nio.serialization.DataSerializerHook;
-import com.hazelcast.nio.serialization.impl.FactoryIdHelper;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.nio.serialization.impl.FactoryIdHelper;
+
+import static com.hazelcast.nio.serialization.impl.FactoryIdHelper.CLIENT_DS_FACTORY;
+import static com.hazelcast.nio.serialization.impl.FactoryIdHelper.CLIENT_DS_FACTORY_ID;
 
 /**
  * Client DataSerializable Factory ID
@@ -30,7 +33,7 @@ public final class ClientDataSerializerHook implements DataSerializerHook {
     /**
      * ClientDataSerializable Factory ID
      */
-    public static final int ID = FactoryIdHelper.getFactoryId(FactoryIdHelper.CLIENT_DS_FACTORY, -3);
+    public static final int ID = FactoryIdHelper.getFactoryId(CLIENT_DS_FACTORY, CLIENT_DS_FACTORY_ID);
 
     /**
      * ClientResponse Class ID

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/client/ClientPortableHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/client/ClientPortableHook.java
@@ -18,19 +18,22 @@ package com.hazelcast.client.impl.client;
 
 import com.hazelcast.nio.serialization.ClassDefinition;
 import com.hazelcast.nio.serialization.ClassDefinitionBuilder;
-import com.hazelcast.nio.serialization.impl.FactoryIdHelper;
 import com.hazelcast.nio.serialization.PortableFactory;
 import com.hazelcast.nio.serialization.PortableHook;
+import com.hazelcast.nio.serialization.impl.FactoryIdHelper;
 
 import java.util.Collection;
 import java.util.Collections;
+
+import static com.hazelcast.nio.serialization.impl.FactoryIdHelper.CLIENT_PORTABLE_FACTORY;
+import static com.hazelcast.nio.serialization.impl.FactoryIdHelper.CLIENT_PORTABLE_FACTORY_ID;
 
 /**
  * Portable that creates a lot of the client related Portable instances.
  */
 public class ClientPortableHook implements PortableHook {
 
-    public static final int ID = FactoryIdHelper.getFactoryId(FactoryIdHelper.CLIENT_PORTABLE_FACTORY, -3);
+    public static final int ID = FactoryIdHelper.getFactoryId(CLIENT_PORTABLE_FACTORY, CLIENT_PORTABLE_FACTORY_ID);
 
     public static final int GENERIC_ERROR = 1;
     public static final int AUTH = 2;

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/CollectionDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/CollectionDataSerializerHook.java
@@ -29,7 +29,6 @@ import com.hazelcast.collection.impl.collection.operations.CollectionIsEmptyOper
 import com.hazelcast.collection.impl.collection.operations.CollectionRemoveBackupOperation;
 import com.hazelcast.collection.impl.collection.operations.CollectionRemoveOperation;
 import com.hazelcast.collection.impl.collection.operations.CollectionSizeOperation;
-import com.hazelcast.collection.impl.txncollection.operations.CollectionTransactionRollbackOperation;
 import com.hazelcast.collection.impl.list.operations.ListAddAllOperation;
 import com.hazelcast.collection.impl.list.operations.ListAddOperation;
 import com.hazelcast.collection.impl.list.operations.ListGetOperation;
@@ -46,20 +45,24 @@ import com.hazelcast.collection.impl.txncollection.operations.CollectionReserveA
 import com.hazelcast.collection.impl.txncollection.operations.CollectionReserveRemoveOperation;
 import com.hazelcast.collection.impl.txncollection.operations.CollectionRollbackBackupOperation;
 import com.hazelcast.collection.impl.txncollection.operations.CollectionRollbackOperation;
+import com.hazelcast.collection.impl.txncollection.operations.CollectionTransactionRollbackOperation;
 import com.hazelcast.collection.impl.txncollection.operations.CollectionTxnAddBackupOperation;
 import com.hazelcast.collection.impl.txncollection.operations.CollectionTxnAddOperation;
 import com.hazelcast.collection.impl.txncollection.operations.CollectionTxnRemoveBackupOperation;
 import com.hazelcast.collection.impl.txncollection.operations.CollectionTxnRemoveOperation;
-import com.hazelcast.nio.serialization.impl.ArrayDataSerializableFactory;
 import com.hazelcast.nio.serialization.DataSerializableFactory;
 import com.hazelcast.nio.serialization.DataSerializerHook;
-import com.hazelcast.nio.serialization.impl.FactoryIdHelper;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.nio.serialization.impl.ArrayDataSerializableFactory;
+import com.hazelcast.nio.serialization.impl.FactoryIdHelper;
 import com.hazelcast.util.ConstructorFunction;
+
+import static com.hazelcast.nio.serialization.impl.FactoryIdHelper.COLLECTION_DS_FACTORY;
+import static com.hazelcast.nio.serialization.impl.FactoryIdHelper.COLLECTION_DS_FACTORY_ID;
 
 public class CollectionDataSerializerHook implements DataSerializerHook {
 
-    public static final int F_ID = FactoryIdHelper.getFactoryId(FactoryIdHelper.COLLECTION_DS_FACTORY, -20);
+    public static final int F_ID = FactoryIdHelper.getFactoryId(COLLECTION_DS_FACTORY, COLLECTION_DS_FACTORY_ID);
 
     public static final int COLLECTION_ADD = 1;
     public static final int COLLECTION_ADD_BACKUP = 2;

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/CollectionPortableHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/CollectionPortableHook.java
@@ -40,19 +40,22 @@ import com.hazelcast.collection.impl.txnlist.client.TxnListSizeRequest;
 import com.hazelcast.collection.impl.txnset.client.TxnSetAddRequest;
 import com.hazelcast.collection.impl.txnset.client.TxnSetRemoveRequest;
 import com.hazelcast.collection.impl.txnset.client.TxnSetSizeRequest;
-import com.hazelcast.nio.serialization.impl.ArrayPortableFactory;
 import com.hazelcast.nio.serialization.ClassDefinition;
-import com.hazelcast.nio.serialization.impl.FactoryIdHelper;
 import com.hazelcast.nio.serialization.Portable;
 import com.hazelcast.nio.serialization.PortableFactory;
 import com.hazelcast.nio.serialization.PortableHook;
+import com.hazelcast.nio.serialization.impl.ArrayPortableFactory;
+import com.hazelcast.nio.serialization.impl.FactoryIdHelper;
 import com.hazelcast.util.ConstructorFunction;
 
 import java.util.Collection;
 
+import static com.hazelcast.nio.serialization.impl.FactoryIdHelper.COLLECTION_PORTABLE_FACTORY;
+import static com.hazelcast.nio.serialization.impl.FactoryIdHelper.COLLECTION_PORTABLE_FACTORY_ID;
+
 public class CollectionPortableHook implements PortableHook {
 
-    public static final int F_ID = FactoryIdHelper.getFactoryId(FactoryIdHelper.COLLECTION_PORTABLE_FACTORY, -20);
+    public static final int F_ID = FactoryIdHelper.getFactoryId(COLLECTION_PORTABLE_FACTORY, COLLECTION_PORTABLE_FACTORY_ID);
 
     public static final int COLLECTION_SIZE = 1;
     public static final int COLLECTION_CONTAINS = 2;

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueDataSerializerHook.java
@@ -16,12 +16,6 @@
 
 package com.hazelcast.collection.impl.queue;
 
-import com.hazelcast.collection.impl.txnqueue.TxQueueItem;
-import com.hazelcast.nio.serialization.impl.ArrayDataSerializableFactory;
-import com.hazelcast.nio.serialization.DataSerializableFactory;
-import com.hazelcast.nio.serialization.DataSerializerHook;
-import com.hazelcast.nio.serialization.impl.FactoryIdHelper;
-import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.collection.impl.queue.operations.AddAllBackupOperation;
 import com.hazelcast.collection.impl.queue.operations.AddAllOperation;
 import com.hazelcast.collection.impl.queue.operations.CheckAndEvictOperation;
@@ -44,6 +38,7 @@ import com.hazelcast.collection.impl.queue.operations.RemainingCapacityOperation
 import com.hazelcast.collection.impl.queue.operations.RemoveBackupOperation;
 import com.hazelcast.collection.impl.queue.operations.RemoveOperation;
 import com.hazelcast.collection.impl.queue.operations.SizeOperation;
+import com.hazelcast.collection.impl.txnqueue.TxQueueItem;
 import com.hazelcast.collection.impl.txnqueue.operations.QueueTransactionRollbackOperation;
 import com.hazelcast.collection.impl.txnqueue.operations.TxnOfferBackupOperation;
 import com.hazelcast.collection.impl.txnqueue.operations.TxnOfferOperation;
@@ -58,14 +53,22 @@ import com.hazelcast.collection.impl.txnqueue.operations.TxnReservePollBackupOpe
 import com.hazelcast.collection.impl.txnqueue.operations.TxnReservePollOperation;
 import com.hazelcast.collection.impl.txnqueue.operations.TxnRollbackBackupOperation;
 import com.hazelcast.collection.impl.txnqueue.operations.TxnRollbackOperation;
+import com.hazelcast.nio.serialization.DataSerializableFactory;
+import com.hazelcast.nio.serialization.DataSerializerHook;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.nio.serialization.impl.ArrayDataSerializableFactory;
+import com.hazelcast.nio.serialization.impl.FactoryIdHelper;
 import com.hazelcast.util.ConstructorFunction;
+
+import static com.hazelcast.nio.serialization.impl.FactoryIdHelper.QUEUE_DS_FACTORY;
+import static com.hazelcast.nio.serialization.impl.FactoryIdHelper.QUEUE_DS_FACTORY_ID;
 
 /**
  * A {@link com.hazelcast.nio.serialization.DataSerializerHook} for the queue operations and support structures.
  */
 public final class QueueDataSerializerHook implements DataSerializerHook {
 
-    public static final int F_ID = FactoryIdHelper.getFactoryId(FactoryIdHelper.QUEUE_DS_FACTORY, -11);
+    public static final int F_ID = FactoryIdHelper.getFactoryId(QUEUE_DS_FACTORY, QUEUE_DS_FACTORY_ID);
 
     public static final int OFFER = 0;
     public static final int POLL = 1;

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueuePortableHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueuePortableHook.java
@@ -16,12 +16,6 @@
 
 package com.hazelcast.collection.impl.queue;
 
-import com.hazelcast.nio.serialization.impl.ArrayPortableFactory;
-import com.hazelcast.nio.serialization.ClassDefinition;
-import com.hazelcast.nio.serialization.impl.FactoryIdHelper;
-import com.hazelcast.nio.serialization.Portable;
-import com.hazelcast.nio.serialization.PortableFactory;
-import com.hazelcast.nio.serialization.PortableHook;
 import com.hazelcast.collection.impl.queue.client.AddAllRequest;
 import com.hazelcast.collection.impl.queue.client.AddListenerRequest;
 import com.hazelcast.collection.impl.queue.client.ClearRequest;
@@ -41,16 +35,25 @@ import com.hazelcast.collection.impl.txnqueue.client.TxnOfferRequest;
 import com.hazelcast.collection.impl.txnqueue.client.TxnPeekRequest;
 import com.hazelcast.collection.impl.txnqueue.client.TxnPollRequest;
 import com.hazelcast.collection.impl.txnqueue.client.TxnSizeRequest;
+import com.hazelcast.nio.serialization.ClassDefinition;
+import com.hazelcast.nio.serialization.Portable;
+import com.hazelcast.nio.serialization.PortableFactory;
+import com.hazelcast.nio.serialization.PortableHook;
+import com.hazelcast.nio.serialization.impl.ArrayPortableFactory;
+import com.hazelcast.nio.serialization.impl.FactoryIdHelper;
 import com.hazelcast.util.ConstructorFunction;
 
 import java.util.Collection;
+
+import static com.hazelcast.nio.serialization.impl.FactoryIdHelper.QUEUE_PORTABLE_FACTORY;
+import static com.hazelcast.nio.serialization.impl.FactoryIdHelper.QUEUE_PORTABLE_FACTORY_ID;
 
 /**
  * Provides a Portable hook for the queue operations.
  */
 public class QueuePortableHook implements PortableHook {
 
-    public static final int F_ID = FactoryIdHelper.getFactoryId(FactoryIdHelper.QUEUE_PORTABLE_FACTORY, -11);
+    public static final int F_ID = FactoryIdHelper.getFactoryId(QUEUE_PORTABLE_FACTORY, QUEUE_PORTABLE_FACTORY_ID);
 
     public static final int OFFER = 1;
     public static final int SIZE = 2;

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/AtomicLongDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/AtomicLongDataSerializerHook.java
@@ -31,12 +31,15 @@ import com.hazelcast.concurrent.atomiclong.operations.SetBackupOperation;
 import com.hazelcast.concurrent.atomiclong.operations.SetOperation;
 import com.hazelcast.nio.serialization.DataSerializableFactory;
 import com.hazelcast.nio.serialization.DataSerializerHook;
-import com.hazelcast.nio.serialization.impl.FactoryIdHelper;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.nio.serialization.impl.FactoryIdHelper;
+
+import static com.hazelcast.nio.serialization.impl.FactoryIdHelper.ATOMIC_LONG_DS_FACTORY;
+import static com.hazelcast.nio.serialization.impl.FactoryIdHelper.ATOMIC_LONG_DS_FACTORY_ID;
 
 public final class AtomicLongDataSerializerHook implements DataSerializerHook {
 
-    public static final int F_ID = FactoryIdHelper.getFactoryId(FactoryIdHelper.ATOMIC_LONG_DS_FACTORY, -17);
+    public static final int F_ID = FactoryIdHelper.getFactoryId(ATOMIC_LONG_DS_FACTORY, ATOMIC_LONG_DS_FACTORY_ID);
 
     public static final int ADD_BACKUP = 0;
     public static final int ADD_AND_GET = 1;

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/client/AtomicLongPortableHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/client/AtomicLongPortableHook.java
@@ -17,16 +17,19 @@
 package com.hazelcast.concurrent.atomiclong.client;
 
 import com.hazelcast.nio.serialization.ClassDefinition;
-import com.hazelcast.nio.serialization.impl.FactoryIdHelper;
 import com.hazelcast.nio.serialization.Portable;
 import com.hazelcast.nio.serialization.PortableFactory;
 import com.hazelcast.nio.serialization.PortableHook;
+import com.hazelcast.nio.serialization.impl.FactoryIdHelper;
 
 import java.util.Collection;
 
+import static com.hazelcast.nio.serialization.impl.FactoryIdHelper.ATOMIC_LONG_PORTABLE_FACTORY;
+import static com.hazelcast.nio.serialization.impl.FactoryIdHelper.ATOMIC_LONG_PORTABLE_FACTORY_ID;
+
 public class AtomicLongPortableHook implements PortableHook {
 
-    static final int F_ID = FactoryIdHelper.getFactoryId(FactoryIdHelper.ATOMIC_LONG_PORTABLE_FACTORY, -17);
+    static final int F_ID = FactoryIdHelper.getFactoryId(ATOMIC_LONG_PORTABLE_FACTORY, ATOMIC_LONG_PORTABLE_FACTORY_ID);
 
     static final int ADD_AND_GET = 1;
     static final int COMPARE_AND_SET = 2;

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/AtomicReferenceDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/AtomicReferenceDataSerializerHook.java
@@ -31,12 +31,15 @@ import com.hazelcast.concurrent.atomicreference.operations.SetBackupOperation;
 import com.hazelcast.concurrent.atomicreference.operations.SetOperation;
 import com.hazelcast.nio.serialization.DataSerializableFactory;
 import com.hazelcast.nio.serialization.DataSerializerHook;
-import com.hazelcast.nio.serialization.impl.FactoryIdHelper;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.nio.serialization.impl.FactoryIdHelper;
+
+import static com.hazelcast.nio.serialization.impl.FactoryIdHelper.ATOMIC_REFERENCE_DS_FACTORY;
+import static com.hazelcast.nio.serialization.impl.FactoryIdHelper.ATOMIC_REFERENCE_DS_FACTORY_ID;
 
 public final class AtomicReferenceDataSerializerHook implements DataSerializerHook {
 
-    public static final int F_ID = FactoryIdHelper.getFactoryId(FactoryIdHelper.ATOMIC_REFERENCE_DS_FACTORY, -21);
+    public static final int F_ID = FactoryIdHelper.getFactoryId(ATOMIC_REFERENCE_DS_FACTORY, ATOMIC_REFERENCE_DS_FACTORY_ID);
 
     public static final int ALTER_AND_GET = 0;
     public static final int ALTER = 1;

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/client/AtomicReferencePortableHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/client/AtomicReferencePortableHook.java
@@ -17,16 +17,19 @@
 package com.hazelcast.concurrent.atomicreference.client;
 
 import com.hazelcast.nio.serialization.ClassDefinition;
-import com.hazelcast.nio.serialization.impl.FactoryIdHelper;
 import com.hazelcast.nio.serialization.Portable;
 import com.hazelcast.nio.serialization.PortableFactory;
 import com.hazelcast.nio.serialization.PortableHook;
+import com.hazelcast.nio.serialization.impl.FactoryIdHelper;
 
 import java.util.Collection;
 
+import static com.hazelcast.nio.serialization.impl.FactoryIdHelper.ATOMIC_REFERENCE_PORTABLE_FACTORY;
+import static com.hazelcast.nio.serialization.impl.FactoryIdHelper.ATOMIC_REFERENCE_PORTABLE_FACTORY_ID;
+
 public class AtomicReferencePortableHook implements PortableHook {
 
-    static final int F_ID = FactoryIdHelper.getFactoryId(FactoryIdHelper.ATOMIC_REFERENCE_PORTABLE_FACTORY, -21);
+    static final int F_ID = FactoryIdHelper.getFactoryId(ATOMIC_REFERENCE_PORTABLE_FACTORY, ATOMIC_REFERENCE_PORTABLE_FACTORY_ID);
 
     static final int GET = 1;
     static final int SET = 2;

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/countdownlatch/CountDownLatchDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/countdownlatch/CountDownLatchDataSerializerHook.java
@@ -24,12 +24,15 @@ import com.hazelcast.concurrent.countdownlatch.operations.GetCountOperation;
 import com.hazelcast.concurrent.countdownlatch.operations.SetCountOperation;
 import com.hazelcast.nio.serialization.DataSerializableFactory;
 import com.hazelcast.nio.serialization.DataSerializerHook;
-import com.hazelcast.nio.serialization.impl.FactoryIdHelper;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.nio.serialization.impl.FactoryIdHelper;
+
+import static com.hazelcast.nio.serialization.impl.FactoryIdHelper.CDL_DS_FACTORY;
+import static com.hazelcast.nio.serialization.impl.FactoryIdHelper.CDL_DS_FACTORY_ID;
 
 public final class CountDownLatchDataSerializerHook implements DataSerializerHook {
 
-    public static final int F_ID = FactoryIdHelper.getFactoryId(FactoryIdHelper.CDL_PORTABLE_FACTORY, -14);
+    public static final int F_ID = FactoryIdHelper.getFactoryId(CDL_DS_FACTORY, CDL_DS_FACTORY_ID);
 
     public static final int AWAIT_OPERATION = 0;
     public static final int COUNT_DOWN_LATCH_BACKUP_OPERATION = 1;

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/countdownlatch/client/CountDownLatchPortableHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/countdownlatch/client/CountDownLatchPortableHook.java
@@ -17,16 +17,19 @@
 package com.hazelcast.concurrent.countdownlatch.client;
 
 import com.hazelcast.nio.serialization.ClassDefinition;
-import com.hazelcast.nio.serialization.impl.FactoryIdHelper;
 import com.hazelcast.nio.serialization.Portable;
 import com.hazelcast.nio.serialization.PortableFactory;
 import com.hazelcast.nio.serialization.PortableHook;
+import com.hazelcast.nio.serialization.impl.FactoryIdHelper;
 
 import java.util.Collection;
 
+import static com.hazelcast.nio.serialization.impl.FactoryIdHelper.CDL_PORTABLE_FACTORY;
+import static com.hazelcast.nio.serialization.impl.FactoryIdHelper.CDL_PORTABLE_FACTORY_ID;
+
 public final class CountDownLatchPortableHook implements PortableHook {
 
-    static final int F_ID = FactoryIdHelper.getFactoryId(FactoryIdHelper.CDL_PORTABLE_FACTORY, -14);
+    static final int F_ID = FactoryIdHelper.getFactoryId(CDL_PORTABLE_FACTORY, CDL_PORTABLE_FACTORY_ID);
 
     static final int COUNT_DOWN = 1;
     static final int AWAIT = 2;

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockDataSerializerHook.java
@@ -16,8 +16,8 @@
 
 package com.hazelcast.concurrent.lock;
 
-import com.hazelcast.concurrent.lock.operations.AwaitOperation;
 import com.hazelcast.concurrent.lock.operations.AwaitBackupOperation;
+import com.hazelcast.concurrent.lock.operations.AwaitOperation;
 import com.hazelcast.concurrent.lock.operations.BeforeAwaitBackupOperation;
 import com.hazelcast.concurrent.lock.operations.BeforeAwaitOperation;
 import com.hazelcast.concurrent.lock.operations.GetLockCountOperation;
@@ -32,12 +32,15 @@ import com.hazelcast.concurrent.lock.operations.UnlockBackupOperation;
 import com.hazelcast.concurrent.lock.operations.UnlockOperation;
 import com.hazelcast.nio.serialization.DataSerializableFactory;
 import com.hazelcast.nio.serialization.DataSerializerHook;
-import com.hazelcast.nio.serialization.impl.FactoryIdHelper;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.nio.serialization.impl.FactoryIdHelper;
+
+import static com.hazelcast.nio.serialization.impl.FactoryIdHelper.LOCK_DS_FACTORY;
+import static com.hazelcast.nio.serialization.impl.FactoryIdHelper.LOCK_DS_FACTORY_ID;
 
 public final class LockDataSerializerHook implements DataSerializerHook {
 
-    public static final int F_ID = FactoryIdHelper.getFactoryId(FactoryIdHelper.LOCK_DS_FACTORY, -15);
+    public static final int F_ID = FactoryIdHelper.getFactoryId(LOCK_DS_FACTORY, LOCK_DS_FACTORY_ID);
 
     public static final int AWAIT_BACKUP = 0;
     public static final int AWAIT = 1;

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/client/LockPortableHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/client/LockPortableHook.java
@@ -17,16 +17,19 @@
 package com.hazelcast.concurrent.lock.client;
 
 import com.hazelcast.nio.serialization.ClassDefinition;
-import com.hazelcast.nio.serialization.impl.FactoryIdHelper;
 import com.hazelcast.nio.serialization.Portable;
 import com.hazelcast.nio.serialization.PortableFactory;
 import com.hazelcast.nio.serialization.PortableHook;
+import com.hazelcast.nio.serialization.impl.FactoryIdHelper;
 
 import java.util.Collection;
 
+import static com.hazelcast.nio.serialization.impl.FactoryIdHelper.LOCK_PORTABLE_FACTORY;
+import static com.hazelcast.nio.serialization.impl.FactoryIdHelper.LOCK_PORTABLE_FACTORY_ID;
+
 public class LockPortableHook implements PortableHook {
 
-    public static final int FACTORY_ID = FactoryIdHelper.getFactoryId(FactoryIdHelper.LOCK_PORTABLE_FACTORY, -15);
+    public static final int FACTORY_ID = FactoryIdHelper.getFactoryId(LOCK_PORTABLE_FACTORY, LOCK_PORTABLE_FACTORY_ID);
 
     public static final int LOCK = 1;
     public static final int UNLOCK = 2;

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/SemaphoreDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/SemaphoreDataSerializerHook.java
@@ -32,12 +32,15 @@ import com.hazelcast.concurrent.semaphore.operations.SemaphoreDeadMemberOperatio
 import com.hazelcast.concurrent.semaphore.operations.SemaphoreReplicationOperation;
 import com.hazelcast.nio.serialization.DataSerializableFactory;
 import com.hazelcast.nio.serialization.DataSerializerHook;
-import com.hazelcast.nio.serialization.impl.FactoryIdHelper;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.nio.serialization.impl.FactoryIdHelper;
+
+import static com.hazelcast.nio.serialization.impl.FactoryIdHelper.SEMAPHORE_DS_FACTORY;
+import static com.hazelcast.nio.serialization.impl.FactoryIdHelper.SEMAPHORE_DS_FACTORY_ID;
 
 public class SemaphoreDataSerializerHook implements DataSerializerHook {
 
-    public static final int F_ID = FactoryIdHelper.getFactoryId(FactoryIdHelper.SEMAPHORE_DS_FACTORY, -16);
+    public static final int F_ID = FactoryIdHelper.getFactoryId(SEMAPHORE_DS_FACTORY, SEMAPHORE_DS_FACTORY_ID);
 
     public static final int ACQUIRE_BACKUP_OPERATION = 0;
     public static final int ACQUIRE_OPERATION = 1;

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/client/SemaphorePortableHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/client/SemaphorePortableHook.java
@@ -17,16 +17,19 @@
 package com.hazelcast.concurrent.semaphore.client;
 
 import com.hazelcast.nio.serialization.ClassDefinition;
-import com.hazelcast.nio.serialization.impl.FactoryIdHelper;
 import com.hazelcast.nio.serialization.Portable;
 import com.hazelcast.nio.serialization.PortableFactory;
 import com.hazelcast.nio.serialization.PortableHook;
+import com.hazelcast.nio.serialization.impl.FactoryIdHelper;
 
 import java.util.Collection;
 
+import static com.hazelcast.nio.serialization.impl.FactoryIdHelper.SEMAPHORE_PORTABLE_FACTORY;
+import static com.hazelcast.nio.serialization.impl.FactoryIdHelper.SEMAPHORE_PORTABLE_FACTORY_ID;
+
 public class SemaphorePortableHook implements PortableHook {
 
-    static final int F_ID = FactoryIdHelper.getFactoryId(FactoryIdHelper.SEMAPHORE_PORTABLE_FACTORY, -16);
+    static final int F_ID = FactoryIdHelper.getFactoryId(SEMAPHORE_PORTABLE_FACTORY, SEMAPHORE_PORTABLE_FACTORY_ID);
     static final int ACQUIRE = 1;
     static final int AVAILABLE = 2;
     static final int DRAIN = 3;

--- a/hazelcast/src/main/java/com/hazelcast/executor/impl/ExecutorDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/executor/impl/ExecutorDataSerializerHook.java
@@ -20,12 +20,15 @@ import com.hazelcast.executor.impl.operations.CallableTaskOperation;
 import com.hazelcast.executor.impl.operations.MemberCallableTaskOperation;
 import com.hazelcast.nio.serialization.DataSerializableFactory;
 import com.hazelcast.nio.serialization.DataSerializerHook;
-import com.hazelcast.nio.serialization.impl.FactoryIdHelper;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.nio.serialization.impl.FactoryIdHelper;
+
+import static com.hazelcast.nio.serialization.impl.FactoryIdHelper.EXECUTOR_DS_FACTORY;
+import static com.hazelcast.nio.serialization.impl.FactoryIdHelper.EXECUTOR_DS_FACTORY_ID;
 
 public class ExecutorDataSerializerHook implements DataSerializerHook {
 
-    public static final int F_ID = FactoryIdHelper.getFactoryId(FactoryIdHelper.EXECUTOR_DS_FACTORY, -13);
+    public static final int F_ID = FactoryIdHelper.getFactoryId(EXECUTOR_DS_FACTORY, EXECUTOR_DS_FACTORY_ID);
 
     public static final int CALLABLE_TASK = 0;
     public static final int MEMBER_CALLABLE_TASK = 1;

--- a/hazelcast/src/main/java/com/hazelcast/executor/impl/ExecutorPortableHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/executor/impl/ExecutorPortableHook.java
@@ -22,16 +22,19 @@ import com.hazelcast.executor.impl.client.PartitionTargetCallableRequest;
 import com.hazelcast.executor.impl.client.ShutdownRequest;
 import com.hazelcast.executor.impl.client.SpecificTargetCallableRequest;
 import com.hazelcast.nio.serialization.ClassDefinition;
-import com.hazelcast.nio.serialization.impl.FactoryIdHelper;
 import com.hazelcast.nio.serialization.Portable;
 import com.hazelcast.nio.serialization.PortableFactory;
 import com.hazelcast.nio.serialization.PortableHook;
+import com.hazelcast.nio.serialization.impl.FactoryIdHelper;
 
 import java.util.Collection;
 
+import static com.hazelcast.nio.serialization.impl.FactoryIdHelper.EXECUTOR_PORTABLE_FACTORY;
+import static com.hazelcast.nio.serialization.impl.FactoryIdHelper.EXECUTOR_PORTABLE_FACTORY_ID;
+
 public final class ExecutorPortableHook implements PortableHook {
 
-    public static final int F_ID = FactoryIdHelper.getFactoryId(FactoryIdHelper.EXECUTOR_PORTABLE_FACTORY, -13);
+    public static final int F_ID = FactoryIdHelper.getFactoryId(EXECUTOR_PORTABLE_FACTORY, EXECUTOR_PORTABLE_FACTORY_ID);
 
     public static final int IS_SHUTDOWN_REQUEST = 1;
     public static final int CANCELLATION_REQUEST = 2;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapDataSerializerHook.java
@@ -21,18 +21,21 @@ import com.hazelcast.map.impl.operation.PutBackupOperation;
 import com.hazelcast.map.impl.operation.PutOperation;
 import com.hazelcast.map.impl.operation.RemoveBackupOperation;
 import com.hazelcast.map.impl.operation.RemoveOperation;
-import com.hazelcast.nio.serialization.impl.ArrayDataSerializableFactory;
 import com.hazelcast.nio.serialization.DataSerializableFactory;
 import com.hazelcast.nio.serialization.DataSerializerHook;
-import com.hazelcast.nio.serialization.impl.FactoryIdHelper;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.nio.serialization.impl.ArrayDataSerializableFactory;
+import com.hazelcast.nio.serialization.impl.FactoryIdHelper;
 import com.hazelcast.query.impl.QueryResultEntryImpl;
 import com.hazelcast.util.ConstructorFunction;
 import com.hazelcast.util.QueryResultSet;
 
+import static com.hazelcast.nio.serialization.impl.FactoryIdHelper.MAP_DS_FACTORY;
+import static com.hazelcast.nio.serialization.impl.FactoryIdHelper.MAP_DS_FACTORY_ID;
+
 public final class MapDataSerializerHook implements DataSerializerHook {
 
-    public static final int F_ID = FactoryIdHelper.getFactoryId(FactoryIdHelper.MAP_DS_FACTORY, -10);
+    public static final int F_ID = FactoryIdHelper.getFactoryId(MAP_DS_FACTORY, MAP_DS_FACTORY_ID);
 
     public static final int PUT = 0;
     public static final int GET = 1;
@@ -46,7 +49,7 @@ public final class MapDataSerializerHook implements DataSerializerHook {
     public static final int VALUES = 9;
     public static final int ENTRY_SET = 10;
     public static final int ENTRY_VIEW = 11;
-//    public static final int MAP_STATS = 12;
+    //    public static final int MAP_STATS = 12;
     public static final int QUERY_RESULT_ENTRY = 13;
     public static final int QUERY_RESULT_SET = 14;
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapPortableHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapPortableHook.java
@@ -65,17 +65,20 @@ import com.hazelcast.map.impl.client.MapValuesRequest;
 import com.hazelcast.map.impl.client.TxnMapRequest;
 import com.hazelcast.map.impl.client.TxnMapRequestWithSQLQuery;
 import com.hazelcast.nio.serialization.ClassDefinition;
-import com.hazelcast.nio.serialization.impl.FactoryIdHelper;
 import com.hazelcast.nio.serialization.Portable;
 import com.hazelcast.nio.serialization.PortableFactory;
 import com.hazelcast.nio.serialization.PortableHook;
+import com.hazelcast.nio.serialization.impl.FactoryIdHelper;
 import com.hazelcast.util.ConstructorFunction;
 
 import java.util.Collection;
 
+import static com.hazelcast.nio.serialization.impl.FactoryIdHelper.MAP_PORTABLE_FACTORY;
+import static com.hazelcast.nio.serialization.impl.FactoryIdHelper.MAP_PORTABLE_FACTORY_ID;
+
 public class MapPortableHook implements PortableHook {
 
-    public static final int F_ID = FactoryIdHelper.getFactoryId(FactoryIdHelper.MAP_PORTABLE_FACTORY, -10);
+    public static final int F_ID = FactoryIdHelper.getFactoryId(MAP_PORTABLE_FACTORY, MAP_PORTABLE_FACTORY_ID);
     public static final int GET = 1;
     public static final int PUT = 2;
     public static final int PUT_IF_ABSENT = 3;

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/AggregationsDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/AggregationsDataSerializerHook.java
@@ -16,12 +16,15 @@
 
 package com.hazelcast.mapreduce.aggregation.impl;
 
-import com.hazelcast.nio.serialization.impl.ArrayDataSerializableFactory;
 import com.hazelcast.nio.serialization.DataSerializableFactory;
 import com.hazelcast.nio.serialization.DataSerializerHook;
-import com.hazelcast.nio.serialization.impl.FactoryIdHelper;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.nio.serialization.impl.ArrayDataSerializableFactory;
+import com.hazelcast.nio.serialization.impl.FactoryIdHelper;
 import com.hazelcast.util.ConstructorFunction;
+
+import static com.hazelcast.nio.serialization.impl.FactoryIdHelper.AGGREGATIONS_DS_FACTORY;
+import static com.hazelcast.nio.serialization.impl.FactoryIdHelper.AGGREGATIONS_DS_FACTORY_ID;
 
 /**
  * This class contains all the ID hooks for IdentifiedDataSerializable classes used for aggregations.
@@ -31,7 +34,7 @@ import com.hazelcast.util.ConstructorFunction;
 public class AggregationsDataSerializerHook
         implements DataSerializerHook {
 
-    public static final int F_ID = FactoryIdHelper.getFactoryId(FactoryIdHelper.AGGREGATIONS_DS_FACTORY, -24);
+    public static final int F_ID = FactoryIdHelper.getFactoryId(AGGREGATIONS_DS_FACTORY, AGGREGATIONS_DS_FACTORY_ID);
 
     public static final int SUPPLIER_CONSUMING_MAPPER = 0;
     public static final int ACCEPT_ALL_SUPPLIER = 1;

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/MapReduceDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/MapReduceDataSerializerHook.java
@@ -34,12 +34,15 @@ import com.hazelcast.mapreduce.impl.operation.RequestPartitionProcessed;
 import com.hazelcast.mapreduce.impl.operation.RequestPartitionReducing;
 import com.hazelcast.mapreduce.impl.operation.RequestPartitionResult;
 import com.hazelcast.mapreduce.impl.operation.StartProcessingJobOperation;
-import com.hazelcast.nio.serialization.impl.ArrayDataSerializableFactory;
 import com.hazelcast.nio.serialization.DataSerializableFactory;
 import com.hazelcast.nio.serialization.DataSerializerHook;
-import com.hazelcast.nio.serialization.impl.FactoryIdHelper;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.nio.serialization.impl.ArrayDataSerializableFactory;
+import com.hazelcast.nio.serialization.impl.FactoryIdHelper;
 import com.hazelcast.util.ConstructorFunction;
+
+import static com.hazelcast.nio.serialization.impl.FactoryIdHelper.MAP_REDUCE_DS_FACTORY;
+import static com.hazelcast.nio.serialization.impl.FactoryIdHelper.MAP_REDUCE_DS_FACTORY_ID;
 
 /**
  * This class contains all the ID hooks for IdentifiedDataSerializable classes used inside the MR framework.
@@ -49,7 +52,7 @@ import com.hazelcast.util.ConstructorFunction;
 public class MapReduceDataSerializerHook
         implements DataSerializerHook {
 
-    public static final int F_ID = FactoryIdHelper.getFactoryId(FactoryIdHelper.MAP_REDUCE_DS_FACTORY, -23);
+    public static final int F_ID = FactoryIdHelper.getFactoryId(MAP_REDUCE_DS_FACTORY, MAP_REDUCE_DS_FACTORY_ID);
 
     public static final int KEY_VALUE_SOURCE_MAP = 0;
     public static final int KEY_VALUE_SOURCE_MULTIMAP = 1;

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/MapReducePortableHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/MapReducePortableHook.java
@@ -21,13 +21,16 @@ import com.hazelcast.mapreduce.impl.client.ClientJobProcessInformationRequest;
 import com.hazelcast.mapreduce.impl.client.ClientMapReduceRequest;
 import com.hazelcast.mapreduce.impl.task.TransferableJobProcessInformation;
 import com.hazelcast.nio.serialization.ClassDefinition;
-import com.hazelcast.nio.serialization.impl.FactoryIdHelper;
 import com.hazelcast.nio.serialization.Portable;
 import com.hazelcast.nio.serialization.PortableFactory;
 import com.hazelcast.nio.serialization.PortableHook;
+import com.hazelcast.nio.serialization.impl.FactoryIdHelper;
 import com.hazelcast.util.ConstructorFunction;
 
 import java.util.Collection;
+
+import static com.hazelcast.nio.serialization.impl.FactoryIdHelper.MAP_REDUCE_PORTABLE_FACTORY;
+import static com.hazelcast.nio.serialization.impl.FactoryIdHelper.MAP_REDUCE_PORTABLE_FACTORY_ID;
 
 /**
  * This class registers all Portable serializers that are needed for communication between nodes and clients
@@ -36,7 +39,7 @@ public class MapReducePortableHook
         implements PortableHook {
 
     //CHECKSTYLE:OFF
-    public static final int F_ID = FactoryIdHelper.getFactoryId(FactoryIdHelper.MAP_REDUCE_PORTABLE_FACTORY, -23);
+    public static final int F_ID = FactoryIdHelper.getFactoryId(MAP_REDUCE_PORTABLE_FACTORY, MAP_REDUCE_PORTABLE_FACTORY_ID);
 
     public static final int CLIENT_JOB_PROCESS_INFO_REQUEST = 1;
     public static final int CLIENT_CANCELLATION_REQUEST = 2;

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapDataSerializerHook.java
@@ -45,16 +45,19 @@ import com.hazelcast.multimap.impl.txn.TxnRemoveBackupOperation;
 import com.hazelcast.multimap.impl.txn.TxnRemoveOperation;
 import com.hazelcast.multimap.impl.txn.TxnRollbackBackupOperation;
 import com.hazelcast.multimap.impl.txn.TxnRollbackOperation;
-import com.hazelcast.nio.serialization.impl.ArrayDataSerializableFactory;
 import com.hazelcast.nio.serialization.DataSerializableFactory;
 import com.hazelcast.nio.serialization.DataSerializerHook;
-import com.hazelcast.nio.serialization.impl.FactoryIdHelper;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.nio.serialization.impl.ArrayDataSerializableFactory;
+import com.hazelcast.nio.serialization.impl.FactoryIdHelper;
 import com.hazelcast.util.ConstructorFunction;
+
+import static com.hazelcast.nio.serialization.impl.FactoryIdHelper.MULTIMAP_DS_FACTORY;
+import static com.hazelcast.nio.serialization.impl.FactoryIdHelper.MULTIMAP_DS_FACTORY_ID;
 
 public class MultiMapDataSerializerHook implements DataSerializerHook {
 
-    public static final int F_ID = FactoryIdHelper.getFactoryId(FactoryIdHelper.MULTIMAP_DS_FACTORY, -12);
+    public static final int F_ID = FactoryIdHelper.getFactoryId(MULTIMAP_DS_FACTORY, MULTIMAP_DS_FACTORY_ID);
 
     public static final int ADD_ALL_BACKUP = 0;
     public static final int ADD_ALL = 1;

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapPortableHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapPortableHook.java
@@ -40,18 +40,22 @@ import com.hazelcast.multimap.impl.client.TxnMultiMapRemoveRequest;
 import com.hazelcast.multimap.impl.client.TxnMultiMapSizeRequest;
 import com.hazelcast.multimap.impl.client.TxnMultiMapValueCountRequest;
 import com.hazelcast.multimap.impl.client.ValuesRequest;
-import com.hazelcast.nio.serialization.impl.ArrayPortableFactory;
 import com.hazelcast.nio.serialization.ClassDefinition;
-import com.hazelcast.nio.serialization.impl.FactoryIdHelper;
 import com.hazelcast.nio.serialization.Portable;
 import com.hazelcast.nio.serialization.PortableFactory;
 import com.hazelcast.nio.serialization.PortableHook;
+import com.hazelcast.nio.serialization.impl.ArrayPortableFactory;
+import com.hazelcast.nio.serialization.impl.FactoryIdHelper;
 import com.hazelcast.util.ConstructorFunction;
+
 import java.util.Collection;
+
+import static com.hazelcast.nio.serialization.impl.FactoryIdHelper.MULTIMAP_PORTABLE_FACTORY;
+import static com.hazelcast.nio.serialization.impl.FactoryIdHelper.MULTIMAP_PORTABLE_FACTORY_ID;
 
 public class MultiMapPortableHook implements PortableHook {
 
-    public static final int F_ID = FactoryIdHelper.getFactoryId(FactoryIdHelper.MULTIMAP_PORTABLE_FACTORY, -12);
+    public static final int F_ID = FactoryIdHelper.getFactoryId(MULTIMAP_PORTABLE_FACTORY, MULTIMAP_PORTABLE_FACTORY_ID);
 
     public static final int CLEAR = 1;
     public static final int CONTAINS_ENTRY = 2;

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/impl/FactoryIdHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/impl/FactoryIdHelper.java
@@ -21,52 +21,134 @@ import com.hazelcast.logging.Logger;
 public final class FactoryIdHelper {
 
     public static final String SPI_DS_FACTORY = "hazelcast.serialization.ds.spi";
+    public static final int SPI_DS_FACTORY_ID = -1;
+
     public static final String PARTITION_DS_FACTORY = "hazelcast.serialization.ds.partition";
+    public static final int PARTITION_DS_FACTORY_ID = -2;
+
     public static final String CLIENT_DS_FACTORY = "hazelcast.serialization.ds.client";
+    public static final int CLIENT_DS_FACTORY_ID = -3;
+
     public static final String MAP_DS_FACTORY = "hazelcast.serialization.ds.map";
+    public static final int MAP_DS_FACTORY_ID = -10;
+
     public static final String QUEUE_DS_FACTORY = "hazelcast.serialization.ds.queue";
+    public static final int QUEUE_DS_FACTORY_ID = -11;
+
     public static final String MULTIMAP_DS_FACTORY = "hazelcast.serialization.ds.multimap";
-    public static final String COLLECTION_DS_FACTORY = "hazelcast.serialization.ds.collection";
+    public static final int MULTIMAP_DS_FACTORY_ID = -12;
+
     public static final String EXECUTOR_DS_FACTORY = "hazelcast.serialization.ds.executor";
-    public static final String TOPIC_DS_FACTORY = "hazelcast.serialization.ds.topic";
-    public static final String LOCK_DS_FACTORY = "hazelcast.serialization.ds.lock";
-    public static final String SEMAPHORE_DS_FACTORY = "hazelcast.serialization.ds.semaphore";
-    public static final String ATOMIC_LONG_DS_FACTORY = "hazelcast.serialization.ds.atomic_long";
+    public static final int EXECUTOR_DS_FACTORY_ID = -13;
+
     public static final String CDL_DS_FACTORY = "hazelcast.serialization.ds.cdl";
+    public static final int CDL_DS_FACTORY_ID = -14;
+
+    public static final String LOCK_DS_FACTORY = "hazelcast.serialization.ds.lock";
+    public static final int LOCK_DS_FACTORY_ID = -15;
+
+    public static final String SEMAPHORE_DS_FACTORY = "hazelcast.serialization.ds.semaphore";
+    public static final int SEMAPHORE_DS_FACTORY_ID = -16;
+
+    public static final String ATOMIC_LONG_DS_FACTORY = "hazelcast.serialization.ds.atomic_long";
+    public static final int ATOMIC_LONG_DS_FACTORY_ID = -17;
+
+    public static final String TOPIC_DS_FACTORY = "hazelcast.serialization.ds.topic";
+    public static final int TOPIC_DS_FACTORY_ID = -18;
+
+    public static final String COLLECTION_DS_FACTORY = "hazelcast.serialization.ds.collection";
+    public static final int COLLECTION_DS_FACTORY_ID = -20;
+
     public static final String ATOMIC_REFERENCE_DS_FACTORY = "hazelcast.serialization.ds.atomic_reference";
+    public static final int ATOMIC_REFERENCE_DS_FACTORY_ID = -21;
+
     public static final String REPLICATED_MAP_DS_FACTORY = "hazelcast.serialization.ds.replicated_map";
-    public static final String AGGREGATIONS_DS_FACTORY = "hazelcast.serialization.ds.aggregations";
+    public static final int REPLICATED_MAP_DS_FACTORY_ID = -22;
+
     public static final String MAP_REDUCE_DS_FACTORY = "hazelcast.serialization.ds.map_reduce";
-    public static final String WEB_DS_FACTORY = "hazelcast.serialization.ds.web";
+    public static final int MAP_REDUCE_DS_FACTORY_ID = -23;
+
+    public static final String AGGREGATIONS_DS_FACTORY = "hazelcast.serialization.ds.aggregations";
+    public static final int AGGREGATIONS_DS_FACTORY_ID = -24;
+
     public static final String CACHE_DS_FACTORY = "hazelcast.serialization.ds.cache";
-    public static final String HIBERNATE_DS_FACTORY = "hazelcast.serialization.ds.hibernate";
-    public static final String ENTERPRISE_CACHE_DS_FACTORY = "hazelcast.serialization.ds.enterprise.cache";
+    public static final int CACHE_DS_FACTORY_ID = -25;
+
     public static final String HIDENSITY_CACHE_DS_FACTORY = "hazelcast.serialization.ds.hidensity.cache";
+    public static final int HIDENSITY_CACHE_DS_FACTORY_ID = -26;
+
+    public static final String ENTERPRISE_CACHE_DS_FACTORY = "hazelcast.serialization.ds.enterprise.cache";
+    public static final int ENTERPRISE_CACHE_DS_FACTORY_ID = -27;
+
     public static final String ENTERPRISE_WAN_REPLICATION_DS_FACTORY = "hazelcast.serialization.ds.enterprise.wan_replication";
+    public static final int ENTERPRISE_WAN_REPLICATION_DS_FACTORY_ID = -28;
+
+    public static final String RINGBUFFER_DS_FACTORY = "hazelcast.serialization.ds.ringbuffer";
+    public static final int RINGBUFFER_DS_FACTORY_ID = -29;
+
+    public static final String HIBERNATE_DS_FACTORY = "hazelcast.serialization.ds.hibernate";
+    public static final String WEB_DS_FACTORY = "hazelcast.serialization.ds.web";
+
+    // =========================== portables =============================================
 
     public static final String SPI_PORTABLE_FACTORY = "hazelcast.serialization.portable.spi";
+    public static final int SPI_PORTABLE_FACTORY_ID = -1;
+
     public static final String PARTITION_PORTABLE_FACTORY = "hazelcast.serialization.portable.partition";
+    public static final int PARTITION_PORTABLE_FACTORY_ID = -2;
+
     public static final String CLIENT_PORTABLE_FACTORY = "hazelcast.serialization.portable.client";
-    public static final String CLIENT_TXN_PORTABLE_FACTORY = "hazelcast.serialization.portable.client.txn";
+    public static final int CLIENT_PORTABLE_FACTORY_ID = -3;
+
     public static final String MAP_PORTABLE_FACTORY = "hazelcast.serialization.portable.map";
+    public static final int MAP_PORTABLE_FACTORY_ID = -10;
+
     public static final String ENTERPRISE_MAP_PORTABLE_FACTORY = "hazelcast.serialization.portable.enterprise.map";
+
     public static final String QUEUE_PORTABLE_FACTORY = "hazelcast.serialization.portable.queue";
+    public static final int QUEUE_PORTABLE_FACTORY_ID = -11;
+
     public static final String MULTIMAP_PORTABLE_FACTORY = "hazelcast.serialization.portable.multimap";
-    public static final String COLLECTION_PORTABLE_FACTORY = "hazelcast.serialization.portable.collection";
+    public static final int MULTIMAP_PORTABLE_FACTORY_ID = -12;
+
     public static final String EXECUTOR_PORTABLE_FACTORY = "hazelcast.serialization.portable.executor";
-    public static final String TOPIC_PORTABLE_FACTORY = "hazelcast.serialization.portable.topic";
-    public static final String LOCK_PORTABLE_FACTORY = "hazelcast.serialization.portable.lock";
-    public static final String SEMAPHORE_PORTABLE_FACTORY = "hazelcast.serialization.portable.semaphore";
-    public static final String ATOMIC_LONG_PORTABLE_FACTORY = "hazelcast.serialization.portable.atomic_long";
-    public static final String ATOMIC_REFERENCE_PORTABLE_FACTORY = "hazelcast.serialization.portable.atomic_reference";
+    public static final int EXECUTOR_PORTABLE_FACTORY_ID = -13;
+
     public static final String CDL_PORTABLE_FACTORY = "hazelcast.serialization.portable.cdl";
+    public static final int CDL_PORTABLE_FACTORY_ID = -14;
+
+    public static final String LOCK_PORTABLE_FACTORY = "hazelcast.serialization.portable.lock";
+    public static final int LOCK_PORTABLE_FACTORY_ID = -15;
+
+    public static final String SEMAPHORE_PORTABLE_FACTORY = "hazelcast.serialization.portable.semaphore";
+    public static final int SEMAPHORE_PORTABLE_FACTORY_ID = -16;
+
+    public static final String ATOMIC_LONG_PORTABLE_FACTORY = "hazelcast.serialization.portable.atomic_long";
+    public static final int ATOMIC_LONG_PORTABLE_FACTORY_ID = -17;
+
+    public static final String TOPIC_PORTABLE_FACTORY = "hazelcast.serialization.portable.topic";
+    public static final int TOPIC_PORTABLE_FACTORY_ID = -18;
+
+    public static final String CLIENT_TXN_PORTABLE_FACTORY = "hazelcast.serialization.portable.client.txn";
+    public static final int CLIENT_TXN_PORTABLE_FACTORY_ID = -19;
+
+    public static final String COLLECTION_PORTABLE_FACTORY = "hazelcast.serialization.portable.collection";
+    public static final int COLLECTION_PORTABLE_FACTORY_ID = -20;
+
+    public static final String ATOMIC_REFERENCE_PORTABLE_FACTORY = "hazelcast.serialization.portable.atomic_reference";
+    public static final int ATOMIC_REFERENCE_PORTABLE_FACTORY_ID = -21;
+
     public static final String REPLICATED_PORTABLE_FACTORY = "hazelcast.serialization.portable.replicated_map";
-    public static final String AGGREGATIONS_PORTABLE_FACTORY = "hazelcast.serialization.portable.aggregations";
+    public static final int REPLICATED_PORTABLE_FACTORY_ID = -22;
+
     public static final String MAP_REDUCE_PORTABLE_FACTORY = "hazelcast.serialization.portable.map_reduce";
-    public static final String WEB_PORTABLE_FACTORY = "hazelcast.serialization.portable.web";
+    public static final int MAP_REDUCE_PORTABLE_FACTORY_ID = -23;
+
     public static final String CACHE_PORTABLE_FACTORY = "hazelcast.serialization.portable.cache";
-    public static final String HIBERNATE_PORTABLE_FACTORY = "hazelcast.serialization.portable.hibernate";
+    public static final int CACHE_PORTABLE_FACTORY_ID = -24;
+
     public static final String RINGBUFFER_PORTABLE_FACTORY = "hazelcast.serialization.portable.ringbuffer";
+    public static final int RINGBUFFER_PORTABLE_FACTORY_ID = -29;
 
     // factory id 0 is reserved for Cluster objects (Data, Address, Member etc)...
 

--- a/hazelcast/src/main/java/com/hazelcast/partition/PartitionDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/PartitionDataSerializerHook.java
@@ -18,13 +18,16 @@ package com.hazelcast.partition;
 
 import com.hazelcast.nio.serialization.DataSerializableFactory;
 import com.hazelcast.nio.serialization.DataSerializerHook;
-import com.hazelcast.nio.serialization.impl.FactoryIdHelper;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.nio.serialization.impl.FactoryIdHelper;
 import com.hazelcast.partition.client.PartitionsResponse;
+
+import static com.hazelcast.nio.serialization.impl.FactoryIdHelper.PARTITION_DS_FACTORY;
+import static com.hazelcast.nio.serialization.impl.FactoryIdHelper.PARTITION_DS_FACTORY_ID;
 
 public final class PartitionDataSerializerHook implements DataSerializerHook {
 
-    public static final int F_ID = FactoryIdHelper.getFactoryId(FactoryIdHelper.PARTITION_DS_FACTORY, -2);
+    public static final int F_ID = FactoryIdHelper.getFactoryId(PARTITION_DS_FACTORY, PARTITION_DS_FACTORY_ID);
 
     public static final int PARTITIONS = 2;
 

--- a/hazelcast/src/main/java/com/hazelcast/partition/PartitionPortableHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/PartitionPortableHook.java
@@ -17,15 +17,18 @@
 package com.hazelcast.partition;
 
 import com.hazelcast.nio.serialization.ClassDefinition;
-import com.hazelcast.nio.serialization.impl.FactoryIdHelper;
 import com.hazelcast.nio.serialization.PortableFactory;
 import com.hazelcast.nio.serialization.PortableHook;
+import com.hazelcast.nio.serialization.impl.FactoryIdHelper;
 
 import java.util.Collection;
 
+import static com.hazelcast.nio.serialization.impl.FactoryIdHelper.PARTITION_PORTABLE_FACTORY;
+import static com.hazelcast.nio.serialization.impl.FactoryIdHelper.PARTITION_PORTABLE_FACTORY_ID;
+
 public final class PartitionPortableHook implements PortableHook {
 
-    public static final int F_ID = FactoryIdHelper.getFactoryId(FactoryIdHelper.PARTITION_PORTABLE_FACTORY, -2);
+    public static final int F_ID = FactoryIdHelper.getFactoryId(PARTITION_PORTABLE_FACTORY, PARTITION_PORTABLE_FACTORY_ID);
 
     @Override
     public int getFactoryId() {

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/client/ReplicatedMapPortableHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/client/ReplicatedMapPortableHook.java
@@ -17,13 +17,16 @@
 package com.hazelcast.replicatedmap.impl.client;
 
 import com.hazelcast.nio.serialization.ClassDefinition;
-import com.hazelcast.nio.serialization.impl.FactoryIdHelper;
 import com.hazelcast.nio.serialization.Portable;
 import com.hazelcast.nio.serialization.PortableFactory;
 import com.hazelcast.nio.serialization.PortableHook;
+import com.hazelcast.nio.serialization.impl.FactoryIdHelper;
 import com.hazelcast.util.ConstructorFunction;
 
 import java.util.Collection;
+
+import static com.hazelcast.nio.serialization.impl.FactoryIdHelper.REPLICATED_PORTABLE_FACTORY;
+import static com.hazelcast.nio.serialization.impl.FactoryIdHelper.REPLICATED_PORTABLE_FACTORY_ID;
 
 /**
  * This class registers all Portable serializers that are needed for communication between nodes and clients
@@ -32,7 +35,7 @@ import java.util.Collection;
 public class ReplicatedMapPortableHook
         implements PortableHook {
 
-    public static final int F_ID = FactoryIdHelper.getFactoryId(FactoryIdHelper.REPLICATED_PORTABLE_FACTORY, -22);
+    public static final int F_ID = FactoryIdHelper.getFactoryId(REPLICATED_PORTABLE_FACTORY, REPLICATED_PORTABLE_FACTORY_ID);
 
     public static final int SIZE = 1;
     public static final int IS_EMPTY = 2;

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/ReplicatedMapDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/ReplicatedMapDataSerializerHook.java
@@ -16,16 +16,19 @@
 
 package com.hazelcast.replicatedmap.impl.operation;
 
-import com.hazelcast.nio.serialization.impl.ArrayDataSerializableFactory;
 import com.hazelcast.nio.serialization.DataSerializableFactory;
 import com.hazelcast.nio.serialization.DataSerializerHook;
-import com.hazelcast.nio.serialization.impl.FactoryIdHelper;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.nio.serialization.impl.ArrayDataSerializableFactory;
+import com.hazelcast.nio.serialization.impl.FactoryIdHelper;
 import com.hazelcast.replicatedmap.impl.messages.MultiReplicationMessage;
 import com.hazelcast.replicatedmap.impl.messages.ReplicationMessage;
 import com.hazelcast.replicatedmap.impl.record.ReplicatedRecord;
 import com.hazelcast.replicatedmap.impl.record.VectorClockTimestamp;
 import com.hazelcast.util.ConstructorFunction;
+
+import static com.hazelcast.nio.serialization.impl.FactoryIdHelper.REPLICATED_MAP_DS_FACTORY;
+import static com.hazelcast.nio.serialization.impl.FactoryIdHelper.REPLICATED_MAP_DS_FACTORY_ID;
 
 /**
  * This class contains all the ID hooks for IdentifiedDataSerializable classes used inside the replicated map.
@@ -35,7 +38,7 @@ import com.hazelcast.util.ConstructorFunction;
 public class ReplicatedMapDataSerializerHook
         implements DataSerializerHook {
 
-    public static final int F_ID = FactoryIdHelper.getFactoryId(FactoryIdHelper.REPLICATED_MAP_DS_FACTORY, -22);
+    public static final int F_ID = FactoryIdHelper.getFactoryId(REPLICATED_MAP_DS_FACTORY, REPLICATED_MAP_DS_FACTORY_ID);
 
     public static final int VECTOR = 0;
     public static final int RECORD = 1;

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/RingbufferDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/RingbufferDataSerializerHook.java
@@ -18,8 +18,8 @@ package com.hazelcast.ringbuffer.impl;
 
 import com.hazelcast.nio.serialization.DataSerializableFactory;
 import com.hazelcast.nio.serialization.DataSerializerHook;
-import com.hazelcast.nio.serialization.impl.FactoryIdHelper;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.nio.serialization.impl.FactoryIdHelper;
 import com.hazelcast.ringbuffer.impl.operations.AddAllBackupOperation;
 import com.hazelcast.ringbuffer.impl.operations.AddAllOperation;
 import com.hazelcast.ringbuffer.impl.operations.AddBackupOperation;
@@ -29,12 +29,15 @@ import com.hazelcast.ringbuffer.impl.operations.ReadManyOperation;
 import com.hazelcast.ringbuffer.impl.operations.ReadOneOperation;
 import com.hazelcast.ringbuffer.impl.operations.ReplicationOperation;
 
+import static com.hazelcast.nio.serialization.impl.FactoryIdHelper.RINGBUFFER_DS_FACTORY;
+import static com.hazelcast.nio.serialization.impl.FactoryIdHelper.RINGBUFFER_DS_FACTORY_ID;
+
 /**
  * The {@link DataSerializerHook} for the Ringbuffer.
  */
 public class RingbufferDataSerializerHook implements DataSerializerHook {
 
-    public static final int F_ID = FactoryIdHelper.getFactoryId(FactoryIdHelper.COLLECTION_DS_FACTORY, -29);
+    public static final int F_ID = FactoryIdHelper.getFactoryId(RINGBUFFER_DS_FACTORY, RINGBUFFER_DS_FACTORY_ID);
 
     public static final int GENERIC_OPERATION = 1;
     public static final int ADD_BACKUP_OPERATION = 2;

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/client/RingbufferPortableHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/client/RingbufferPortableHook.java
@@ -24,12 +24,15 @@ import com.hazelcast.nio.serialization.impl.FactoryIdHelper;
 
 import java.util.Collection;
 
+import static com.hazelcast.nio.serialization.impl.FactoryIdHelper.RINGBUFFER_PORTABLE_FACTORY;
+import static com.hazelcast.nio.serialization.impl.FactoryIdHelper.RINGBUFFER_PORTABLE_FACTORY_ID;
+
 /**
  * Provides a Portable hook for the ringbuffer operations.
  */
 public class RingbufferPortableHook implements PortableHook {
 
-    public static final int F_ID = FactoryIdHelper.getFactoryId(FactoryIdHelper.RINGBUFFER_PORTABLE_FACTORY, -29);
+    public static final int F_ID = FactoryIdHelper.getFactoryId(RINGBUFFER_PORTABLE_FACTORY, RINGBUFFER_PORTABLE_FACTORY_ID);
 
     public static final int ADD_ALL = 1;
     public static final int ADD = 2;

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/SpiDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/SpiDataSerializerHook.java
@@ -29,9 +29,12 @@ import com.hazelcast.spi.impl.operationservice.impl.responses.CallTimeoutRespons
 import com.hazelcast.spi.impl.operationservice.impl.responses.ErrorResponse;
 import com.hazelcast.spi.impl.operationservice.impl.responses.NormalResponse;
 
+import static com.hazelcast.nio.serialization.impl.FactoryIdHelper.SPI_DS_FACTORY;
+import static com.hazelcast.nio.serialization.impl.FactoryIdHelper.SPI_DS_FACTORY_ID;
+
 public final class SpiDataSerializerHook implements DataSerializerHook {
 
-    public static final int F_ID = FactoryIdHelper.getFactoryId(FactoryIdHelper.SPI_DS_FACTORY, -1);
+    public static final int F_ID = FactoryIdHelper.getFactoryId(SPI_DS_FACTORY, SPI_DS_FACTORY_ID);
 
     public static final int NORMAL_RESPONSE = 0;
     public static final int BACKUP = 1;

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/SpiPortableHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/SpiPortableHook.java
@@ -17,17 +17,20 @@
 package com.hazelcast.spi.impl;
 
 import com.hazelcast.nio.serialization.ClassDefinition;
-import com.hazelcast.nio.serialization.impl.FactoryIdHelper;
 import com.hazelcast.nio.serialization.Portable;
 import com.hazelcast.nio.serialization.PortableFactory;
 import com.hazelcast.nio.serialization.PortableHook;
+import com.hazelcast.nio.serialization.impl.FactoryIdHelper;
 import com.hazelcast.security.UsernamePasswordCredentials;
 
 import java.util.Collection;
 
+import static com.hazelcast.nio.serialization.impl.FactoryIdHelper.SPI_PORTABLE_FACTORY;
+import static com.hazelcast.nio.serialization.impl.FactoryIdHelper.SPI_PORTABLE_FACTORY_ID;
+
 public final class SpiPortableHook implements PortableHook {
 
-    public static final int ID = FactoryIdHelper.getFactoryId(FactoryIdHelper.SPI_PORTABLE_FACTORY, -1);
+    public static final int ID = FactoryIdHelper.getFactoryId(SPI_PORTABLE_FACTORY, SPI_PORTABLE_FACTORY_ID);
 
     public static final int USERNAME_PWD_CRED = 1;
     public static final int COLLECTION = 2;

--- a/hazelcast/src/main/java/com/hazelcast/topic/impl/TopicDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/impl/TopicDataSerializerHook.java
@@ -18,13 +18,16 @@ package com.hazelcast.topic.impl;
 
 import com.hazelcast.nio.serialization.DataSerializableFactory;
 import com.hazelcast.nio.serialization.DataSerializerHook;
-import com.hazelcast.nio.serialization.impl.FactoryIdHelper;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.nio.serialization.impl.FactoryIdHelper;
 import com.hazelcast.topic.impl.reliable.ReliableTopicMessage;
+
+import static com.hazelcast.nio.serialization.impl.FactoryIdHelper.TOPIC_DS_FACTORY;
+import static com.hazelcast.nio.serialization.impl.FactoryIdHelper.TOPIC_DS_FACTORY_ID;
 
 public final class TopicDataSerializerHook implements DataSerializerHook {
 
-    public static final int F_ID = FactoryIdHelper.getFactoryId(FactoryIdHelper.TOPIC_DS_FACTORY, -18);
+    public static final int F_ID = FactoryIdHelper.getFactoryId(TOPIC_DS_FACTORY, TOPIC_DS_FACTORY_ID);
 
     public static final int PUBLISH = 0;
     public static final int TOPIC_EVENT = 1;

--- a/hazelcast/src/main/java/com/hazelcast/topic/impl/TopicPortableHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/impl/TopicPortableHook.java
@@ -17,10 +17,10 @@
 package com.hazelcast.topic.impl;
 
 import com.hazelcast.nio.serialization.ClassDefinition;
-import com.hazelcast.nio.serialization.impl.FactoryIdHelper;
 import com.hazelcast.nio.serialization.Portable;
 import com.hazelcast.nio.serialization.PortableFactory;
 import com.hazelcast.nio.serialization.PortableHook;
+import com.hazelcast.nio.serialization.impl.FactoryIdHelper;
 import com.hazelcast.topic.impl.client.AddMessageListenerRequest;
 import com.hazelcast.topic.impl.client.PortableMessage;
 import com.hazelcast.topic.impl.client.PublishRequest;
@@ -28,9 +28,12 @@ import com.hazelcast.topic.impl.client.RemoveMessageListenerRequest;
 
 import java.util.Collection;
 
+import static com.hazelcast.nio.serialization.impl.FactoryIdHelper.TOPIC_PORTABLE_FACTORY;
+import static com.hazelcast.nio.serialization.impl.FactoryIdHelper.TOPIC_PORTABLE_FACTORY_ID;
+
 public class TopicPortableHook implements PortableHook {
 
-    public static final int F_ID = FactoryIdHelper.getFactoryId(FactoryIdHelper.TOPIC_PORTABLE_FACTORY, -18);
+    public static final int F_ID = FactoryIdHelper.getFactoryId(TOPIC_PORTABLE_FACTORY, TOPIC_PORTABLE_FACTORY_ID);
 
     public static final int PUBLISH = 1;
     public static final int ADD_LISTENER = 2;

--- a/hazelcast/src/main/java/com/hazelcast/transaction/client/ClientTxnPortableHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/client/ClientTxnPortableHook.java
@@ -17,19 +17,22 @@
 package com.hazelcast.transaction.client;
 
 import com.hazelcast.nio.serialization.ClassDefinition;
-import com.hazelcast.nio.serialization.impl.FactoryIdHelper;
 import com.hazelcast.nio.serialization.Portable;
 import com.hazelcast.nio.serialization.PortableFactory;
 import com.hazelcast.nio.serialization.PortableHook;
+import com.hazelcast.nio.serialization.impl.FactoryIdHelper;
 
 import java.util.Collection;
+
+import static com.hazelcast.nio.serialization.impl.FactoryIdHelper.CLIENT_TXN_PORTABLE_FACTORY;
+import static com.hazelcast.nio.serialization.impl.FactoryIdHelper.CLIENT_TXN_PORTABLE_FACTORY_ID;
 
 /**
  * Factory class for client transaction related classes
  */
 public class ClientTxnPortableHook implements PortableHook {
 
-    public static final int F_ID = FactoryIdHelper.getFactoryId(FactoryIdHelper.CLIENT_TXN_PORTABLE_FACTORY, -19);
+    public static final int F_ID = FactoryIdHelper.getFactoryId(CLIENT_TXN_PORTABLE_FACTORY, CLIENT_TXN_PORTABLE_FACTORY_ID);
 
     public static final int CREATE = 1;
     public static final int COMMIT = 2;


### PR DESCRIPTION
  Cleanup of FactoryIdHelper
    
    1: all factory id's are now stored in the FactoryIdHelper. So one central place where
    you can see all the values.
    
    2: removed unused constants
    
    3: resolves issue with the count down latch serializer; it was pointing to the portable version
      and not the regular version
    
    4: resolved issue with the ringbuffer (wrong value being used).
