### PR TITLE
[Backport] - Barrier to prevent re-ordering of LoadAllOperation and LoadStatusOperation during partition migrations.

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapKeyLoader.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapKeyLoader.java
@@ -26,17 +26,21 @@ import com.hazelcast.map.impl.operation.PartitionCheckIfLoadedOperation;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.partition.InternalPartitionService;
 import com.hazelcast.spi.ExecutionService;
+import com.hazelcast.spi.InternalCompletableFuture;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.OperationService;
 import com.hazelcast.spi.impl.AbstractCompletableFuture;
+import com.hazelcast.util.FutureUtil;
 import com.hazelcast.util.StateMachine;
 import com.hazelcast.util.scheduler.CoalescingDelayedTrigger;
 
 import java.io.Closeable;
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
@@ -60,6 +64,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 public class MapKeyLoader {
 
     private static final long LOADING_TRIGGER_DELAY = SECONDS.toMillis(5);
+    private static final long KEY_DISTRIBUTION_TIMEOUT_MINUTES = 15;
 
     private String mapName;
     private OperationService opService;
@@ -250,14 +255,20 @@ public class MapKeyLoader {
             Iterator<Entry<Integer, Data>> partitionsAndKeys = map(dataKeys, toPartition(partitionService));
             Iterator<Map<Integer, List<Data>>> batches = toBatches(partitionsAndKeys, maxBatch);
 
+            List<Future> futures = new ArrayList<Future>();
             while (batches.hasNext()) {
                 Map<Integer, List<Data>> batch = batches.next();
-                sendBatch(batch, replaceExistingValues);
+                futures.addAll(sendBatch(batch, replaceExistingValues));
             }
 
+            // This acts as a barrier to prevent re-ordering of key distribution operations (LoadAllOperation)
+            // and LoadStatusOperation(s) which indicates all keys were already loaded.
+            // Re-ordering of in-flight operations can happen during a partition migration. We are waiting here
+            // for all LoadAllOperation(s) to be ACKed by receivers and only then we send them the LoadStatusOperation
+            // See https://github.com/hazelcast/hazelcast/issues/4024 for additional details
+            FutureUtil.waitWithDeadline(futures, KEY_DISTRIBUTION_TIMEOUT_MINUTES, TimeUnit.MINUTES);
         } catch (Exception caught) {
             loadError = caught;
-
         } finally {
             sendLoadCompleted(clusterSize, partitionService.getPartitionCount(), replaceExistingValues, loadError);
 
@@ -267,18 +278,21 @@ public class MapKeyLoader {
         }
     }
 
-    private void sendBatch(Map<Integer, List<Data>> batch, boolean replaceExistingValues) {
-        for (Entry<Integer, List<Data>> e : batch.entrySet()) {
+    private List<Future> sendBatch(Map<Integer, List<Data>> batch, boolean replaceExistingValues) {
+        Set<Entry<Integer, List<Data>>> entries = batch.entrySet();
+        List<Future> futures = new ArrayList<Future>(entries.size());
+        for (Entry<Integer, List<Data>> e : entries) {
             int partitionId = e.getKey();
             List<Data> keys = e.getValue();
             LoadAllOperation op = new LoadAllOperation(mapName, keys, replaceExistingValues);
-            opService.invokeOnPartition(SERVICE_NAME, op, partitionId);
+            InternalCompletableFuture<Object> future = opService.invokeOnPartition(SERVICE_NAME, op, partitionId);
+            futures.add(future);
         }
+        return futures;
     }
 
     private void sendLoadCompleted(int clusterSize, int partitions,
             boolean replaceExistingValues, Throwable exception) {
-
         for (int partitionId = 0; partitionId < partitions; partitionId++) {
             Operation op = new LoadStatusOperation(mapName, exception);
             opService.invokeOnPartition(SERVICE_NAME, op, partitionId);

--- a/hazelcast/src/test/java/com/hazelcast/map/mapstore/MapStoreTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/mapstore/MapStoreTest.java
@@ -461,7 +461,6 @@ public class MapStoreTest extends HazelcastTestSupport {
         assertEquals(1, testMapStore.getDestroyCount());
     }
 
-    // fails randomly
     @Test(timeout = 120000)
     public void testGetAllKeys() throws Exception {
         TestEventBasedMapStore testMapStore = new TestEventBasedMapStore();


### PR DESCRIPTION
Backport of #5489, fixes #4024 - a test failure.
(cherry picked from commit e9b82e3)