### PR TITLE
arquillian test breaks mockito when it is run before them.

### DIFF
--- a/hazelcast-ra/hazelcast-jca/pom.xml
+++ b/hazelcast-ra/hazelcast-jca/pom.xml
@@ -109,52 +109,64 @@
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.12</version>
+                <executions>
+                    <execution>
+                        <id>default-test</id>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <phase>test</phase>
+                        <configuration>
+                        <excludes>
+                            <exclude>**/TestInContainer*</exclude>
+                            <exclude>**/XATransactionTest*</exclude>
+                        </excludes>
+                    </configuration>
+                    </execution>
+
+                    <execution>
+                        <id>arquillian</id>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <phase>test</phase>
+                        <configuration>
+                            <excludes>
+                                <exclude>*</exclude>
+                            </excludes>
+                            <includes>
+                                <include>**/AbstractDeploymentTest/*</include>
+                                <include>**/TestInContainer*</include>
+
+                                <exclude>**/XATransactionTest*</exclude>
+                            </includes>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.jboss.arquillian</groupId>
-                <artifactId>arquillian-bom</artifactId>
-                <version>1.1.8.Final</version>
-                <scope>import</scope>
-                <type>pom</type>
-            </dependency>
-
-            <dependency>
-                <groupId>org.jboss.arquillian.extension</groupId>
-                <artifactId>arquillian-transaction-bom</artifactId>
-                <version>1.0.1.Final</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-
-        </dependencies>
-    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
             <version>${h2.version}</version>
         </dependency>
-
         <dependency>
             <groupId>org.jboss.arquillian.container</groupId>
             <artifactId>arquillian-glassfish-embedded-3.1</artifactId>
             <version>1.0.0.CR4</version>
             <scope>test</scope>
         </dependency>
-
         <dependency>
             <groupId>javax.enterprise</groupId>
             <artifactId>cdi-api</artifactId>
             <version>1.0-SP1</version>
         </dependency>
-
         <dependency>
             <groupId>org.jboss.arquillian.junit</groupId>
             <artifactId>arquillian-junit-container</artifactId>
+            <version>1.0.3.Final</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -163,7 +175,6 @@
             <version>3.1</version>
             <scope>test</scope>
         </dependency>
-
         <dependency>
             <groupId>org.apache.geronimo.specs</groupId>
             <artifactId>geronimo-j2ee-connector_1.5_spec</artifactId>
@@ -176,7 +187,6 @@
             <version>${project.parent.version}</version>
             <scope>provided</scope>
         </dependency>
-
         <dependency>
             <groupId>com.hazelcast</groupId>
             <artifactId>hazelcast</artifactId>
@@ -196,9 +206,5 @@
             <scope>test</scope>
             <version>${project.parent.version}</version>
         </dependency>
-
-
     </dependencies>
-
-
 </project>

--- a/hazelcast-ra/hazelcast-jca/src/test/java/com/hazelcast/jca/HazelcastConnectionImplTest.java
+++ b/hazelcast-ra/hazelcast-jca/src/test/java/com/hazelcast/jca/HazelcastConnectionImplTest.java
@@ -39,7 +39,7 @@ import com.hazelcast.map.impl.MapService;
 import com.hazelcast.mapreduce.JobTracker;
 import com.hazelcast.quorum.QuorumService;
 import com.hazelcast.ringbuffer.Ringbuffer;
-import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
@@ -59,7 +59,7 @@ import static org.junit.Assert.assertSame;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-@RunWith(HazelcastParallelClassRunner.class)
+@RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
 public class HazelcastConnectionImplTest extends HazelcastTestSupport {
 

--- a/hazelcast-ra/hazelcast-jca/src/test/java/com/hazelcast/jca/ManagedConnectionFactoryImplTest.java
+++ b/hazelcast-ra/hazelcast-jca/src/test/java/com/hazelcast/jca/ManagedConnectionFactoryImplTest.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.jca;
 
-import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
@@ -36,7 +36,7 @@ import static org.junit.Assert.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-@RunWith(HazelcastParallelClassRunner.class)
+@RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
 public class ManagedConnectionFactoryImplTest extends HazelcastTestSupport {
 


### PR DESCRIPTION
Arquillian does not shutdown properly until all the tests in the package is run. There is an open issue about that https://issues.jboss.org/browse/ARQ-1663 .

This commit splits the tests in JCA module in to two executions. First one runs non container tests and second one runs container tests.
https://developer.jboss.org/thread/230602?tstart=0

Mockito is not thread safe in stubbing. It is safer to run mockito tests in serial mode than parallel. https://groups.google.com/forum/#!topic/mockito/ctFkNxrwcWc
