### PR TITLE
Cache entry event improvements

### DIFF
--- a/hazelcast-client-new/src/test/java/com/hazelcast/client/cache/ClientCacheContextTest.java
+++ b/hazelcast-client-new/src/test/java/com/hazelcast/client/cache/ClientCacheContextTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.cache;
+
+import com.hazelcast.cache.CacheContextTest;
+import com.hazelcast.client.HazelcastClient;
+import com.hazelcast.client.cache.impl.HazelcastClientCachingProvider;
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.config.Config;
+import com.hazelcast.config.JoinConfig;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import javax.cache.spi.CachingProvider;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class ClientCacheContextTest extends CacheContextTest {
+
+    @Override
+    protected CachingProvider initAndGetCachingProvider() {
+        Config config = new Config();
+        JoinConfig joinConfig = config.getNetworkConfig().getJoin();
+        joinConfig.getAwsConfig().setEnabled(false);
+        joinConfig.getMulticastConfig().setEnabled(false);
+        joinConfig.getTcpIpConfig().setEnabled(true).addMember("127.0.0.1");
+
+        hazelcastInstance1 = Hazelcast.newHazelcastInstance(config);
+        hazelcastInstance2 = Hazelcast.newHazelcastInstance(config);
+
+        ClientConfig clientConfig = new ClientConfig();
+        clientConfig.getNetworkConfig().addAddress("127.0.0.1");
+
+        driverInstance = HazelcastClient.newHazelcastClient(clientConfig);
+
+        return HazelcastClientCachingProvider.createCachingProvider(driverInstance);
+    }
+
+    @After
+    public void tearDown() {
+        driverInstance.shutdown();
+        hazelcastInstance1.shutdown();
+        hazelcastInstance2.shutdown();
+    }
+
+    @Test
+    public void cacheEntryListenerCountIncreasedAfterRegisterAndDecreasedAfterDeregister() {
+        cacheEntryListenerCountIncreasedAndDecreasedCorrectly(DecreaseType.DEREGISTER);
+    }
+
+    @Test
+    public void cacheEntryListenerCountIncreasedAfterRegisterAndDecreasedAfterShutdown() {
+        cacheEntryListenerCountIncreasedAndDecreasedCorrectly(DecreaseType.SHUTDOWN);
+    }
+
+    @Test
+    public void cacheEntryListenerCountIncreasedAfterRegisterAndDecreasedAfterTerminate() {
+        cacheEntryListenerCountIncreasedAndDecreasedCorrectly(DecreaseType.TERMINATE);
+    }
+
+}

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/ClientCacheContextTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/ClientCacheContextTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.cache;
+
+import com.hazelcast.cache.CacheContextTest;
+import com.hazelcast.client.HazelcastClient;
+import com.hazelcast.client.cache.impl.HazelcastClientCachingProvider;
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.config.Config;
+import com.hazelcast.config.JoinConfig;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import javax.cache.spi.CachingProvider;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class ClientCacheContextTest extends CacheContextTest {
+
+    @Override
+    protected CachingProvider initAndGetCachingProvider() {
+        Config config = new Config();
+        JoinConfig joinConfig = config.getNetworkConfig().getJoin();
+        joinConfig.getAwsConfig().setEnabled(false);
+        joinConfig.getMulticastConfig().setEnabled(false);
+        joinConfig.getTcpIpConfig().setEnabled(true).addMember("127.0.0.1");
+
+        hazelcastInstance1 = Hazelcast.newHazelcastInstance(config);
+        hazelcastInstance2 = Hazelcast.newHazelcastInstance(config);
+
+        ClientConfig clientConfig = new ClientConfig();
+        clientConfig.getNetworkConfig().addAddress("127.0.0.1");
+
+        driverInstance = HazelcastClient.newHazelcastClient(clientConfig);
+
+        return HazelcastClientCachingProvider.createCachingProvider(driverInstance);
+    }
+
+    @After
+    public void tearDown() {
+        driverInstance.shutdown();
+        hazelcastInstance1.shutdown();
+        hazelcastInstance2.shutdown();
+    }
+
+    @Test
+    public void cacheEntryListenerCountIncreasedAfterRegisterAndDecreasedAfterDeregister() {
+        cacheEntryListenerCountIncreasedAndDecreasedCorrectly(DecreaseType.DEREGISTER);
+    }
+
+    @Test
+    public void cacheEntryListenerCountIncreasedAfterRegisterAndDecreasedAfterShutdown() {
+        cacheEntryListenerCountIncreasedAndDecreasedCorrectly(DecreaseType.SHUTDOWN);
+    }
+
+    @Test
+    public void cacheEntryListenerCountIncreasedAfterRegisterAndDecreasedAfterTerminate() {
+        cacheEntryListenerCountIncreasedAndDecreasedCorrectly(DecreaseType.TERMINATE);
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheService.java
@@ -17,7 +17,6 @@
 package com.hazelcast.cache.impl;
 
 import com.hazelcast.cache.impl.operation.CacheDestroyOperation;
-import com.hazelcast.cache.impl.operation.CacheGetConfigOperation;
 import com.hazelcast.cache.impl.operation.PostJoinCacheOperation;
 import com.hazelcast.config.CacheConfig;
 import com.hazelcast.config.CacheSimpleConfig;
@@ -27,9 +26,9 @@ import com.hazelcast.instance.MemberImpl;
 import com.hazelcast.nio.IOUtil;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.partition.MigrationEndpoint;
+import com.hazelcast.spi.EventFilter;
 import com.hazelcast.spi.EventRegistration;
 import com.hazelcast.spi.EventService;
-import com.hazelcast.spi.InternalCompletableFuture;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.OperationService;
@@ -39,6 +38,7 @@ import com.hazelcast.util.ConcurrencyUtil;
 import com.hazelcast.util.ConstructorFunction;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
+import javax.cache.configuration.CacheEntryListenerConfiguration;
 import javax.cache.event.CacheEntryListener;
 import java.io.Closeable;
 import java.util.Collection;
@@ -53,11 +53,19 @@ public abstract class AbstractCacheService
         implements ICacheService, PostJoinAwareService {
 
     protected final ConcurrentMap<String, CacheConfig> configs = new ConcurrentHashMap<String, CacheConfig>();
+    protected final ConcurrentMap<String, CacheContext> cacheContexts = new ConcurrentHashMap<String, CacheContext>();
     protected final ConcurrentMap<String, CacheStatisticsImpl> statistics = new ConcurrentHashMap<String, CacheStatisticsImpl>();
     protected final ConcurrentMap<String, Set<Closeable>> resources = new ConcurrentHashMap<String, Set<Closeable>>();
     protected final ConcurrentMap<String, Closeable> closeableListeners = new ConcurrentHashMap<String, Closeable>();
     protected final ConcurrentMap<String, CacheOperationProvider> operationProviderCache =
             new ConcurrentHashMap<String, CacheOperationProvider>();
+    protected final ConstructorFunction<String, CacheContext> cacheContexesConstructorFunction =
+            new ConstructorFunction<String, CacheContext>() {
+                @Override
+                public CacheContext createNew(String name) {
+                    return new CacheContext();
+                }
+            };
     protected final ConstructorFunction<String, CacheStatisticsImpl> cacheStatisticsConstructorFunction =
             new ConstructorFunction<String, CacheStatisticsImpl>() {
                 @Override
@@ -131,37 +139,38 @@ public abstract class AbstractCacheService
         return segments[partitionId];
     }
 
-    protected void destroySegments(String objectName) {
+    protected void destroySegments(String name) {
         for (CachePartitionSegment segment : segments) {
-            segment.deleteCache(objectName);
+            segment.deleteCache(name);
         }
     }
 
     @Override
-    public void destroyCache(String objectName, boolean isLocal, String callerUuid) {
-        CacheConfig config = deleteCacheConfig(objectName);
-        destroySegments(objectName);
+    public void destroyCache(String name, boolean isLocal, String callerUuid) {
+        CacheConfig config = deleteCacheConfig(name);
+        destroySegments(name);
 
         if (!isLocal) {
-            deregisterAllListener(objectName);
+            deregisterAllListener(name);
+            cacheContexts.remove(name);
         }
-        operationProviderCache.remove(objectName);
-        setStatisticsEnabled(config, objectName, false);
-        setManagementEnabled(config, objectName, false);
-        deleteCacheConfig(objectName);
-        deleteCacheStat(objectName);
-        deleteCacheResources(objectName);
+        operationProviderCache.remove(name);
+        setStatisticsEnabled(config, name, false);
+        setManagementEnabled(config, name, false);
+        deleteCacheConfig(name);
+        deleteCacheStat(name);
+        deleteCacheResources(name);
         if (!isLocal) {
-            destroyCacheOnAllMembers(objectName, callerUuid);
+            destroyCacheOnAllMembers(name, callerUuid);
         }
     }
 
-    protected void destroyCacheOnAllMembers(String objectName, String callerUuid) {
+    protected void destroyCacheOnAllMembers(String name, String callerUuid) {
         final OperationService operationService = nodeEngine.getOperationService();
         final Collection<MemberImpl> members = nodeEngine.getClusterService().getMemberList();
         for (MemberImpl member : members) {
             if (!member.localMember() && !member.getUuid().equals(callerUuid)) {
-                final CacheDestroyOperation op = new CacheDestroyOperation(objectName, true);
+                final CacheDestroyOperation op = new CacheDestroyOperation(name, true);
                 operationService.invokeOnTarget(AbstractCacheService.SERVICE_NAME, op, member.getAddress());
             }
         }
@@ -189,6 +198,14 @@ public abstract class AbstractCacheService
     @Override
     public CacheStatisticsImpl createCacheStatIfAbsent(String name) {
         return ConcurrencyUtil.getOrPutIfAbsent(statistics, name, cacheStatisticsConstructorFunction);
+    }
+
+    public CacheContext getCacheContext(String name) {
+        return cacheContexts.get(name);
+    }
+
+    public CacheContext getOrCreateCacheContext(String name) {
+        return ConcurrencyUtil.getOrPutIfAbsent(cacheContexts, name, cacheContexesConstructorFunction);
     }
 
     @Override
@@ -242,16 +259,6 @@ public abstract class AbstractCacheService
         return nodeEngine.getConfig().findCacheConfig(simpleName);
     }
 
-    protected <K, V> CacheConfig<K, V> getCacheConfigFromPartition(String cacheNameWithPrefix, String cacheName) {
-        //remote check
-        final CacheGetConfigOperation op = new CacheGetConfigOperation(cacheNameWithPrefix, cacheName);
-        int partitionId = nodeEngine.getPartitionService().getPartitionId(cacheNameWithPrefix);
-        final InternalCompletableFuture<CacheConfig> f =
-                nodeEngine.getOperationService()
-                    .invokeOnPartition(CacheService.SERVICE_NAME, op, partitionId);
-        return f.getSafely();
-    }
-
     public Collection<CacheConfig> getCacheConfigs() {
         return configs.values();
     }
@@ -296,7 +303,7 @@ public abstract class AbstractCacheService
             case EXPIRED:
                 final CacheEventData cacheEventData =
                         new CacheEventDataImpl(cacheName, eventType, cacheEventContext.getDataKey(),
-                                cacheEventContext.getDataValue(), cacheEventContext.getDataOldValue(),
+                                               cacheEventContext.getDataValue(), cacheEventContext.getDataOldValue(),
                                                cacheEventContext.isOldValueAvailable());
                 CacheEventSet eventSet = new CacheEventSet(eventType, cacheEventContext.getCompletionId());
                 eventSet.addEventData(cacheEventData);
@@ -304,16 +311,16 @@ public abstract class AbstractCacheService
                 break;
             case EVICTED:
                 eventData = new CacheEventDataImpl(cacheName, CacheEventType.EVICTED,
-                        cacheEventContext.getDataKey(), null, null, false);
+                                                   cacheEventContext.getDataKey(), null, null, false);
                 break;
             case INVALIDATED:
                 eventData = new CacheEventDataImpl(cacheName, CacheEventType.INVALIDATED,
-                        cacheEventContext.getDataKey(), null, null, false);
+                                                   cacheEventContext.getDataKey(), null, null, false);
                 break;
             case COMPLETED:
                 CacheEventData completedEventData =
-                        new CacheEventDataImpl(cacheName, CacheEventType.COMPLETED,
-                                cacheEventContext.getDataKey(), cacheEventContext.getDataValue(), null, false);
+                        new CacheEventDataImpl(cacheName, CacheEventType.COMPLETED, cacheEventContext.getDataKey(),
+                                               cacheEventContext.getDataValue(), null, false);
                 eventSet = new CacheEventSet(eventType, cacheEventContext.getCompletionId());
                 eventSet.addEventData(completedEventData);
                 eventData = eventSet;
@@ -346,12 +353,23 @@ public abstract class AbstractCacheService
     }
 
     @Override
-    public String registerListener(String distributedObjectName, CacheEventListener listener) {
+    public String registerListener(String name, CacheEventListener listener) {
+        return registerListenerInternal(name, listener, null);
+    }
+
+    @Override
+    public String registerListener(String name, CacheEventListener listener, EventFilter eventFilter) {
+        return registerListenerInternal(name, listener, eventFilter);
+    }
+
+    protected String registerListenerInternal(String name, CacheEventListener listener, EventFilter eventFilter) {
         final EventService eventService = getNodeEngine().getEventService();
-        final EventRegistration registration =
-                eventService.registerListener(AbstractCacheService.SERVICE_NAME,
-                                              distributedObjectName,
-                                              listener);
+        final EventRegistration registration;
+        if (eventFilter == null) {
+            registration = eventService.registerListener(AbstractCacheService.SERVICE_NAME, name, listener);
+        } else {
+            registration = eventService.registerListener(AbstractCacheService.SERVICE_NAME, name, eventFilter, listener);
+        }
         final String id = registration.getId();
         if (listener instanceof Closeable) {
             closeableListeners.put(id, (Closeable) listener);
@@ -388,6 +406,11 @@ public abstract class AbstractCacheService
             }
         }
         eventService.deregisterAllListeners(AbstractCacheService.SERVICE_NAME, name);
+        CacheContext cacheContext = cacheContexts.get(name);
+        if (cacheContext != null) {
+            cacheContext.resetCacheEntryListenerCount();
+            cacheContext.resetInvalidationListenerCount();
+        }
     }
 
     @Override
@@ -446,6 +469,24 @@ public abstract class AbstractCacheService
             postJoinCacheOperation.addCacheConfig(cacheConfigEntry.getValue());
         }
         return postJoinCacheOperation;
+    }
+
+    public void cacheEntryListenerRegistered(String name,
+                                             CacheEntryListenerConfiguration cacheEntryListenerConfiguration) {
+        CacheConfig cacheConfig = getCacheConfig(name);
+        if (cacheConfig == null) {
+            throw new IllegalStateException("CacheConfig does not exist for cache " + name);
+        }
+        cacheConfig.addCacheEntryListenerConfiguration(cacheEntryListenerConfiguration);
+    }
+
+    public void cacheEntryListenerDeregistered(String name,
+                                               CacheEntryListenerConfiguration cacheEntryListenerConfiguration) {
+        CacheConfig cacheConfig = getCacheConfig(name);
+        if (cacheConfig == null) {
+            throw new IllegalStateException("CacheConfig does not exist for cache " + name);
+        }
+        cacheConfig.removeCacheEntryListenerConfiguration(cacheEntryListenerConfiguration);
     }
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheContext.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.cache.impl;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Holds some specific informations for per cache in the node and shared by all partitions of that cache on the node.
+ */
+public class CacheContext {
+
+    private final AtomicInteger cacheEntryListenerCount = new AtomicInteger(0);
+    private final AtomicInteger invalidationListenerCount = new AtomicInteger(0);
+
+    public int getCacheEntryListenerCount() {
+        return cacheEntryListenerCount.get();
+    }
+
+    public void increaseCacheEntryListenerCount() {
+        cacheEntryListenerCount.incrementAndGet();
+    }
+
+    public void decreaseCacheEntryListenerCount() {
+        cacheEntryListenerCount.decrementAndGet();
+    }
+
+    public void resetCacheEntryListenerCount() {
+        cacheEntryListenerCount.set(0);
+    }
+
+    public int getInvalidationListenerCount() {
+        return invalidationListenerCount.get();
+    }
+
+    public void increaseInvalidationListenerCount() {
+        invalidationListenerCount.incrementAndGet();
+    }
+
+    public void decreaseInvalidationListenerCount() {
+        invalidationListenerCount.decrementAndGet();
+    }
+
+    public void resetInvalidationListenerCount() {
+        invalidationListenerCount.set(0);
+    }
+
+    @Override
+    public String toString() {
+        return "CacheContext{"
+                + "cacheEntryListenerCount=" + cacheEntryListenerCount.get()
+                + ", invalidationListenerCount=" + invalidationListenerCount.get()
+                + '}';
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheProxy.java
@@ -295,7 +295,8 @@ public class CacheProxy<K, V>
         final ICacheService service = getService();
         final CacheEventListenerAdaptor<K, V> entryListener = new CacheEventListenerAdaptor<K, V>(this,
                 cacheEntryListenerConfiguration, getNodeEngine().getSerializationService());
-        final String regId = service.registerListener(getDistributedObjectName(), entryListener);
+        final String regId =
+                service.registerListener(getDistributedObjectName(), entryListener, entryListener);
         if (regId != null) {
             cacheConfig.addCacheEntryListenerConfiguration(cacheEntryListenerConfiguration);
             addListenerLocally(regId, cacheEntryListenerConfiguration);

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/ICacheService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/ICacheService.java
@@ -20,6 +20,7 @@ import com.hazelcast.config.CacheConfig;
 import com.hazelcast.config.CacheSimpleConfig;
 import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.spi.EventFilter;
 import com.hazelcast.spi.EventPublishingService;
 import com.hazelcast.spi.ManagedService;
 import com.hazelcast.spi.MigrationAwareService;
@@ -68,7 +69,9 @@ public interface ICacheService extends ManagedService, RemoteService, MigrationA
 
     NodeEngine getNodeEngine();
 
-    String registerListener(String distributedObjectName, CacheEventListener listener);
+    String registerListener(String name, CacheEventListener listener);
+
+    String registerListener(String name, CacheEventListener listener, EventFilter eventFilter);
 
     boolean deregisterListener(String name, String registrationId);
 

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/client/CacheAddInvalidationListenerRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/client/CacheAddInvalidationListenerRequest.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.cache.impl.client;
 
+import com.hazelcast.cache.impl.CacheContext;
 import com.hazelcast.cache.impl.CachePortableHook;
 import com.hazelcast.cache.impl.CacheService;
 import com.hazelcast.client.ClientEndpoint;
@@ -45,7 +46,8 @@ public class CacheAddInvalidationListenerRequest
     public Object call() {
         ClientEndpoint endpoint = getEndpoint();
         CacheService cacheService = getService();
-        CacheInvalidationListener listener = new CacheInvalidationListener(endpoint, getCallId());
+        CacheContext cacheContext = cacheService.getOrCreateCacheContext(name);
+        CacheInvalidationListener listener = new CacheInvalidationListener(endpoint, getCallId(), cacheContext);
         String registrationId = cacheService.addInvalidationListener(name, listener);
         endpoint.setListenerRegistration(CacheService.SERVICE_NAME, name, registrationId);
         return registrationId;

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/client/CacheInvalidationListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/client/CacheInvalidationListener.java
@@ -16,20 +16,27 @@
 
 package com.hazelcast.cache.impl.client;
 
+import com.hazelcast.cache.impl.CacheContext;
 import com.hazelcast.cache.impl.CacheEventListener;
+import com.hazelcast.cache.impl.CacheService;
 import com.hazelcast.client.ClientEndpoint;
+import com.hazelcast.spi.EventRegistration;
+import com.hazelcast.spi.NotifiableEventListener;
 
 import java.util.ArrayList;
 import java.util.List;
 
-public final class CacheInvalidationListener implements CacheEventListener {
+public final class CacheInvalidationListener
+        implements CacheEventListener, NotifiableEventListener<CacheService> {
 
     private final ClientEndpoint endpoint;
     private final int callId;
+    private final CacheContext cacheContext;
 
-    public CacheInvalidationListener(ClientEndpoint endpoint, int callId) {
+    public CacheInvalidationListener(ClientEndpoint endpoint, int callId, CacheContext cacheContext) {
         this.endpoint = endpoint;
         this.callId = callId;
+        this.cacheContext = cacheContext;
     }
 
     @Override
@@ -73,6 +80,18 @@ public final class CacheInvalidationListener implements CacheEventListener {
                                    callId);
             }
         }
+    }
+
+    @Override
+    public void onRegister(CacheService cacheService, String serviceName,
+                           String topic, EventRegistration registration) {
+        cacheContext.increaseInvalidationListenerCount();
+    }
+
+    @Override
+    public void onDeregister(CacheService cacheService, String serviceName,
+                             String topic, EventRegistration registration) {
+        cacheContext.decreaseInvalidationListenerCount();
     }
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheListenerRegistrationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheListenerRegistrationOperation.java
@@ -54,14 +54,9 @@ public class CacheListenerRegistrationOperation
         final CacheService service = getService();
         CacheConfig cacheConfig = service.getCacheConfig(name);
         if (register) {
-            //REGISTER
-            if (cacheConfig == null) {
-                throw new IllegalStateException("CacheConfig does not exist!!! name: " + name);
-            }
-            cacheConfig.addCacheEntryListenerConfiguration(cacheEntryListenerConfiguration);
+            service.cacheEntryListenerRegistered(name, cacheEntryListenerConfiguration);
         } else if (cacheConfig != null) {
-            //UNREGISTER
-            cacheConfig.removeCacheEntryListenerConfiguration(cacheEntryListenerConfiguration);
+            service.cacheEntryListenerDeregistered(name, cacheEntryListenerConfiguration);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheAddEntryListenerMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheAddEntryListenerMessageTask.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.client.impl.protocol.task.cache;
 
+import com.hazelcast.cache.impl.CacheContext;
 import com.hazelcast.cache.impl.CacheEventData;
 import com.hazelcast.cache.impl.CacheEventListener;
 import com.hazelcast.cache.impl.CacheEventSet;
@@ -27,8 +28,12 @@ import com.hazelcast.client.impl.protocol.task.AbstractCallableMessageTask;
 import com.hazelcast.instance.Node;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.spi.EventRegistration;
+import com.hazelcast.spi.ListenerWrapperEventFilter;
+import com.hazelcast.spi.NotifiableEventListener;
 import com.hazelcast.nio.serialization.impl.DefaultData;
 
+import java.io.Serializable;
 import java.security.Permission;
 import java.util.Set;
 
@@ -49,37 +54,79 @@ public class CacheAddEntryListenerMessageTask
     protected Object call() {
         final ClientEndpoint endpoint = getEndpoint();
         final CacheService service = getService(CacheService.SERVICE_NAME);
-        CacheEventListener entryListener = new CacheEventListener() {
-            @Override
-            public void handleEvent(Object eventObject) {
-                if (!endpoint.isAlive()) {
-                    return;
-                }
-                if (eventObject instanceof CacheEventSet) {
-                    CacheEventSet ces = (CacheEventSet) eventObject;
-                    Data partitionKey = getPartitionKey(eventObject);
-                    ClientMessage clientMessage = CacheAddEntryListenerCodec
-                            .encodeCacheEvent(ces.getEventType().getType(), ces.getEvents(), ces.getCompletionId());
-                    sendClientMessage(partitionKey, clientMessage);
-                }
-            }
-        };
-        return service.registerListener(parameters.name, entryListener);
+        CacheEntryListener cacheEntryListener = new CacheEntryListener(endpoint, this);
+        return service.registerListener(parameters.name, cacheEntryListener, cacheEntryListener);
     }
 
-    private Data getPartitionKey(Object eventObject) {
-        Data partitionKey = null;
-        if (eventObject instanceof CacheEventSet) {
-            Set<CacheEventData> events = ((CacheEventSet) eventObject).getEvents();
-            if (events.size() > 1) {
-                partitionKey = new DefaultData();
-            } else if (events.size() == 1) {
-                partitionKey = events.iterator().next().getDataKey();
-            }
-        } else if (eventObject instanceof CacheEventData) {
-            partitionKey = ((CacheEventData) eventObject).getDataKey();
+    private static final class CacheEntryListener
+            implements CacheEventListener,
+                       NotifiableEventListener<CacheService>,
+                       ListenerWrapperEventFilter,
+                       Serializable {
+
+        private final transient ClientEndpoint endpoint;
+        private final transient CacheAddEntryListenerMessageTask cacheAddEntryListenerMessageTask;
+
+        private CacheEntryListener(ClientEndpoint endpoint,
+                                   CacheAddEntryListenerMessageTask cacheAddEntryListenerMessageTask) {
+            this.endpoint = endpoint;
+            this.cacheAddEntryListenerMessageTask = cacheAddEntryListenerMessageTask;
         }
-        return partitionKey;
+
+        private Data getPartitionKey(Object eventObject) {
+            Data partitionKey = null;
+            if (eventObject instanceof CacheEventSet) {
+                Set<CacheEventData> events = ((CacheEventSet) eventObject).getEvents();
+                if (events.size() > 1) {
+                    partitionKey = new DefaultData();
+                } else if (events.size() == 1) {
+                    partitionKey = events.iterator().next().getDataKey();
+                }
+            } else if (eventObject instanceof CacheEventData) {
+                partitionKey = ((CacheEventData) eventObject).getDataKey();
+            }
+            return partitionKey;
+        }
+
+        @Override
+        public void handleEvent(Object eventObject) {
+            if (!endpoint.isAlive()) {
+                return;
+            }
+            if (eventObject instanceof CacheEventSet) {
+                CacheEventSet ces = (CacheEventSet) eventObject;
+                Data partitionKey = getPartitionKey(eventObject);
+                ClientMessage clientMessage =
+                        CacheAddEntryListenerCodec.
+                                encodeCacheEvent(ces.getEventType().getType(), ces.getEvents(), ces.getCompletionId());
+                cacheAddEntryListenerMessageTask.sendClientMessage(partitionKey, clientMessage);
+            }
+        }
+
+        @Override
+        public void onRegister(CacheService service, String serviceName,
+                               String topic, EventRegistration registration) {
+            CacheContext cacheContext = service.getOrCreateCacheContext(topic);
+            cacheContext.increaseCacheEntryListenerCount();
+        }
+
+        @Override
+        public void onDeregister(CacheService service, String serviceName,
+                                 String topic, EventRegistration registration) {
+            CacheContext cacheContext = service.getOrCreateCacheContext(topic);
+            cacheContext.decreaseCacheEntryListenerCount();
+        }
+
+        @Override
+        public Object getListener() {
+            return this;
+        }
+
+        @Override
+        public boolean eval(Object event) {
+            return true;
+        }
+
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheAddInvalidationListenerTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheAddInvalidationListenerTask.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.client.impl.protocol.task.cache;
 
+import com.hazelcast.cache.impl.CacheContext;
 import com.hazelcast.cache.impl.CacheEventListener;
 import com.hazelcast.cache.impl.CacheService;
 import com.hazelcast.cache.impl.client.CacheBatchInvalidationMessage;
@@ -28,6 +29,8 @@ import com.hazelcast.client.impl.protocol.task.AbstractCallableMessageTask;
 import com.hazelcast.instance.Node;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.spi.EventRegistration;
+import com.hazelcast.spi.NotifiableEventListener;
 
 import java.security.Permission;
 import java.util.ArrayList;
@@ -44,18 +47,23 @@ public class CacheAddInvalidationListenerTask
     protected Object call() {
         final ClientEndpoint endpoint = getEndpoint();
         CacheService cacheService = getService(CacheService.SERVICE_NAME);
-        String registrationId = cacheService.addInvalidationListener(parameters.name,
-                                                                     new CacheInvalidationEventListener(endpoint));
+        CacheContext cacheContext = cacheService.getOrCreateCacheContext(parameters.name);
+        String registrationId =
+                cacheService.addInvalidationListener(parameters.name,
+                                                     new CacheInvalidationEventListener(endpoint, cacheContext));
         endpoint.setListenerRegistration(CacheService.SERVICE_NAME, parameters.name, registrationId);
         return registrationId;
     }
 
-    private final class CacheInvalidationEventListener implements CacheEventListener {
+    private final class CacheInvalidationEventListener
+            implements CacheEventListener, NotifiableEventListener<CacheService> {
 
         private final ClientEndpoint endpoint;
+        private final CacheContext cacheContext;
 
-        private CacheInvalidationEventListener(ClientEndpoint endpoint) {
+        private CacheInvalidationEventListener(ClientEndpoint endpoint, CacheContext cacheContext) {
             this.endpoint = endpoint;
+            this.cacheContext = cacheContext;
         }
 
         @Override
@@ -97,6 +105,18 @@ public class CacheAddInvalidationListenerTask
                     sendClientMessage(message.getName(), eventMessage);
                 }
             }
+        }
+
+        @Override
+        public void onRegister(CacheService cacheService, String serviceName,
+                               String topic, EventRegistration registration) {
+            cacheContext.increaseInvalidationListenerCount();
+        }
+
+        @Override
+        public void onDeregister(CacheService cacheService, String serviceName,
+                                 String topic, EventRegistration registration) {
+            cacheContext.decreaseInvalidationListenerCount();
         }
 
     }

--- a/hazelcast/src/main/java/com/hazelcast/spi/ListenerWrapperEventFilter.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/ListenerWrapperEventFilter.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi;
+
+/**
+ * Contract point for {@link com.hazelcast.spi.EventFilter} instances these wrap listeners.
+ */
+public interface ListenerWrapperEventFilter extends EventFilter {
+
+    /**
+     * Gets the wrapped listener.
+     *
+     * @return the wrapped listener
+     */
+    Object getListener();
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/NotifiableEventListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/NotifiableEventListener.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi;
+
+/**
+ * Contract point for event listeners to be notified by {@link com.hazelcast.spi.EventService}.
+ *
+ * @param <S> the type of the {@link com.hazelcast.spi.ManagedService}
+ */
+public interface NotifiableEventListener<S> {
+
+    /**
+     * Called when this listener registered to {@link com.hazelcast.spi.EventService}.
+     *
+     * @param service       the service instance that event belongs to
+     * @param serviceName   name of the service that event belongs to
+     * @param topic         name of the topic that event belongs to
+     * @param registration  the {@link com.hazelcast.spi.EventRegistration} instance
+     *                      that holds information about the registration
+     */
+    void onRegister(S service, String serviceName, String topic, EventRegistration registration);
+
+    /**
+     * Called when this listener deregistered from {@link com.hazelcast.spi.EventService}.
+     *
+     * @param service       the service instance that event belongs to
+     * @param serviceName   name of the service that event belongs to
+     * @param topic         name of the topic that event belongs to
+     * @param registration  the {@link com.hazelcast.spi.EventRegistration} instance
+     *                      that holds information about the registration
+     */
+    void onDeregister(S service, String serviceName, String topic, EventRegistration registration);
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/EventPacketProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/EventPacketProcessor.java
@@ -21,6 +21,7 @@ import com.hazelcast.spi.EventPublishingService;
 import com.hazelcast.util.executor.StripedRunnable;
 
 public class EventPacketProcessor implements StripedRunnable {
+
     private final EventServiceImpl eventService;
     private final int orderKey;
     private final EventPacket eventPacket;
@@ -73,7 +74,7 @@ public class EventPacketProcessor implements StripedRunnable {
         }
 
         String id = eventPacket.getEventId();
-        Registration registration = segment.getRegistrationIdMap().get(id);
+        Registration registration = (Registration) segment.getRegistrationIdMap().get(id);
         if (registration == null) {
             if (eventService.nodeEngine.isActive()) {
                 if (eventService.logger.isFinestEnabled()) {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/EventServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/EventServiceImpl.java
@@ -60,6 +60,7 @@ import static com.hazelcast.util.FutureUtil.ExceptionHandler;
 import static com.hazelcast.util.FutureUtil.waitWithDeadline;
 
 public class EventServiceImpl implements InternalEventService {
+
     private static final EventRegistration[] EMPTY_REGISTRATIONS = new EventRegistration[0];
 
     private static final int EVENT_SYNC_FREQUENCY = 100000;
@@ -380,7 +381,7 @@ public class EventServiceImpl implements InternalEventService {
                     = new ConstructorFunction<String, EventServiceSegment>() {
                 @Override
                 public EventServiceSegment createNew(String key) {
-                    return new EventServiceSegment(key);
+                    return new EventServiceSegment(key, nodeEngine.getService(key));
                 }
             };
             return ConcurrencyUtil.getOrPutIfAbsent(segments, service, func);
@@ -422,7 +423,7 @@ public class EventServiceImpl implements InternalEventService {
         final Collection<Registration> registrations = new LinkedList<Registration>();
         for (EventServiceSegment segment : segments.values()) {
             //todo: this should be moved into the Segment.
-            for (Registration reg : segment.getRegistrationIdMap().values()) {
+            for (Registration reg : (Iterable<Registration>) segment.getRegistrationIdMap().values()) {
                 if (!reg.isLocalOnly()) {
                     registrations.add(reg);
                 }
@@ -455,4 +456,5 @@ public class EventServiceImpl implements InternalEventService {
             logger.log(level, String.format(message, args));
         }
     }
+
 }

--- a/hazelcast/src/test/java/com/hazelcast/cache/CacheContextTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CacheContextTest.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.cache;
+
+import com.hazelcast.cache.impl.CacheContext;
+import com.hazelcast.cache.impl.CacheService;
+import com.hazelcast.cache.impl.HazelcastServerCachingProvider;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.instance.TestUtil;
+import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import javax.cache.Cache;
+import javax.cache.CacheManager;
+import javax.cache.configuration.CacheEntryListenerConfiguration;
+import javax.cache.configuration.CompleteConfiguration;
+import javax.cache.configuration.FactoryBuilder;
+import javax.cache.configuration.MutableCacheEntryListenerConfiguration;
+import javax.cache.configuration.MutableConfiguration;
+import javax.cache.event.CacheEntryCreatedListener;
+import javax.cache.event.CacheEntryEvent;
+import javax.cache.event.CacheEntryListenerException;
+import javax.cache.spi.CachingProvider;
+import java.io.Serializable;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class CacheContextTest extends HazelcastTestSupport {
+
+    protected HazelcastInstance driverInstance;
+    protected HazelcastInstance hazelcastInstance1;
+    protected HazelcastInstance hazelcastInstance2;
+
+    protected CachingProvider initAndGetCachingProvider() {
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(2);
+        hazelcastInstance1 = factory.newHazelcastInstance();
+        hazelcastInstance2 = factory.newHazelcastInstance();
+        driverInstance = hazelcastInstance1;
+        return HazelcastServerCachingProvider.createCachingProvider(driverInstance);
+    }
+
+    protected static class TestListener
+            implements CacheEntryCreatedListener<String, String>, Serializable {
+
+        @Override
+        public void onCreated(Iterable<CacheEntryEvent<? extends String, ? extends String>> cacheEntryEvents)
+                throws CacheEntryListenerException {
+        }
+
+    }
+
+    protected CacheService getCacheService(HazelcastInstance instance) {
+        return TestUtil.getNode(instance).getNodeEngine().getService(CacheService.SERVICE_NAME);
+    }
+
+    protected enum DecreaseType {
+
+        DEREGISTER,
+        SHUTDOWN,
+        TERMINATE
+
+    }
+
+    protected void cacheEntryListenerCountIncreasedAndDecreasedCorrectly(DecreaseType decreaseType) {
+        final String CACHE_NAME = "MyCache";
+        final String CACHE_NAME_WITH_PREFIX = "/hz/" + CACHE_NAME;
+
+        CachingProvider provider = initAndGetCachingProvider();
+        CacheManager cacheManager = provider.getCacheManager();
+        CacheEntryListenerConfiguration<String, String> cacheEntryListenerConfig =
+                new MutableCacheEntryListenerConfiguration<String, String>(
+                        FactoryBuilder.factoryOf(new TestListener()), null, true, true);
+        CompleteConfiguration<String, String> cacheConfig = new MutableConfiguration<String, String>();
+        Cache<String, String> cache = cacheManager.createCache(CACHE_NAME, cacheConfig);
+
+        cache.registerCacheEntryListener(cacheEntryListenerConfig);
+
+        final CacheService cacheService1 = getCacheService(hazelcastInstance1);
+        final CacheService cacheService2 = getCacheService(hazelcastInstance2);
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertNotNull(cacheService1.getCacheContext(CACHE_NAME_WITH_PREFIX));
+            }
+        });
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertNotNull(cacheService2.getCacheContext(CACHE_NAME_WITH_PREFIX));
+            }
+        });
+
+        final CacheContext cacheContext1 = cacheService1.getCacheContext(CACHE_NAME_WITH_PREFIX);
+        final CacheContext cacheContext2 = cacheService2.getCacheContext(CACHE_NAME_WITH_PREFIX);
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertEquals(cacheContext1.getCacheEntryListenerCount(), 1);
+            }
+        });
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertEquals(cacheContext2.getCacheEntryListenerCount(), 1);
+            }
+        });
+
+        switch (decreaseType) {
+            case DEREGISTER:
+                cache.deregisterCacheEntryListener(cacheEntryListenerConfig);
+                break;
+            case SHUTDOWN:
+                driverInstance.getLifecycleService().shutdown();
+                break;
+            case TERMINATE:
+                driverInstance.getLifecycleService().terminate();
+                break;
+            default:
+                throw new IllegalArgumentException("Unsupported decrease type: " + decreaseType);
+        }
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertEquals(cacheContext1.getCacheEntryListenerCount(), 0);
+            }
+        });
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertEquals(cacheContext2.getCacheEntryListenerCount(), 0);
+            }
+        });
+    }
+
+    @Test
+    public void cacheEntryListenerCountIncreasedAfterRegisterAndDecreasedAfterDeregister() {
+        cacheEntryListenerCountIncreasedAndDecreasedCorrectly(DecreaseType.DEREGISTER);
+    }
+
+    @Test
+    public void cacheEntryListenerCountIncreasedAfterRegisterAndDecreasedAfterShutdown() {
+        cacheEntryListenerCountIncreasedAndDecreasedCorrectly(DecreaseType.SHUTDOWN);
+    }
+
+    @Test
+    public void cacheEntryListenerCountIncreasedAfterRegisterAndDecreasedAfterTerminate() {
+        cacheEntryListenerCountIncreasedAndDecreasedCorrectly(DecreaseType.TERMINATE);
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/cache/JCacheListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/JCacheListenerTest.java
@@ -358,4 +358,18 @@ public class JCacheListenerTest extends HazelcastTestSupport {
             counter.addAndGet(count);
         }
     }
+
+    @Test
+    public void cacheEntryListenerCountIncreasedAndDecreasedCorrectly() {
+        final CachingProvider provider = getCachingProvider();
+        CacheManager cacheManager = provider.getCacheManager();
+
+        CompleteConfiguration<String, String> config = new MutableConfiguration<String, String>()
+                .addCacheEntryListenerConfiguration(new MutableCacheEntryListenerConfiguration<String, String>(
+                        FactoryBuilder.factoryOf(new TestListener(new AtomicInteger())), null, true,
+                        true));
+
+        final Cache<String, String> cache = cacheManager.createCache("MyCache", config);
+    }
+
 }


### PR DESCRIPTION
Before this improvement;

- Even though there is no cache entry listener registered and only invalidation listener is registered, cache entry events are created and sent to event system because of registered invalidation listener. By this improvement, cache entry events are sent to event system if there is any cache entry listener registered. 

- Same logic is available also for cache invalidation listener