### PR TITLE
Fixes for FindBugs-raised issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ target/
 .settings/
 .idea/
 .patch
+.surefire-*
 *.iml
 *.ipr
 *.iws

--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -553,7 +553,7 @@
     <suppress checks="JavadocVariable|VisibilityModifier" files="com.hazelcast.internal.management.dto.*"/>
 
     <!-- Agrona backport -->
-    <suppress checks="MagicNumber" files="com/hazelcast/util/collection/" />
+    <suppress checks="MagicNumber|Header" files="com/hazelcast/util/collection/" />
     <suppress checks="JavadocType" files="com/hazelcast/util/collection/.*2ObjectHashMap" />
     <suppress checks="MethodCount" files="com/hazelcast/util/collection/.*HashSet" />
 

--- a/hazelcast-build-utils/src/main/java/com/hazelcast/buildutils/HazelcastManifestTransformer.java
+++ b/hazelcast-build-utils/src/main/java/com/hazelcast/buildutils/HazelcastManifestTransformer.java
@@ -19,6 +19,7 @@ package com.hazelcast.buildutils;
 import aQute.lib.osgi.Instruction;
 import edu.emory.mathcs.backport.java.util.Arrays;
 import edu.emory.mathcs.backport.java.util.Collections;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.maven.plugins.shade.relocation.Relocator;
 import org.apache.maven.plugins.shade.resource.ManifestResourceTransformer;
 import org.codehaus.plexus.util.IOUtil;
@@ -64,15 +65,15 @@ public class HazelcastManifestTransformer
     private Manifest shadedManifest;
 
     // Configuration
-    @edu.umd.cs.findbugs.annotations.SuppressWarnings(value = "UWF_UNWRITTEN_FIELD",
+    @SuppressFBWarnings(value = "UWF_UNWRITTEN_FIELD",
             justification = "Filled by Maven")
     private Map<String, Attributes> manifestEntries;
 
-    @edu.umd.cs.findbugs.annotations.SuppressWarnings(value = "UWF_UNWRITTEN_FIELD",
+    @SuppressFBWarnings(value = "UWF_UNWRITTEN_FIELD",
             justification = "Filled by Maven")
     private String mainClass;
 
-    @edu.umd.cs.findbugs.annotations.SuppressWarnings(value = "UWF_UNWRITTEN_FIELD",
+    @SuppressFBWarnings(value = "UWF_UNWRITTEN_FIELD",
             justification = "Filled by Maven")
     private Map<String, String> overrideInstructions;
 
@@ -197,7 +198,7 @@ public class HazelcastManifestTransformer
         jarOutputStream.flush();
     }
 
-    @edu.umd.cs.findbugs.annotations.SuppressWarnings(value = "NP_UNWRITTEN_FIELD",
+    @SuppressFBWarnings(value = "NP_UNWRITTEN_FIELD",
             justification = "Field is set by Maven")
     private void precompileOverrideInstructions() {
         String importPackageInstructions = overrideInstructions.get(IMPORT_PACKAGE);

--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/connection/nio/ClientConnection.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/connection/nio/ClientConnection.java
@@ -30,6 +30,7 @@ import com.hazelcast.nio.SocketWritable;
 import com.hazelcast.nio.serialization.SerializationService;
 import com.hazelcast.nio.tcp.IOSelector;
 import com.hazelcast.nio.tcp.SocketChannelWrapper;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -224,8 +225,7 @@ public class ClientConnection implements Connection, Closeable {
         }
     }
 
-    //failedHeartBeat is incremented in single thread.
-    @edu.umd.cs.findbugs.annotations.SuppressWarnings("VO_VOLATILE_INCREMENT")
+    @SuppressFBWarnings(value = "VO_VOLATILE_INCREMENT", justification = "incremented in single thread")
     void heartBeatingFailed() {
         heartBeating = false;
     }

--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/console/ClientConsoleApp.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/console/ClientConsoleApp.java
@@ -42,6 +42,7 @@ import com.hazelcast.core.MessageListener;
 import com.hazelcast.core.MultiMap;
 import com.hazelcast.core.Partition;
 import com.hazelcast.util.Clock;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -208,7 +209,7 @@ public class ClientConsoleApp implements EntryListener, ItemListener, MessageLis
      *
      * @param commandInputted
      */
-    @edu.umd.cs.findbugs.annotations.SuppressWarnings("DM_EXIT")
+    @SuppressFBWarnings("DM_EXIT")
     protected void handleCommand(String commandInputted) {
 
         String command = commandInputted;
@@ -500,7 +501,7 @@ public class ClientConsoleApp implements EntryListener, ItemListener, MessageLis
         }
     }
 
-    @edu.umd.cs.findbugs.annotations.SuppressWarnings("DM_DEFAULT_ENCODING")
+    @SuppressFBWarnings("DM_DEFAULT_ENCODING")
     private void handleAt(String first) {
         if (first.length() == 1) {
             println("usage: @<file-name>");
@@ -542,7 +543,7 @@ public class ClientConsoleApp implements EntryListener, ItemListener, MessageLis
     }
 
 
-    @edu.umd.cs.findbugs.annotations.SuppressWarnings("DM_GC")
+    @SuppressFBWarnings("DM_GC")
     private void handleJvm() {
         System.gc();
         println("Memory max: " + Runtime.getRuntime().maxMemory() / ONE_KB / ONE_KB

--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnection.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnection.java
@@ -30,6 +30,7 @@ import com.hazelcast.nio.SocketWritable;
 import com.hazelcast.nio.serialization.SerializationService;
 import com.hazelcast.nio.tcp.IOSelector;
 import com.hazelcast.nio.tcp.SocketChannelWrapper;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -224,8 +225,7 @@ public class ClientConnection implements Connection, Closeable {
         }
     }
 
-    //failedHeartBeat is incremented in single thread.
-    @edu.umd.cs.findbugs.annotations.SuppressWarnings("VO_VOLATILE_INCREMENT")
+    @SuppressFBWarnings(value = "VO_VOLATILE_INCREMENT", justification = "incremented in single thread")
     void heartBeatingFailed() {
         heartBeating = false;
     }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/console/ClientConsoleApp.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/console/ClientConsoleApp.java
@@ -42,6 +42,7 @@ import com.hazelcast.core.MessageListener;
 import com.hazelcast.core.MultiMap;
 import com.hazelcast.core.Partition;
 import com.hazelcast.util.Clock;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -208,7 +209,7 @@ public class ClientConsoleApp implements EntryListener, ItemListener, MessageLis
      *
      * @param commandInputted
      */
-    @edu.umd.cs.findbugs.annotations.SuppressWarnings("DM_EXIT")
+    @SuppressFBWarnings("DM_EXIT")
     protected void handleCommand(String commandInputted) {
 
         String command = commandInputted;
@@ -500,7 +501,7 @@ public class ClientConsoleApp implements EntryListener, ItemListener, MessageLis
         }
     }
 
-    @edu.umd.cs.findbugs.annotations.SuppressWarnings("DM_DEFAULT_ENCODING")
+    @SuppressFBWarnings("DM_DEFAULT_ENCODING")
     private void handleAt(String first) {
         if (first.length() == 1) {
             println("usage: @<file-name>");
@@ -542,7 +543,7 @@ public class ClientConsoleApp implements EntryListener, ItemListener, MessageLis
     }
 
 
-    @edu.umd.cs.findbugs.annotations.SuppressWarnings("DM_GC")
+    @SuppressFBWarnings("DM_GC")
     private void handleJvm() {
         System.gc();
         println("Memory max: " + Runtime.getRuntime().maxMemory() / ONE_KB / ONE_KB

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheService.java
@@ -37,6 +37,7 @@ import com.hazelcast.spi.PartitionMigrationEvent;
 import com.hazelcast.spi.PostJoinAwareService;
 import com.hazelcast.util.ConcurrencyUtil;
 import com.hazelcast.util.ConstructorFunction;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import javax.cache.event.CacheEntryListener;
 import java.io.Closeable;
@@ -408,10 +409,8 @@ public abstract class AbstractCacheService
         return current == null ? cacheOperationProvider : current;
     }
 
-    // This method will be called at cache creation from each partition while creating cache record store.
-    // A better synchronization may be implemented but
-    // since these are not called so much periodically, but it is not needed at this time.
-    @edu.umd.cs.findbugs.annotations.SuppressWarnings(value = "JLM_JSR166_UTILCONCURRENT_MONITORENTER")
+    @SuppressFBWarnings(value = "JLM_JSR166_UTILCONCURRENT_MONITORENTER", justification =
+            "several ops performed on concurrent map, need synchronization for atomicity")
     public void addCacheResource(String name, Closeable resource) {
         Set<Closeable> cacheResources = resources.get(name);
         if (cacheResources == null) {

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/record/AbstractCacheRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/record/AbstractCacheRecord.java
@@ -19,6 +19,7 @@ package com.hazelcast.cache.impl.record;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.DataSerializable;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.IOException;
 
@@ -84,7 +85,7 @@ public abstract class AbstractCacheRecord<V> implements CacheRecord<V>, DataSeri
     }
 
     @Override
-    @edu.umd.cs.findbugs.annotations.SuppressWarnings(value = "VO_VOLATILE_INCREMENT",
+    @SuppressFBWarnings(value = "VO_VOLATILE_INCREMENT",
             justification = "CacheRecord can be accessed by only its own partition thread.")
     public void incrementAccessHit() {
         accessHit++;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/MemberImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/MemberImpl.java
@@ -20,6 +20,7 @@ import com.hazelcast.core.Member;
 import com.hazelcast.instance.AbstractMember;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Address;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.util.Map;
 
@@ -72,7 +73,7 @@ public final class MemberImpl
         notSupportedOnClient();
     }
 
-    @edu.umd.cs.findbugs.annotations.SuppressWarnings("NP_BOOLEAN_RETURN_NULL")
+    @SuppressFBWarnings(value = "NP_BOOLEAN_RETURN_NULL", justification = "null means 'missing'")
     @Override
     public Boolean getBooleanAttribute(String key) {
         final Object attribute = getAttribute(key);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/parameters/ExceptionResultParameters.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/parameters/ExceptionResultParameters.java
@@ -20,11 +20,13 @@ import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.ResponseMessageConst;
 import com.hazelcast.client.impl.protocol.util.ParameterUtil;
 import com.hazelcast.nio.Bits;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 /**
  * ExceptionResultParameters
  */
-@edu.umd.cs.findbugs.annotations.SuppressWarnings({"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"})
+@SuppressFBWarnings(value = "URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD",
+        justification = "fields may be needed for diagnostic")
 public class ExceptionResultParameters {
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/util/UnsafeBuffer.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/util/UnsafeBuffer.java
@@ -18,6 +18,7 @@ package com.hazelcast.client.impl.protocol.util;
 
 import com.hazelcast.nio.Bits;
 import com.hazelcast.nio.UnsafeHelper;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import sun.misc.Unsafe;
 
 import java.nio.ByteOrder;
@@ -25,7 +26,7 @@ import java.nio.ByteOrder;
 /**
  * Supports regular, byte ordered, access to an underlying buffer.
  */
-@edu.umd.cs.findbugs.annotations.SuppressWarnings({ "EI_EXPOSE_REP", "EI_EXPOSE_REP2" })
+@SuppressFBWarnings({ "EI_EXPOSE_REP", "EI_EXPOSE_REP2" })
 public class UnsafeBuffer implements ClientProtocolBuffer {
     private static final String DISABLE_BOUNDS_CHECKS_PROP_NAME = "hazelcast.disable.bounds.checks";
     private static final boolean SHOULD_BOUNDS_CHECK = !Boolean.getBoolean(DISABLE_BOUNDS_CHECKS_PROP_NAME);

--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/ClusterServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/ClusterServiceImpl.java
@@ -70,6 +70,7 @@ import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.util.Clock;
 import com.hazelcast.util.EmptyStatement;
 import com.hazelcast.util.executor.ExecutorType;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import javax.security.auth.login.LoginContext;
 import javax.security.auth.login.LoginException;
@@ -1411,7 +1412,7 @@ public final class ClusterServiceImpl implements ClusterService, ConnectionListe
         return eventService.deregisterListener(SERVICE_NAME, SERVICE_NAME, registrationId);
     }
 
-    @edu.umd.cs.findbugs.annotations.SuppressWarnings("BC_UNCONFIRMED_CAST")
+    @SuppressFBWarnings("BC_UNCONFIRMED_CAST")
     @Override
     public void dispatchEvent(MembershipEvent event, MembershipListener listener) {
         switch (event.getEventType()) {

--- a/hazelcast/src/main/java/com/hazelcast/config/AbstractXmlConfigHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/AbstractXmlConfigHelper.java
@@ -24,6 +24,7 @@ import com.hazelcast.logging.Logger;
 import com.hazelcast.memory.MemorySize;
 import com.hazelcast.memory.MemoryUnit;
 import com.hazelcast.util.StringUtil;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NamedNodeMap;
@@ -457,7 +458,7 @@ public abstract class AbstractXmlConfigHelper {
         }
     }
 
-    @edu.umd.cs.findbugs.annotations.SuppressWarnings("DM_BOXED_PRIMITIVE_FOR_PARSING")
+    @SuppressFBWarnings("DM_BOXED_PRIMITIVE_FOR_PARSING")
     protected void fillNativeMemoryConfig(Node node, NativeMemoryConfig nativeMemoryConfig) {
         final NamedNodeMap atts = node.getAttributes();
         final Node enabledNode = atts.getNamedItem("enabled");

--- a/hazelcast/src/main/java/com/hazelcast/console/ConsoleApp.java
+++ b/hazelcast/src/main/java/com/hazelcast/console/ConsoleApp.java
@@ -40,6 +40,7 @@ import com.hazelcast.core.MessageListener;
 import com.hazelcast.core.MultiMap;
 import com.hazelcast.core.Partition;
 import com.hazelcast.util.Clock;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -215,7 +216,7 @@ public class ConsoleApp implements EntryListener, ItemListener, MessageListener 
      *
      * @param commandInputted
      */
-    @edu.umd.cs.findbugs.annotations.SuppressWarnings("DM_EXIT")
+    @SuppressFBWarnings("DM_EXIT")
     protected void handleCommand(String commandInputted) {
 
         String command = commandInputted;
@@ -545,7 +546,7 @@ public class ConsoleApp implements EntryListener, ItemListener, MessageListener 
         }
     }
 
-    @edu.umd.cs.findbugs.annotations.SuppressWarnings("DM_GC")
+    @SuppressFBWarnings("DM_GC")
     private void handleJvm() {
         System.gc();
         println("Memory max: " + Runtime.getRuntime().maxMemory() / ONE_KB / ONE_KB

--- a/hazelcast/src/main/java/com/hazelcast/core/EntryEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/EntryEvent.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.core;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 /**
  * Map Entry event.
  *
@@ -25,7 +27,7 @@ package com.hazelcast.core;
  * @see com.hazelcast.map.listener.MapListener
  * @see com.hazelcast.core.IMap#addEntryListener(com.hazelcast.map.listener.MapListener, boolean)
  */
-@edu.umd.cs.findbugs.annotations.SuppressWarnings("SE_BAD_FIELD")
+@SuppressFBWarnings("SE_BAD_FIELD")
 public class EntryEvent<K, V> extends AbstractIMapEvent {
 
     private static final long serialVersionUID = -2296203982913729851L;

--- a/hazelcast/src/main/java/com/hazelcast/core/InitialMembershipEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/InitialMembershipEvent.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.core;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import java.util.EventObject;
 import java.util.Set;
 
@@ -28,7 +30,7 @@ import java.util.Set;
  * @see MembershipListener
  * @see MembershipEvent
  */
-@edu.umd.cs.findbugs.annotations.SuppressWarnings("SE_BAD_FIELD")
+@SuppressFBWarnings("SE_BAD_FIELD")
 public class InitialMembershipEvent extends EventObject {
 
     private static final long serialVersionUID = -2010865371829087371L;

--- a/hazelcast/src/main/java/com/hazelcast/core/MemberAttributeEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/MemberAttributeEvent.java
@@ -22,12 +22,13 @@ import com.hazelcast.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.DataSerializable;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.IOException;
 
 import static com.hazelcast.cluster.MemberAttributeOperationType.PUT;
 
-@edu.umd.cs.findbugs.annotations.SuppressWarnings("SE_BAD_FIELD")
+@SuppressFBWarnings("SE_BAD_FIELD")
 public class MemberAttributeEvent extends MembershipEvent implements DataSerializable {
 
     private MemberAttributeOperationType operationType;

--- a/hazelcast/src/main/java/com/hazelcast/core/MembershipEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/MembershipEvent.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.core;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import java.util.EventObject;
 import java.util.Set;
 
@@ -27,7 +29,7 @@ import static java.lang.String.format;
  *
  * @see MembershipListener
  */
-@edu.umd.cs.findbugs.annotations.SuppressWarnings("SE_BAD_FIELD")
+@SuppressFBWarnings("SE_BAD_FIELD")
 public class MembershipEvent extends EventObject {
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/TextCommandConstants.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/TextCommandConstants.java
@@ -16,9 +16,11 @@
 
 package com.hazelcast.internal.ascii;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import static com.hazelcast.util.StringUtil.stringToBytes;
 
-@edu.umd.cs.findbugs.annotations.SuppressWarnings("MS_MUTABLE_ARRAY")
+@SuppressFBWarnings("MS_MUTABLE_ARRAY")
 public final class TextCommandConstants {
 
     public static final byte[] SPACE = stringToBytes(" ");

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/TextCommandServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/TextCommandServiceImpl.java
@@ -40,6 +40,7 @@ import com.hazelcast.nio.ascii.SocketTextWriter;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.util.Clock;
 import com.hazelcast.util.EmptyStatement;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.nio.ByteBuffer;
 import java.util.concurrent.ArrayBlockingQueue;
@@ -359,7 +360,7 @@ public class TextCommandServiceImpl implements TextCommandService {
         private final BlockingQueue<TextCommand> blockingQueue = new ArrayBlockingQueue<TextCommand>(200);
         private final Object stopObject = new Object();
 
-        @edu.umd.cs.findbugs.annotations.SuppressWarnings("RV_RETURN_VALUE_IGNORED_BAD_PRACTICE")
+        @SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_BAD_PRACTICE")
         public void sendResponse(TextCommand textCommand) {
             blockingQueue.offer(textCommand);
         }
@@ -386,7 +387,7 @@ public class TextCommandServiceImpl implements TextCommandService {
             }
         }
 
-        @edu.umd.cs.findbugs.annotations.SuppressWarnings("RV_RETURN_VALUE_IGNORED_BAD_PRACTICE")
+        @SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_BAD_PRACTICE")
         void stop() {
             running = false;
             synchronized (stopObject) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/MemcacheEntry.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/MemcacheEntry.java
@@ -20,6 +20,7 @@ import com.hazelcast.internal.ascii.TextCommandConstants;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.DataSerializable;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -28,7 +29,7 @@ import java.util.Arrays;
 import static com.hazelcast.util.StringUtil.bytesToString;
 import static com.hazelcast.util.StringUtil.stringToBytes;
 
-@edu.umd.cs.findbugs.annotations.SuppressWarnings("EI_EXPOSE_REP")
+@SuppressFBWarnings("EI_EXPOSE_REP")
 public class MemcacheEntry implements DataSerializable {
     private byte[] bytes;
     private byte[] value;

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpCommand.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpCommand.java
@@ -19,11 +19,12 @@ package com.hazelcast.internal.ascii.rest;
 import com.hazelcast.internal.ascii.AbstractTextCommand;
 import com.hazelcast.internal.ascii.TextCommandConstants;
 import com.hazelcast.nio.IOUtil;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.nio.ByteBuffer;
 
 import static com.hazelcast.util.StringUtil.stringToBytes;
-@edu.umd.cs.findbugs.annotations.SuppressWarnings({ "EI_EXPOSE_REP", "MS_MUTABLE_ARRAY", "MS_PKGPROTECT" })
+@SuppressFBWarnings({ "EI_EXPOSE_REP", "MS_MUTABLE_ARRAY", "MS_PKGPROTECT" })
 public abstract class HttpCommand extends AbstractTextCommand {
     public static final String HEADER_CONTENT_TYPE = "content-type: ";
     public static final String HEADER_CONTENT_LENGTH = "content-length: ";

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/RestValue.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/RestValue.java
@@ -19,12 +19,13 @@ package com.hazelcast.internal.ascii.rest;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.DataSerializable;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.IOException;
 
 import static com.hazelcast.util.StringUtil.bytesToString;
 
-@edu.umd.cs.findbugs.annotations.SuppressWarnings("EI_EXPOSE_REP")
+@SuppressFBWarnings("EI_EXPOSE_REP")
 public class RestValue implements DataSerializable {
     private byte[] value;
     private byte[] contentType;

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/request/RunGcRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/request/RunGcRequest.java
@@ -18,12 +18,11 @@ package com.hazelcast.internal.management.request;
 
 import com.eclipsesource.json.JsonObject;
 import com.hazelcast.internal.management.ManagementCenterService;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 /**
  * Request for invoking Garbage Collection on the node.
  */
-//We want to be able to force a gc.
-@edu.umd.cs.findbugs.annotations.SuppressWarnings("DM_GC")
 public class RunGcRequest implements ConsoleRequest {
 
     public RunGcRequest() {
@@ -40,6 +39,7 @@ public class RunGcRequest implements ConsoleRequest {
     }
 
     @Override
+    @SuppressFBWarnings(value = "DM_GC", justification = "Explicit GC is the point of this class")
     public void writeResponse(ManagementCenterService mcs, JsonObject root) throws Exception {
         System.gc();
         root.add("result", new JsonObject());

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/metricsets/GarbageCollectionMetricSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/metricsets/GarbageCollectionMetricSet.java
@@ -19,6 +19,7 @@ package com.hazelcast.internal.metrics.metricsets;
 
 import com.hazelcast.internal.metrics.MetricsRegistry;
 import com.hazelcast.internal.metrics.Probe;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.lang.management.GarbageCollectorMXBean;
 import java.lang.management.ManagementFactory;
@@ -64,7 +65,7 @@ public final class GarbageCollectionMetricSet {
     }
 
 
-    @edu.umd.cs.findbugs.annotations.SuppressWarnings({"URF_UNREAD_FIELD" })
+    @SuppressFBWarnings(value = "URF_UNREAD_FIELD", justification = "used by instrumentation tools")
     static class GcStats implements Runnable {
         @Probe
         volatile long minorCount;

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/DistinctValuesAggregation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/DistinctValuesAggregation.java
@@ -27,6 +27,7 @@ import com.hazelcast.mapreduce.aggregation.Supplier;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.IOException;
 import java.util.HashSet;
@@ -166,7 +167,7 @@ public class DistinctValuesAggregation<Key, Value, DistinctType>
      * @param <Value>        the input value type
      * @param <DistinctType> the type of distinct values
      */
-    @edu.umd.cs.findbugs.annotations.SuppressWarnings("SE_NO_SERIALVERSIONID")
+    @SuppressFBWarnings("SE_NO_SERIALVERSIONID")
     static class DistinctValueMapper<Key, Value, DistinctType>
             implements Mapper<Key, Value, Integer, DistinctType>, IdentifiedDataSerializable {
 

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/SupplierConsumingMapper.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/SupplierConsumingMapper.java
@@ -22,6 +22,7 @@ import com.hazelcast.mapreduce.aggregation.Supplier;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.IOException;
 import java.util.Map;
@@ -33,7 +34,7 @@ import java.util.Map;
  * @param <ValueIn>  the input value type
  * @param <ValueOut> the output value type
  */
-@edu.umd.cs.findbugs.annotations.SuppressWarnings("SE_NO_SERIALVERSIONID")
+@SuppressFBWarnings("SE_NO_SERIALVERSIONID")
 class SupplierConsumingMapper<Key, ValueIn, ValueOut>
         implements Mapper<Key, ValueIn, Key, ValueOut>, IdentifiedDataSerializable {
 

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/JobProcessInformationImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/JobProcessInformationImpl.java
@@ -19,7 +19,7 @@ package com.hazelcast.mapreduce.impl.task;
 import com.hazelcast.mapreduce.JobPartitionState;
 import com.hazelcast.mapreduce.JobProcessInformation;
 import com.hazelcast.nio.Address;
-import edu.umd.cs.findbugs.annotations.SuppressWarnings;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
@@ -35,12 +35,11 @@ import static com.hazelcast.util.Preconditions.isNotNull;
 public class JobProcessInformationImpl
         implements JobProcessInformation {
 
-    //CHECKSTYLE:OFF
-    private static final AtomicReferenceFieldUpdater<JobProcessInformationImpl, JobPartitionState[]> PARTITION_STATE_UPDATER = //
-            AtomicReferenceFieldUpdater.newUpdater(JobProcessInformationImpl.class, JobPartitionState[].class, "partitionStates");
-    private static final AtomicIntegerFieldUpdater<JobProcessInformationImpl> PROCESSED_RECORDS_UPDATER = AtomicIntegerFieldUpdater
-            .newUpdater(JobProcessInformationImpl.class, "processedRecords");
-    //CHECKSTYLE:ON
+    private static final AtomicReferenceFieldUpdater<JobProcessInformationImpl, JobPartitionState[]>
+            PARTITION_STATE_UPDATER = AtomicReferenceFieldUpdater.newUpdater(JobProcessInformationImpl.class,
+            JobPartitionState[].class, "partitionStates");
+    private static final AtomicIntegerFieldUpdater<JobProcessInformationImpl> PROCESSED_RECORDS_UPDATER =
+            AtomicIntegerFieldUpdater.newUpdater(JobProcessInformationImpl.class, "processedRecords");
 
     private final JobSupervisor supervisor;
 
@@ -55,11 +54,10 @@ public class JobProcessInformationImpl
     }
 
     @Override
-    // Expose warning suppressed, this exposed array is used a lot on internals
-    // and is explicitly exposed for speed / object creation reasons.
-    // It is never exposed to the end user (either through serialization cycle
-    // or by hiding in through a wrapper class
-    @SuppressWarnings("EI_EXPOSE_REP")
+    @SuppressFBWarnings(value = "EI_EXPOSE_REP", justification = "Exposed array is used a lot on internals"
+            + " and is explicitly exposed for speed / object creation reasons."
+            + " It is never exposed to the end user (either through serialization cycle"
+            + " or by hiding in through a wrapper class")
     public JobPartitionState[] getPartitionStates() {
         return partitionStates;
     }

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/TransferableJobProcessInformation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/TransferableJobProcessInformation.java
@@ -23,7 +23,7 @@ import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Portable;
 import com.hazelcast.nio.serialization.PortableReader;
 import com.hazelcast.nio.serialization.PortableWriter;
-import edu.umd.cs.findbugs.annotations.SuppressWarnings;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.IOException;
 
@@ -52,7 +52,9 @@ public class TransferableJobProcessInformation
     // This field is explicitly exposed since it is guarded by a serialization cycle
     // or by a copy inside the constructor. This class is only used for transfer of
     // the states and user can change it without breaking anything.
-    @SuppressWarnings("EI_EXPOSE_REP")
+    @SuppressFBWarnings(value = "EI_EXPOSE_REP", justification = "exposed since it is guarded by serialization cycle"
+            + " or by copy inside the constructor. This class is only used for transfer of"
+            + " the states and user can change it without breaking anything.")
     public JobPartitionState[] getPartitionStates() {
         return partitionStates;
     }

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/impl/DefaultData.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/impl/DefaultData.java
@@ -19,10 +19,11 @@ package com.hazelcast.nio.serialization.impl;
 import com.hazelcast.nio.Bits;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.util.HashUtil;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.util.Arrays;
 
-@edu.umd.cs.findbugs.annotations.SuppressWarnings("EI_EXPOSE_REP")
+@SuppressFBWarnings("EI_EXPOSE_REP")
 public final class DefaultData implements Data {
   // type and partition_hash are always written with BIG_ENDIAN byte-order
     public static final int TYPE_OFFSET = 0;

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/impl/DefaultSerializers.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/impl/DefaultSerializers.java
@@ -21,6 +21,7 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.HazelcastSerializationException;
 import com.hazelcast.nio.serialization.StreamSerializer;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.Externalizable;
 import java.io.IOException;
@@ -220,7 +221,7 @@ public final class DefaultSerializers {
             return result;
         }
 
-        @edu.umd.cs.findbugs.annotations.SuppressWarnings({"OS_OPEN_STREAM" })
+        @SuppressFBWarnings({"OS_OPEN_STREAM" })
         @Override
         public void write(final ObjectDataOutput out, final Object obj) throws IOException {
             final ObjectOutputStream objectOutputStream;

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/InSelectorImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/InSelectorImpl.java
@@ -17,6 +17,7 @@
 package com.hazelcast.nio.tcp;
 
 import com.hazelcast.logging.ILogger;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.nio.channels.SelectionKey;
 
@@ -41,7 +42,7 @@ public final class InSelectorImpl extends AbstractIOSelector {
     }
 
     @Override
-    @edu.umd.cs.findbugs.annotations.SuppressWarnings({"VO_VOLATILE_INCREMENT" })
+    @SuppressFBWarnings({"VO_VOLATILE_INCREMENT" })
     protected void handleSelectionKey(SelectionKey sk) {
         if (sk.isValid() && sk.isReadable()) {
             readEvents++;

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/OutSelectorImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/OutSelectorImpl.java
@@ -17,6 +17,7 @@
 package com.hazelcast.nio.tcp;
 
 import com.hazelcast.logging.ILogger;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.nio.channels.SelectionKey;
 
@@ -41,7 +42,7 @@ public final class OutSelectorImpl extends AbstractIOSelector {
     }
 
     @Override
-    @edu.umd.cs.findbugs.annotations.SuppressWarnings({"VO_VOLATILE_INCREMENT" })
+    @SuppressFBWarnings({"VO_VOLATILE_INCREMENT" })
     protected void handleSelectionKey(SelectionKey sk) {
         if (sk.isValid() && sk.isWritable()) {
             writeEvents++;

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/ReadHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/ReadHandler.java
@@ -20,6 +20,7 @@ import com.hazelcast.nio.ConnectionType;
 import com.hazelcast.nio.Protocols;
 import com.hazelcast.nio.ascii.SocketTextReader;
 import com.hazelcast.util.Clock;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.EOFException;
 import java.io.IOException;
@@ -79,7 +80,7 @@ public final class ReadHandler extends AbstractSelectionHandler {
     }
 
     @Override
-    @edu.umd.cs.findbugs.annotations.SuppressWarnings(value = "VO_VOLATILE_INCREMENT",
+    @SuppressFBWarnings(value = "VO_VOLATILE_INCREMENT",
             justification = "eventCount is accessed by a single thread only.")
     public void handle() {
         eventCount++;

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnectionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnectionManager.java
@@ -34,6 +34,7 @@ import com.hazelcast.nio.tcp.iobalancer.IOBalancer;
 import com.hazelcast.util.ConcurrencyUtil;
 import com.hazelcast.util.ConstructorFunction;
 import com.hazelcast.util.executor.StripedRunnable;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.IOException;
 import java.net.Socket;
@@ -181,14 +182,12 @@ public class TcpIpConnectionManager implements ConnectionManager {
         return activeConnections;
     }
 
-    // just for testing
-    @edu.umd.cs.findbugs.annotations.SuppressWarnings({"EI_EXPOSE_REP" })
+    @SuppressFBWarnings(value = "EI_EXPOSE_REP", justification = "used only for testing")
     public InSelectorImpl[] getInSelectors() {
         return inSelectors;
     }
 
-    // just for testing
-    @edu.umd.cs.findbugs.annotations.SuppressWarnings({"EI_EXPOSE_REP" })
+    @SuppressFBWarnings(value = "EI_EXPOSE_REP", justification = "used only for testing")
     public OutSelectorImpl[] getOutSelectors() {
         return outSelectors;
     }

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/WriteHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/WriteHandler.java
@@ -21,6 +21,7 @@ import com.hazelcast.nio.SocketWritable;
 import com.hazelcast.nio.ascii.SocketTextWriter;
 import com.hazelcast.util.Clock;
 import com.hazelcast.util.EmptyStatement;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -210,7 +211,7 @@ public final class WriteHandler extends AbstractSelectionHandler implements Runn
 
     @Override
     @SuppressWarnings("unchecked")
-    @edu.umd.cs.findbugs.annotations.SuppressWarnings(value = "VO_VOLATILE_INCREMENT",
+    @SuppressFBWarnings(value = "VO_VOLATILE_INCREMENT",
             justification = "eventCount is accessed by a single thread only.")
     public void handle() {
         eventCount++;

--- a/hazelcast/src/main/java/com/hazelcast/partition/PartitionInfo.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/PartitionInfo.java
@@ -17,6 +17,7 @@
 package com.hazelcast.partition;
 
 import com.hazelcast.nio.Address;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.util.Arrays;
 
@@ -38,8 +39,7 @@ public class PartitionInfo {
         return addresses[index];
     }
 
-    //Internal structure, so it doesn't matter if we expose this array.
-    @edu.umd.cs.findbugs.annotations.SuppressWarnings("EI_EXPOSE_REP")
+    @SuppressFBWarnings(value = "EI_EXPOSE_REP", justification = "internal structure")
     public Address[] getReplicaAddresses() {
         return addresses;
     }

--- a/hazelcast/src/main/java/com/hazelcast/partition/client/PartitionsResponse.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/client/PartitionsResponse.java
@@ -21,11 +21,11 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.partition.PartitionDataSerializerHook;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.IOException;
 
-//This is an internal structure, so doesn't matter if we expose arrays.
-@edu.umd.cs.findbugs.annotations.SuppressWarnings("EI_EXPOSE_REP")
+@SuppressFBWarnings(value = "EI_EXPOSE_REP", justification = "internal structure")
 public final class PartitionsResponse implements IdentifiedDataSerializable {
 
     private Address[] members;

--- a/hazelcast/src/main/java/com/hazelcast/partition/impl/InternalPartitionImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/impl/InternalPartitionImpl.java
@@ -18,15 +18,16 @@ package com.hazelcast.partition.impl;
 
 import com.hazelcast.nio.Address;
 import com.hazelcast.partition.InternalPartition;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.util.Arrays;
 
 class InternalPartitionImpl implements InternalPartition {
 
-    // The content of this array will never be updated, so it can be safely read using a volatile read.
-    // Writing to 'addresses' is done under InternalPartitionServiceImpl.lock,
-    // so there's no need to guard `addresses` field or to use a CAS.
-    @edu.umd.cs.findbugs.annotations.SuppressWarnings("VO_VOLATILE_REFERENCE_TO_ARRAY")
+    @SuppressFBWarnings(value = "VO_VOLATILE_REFERENCE_TO_ARRAY", justification =
+            "The contents of this array will never be updated, so it can be safely read using a volatile read."
+                    + " Writing to `addresses` is done under InternalPartitionServiceImpl.lock,"
+                    + " so there's no need to guard `addresses` field or to use a CAS.")
     private volatile Address[] addresses = new Address[MAX_REPLICA_COUNT];
     private final int partitionId;
     private final PartitionListener partitionListener;

--- a/hazelcast/src/main/java/com/hazelcast/partition/impl/MigrationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/impl/MigrationOperation.java
@@ -30,6 +30,7 @@ import com.hazelcast.spi.OperationAccessor;
 import com.hazelcast.spi.OperationResponseHandler;
 import com.hazelcast.spi.PartitionMigrationEvent;
 import com.hazelcast.spi.exception.RetryableHazelcastException;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -37,7 +38,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.logging.Level;
 
-@edu.umd.cs.findbugs.annotations.SuppressWarnings("EI_EXPOSE_REP")
+@SuppressFBWarnings("EI_EXPOSE_REP")
 public final class MigrationOperation extends BaseMigrationOperation {
 
     private static final OperationResponseHandler ERROR_RESPONSE_HANDLER = new OperationResponseHandler() {

--- a/hazelcast/src/main/java/com/hazelcast/partition/impl/ReplicaSyncResponse.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/impl/ReplicaSyncResponse.java
@@ -28,6 +28,7 @@ import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.OperationResponseHandler;
 import com.hazelcast.spi.PartitionAwareOperation;
 import com.hazelcast.spi.UrgentSystemOperation;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -35,7 +36,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.logging.Level;
 
-@edu.umd.cs.findbugs.annotations.SuppressWarnings("EI_EXPOSE_REP")
+@SuppressFBWarnings("EI_EXPOSE_REP")
 public class ReplicaSyncResponse extends Operation
         implements PartitionAwareOperation, BackupOperation, UrgentSystemOperation {
 

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/messages/MultiReplicationMessage.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/messages/MultiReplicationMessage.java
@@ -20,7 +20,7 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.replicatedmap.impl.operation.ReplicatedMapDataSerializerHook;
-import edu.umd.cs.findbugs.annotations.SuppressWarnings;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.IOException;
 
@@ -36,15 +36,15 @@ public class MultiReplicationMessage
     public MultiReplicationMessage() {
     }
 
-    // Findbugs warning suppressed since the array is serialized anyways and is never about to be changed
-    @SuppressWarnings("EI_EXPOSE_REP")
+    @SuppressFBWarnings(value = "EI_EXPOSE_REP", justification =
+            "array is serialized anyways and is never about to be changed")
     public MultiReplicationMessage(String name, ReplicationMessage[] replicationMessages) {
         this.name = name;
         this.replicationMessages = replicationMessages;
     }
 
-    // Findbugs warning suppressed since the array is serialized anyways and is never about to be changed
-    @SuppressWarnings("EI_EXPOSE_REP")
+    @SuppressFBWarnings(value = "EI_EXPOSE_REP", justification =
+            "array is serialized anyways and is never about to be changed")
     public ReplicationMessage[] getReplicationMessages() {
         return replicationMessages;
     }

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/ReplicatedMapInitChunkOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/ReplicatedMapInitChunkOperation.java
@@ -27,7 +27,7 @@ import com.hazelcast.replicatedmap.impl.record.AbstractReplicatedRecordStore;
 import com.hazelcast.replicatedmap.impl.record.ReplicatedRecord;
 import com.hazelcast.replicatedmap.impl.record.ReplicationPublisher;
 import com.hazelcast.replicatedmap.impl.record.VectorClockTimestamp;
-import edu.umd.cs.findbugs.annotations.SuppressWarnings;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.IOException;
 
@@ -53,8 +53,8 @@ public class ReplicatedMapInitChunkOperation
         this.notYetReadyChooseSomeoneElse = true;
     }
 
-    // Findbugs warning suppressed since the array is serialized anyways and is never about to be changed
-    @SuppressWarnings("EI_EXPOSE_REP")
+    @SuppressFBWarnings(value = "EI_EXPOSE_REP", justification =
+            "array is serialized anyways and is never about to be changed")
     public ReplicatedMapInitChunkOperation(String name, Member origin, ReplicatedRecord[] replicatedRecords, int recordCount,
                                            boolean finalChunk) {
         this.name = name;

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/client/AddAllRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/client/AddAllRequest.java
@@ -22,6 +22,7 @@ import com.hazelcast.nio.serialization.PortableWriter;
 import com.hazelcast.ringbuffer.OverflowPolicy;
 import com.hazelcast.ringbuffer.impl.operations.AddAllOperation;
 import com.hazelcast.spi.Operation;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.IOException;
 import java.security.Permission;
@@ -34,7 +35,7 @@ public class AddAllRequest extends RingbufferRequest {
     public AddAllRequest() {
     }
 
-    @edu.umd.cs.findbugs.annotations.SuppressWarnings({"EI_EXPOSE_REP" })
+    @SuppressFBWarnings("EI_EXPOSE_REP")
     public AddAllRequest(String name, Data[] items, OverflowPolicy overflowPolicy) {
         super(name);
         this.items = items;

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/client/ReadManyRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/client/ReadManyRequest.java
@@ -33,7 +33,6 @@ public class ReadManyRequest extends RingbufferRequest {
     private long startSequence;
     private int minCount;
     private int maxCount;
-    private Data filter;
 
     public ReadManyRequest() {
     }
@@ -43,7 +42,6 @@ public class ReadManyRequest extends RingbufferRequest {
         this.startSequence = startSequence;
         this.minCount = minCount;
         this.maxCount = maxCount;
-        this.filter = filter;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/AddAllBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/AddAllBackupOperation.java
@@ -21,6 +21,7 @@ import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.ringbuffer.impl.RingbufferContainer;
 import com.hazelcast.spi.BackupOperation;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.IOException;
 
@@ -33,7 +34,7 @@ public class AddAllBackupOperation extends AbstractRingBufferOperation implement
     public AddAllBackupOperation() {
     }
 
-    @edu.umd.cs.findbugs.annotations.SuppressWarnings({"EI_EXPOSE_REP" })
+    @SuppressFBWarnings({"EI_EXPOSE_REP" })
     public AddAllBackupOperation(String name, Data[] items) {
         super(name);
         this.items = items;

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/AddAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/AddAllOperation.java
@@ -25,6 +25,7 @@ import com.hazelcast.spi.BackupAwareOperation;
 import com.hazelcast.spi.Notifier;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.WaitNotifyKey;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.IOException;
 
@@ -41,7 +42,7 @@ public class AddAllOperation extends AbstractRingBufferOperation
     public AddAllOperation() {
     }
 
-    @edu.umd.cs.findbugs.annotations.SuppressWarnings({"EI_EXPOSE_REP" })
+    @SuppressFBWarnings({"EI_EXPOSE_REP" })
     public AddAllOperation(String name, Data[] items, OverflowPolicy overflowPolicy) {
         super(name);
         this.items = items;

--- a/hazelcast/src/main/java/com/hazelcast/spi/Operation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/Operation.java
@@ -29,6 +29,7 @@ import com.hazelcast.quorum.QuorumException;
 import com.hazelcast.spi.exception.RetryableException;
 import com.hazelcast.spi.exception.RetryableHazelcastException;
 import com.hazelcast.spi.impl.NodeEngineImpl;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.IOException;
 import java.util.logging.Level;
@@ -106,7 +107,7 @@ public abstract class Operation implements DataSerializable {
         return serviceName;
     }
 
-    @edu.umd.cs.findbugs.annotations.SuppressWarnings("ES_COMPARING_PARAMETER_STRING_WITH_EQ")
+    @SuppressFBWarnings("ES_COMPARING_PARAMETER_STRING_WITH_EQ")
     public final Operation setServiceName(String serviceName) {
         // If the name of the service is the same as the name already provided, the call is skipped.
         // We can do a == instead of an equals because serviceName are typically constants, and it will

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/classic/ClassicOperationExecutor.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/classic/ClassicOperationExecutor.java
@@ -30,6 +30,7 @@ import com.hazelcast.spi.impl.operationexecutor.OperationHostileThread;
 import com.hazelcast.spi.impl.operationexecutor.OperationRunner;
 import com.hazelcast.spi.impl.operationexecutor.OperationRunnerFactory;
 import com.hazelcast.spi.impl.operationexecutor.ResponsePacketHandler;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.util.concurrent.TimeUnit;
 
@@ -189,13 +190,13 @@ public final class ClassicOperationExecutor implements OperationExecutor {
         return thread;
     }
 
-    @edu.umd.cs.findbugs.annotations.SuppressWarnings({"EI_EXPOSE_REP" })
+    @SuppressFBWarnings({"EI_EXPOSE_REP" })
     @Override
     public OperationRunner[] getPartitionOperationRunners() {
         return partitionOperationRunners;
     }
 
-    @edu.umd.cs.findbugs.annotations.SuppressWarnings({"EI_EXPOSE_REP" })
+    @SuppressFBWarnings({"EI_EXPOSE_REP" })
     @Override
     public OperationRunner[] getGenericOperationRunners() {
         return genericOperationRunners;

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/classic/OperationThread.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/classic/OperationThread.java
@@ -24,6 +24,7 @@ import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.impl.operationexecutor.OperationRunner;
 import com.hazelcast.spi.impl.PartitionSpecificRunnable;
 import com.hazelcast.util.executor.HazelcastManagedThread;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.util.concurrent.TimeUnit;
 
@@ -102,7 +103,7 @@ public abstract class OperationThread extends HazelcastManagedThread {
         }
     }
 
-    @edu.umd.cs.findbugs.annotations.SuppressWarnings({"VO_VOLATILE_INCREMENT" })
+    @SuppressFBWarnings({"VO_VOLATILE_INCREMENT" })
     private void process(Object task) {
         processedCount++;
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/classic/PartitionOperationThread.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/classic/PartitionOperationThread.java
@@ -20,6 +20,7 @@ import com.hazelcast.instance.HazelcastThreadGroup;
 import com.hazelcast.instance.NodeExtension;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.spi.impl.operationexecutor.OperationRunner;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 /**
  * An {@link OperationThread} that executes Operations for a particular partition, e.g. a map.get operation.
@@ -28,7 +29,7 @@ public final class PartitionOperationThread extends OperationThread {
 
     private final OperationRunner[] partitionOperationRunners;
 
-    @edu.umd.cs.findbugs.annotations.SuppressWarnings({"EI_EXPOSE_REP" })
+    @SuppressFBWarnings({"EI_EXPOSE_REP" })
     public PartitionOperationThread(String name, int threadId,
                                     ScheduleQueue scheduleQueue, ILogger logger,
                                     HazelcastThreadGroup threadGroup, NodeExtension nodeExtension,

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/classic/ResponseThread.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/classic/ResponseThread.java
@@ -21,6 +21,7 @@ import com.hazelcast.logging.ILogger;
 import com.hazelcast.spi.impl.operationexecutor.OperationHostileThread;
 import com.hazelcast.nio.Packet;
 import com.hazelcast.spi.impl.operationexecutor.ResponsePacketHandler;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -89,7 +90,7 @@ public final class ResponseThread extends Thread implements OperationHostileThre
         }
     }
 
-    @edu.umd.cs.findbugs.annotations.SuppressWarnings({ "VO_VOLATILE_INCREMENT" })
+    @SuppressFBWarnings({ "VO_VOLATILE_INCREMENT" })
     private void process(Packet responsePacket) {
         processedResponses++;
         try {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/slowoperationdetector/SlowOperationDetector.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/slowoperationdetector/SlowOperationDetector.java
@@ -24,6 +24,7 @@ import com.hazelcast.logging.LoggingService;
 import com.hazelcast.spi.impl.operationexecutor.OperationExecutor;
 import com.hazelcast.spi.impl.operationexecutor.OperationRunner;
 import com.hazelcast.util.EmptyStatement;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -64,7 +65,7 @@ public final class SlowOperationDetector {
 
     private boolean isFirstLog = true;
 
-    @edu.umd.cs.findbugs.annotations.SuppressWarnings({"EI_EXPOSE_REP2" })
+    @SuppressFBWarnings({"EI_EXPOSE_REP2" })
     public SlowOperationDetector(LoggingService loggingServices,
                                  OperationRunner[] genericOperationRunners,
                                  OperationRunner[] partitionOperationRunners,

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/Invocation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/Invocation.java
@@ -40,6 +40,7 @@ import com.hazelcast.spi.impl.operationservice.impl.responses.ErrorResponse;
 import com.hazelcast.spi.impl.operationservice.impl.responses.NormalResponse;
 import com.hazelcast.util.Clock;
 import com.hazelcast.util.ExceptionUtil;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
@@ -210,7 +211,7 @@ abstract class Invocation implements OperationResponseHandler, Runnable {
         }
     }
 
-    @edu.umd.cs.findbugs.annotations.SuppressWarnings(value = "VO_VOLATILE_INCREMENT",
+    @SuppressFBWarnings(value = "VO_VOLATILE_INCREMENT",
             justification = "We have the guarantee that only a single thread at any given time can change the volatile field")
     private void doInvoke(boolean isAsync) {
         if (!engineActive()) {
@@ -415,7 +416,7 @@ abstract class Invocation implements OperationResponseHandler, Runnable {
         invocationFuture.set(value);
     }
 
-    @edu.umd.cs.findbugs.annotations.SuppressWarnings(value = "VO_VOLATILE_INCREMENT",
+    @SuppressFBWarnings(value = "VO_VOLATILE_INCREMENT",
             justification = "We have the guarantee that only a single thread at any given time can change the volatile field")
     void notifyCallTimeout() {
         if (logger.isFinestEnabled()) {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/operations/Backup.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/operations/Backup.java
@@ -34,6 +34,7 @@ import com.hazelcast.spi.impl.SpiDataSerializerHook;
 import com.hazelcast.spi.impl.operationservice.impl.OperationServiceImpl;
 import com.hazelcast.spi.impl.operationservice.impl.responses.BackupResponse;
 import com.hazelcast.util.Clock;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -53,7 +54,7 @@ public final class Backup extends Operation implements BackupOperation, Identifi
     public Backup() {
     }
 
-    @edu.umd.cs.findbugs.annotations.SuppressWarnings("EI_EXPOSE_REP")
+    @SuppressFBWarnings("EI_EXPOSE_REP")
     public Backup(Data backupOp, Address originalCaller, long[] replicaVersions, boolean sync) {
         this.backupOpData = backupOp;
         this.originalCaller = originalCaller;

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/transceiver/impl/PacketTransceiverImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/transceiver/impl/PacketTransceiverImpl.java
@@ -29,6 +29,7 @@ import com.hazelcast.spi.impl.eventservice.InternalEventService;
 import com.hazelcast.spi.impl.operationexecutor.OperationExecutor;
 import com.hazelcast.spi.impl.transceiver.PacketTransceiver;
 import com.hazelcast.wan.WanReplicationService;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.util.concurrent.TimeUnit;
 
@@ -125,8 +126,7 @@ public class PacketTransceiverImpl implements PacketTransceiver {
             this.target = target;
         }
 
-        //retries is incremented by a single thread, but will be read by multiple. So there is no problem.
-        @edu.umd.cs.findbugs.annotations.SuppressWarnings("VO_VOLATILE_INCREMENT")
+        @SuppressFBWarnings(value = "VO_VOLATILE_INCREMENT", justification = "single-writer, many-reader")
         @Override
         public void run() {
             retries++;

--- a/hazelcast/src/main/java/com/hazelcast/util/ConcurrentReferenceHashMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/ConcurrentReferenceHashMap.java
@@ -22,6 +22,8 @@ package com.hazelcast.util;
  * http://creativecommons.org/licenses/publicdomain
  */
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import java.io.IOException;
 import java.io.Serializable;
 import java.lang.ref.Reference;
@@ -500,8 +502,8 @@ public class ConcurrentReferenceHashMap<K, V> extends AbstractMap<K, V>
         /**
          * The number of elements in this segment's region.
          */
-        // I have faith in Doug Lea's techical decision
-        @edu.umd.cs.findbugs.annotations.SuppressWarnings("SE_TRANSIENT_FIELD_NOT_RESTORED")
+        @SuppressFBWarnings(value = "SE_TRANSIENT_FIELD_NOT_RESTORED", justification =
+                "I have faith in Doug Lea's technical decision")
         transient volatile int count;
 
         /**
@@ -512,8 +514,8 @@ public class ConcurrentReferenceHashMap<K, V> extends AbstractMap<K, V>
          * we might have an inconsistent view of state so (usually) we
          * must retry.
          */
-        // I have faith in Doug Lea's techical decision
-        @edu.umd.cs.findbugs.annotations.SuppressWarnings("SE_TRANSIENT_FIELD_NOT_RESTORED")
+        @SuppressFBWarnings(value = "SE_TRANSIENT_FIELD_NOT_RESTORED", justification =
+                "I have faith in Doug Lea's technical decision")
         transient int modCount;
 
         /**

--- a/hazelcast/src/main/java/com/hazelcast/util/DebugUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/DebugUtil.java
@@ -1,6 +1,7 @@
 package com.hazelcast.util;
 
 import com.hazelcast.nio.IOUtil;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.BufferedWriter;
 import java.io.File;
@@ -11,7 +12,7 @@ import java.io.PrintWriter;
 /**
  * Contains some debugging functionality; useful if you are running large testsuites and can't rely on a debugger.
  */
-@edu.umd.cs.findbugs.annotations.SuppressWarnings({"DM_DEFAULT_ENCODING"})
+@SuppressFBWarnings({"DM_DEFAULT_ENCODING"})
 public final class DebugUtil {
 
     private DebugUtil() {

--- a/hazelcast/src/main/java/com/hazelcast/util/HashUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/HashUtil.java
@@ -17,12 +17,13 @@
 package com.hazelcast.util;
 
 import com.hazelcast.nio.UnsafeHelper;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import sun.misc.Unsafe;
 
 import java.nio.ByteOrder;
 import java.util.Arrays;
 
-@edu.umd.cs.findbugs.annotations.SuppressWarnings({"SF_SWITCH_FALLTHROUGH", "SF_SWITCH_NO_DEFAULT"})
+@SuppressFBWarnings({"SF_SWITCH_FALLTHROUGH", "SF_SWITCH_NO_DEFAULT"})
 public final class HashUtil {
 
     private static final boolean LITTLE_ENDIAN = ByteOrder.LITTLE_ENDIAN == ByteOrder.nativeOrder();

--- a/hazelcast/src/main/java/com/hazelcast/util/SampleableConcurrentHashMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/SampleableConcurrentHashMap.java
@@ -18,6 +18,7 @@ package com.hazelcast.util;
 
 import com.hazelcast.cache.impl.eviction.Expirable;
 import com.hazelcast.nio.serialization.Data;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.util.Collections;
 import java.util.EnumSet;
@@ -134,7 +135,7 @@ public class SampleableConcurrentHashMap<K, V> extends ConcurrentReferenceHashMa
      *
      * NOTE: Assumed that it is not accessed by multiple threads. So there is no synchronization.
      */
-    @edu.umd.cs.findbugs.annotations.SuppressWarnings("PZ_DONT_REUSE_ENTRY_OBJECTS_IN_ITERATORS")
+    @SuppressFBWarnings("PZ_DONT_REUSE_ENTRY_OBJECTS_IN_ITERATORS")
     public class IterableSamplingEntry
             extends SamplingEntry
             implements Iterable<IterableSamplingEntry>, Iterator<IterableSamplingEntry> {

--- a/hazelcast/src/main/java/com/hazelcast/util/collection/BiInt2ObjectMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/collection/BiInt2ObjectMap.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2014 Real Logic Ltd.
  * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/hazelcast/src/main/java/com/hazelcast/util/collection/Hashing.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/collection/Hashing.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2014 Real Logic Ltd.
  * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/hazelcast/src/main/java/com/hazelcast/util/collection/IntHashSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/collection/IntHashSet.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2014 Real Logic Ltd.
  * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,6 +20,7 @@ package com.hazelcast.util.collection;
 import com.hazelcast.util.QuickMath;
 import com.hazelcast.util.function.Predicate;
 
+import java.lang.reflect.Array;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Set;
@@ -181,14 +183,6 @@ public final class IntHashSet implements Set<Integer> {
     /**
      * {@inheritDoc}
      */
-    @SuppressWarnings("unchecked")
-    public <T> T[] toArray(final T[] ignore) {
-        return (T[]) (Object) Arrays.copyOf(values, values.length);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
     public boolean addAll(final Collection<? extends Integer> coll) {
         return addAllCapture(coll);
     }
@@ -212,8 +206,7 @@ public final class IntHashSet implements Set<Integer> {
 
     private <E> boolean containsAllCapture(Collection<E> coll) {
         return conjunction(coll, new Predicate<E>() {
-            @Override
-            public boolean test(E value) {
+            @Override public boolean test(E value) {
                 return contains(value);
             }
         });
@@ -273,8 +266,7 @@ public final class IntHashSet implements Set<Integer> {
 
     private <E> boolean removeAllCapture(final Collection<E> coll) {
         return conjunction(coll, new Predicate<E>() {
-            @Override
-            public boolean test(E value) {
+            @Override public boolean test(E value) {
                 return remove(value);
             }
         });
@@ -336,11 +328,38 @@ public final class IntHashSet implements Set<Integer> {
      */
     public Object[] toArray() {
         final int[] values = this.values;
-        final Object[] array = new Object[values.length];
-        for (int i = 0; i < values.length; i++) {
-            array[i] = values[i];
+        final Object[] ret = new Object[size];
+        for (int from = 0, to = 0; from < values.length; from++) {
+            final int val = values[from];
+            if (val != missingValue) {
+                ret[to++] = val;
+            }
         }
-        return array;
+        return ret;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @SuppressWarnings("unchecked")
+    public <T> T[] toArray(T[] into) {
+        checkNotNull(into);
+        final Class<?> aryType = into.getClass().getComponentType();
+        if (!aryType.isAssignableFrom(Integer.class)) {
+            throw new ArrayStoreException("Cannot store Integers in array of type " + aryType);
+        }
+        final int[] values = this.values;
+        final Object[] ret = into.length >= this.size ? into : (T[]) Array.newInstance(aryType, this.size);
+        for (int from = 0, to = 0; from < values.length; from++) {
+            final int val = values[from];
+            if (val != missingValue) {
+                ret[to++] = val;
+            }
+        }
+        if (ret.length > values.length) {
+            ret[values.length] = null;
+        }
+        return (T[]) ret;
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/util/collection/IntIterator.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/collection/IntIterator.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2014 Real Logic Ltd.
  * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,7 +17,10 @@
 
 package com.hazelcast.util.collection;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import java.util.Iterator;
+import java.util.NoSuchElementException;
 
 /**
  * An iterator for a sequence of primitive integers.
@@ -33,21 +37,22 @@ public class IntIterator implements Iterator<Integer> {
      * @param missingValue to indicate the value is missing, i.e. not present or null.
      * @param values       to iterate over.
      */
+    @SuppressFBWarnings(value = "EI2", justification =
+            "This is flyweight over caller's array, so no copying")
     public IntIterator(final int missingValue, final int[] values) {
         this.missingValue = missingValue;
         this.values = values;
+        this.position = -1;
     }
 
     public boolean hasNext() {
         final int[] values = this.values;
         while (position < values.length) {
-            if (values[position] != missingValue) {
+            if (position >= 0 && values[position] != missingValue) {
                 return true;
             }
-
             position++;
         }
-
         return false;
     }
 
@@ -65,6 +70,9 @@ public class IntIterator implements Iterator<Integer> {
      * @return the next int value.
      */
     public int nextValue() {
+        if (!hasNext()) {
+            throw new NoSuchElementException();
+        }
         final int value = values[position];
         position++;
         return value;

--- a/hazelcast/src/main/java/com/hazelcast/util/collection/Long2ObjectHashMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/collection/Long2ObjectHashMap.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2014 Real Logic Ltd.
  * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,6 +19,7 @@ package com.hazelcast.util.collection;
 
 import com.hazelcast.util.QuickMath;
 import com.hazelcast.util.function.LongFunction;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.util.AbstractCollection;
 import java.util.AbstractSet;
@@ -181,7 +183,6 @@ public class Long2ObjectHashMap<V> implements Map<Long, V> {
      * Get a value for a given key, or if it does ot exist then default the value via a {@link LongFunction}
      * and put it in the map.
      * <p/>
-     * Primitive specialized version of {@link java.util.Map#computeIfAbsent}.
      *
      * @param key             to search on.
      * @param mappingFunction to provide a value if the get returns null.
@@ -307,6 +308,11 @@ public class Long2ObjectHashMap<V> implements Map<Long, V> {
 
     /**
      * {@inheritDoc}
+     * This set's iterator also implements <code>Map.Entry</code>
+     * so the <code>next()</code> method can just return the iterator
+     * instance itself with no heap allocation. This characteristic
+     * makes the set unusable wherever the returned entries are
+     * retained (such as <code>coll.addAll(entrySet)</code>.
      */
     public Set<Entry<Long, V>> entrySet() {
         return entrySet;
@@ -554,7 +560,12 @@ public class Long2ObjectHashMap<V> implements Map<Long, V> {
     }
 
     @SuppressWarnings("unchecked")
-    public class EntryIterator<V> extends AbstractIterator<Entry<Long, V>> implements Entry<Long, V> {
+    @SuppressFBWarnings(value = "PZ_DONT_REUSE_ENTRY_OBJECTS_IN_ITERATORS",
+            justification = "deliberate, documented choice")
+    public class EntryIterator<V>
+            extends AbstractIterator<Entry<Long, V>>
+            implements Entry<Long, V> {
+
         public Entry<Long, V> next() {
             findNext();
             return this;

--- a/hazelcast/src/main/java/com/hazelcast/util/collection/LongIterator.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/collection/LongIterator.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2014 Real Logic Ltd.
  * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,11 +17,14 @@
 
 package com.hazelcast.util.collection;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import java.util.Iterator;
 
 /**
  * An iterator for a sequence of primitive integers.
  */
+@SuppressFBWarnings("EI2")
 public class LongIterator implements Iterator<Long> {
     private final long missingValue;
     private final long[] values;

--- a/hazelcast/src/main/java/com/hazelcast/util/collection/MapDelegatingSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/collection/MapDelegatingSet.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2014 Real Logic Ltd.
  * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/hazelcast/src/main/java/com/hazelcast/util/executor/CachedExecutorServiceDelegate.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/executor/CachedExecutorServiceDelegate.java
@@ -19,6 +19,7 @@ package com.hazelcast.util.executor;
 import com.hazelcast.spi.ExecutionService;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.util.EmptyStatement;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.util.Collection;
 import java.util.List;
@@ -125,7 +126,7 @@ public final class CachedExecutorServiceDelegate implements ExecutorService, Man
         return submit(task, null);
     }
 
-    @edu.umd.cs.findbugs.annotations.SuppressWarnings("VO_VOLATILE_INCREMENT")
+    @SuppressFBWarnings("VO_VOLATILE_INCREMENT")
     private void addNewWorkerIfRequired() {
         if (size < maxPoolSize) {
             try {

--- a/hazelcast/src/main/java/com/hazelcast/util/executor/DelegatingFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/executor/DelegatingFuture.java
@@ -21,6 +21,7 @@ import com.hazelcast.core.ICompletableFuture;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.SerializationService;
 import com.hazelcast.util.ExceptionUtil;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
@@ -61,7 +62,7 @@ public class DelegatingFuture<V> implements ICompletableFuture<V> {
     }
 
 
-    @edu.umd.cs.findbugs.annotations.SuppressWarnings("IS2_INCONSISTENT_SYNC")
+    @SuppressFBWarnings("IS2_INCONSISTENT_SYNC")
     @Override
     public final V get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
         if (!done) {

--- a/hazelcast/src/test/java/com/hazelcast/util/collection/BiInt2ObjectMapTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/collection/BiInt2ObjectMapTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2014 Real Logic Ltd.
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/util/collection/Int2ObjectHashMapTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/collection/Int2ObjectHashMapTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2014 Real Logic Ltd.
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,12 +28,15 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
 
 import static java.lang.Integer.valueOf;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.hamcrest.number.IsCloseTo.closeTo;
 import static org.hamcrest.number.OrderingComparison.lessThan;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
 @RunWith(HazelcastSerialClassRunner.class)

--- a/hazelcast/src/test/java/com/hazelcast/util/collection/IntHashSetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/collection/IntHashSetTest.java
@@ -1,5 +1,6 @@
 /*
- * Copyright 2015 Real Logic Ltd.
+ * Copyright 2014 Real Logic Ltd.
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +23,10 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Iterator;
+import java.util.Set;
 
 import static org.hamcrest.Matchers.contains;
 import static org.junit.Assert.assertEquals;
@@ -226,5 +230,23 @@ public class IntHashSetTest {
         assertTrue(iter.hasNext());
         assertEquals(Integer.valueOf(2), iter.next());
         assertFalse(iter.hasNext());
+    }
+
+    @Test public void toArrayReturnsArrayOfAllElements() {
+        final IntHashSet initial = new IntHashSet(100, -1);
+        initial.add(1);
+        initial.add(13);
+        final Object[] ary = initial.toArray();
+        final Set<Object> fromArray = new HashSet<Object>(Arrays.asList(ary));
+        assertEquals(new HashSet<Object>(initial), fromArray);
+    }
+
+    @Test public void intoArrayReturnsArrayOfAllElements() {
+        final IntHashSet initial = new IntHashSet(100, -1);
+        initial.add(1);
+        initial.add(13);
+        final Object[] ary = initial.toArray(new Integer[2]);
+        final Set<Object> fromArray = new HashSet<Object>(Arrays.asList(ary));
+        assertEquals(new HashSet<Object>(initial), fromArray);
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/util/collection/Long2LongHashMapTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/collection/Long2LongHashMapTest.java
@@ -1,5 +1,6 @@
 /*
- * Copyright 2015 Real Logic Ltd.
+ * Copyright 2014 Real Logic Ltd.
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +27,7 @@ import org.mockito.InOrder;
 
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;

--- a/hazelcast/src/test/java/com/hazelcast/util/collection/Long2ObjectHashMapTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/collection/Long2ObjectHashMapTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2014 Real Logic Ltd.
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,15 +26,19 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
 
 import static java.lang.Long.valueOf;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.hamcrest.number.IsCloseTo.closeTo;
 import static org.hamcrest.number.OrderingComparison.lessThan;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
 @RunWith(HazelcastSerialClassRunner.class)

--- a/pom.xml
+++ b/pom.xml
@@ -868,9 +868,9 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>net.sourceforge.findbugs</groupId>
+            <groupId>com.google.code.findbugs</groupId>
             <artifactId>annotations</artifactId>
-            <version>1.3.2</version>
+            <version>3.0.0</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
FindBugs discovered several issues with the Agrona backport classes. Some of them were legitimate and code was changed accordingly. Others just needed suppression.

Additionally this PR removes the usage of the outdated and deprecated `SuppressWarnings` annotation. The replacement is `SuppressFBWarnings` which avoids the name clash with the JDK standard annotation. The dependency to the FindBugs-annotations artifact was severely outdated (1.0.2 vs. current 3.0.0), which is the reason why the old annotation was not raising deprecation warnings.