### PR TITLE
[BACKPORT] Cache entry event improvements

### DIFF
--- a/hazelcast-client-new/src/test/java/com/hazelcast/client/cache/ClientCacheContextTest.java
+++ b/hazelcast-client-new/src/test/java/com/hazelcast/client/cache/ClientCacheContextTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.cache;
+
+import com.hazelcast.cache.CacheContextTest;
+import com.hazelcast.client.HazelcastClient;
+import com.hazelcast.client.cache.impl.HazelcastClientCachingProvider;
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.config.Config;
+import com.hazelcast.config.JoinConfig;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import javax.cache.spi.CachingProvider;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class ClientCacheContextTest extends CacheContextTest {
+
+    @Override
+    protected CachingProvider initAndGetCachingProvider() {
+        Config config = new Config();
+        JoinConfig joinConfig = config.getNetworkConfig().getJoin();
+        joinConfig.getAwsConfig().setEnabled(false);
+        joinConfig.getMulticastConfig().setEnabled(false);
+        joinConfig.getTcpIpConfig().setEnabled(true).addMember("127.0.0.1");
+
+        hazelcastInstance1 = Hazelcast.newHazelcastInstance(config);
+        hazelcastInstance2 = Hazelcast.newHazelcastInstance(config);
+
+        ClientConfig clientConfig = new ClientConfig();
+        clientConfig.getNetworkConfig().addAddress("127.0.0.1");
+
+        driverInstance = HazelcastClient.newHazelcastClient(clientConfig);
+
+        return HazelcastClientCachingProvider.createCachingProvider(driverInstance);
+    }
+
+    @After
+    public void tearDown() {
+        driverInstance.shutdown();
+        hazelcastInstance1.shutdown();
+        hazelcastInstance2.shutdown();
+    }
+
+    @Test
+    public void cacheEntryListenerCountIncreasedAfterRegisterAndDecreasedAfterDeregister() {
+        cacheEntryListenerCountIncreasedAndDecreasedCorrectly(DecreaseType.DEREGISTER);
+    }
+
+    @Test
+    public void cacheEntryListenerCountIncreasedAfterRegisterAndDecreasedAfterShutdown() {
+        cacheEntryListenerCountIncreasedAndDecreasedCorrectly(DecreaseType.SHUTDOWN);
+    }
+
+    @Test
+    public void cacheEntryListenerCountIncreasedAfterRegisterAndDecreasedAfterTerminate() {
+        cacheEntryListenerCountIncreasedAndDecreasedCorrectly(DecreaseType.TERMINATE);
+    }
+
+}

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/ClientCacheContextTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/ClientCacheContextTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.cache;
+
+import com.hazelcast.cache.CacheContextTest;
+import com.hazelcast.client.HazelcastClient;
+import com.hazelcast.client.cache.impl.HazelcastClientCachingProvider;
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.config.Config;
+import com.hazelcast.config.JoinConfig;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import javax.cache.spi.CachingProvider;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class ClientCacheContextTest extends CacheContextTest {
+
+    @Override
+    protected CachingProvider initAndGetCachingProvider() {
+        Config config = new Config();
+        JoinConfig joinConfig = config.getNetworkConfig().getJoin();
+        joinConfig.getAwsConfig().setEnabled(false);
+        joinConfig.getMulticastConfig().setEnabled(false);
+        joinConfig.getTcpIpConfig().setEnabled(true).addMember("127.0.0.1");
+
+        hazelcastInstance1 = Hazelcast.newHazelcastInstance(config);
+        hazelcastInstance2 = Hazelcast.newHazelcastInstance(config);
+
+        ClientConfig clientConfig = new ClientConfig();
+        clientConfig.getNetworkConfig().addAddress("127.0.0.1");
+
+        driverInstance = HazelcastClient.newHazelcastClient(clientConfig);
+
+        return HazelcastClientCachingProvider.createCachingProvider(driverInstance);
+    }
+
+    @After
+    public void tearDown() {
+        driverInstance.shutdown();
+        hazelcastInstance1.shutdown();
+        hazelcastInstance2.shutdown();
+    }
+
+    @Test
+    public void cacheEntryListenerCountIncreasedAfterRegisterAndDecreasedAfterDeregister() {
+        cacheEntryListenerCountIncreasedAndDecreasedCorrectly(DecreaseType.DEREGISTER);
+    }
+
+    @Test
+    public void cacheEntryListenerCountIncreasedAfterRegisterAndDecreasedAfterShutdown() {
+        cacheEntryListenerCountIncreasedAndDecreasedCorrectly(DecreaseType.SHUTDOWN);
+    }
+
+    @Test
+    public void cacheEntryListenerCountIncreasedAfterRegisterAndDecreasedAfterTerminate() {
+        cacheEntryListenerCountIncreasedAndDecreasedCorrectly(DecreaseType.TERMINATE);
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheRecordStore.java
@@ -34,6 +34,7 @@ import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.map.impl.MapEntrySet;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.DefaultData;
+import com.hazelcast.partition.InternalPartitionService;
 import com.hazelcast.spi.EventRegistration;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.impl.eventservice.InternalEventService;
@@ -75,43 +76,50 @@ import static com.hazelcast.cache.impl.record.CacheRecordFactory.isExpiredAt;
 public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extends SampleableCacheRecordMap<Data, R>>
         implements ICacheRecordStore, EvictionListener<Data, R> {
 
-    protected static final int DEFAULT_INITIAL_CAPACITY = 1000;
+    protected static final int DEFAULT_INITIAL_CAPACITY = 256;
     protected static final String SOURCE_NOT_AVAILABLE = "<NA>";
 
     protected final String name;
     protected final int partitionId;
     protected final int partitionCount;
     protected final NodeEngine nodeEngine;
+    protected final InternalPartitionService partitionService;
     protected final AbstractCacheService cacheService;
     protected final CacheConfig cacheConfig;
     protected CRM records;
+    protected CacheContext cacheContext;
     protected CacheStatisticsImpl statistics;
     protected CacheLoader cacheLoader;
     protected CacheWriter cacheWriter;
-    protected boolean isEventsEnabled = true;
-    protected boolean isEventBatchingEnabled;
+    protected boolean eventsEnabled = true;
+    protected boolean eventsBatchingEnabled;
     protected ExpiryPolicy defaultExpiryPolicy;
     protected final EvictionConfig evictionConfig;
     protected volatile boolean hasExpiringEntry;
-    protected final Map<CacheEventType, Set<CacheEventData>> batchEvent = new HashMap<CacheEventType, Set<CacheEventData>>();
+    protected final Map<CacheEventType, Set<CacheEventData>> batchEvent
+            = new HashMap<CacheEventType, Set<CacheEventData>>();
     protected final MaxSizeChecker maxSizeChecker;
     protected final EvictionPolicyEvaluator<Data, R> evictionPolicyEvaluator;
     protected final EvictionChecker evictionChecker;
     protected final EvictionStrategy<Data, R, CRM> evictionStrategy;
+    protected final boolean wanReplicationEnabled;
 
     //CHECKSTYLE:OFF
     public AbstractCacheRecordStore(final String name, final int partitionId, final NodeEngine nodeEngine,
                                     final AbstractCacheService cacheService) {
         this.name = name;
         this.partitionId = partitionId;
-        this.partitionCount = nodeEngine.getPartitionService().getPartitionCount();
         this.nodeEngine = nodeEngine;
+        this.partitionService = nodeEngine.getPartitionService();
+        this.partitionCount = partitionService.getPartitionCount();
         this.cacheService = cacheService;
         this.cacheConfig = cacheService.getCacheConfig(name);
+        this.cacheContext = cacheService.getOrCreateCacheContext(name);
         if (cacheConfig == null) {
             throw new CacheNotExistsException("Cache is already destroyed or not created yet, on "
                     + nodeEngine.getLocalMember());
         }
+        this.wanReplicationEnabled = cacheConfig.getWanReplicationRef() != null;
         this.evictionConfig = cacheConfig.getEvictionConfig();
         if (evictionConfig == null) {
             throw new IllegalStateException("Eviction config cannot be null");
@@ -173,7 +181,7 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
     protected abstract Data toHeapData(Object obj);
 
     protected MaxSizeChecker createCacheMaxSizeChecker(int size,
-                                                            EvictionConfig.MaxSizePolicy maxSizePolicy) {
+                                                       EvictionConfig.MaxSizePolicy maxSizePolicy) {
         if (maxSizePolicy == null) {
             throw new IllegalArgumentException("Max-Size policy cannot be null");
         }
@@ -207,6 +215,14 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
 
     public boolean isEvictionEnabled() {
         return evictionStrategy != null && evictionPolicyEvaluator != null;
+    }
+
+    protected boolean isEventsEnabled() {
+        return eventsEnabled && (cacheContext.getCacheEntryListenerCount() > 0 || wanReplicationEnabled);
+    }
+
+    protected boolean isInvalidationEnabled() {
+        return cacheContext.getInvalidationListenerCount() > 0;
     }
 
     @Override
@@ -256,7 +272,7 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
     }
 
     protected Data toEventData(Object obj) {
-        return isEventsEnabled ? toHeapData(obj) : null;
+        return isEventsEnabled() ? toHeapData(obj) : null;
     }
 
     protected ExpiryPolicy getExpiryPolicy(ExpiryPolicy expiryPolicy) {
@@ -277,9 +293,9 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
             return false;
         }
         doRemoveRecord(key, source);
-        if (isEventsEnabled) {
-            publishEvent(createCacheExpiredEvent(key, toEventData(record),
-                    CacheRecord.EXPIRATION_TIME_NOT_AVAILABLE, origin, IGNORE_COMPLETION));
+        if (isEventsEnabled()) {
+            publishEvent(createCacheExpiredEvent(key, toEventData(record), CacheRecord.EXPIRATION_TIME_NOT_AVAILABLE,
+                                                 origin, IGNORE_COMPLETION));
         }
         return true;
     }
@@ -301,9 +317,9 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
             statistics.increaseCacheExpiries(1);
         }
         doRemoveRecord(key, source);
-        if (isEventsEnabled) {
-            publishEvent(createCacheExpiredEvent(key, toEventData(record),
-                         CacheRecord.EXPIRATION_TIME_NOT_AVAILABLE, origin, IGNORE_COMPLETION));
+        if (isEventsEnabled()) {
+            publishEvent(createCacheExpiredEvent(key, toEventData(record), CacheRecord.EXPIRATION_TIME_NOT_AVAILABLE,
+                                                 origin, IGNORE_COMPLETION));
         }
         return null;
     }
@@ -318,12 +334,14 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
         invalidateEntry(key);
     }
 
-    protected void invalidateEntry(Data key) {
-        invalidateEntry(key, SOURCE_NOT_AVAILABLE);
+    protected void invalidateEntry(Data key, String source) {
+        if (isInvalidationEnabled()) {
+            cacheService.sendInvalidationEvent(name, toHeapData(key), source);
+        }
     }
 
-    protected void invalidateEntry(Data key, String source) {
-        cacheService.sendInvalidationEvent(name, key, source);
+    protected void invalidateEntry(Data key) {
+        invalidateEntry(key, SOURCE_NOT_AVAILABLE);
     }
 
     protected void invalidateAllEntries() {
@@ -331,7 +349,7 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
     }
 
     protected void invalidateAllEntries(String source) {
-        cacheService.sendInvalidationEvent(name, null, source);
+        invalidateEntry(null, source);
     }
 
     protected void updateGetAndPutStat(boolean isPutSucceed, boolean getValue, boolean oldValueNull, long start) {
@@ -358,9 +376,10 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
             if (expiryDuration != null) {
                 expiryTime = expiryDuration.getAdjustedTime(now);
                 record.setExpirationTime(expiryTime);
-                if (isEventsEnabled) {
-                    CacheEventContext cacheEventContext = createBaseEventContext(CacheEventType.EXPIRATION_TIME_UPDATED,
-                            toHeapData(key), toEventData(record.getValue()), expiryTime, null, IGNORE_COMPLETION);
+                if (isEventsEnabled()) {
+                    CacheEventContext cacheEventContext =
+                            createBaseEventContext(CacheEventType.EXPIRATION_TIME_UPDATED, toHeapData(key),
+                                                   toEventData(record.getValue()), expiryTime, null, IGNORE_COMPLETION);
                     cacheEventContext.setAccessHit(record.getAccessHit());
                     publishEvent(cacheEventContext);
                 }
@@ -393,27 +412,31 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
     }
 
     protected void publishEvent(CacheEventContext cacheEventContext) {
-        cacheEventContext.setCacheName(name);
-        if (isEventBatchingEnabled) {
-            final CacheEventDataImpl cacheEventData =
-                    new CacheEventDataImpl(name, cacheEventContext.getEventType(), cacheEventContext.getDataKey(),
-                                           cacheEventContext.getDataValue(), cacheEventContext.getDataOldValue(),
-                            cacheEventContext.isOldValueAvailable());
-            Set<CacheEventData> cacheEventDataSet = batchEvent.get(cacheEventContext.getEventType());
-            if (cacheEventDataSet == null) {
-                cacheEventDataSet = new HashSet<CacheEventData>();
-                batchEvent.put(cacheEventContext.getEventType(), cacheEventDataSet);
+        if (isEventsEnabled()) {
+            cacheEventContext.setCacheName(name);
+            if (eventsBatchingEnabled) {
+                final CacheEventDataImpl cacheEventData =
+                        new CacheEventDataImpl(name, cacheEventContext.getEventType(), cacheEventContext.getDataKey(),
+                                               cacheEventContext.getDataValue(), cacheEventContext.getDataOldValue(),
+                                               cacheEventContext.isOldValueAvailable());
+                Set<CacheEventData> cacheEventDataSet = batchEvent.get(cacheEventContext.getEventType());
+                if (cacheEventDataSet == null) {
+                    cacheEventDataSet = new HashSet<CacheEventData>();
+                    batchEvent.put(cacheEventContext.getEventType(), cacheEventDataSet);
+                }
+                cacheEventDataSet.add(cacheEventData);
+            } else {
+                cacheService.publishEvent(cacheEventContext);
             }
-            cacheEventDataSet.add(cacheEventData);
-        } else {
-            cacheService.publishEvent(cacheEventContext);
         }
     }
 
     protected void publishBatchedEvents(String cacheName, CacheEventType cacheEventType, int orderKey) {
-        final Set<CacheEventData> cacheEventDatas = batchEvent.get(cacheEventType);
-        CacheEventSet ces = new CacheEventSet(cacheEventType, cacheEventDatas);
-        cacheService.publishEvent(cacheName, ces, orderKey);
+        if (isEventsEnabled()) {
+            final Set<CacheEventData> cacheEventDatas = batchEvent.get(cacheEventType);
+            CacheEventSet ces = new CacheEventSet(cacheEventType, cacheEventDatas);
+            cacheService.publishEvent(cacheName, ces, orderKey);
+        }
     }
 
     protected boolean compare(Object v1, Object v2) {
@@ -469,9 +492,8 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
     protected R createRecord(Data keyData, Object value, long expirationTime, int completionId, String origin) {
         final R record = createRecord(value, expirationTime);
         updateHasExpiringEntry(record);
-        if (isEventsEnabled) {
-            publishEvent(createCacheCreatedEvent(keyData, toEventData(value),
-                    expirationTime, origin, completionId));
+        if (isEventsEnabled()) {
+            publishEvent(createCacheCreatedEvent(keyData, toEventData(value), expirationTime, origin, completionId));
         }
         return record;
     }
@@ -491,8 +513,10 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
             doPutRecord(key, record);
             return record;
         }
-        publishEvent(createCacheCompleteEvent(key, CacheRecord.EXPIRATION_TIME_NOT_AVAILABLE,
-                origin, completionId));
+        if (isEventsEnabled()) {
+            publishEvent(createCacheCompleteEvent(key, CacheRecord.EXPIRATION_TIME_NOT_AVAILABLE,
+                                                  origin, completionId));
+        }
         return null;
     }
 
@@ -565,11 +589,12 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
             record.setValue(recordValue);
             onUpdateRecord(key, record, value, dataOldValue);
             updateHasExpiringEntry(record);
-            invalidateEntry(toHeapData(key), source);
+            invalidateEntry(key, source);
 
-            if (isEventsEnabled) {
+            if (isEventsEnabled()) {
                 publishEvent(createCacheUpdatedEvent(eventDataKey, eventDataValue, eventDataOldValue,
-                        record.getExpirationTime(), record.getAccessHit(), origin, completionId));
+                                                     record.getExpirationTime(), record.getAccessHit(),
+                                                     origin, completionId));
             }
             return record;
         } catch (Throwable error) {
@@ -581,13 +606,13 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
     public boolean updateRecordWithExpiry(Data key, Object value, R record, long expiryTime,
                                           long now, boolean disableWriteThrough, int completionId) {
         return updateRecordWithExpiry(key, value, record, expiryTime, now, disableWriteThrough,
-                                      completionId, SOURCE_NOT_AVAILABLE);
+                completionId, SOURCE_NOT_AVAILABLE);
     }
 
     public boolean updateRecordWithExpiry(Data key, Object value, R record, long expiryTime,
                                           long now, boolean disableWriteThrough, int completionId, String source) {
         return updateRecordWithExpiry(key, value, record, expiryTime, now,
-                                      disableWriteThrough, completionId, source, null);
+                disableWriteThrough, completionId, source, null);
     }
 
     public boolean updateRecordWithExpiry(Data key, Object value, R record, long expiryTime, long now,
@@ -603,13 +628,13 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
     public boolean updateRecordWithExpiry(Data key, Object value, R record, ExpiryPolicy expiryPolicy,
                                           long now, boolean disableWriteThrough, int completionId) {
         return updateRecordWithExpiry(key, value, record, expiryPolicy, now,
-                                      disableWriteThrough, completionId, SOURCE_NOT_AVAILABLE);
+                disableWriteThrough, completionId, SOURCE_NOT_AVAILABLE);
     }
 
     public boolean updateRecordWithExpiry(Data key, Object value, R record, ExpiryPolicy expiryPolicy,
                                           long now, boolean disableWriteThrough, int completionId, String source) {
         return updateRecordWithExpiry(key, value, record, expiryPolicy, now,
-                                      disableWriteThrough, completionId, source, null);
+                disableWriteThrough, completionId, source, null);
     }
 
     public boolean updateRecordWithExpiry(Data key, Object value, R record, ExpiryPolicy expiryPolicy, long now,
@@ -663,9 +688,9 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
             if (records.size() == 0) {
                 hasExpiringEntry = false;
             }
-            if (isEventsEnabled) {
+            if (isEventsEnabled()) {
                 publishEvent(createCacheRemovedEvent(eventDataKey, eventDataValue,
-                        CacheRecord.EXPIRATION_TIME_NOT_AVAILABLE, origin, completionId));
+                                                     CacheRecord.EXPIRATION_TIME_NOT_AVAILABLE, origin, completionId));
             }
             return record != null;
         } catch (Throwable error) {
@@ -819,7 +844,7 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
     protected final R doPutRecord(Data key, R record, String source) {
         R oldRecord = records.put(key, record);
         if (oldRecord != null) {
-            invalidateEntry(toHeapData(key), source);
+            invalidateEntry(key, source);
         }
         return oldRecord;
     }
@@ -836,7 +861,7 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
     protected R doRemoveRecord(Data key, String source) {
         R removedRecord = records.remove(key);
         if (removedRecord != null) {
-            invalidateEntry(toHeapData(key), source);
+            invalidateEntry(key, source);
         }
         return removedRecord;
     }
@@ -872,9 +897,7 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
                     statistics.increaseCacheHits(1);
                 }
             }
-
             onGet(key, expiryPolicy, value, record);
-
             return value;
         } catch (Throwable error) {
             onGetError(key, expiryPolicy, value, record, error);
@@ -927,14 +950,10 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
                 isSaveSucceed = updateRecordWithExpiry(key, value, record, expiryPolicy,
                                                        now, disableWriteThrough, completionId, source);
             }
-
             onPut(key, value, expiryPolicy, source, getValue, disableWriteThrough,
                   record, oldValue, isExpired, isOnNewPut, isSaveSucceed);
-
             updateGetAndPutStat(isSaveSucceed, getValue, oldValue == null, start);
-
             updateHasExpiringEntry(record);
-
             return oldValue;
         } catch (Throwable error) {
             onPutError(key, value, expiryPolicy, source, getValue, disableWriteThrough,
@@ -982,19 +1001,17 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
                                                 disableWriteThrough, completionId) != null;
             } else {
                 result = false;
-                publishEvent(createCacheCompleteEvent(key, completionId));
+                if (isEventsEnabled()) {
+                    publishEvent(createCacheCompleteEvent(key, completionId));
+                }
             }
-
             onPutIfAbsent(key, value, expiryPolicy, source, disableWriteThrough,
                           record, isExpired, result);
-
             updateHasExpiringEntry(record);
-
             if (result && isStatisticsEnabled()) {
                 statistics.increaseCachePuts(1);
                 statistics.addPutTimeNanos(System.nanoTime() - start);
             }
-
             return result;
         } catch (Throwable error) {
             onPutIfAbsentError(key, value, expiryPolicy, source, disableWriteThrough, record, error);
@@ -1028,16 +1045,16 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
         try {
             if (record == null || isExpired) {
                 replaced = false;
-                publishEvent(createCacheCompleteEvent(key, completionId));
+                if (isEventsEnabled()) {
+                    publishEvent(createCacheCompleteEvent(key, completionId));
+                }
             } else {
                 replaced = updateRecordWithExpiry(key, value, record, expiryPolicy,
                                                   now, false, completionId, source);
             }
 
             onReplace(key, null, value, expiryPolicy, source, false, record, isExpired, replaced);
-
             updateHasExpiringEntry(record);
-
             if (isStatisticsEnabled()) {
                 statistics.addGetTimeNanos(System.nanoTime() - start);
                 if (replaced) {
@@ -1048,7 +1065,6 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
                     statistics.increaseCacheMisses(1);
                 }
             }
-
             return replaced;
         } catch (Throwable error) {
             onReplaceError(key, null, value, expiryPolicy, source, false, record, isExpired, replaced, error);
@@ -1082,15 +1098,13 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
                 }
             }
             if (!replaced) {
-                publishEvent(createCacheCompleteEvent(key, completionId));
+                if (isEventsEnabled()) {
+                    publishEvent(createCacheCompleteEvent(key, completionId));
+                }
             }
-
             onReplace(key, oldValue, newValue, expiryPolicy, source, false, record, isExpired, replaced);
-
             updateReplaceStat(replaced, isHit, start);
-
             updateHasExpiringEntry(record);
-
             return replaced;
         } catch (Throwable error) {
             onReplaceError(key, oldValue, newValue, expiryPolicy, source, false,
@@ -1116,17 +1130,15 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
             if (record == null || isExpired) {
                 obj = null;
                 replaced = false;
-                publishEvent(createCacheCompleteEvent(key, completionId));
+                if (isEventsEnabled()) {
+                    publishEvent(createCacheCompleteEvent(key, completionId));
+                }
             } else {
                 replaced = updateRecordWithExpiry(key, value, record, expiryPolicy,
                                                   now, false, completionId, source);
             }
-
-            onReplace(key, null, value, expiryPolicy, source, false,
-                      record, isExpired, replaced);
-
+            onReplace(key, null, value, expiryPolicy, source, false, record, isExpired, replaced);
             updateHasExpiringEntry(record);
-
             if (isStatisticsEnabled()) {
                 statistics.addGetTimeNanos(System.nanoTime() - start);
                 if (obj != null) {
@@ -1137,7 +1149,6 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
                     statistics.increaseCacheMisses(1);
                 }
             }
-
             return obj;
         } catch (Throwable error) {
             onReplaceError(key, null, value, expiryPolicy, source, false, record, isExpired, replaced, error);
@@ -1170,23 +1181,21 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
         try {
             if (record == null || isExpired) {
                 removed = false;
-                publishEvent(createCacheCompleteEvent(key,
-                        CacheRecord.EXPIRATION_TIME_NOT_AVAILABLE, origin, completionId));
+                if (isEventsEnabled()) {
+                    publishEvent(createCacheCompleteEvent(key, CacheRecord.EXPIRATION_TIME_NOT_AVAILABLE,
+                                                          origin, completionId));
+                }
             } else {
                 removed = deleteRecord(key, completionId, source, origin);
             }
-
             onRemove(key, null, source, false, record, removed);
-
             if (records.size() == 0) {
                 hasExpiringEntry = false;
             }
-
             if (removed && isStatisticsEnabled()) {
                 statistics.increaseCacheRemovals(1);
                 statistics.addRemoveTimeNanos(System.nanoTime() - start);
             }
-
             return removed;
         } catch (Throwable error) {
             onRemoveError(key, null, source, false, record, removed, error);
@@ -1224,20 +1233,17 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
                     removed = false;
                 }
             }
-
             if (!removed) {
-                publishEvent(createCacheCompleteEvent(key,
-                        CacheRecord.EXPIRATION_TIME_NOT_AVAILABLE, origin, completionId));
+                if (isEventsEnabled()) {
+                    publishEvent(createCacheCompleteEvent(key, CacheRecord.EXPIRATION_TIME_NOT_AVAILABLE,
+                                                          origin, completionId));
+                }
             }
-
             onRemove(key, value, source, false, record, removed);
-
             if (records.size() == 0) {
                 hasExpiringEntry = false;
             }
-
             updateRemoveStatistics(removed, hitCount, start);
-
             return removed;
         } catch (Throwable error) {
             onRemoveError(key, null, source, false, record, removed, error);
@@ -1277,19 +1283,18 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
             if (record == null || isExpired) {
                 obj = null;
                 removed = false;
-                publishEvent(createCacheCompleteEvent(key,
-                        CacheRecord.EXPIRATION_TIME_NOT_AVAILABLE, origin, completionId));
+                if (isEventsEnabled()) {
+                    publishEvent(createCacheCompleteEvent(key, CacheRecord.EXPIRATION_TIME_NOT_AVAILABLE,
+                                                          origin, completionId));
+                }
             } else {
                 obj = toValue(record);
                 removed = deleteRecord(key, completionId, source, origin);
             }
-
             onRemove(key, null, source, false, record, removed);
-
             if (records.size() == 0) {
                 hasExpiringEntry = false;
             }
-
             if (isStatisticsEnabled()) {
                 statistics.addGetTimeNanos(System.nanoTime() - start);
                 if (obj != null) {
@@ -1300,7 +1305,6 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
                     statistics.increaseCacheMisses(1);
                 }
             }
-
             return obj;
         } catch (Throwable error) {
             onRemoveError(key, null, source, false, record, removed, error);
@@ -1330,7 +1334,7 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
         } finally {
             final Set<Data> keysToClean = new HashSet<Data>(keys.isEmpty() ? records.keySet() : keys);
             for (Data key : keysToClean) {
-                isEventBatchingEnabled = true;
+                eventsBatchingEnabled = true;
                 final R record = records.get(key);
                 if (localKeys.contains(key) && record != null) {
                     final boolean isExpired = processExpiredEntry(key, record, now);
@@ -1344,12 +1348,14 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
                 } else {
                     keys.remove(key);
                 }
-                isEventBatchingEnabled = false;
+                eventsBatchingEnabled = false;
                 hasExpiringEntry = false;
             }
             int orderKey = keys.hashCode();
             publishBatchedEvents(name, CacheEventType.REMOVED, orderKey);
-            publishEvent(createCacheCompleteEvent(new DefaultData(), completionId));
+            if (isEventsEnabled()) {
+                publishEvent(createCacheCompleteEvent(new DefaultData(), completionId));
+            }
         }
     }
 
@@ -1461,16 +1467,13 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
 
     protected void closeListeners() {
         InternalEventService eventService = (InternalEventService) cacheService.getNodeEngine().getEventService();
-        Collection<EventRegistration> candidates =
-                eventService.getRegistrations(CacheService.SERVICE_NAME, name);
-
+        Collection<EventRegistration> candidates = eventService.getRegistrations(CacheService.SERVICE_NAME, name);
         for (EventRegistration eventRegistration : candidates) {
             eventService.close(eventRegistration);
         }
     }
 
     protected class MaxSizeEvictionChecker implements EvictionChecker {
-
         @Override
         public boolean isEvictionRequired() {
             if (maxSizeChecker != null) {
@@ -1479,7 +1482,6 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
                 return false;
             }
         }
-
     }
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheService.java
@@ -199,6 +199,10 @@ public abstract class AbstractCacheService
         return ConcurrencyUtil.getOrPutIfAbsent(statistics, name, cacheStatisticsConstructorFunction);
     }
 
+    public CacheContext getCacheContext(String name) {
+        return cacheContexts.get(name);
+    }
+
     public CacheContext getOrCreateCacheContext(String name) {
         return ConcurrencyUtil.getOrPutIfAbsent(cacheContexts, name, cacheContexesConstructorFunction);
     }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheContext.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.cache.impl;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Holds some specific informations for per cache in the node and shared by all partitions of that cache on the node.
+ */
+public class CacheContext {
+
+    private final AtomicInteger cacheEntryListenerCount = new AtomicInteger(0);
+    private final AtomicInteger invalidationListenerCount = new AtomicInteger(0);
+
+    public int getCacheEntryListenerCount() {
+        return cacheEntryListenerCount.get();
+    }
+
+    public void increaseCacheEntryListenerCount() {
+        cacheEntryListenerCount.incrementAndGet();
+    }
+
+    public void decreaseCacheEntryListenerCount() {
+        cacheEntryListenerCount.decrementAndGet();
+    }
+
+    public void resetCacheEntryListenerCount() {
+        cacheEntryListenerCount.set(0);
+    }
+
+    public int getInvalidationListenerCount() {
+        return invalidationListenerCount.get();
+    }
+
+    public void increaseInvalidationListenerCount() {
+        invalidationListenerCount.incrementAndGet();
+    }
+
+    public void decreaseInvalidationListenerCount() {
+        invalidationListenerCount.decrementAndGet();
+    }
+
+    public void resetInvalidationListenerCount() {
+        invalidationListenerCount.set(0);
+    }
+
+    @Override
+    public String toString() {
+        return "CacheContext{"
+                + "cacheEntryListenerCount=" + cacheEntryListenerCount.get()
+                + ", invalidationListenerCount=" + invalidationListenerCount.get()
+                + '}';
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheEventListenerAdaptor.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheEventListenerAdaptor.java
@@ -19,6 +19,8 @@ package com.hazelcast.cache.impl;
 import com.hazelcast.cache.ICache;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.SerializationService;
+import com.hazelcast.spi.EventRegistration;
+import com.hazelcast.spi.NotifiableEventListener;
 
 import javax.cache.configuration.CacheEntryListenerConfiguration;
 import javax.cache.configuration.Factory;
@@ -51,7 +53,9 @@ import java.util.HashSet;
  * @see javax.cache.event.CacheEntryEventFilter
  */
 public class CacheEventListenerAdaptor<K, V>
-        implements CacheEventListener, CacheEntryListenerProvider<K, V> {
+        implements CacheEventListener,
+                   CacheEntryListenerProvider<K, V>,
+                   NotifiableEventListener<CacheService> {
 
     private final CacheEntryListener<K, V> cacheEntryListener;
     private final CacheEntryCreatedListener cacheEntryCreatedListener;
@@ -61,17 +65,17 @@ public class CacheEventListenerAdaptor<K, V>
     private final CacheEntryEventFilter<? super K, ? super V> filter;
     private final boolean isOldValueRequired;
 
-    private SerializationService serializationService;
-
+    private transient SerializationService serializationService;
     private transient ICache<K, V> source;
 
-    public CacheEventListenerAdaptor(ICache<K, V> source, CacheEntryListenerConfiguration<K, V> cacheEntryListenerConfiguration,
+    public CacheEventListenerAdaptor(ICache<K, V> source,
+                                     CacheEntryListenerConfiguration<K, V> cacheEntryListenerConfiguration,
                                      SerializationService serializationService) {
         this.source = source;
         this.serializationService = serializationService;
 
-        final CacheEntryListener<? super K, ? super V> cacheEntryListener = cacheEntryListenerConfiguration
-                .getCacheEntryListenerFactory().create();
+        final CacheEntryListener<? super K, ? super V> cacheEntryListener =
+                cacheEntryListenerConfiguration.getCacheEntryListenerFactory().create();
 
         this.cacheEntryListener = (CacheEntryListener<K, V>) cacheEntryListener;
         if (cacheEntryListener instanceof CacheEntryCreatedListener) {
@@ -94,8 +98,8 @@ public class CacheEventListenerAdaptor<K, V>
         } else {
             this.cacheEntryExpiredListener = null;
         }
-        final Factory<CacheEntryEventFilter<? super K, ? super V>> filterFactory = cacheEntryListenerConfiguration
-                .getCacheEntryEventFilterFactory();
+        final Factory<CacheEntryEventFilter<? super K, ? super V>> filterFactory =
+                cacheEntryListenerConfiguration.getCacheEntryEventFilterFactory();
         if (filterFactory != null) {
             this.filter = filterFactory.create();
         } else {
@@ -164,7 +168,8 @@ public class CacheEventListenerAdaptor<K, V>
             } else {
                 oldValue = null;
             }
-            final CacheEntryEventImpl<K, V> event = new CacheEntryEventImpl<K, V>(source, eventType, key, newValue, oldValue);
+            final CacheEntryEventImpl<K, V> event =
+                    new CacheEntryEventImpl<K, V>(source, eventType, key, newValue, oldValue);
             if (filter == null || filter.evaluate(event)) {
                 evt.add(event);
             }
@@ -184,6 +189,20 @@ public class CacheEventListenerAdaptor<K, V>
         } finally {
             ((CacheSyncListenerCompleter) source).countDownCompletionLatch(completionId);
         }
-
     }
+
+    @Override
+    public void onRegister(CacheService cacheService, String serviceName,
+                           String topic, EventRegistration registration) {
+        CacheContext cacheContext = cacheService.getOrCreateCacheContext(topic);
+        cacheContext.increaseCacheEntryListenerCount();
+    }
+
+    @Override
+    public void onDeregister(CacheService cacheService, String serviceName,
+                             String topic, EventRegistration registration) {
+        CacheContext cacheContext = cacheService.getOrCreateCacheContext(topic);
+        cacheContext.decreaseCacheEntryListenerCount();
+    }
+
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheEventListenerAdaptor.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheEventListenerAdaptor.java
@@ -20,6 +20,7 @@ import com.hazelcast.cache.ICache;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.SerializationService;
 import com.hazelcast.spi.EventRegistration;
+import com.hazelcast.spi.ListenerWrapperEventFilter;
 import com.hazelcast.spi.NotifiableEventListener;
 
 import javax.cache.configuration.CacheEntryListenerConfiguration;
@@ -32,6 +33,7 @@ import javax.cache.event.CacheEntryListener;
 import javax.cache.event.CacheEntryRemovedListener;
 import javax.cache.event.CacheEntryUpdatedListener;
 import javax.cache.event.EventType;
+import java.io.Serializable;
 import java.util.Collection;
 import java.util.HashSet;
 
@@ -55,7 +57,9 @@ import java.util.HashSet;
 public class CacheEventListenerAdaptor<K, V>
         implements CacheEventListener,
                    CacheEntryListenerProvider<K, V>,
-                   NotifiableEventListener<CacheService> {
+                   NotifiableEventListener<CacheService>,
+                   ListenerWrapperEventFilter,
+                   Serializable {
 
     private final CacheEntryListener<K, V> cacheEntryListener;
     private final CacheEntryCreatedListener cacheEntryCreatedListener;
@@ -203,6 +207,16 @@ public class CacheEventListenerAdaptor<K, V>
                              String topic, EventRegistration registration) {
         CacheContext cacheContext = cacheService.getOrCreateCacheContext(topic);
         cacheContext.decreaseCacheEntryListenerCount();
+    }
+
+    @Override
+    public boolean eval(Object event) {
+        return true;
+    }
+
+    @Override
+    public Object getListener() {
+        return this;
     }
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheProxy.java
@@ -295,7 +295,8 @@ public class CacheProxy<K, V>
         final ICacheService service = getService();
         final CacheEventListenerAdaptor<K, V> entryListener = new CacheEventListenerAdaptor<K, V>(this,
                 cacheEntryListenerConfiguration, getNodeEngine().getSerializationService());
-        final String regId = service.registerListener(getDistributedObjectName(), entryListener);
+        final String regId =
+                service.registerListener(getDistributedObjectName(), entryListener, entryListener);
         if (regId != null) {
             cacheConfig.addCacheEntryListenerConfiguration(cacheEntryListenerConfiguration);
             addListenerLocally(regId, cacheEntryListenerConfiguration);

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheService.java
@@ -318,6 +318,7 @@ public class CacheService extends AbstractCacheService {
             //   - It is not used at the moment
             //   - It may or may not use "poll" method internally and this depends on the implementation
             //     so it may change between different version of Java
+            throw new UnsupportedOperationException();
         }
 
     }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheService.java
@@ -31,7 +31,6 @@ import com.hazelcast.spi.PartitionReplicationEvent;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Properties;
-import java.util.Queue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ConcurrentMap;
@@ -69,10 +68,9 @@ public class CacheService extends AbstractCacheService {
 
     protected boolean invalidationMessageBatchEnabled;
     protected int invalidationMessageBatchSize;
-    protected final ConcurrentMap<String, Queue<CacheSingleInvalidationMessage>> invalidationMessageMap =
-            new ConcurrentHashMap<String, Queue<CacheSingleInvalidationMessage>>();
+    protected final ConcurrentMap<String, InvalidationEventQueue> invalidationMessageMap =
+            new ConcurrentHashMap<String, InvalidationEventQueue>();
     protected ScheduledFuture cacheBatchInvalidationMessageSenderScheduler;
-    protected final AtomicBoolean cacheBatchInvalidationMessageSenderInProgress = new AtomicBoolean(false);
 
     protected ICacheRecordStore createNewRecordStore(String name, int partitionId) {
         return new CacheRecordStore(name, partitionId, nodeEngine, CacheService.this);
@@ -169,7 +167,7 @@ public class CacheService extends AbstractCacheService {
         Collection<EventRegistration> registrations = eventService.getRegistrations(SERVICE_NAME, name);
         if (!registrations.isEmpty()) {
             eventService.publishEvent(SERVICE_NAME, registrations,
-                    new CacheSingleInvalidationMessage(name, key, sourceUuid), name.hashCode());
+                                      new CacheSingleInvalidationMessage(name, key, sourceUuid), name.hashCode());
 
         }
     }
@@ -180,11 +178,9 @@ public class CacheService extends AbstractCacheService {
         if (registrations.isEmpty()) {
             return;
         }
-        Queue<CacheSingleInvalidationMessage> invalidationMessageQueue =
-                invalidationMessageMap.get(name);
+        InvalidationEventQueue invalidationMessageQueue =  invalidationMessageMap.get(name);
         if (invalidationMessageQueue == null) {
-            Queue<CacheSingleInvalidationMessage> newInvalidationMessageQueue =
-                    new InvalidationEventQueue();
+            InvalidationEventQueue newInvalidationMessageQueue = new InvalidationEventQueue();
             invalidationMessageQueue = invalidationMessageMap.putIfAbsent(name, newInvalidationMessageQueue);
             if (invalidationMessageQueue == null) {
                 invalidationMessageQueue = newInvalidationMessageQueue;
@@ -197,43 +193,40 @@ public class CacheService extends AbstractCacheService {
         }
     }
 
-    protected void flushInvalidationMessages(String cacheName,
-                                             Queue<CacheSingleInvalidationMessage> invalidationMessageQueue) {
-        CacheBatchInvalidationMessage batchInvalidationMessage =
-                new CacheBatchInvalidationMessage(cacheName, invalidationMessageQueue.size());
-        CacheSingleInvalidationMessage invalidationMessage;
-        while ((invalidationMessage = invalidationMessageQueue.poll()) != null) {
-            batchInvalidationMessage.addInvalidationMessage(invalidationMessage);
-        }
-        EventService eventService = nodeEngine.getEventService();
-        Collection<EventRegistration> registrations = eventService.getRegistrations(SERVICE_NAME, cacheName);
-        if (!registrations.isEmpty()) {
-            eventService.publishEvent(SERVICE_NAME, registrations,
-                    batchInvalidationMessage, cacheName.hashCode());
-
-        }
+    protected void flushInvalidationMessages(String cacheName, InvalidationEventQueue invalidationMessageQueue) {
+         // If still in progress, no need to another attempt. So just ignore.
+         if (invalidationMessageQueue.flushingInProgress.compareAndSet(false, true)) {
+             try {
+                 CacheBatchInvalidationMessage batchInvalidationMessage =
+                         new CacheBatchInvalidationMessage(cacheName, invalidationMessageQueue.size());
+                 CacheSingleInvalidationMessage invalidationMessage;
+                 while ((invalidationMessage = invalidationMessageQueue.poll()) != null) {
+                     batchInvalidationMessage.addInvalidationMessage(invalidationMessage);
+                 }
+                 EventService eventService = nodeEngine.getEventService();
+                 Collection<EventRegistration> registrations = eventService.getRegistrations(SERVICE_NAME, cacheName);
+                 if (!registrations.isEmpty()) {
+                     eventService.publishEvent(SERVICE_NAME, registrations,
+                                               batchInvalidationMessage, cacheName.hashCode());
+                 }
+             } finally {
+                 invalidationMessageQueue.flushingInProgress.set(false);
+             }
+         }
     }
 
     protected class CacheBatchInvalidationMessageSender implements Runnable {
 
         @Override
         public void run() {
-            // If still in progress, no need to another attempt. So just ignore.
-            if (cacheBatchInvalidationMessageSenderInProgress.compareAndSet(false, true)) {
-                try {
-                    for (Map.Entry<String, Queue<CacheSingleInvalidationMessage>> entry
-                            : invalidationMessageMap.entrySet()) {
-                        if (Thread.currentThread().isInterrupted()) {
-                            break;
-                        }
-                        String cacheName = entry.getKey();
-                        Queue<CacheSingleInvalidationMessage> invalidationMessageQueue = entry.getValue();
-                        if (invalidationMessageQueue.size() > 0) {
-                            flushInvalidationMessages(cacheName, invalidationMessageQueue);
-                        }
-                    }
-                } finally {
-                    cacheBatchInvalidationMessageSenderInProgress.set(false);
+            for (Map.Entry<String, InvalidationEventQueue> entry : invalidationMessageMap.entrySet()) {
+                if (Thread.currentThread().isInterrupted()) {
+                    break;
+                }
+                String cacheName = entry.getKey();
+                InvalidationEventQueue invalidationMessageQueue = entry.getValue();
+                if (invalidationMessageQueue.size() > 0) {
+                    flushInvalidationMessages(cacheName, invalidationMessageQueue);
                 }
             }
         }
@@ -243,6 +236,7 @@ public class CacheService extends AbstractCacheService {
     protected class InvalidationEventQueue extends ConcurrentLinkedQueue<CacheSingleInvalidationMessage> {
 
         private final AtomicInteger elementCount = new AtomicInteger(0);
+        private final AtomicBoolean flushingInProgress = new AtomicBoolean(false);
 
         @Override
         public int size() {

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheService.java
@@ -38,6 +38,7 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Cache Service is the main access point of JCache implementation.
@@ -183,7 +184,7 @@ public class CacheService extends AbstractCacheService {
                 invalidationMessageMap.get(name);
         if (invalidationMessageQueue == null) {
             Queue<CacheSingleInvalidationMessage> newInvalidationMessageQueue =
-                    new ConcurrentLinkedQueue<CacheSingleInvalidationMessage>();
+                    new InvalidationEventQueue();
             invalidationMessageQueue = invalidationMessageMap.putIfAbsent(name, newInvalidationMessageQueue);
             if (invalidationMessageQueue == null) {
                 invalidationMessageQueue = newInvalidationMessageQueue;
@@ -235,6 +236,88 @@ public class CacheService extends AbstractCacheService {
                     cacheBatchInvalidationMessageSenderInProgress.set(false);
                 }
             }
+        }
+
+    }
+
+    protected class InvalidationEventQueue extends ConcurrentLinkedQueue<CacheSingleInvalidationMessage> {
+
+        private final AtomicInteger elementCount = new AtomicInteger(0);
+
+        @Override
+        public int size() {
+            return elementCount.get();
+        }
+
+        @Override
+        public boolean offer(CacheSingleInvalidationMessage invalidationMessage) {
+            boolean offered = super.offer(invalidationMessage);
+            if (offered) {
+                elementCount.incrementAndGet();
+            }
+            return offered;
+        }
+
+        @Override
+        public boolean add(CacheSingleInvalidationMessage invalidationMessage) {
+            // We don't support this at the moment, because
+            //   - It is not used at the moment
+            //   - It may or may not use "offer" method internally and this depends on the implementation
+            //     so it may change between different version of Java
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public CacheSingleInvalidationMessage poll() {
+            CacheSingleInvalidationMessage polledItem = super.poll();
+            if (polledItem != null) {
+                elementCount.decrementAndGet();
+            }
+            return polledItem;
+        }
+
+        @Override
+        public CacheSingleInvalidationMessage remove() {
+            // We don't support this at the moment, because
+            //   - It is not used at the moment
+            //   - It may or may not use "poll" method internally and this depends on the implementation
+            //     so it may change between different version of Java
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean remove(Object o) {
+            boolean removed = super.remove(o);
+            if (removed) {
+                elementCount.decrementAndGet();
+            }
+            return removed;
+        }
+
+        @Override
+        public boolean addAll(Collection<? extends CacheSingleInvalidationMessage> c) {
+            // We don't support this at the moment, because it is not used at the moment
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean removeAll(Collection<?> c) {
+            // We don't support this at the moment, because it is not used at the moment
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean retainAll(Collection<?> c) {
+            // We don't support this at the moment, because it is not used at the moment
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void clear() {
+            // We don't support this at the moment, because
+            //   - It is not used at the moment
+            //   - It may or may not use "poll" method internally and this depends on the implementation
+            //     so it may change between different version of Java
         }
 
     }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/ICacheService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/ICacheService.java
@@ -20,6 +20,7 @@ import com.hazelcast.config.CacheConfig;
 import com.hazelcast.config.CacheSimpleConfig;
 import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.spi.EventFilter;
 import com.hazelcast.spi.EventPublishingService;
 import com.hazelcast.spi.ManagedService;
 import com.hazelcast.spi.MigrationAwareService;
@@ -68,7 +69,9 @@ public interface ICacheService extends ManagedService, RemoteService, MigrationA
 
     NodeEngine getNodeEngine();
 
-    String registerListener(String distributedObjectName, CacheEventListener listener);
+    String registerListener(String name, CacheEventListener listener);
+
+    String registerListener(String name, CacheEventListener listener, EventFilter eventFilter);
 
     boolean deregisterListener(String name, String registrationId);
 

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/client/CacheAddInvalidationListenerRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/client/CacheAddInvalidationListenerRequest.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.cache.impl.client;
 
+import com.hazelcast.cache.impl.CacheContext;
 import com.hazelcast.cache.impl.CachePortableHook;
 import com.hazelcast.cache.impl.CacheService;
 import com.hazelcast.client.ClientEndpoint;
@@ -45,7 +46,8 @@ public class CacheAddInvalidationListenerRequest
     public Object call() {
         ClientEndpoint endpoint = getEndpoint();
         CacheService cacheService = getService();
-        CacheInvalidationListener listener = new CacheInvalidationListener(endpoint, getCallId());
+        CacheContext cacheContext = cacheService.getOrCreateCacheContext(name);
+        CacheInvalidationListener listener = new CacheInvalidationListener(endpoint, getCallId(), cacheContext);
         String registrationId = cacheService.addInvalidationListener(name, listener);
         endpoint.setListenerRegistration(CacheService.SERVICE_NAME, name, registrationId);
         return registrationId;

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/client/CacheInvalidationListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/client/CacheInvalidationListener.java
@@ -16,20 +16,27 @@
 
 package com.hazelcast.cache.impl.client;
 
+import com.hazelcast.cache.impl.CacheContext;
 import com.hazelcast.cache.impl.CacheEventListener;
+import com.hazelcast.cache.impl.CacheService;
 import com.hazelcast.client.ClientEndpoint;
+import com.hazelcast.spi.EventRegistration;
+import com.hazelcast.spi.NotifiableEventListener;
 
 import java.util.ArrayList;
 import java.util.List;
 
-public final class CacheInvalidationListener implements CacheEventListener {
+public final class CacheInvalidationListener
+        implements CacheEventListener, NotifiableEventListener<CacheService> {
 
     private final ClientEndpoint endpoint;
     private final int callId;
+    private final CacheContext cacheContext;
 
-    public CacheInvalidationListener(ClientEndpoint endpoint, int callId) {
+    public CacheInvalidationListener(ClientEndpoint endpoint, int callId, CacheContext cacheContext) {
         this.endpoint = endpoint;
         this.callId = callId;
+        this.cacheContext = cacheContext;
     }
 
     @Override
@@ -73,6 +80,18 @@ public final class CacheInvalidationListener implements CacheEventListener {
                                    callId);
             }
         }
+    }
+
+    @Override
+    public void onRegister(CacheService cacheService, String serviceName,
+                           String topic, EventRegistration registration) {
+        cacheContext.increaseInvalidationListenerCount();
+    }
+
+    @Override
+    public void onDeregister(CacheService cacheService, String serviceName,
+                             String topic, EventRegistration registration) {
+        cacheContext.decreaseInvalidationListenerCount();
     }
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheListenerRegistrationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheListenerRegistrationOperation.java
@@ -54,14 +54,9 @@ public class CacheListenerRegistrationOperation
         final CacheService service = getService();
         CacheConfig cacheConfig = service.getCacheConfig(name);
         if (register) {
-            //REGISTER
-            if (cacheConfig == null) {
-                throw new IllegalStateException("CacheConfig does not exist!!! name: " + name);
-            }
-            cacheConfig.addCacheEntryListenerConfiguration(cacheEntryListenerConfiguration);
+            service.cacheEntryListenerRegistered(name, cacheEntryListenerConfiguration);
         } else if (cacheConfig != null) {
-            //UNREGISTER
-            cacheConfig.removeCacheEntryListenerConfiguration(cacheEntryListenerConfiguration);
+            service.cacheEntryListenerDeregistered(name, cacheEntryListenerConfiguration);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheAddInvalidationListenerTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheAddInvalidationListenerTask.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.client.impl.protocol.task.cache;
 
+import com.hazelcast.cache.impl.CacheContext;
 import com.hazelcast.cache.impl.CacheEventListener;
 import com.hazelcast.cache.impl.CacheService;
 import com.hazelcast.cache.impl.client.CacheBatchInvalidationMessage;
@@ -28,6 +29,8 @@ import com.hazelcast.client.impl.protocol.task.AbstractCallableMessageTask;
 import com.hazelcast.instance.Node;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.spi.EventRegistration;
+import com.hazelcast.spi.NotifiableEventListener;
 
 import java.security.Permission;
 import java.util.ArrayList;
@@ -44,18 +47,23 @@ public class CacheAddInvalidationListenerTask
     protected Object call() {
         final ClientEndpoint endpoint = getEndpoint();
         CacheService cacheService = getService(CacheService.SERVICE_NAME);
-        String registrationId = cacheService.addInvalidationListener(parameters.name,
-                                                                     new CacheInvalidationEventListener(endpoint));
+        CacheContext cacheContext = cacheService.getOrCreateCacheContext(parameters.name);
+        String registrationId =
+                cacheService.addInvalidationListener(parameters.name,
+                                                     new CacheInvalidationEventListener(endpoint, cacheContext));
         endpoint.setListenerRegistration(CacheService.SERVICE_NAME, parameters.name, registrationId);
         return registrationId;
     }
 
-    private final class CacheInvalidationEventListener implements CacheEventListener {
+    private final class CacheInvalidationEventListener
+            implements CacheEventListener, NotifiableEventListener<CacheService> {
 
         private final ClientEndpoint endpoint;
+        private final CacheContext cacheContext;
 
-        private CacheInvalidationEventListener(ClientEndpoint endpoint) {
+        private CacheInvalidationEventListener(ClientEndpoint endpoint, CacheContext cacheContext) {
             this.endpoint = endpoint;
+            this.cacheContext = cacheContext;
         }
 
         @Override
@@ -97,6 +105,18 @@ public class CacheAddInvalidationListenerTask
                     sendClientMessage(message.getName(), eventMessage);
                 }
             }
+        }
+
+        @Override
+        public void onRegister(CacheService cacheService, String serviceName,
+                               String topic, EventRegistration registration) {
+            cacheContext.increaseInvalidationListenerCount();
+        }
+
+        @Override
+        public void onDeregister(CacheService cacheService, String serviceName,
+                                 String topic, EventRegistration registration) {
+            cacheContext.decreaseInvalidationListenerCount();
         }
 
     }

--- a/hazelcast/src/main/java/com/hazelcast/spi/ListenerWrapperEventFilter.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/ListenerWrapperEventFilter.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi;
+
+/**
+ * Contract point for {@link com.hazelcast.spi.EventFilter} instances these wrap listeners.
+ */
+public interface ListenerWrapperEventFilter extends EventFilter {
+
+    /**
+     * Gets the wrapped listener.
+     *
+     * @return the wrapped listener
+     */
+    Object getListener();
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/NotifiableEventListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/NotifiableEventListener.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi;
+
+/**
+ * Contract point for event listeners to be notified by {@link com.hazelcast.spi.EventService}.
+ *
+ * @param <S> the type of the {@link com.hazelcast.spi.ManagedService}
+ */
+public interface NotifiableEventListener<S> {
+
+    /**
+     * Called when this listener registered to {@link com.hazelcast.spi.EventService}.
+     *
+     * @param service       the service instance that event belongs to
+     * @param serviceName   name of the service that event belongs to
+     * @param topic         name of the topic that event belongs to
+     * @param registration  the {@link com.hazelcast.spi.EventRegistration} instance
+     *                      that holds information about the registration
+     */
+    void onRegister(S service, String serviceName, String topic, EventRegistration registration);
+
+    /**
+     * Called when this listener deregistered from {@link com.hazelcast.spi.EventService}.
+     *
+     * @param service       the service instance that event belongs to
+     * @param serviceName   name of the service that event belongs to
+     * @param topic         name of the topic that event belongs to
+     * @param registration  the {@link com.hazelcast.spi.EventRegistration} instance
+     *                      that holds information about the registration
+     */
+    void onDeregister(S service, String serviceName, String topic, EventRegistration registration);
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/EventPacketProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/EventPacketProcessor.java
@@ -21,6 +21,7 @@ import com.hazelcast.spi.EventPublishingService;
 import com.hazelcast.util.executor.StripedRunnable;
 
 public class EventPacketProcessor implements StripedRunnable {
+
     private final EventServiceImpl eventService;
     private final int orderKey;
     private final EventPacket eventPacket;
@@ -73,7 +74,7 @@ public class EventPacketProcessor implements StripedRunnable {
         }
 
         String id = eventPacket.getEventId();
-        Registration registration = segment.getRegistrationIdMap().get(id);
+        Registration registration = (Registration) segment.getRegistrationIdMap().get(id);
         if (registration == null) {
             if (eventService.nodeEngine.isActive()) {
                 if (eventService.logger.isFinestEnabled()) {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/EventServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/EventServiceImpl.java
@@ -456,4 +456,5 @@ public class EventServiceImpl implements InternalEventService {
             logger.log(level, String.format(message, args));
         }
     }
+
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/EventServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/EventServiceImpl.java
@@ -60,6 +60,7 @@ import static com.hazelcast.util.FutureUtil.ExceptionHandler;
 import static com.hazelcast.util.FutureUtil.waitWithDeadline;
 
 public class EventServiceImpl implements InternalEventService {
+
     private static final EventRegistration[] EMPTY_REGISTRATIONS = new EventRegistration[0];
 
     private static final int EVENT_SYNC_FREQUENCY = 100000;
@@ -380,7 +381,7 @@ public class EventServiceImpl implements InternalEventService {
                     = new ConstructorFunction<String, EventServiceSegment>() {
                 @Override
                 public EventServiceSegment createNew(String key) {
-                    return new EventServiceSegment(key);
+                    return new EventServiceSegment(key, nodeEngine.getService(key));
                 }
             };
             return ConcurrencyUtil.getOrPutIfAbsent(segments, service, func);
@@ -422,7 +423,7 @@ public class EventServiceImpl implements InternalEventService {
         final Collection<Registration> registrations = new LinkedList<Registration>();
         for (EventServiceSegment segment : segments.values()) {
             //todo: this should be moved into the Segment.
-            for (Registration reg : segment.getRegistrationIdMap().values()) {
+            for (Registration reg : (Iterable<Registration>) segment.getRegistrationIdMap().values()) {
                 if (!reg.isLocalOnly()) {
                     registrations.add(reg);
                 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/EventServiceSegment.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/EventServiceSegment.java
@@ -17,6 +17,7 @@
 package com.hazelcast.spi.impl.eventservice.impl;
 
 import com.hazelcast.nio.Address;
+import com.hazelcast.spi.NotifiableEventListener;
 import com.hazelcast.util.ConcurrencyUtil;
 import com.hazelcast.util.ConstructorFunction;
 
@@ -27,23 +28,24 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicLong;
 
-public class EventServiceSegment {
+public class EventServiceSegment<S> {
+
     private final String serviceName;
+    private final S service;
 
     private final ConcurrentMap<String, Collection<Registration>> registrations
             = new ConcurrentHashMap<String, Collection<Registration>>();
-
-    private final ConcurrentMap<String, Registration> registrationIdMap = new ConcurrentHashMap<String, Registration>();
-
+    private final ConcurrentMap<String, Registration> registrationIdMap
+            = new ConcurrentHashMap<String, Registration>();
     private final AtomicLong totalPublishes = new AtomicLong();
 
-    public EventServiceSegment(String serviceName) {
+    public EventServiceSegment(String serviceName, S service) {
         this.serviceName = serviceName;
+        this.service = service;
     }
 
     public Collection<Registration> getRegistrations(String topic, boolean forceCreate) {
         Collection<Registration> listenerList = registrations.get(topic);
-
         if (listenerList == null && forceCreate) {
             ConstructorFunction<String, Collection<Registration>> func
                     = new ConstructorFunction<String, Collection<Registration>>() {
@@ -51,7 +53,6 @@ public class EventServiceSegment {
                     return Collections.newSetFromMap(new ConcurrentHashMap<Registration, Boolean>());
                 }
             };
-
             return ConcurrencyUtil.getOrPutIfAbsent(registrations, topic, func);
         }
         return listenerList;
@@ -65,6 +66,11 @@ public class EventServiceSegment {
         final Collection<Registration> registrations = getRegistrations(topic, true);
         if (registrations.add(registration)) {
             registrationIdMap.put(registration.getId(), registration);
+            Object listener = registration.getListener();
+            if (listener instanceof NotifiableEventListener) {
+                ((NotifiableEventListener) listener).
+                        onRegister(service, serviceName, topic, registration);
+            }
             return true;
         }
         return false;
@@ -76,6 +82,13 @@ public class EventServiceSegment {
             final Collection<Registration> all = registrations.get(topic);
             if (all != null) {
                 all.remove(registration);
+                for (Registration reg : all) {
+                    Object listener = reg.getListener();
+                    if (listener instanceof NotifiableEventListener) {
+                        ((NotifiableEventListener) listener).
+                                onDeregister(service, serviceName, topic, reg);
+                    }
+                }
             }
         }
         return registration;
@@ -86,13 +99,29 @@ public class EventServiceSegment {
         if (all != null) {
             for (Registration reg : all) {
                 registrationIdMap.remove(reg.getId());
+                Object listener = reg.getListener();
+                if (listener instanceof NotifiableEventListener) {
+                    ((NotifiableEventListener) listener).
+                            onDeregister(service, serviceName, topic, reg);
+                }
             }
         }
     }
 
     void clear() {
-        registrations.clear();
-        registrationIdMap.clear();
+        for (Collection<Registration> all : registrations.values()) {
+            Iterator<Registration> iter = all.iterator();
+            while (iter.hasNext()) {
+                Registration reg = iter.next();
+                iter.remove();
+                registrationIdMap.remove(reg.getId());
+                Object listener = reg.getListener();
+                if (listener instanceof NotifiableEventListener) {
+                    ((NotifiableEventListener) listener).
+                            onDeregister(service, serviceName, reg.getTopic(), reg);
+                }
+            }
+        }
     }
 
     void onMemberLeft(Address address) {
@@ -103,6 +132,11 @@ public class EventServiceSegment {
                 if (address.equals(reg.getSubscriber())) {
                     iter.remove();
                     registrationIdMap.remove(reg.getId());
+                    Object listener = reg.getListener();
+                    if (listener instanceof NotifiableEventListener) {
+                        ((NotifiableEventListener) listener).
+                                onDeregister(service, serviceName, reg.getTopic(), reg);
+                    }
                 }
             }
         }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/EventServiceSegment.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/EventServiceSegment.java
@@ -98,10 +98,8 @@ public class EventServiceSegment<S> {
             final Collection<Registration> all = registrations.get(topic);
             if (all != null) {
                 all.remove(registration);
-                for (Registration reg : all) {
-                    pingNotifiableEventListenerIfAvailable(topic, reg, false);
-                }
             }
+            pingNotifiableEventListenerIfAvailable(topic, registration, false);
         }
         return registration;
     }

--- a/hazelcast/src/test/java/com/hazelcast/cache/CacheContextTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CacheContextTest.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.cache;
+
+import com.hazelcast.cache.impl.CacheContext;
+import com.hazelcast.cache.impl.CacheService;
+import com.hazelcast.cache.impl.HazelcastServerCachingProvider;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.instance.TestUtil;
+import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import javax.cache.Cache;
+import javax.cache.CacheManager;
+import javax.cache.configuration.CacheEntryListenerConfiguration;
+import javax.cache.configuration.CompleteConfiguration;
+import javax.cache.configuration.FactoryBuilder;
+import javax.cache.configuration.MutableCacheEntryListenerConfiguration;
+import javax.cache.configuration.MutableConfiguration;
+import javax.cache.event.CacheEntryCreatedListener;
+import javax.cache.event.CacheEntryEvent;
+import javax.cache.event.CacheEntryListenerException;
+import javax.cache.spi.CachingProvider;
+import java.io.Serializable;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class CacheContextTest extends HazelcastTestSupport {
+
+    protected HazelcastInstance driverInstance;
+    protected HazelcastInstance hazelcastInstance1;
+    protected HazelcastInstance hazelcastInstance2;
+
+    protected CachingProvider initAndGetCachingProvider() {
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(2);
+        hazelcastInstance1 = factory.newHazelcastInstance();
+        hazelcastInstance2 = factory.newHazelcastInstance();
+        driverInstance = hazelcastInstance1;
+        return HazelcastServerCachingProvider.createCachingProvider(driverInstance);
+    }
+
+    protected static class TestListener
+            implements CacheEntryCreatedListener<String, String>, Serializable {
+
+        @Override
+        public void onCreated(Iterable<CacheEntryEvent<? extends String, ? extends String>> cacheEntryEvents)
+                throws CacheEntryListenerException {
+        }
+
+    }
+
+    protected CacheService getCacheService(HazelcastInstance instance) {
+        return TestUtil.getNode(instance).getNodeEngine().getService(CacheService.SERVICE_NAME);
+    }
+
+    protected enum DecreaseType {
+
+        DEREGISTER,
+        SHUTDOWN,
+        TERMINATE
+
+    }
+
+    protected void cacheEntryListenerCountIncreasedAndDecreasedCorrectly(DecreaseType decreaseType) {
+        final String CACHE_NAME = "MyCache";
+        final String CACHE_NAME_WITH_PREFIX = "/hz/" + CACHE_NAME;
+
+        CachingProvider provider = initAndGetCachingProvider();
+        CacheManager cacheManager = provider.getCacheManager();
+        CacheEntryListenerConfiguration<String, String> cacheEntryListenerConfig =
+                new MutableCacheEntryListenerConfiguration<String, String>(
+                        FactoryBuilder.factoryOf(new TestListener()), null, true, true);
+        CompleteConfiguration<String, String> cacheConfig = new MutableConfiguration<String, String>();
+        Cache<String, String> cache = cacheManager.createCache(CACHE_NAME, cacheConfig);
+
+        cache.registerCacheEntryListener(cacheEntryListenerConfig);
+
+        final CacheService cacheService1 = getCacheService(hazelcastInstance1);
+        final CacheService cacheService2 = getCacheService(hazelcastInstance2);
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertNotNull(cacheService1.getCacheContext(CACHE_NAME_WITH_PREFIX));
+            }
+        });
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertNotNull(cacheService2.getCacheContext(CACHE_NAME_WITH_PREFIX));
+            }
+        });
+
+        final CacheContext cacheContext1 = cacheService1.getCacheContext(CACHE_NAME_WITH_PREFIX);
+        final CacheContext cacheContext2 = cacheService2.getCacheContext(CACHE_NAME_WITH_PREFIX);
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertEquals(cacheContext1.getCacheEntryListenerCount(), 1);
+            }
+        });
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertEquals(cacheContext2.getCacheEntryListenerCount(), 1);
+            }
+        });
+
+        switch (decreaseType) {
+            case DEREGISTER:
+                cache.deregisterCacheEntryListener(cacheEntryListenerConfig);
+                break;
+            case SHUTDOWN:
+                driverInstance.getLifecycleService().shutdown();
+                break;
+            case TERMINATE:
+                driverInstance.getLifecycleService().terminate();
+                break;
+            default:
+                throw new IllegalArgumentException("Unsupported decrease type: " + decreaseType);
+        }
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertEquals(cacheContext1.getCacheEntryListenerCount(), 0);
+            }
+        });
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertEquals(cacheContext2.getCacheEntryListenerCount(), 0);
+            }
+        });
+    }
+
+    @Test
+    public void cacheEntryListenerCountIncreasedAfterRegisterAndDecreasedAfterDeregister() {
+        cacheEntryListenerCountIncreasedAndDecreasedCorrectly(DecreaseType.DEREGISTER);
+    }
+
+    @Test
+    public void cacheEntryListenerCountIncreasedAfterRegisterAndDecreasedAfterShutdown() {
+        cacheEntryListenerCountIncreasedAndDecreasedCorrectly(DecreaseType.SHUTDOWN);
+    }
+
+    @Test
+    public void cacheEntryListenerCountIncreasedAfterRegisterAndDecreasedAfterTerminate() {
+        cacheEntryListenerCountIncreasedAndDecreasedCorrectly(DecreaseType.TERMINATE);
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/cache/JCacheListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/JCacheListenerTest.java
@@ -358,4 +358,18 @@ public class JCacheListenerTest extends HazelcastTestSupport {
             counter.addAndGet(count);
         }
     }
+
+    @Test
+    public void cacheEntryListenerCountIncreasedAndDecreasedCorrectly() {
+        final CachingProvider provider = getCachingProvider();
+        CacheManager cacheManager = provider.getCacheManager();
+
+        CompleteConfiguration<String, String> config = new MutableConfiguration<String, String>()
+                .addCacheEntryListenerConfiguration(new MutableCacheEntryListenerConfiguration<String, String>(
+                        FactoryBuilder.factoryOf(new TestListener(new AtomicInteger())), null, true,
+                        true));
+
+        final Cache<String, String> cache = cacheManager.createCache("MyCache", config);
+    }
+
 }


### PR DESCRIPTION
Before this improvement;

- Even though there is no cache entry listener registered and only invalidation listener is registered, cache entry events are created and sent to event system because of registered invalidation listener. By this improvement, cache entry events are sent to event system if there is any cache entry listener registered. 

- Same logic is available also for cache invalidation listener