### PR TITLE
[3.1.8] Fixes #4888 - LockStore memory leak on map/multimap destroy

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockStoreContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockStoreContainer.java
@@ -28,7 +28,7 @@ import java.util.concurrent.ConcurrentMap;
 /**
  * @author mdogan 2/12/13
  */
-final class LockStoreContainer {
+public final class LockStoreContainer {
 
     private final LockServiceImpl lockService;
     private final int partitionId;
@@ -52,7 +52,7 @@ final class LockStoreContainer {
     }
 
     void clearLockStore(ObjectNamespace namespace) {
-        final LockStoreImpl lockStore = lockStores.get(namespace);
+        final LockStoreImpl lockStore = lockStores.remove(namespace);
         if (lockStore != null) {
             lockStore.clear();
         }
@@ -66,7 +66,7 @@ final class LockStoreContainer {
         return lockStores.get(namespace);
     }
 
-    Collection<LockStoreImpl> getLockStores() {
+    public Collection<LockStoreImpl> getLockStores() {
         return Collections.unmodifiableCollection(lockStores.values());
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/PartitionContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/PartitionContainer.java
@@ -16,6 +16,9 @@
 
 package com.hazelcast.map;
 
+import com.hazelcast.concurrent.lock.LockService;
+import com.hazelcast.spi.DefaultObjectNamespace;
+import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.util.ConcurrencyUtil;
 import com.hazelcast.util.ConstructorFunction;
 
@@ -61,8 +64,24 @@ public class PartitionContainer {
 
     void destroyMap(String name) {
         RecordStore recordStore = maps.remove(name);
-        if (recordStore != null)
+        if (recordStore != null) {
             recordStore.clear();
+        }  else {
+            // It can be that, map is used only for locking,
+            // because of that RecordStore is not created.
+            // We will try to remove/clear LockStore belonging to
+            // this IMap partition.
+            clearLockStore(name);
+        }
+    }
+
+    private void clearLockStore(String name) {
+        final NodeEngine nodeEngine = mapService.getNodeEngine();
+        final LockService lockService = nodeEngine.getSharedService(LockService.SERVICE_NAME);
+        if (lockService != null) {
+            final DefaultObjectNamespace namespace = new DefaultObjectNamespace(MapService.SERVICE_NAME, name);
+            lockService.clearLockStore(partitionId, namespace);
+        }
     }
 
     void clear() {


### PR DESCRIPTION
**Backport to 3.1.8**

LockStore should be removed from registry when map/multimap is destroyed. Otherwise it will be a memory leak.

Backport of #5674 
Fixes #4888