### PR TITLE
Clean up regexes in suppressions.xml

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -7,11 +7,11 @@
 <suppressions>
 
     <!-- Suppress checking of copyright notice -->
-    <suppress checks="Header" files="com.hazelcast.logging.Log4j2Factory.java"/>
-    <suppress checks="Header" files="[\\/]hazelcast-code-generator[\\/]"/>
+    <suppress checks="Header" files="com/hazelcast/logging/Log4j2Factory\.java"/>
+    <suppress checks="Header" files="/hazelcast-code-generator/"/>
 
     <!-- Suppress strict duplicate code checking -->
-    <suppress checks="StrictDuplicateCode" files=".java" lines="1-15"/>
+    <suppress checks="StrictDuplicateCode" files="\.java" lines="1-15"/>
 
     <!-- Suppressing warnings on the PortableHook -->
     <suppress checks="MethodLength" files=".*(?:PortableHook)\.java$"/>
@@ -34,552 +34,553 @@
     <suppress checks="CyclomaticComplexityCheck" files=".*(?:SerializerHook)\.java$"/>
     <suppress checks="IllegalType" files=".*(?:SerializerHook)\.java$"/>
 
-    <!--<suppress checks="" files="[\\/]examples[\\/]"/>-->
-    <suppress checks="FileLengthCheck" files="ConsoleApp.java"/>
-    <suppress checks="MethodCountCheck" files="ConsoleApp.java"/>
-    <suppress checks="ClassFanOutComplexityCheck" files="ConsoleApp.java"/>
-    <suppress checks="CyclomaticComplexityCheck" files="ConsoleApp.java"/>
-    <suppress checks="NPathComplexityCheck" files="ConsoleApp.java"/>
-    <suppress checks="MethodLengthCheck" files="ConsoleApp.java"/>
+    <!--<suppress checks="" files="/examples/"/>-->
+    <suppress checks="FileLengthCheck" files="ConsoleApp\.java"/>
+    <suppress checks="MethodCountCheck" files="ConsoleApp\.java"/>
+    <suppress checks="ClassFanOutComplexityCheck" files="ConsoleApp\.java"/>
+    <suppress checks="CyclomaticComplexityCheck" files="ConsoleApp\.java"/>
+    <suppress checks="NPathComplexityCheck" files="ConsoleApp\.java"/>
+    <suppress checks="MethodLengthCheck" files="ConsoleApp\.java"/>
 
     <!--Code Smells -->
 
     <!--Exclude Clover instrumented sources-->
-    <suppress checks="" files="[\\/]src-instrumented[\\/]"/>
+    <suppress checks="" files="/src-instrumented/"/>
 
     <!-- Exclude implementation packages from JavaDoc on public methods checkstyle enforcement -->
-    <suppress checks="JavadocMethod" files="[\\/]impl[\\/]"/>
-    <suppress checks="JavadocPackage" files="[\\/]impl[\\/]"/>
+    <suppress checks="JavadocMethod" files="/impl/"/>
+    <suppress checks="JavadocPackage" files="/impl/"/>
 
     <!-- Cluster -->
-    <suppress checks="JavadocMethod" files="com.hazelcast.cluster[\\/]"/>
-    <suppress checks="JavadocType" files="com.hazelcast.cluster[\\/]"/>
-    <suppress checks="JavadocMethod" files="com.hazelcast.cluster[\\/]"/>
-    <suppress checks="JavadocVariable" files="com.hazelcast.cluster[\\/]"/>
+    <suppress checks="JavadocMethod" files="com/hazelcast/cluster/"/>
+    <suppress checks="JavadocType" files="com/hazelcast/cluster/"/>
+    <suppress checks="JavadocMethod" files="com/hazelcast/cluster/"/>
+    <suppress checks="JavadocVariable" files="com/hazelcast/cluster/"/>
     <!-- TODO: Needs to be fixed -->
-    <suppress checks="" files="com.hazelcast.cluster.impl.ClusterServiceImpl"/>
-    <suppress checks="" files="com.hazelcast.cluster.impl.MulticastService"/>
-    <suppress checks="" files="com.hazelcast.cluster.impl.ConfigCheck"/>
-    <suppress checks="" files="com.hazelcast.cluster.impl.TcpIpJoiner"/>
-    <suppress checks="" files="com.hazelcast.cluster.impl.AbstractJoiner"/>
-    <suppress checks="" files="com.hazelcast.cluster.impl.MulticastJoiner"/>
+    <suppress checks="" files="com/hazelcast/cluster/impl/ClusterServiceImpl"/>
+    <suppress checks="" files="com/hazelcast/cluster/impl/MulticastService"/>
+    <suppress checks="" files="com/hazelcast/cluster/impl/ConfigCheck"/>
+    <suppress checks="" files="com/hazelcast/cluster/impl/TcpIpJoiner"/>
+    <suppress checks="" files="com/hazelcast/cluster/impl/AbstractJoiner"/>
+    <suppress checks="" files="com/hazelcast/cluster/impl/MulticastJoiner"/>
 
-    <suppress checks="JavadocMethod" files="com.hazelcast.cluster.impl.operations[\\/]"/>
-    <suppress checks="JavadocType" files="com.hazelcast.cluster.impl.operations[\\/]"/>
-    <suppress checks="JavadocMethod" files="com.hazelcast.cluster.impl.operations[\\/]"/>
-    <suppress checks="JavadocVariable" files="com.hazelcast.cluster.impl.operations[\\/]"/>
+    <suppress checks="JavadocMethod" files="com/hazelcast/cluster/impl/operations/"/>
+    <suppress checks="JavadocType" files="com/hazelcast/cluster/impl/operations/"/>
+    <suppress checks="JavadocMethod" files="com/hazelcast/cluster/impl/operations/"/>
+    <suppress checks="JavadocVariable" files="com/hazelcast/cluster/impl/operations/"/>
     <!-- TODO: Needs to be fixed -->
-    <suppress checks="" files="com.hazelcast.cluster.impl.operations.FinalizeJoinOperation"/>
-    <suppress checks="" files="com.hazelcast.cluster.impl.operations.JoinCheckOperation"/>
+    <suppress checks="" files="com/hazelcast/cluster/impl/operations/FinalizeJoinOperation"/>
+    <suppress checks="" files="com/hazelcast/cluster/impl/operations/JoinCheckOperation"/>
 
     <!-- Cache-->
-    <suppress checks="JavadocMethod" files="com.hazelcast.cache.impl[\\/]"/>
-    <suppress checks="JavadocType" files="com.hazelcast.cache.impl[\\/]"/>
-    <suppress checks="JavadocMethod" files="com.hazelcast.cache.impl[\\/]"/>
-    <suppress checks="JavadocVariable" files="com.hazelcast.cache.impl[\\/]"/>
-    <suppress checks="MethodCount" files="com.hazelcast.cache.ICache"/>
-    <suppress checks="MethodCount" files="com.hazelcast.client.cache.impl.AbstractClientCacheProxy"/>
+    <suppress checks="JavadocMethod" files="com/hazelcast/cache/impl/"/>
+    <suppress checks="JavadocType" files="com/hazelcast/cache/impl/"/>
+    <suppress checks="JavadocMethod" files="com/hazelcast/cache/impl/"/>
+    <suppress checks="JavadocVariable" files="com/hazelcast/cache/impl/"/>
+    <suppress checks="MethodCount" files="com/hazelcast/cache/ICache"/>
+    <suppress checks="MethodCount" files="com/hazelcast/client/cache/impl/AbstractClientCacheProxy"/>
     <suppress checks="ClassDataAbstractionCoupling|MethodCount|"
-              files="com.hazelcast.client.cache.impl.AbstractClientInternalCacheProxy"/>
-    <suppress checks="MethodCount" files="com.hazelcast.cache.impl.CacheRecordStore"/>
-    <suppress checks="MethodCount" files="com.hazelcast.cache.impl.CacheService"/>
-    <suppress checks="NPathComplexity" files="com.hazelcast.config.CacheConfig"/>
-    <suppress checks="NPathComplexity" files="com.hazelcast.cache.impl.HazelcastServerCachingProvider"/>
-    <suppress checks="NPathComplexity" files="com.hazelcast.client.cache.impl.HazelcastClientCachingProvider"/>
-    <suppress checks="NPathComplexity|CyclomaticComplexity" files="com.hazelcast.config.AbstractCacheConfig"/>
+              files="com/hazelcast/client/cache/impl/AbstractClientInternalCacheProxy"/>
+    <suppress checks="MethodCount" files="com/hazelcast/cache/impl/CacheRecordStore"/>
+    <suppress checks="MethodCount" files="com/hazelcast/cache/impl/CacheService"/>
+    <suppress checks="NPathComplexity" files="com/hazelcast/config/CacheConfig"/>
+    <suppress checks="NPathComplexity" files="com/hazelcast/cache/impl/HazelcastServerCachingProvider"/>
+    <suppress checks="NPathComplexity" files="com/hazelcast/client/cache/impl/HazelcastClientCachingProvider"/>
+    <suppress checks="NPathComplexity|CyclomaticComplexity" files="com/hazelcast/config/AbstractCacheConfig"/>
     <suppress checks="MethodCount|ParameterNumber|ClassFanOutComplexity|ClassDataAbstractionCoupling"
-              files="com.hazelcast.cache.impl.AbstractCacheRecordStore"/>
-    <suppress checks="MethodCount" files="com.hazelcast.cache.impl.AbstractCacheService"/>
-    <suppress checks="MethodCount" files="com.hazelcast.cache.impl.nearcache.impl.store.AbstractNearCacheRecordStore"/>
+              files="com/hazelcast/cache/impl/AbstractCacheRecordStore"/>
+    <suppress checks="MethodCount" files="com/hazelcast/cache/impl/AbstractCacheService"/>
+    <suppress checks="MethodCount" files="com/hazelcast/cache/impl/nearcache/impl/store/AbstractNearCacheRecordStore"/>
     <suppress checks="NPathComplexity"
-              files="com.hazelcast.cache.impl.eviction.impl.evaluator.AbstractEvictionPolicyEvaluator"/>
-    <suppress checks="MethodCount" files="com.hazelcast.cache.impl.AbstractHazelcastCacheManager"/>
+              files="com/hazelcast/cache/impl/eviction/impl/evaluator/AbstractEvictionPolicyEvaluator"/>
+    <suppress checks="MethodCount" files="com/hazelcast/cache/impl/AbstractHazelcastCacheManager"/>
 
     <!-- Core-->
-    <suppress checks="JavadocMethod" files="com.hazelcast.core[\\/]"/>
-    <suppress checks="JavadocType" files="com.hazelcast.core[\\/]"/>
-    <suppress checks="JavadocMethod" files="com.hazelcast.core[\\/]"/>
-    <suppress checks="JavadocVariable" files="com.hazelcast.core[\\/]"/>
-    <suppress checks="MethodCount" files="com.hazelcast.core.HazelcastInstance"/>
-    <suppress checks="MethodCount" files="com.hazelcast.core.IMap"/>
+    <suppress checks="JavadocMethod" files="com/hazelcast/core/"/>
+    <suppress checks="JavadocType" files="com/hazelcast/core/"/>
+    <suppress checks="JavadocMethod" files="com/hazelcast/core/"/>
+    <suppress checks="JavadocVariable" files="com/hazelcast/core/"/>
+    <suppress checks="MethodCount" files="com/hazelcast/core/HazelcastInstance"/>
+    <suppress checks="MethodCount" files="com/hazelcast/core/IMap"/>
 
     <!-- Config-->
-    <suppress checks="MethodCount" files="com.hazelcast.config.Config"/>
-    <suppress checks="ClassDataAbstractionCoupling" files="com.hazelcast.config.Config"/>
-    <suppress checks="CyclomaticComplexity" files="com.hazelcast.config.AbstractXmlConfigHelper"/>
-    <suppress checks="ClassDataAbstractionCoupling" files="com.hazelcast.config.AbstractXmlConfigHelper"/>
-    <suppress checks="FanOutComplexity" files="com.hazelcast.config.ConfigXmlGenerator"/>
+    <suppress checks="MethodCount" files="com/hazelcast/config/Config"/>
+    <suppress checks="ClassDataAbstractionCoupling" files="com/hazelcast/config/Config"/>
+    <suppress checks="CyclomaticComplexity" files="com/hazelcast/config/AbstractXmlConfigHelper"/>
+    <suppress checks="ClassDataAbstractionCoupling" files="com/hazelcast/config/AbstractXmlConfigHelper"/>
+    <suppress checks="FanOutComplexity" files="com/hazelcast/config/ConfigXmlGenerator"/>
 
     <!--Couldn't change structure because of API -->
-    <suppress checks="CyclomaticComplexity" files="com.hazelcast.config.MapConfig"/>
-    <suppress checks="BooleanExpressionComplexity" files="com.hazelcast.config.MapConfig"/>
-    <suppress checks="NPathComplexity" files="com.hazelcast.config.MapConfig"/>
-    <suppress checks="MethodCount" files="com.hazelcast.config.MapConfig"/>
-    <suppress checks="MethodCount" files="com.hazelcast.config.CacheSimpleConfig"/>
-    <suppress checks="ExecutableStatementCount" files="com.hazelcast.config.CacheConfig"/>
-    <suppress checks="ExecutableStatementCount" files="com.hazelcast.config.MapConfig"/>
+    <suppress checks="CyclomaticComplexity" files="com/hazelcast/config/MapConfig"/>
+    <suppress checks="BooleanExpressionComplexity" files="com/hazelcast/config/MapConfig"/>
+    <suppress checks="NPathComplexity" files="com/hazelcast/config/MapConfig"/>
+    <suppress checks="MethodCount" files="com/hazelcast/config/MapConfig"/>
+    <suppress checks="MethodCount" files="com/hazelcast/config/CacheSimpleConfig"/>
+    <suppress checks="ExecutableStatementCount" files="com/hazelcast/config/CacheConfig"/>
+    <suppress checks="ExecutableStatementCount" files="com/hazelcast/config/MapConfig"/>
     <!---->
-    <suppress checks="MethodCount" files="com.hazelcast.config.SerializationConfig"/>
-    <suppress checks="MethodCount" files="com.hazelcast.config.XmlConfigBuilder"/>
-    <suppress checks="FileLengthCheck" files="com.hazelcast.config.XmlConfigBuilder"/>
-    <suppress checks="CyclomaticComplexity" files="com.hazelcast.config.XmlConfigBuilder"/>
-    <suppress checks="ClassFanOutComplexity" files="com.hazelcast.config.XmlConfigBuilder"/>
-    <suppress checks="ClassDataAbstractionCoupling" files="com.hazelcast.config.XmlConfigBuilder"/>
-    <suppress checks="MethodLength" files="com.hazelcast.config.XmlConfigBuilder"/>
+    <suppress checks="MethodCount" files="com/hazelcast/config/SerializationConfig"/>
+    <suppress checks="MethodCount" files="com/hazelcast/config/XmlConfigBuilder"/>
+    <suppress checks="FileLengthCheck" files="com/hazelcast/config/XmlConfigBuilder"/>
+    <suppress checks="CyclomaticComplexity" files="com/hazelcast/config/XmlConfigBuilder"/>
+    <suppress checks="ClassFanOutComplexity" files="com/hazelcast/config/XmlConfigBuilder"/>
+    <suppress checks="ClassDataAbstractionCoupling" files="com/hazelcast/config/XmlConfigBuilder"/>
+    <suppress checks="MethodLength" files="com/hazelcast/config/XmlConfigBuilder"/>
 
     <!-- Exclude implementation packages from some checkstyle enforcement -->
-    <suppress checks="JavadocMethod" files="com.hazelcast.concurrent[\\/]"/>
-    <suppress checks="JavadocType" files="com.hazelcast.concurrent[\\/]"/>
-    <suppress checks="JavadocMethod" files="com.hazelcast.concurrent[\\/]"/>
-    <suppress checks="JavadocVariable" files="com.hazelcast.concurrent[\\/]"/>
+    <suppress checks="JavadocMethod" files="com/hazelcast/concurrent/"/>
+    <suppress checks="JavadocType" files="com/hazelcast/concurrent/"/>
+    <suppress checks="JavadocMethod" files="com/hazelcast/concurrent/"/>
+    <suppress checks="JavadocVariable" files="com/hazelcast/concurrent/"/>
 
-    <!-- concurrent.atomiclong-->
-    <suppress checks="MethodCount" files="com.hazelcast.concurrent.atomiclong.AtomicLongProxy"/>
+    <!-- concurrent/atomiclong-->
+    <suppress checks="MethodCount" files="com/hazelcast/concurrent/atomiclong/AtomicLongProxy"/>
 
-    <!-- concurrent.lock -->
-    <suppress checks="MethodCount" files="com.hazelcast.concurrent.lock.LockServiceImpl"/>
-    <suppress checks="MethodCount" files="com.hazelcast.concurrent.lock.LockResourceImpl"/>
-    <suppress checks="MethodCount" files="com.hazelcast.concurrent.lock.LockStoreImpl"/>
-    <suppress checks="Todo" files="com.hazelcast.concurrent.lock.ConditionImpl"/>
+    <!-- concurrent/lock -->
+    <suppress checks="MethodCount" files="com/hazelcast/concurrent/lock/LockServiceImpl"/>
+    <suppress checks="MethodCount" files="com/hazelcast/concurrent/lock/LockResourceImpl"/>
+    <suppress checks="MethodCount" files="com/hazelcast/concurrent/lock/LockStoreImpl"/>
+    <suppress checks="Todo" files="com/hazelcast/concurrent/lock/ConditionImpl"/>
 
     <!-- ringbuffer -->
-    <suppress checks="JavadocMethod" files="com.hazelcast.ringbuffer.impl.operations[\\/]"/>
-    <suppress checks="JavadocType" files="com.hazelcast.ringbuffer.impl.operations[\\/]"/>
-    <suppress checks="JavadocMethod" files="com.hazelcast.ringbuffer.impl.operations[\\/]"/>
-    <suppress checks="JavadocVariable" files="com.hazelcast.ringbuffer.impl.operations[\\/]"/>
-    <suppress checks="JavadocPackage" files="com.hazelcast.ringbuffer.impl.operations[\\/]"/>
-    <suppress checks="JavadocVariable" files="com.hazelcast.ringbuffer.impl.RingbufferDataSerializerHook"/>
+    <suppress checks="JavadocMethod" files="com/hazelcast/ringbuffer/impl/operations/"/>
+    <suppress checks="JavadocType" files="com/hazelcast/ringbuffer/impl/operations/"/>
+    <suppress checks="JavadocMethod" files="com/hazelcast/ringbuffer/impl/operations/"/>
+    <suppress checks="JavadocVariable" files="com/hazelcast/ringbuffer/impl/operations/"/>
+    <suppress checks="JavadocPackage" files="com/hazelcast/ringbuffer/impl/operations/"/>
+    <suppress checks="JavadocVariable" files="com/hazelcast/ringbuffer/impl/RingbufferDataSerializerHook"/>
 
     <!-- Storage -->
-    <suppress checks="JavadocMethod" files="com.hazelcast.internal.storage[\\/]"/>
-    <suppress checks="JavadocType" files="com.hazelcast.internal.storage[\\/]"/>
-    <suppress checks="JavadocMethod" files="com.hazelcast.internal.storage[\\/]"/>
-    <suppress checks="JavadocVariable" files="com.hazelcast.internal.storage[\\/]"/>
+    <suppress checks="JavadocMethod" files="com/hazelcast/internal/storage/"/>
+    <suppress checks="JavadocType" files="com/hazelcast/internal/storage/"/>
+    <suppress checks="JavadocMethod" files="com/hazelcast/internal/storage/"/>
+    <suppress checks="JavadocVariable" files="com/hazelcast/internal/storage/"/>
 
 
     <!-- client -->
     <!-- TODO: These javadoc issues need to be addressed -->
-    <suppress checks="JavadocMethod" files="com.hazelcast.client[\\/]"/>
-    <suppress checks="JavadocMethod" files="com.hazelcast.client.proxy[\\/]"/>
-    <suppress checks="JavadocType" files="com.hazelcast.client.proxy[\\/]"/>
-    <suppress checks="JavadocMethod" files="com.hazelcast.client.proxy[\\/]"/>
-    <suppress checks="JavadocVariable" files="com.hazelcast.client.proxy[\\/]"/>
+    <suppress checks="JavadocMethod" files="com/hazelcast/client/"/>
+    <suppress checks="JavadocMethod" files="com/hazelcast/client/proxy/"/>
+    <suppress checks="JavadocType" files="com/hazelcast/client/proxy/"/>
+    <suppress checks="JavadocMethod" files="com/hazelcast/client/proxy/"/>
+    <suppress checks="JavadocVariable" files="com/hazelcast/client/proxy/"/>
 
-    <suppress checks="JavadocMethod" files="com.hazelcast.client.connection.nio[\\/]"/>
-    <suppress checks="JavadocType" files="com.hazelcast.client.connection.nio[\\/]"/>
-    <suppress checks="JavadocMethod" files="com.hazelcast.client.connection.nio[\\/]"/>
-    <suppress checks="JavadocVariable" files="com.hazelcast.client.connection.nio[\\/]"/>
+    <suppress checks="JavadocMethod" files="com/hazelcast/client/connection/nio/"/>
+    <suppress checks="JavadocType" files="com/hazelcast/client/connection/nio/"/>
+    <suppress checks="JavadocMethod" files="com/hazelcast/client/connection/nio/"/>
+    <suppress checks="JavadocVariable" files="com/hazelcast/client/connection/nio/"/>
 
-    <suppress checks="JavadocMethod" files="com.hazelcast.client.spi[\\/]"/>
-    <suppress checks="JavadocType" files="com.hazelcast.client.spi[\\/]"/>
-    <suppress checks="JavadocMethod" files="com.hazelcast.client.spi[\\/]"/>
-    <suppress checks="JavadocVariable" files="com.hazelcast.client.spi[\\/]"/>
+    <suppress checks="JavadocMethod" files="com/hazelcast/client/spi/"/>
+    <suppress checks="JavadocType" files="com/hazelcast/client/spi/"/>
+    <suppress checks="JavadocMethod" files="com/hazelcast/client/spi/"/>
+    <suppress checks="JavadocVariable" files="com/hazelcast/client/spi/"/>
 
 
     <!-- TODO: We need to get these wildcard suppressions fixed -->
-    <suppress checks="" files="com.hazelcast.client.proxy.ClientQueueProxy"/>
-    <suppress checks="MethodCount" files="com.hazelcast.client.proxy.ClientListProxy"/>
-    <suppress checks="" files="com.hazelcast.client.proxy.ClientMultiMapProxy"/>
-    <suppress checks="" files="com.hazelcast.client.proxy.ClientMapProxy"/>
-    <suppress checks="" files="com.hazelcast.client.HazelcastClient"/>
-    <suppress checks="Javadoc" files="com.hazelcast.client.impl.operations[\\/]"/>
-    <suppress checks="Javadoc" files="com.hazelcast.client.impl.client[\\/]"/>
-    <suppress checks="" files="com.hazelcast.client.impl.HazelcastClientInstance"/>
-    <suppress checks="" files="com.hazelcast.client.impl.HazelcastClientProxy"/>
-    <suppress checks="ClassDataAbstractionCoupling" files="com.hazelcast.client.proxy.ClientExecutorServiceProxy"/>
-    <suppress checks="MethodCount" files="com.hazelcast.client.proxy.ClientExecutorServiceProxy"/>
-    <suppress checks="MethodCount" files="com.hazelcast.client.impl.HazelcastClientProxy"/>
-    <suppress checks="CyclomaticComplexity" files="com.hazelcast.client.impl.client.ClientPortableFactory"/>
-    <suppress checks="ClassDataAbstractionCoupling" files="com.hazelcast.client.impl.client.ClientPortableFactory"/>
-    <suppress checks="MethodCount" files="com.hazelcast.client.config.ClientConfig"/>
-    <suppress checks="MethodCount" files="com.hazelcast.client.connection.nio.ClientConnection"/>
-    <suppress checks="MethodCount" files="com.hazelcast.client.impl.ClientEngineImpl"/>
-    <suppress checks="ClassFanOutComplexity" files="com.hazelcast.client.impl.ClientEngineImpl"/>
+    <suppress checks="" files="com/hazelcast/client/proxy/ClientQueueProxy"/>
+    <suppress checks="MethodCount" files="com/hazelcast/client/proxy/ClientListProxy"/>
+    <suppress checks="" files="com/hazelcast/client/proxy/ClientMultiMapProxy"/>
+    <suppress checks="" files="com/hazelcast/client/proxy/ClientMapProxy"/>
+    <suppress checks="" files="com/hazelcast/client/HazelcastClient"/>
+    <suppress checks="Javadoc" files="com/hazelcast/client/impl/operations/"/>
+    <suppress checks="Javadoc" files="com/hazelcast/client/impl/client/"/>
+    <suppress checks="" files="com/hazelcast/client/impl/HazelcastClientInstance"/>
+    <suppress checks="" files="com/hazelcast/client/impl/HazelcastClientProxy"/>
+    <suppress checks="ClassDataAbstractionCoupling" files="com/hazelcast/client/proxy/ClientExecutorServiceProxy"/>
+    <suppress checks="MethodCount" files="com/hazelcast/client/proxy/ClientExecutorServiceProxy"/>
+    <suppress checks="MethodCount" files="com/hazelcast/client/impl/HazelcastClientProxy"/>
+    <suppress checks="CyclomaticComplexity" files="com/hazelcast/client/impl/client/ClientPortableFactory"/>
+    <suppress checks="ClassDataAbstractionCoupling" files="com/hazelcast/client/impl/client/ClientPortableFactory"/>
+    <suppress checks="MethodCount" files="com/hazelcast/client/config/ClientConfig"/>
+    <suppress checks="MethodCount" files="com/hazelcast/client/connection/nio/ClientConnection"/>
+    <suppress checks="MethodCount" files="com/hazelcast/client/impl/ClientEngineImpl"/>
+    <suppress checks="ClassFanOutComplexity" files="com/hazelcast/client/impl/ClientEngineImpl"/>
     <!-- TODO: We need to get this wildcard suppressions fixed -->
-    <suppress checks="" files="com.hazelcast.client.connection.nio.ClientConnectionManagerImpl"/>
-    <suppress checks="CyclomaticComplexity" files="com.hazelcast.client.config.XmlClientConfigBuilder"/>
-    <suppress checks="ClassDataAbstractionCoupling" files="com.hazelcast.client.config.XmlClientConfigBuilder"/>
-    <suppress checks="MethodCount" files="com.hazelcast.client.impl.MemberImpl"/>
+    <suppress checks="" files="com/hazelcast/client/connection/nio/ClientConnectionManagerImpl"/>
+    <suppress checks="CyclomaticComplexity" files="com/hazelcast/client/config/XmlClientConfigBuilder"/>
+    <suppress checks="ClassDataAbstractionCoupling" files="com/hazelcast/client/config/XmlClientConfigBuilder"/>
+    <suppress checks="MethodCount" files="com/hazelcast/client/impl/MemberImpl"/>
 
-    <suppress checks="JavadocMethod" files="com.hazelcast.client[\\/]"/>
-    <suppress checks="JavadocType" files="com.hazelcast.client[\\/]"/>
-    <suppress checks="JavadocMethod" files="com.hazelcast.client[\\/]"/>
+    <suppress checks="JavadocMethod" files="com/hazelcast/client/"/>
+    <suppress checks="JavadocType" files="com/hazelcast/client/"/>
+    <suppress checks="JavadocMethod" files="com/hazelcast/client/"/>
     <suppress checks="ClassFanOutComplexity|ClassDataAbstractionCoupling"
-              files="com.hazelcast.client.connection.nio.ClientConnectionManagerImpl"/>
+              files="com/hazelcast/client/connection/nio/ClientConnectionManagerImpl"/>
 
 
-    <suppress checks="JavadocMethod" files="com.hazelcast.client.impl[\\/]"/>
-    <suppress checks="JavadocType" files="com.hazelcast.client.impl[\\/]"/>
-    <suppress checks="JavadocMethod" files="com.hazelcast.client.impl[\\/]"/>
+    <suppress checks="JavadocMethod" files="com/hazelcast/client/impl/"/>
+    <suppress checks="JavadocType" files="com/hazelcast/client/impl/"/>
+    <suppress checks="JavadocMethod" files="com/hazelcast/client/impl/"/>
 
     <!--CLIENT PROTOCOL-->
     <suppress checks="IllegalImport" files="com/hazelcast/client/impl/protocol/util/UnsafeBuffer"/>
     <!--Parameters classes are auto-generated-->
-    <suppress checks="" files="com.hazelcast.client.impl.protocol.map.*Parameters"/>
-    <suppress checks="" files="com.hazelcast.client.impl.protocol.*Parameters"/>
-    <suppress checks="" files="com.hazelcast.client.impl.protocol.*Codec"/>
-    <suppress checks="" files="com.hazelcast.client.impl.protocol.template.*Template*"/>
-    <suppress checks="CyclomaticComplexity" files="com.hazelcast.client.protocol.generator.CodecModel"/>
-    <suppress checks="" files="com.hazelcast.client.impl.protocol.*Const"/>
-    <suppress checks="MethodCount" files="com.hazelcast.client.impl.protocol.parameters.MapTemplate"/>
-    <suppress checks="MethodCount" files="com.hazelcast.client.impl.protocol.parameters.CacheTemplate"/>
-    <suppress checks="ParameterNumber" files="com.hazelcast.client.impl.protocol.parameters.MapReduceTemplate"/>
-    <suppress checks="ParameterNumber" files="com.hazelcast.client.proxy.ClientMapReduceProxy"/>
+    <suppress checks="" files="com/hazelcast/client/impl/protocol/map/.*Parameters"/>
+    <suppress checks="" files="com/hazelcast/client/impl/protocol/.*Parameters"/>
+    <suppress checks="" files="com/hazelcast/client/impl/protocol/.*Codec"/>
+    <suppress checks="" files="com/hazelcast/client/impl/protocol/template/.*Template*"/>
+    <suppress checks="CyclomaticComplexity" files="com/hazelcast/client/protocol/generator/CodecModel"/>
+    <suppress checks="" files="com/hazelcast/client/impl/protocol/.*Const"/>
+    <suppress checks="MethodCount" files="com/hazelcast/client/impl/protocol/parameters/MapTemplate"/>
+    <suppress checks="MethodCount" files="com/hazelcast/client/impl/protocol/parameters/CacheTemplate"/>
+    <suppress checks="ParameterNumber" files="com/hazelcast/client/impl/protocol/parameters/MapReduceTemplate"/>
+    <suppress checks="ParameterNumber" files="com/hazelcast/client/proxy/ClientMapReduceProxy"/>
 
-    <suppress checks="MethodCount" files="com.hazelcast.client.impl.protocol.ClientMessage"/>
-    <suppress checks="JavadocType" files="com.hazelcast.client.impl.protocol.ClientMessageType"/>
-    <suppress checks="JavadocVariable" files="com.hazelcast.client.impl.protocol.ClientMessageType"/>
+    <suppress checks="MethodCount" files="com/hazelcast/client/impl/protocol/ClientMessage"/>
+    <suppress checks="JavadocType" files="com/hazelcast/client/impl/protocol/ClientMessageType"/>
+    <suppress checks="JavadocVariable" files="com/hazelcast/client/impl/protocol/ClientMessageType"/>
 
-    <suppress checks="JavadocMethod" files="com.hazelcast.client.impl[\\/]"/>
-    <suppress checks="JavadocType" files="com.hazelcast.client.impl[\\/]"/>
+    <suppress checks="JavadocMethod" files="com/hazelcast/client/impl/"/>
+    <suppress checks="JavadocType" files="com/hazelcast/client/impl/"/>
 
-    <suppress checks="ClassFanOutComplexity" files="com.hazelcast.client.cache.impl.AbstractClientInternalCacheProxy"/>
+    <suppress checks="ClassFanOutComplexity" files="com/hazelcast/client/cache/impl/AbstractClientInternalCacheProxy"/>
 
     <!-- Monitor -->
-    <suppress checks="JavadocMethod" files="com.hazelcast.monitor[\\/]"/>
-    <suppress checks="JavadocType" files="com.hazelcast.monitor[\\/]"/>
-    <suppress checks="JavadocVariable" files="com.hazelcast.monitor[\\/]"/>
-    <suppress checks="CyclomaticComplexity" files="com.hazelcast.monitor.TimedMemberState"/>
-    <suppress checks="NPathComplexity" files="com.hazelcast.monitor.TimedMemberState"/>
-    <suppress checks="CyclomaticComplexity" files="com.hazelcast.monitor.impl.LocalCacheStatsImpl"/>
-    <suppress checks="NPathComplexity" files="com.hazelcast.monitor.impl.LocalCacheStatsImpl"/>
-    <suppress checks="CyclomaticComplexity" files="com.hazelcast.monitor.impl.MemberStateImpl"/>
-    <suppress checks="NPathComplexity" files="com.hazelcast.monitor.impl.MemberStateImpl"/>
-    <suppress checks="CyclomaticComplexity" files="com.hazelcast.monitor.impl.LocalMapStatsImpl"/>
-    <suppress checks="NPathComplexity" files="com.hazelcast.monitor.impl.LocalMapStatsImpl"/>
-    <suppress checks="MethodCount" files="com.hazelcast.monitor.impl.LocalMapStatsImpl"/>
-    <suppress checks="MethodLength" files="com.hazelcast.monitor.impl.LocalMapStatsImpl"/>
-    <suppress checks="CyclomaticComplexity" files="com.hazelcast.monitor.impl.LocalQueueStatsImpl"/>
-    <suppress checks="NPathComplexity" files="com.hazelcast.monitor.impl.LocalQueueStatsImpl"/>
+    <suppress checks="JavadocMethod" files="com/hazelcast/monitor/"/>
+    <suppress checks="JavadocType" files="com/hazelcast/monitor/"/>
+    <suppress checks="JavadocVariable" files="com/hazelcast/monitor/"/>
+    <suppress checks="CyclomaticComplexity" files="com/hazelcast/monitor/TimedMemberState"/>
+    <suppress checks="NPathComplexity" files="com/hazelcast/monitor/TimedMemberState"/>
+    <suppress checks="CyclomaticComplexity" files="com/hazelcast/monitor/impl/LocalCacheStatsImpl"/>
+    <suppress checks="NPathComplexity" files="com/hazelcast/monitor/impl/LocalCacheStatsImpl"/>
+    <suppress checks="CyclomaticComplexity" files="com/hazelcast/monitor/impl/MemberStateImpl"/>
+    <suppress checks="NPathComplexity" files="com/hazelcast/monitor/impl/MemberStateImpl"/>
+    <suppress checks="CyclomaticComplexity" files="com/hazelcast/monitor/impl/LocalMapStatsImpl"/>
+    <suppress checks="NPathComplexity" files="com/hazelcast/monitor/impl/LocalMapStatsImpl"/>
+    <suppress checks="MethodCount" files="com/hazelcast/monitor/impl/LocalMapStatsImpl"/>
+    <suppress checks="MethodLength" files="com/hazelcast/monitor/impl/LocalMapStatsImpl"/>
+    <suppress checks="CyclomaticComplexity" files="com/hazelcast/monitor/impl/LocalQueueStatsImpl"/>
+    <suppress checks="NPathComplexity" files="com/hazelcast/monitor/impl/LocalQueueStatsImpl"/>
 
     <!-- jca -->
-    <suppress checks="ClassFanOutComplexityCheck" files="HazelcastConnectionImpl.java"/>
-    <suppress checks="MethodCount" files="HazelcastConnectionImpl.java"/>
-    <suppress checks="JavadocMethod" files="com.hazelcast.jca[\\/]"/>
-    <suppress checks="JavadocType" files="com.hazelcast.jca[\\/]"/>
-    <suppress checks="JavadocMethod" files="com.hazelcast.jca[\\/]"/>
-    <suppress checks="JavadocVariable" files="com.hazelcast.jca[\\/]"/>
+    <suppress checks="ClassFanOutComplexityCheck" files="HazelcastConnectionImpl\.java"/>
+    <suppress checks="MethodCount" files="HazelcastConnectionImpl\.java"/>
+    <suppress checks="JavadocMethod" files="com/hazelcast/jca/"/>
+    <suppress checks="JavadocType" files="com/hazelcast/jca/"/>
+    <suppress checks="JavadocMethod" files="com/hazelcast/jca/"/>
+    <suppress checks="JavadocVariable" files="com/hazelcast/jca/"/>
 
-    <suppress checks="EmptyStatement" files="com.hazelcast.jca.ResourceAdapterImpl"/>
+    <suppress checks="EmptyStatement" files="com/hazelcast/jca/ResourceAdapterImpl"/>
 
     <!-- Query -->
-    <suppress checks="CyclomaticComplexity" files="com.hazelcast.query.SqlPredicate"/>
-    <suppress checks="NPathComplexity" files="com.hazelcast.query.SqlPredicate"/>
-    <suppress checks="MethodLength" files="com.hazelcast.query.SqlPredicate"/>
-    <suppress checks="MethodLength" files="com.hazelcast.query.impl.getters.ReflectionHelper"/>
-    <suppress checks="CyclomaticComplexity" files="com.hazelcast.query.impl.getters.ReflectionHelper"/>
-    <suppress checks="NPathComplexity" files="com.hazelcast.query.impl.getters.ReflectionHelper"/>
-    <suppress checks="ReturnCount" files="com.hazelcast.query.impl.getters.ReflectionHelper"/>
+    <suppress checks="CyclomaticComplexity" files="com/hazelcast/query/SqlPredicate"/>
+    <suppress checks="NPathComplexity" files="com/hazelcast/query/SqlPredicate"/>
+    <suppress checks="MethodLength" files="com/hazelcast/query/SqlPredicate"/>
+    <suppress checks="MethodLength" files="com/hazelcast/query/impl/getters/ReflectionHelper"/>
+    <suppress checks="CyclomaticComplexity" files="com/hazelcast/query/impl/getters/ReflectionHelper"/>
+    <suppress checks="NPathComplexity" files="com/hazelcast/query/impl/getters/ReflectionHelper"/>
+    <suppress checks="ReturnCount" files="com/hazelcast/query/impl/getters/ReflectionHelper"/>
 
     <!-- hazelcast-wm -->
-    <suppress checks="JavadocMethod" files="com.hazelcast.web[\\/]"/>
-    <suppress checks="JavadocType" files="com.hazelcast.web[\\/]"/>
-    <suppress checks="JavadocMethod" files="com.hazelcast.web[\\/]"/>
-    <suppress checks="JavadocVariable" files="com.hazelcast.web[\\/]"/>
+    <suppress checks="JavadocMethod" files="com/hazelcast/web/"/>
+    <suppress checks="JavadocType" files="com/hazelcast/web/"/>
+    <suppress checks="JavadocMethod" files="com/hazelcast/web/"/>
+    <suppress checks="JavadocVariable" files="com/hazelcast/web/"/>
 
 
     <!-- Instance -->
-    <suppress checks="JavadocMethod" files="com.hazelcast.instance[\\/]"/>
-    <suppress checks="JavadocType" files="com.hazelcast.instance[\\/]"/>
-    <suppress checks="JavadocMethod" files="com.hazelcast.instance[\\/]"/>
-    <suppress checks="JavadocVariable" files="com.hazelcast.instance[\\/]"/>
-    <suppress checks="MethodCount" files="com.hazelcast.instance.HazelcastInstanceProxy"/>
-    <suppress checks="MethodCount" files="com.hazelcast.instance.MemberImpl"/>
-    <suppress checks="EmptyBlock" files="com.hazelcast.instance.NodeShutdownLatch"/>
-    <suppress checks="MethodCount" files="com.hazelcast.instance.HazelcastInstanceImpl"/>
-    <suppress checks="ClassFanOutComplexity" files="com.hazelcast.instance.HazelcastInstanceImpl"/>
-    <suppress checks="VisibilityModifier" files="com.hazelcast.instance.HazelcastInstanceImpl"/>
-    <suppress checks="VisibilityModifier" files="com.hazelcast.instance.GroupProperties"/>
-    <suppress checks="MemberName" files="com.hazelcast.instance.GroupProperties"/>
-    <suppress checks="ConstantName" files="com.hazelcast.instance.GroupProperties"/>
-    <suppress checks="VariableName" files="com.hazelcast.instance.GroupProperties"/>
-    <suppress checks="MethodLength" files="com.hazelcast.instance.GroupProperties"/>
-    <suppress checks="ExecutableStatementCount" files="com.hazelcast.instance.GroupProperties"/>
+    <suppress checks="JavadocMethod" files="com/hazelcast/instance/"/>
+    <suppress checks="JavadocType" files="com/hazelcast/instance/"/>
+    <suppress checks="JavadocMethod" files="com/hazelcast/instance/"/>
+    <suppress checks="JavadocVariable" files="com/hazelcast/instance/"/>
+    <suppress checks="MethodCount" files="com/hazelcast/instance/HazelcastInstanceProxy"/>
+    <suppress checks="MethodCount" files="com/hazelcast/instance/MemberImpl"/>
+    <suppress checks="EmptyBlock" files="com/hazelcast/instance/NodeShutdownLatch"/>
+    <suppress checks="MethodCount" files="com/hazelcast/instance/HazelcastInstanceImpl"/>
+    <suppress checks="ClassFanOutComplexity" files="com/hazelcast/instance/HazelcastInstanceImpl"/>
+    <suppress checks="VisibilityModifier" files="com/hazelcast/instance/HazelcastInstanceImpl"/>
+    <suppress checks="VisibilityModifier" files="com/hazelcast/instance/GroupProperties"/>
+    <suppress checks="MemberName" files="com/hazelcast/instance/GroupProperties"/>
+    <suppress checks="ConstantName" files="com/hazelcast/instance/GroupProperties"/>
+    <suppress checks="VariableName" files="com/hazelcast/instance/GroupProperties"/>
+    <suppress checks="MethodLength" files="com/hazelcast/instance/GroupProperties"/>
+    <suppress checks="ExecutableStatementCount" files="com/hazelcast/instance/GroupProperties"/>
     <!-- todo-->
-    <suppress checks="" files="com.hazelcast.instance.DefaultAddressPicker"/>
-    <suppress checks="" files="com.hazelcast.instance.HazelcastInstanceFactory"/>
-    <suppress checks="" files="com.hazelcast.instance.Node"/>
+    <suppress checks="" files="com/hazelcast/instance/DefaultAddressPicker"/>
+    <suppress checks="" files="com/hazelcast/instance/HazelcastInstanceFactory"/>
+    <suppress checks="" files="com/hazelcast/instance/Node"/>
 
     <!-- SPI -->
-    <suppress checks="JavadocMethod" files="com.hazelcast.spi[\\/]"/>
-    <suppress checks="JavadocType" files="com.hazelcast.spi[\\/]"/>
-    <suppress checks="JavadocMethod" files="com.hazelcast.spi[\\/]"/>
-    <suppress checks="JavadocVariable" files="com.hazelcast.spi[\\/]"/>
-    <suppress checks="MethodCount|NPathComplexity|MagicNumber" files="com.hazelcast.spi.Operation"/>
-    <suppress checks="MethodCount" files="com.hazelcast.spi.impl.NodeEngineImpl"/>
-    <suppress checks="ClassFanOutComplexity" files="com.hazelcast.spi.impl.NodeEngineImpl"/>
-    <!-- since this class needs to manage services, it knows about them. So it is fine to have lots
+    <suppress checks="JavadocMethod" files="com/hazelcast/spi/"/>
+    <suppress checks="JavadocType" files="com/hazelcast/spi/"/>
+    <suppress checks="JavadocMethod" files="com/hazelcast/spi/"/>
+    <suppress checks="JavadocVariable" files="com/hazelcast/spi/"/>
+    <suppress checks="MethodCount|NPathComplexity|MagicNumber" files="com/hazelcast/spi/Operation"/>
+    <suppress checks="MethodCount" files="com/hazelcast/spi/impl/NodeEngineImpl"/>
+    <suppress checks="ClassFanOutComplexity" files="com/hazelcast/spi/impl/NodeEngineImpl"/>
+    <!-- since this class needs to manage services, it knows about them/ So it is fine to have lots
          of dependencies on these classes-->
-    <suppress checks="ClassDataAbstractionCoupling" files="com.hazelcast.spi.impl.servicemanager.impl.ServiceManager"/>
+    <suppress checks="ClassDataAbstractionCoupling" files="com/hazelcast/spi/impl/servicemanager/impl/ServiceManager"/>
 
     <suppress checks="MethodCount"
-              files="com.hazelcast.spi.impl.operationservice.impl.OperationServiceImpl"/>
-    <!-- the invocation just has many parameters because there are a lot of things to tune.-->
+              files="com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl"/>
+    <!-- the invocation just has many parameters because there are a lot of things to tune/-->
     <suppress checks="ParameterNumber"
-              files="com.hazelcast.spi.impl.operationservice.impl.InvocationImpl"/>
-    <!-- the partition-invocation just has many parameters because there are a lot of things to tune.-->
+              files="com/hazelcast/spi/impl/operationservice/impl/InvocationImpl"/>
+    <!-- the partition-invocation just has many parameters because there are a lot of things to tune/-->
     <suppress checks="ParameterNumber"
-              files="com.hazelcast.spi.impl.operationservice.impl.PartitionInvocation"/>
+              files="com/hazelcast/spi/impl/operationservice/impl/PartitionInvocation"/>
     <!-- these need to be solved-->
     <suppress checks="NPathComplexity"
-              files="com.hazelcast.spi.impl.operationservice.impl.InvocationFuture"/>
+              files="com/hazelcast/spi/impl/operationservice/impl/InvocationFuture"/>
     <suppress checks="ReturnCount"
-              files="com.hazelcast.spi.impl.operationservice.impl.InvocationFuture"/>
+              files="com/hazelcast/spi/impl/operationservice/impl/InvocationFuture"/>
     <suppress checks="CyclomaticComplexity"
-              files="com.hazelcast.spi.impl.operationservice.impl.InvocationFuture"/>
+              files="com/hazelcast/spi/impl/operationservice/impl/InvocationFuture"/>
 
     <suppress checks="ClassDataAbstractionCoupling|MethodCount"
-              files="com.hazelcast.spi.impl.eventservice.impl.EventServiceImpl"/>
+              files="com/hazelcast/spi/impl/eventservice/impl/EventServiceImpl"/>
 
     <!-- Transaction -->
-    <suppress checks="JavadocMethod" files="com.hazelcast.transaction[\\/]"/>
-    <suppress checks="JavadocType" files="com.hazelcast.transaction[\\/]"/>
-    <suppress checks="JavadocMethod" files="com.hazelcast.transaction[\\/]"/>
-    <suppress checks="JavadocVariable" files="com.hazelcast.transaction[\\/]"/>
+    <suppress checks="JavadocMethod" files="com/hazelcast/transaction/"/>
+    <suppress checks="JavadocType" files="com/hazelcast/transaction/"/>
+    <suppress checks="JavadocMethod" files="com/hazelcast/transaction/"/>
+    <suppress checks="JavadocVariable" files="com/hazelcast/transaction/"/>
 
     <!-- Security -->
-    <suppress checks="JavadocMethod" files="com.hazelcast.security[\\/]"/>
-    <suppress checks="JavadocType" files="com.hazelcast.security[\\/]"/>
-    <suppress checks="JavadocMethod" files="com.hazelcast.security[\\/]"/>
-    <suppress checks="JavadocVariable" files="com.hazelcast.security[\\/]"/>
-    <suppress checks="BooleanExpressionComplexityCheck" files="com.hazelcast.security.permission.QueuePermission"/>
+    <suppress checks="JavadocMethod" files="com/hazelcast/security/"/>
+    <suppress checks="JavadocType" files="com/hazelcast/security/"/>
+    <suppress checks="JavadocMethod" files="com/hazelcast/security/"/>
+    <suppress checks="JavadocVariable" files="com/hazelcast/security/"/>
+    <suppress checks="BooleanExpressionComplexityCheck" files="com/hazelcast/security/permission/QueuePermission"/>
     <suppress checks="BooleanExpressionComplexityCheck"
-              files="com.hazelcast.security.permission.ReplicatedMapPermission"/>
-    <suppress checks="BooleanExpressionComplexityCheck" files="com.hazelcast.security.permission.MapPermission"/>
-    <suppress checks="BooleanExpressionComplexityCheck" files="com.hazelcast.security.permission.ListPermission"/>
-    <suppress checks="NPathComplexity" files="com.hazelcast.security.permission.InstancePermission"/>
+              files="com/hazelcast/security/permission/ReplicatedMapPermission"/>
+    <suppress checks="BooleanExpressionComplexityCheck" files="com/hazelcast/security/permission/MapPermission"/>
+    <suppress checks="BooleanExpressionComplexityCheck" files="com/hazelcast/security/permission/ListPermission"/>
+    <suppress checks="NPathComplexity" files="com/hazelcast/security/permission/InstancePermission"/>
 
     <!-- Logging -->
-    <suppress checks="JavadocMethod" files="com.hazelcast.logging[\\/]"/>
-    <suppress checks="JavadocType" files="com.hazelcast.logging[\\/]"/>
-    <suppress checks="JavadocMethod" files="com.hazelcast.logging[\\/]"/>
-    <suppress checks="JavadocVariable" files="com.hazelcast.logging[\\/]"/>
-    <suppress checks="ReturnCount" files="com.hazelcast.logging.Slf4jFactory"/>
+    <suppress checks="JavadocMethod" files="com/hazelcast/logging/"/>
+    <suppress checks="JavadocType" files="com/hazelcast/logging/"/>
+    <suppress checks="JavadocMethod" files="com/hazelcast/logging/"/>
+    <suppress checks="JavadocVariable" files="com/hazelcast/logging/"/>
+    <suppress checks="ReturnCount" files="com/hazelcast/logging/Slf4jFactory"/>
 
     <!-- Partition -->
-    <suppress checks="JavadocMethod" files="com.hazelcast.partition[\\/]"/>
-    <suppress checks="JavadocType" files="com.hazelcast.partition[\\/]"/>
-    <suppress checks="JavadocMethod" files="com.hazelcast.partition[\\/]"/>
-    <suppress checks="JavadocVariable" files="com.hazelcast.partition[\\/]"/>
+    <suppress checks="JavadocMethod" files="com/hazelcast/partition/"/>
+    <suppress checks="JavadocType" files="com/hazelcast/partition/"/>
+    <suppress checks="JavadocMethod" files="com/hazelcast/partition/"/>
+    <suppress checks="JavadocVariable" files="com/hazelcast/partition/"/>
 
-    <suppress checks="JavadocMethod" files="com.hazelcast.partition.impl[\\/]"/>
-    <suppress checks="JavadocType" files="com.hazelcast.partition.impl[\\/]"/>
-    <suppress checks="JavadocMethod" files="com.hazelcast.partition.impl[\\/]"/>
-    <suppress checks="JavadocVariable" files="com.hazelcast.partition.impl[\\/]"/>
+    <suppress checks="JavadocMethod" files="com/hazelcast/partition/impl/"/>
+    <suppress checks="JavadocType" files="com/hazelcast/partition/impl/"/>
+    <suppress checks="JavadocMethod" files="com/hazelcast/partition/impl/"/>
+    <suppress checks="JavadocVariable" files="com/hazelcast/partition/impl/"/>
 
-    <suppress checks="MagicNumber" files="com.hazelcast.partition.impl.InternalPartitionServiceImpl"/>
-    <suppress checks="ClassFanOutComplexity" files="com.hazelcast.partition.impl.InternalPartitionServiceImpl"/>
-    <suppress checks="ClassDataAbstractionCoupling" files="com.hazelcast.partition.impl.InternalPartitionServiceImpl"/>
-    <suppress checks="FileLengthCheck" files="com.hazelcast.partition.impl.InternalPartitionServiceImpl"/>
-    <suppress checks="MethodCount" files="com.hazelcast.partition.InternalPartitionService"/>
-    <suppress checks="MethodCount" files="com.hazelcast.partition.impl.InternalPartitionServiceImpl"/>
-    <suppress checks="ExecutableStatementCount" files="com.hazelcast.partition.impl.InternalPartitionServiceImpl"/>
+    <suppress checks="MagicNumber" files="com/hazelcast/partition/impl/InternalPartitionServiceImpl"/>
+    <suppress checks="ClassFanOutComplexity" files="com/hazelcast/partition/impl/InternalPartitionServiceImpl"/>
+    <suppress checks="ClassDataAbstractionCoupling" files="com/hazelcast/partition/impl/InternalPartitionServiceImpl"/>
+    <suppress checks="FileLengthCheck" files="com/hazelcast/partition/impl/InternalPartitionServiceImpl"/>
+    <suppress checks="MethodCount" files="com/hazelcast/partition/InternalPartitionService"/>
+    <suppress checks="MethodCount" files="com/hazelcast/partition/impl/InternalPartitionServiceImpl"/>
+    <suppress checks="ExecutableStatementCount" files="com/hazelcast/partition/impl/InternalPartitionServiceImpl"/>
     <!-- one method left -->
-    <suppress checks="CyclomaticComplexity" files="com.hazelcast.partition.impl.PartitionStateGeneratorImpl"/>
-    <suppress checks="NPathComplexity" files="com.hazelcast.partition.impl.PartitionStateGeneratorImpl"/>
+    <suppress checks="CyclomaticComplexity" files="com/hazelcast/partition/impl/PartitionStateGeneratorImpl"/>
+    <suppress checks="NPathComplexity" files="com/hazelcast/partition/impl/PartitionStateGeneratorImpl"/>
 
     <!-- Topic -->
-    <suppress checks="JavadocMethod" files="com.hazelcast.topic.impl[\\/]"/>
-    <suppress checks="JavadocType" files="com.hazelcast.topic.impl[\\/]"/>
-    <suppress checks="JavadocMethod" files="com.hazelcast.topic.impl[\\/]"/>
-    <suppress checks="JavadocVariable" files="com.hazelcast.topic.impl[\\/]"/>
-    <suppress checks="VisibilityModifier" files="com.hazelcast.topic.impl.TopicEvent"/>
-    <suppress checks="" files="com.hazelcast.topic.DataAwareMessage"/>
-    <suppress checks="Todo" files="com.hazelcast.topic.impl.TopicEvent"/>
+    <suppress checks="JavadocMethod" files="com/hazelcast/topic/impl/"/>
+    <suppress checks="JavadocType" files="com/hazelcast/topic/impl/"/>
+    <suppress checks="JavadocMethod" files="com/hazelcast/topic/impl/"/>
+    <suppress checks="JavadocVariable" files="com/hazelcast/topic/impl/"/>
+    <suppress checks="VisibilityModifier" files="com/hazelcast/topic/impl/TopicEvent"/>
+    <suppress checks="" files="com/hazelcast/topic/DataAwareMessage"/>
+    <suppress checks="Todo" files="com/hazelcast/topic/impl/TopicEvent"/>
 
     <!-- Ascii-->
 
-    <suppress checks="JavadocMethod" files="com.hazelcast.internal.ascii[\\/]"/>
-    <suppress checks="JavadocType" files="com.hazelcast.internal.ascii[\\/]"/>
-    <suppress checks="JavadocMethod" files="com.hazelcast.internal.ascii[\\/]"/>
-    <suppress checks="JavadocVariable" files="com.hazelcast.internal.ascii[\\/]"/>
+    <suppress checks="JavadocMethod" files="com/hazelcast/internal/ascii/"/>
+    <suppress checks="JavadocType" files="com/hazelcast/internal/ascii/"/>
+    <suppress checks="JavadocMethod" files="com/hazelcast/internal/ascii/"/>
+    <suppress checks="JavadocVariable" files="com/hazelcast/internal/ascii/"/>
 
-    <suppress checks="ExecutableStatement" files="com.hazelcast.internal.ascii.TextCommandServiceImpl"/>
-    <suppress checks="ClassDataAbstractionCoupling" files="com.hazelcast.internal.ascii.TextCommandServiceImpl"/>
-    <suppress checks="MethodCount" files="com.hazelcast.internal.ascii.TextCommandServiceImpl"/>
-    <suppress checks="MagicNumber" files="com.hazelcast.internal.ascii.memcache.MemcacheCommandProcessor"/>
-    <suppress checks="MethodCount" files="com.hazelcast.internal.ascii.memcache.Stats"/>
+    <suppress checks="ExecutableStatement" files="com/hazelcast/internal/ascii/TextCommandServiceImpl"/>
+    <suppress checks="ClassDataAbstractionCoupling" files="com/hazelcast/internal/ascii/TextCommandServiceImpl"/>
+    <suppress checks="MethodCount" files="com/hazelcast/internal/ascii/TextCommandServiceImpl"/>
+    <suppress checks="MagicNumber" files="com/hazelcast/internal/ascii/memcache/MemcacheCommandProcessor"/>
+    <suppress checks="MethodCount" files="com/hazelcast/internal/ascii/memcache/Stats"/>
 
     <!-- Executor -->
-    <suppress checks="JavadocMethod" files="com.hazelcast.executor.impl[\\/]"/>
-    <suppress checks="JavadocType" files="com.hazelcast.executor.impl[\\/]"/>
-    <suppress checks="JavadocMethod" files="com.hazelcast.executor.impl[\\/]"/>
-    <suppress checks="JavadocVariable" files="com.hazelcast.executor.impl[\\/]"/>
-    <suppress checks="ClassFanOutComplexity|MethodCount" files="com.hazelcast.executor.impl.ExecutorServiceProxy"/>
+    <suppress checks="JavadocMethod" files="com/hazelcast/executor/impl/"/>
+    <suppress checks="JavadocType" files="com/hazelcast/executor/impl/"/>
+    <suppress checks="JavadocMethod" files="com/hazelcast/executor/impl/"/>
+    <suppress checks="JavadocVariable" files="com/hazelcast/executor/impl/"/>
+    <suppress checks="ClassFanOutComplexity|MethodCount" files="com/hazelcast/executor/impl/ExecutorServiceProxy"/>
 
     <!-- Ringbuffer -->
     <suppress checks="JavadocMethod|JavadocType|JavadocMethod|JavadocVariable|JavadocPackage"
-              files="com.hazelcast.ringbuffer.impl[\\/]"/>
+              files="com/hazelcast/ringbuffer/impl/"/>
 
     <!-- Collections -->
-    <suppress checks="JavadocMethod" files="com.hazelcast.collection.impl[\\/]"/>
-    <suppress checks="JavadocType" files="com.hazelcast.collection.impl[\\/]"/>
-    <suppress checks="JavadocMethod" files="com.hazelcast.collection.impl[\\/]"/>
-    <suppress checks="JavadocVariable" files="com.hazelcast.collection.impl[\\/]"/>
-    <suppress checks="JavadocPackage" files="com.hazelcast.collection.impl[\\/]"/>
+    <suppress checks="JavadocMethod" files="com/hazelcast/collection/impl/"/>
+    <suppress checks="JavadocType" files="com/hazelcast/collection/impl/"/>
+    <suppress checks="JavadocMethod" files="com/hazelcast/collection/impl/"/>
+    <suppress checks="JavadocVariable" files="com/hazelcast/collection/impl/"/>
+    <suppress checks="JavadocPackage" files="com/hazelcast/collection/impl/"/>
 
-    <suppress checks="MethodCount" files="com.hazelcast.collection.impl.collection.CollectionContainer"/>
+    <suppress checks="MethodCount" files="com/hazelcast/collection/impl/collection/CollectionContainer"/>
 
     <!-- List -->
-    <suppress checks="JavadocMethod" files="com.hazelcast.collection.impl.list[\\/]"/>
-    <suppress checks="JavadocType" files="com.hazelcast.collection.impl.list[\\/]"/>
-    <suppress checks="JavadocMethod" files="com.hazelcast.collection.impl.list[\\/]"/>
-    <suppress checks="JavadocVariable" files="com.hazelcast.collection.impl.list[\\/]"/>
+    <suppress checks="JavadocMethod" files="com/hazelcast/collection/impl/list/"/>
+    <suppress checks="JavadocType" files="com/hazelcast/collection/impl/list/"/>
+    <suppress checks="JavadocMethod" files="com/hazelcast/collection/impl/list/"/>
+    <suppress checks="JavadocVariable" files="com/hazelcast/collection/impl/list/"/>
 
-    <!--<suppress checks="" files="com.hazelcast.queue.DataAwareItemEvent"/>-->
-    <suppress checks="MethodCount" files="com.hazelcast.collection.impl.queue.QueueContainer"/>
+    <!--<suppress checks="" files="com/hazelcast/queue/DataAwareItemEvent"/>-->
+    <suppress checks="MethodCount" files="com/hazelcast/collection/impl/queue/QueueContainer"/>
 
 
     <!-- Multimap -->
-    <suppress checks="JavadocMethod" files="com.hazelcast.multimap[\\/]"/>
-    <suppress checks="JavadocType" files="com.hazelcast.multimap[\\/]"/>
-    <suppress checks="JavadocMethod" files="com.hazelcast.multimap[\\/]"/>
-    <suppress checks="JavadocVariable" files="com.hazelcast.multimap[\\/]"/>
-    <suppress checks="ReturnCount" files="com.hazelcast.multimap.impl.operations.MultiMapOperationFactory"/>
+    <suppress checks="JavadocMethod" files="com/hazelcast/multimap/"/>
+    <suppress checks="JavadocType" files="com/hazelcast/multimap/"/>
+    <suppress checks="JavadocMethod" files="com/hazelcast/multimap/"/>
+    <suppress checks="JavadocVariable" files="com/hazelcast/multimap/"/>
+    <suppress checks="ReturnCount" files="com/hazelcast/multimap/impl/operations/MultiMapOperationFactory"/>
     <!-- todo: needs to be fixed -->
     <suppress checks="CyclomaticComplexity|MethodCount|ClassFanOutComplexity"
-              files="com.hazelcast.multimap.impl.MultiMapService"/>
-    <suppress checks="MethodCount" files="com.hazelcast.multimap.impl.MultiMapService"/>
+              files="com/hazelcast/multimap/impl/MultiMapService"/>
+    <suppress checks="MethodCount" files="com/hazelcast/multimap/impl/MultiMapService"/>
 
     <!-- Util -->
     <!-- /*
          * Written by Doug Lea with assistance from members of JCP JSR-166
          * Expert Group and released to the public domain, as explained at
-         * http://creativecommons.org/licenses/publicdomain
+         * http://creativecommons/org/licenses/publicdomain
 
-       I don't think we want to change this class.
+       I don't think we want to change this class/
    -->
-    <suppress checks="" files="com.hazelcast.util.ConcurrentReferenceHashMap"/>
+    <suppress checks="" files="com/hazelcast/util/ConcurrentReferenceHashMap"/>
 
-    <suppress checks="" files="com.hazelcast.util.DebugUtil"/>
+    <suppress checks="" files="com/hazelcast/util/DebugUtil"/>
 
     <!-- Too complex to change, I am leaving it to implementer -->
-    <suppress checks="" files="com.hazelcast.util.Base64"/>
+    <suppress checks="" files="com/hazelcast/util/Base64"/>
 
-    <suppress checks="" files="com.hazelcast.util.DebugUtil"/>
+    <suppress checks="" files="com/hazelcast/util/DebugUtil"/>
 
-    <suppress checks="IllegalImport" files="com.hazelcast.util.counters.SwCounter"/>
-    <suppress checks="InnerAssignment" files="com.hazelcast.util.counters.SwCounter"/>
+    <suppress checks="IllegalImport" files="com/hazelcast/util/counters/SwCounter"/>
+    <suppress checks="InnerAssignment" files="com/hazelcast/util/counters/SwCounter"/>
 
-    <suppress checks="" files="com.hazelcast.util.HashUtil"/>
-    <suppress checks="MagicNumber" files="com.hazelcast.util.QuickMath"/>
-    <suppress checks="MagicNumber" files="com.hazelcast.nio.Bits"/>
-    <suppress checks="MethodCount" files="com.hazelcast.nio.Bits"/>
+    <suppress checks="" files="com/hazelcast/util/HashUtil"/>
+    <suppress checks="MagicNumber" files="com/hazelcast/util/QuickMath"/>
+    <suppress checks="MagicNumber" files="com/hazelcast/nio/Bits"/>
+    <suppress checks="MethodCount" files="com/hazelcast/nio/Bits"/>
 
     <!-- Util executor package javadocs, leaving javadocs to someone who can explain better -->
-    <suppress checks="JavadocMethod" files="com.hazelcast.util.executor[\\/]"/>
-    <suppress checks="JavadocType" files="com.hazelcast.util.executor[\\/]"/>
-    <suppress checks="JavadocMethod" files="com.hazelcast.util.executor[\\/]"/>
-    <suppress checks="JavadocVariable" files="com.hazelcast.util.executor[\\/]"/>
-    <suppress checks="JavadocType" files="com.hazelcast.util.scheduler.SecondsBasedEntryTaskScheduler"/>
-    <suppress checks="" files="com.hazelcast.util.scheduler.ScheduleType"/>
+    <suppress checks="JavadocMethod" files="com/hazelcast/util/executor/"/>
+    <suppress checks="JavadocType" files="com/hazelcast/util/executor/"/>
+    <suppress checks="JavadocMethod" files="com/hazelcast/util/executor/"/>
+    <suppress checks="JavadocVariable" files="com/hazelcast/util/executor/"/>
+    <suppress checks="JavadocType" files="com/hazelcast/util/scheduler/SecondsBasedEntryTaskScheduler"/>
+    <suppress checks="" files="com/hazelcast/util/scheduler/ScheduleType"/>
 
     <!-- ReplicatedMap -->
-    <suppress checks="ClassDataAbstractionCouplingC" files="com.hazelcast.client.proxy.ClientReplicatedMapProxy"/>
-    <suppress checks="MethodCountCheck" files="com.hazelcast.monitor.impl.LocalReplicatedMapStatsImpl"/>
+    <suppress checks="ClassDataAbstractionCouplingC" files="com/hazelcast/client/proxy/ClientReplicatedMapProxy"/>
+    <suppress checks="MethodCountCheck" files="com/hazelcast/monitor/impl/LocalReplicatedMapStatsImpl"/>
 
     <!-- Aggregations -->
-    <suppress checks="ClassDataAbstractionCouplingC" files="com.hazelcast.mapreduce.aggregation.Aggregations"/>
+    <suppress checks="ClassDataAbstractionCouplingC" files="com/hazelcast/mapreduce/aggregation/Aggregations"/>
 
     <!-- NIO -->
-    <suppress checks="JavadocMethod" files="com.hazelcast.nio[\\/]"/>
-    <suppress checks="JavadocType" files="com.hazelcast.nio[\\/]"/>
-    <suppress checks="JavadocVariable" files="com.hazelcast.nio[\\/]"/>
-    <suppress checks="ExecutableStatementCount|ClassDataAbstractionCoupling|ClassFanOutComplexity" files="com.hazelcast.nio.tcp.TcpIpConnectionManager"/>
+    <suppress checks="JavadocMethod" files="com/hazelcast/nio/"/>
+    <suppress checks="JavadocType" files="com/hazelcast/nio/"/>
+    <suppress checks="JavadocVariable" files="com/hazelcast/nio/"/>
+    <suppress checks="ExecutableStatementCount|ClassDataAbstractionCoupling|ClassFanOutComplexity"
+              files="com/hazelcast/nio/tcp/TcpIpConnectionManager"/>
 
-    <suppress checks="MethodCount|MagicNumber" files="com.hazelcast.nio.serialization.impl.ByteArrayObjectDataInput"/>
-    <suppress checks="MethodCount|MagicNumber" files="com.hazelcast.nio.serialization.impl.ByteArrayObjectDataOutput"/>
-    <suppress checks="MethodCount|MagicNumber" files="com.hazelcast.nio.serialization.impl.ByteBufferObjectDataInput"/>
-    <suppress checks="MethodCount" files="com.hazelcast.nio.serialization.ObjectDataInputStream"/>
+    <suppress checks="MethodCount|MagicNumber" files="com/hazelcast/nio/serialization/impl/ByteArrayObjectDataInput"/>
+    <suppress checks="MethodCount|MagicNumber" files="com/hazelcast/nio/serialization/impl/ByteArrayObjectDataOutput"/>
+    <suppress checks="MethodCount|MagicNumber" files="com/hazelcast/nio/serialization/impl/ByteBufferObjectDataInput"/>
+    <suppress checks="MethodCount" files="com/hazelcast/nio/serialization/ObjectDataInputStream"/>
 
-    <suppress checks="MethodCount" files="com.hazelcast.nio.serialization.impl.ByteBufferObjectDataOutput"/>
-    <suppress checks="MagicNumber" files="com.hazelcast.nio.CipherHelper"/>
-    <suppress checks="MagicNumber|NPathComplexity" files="com.hazelcast.nio.ClassLoaderUtil"/>
-    <suppress checks="MagicNumber" files="com.hazelcast.nio.serialization.impl.DefaultPortableReader"/>
-    <suppress checks="MagicNumber" files="com.hazelcast.nio.serialization.impl.DefaultPortableWriter"/>
-    <suppress checks="MethodCount|MagicNumber" files="com.hazelcast.nio.DynamicByteBuffer"/>
-    <suppress checks="MethodCount" files="com.hazelcast.nio.IOService"/>
-    <suppress checks="MagicNumber|ReturnCount" files="com.hazelcast.nio.IOUtil"/>
-    <suppress checks="ReturnCount" files="com.hazelcast.nio.serialization.impl.MorphingPortableReader"/>
-    <suppress checks="MethodCount" files="com.hazelcast.nio.NodeIOService"/>
-    <suppress checks="MagicNumber|ReturnCount|MethodCount|NPathComplexity" files="com.hazelcast.nio.Packet"/>
-    <suppress checks="NPathComplexity" files="com.hazelcast.nio.tcp.ReadHandler"/>
+    <suppress checks="MethodCount" files="com/hazelcast/nio/serialization/impl/ByteBufferObjectDataOutput"/>
+    <suppress checks="MagicNumber" files="com/hazelcast/nio/CipherHelper"/>
+    <suppress checks="MagicNumber|NPathComplexity" files="com/hazelcast/nio/ClassLoaderUtil"/>
+    <suppress checks="MagicNumber" files="com/hazelcast/nio/serialization/impl/DefaultPortableReader"/>
+    <suppress checks="MagicNumber" files="com/hazelcast/nio/serialization/impl/DefaultPortableWriter"/>
+    <suppress checks="MethodCount|MagicNumber" files="com/hazelcast/nio/DynamicByteBuffer"/>
+    <suppress checks="MethodCount" files="com/hazelcast/nio/IOService"/>
+    <suppress checks="MagicNumber|ReturnCount" files="com/hazelcast/nio/IOUtil"/>
+    <suppress checks="ReturnCount" files="com/hazelcast/nio/serialization/impl/MorphingPortableReader"/>
+    <suppress checks="MethodCount" files="com/hazelcast/nio/NodeIOService"/>
+    <suppress checks="MagicNumber|ReturnCount|MethodCount|NPathComplexity" files="com/hazelcast/nio/Packet"/>
+    <suppress checks="NPathComplexity" files="com/hazelcast/nio/tcp/ReadHandler"/>
     <suppress checks="ClassFanOutComplexity|ClassDataAbstractionCoupling|MethodCount|ParameterNumber"
-              files="com.hazelcast.nio.serialization.impl.SerializationServiceImpl"/>
-    <suppress checks="MethodCount" files="com.hazelcast.nio.tcp.TcpIpConnectionManager"/>
-    <suppress checks="ExecutableStatement" files="com.hazelcast.nio.UnsafeHelper"/>
-    <suppress checks="MagicNumber" files="com.hazelcast.nio.UnsafeHelper"/>
-    <suppress checks="IllegalImport" files="com.hazelcast.nio.UnsafeHelper"/>
-    <suppress checks="MagicNumber" files="com.hazelcast.nio.serialization.impl.UnsafeObjectDataInput"/>
-    <suppress checks="MagicNumber" files="com.hazelcast.nio.serialization.impl.UnsafeObjectDataOutput"/>
-    <suppress checks="MagicNumber|EmptyBlock" files="com.hazelcast.nio.tcp.WriteHandler"/>
-    <suppress checks="MagicNumber" files="com.hazelcast.nio.UTFEncoderDecoder"/>
+              files="com/hazelcast/nio/serialization/impl/SerializationServiceImpl"/>
+    <suppress checks="MethodCount" files="com/hazelcast/nio/tcp/TcpIpConnectionManager"/>
+    <suppress checks="ExecutableStatement" files="com/hazelcast/nio/UnsafeHelper"/>
+    <suppress checks="MagicNumber" files="com/hazelcast/nio/UnsafeHelper"/>
+    <suppress checks="IllegalImport" files="com/hazelcast/nio/UnsafeHelper"/>
+    <suppress checks="MagicNumber" files="com/hazelcast/nio/serialization/impl/UnsafeObjectDataInput"/>
+    <suppress checks="MagicNumber" files="com/hazelcast/nio/serialization/impl/UnsafeObjectDataOutput"/>
+    <suppress checks="MagicNumber|EmptyBlock" files="com/hazelcast/nio/tcp/WriteHandler"/>
+    <suppress checks="MagicNumber" files="com/hazelcast/nio/UTFEncoderDecoder"/>
 
     <!-- Jmx-->
-    <suppress checks="CyclomaticComplexity" files="com.hazelcast.jmx.ManagementService"/>
-    <!-- Since IMap interface has a lot of methods... -->
-    <suppress checks="MethodCount" files="com.hazelcast.jmx.MapMBean"/>
-    <suppress checks="MethodCount" files="com.hazelcast.jmx.ReplicatedMapMBean"/>
+    <suppress checks="CyclomaticComplexity" files="com/hazelcast/jmx/ManagementService"/>
+    <!-- Since IMap interface has a lot of methods/// -->
+    <suppress checks="MethodCount" files="com/hazelcast/jmx/MapMBean"/>
+    <suppress checks="MethodCount" files="com/hazelcast/jmx/ReplicatedMapMBean"/>
 
     <!-- Aws-->
-    <suppress checks="JavadocMethod" files="com.hazelcast.aws[\\/]"/>
-    <suppress checks="JavadocType" files="com.hazelcast.aws[\\/]"/>
-    <suppress checks="JavadocMethod" files="com.hazelcast.aws[\\/]"/>
-    <suppress checks="JavadocVariable" files="com.hazelcast.aws[\\/]"/>
-    <suppress checks="HideUtilityClassConstructor" files="com.hazelcast.aws.impl.Constants"/>
+    <suppress checks="JavadocMethod" files="com/hazelcast/aws/"/>
+    <suppress checks="JavadocType" files="com/hazelcast/aws/"/>
+    <suppress checks="JavadocMethod" files="com/hazelcast/aws/"/>
+    <suppress checks="JavadocVariable" files="com/hazelcast/aws/"/>
+    <suppress checks="HideUtilityClassConstructor" files="com/hazelcast/aws/impl/Constants"/>
 
     <!-- Hibernate-->
-    <suppress checks="IllegalImport" files="com.hazelcast.hibernate.serialization.Hibernate3CacheEntrySerializer"/>
-    <suppress checks="IllegalImport" files="com.hazelcast.hibernate.serialization.Hibernate41CacheEntrySerializer"/>
-    <suppress checks="IllegalImport" files="com.hazelcast.hibernate.serialization.Hibernate3CacheKeySerializer"/>
-    <suppress checks="IllegalImport" files="com.hazelcast.hibernate.serialization.Hibernate4CacheKeySerializer"/>
+    <suppress checks="IllegalImport" files="com/hazelcast/hibernate/serialization/Hibernate3CacheEntrySerializer"/>
+    <suppress checks="IllegalImport" files="com/hazelcast/hibernate/serialization/Hibernate41CacheEntrySerializer"/>
+    <suppress checks="IllegalImport" files="com/hazelcast/hibernate/serialization/Hibernate3CacheKeySerializer"/>
+    <suppress checks="IllegalImport" files="com/hazelcast/hibernate/serialization/Hibernate4CacheKeySerializer"/>
 
     <!-- Spring-->
-    <suppress checks="MethodCount" files="com.hazelcast.spring.HazelcastConfigBeanDefinitionParser"/>
-    <suppress checks="MethodLength" files="com.hazelcast.spring.HazelcastConfigBeanDefinitionParser"/>
-    <suppress checks="CyclomaticComplexity|NPathComplexity" files="com.hazelcast.spring.HazelcastConfigBeanDefinitionParser"/>
+    <suppress checks="MethodCount" files="com/hazelcast/spring/HazelcastConfigBeanDefinitionParser"/>
+    <suppress checks="MethodLength" files="com/hazelcast/spring/HazelcastConfigBeanDefinitionParser"/>
+    <suppress checks="CyclomaticComplexity|NPathComplexity" files="com/hazelcast/spring/HazelcastConfigBeanDefinitionParser"/>
 
     <!-- Spring Framework breaks the rule IllegalTypeCheck in its own implementation -->
-    <suppress checks="IllegalType" files="com.hazelcast.spring.HazelcastClientBeanDefinitionParser"/>
-    <suppress checks="IllegalType" files="com.hazelcast.spring.HazelcastInstanceDefinitionParser"/>
-    <suppress checks="IllegalType" files="com.hazelcast.spring.HazelcastConfigBeanDefinitionParser"/>
-    <suppress checks="IllegalType" files="com.hazelcast.spring.HazelcastTypeBeanDefinitionParser"/>
-    <suppress checks="IllegalType" files="com.hazelcast.spring.hibernate.RegionFactoryBeanDefinitionParser"/>
+    <suppress checks="IllegalType" files="com/hazelcast/spring/HazelcastClientBeanDefinitionParser"/>
+    <suppress checks="IllegalType" files="com/hazelcast/spring/HazelcastInstanceDefinitionParser"/>
+    <suppress checks="IllegalType" files="com/hazelcast/spring/HazelcastConfigBeanDefinitionParser"/>
+    <suppress checks="IllegalType" files="com/hazelcast/spring/HazelcastTypeBeanDefinitionParser"/>
+    <suppress checks="IllegalType" files="com/hazelcast/spring/hibernate/RegionFactoryBeanDefinitionParser"/>
 
     <!-- Management -->
-    <suppress checks="ClassDataAbstractionCoupling" files="com.hazelcast.internal.management.ManagementCenterService"/>
-    <suppress checks="ClassFanOutComplexityCheck" files="com.hazelcast.internal.management.TimedMemberStateFactory"/>
-    <suppress checks="JavadocVariable" files="com.hazelcast.internal.management.request.ConsoleRequestConstants"/>
-    <suppress checks="JavadocVariable|VisibilityModifier" files="com.hazelcast.internal.management.dto.*"/>
+    <suppress checks="ClassDataAbstractionCoupling" files="com/hazelcast/internal/management/ManagementCenterService"/>
+    <suppress checks="ClassFanOutComplexityCheck" files="com/hazelcast/internal/management/TimedMemberStateFactory"/>
+    <suppress checks="JavadocVariable" files="com/hazelcast/internal/management/request/ConsoleRequestConstants"/>
+    <suppress checks="JavadocVariable|VisibilityModifier" files="com/hazelcast/internal/management/dto/\w*"/>
 
     <!-- Agrona backport -->
     <suppress checks="MagicNumber|Header" files="com/hazelcast/util/collection/" />
-    <suppress checks="JavadocType" files="com/hazelcast/util/collection/.*2ObjectHashMap" />
-    <suppress checks="MethodCount" files="com/hazelcast/util/collection/.*HashSet" />
+    <suppress checks="JavadocType" files="com/hazelcast/util/collection/\w*2ObjectHashMap" />
+    <suppress checks="MethodCount" files="com/hazelcast/util/collection/\w*HashSet" />
 
     <!-- Map -->
-    <suppress checks="JavadocMethod" files="com.hazelcast.map[\\/]"/>
-    <suppress checks="JavadocType" files="com.hazelcast.map[\\/]"/>
-    <suppress checks="JavadocMethod" files="com.hazelcast.map[\\/]"/>
-    <suppress checks="JavadocVariable" files="com.hazelcast.map[\\/]"/>
+    <suppress checks="JavadocMethod" files="com/hazelcast/map/"/>
+    <suppress checks="JavadocType" files="com/hazelcast/map/"/>
+    <suppress checks="JavadocMethod" files="com/hazelcast/map/"/>
+    <suppress checks="JavadocVariable" files="com/hazelcast/map/"/>
 
-    <suppress checks="MethodCountCheck" files="com.hazelcast.map.impl.RecordStore"/>
-    <suppress checks="MethodCountCheck" files="com.hazelcast.map.impl.DefaultRecordStore"/>
-    <suppress checks="MethodCountCheck" files="com.hazelcast.map.impl.proxy.MapProxyImpl"/>
-    <suppress checks="MethodCountCheck" files="com.hazelcast.map.impl.proxy.MapProxySupport"/>
-    <suppress checks="ClassFanOutComplexityCheck" files="com.hazelcast.map.impl.proxy.MapProxySupport"/>
-    <suppress checks="ClassDataAbstractionCoupling" files="com.hazelcast.map.impl.proxy.MapProxySupport"/>
-    <suppress checks="CyclomaticComplexity" files="com.hazelcast.map.impl.client.AbstractTxnMapRequest"/>
-    <suppress checks="MethodCount|ClassDataAbstractionCoupling" files="com.hazelcast.map.impl.MapServiceContextImpl"/>
-    <suppress checks="MethodCount" files="com.hazelcast.map.impl.MapServiceContext"/>
+    <suppress checks="MethodCountCheck" files="com/hazelcast/map/impl/RecordStore"/>
+    <suppress checks="MethodCountCheck" files="com/hazelcast/map/impl/DefaultRecordStore"/>
+    <suppress checks="MethodCountCheck" files="com/hazelcast/map/impl/proxy/MapProxyImpl"/>
+    <suppress checks="MethodCountCheck" files="com/hazelcast/map/impl/proxy/MapProxySupport"/>
+    <suppress checks="ClassFanOutComplexityCheck" files="com/hazelcast/map/impl/proxy/MapProxySupport"/>
+    <suppress checks="ClassDataAbstractionCoupling" files="com/hazelcast/map/impl/proxy/MapProxySupport"/>
+    <suppress checks="CyclomaticComplexity" files="com/hazelcast/map/impl/client/AbstractTxnMapRequest"/>
+    <suppress checks="MethodCount|ClassDataAbstractionCoupling" files="com/hazelcast/map/impl/MapServiceContextImpl"/>
+    <suppress checks="MethodCount" files="com/hazelcast/map/impl/MapServiceContext"/>
 
-    <!-- map.proxy-->
-    <!--<suppress checks="" files="com.hazelcast.map.impl.proxy[\\/]"/>-->
-    <suppress checks="ClassDataAbstractionCoupling" files="com.hazelcast.map.impl.tx.TransactionalMapProxySupport"/>
+    <!-- map/proxy-->
+    <!--<suppress checks="" files="com/hazelcast/map/impl/proxy/"/>-->
+    <suppress checks="ClassDataAbstractionCoupling" files="com/hazelcast/map/impl/tx/TransactionalMapProxySupport"/>
 
     <!-- build utils -->
     <!-- Taken from JBOSS project, suppress checkstyles -->
-    <suppress checks="" files="com.hazelcast.buildutils.ElementParser"/>
+    <suppress checks="" files="com/hazelcast/buildutils/ElementParser"/>
 
 </suppressions>
 


### PR DESCRIPTION
Our suppressions.xml contained a lot of `<suppress files="..." />` attributes which variably assumed they were java class names, platform-dependent pathnames, and pathname regexes. This PR turns them into the one thing they actually are, which is Java pathname regexes. 