### PR TITLE
TransactionLog renaming

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/list/ListService.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/list/ListService.java
@@ -24,7 +24,7 @@ import com.hazelcast.core.DistributedObject;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.PartitionReplicationEvent;
-import com.hazelcast.transaction.impl.TransactionSupport;
+import com.hazelcast.transaction.impl.InternalTransaction;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -68,7 +68,7 @@ public class ListService extends CollectionService {
     }
 
     @Override
-    public TransactionalListProxy createTransactionalObject(String name, TransactionSupport transaction) {
+    public TransactionalListProxy createTransactionalObject(String name, InternalTransaction transaction) {
         return new TransactionalListProxy(name, transaction, nodeEngine, this);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueService.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueService.java
@@ -47,7 +47,7 @@ import com.hazelcast.spi.PartitionReplicationEvent;
 import com.hazelcast.spi.RemoteService;
 import com.hazelcast.spi.StatisticsAwareService;
 import com.hazelcast.spi.TransactionalService;
-import com.hazelcast.transaction.impl.TransactionSupport;
+import com.hazelcast.transaction.impl.InternalTransaction;
 import com.hazelcast.util.ConcurrencyUtil;
 import com.hazelcast.util.ConstructorFunction;
 import com.hazelcast.util.MapUtil;
@@ -292,7 +292,7 @@ public class QueueService implements ManagedService, MigrationAwareService, Tran
     }
 
     @Override
-    public TransactionalQueueProxy createTransactionalObject(String name, TransactionSupport transaction) {
+    public TransactionalQueueProxy createTransactionalObject(String name, InternalTransaction transaction) {
         return new TransactionalQueueProxy(nodeEngine, this, name, transaction);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/set/SetService.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/set/SetService.java
@@ -24,7 +24,7 @@ import com.hazelcast.core.DistributedObject;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.PartitionReplicationEvent;
-import com.hazelcast.transaction.impl.TransactionSupport;
+import com.hazelcast.transaction.impl.InternalTransaction;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -68,7 +68,7 @@ public class SetService extends CollectionService {
     }
 
     @Override
-    public TransactionalSetProxy createTransactionalObject(String name, TransactionSupport transaction) {
+    public TransactionalSetProxy createTransactionalObject(String name, InternalTransaction transaction) {
         return new TransactionalSetProxy(name, transaction, nodeEngine, this);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txncollection/AbstractTransactionalCollectionProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txncollection/AbstractTransactionalCollectionProxy.java
@@ -30,7 +30,7 @@ import com.hazelcast.spi.RemoteService;
 import com.hazelcast.transaction.TransactionException;
 import com.hazelcast.transaction.TransactionNotActiveException;
 import com.hazelcast.transaction.impl.Transaction;
-import com.hazelcast.transaction.impl.TransactionSupport;
+import com.hazelcast.transaction.impl.InternalTransaction;
 import com.hazelcast.util.ExceptionUtil;
 
 import java.util.Collection;
@@ -44,11 +44,11 @@ import static com.hazelcast.util.Preconditions.checkNotNull;
 public abstract class AbstractTransactionalCollectionProxy<S extends RemoteService, E> extends AbstractDistributedObject<S> {
 
     protected final String name;
-    protected final TransactionSupport tx;
+    protected final InternalTransaction tx;
     protected final int partitionId;
     protected final Set<Long> itemIdSet = new HashSet<Long>();
 
-    public AbstractTransactionalCollectionProxy(String name, TransactionSupport tx, NodeEngine nodeEngine, S service) {
+    public AbstractTransactionalCollectionProxy(String name, InternalTransaction tx, NodeEngine nodeEngine, S service) {
         super(nodeEngine, service);
         this.name = name;
         this.tx = tx;
@@ -80,7 +80,7 @@ public abstract class AbstractTransactionalCollectionProxy<S extends RemoteServi
                 CollectionTxnAddOperation op = new CollectionTxnAddOperation(name, itemId, value);
                 final String serviceName = getServiceName();
                 final String txnId = tx.getTxnId();
-                tx.addTransactionLog(new CollectionTransactionLog(itemId, name, partitionId, serviceName, txnId, op));
+                tx.add(new CollectionTransactionRecord(itemId, name, partitionId, serviceName, txnId, op));
                 return true;
             }
         } catch (Throwable t) {
@@ -116,7 +116,7 @@ public abstract class AbstractTransactionalCollectionProxy<S extends RemoteServi
             if (item != null) {
                 if (reservedItemId == item.getItemId()) {
                     iterator.remove();
-                    tx.removeTransactionLog(reservedItemId);
+                    tx.remove(reservedItemId);
                     itemIdSet.remove(reservedItemId);
                     return true;
                 }
@@ -124,7 +124,7 @@ public abstract class AbstractTransactionalCollectionProxy<S extends RemoteServi
                     throw new TransactionException("Duplicate itemId: " + item.getItemId());
                 }
                 CollectionTxnRemoveOperation op = new CollectionTxnRemoveOperation(name, item.getItemId());
-                tx.addTransactionLog(new CollectionTransactionLog(
+                tx.add(new CollectionTransactionRecord(
                         item.getItemId(),
                         name,
                         partitionId,

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txncollection/CollectionTransactionRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txncollection/CollectionTransactionRecord.java
@@ -25,12 +25,12 @@ import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.impl.operationservice.InternalOperationService;
-import com.hazelcast.transaction.impl.KeyAwareTransactionLog;
+import com.hazelcast.transaction.impl.KeyAwareTransactionRecord;
 import com.hazelcast.util.ExceptionUtil;
 import java.io.IOException;
 import java.util.concurrent.Future;
 
-public class CollectionTransactionLog implements KeyAwareTransactionLog {
+public class CollectionTransactionRecord implements KeyAwareTransactionRecord {
 
     String transactionId;
     private long itemId;
@@ -39,15 +39,15 @@ public class CollectionTransactionLog implements KeyAwareTransactionLog {
     private int partitionId;
     private String serviceName;
 
-    public CollectionTransactionLog() {
+    public CollectionTransactionRecord() {
     }
 
-    public CollectionTransactionLog(long itemId,
-                                    String name,
-                                    int partitionId,
-                                    String serviceName,
-                                    String transactionId,
-                                    Operation op) {
+    public CollectionTransactionRecord(long itemId,
+                                       String name,
+                                       int partitionId,
+                                       String serviceName,
+                                       String transactionId,
+                                       Operation op) {
         this.itemId = itemId;
         this.name = name;
         this.op = op;
@@ -58,7 +58,7 @@ public class CollectionTransactionLog implements KeyAwareTransactionLog {
 
     @Override
     public Object getKey() {
-        return new TransactionLogKey(name, itemId, serviceName);
+        return new TransactionRecordKey(name, itemId, serviceName);
     }
 
     @Override
@@ -128,7 +128,7 @@ public class CollectionTransactionLog implements KeyAwareTransactionLog {
 
     @Override
     public String toString() {
-        return "CollectionTransactionLog{"
+        return "CollectionTransactionRecord{"
                 + "transactionId='" + transactionId + '\''
                 + ", itemId=" + itemId
                 + ", name='" + name + '\''

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txncollection/TransactionRecordKey.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txncollection/TransactionRecordKey.java
@@ -14,44 +14,51 @@
  * limitations under the License.
  */
 
-package com.hazelcast.multimap.impl.txn;
+package com.hazelcast.collection.impl.txncollection;
 
-import com.hazelcast.nio.serialization.Data;
+class TransactionRecordKey {
 
-class TransactionLogKey {
+    private final String name;
 
-    final String name;
+    private final long itemId;
 
-    final Data key;
+    private final String serviceName;
 
-    public TransactionLogKey(String name, Data key) {
+    TransactionRecordKey(String name, long itemId, String serviceName) {
         this.name = name;
-        this.key = key;
+        this.itemId = itemId;
+        this.serviceName = serviceName;
     }
 
+    @Override
     public boolean equals(Object o) {
         if (this == o) {
             return true;
         }
-        if (!(o instanceof TransactionLogKey)) {
+        if (!(o instanceof TransactionRecordKey)) {
             return false;
         }
 
-        TransactionLogKey that = (TransactionLogKey) o;
+        TransactionRecordKey that = (TransactionRecordKey) o;
 
-        if (!key.equals(that.key)) {
+        if (itemId != that.itemId) {
             return false;
         }
         if (!name.equals(that.name)) {
+            return false;
+        }
+        if (!serviceName.equals(that.serviceName)) {
             return false;
         }
 
         return true;
     }
 
+    @Override
     public int hashCode() {
         int result = name.hashCode();
-        result = 31 * result + key.hashCode();
+        result = 31 * result + (int) (itemId ^ (itemId >>> 32));
+        result = 31 * result + serviceName.hashCode();
         return result;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txnlist/TransactionalListProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txnlist/TransactionalListProxy.java
@@ -21,7 +21,7 @@ import com.hazelcast.collection.impl.list.ListService;
 import com.hazelcast.collection.impl.txncollection.AbstractTransactionalCollectionProxy;
 import com.hazelcast.core.TransactionalList;
 import com.hazelcast.spi.NodeEngine;
-import com.hazelcast.transaction.impl.TransactionSupport;
+import com.hazelcast.transaction.impl.InternalTransaction;
 import java.util.Collection;
 import java.util.LinkedList;
 
@@ -30,7 +30,7 @@ public class TransactionalListProxy<E> extends AbstractTransactionalCollectionPr
 
     private final LinkedList<CollectionItem> list = new LinkedList<CollectionItem>();
 
-    public TransactionalListProxy(String name, TransactionSupport tx, NodeEngine nodeEngine, ListService service) {
+    public TransactionalListProxy(String name, InternalTransaction tx, NodeEngine nodeEngine, ListService service) {
         super(name, tx, nodeEngine, service);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/QueueTransactionRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/QueueTransactionRecord.java
@@ -28,7 +28,7 @@ import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.OperationService;
 import com.hazelcast.spi.impl.operationservice.InternalOperationService;
-import com.hazelcast.transaction.impl.KeyAwareTransactionLog;
+import com.hazelcast.transaction.impl.KeyAwareTransactionRecord;
 import com.hazelcast.util.ExceptionUtil;
 
 import java.io.IOException;
@@ -37,7 +37,7 @@ import java.util.concurrent.Future;
 /**
  * This class contains Transaction log for the Queue.
  */
-public class QueueTransactionLog implements KeyAwareTransactionLog {
+public class QueueTransactionRecord implements KeyAwareTransactionRecord {
 
     private long itemId;
     private String name;
@@ -45,10 +45,10 @@ public class QueueTransactionLog implements KeyAwareTransactionLog {
     private int partitionId;
     private String transactionId;
 
-    public QueueTransactionLog() {
+    public QueueTransactionRecord() {
     }
 
-    public QueueTransactionLog(String transactionId, long itemId, String name, int partitionId, Operation op) {
+    public QueueTransactionRecord(String transactionId, long itemId, String name, int partitionId, Operation op) {
         this.transactionId = transactionId;
         this.itemId = itemId;
         this.name = name;
@@ -127,6 +127,6 @@ public class QueueTransactionLog implements KeyAwareTransactionLog {
 
     @Override
     public Object getKey() {
-        return new TransactionLogKey(itemId, name);
+        return new TransactionRecordKey(itemId, name);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/TransactionRecordKey.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/TransactionRecordKey.java
@@ -16,13 +16,13 @@
 
 package com.hazelcast.collection.impl.txnqueue;
 
-class TransactionLogKey {
+class TransactionRecordKey {
 
     private final long itemId;
 
     private final String name;
 
-    public TransactionLogKey(long itemId, String name) {
+    public TransactionRecordKey(long itemId, String name) {
         this.itemId = itemId;
         this.name = name;
     }
@@ -31,11 +31,11 @@ class TransactionLogKey {
         if (this == o) {
             return true;
         }
-        if (!(o instanceof TransactionLogKey)) {
+        if (!(o instanceof TransactionRecordKey)) {
             return false;
         }
 
-        TransactionLogKey that = (TransactionLogKey) o;
+        TransactionRecordKey that = (TransactionRecordKey) o;
 
         if (itemId != that.itemId) {
             return false;

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/TransactionalQueueProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/TransactionalQueueProxy.java
@@ -20,7 +20,7 @@ import com.hazelcast.core.TransactionalQueue;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.collection.impl.queue.QueueService;
 import com.hazelcast.spi.NodeEngine;
-import com.hazelcast.transaction.impl.TransactionSupport;
+import com.hazelcast.transaction.impl.InternalTransaction;
 import com.hazelcast.util.EmptyStatement;
 
 import java.util.concurrent.TimeUnit;
@@ -34,7 +34,7 @@ import static com.hazelcast.util.Preconditions.checkNotNull;
  */
 public class TransactionalQueueProxy<E> extends TransactionalQueueProxySupport implements TransactionalQueue<E> {
 
-    public TransactionalQueueProxy(NodeEngine nodeEngine, QueueService service, String name, TransactionSupport tx) {
+    public TransactionalQueueProxy(NodeEngine nodeEngine, QueueService service, String name, InternalTransaction tx) {
         super(nodeEngine, service, name, tx);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txnset/TransactionalSetProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txnset/TransactionalSetProxy.java
@@ -20,13 +20,13 @@ import com.hazelcast.collection.impl.collection.CollectionItem;
 import com.hazelcast.collection.impl.set.SetService;
 import com.hazelcast.collection.impl.txncollection.AbstractTransactionalCollectionProxy;
 import com.hazelcast.collection.impl.txncollection.operations.CollectionReserveAddOperation;
-import com.hazelcast.collection.impl.txncollection.CollectionTransactionLog;
+import com.hazelcast.collection.impl.txncollection.CollectionTransactionRecord;
 import com.hazelcast.collection.impl.txncollection.operations.CollectionTxnAddOperation;
 import com.hazelcast.core.TransactionalSet;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.transaction.TransactionException;
-import com.hazelcast.transaction.impl.TransactionSupport;
+import com.hazelcast.transaction.impl.InternalTransaction;
 import com.hazelcast.util.ExceptionUtil;
 import java.util.Collection;
 import java.util.HashSet;
@@ -37,7 +37,7 @@ public class TransactionalSetProxy<E> extends AbstractTransactionalCollectionPro
 
     private final HashSet<CollectionItem> set = new HashSet<CollectionItem>();
 
-    public TransactionalSetProxy(String name, TransactionSupport tx, NodeEngine nodeEngine, SetService service) {
+    public TransactionalSetProxy(String name, InternalTransaction tx, NodeEngine nodeEngine, SetService service) {
         super(name, tx, nodeEngine, service);
     }
 
@@ -63,7 +63,7 @@ public class TransactionalSetProxy<E> extends AbstractTransactionalCollectionPro
                 CollectionTxnAddOperation op = new CollectionTxnAddOperation(name, itemId, value);
                 final String txnId = tx.getTxnId();
                 final String serviceName = getServiceName();
-                tx.addTransactionLog(new CollectionTransactionLog(itemId, name, partitionId, serviceName, txnId, op));
+                tx.add(new CollectionTransactionRecord(itemId, name, partitionId, serviceName, txnId, op));
                 return true;
             }
         } catch (Throwable t) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapService.java
@@ -36,7 +36,7 @@ import com.hazelcast.spi.SplitBrainHandlerService;
 import com.hazelcast.spi.StatisticsAwareService;
 import com.hazelcast.spi.TransactionalService;
 import com.hazelcast.transaction.TransactionalObject;
-import com.hazelcast.transaction.impl.TransactionSupport;
+import com.hazelcast.transaction.impl.InternalTransaction;
 import com.hazelcast.wan.WanReplicationEvent;
 import java.util.Map;
 import java.util.Properties;
@@ -162,7 +162,7 @@ public class MapService implements ManagedService, MigrationAwareService,
     }
 
     @Override
-    public <T extends TransactionalObject> T createTransactionalObject(String name, TransactionSupport transaction) {
+    public <T extends TransactionalObject> T createTransactionalObject(String name, InternalTransaction transaction) {
         return transactionalService.createTransactionalObject(name, transaction);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapTransactionalService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapTransactionalService.java
@@ -19,7 +19,7 @@ package com.hazelcast.map.impl;
 import com.hazelcast.map.impl.tx.TransactionalMapProxy;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.TransactionalService;
-import com.hazelcast.transaction.impl.TransactionSupport;
+import com.hazelcast.transaction.impl.InternalTransaction;
 
 /**
  * Defines transactional service behavior of map service.
@@ -38,7 +38,7 @@ class MapTransactionalService implements TransactionalService {
 
     @SuppressWarnings("unchecked")
     @Override
-    public TransactionalMapProxy createTransactionalObject(String name, TransactionSupport transaction) {
+    public TransactionalMapProxy createTransactionalObject(String name, InternalTransaction transaction) {
         return new TransactionalMapProxy(name, mapServiceContext.getService(), nodeEngine, transaction);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/MapTransactionRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/MapTransactionRecord.java
@@ -26,7 +26,7 @@ import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.impl.operationservice.InternalOperationService;
 import com.hazelcast.transaction.TransactionException;
-import com.hazelcast.transaction.impl.KeyAwareTransactionLog;
+import com.hazelcast.transaction.impl.KeyAwareTransactionRecord;
 import com.hazelcast.util.ExceptionUtil;
 import com.hazelcast.util.ThreadUtil;
 
@@ -36,7 +36,7 @@ import java.util.concurrent.Future;
 /**
  * Represents an operation on the map in the transaction log.
  */
-public class MapTransactionLog implements KeyAwareTransactionLog {
+public class MapTransactionRecord implements KeyAwareTransactionRecord {
 
     String name;
     Data key;
@@ -44,10 +44,10 @@ public class MapTransactionLog implements KeyAwareTransactionLog {
     String ownerUuid;
     Operation op;
 
-    public MapTransactionLog() {
+    public MapTransactionRecord() {
     }
 
-    public MapTransactionLog(String name, Data key, Operation op, long version, String ownerUuid) {
+    public MapTransactionRecord(String name, Data key, Operation op, long version, String ownerUuid) {
         this.name = name;
         this.key = key;
         if (!(op instanceof MapTxnOperation)) {
@@ -144,7 +144,7 @@ public class MapTransactionLog implements KeyAwareTransactionLog {
 
     @Override
     public String toString() {
-        return "MapTransactionLog{"
+        return "MapTransactionRecord{"
                 + "name='" + name + '\''
                 + ", key=" + key
                 + ", threadId=" + threadId

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TransactionalMapProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TransactionalMapProxy.java
@@ -25,7 +25,7 @@ import com.hazelcast.query.PagingPredicate;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.impl.QueryEntry;
 import com.hazelcast.spi.NodeEngine;
-import com.hazelcast.transaction.impl.TransactionSupport;
+import com.hazelcast.transaction.impl.InternalTransaction;
 import com.hazelcast.util.IterationType;
 import com.hazelcast.util.QueryResultSet;
 
@@ -49,7 +49,7 @@ public class TransactionalMapProxy extends TransactionalMapProxySupport implemen
 
     private final Map<Data, TxnValueWrapper> txMap = new HashMap<Data, TxnValueWrapper>();
 
-    public TransactionalMapProxy(String name, MapService mapService, NodeEngine nodeEngine, TransactionSupport transaction) {
+    public TransactionalMapProxy(String name, MapService mapService, NodeEngine nodeEngine, InternalTransaction transaction) {
         super(name, mapService, nodeEngine, transaction);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapService.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapService.java
@@ -48,7 +48,7 @@ import com.hazelcast.spi.RemoteService;
 import com.hazelcast.spi.StatisticsAwareService;
 import com.hazelcast.spi.TransactionalService;
 import com.hazelcast.transaction.TransactionalObject;
-import com.hazelcast.transaction.impl.TransactionSupport;
+import com.hazelcast.transaction.impl.InternalTransaction;
 import com.hazelcast.util.ConcurrencyUtil;
 import com.hazelcast.util.ConstructorFunction;
 import com.hazelcast.util.ExceptionUtil;
@@ -341,7 +341,7 @@ public class MultiMapService implements ManagedService, RemoteService, Migration
         return ConcurrencyUtil.getOrPutIfAbsent(statsMap, name, localMultiMapStatsConstructorFunction);
     }
 
-    public <T extends TransactionalObject> T createTransactionalObject(String name, TransactionSupport transaction) {
+    public <T extends TransactionalObject> T createTransactionalObject(String name, InternalTransaction transaction) {
         return (T) new TransactionalMultiMapProxy(nodeEngine, this, name, transaction);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/MultiMapTransactionRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/MultiMapTransactionRecord.java
@@ -25,7 +25,7 @@ import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.OperationService;
 import com.hazelcast.spi.impl.operationservice.InternalOperationService;
-import com.hazelcast.transaction.impl.KeyAwareTransactionLog;
+import com.hazelcast.transaction.impl.KeyAwareTransactionRecord;
 import com.hazelcast.util.ExceptionUtil;
 
 import java.io.IOException;
@@ -35,7 +35,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.Future;
 
-public class MultiMapTransactionLog implements KeyAwareTransactionLog {
+public class MultiMapTransactionRecord implements KeyAwareTransactionRecord {
 
     final List<Operation> opList = new LinkedList<Operation>();
     String name;
@@ -43,10 +43,10 @@ public class MultiMapTransactionLog implements KeyAwareTransactionLog {
     long ttl;
     long threadId;
 
-    public MultiMapTransactionLog() {
+    public MultiMapTransactionRecord() {
     }
 
-    public MultiMapTransactionLog(Data key, String name, long ttl, long threadId) {
+    public MultiMapTransactionRecord(Data key, String name, long ttl, long threadId) {
         this.key = key;
         this.name = name;
         this.ttl = ttl;
@@ -125,7 +125,7 @@ public class MultiMapTransactionLog implements KeyAwareTransactionLog {
     }
 
     public Object getKey() {
-        return new TransactionLogKey(name, key);
+        return new TransactionRecordKey(name, key);
     }
 
     public void addOperation(Operation op) {
@@ -179,7 +179,7 @@ public class MultiMapTransactionLog implements KeyAwareTransactionLog {
 
     @Override
     public String toString() {
-        return "MultiMapTransactionLog{"
+        return "MultiMapTransactionRecord{"
                 + "name='" + name + '\''
                 + ", opList=" + opList
                 + ", key=" + key

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TransactionRecordKey.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TransactionRecordKey.java
@@ -14,51 +14,44 @@
  * limitations under the License.
  */
 
-package com.hazelcast.collection.impl.txncollection;
+package com.hazelcast.multimap.impl.txn;
 
-class TransactionLogKey {
+import com.hazelcast.nio.serialization.Data;
 
-    private final String name;
+class TransactionRecordKey {
 
-    private final long itemId;
+    final String name;
 
-    private final String serviceName;
+    final Data key;
 
-    TransactionLogKey(String name, long itemId, String serviceName) {
+    public TransactionRecordKey(String name, Data key) {
         this.name = name;
-        this.itemId = itemId;
-        this.serviceName = serviceName;
+        this.key = key;
     }
 
-    @Override
     public boolean equals(Object o) {
         if (this == o) {
             return true;
         }
-        if (!(o instanceof TransactionLogKey)) {
+        if (!(o instanceof TransactionRecordKey)) {
             return false;
         }
 
-        TransactionLogKey that = (TransactionLogKey) o;
+        TransactionRecordKey that = (TransactionRecordKey) o;
 
-        if (itemId != that.itemId) {
+        if (!key.equals(that.key)) {
             return false;
         }
         if (!name.equals(that.name)) {
-            return false;
-        }
-        if (!serviceName.equals(that.serviceName)) {
             return false;
         }
 
         return true;
     }
 
-    @Override
     public int hashCode() {
         int result = name.hashCode();
-        result = 31 * result + (int) (itemId ^ (itemId >>> 32));
-        result = 31 * result + serviceName.hashCode();
+        result = 31 * result + key.hashCode();
         return result;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TransactionalMultiMapProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TransactionalMultiMapProxy.java
@@ -22,7 +22,7 @@ import com.hazelcast.multimap.impl.MultiMapService;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.transaction.TransactionException;
-import com.hazelcast.transaction.impl.TransactionSupport;
+import com.hazelcast.transaction.impl.InternalTransaction;
 import java.util.ArrayList;
 import java.util.Collection;
 
@@ -32,7 +32,7 @@ public class TransactionalMultiMapProxy<K, V> extends TransactionalMultiMapProxy
     public TransactionalMultiMapProxy(NodeEngine nodeEngine,
                                       MultiMapService service,
                                       String name,
-                                      TransactionSupport tx) {
+                                      InternalTransaction tx) {
         super(nodeEngine, service, name, tx);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/TransactionalService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/TransactionalService.java
@@ -17,14 +17,14 @@
 package com.hazelcast.spi;
 
 import com.hazelcast.transaction.TransactionalObject;
-import com.hazelcast.transaction.impl.TransactionSupport;
+import com.hazelcast.transaction.impl.InternalTransaction;
 
 /**
  * An interface that can be implemented by SPI services that want to deal with transactions.
  */
 public interface TransactionalService {
 
-    <T extends TransactionalObject> T createTransactionalObject(String name, TransactionSupport transaction);
+    <T extends TransactionalObject> T createTransactionalObject(String name, InternalTransaction transaction);
 
     void rollbackTransaction(String transactionId);
 }

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/InternalTransaction.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/InternalTransaction.java
@@ -16,8 +16,19 @@
 
 package com.hazelcast.transaction.impl;
 
-public interface KeyAwareTransactionLog extends TransactionLog {
+/**
+ * A Internal Transaction interface that adds the ability to track TransactionRecords.
+ *
+ * E.g. if 3 puts on a transactional map and 3 adds on a transactional-queue are done, there will
+ * be 5 records for that transaction.
+ */
+public interface InternalTransaction extends Transaction {
 
-    Object getKey();
+    void add(TransactionRecord record);
 
+    void remove(Object key);
+
+    TransactionRecord get(Object key);
+
+    String getOwnerUuid();
 }

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/KeyAwareTransactionRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/KeyAwareTransactionRecord.java
@@ -16,20 +16,8 @@
 
 package com.hazelcast.transaction.impl;
 
-public interface TransactionSupport {
+public interface KeyAwareTransactionRecord extends TransactionRecord {
 
-    void addTransactionLog(TransactionLog transactionLog);
-
-    void removeTransactionLog(Object key);
-
-    TransactionLog getTransactionLog(Object key);
-
-    String getTxnId();
-
-    long getTimeoutMillis();
-
-    Transaction.State getState();
-
-    String getOwnerUuid();
+    Object getKey();
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/ReplicateTxOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/ReplicateTxOperation.java
@@ -29,7 +29,7 @@ import java.util.List;
 
 public final class ReplicateTxOperation extends Operation {
 
-    private final List<TransactionLog> txLogs = new LinkedList<TransactionLog>();
+    private final List<TransactionRecord> txLogs = new LinkedList<TransactionRecord>();
     private String callerUuid;
     private String txnId;
     private long timeoutMillis;
@@ -38,7 +38,7 @@ public final class ReplicateTxOperation extends Operation {
     public ReplicateTxOperation() {
     }
 
-    public ReplicateTxOperation(List<TransactionLog> logs, String callerUuid, String txnId,
+    public ReplicateTxOperation(List<TransactionRecord> logs, String callerUuid, String txnId,
                                 long timeoutMillis, long startTime) {
         txLogs.addAll(logs);
         this.callerUuid = callerUuid;
@@ -93,7 +93,7 @@ public final class ReplicateTxOperation extends Operation {
         int len = txLogs.size();
         out.writeInt(len);
         if (len > 0) {
-            for (TransactionLog txLog : txLogs) {
+            for (TransactionRecord txLog : txLogs) {
                 out.writeObject(txLog);
             }
         }
@@ -108,7 +108,7 @@ public final class ReplicateTxOperation extends Operation {
         int len = in.readInt();
         if (len > 0) {
             for (int i = 0; i < len; i++) {
-                TransactionLog txLog = in.readObject();
+                TransactionRecord txLog = in.readObject();
                 txLogs.add(txLog);
             }
         }

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionManagerServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionManagerServiceImpl.java
@@ -202,13 +202,13 @@ public class TransactionManagerServiceImpl implements TransactionManagerService,
     }
 
     void beginTxBackupLog(String callerUuid, String txnId) {
-        TxBackupLog log = new TxBackupLog(Collections.<TransactionLog>emptyList(), callerUuid, State.ACTIVE, -1, -1);
+        TxBackupLog log = new TxBackupLog(Collections.<TransactionRecord>emptyList(), callerUuid, State.ACTIVE, -1, -1);
         if (txBackupLogs.putIfAbsent(txnId, log) != null) {
             throw new TransactionException("TxLog already exists!");
         }
     }
 
-    void prepareTxBackupLog(List<TransactionLog> txLogs, String callerUuid, String txnId,
+    void prepareTxBackupLog(List<TransactionRecord> txLogs, String callerUuid, String txnId,
                             long timeoutMillis, long startTime) {
         TxBackupLog beginLog = txBackupLogs.get(txnId);
         if (beginLog == null) {
@@ -238,13 +238,13 @@ public class TransactionManagerServiceImpl implements TransactionManagerService,
     }
 
     private static final class TxBackupLog {
-        private final List<TransactionLog> txLogs;
+        private final List<TransactionRecord> txLogs;
         private final String callerUuid;
         private final long timeoutMillis;
         private final long startTime;
         private volatile State state;
 
-        private TxBackupLog(List<TransactionLog> txLogs, String callerUuid, State state, long timeoutMillis, long startTime) {
+        private TxBackupLog(List<TransactionRecord> txLogs, String callerUuid, State state, long timeoutMillis, long startTime) {
             this.txLogs = txLogs;
             this.callerUuid = callerUuid;
             this.state = state;

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionRecord.java
@@ -22,7 +22,12 @@ import com.hazelcast.spi.NodeEngine;
 
 import java.util.concurrent.Future;
 
-public interface TransactionLog extends DataSerializable {
+/**
+ * Every change made in a transaction is recorded on the transaction using a transaction-record.
+ *
+ * @see InternalTransaction
+ */
+public interface TransactionRecord extends DataSerializable {
 
     Future prepare(NodeEngine nodeEngine);
 

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/PutRemoteTransactionBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/PutRemoteTransactionBackupOperation.java
@@ -21,7 +21,7 @@ import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.spi.BackupOperation;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.Operation;
-import com.hazelcast.transaction.impl.TransactionLog;
+import com.hazelcast.transaction.impl.TransactionRecord;
 
 import java.io.IOException;
 import java.util.LinkedList;
@@ -29,7 +29,7 @@ import java.util.List;
 
 public class PutRemoteTransactionBackupOperation extends Operation implements BackupOperation {
 
-    private final List<TransactionLog> txLogs = new LinkedList<TransactionLog>();
+    private final List<TransactionRecord> txLogs = new LinkedList<TransactionRecord>();
 
     private SerializableXID xid;
     private String txnId;
@@ -40,7 +40,7 @@ public class PutRemoteTransactionBackupOperation extends Operation implements Ba
     public PutRemoteTransactionBackupOperation() {
     }
 
-    public PutRemoteTransactionBackupOperation(List<TransactionLog> logs, String txnId, SerializableXID xid,
+    public PutRemoteTransactionBackupOperation(List<TransactionRecord> logs, String txnId, SerializableXID xid,
                                                String txOwnerUuid, long timeoutMillis, long startTime) {
         txLogs.addAll(logs);
         this.txnId = txnId;
@@ -92,7 +92,7 @@ public class PutRemoteTransactionBackupOperation extends Operation implements Ba
         int len = txLogs.size();
         out.writeInt(len);
         if (len > 0) {
-            for (TransactionLog txLog : txLogs) {
+            for (TransactionRecord txLog : txLogs) {
                 out.writeObject(txLog);
             }
         }
@@ -108,7 +108,7 @@ public class PutRemoteTransactionBackupOperation extends Operation implements Ba
         int len = in.readInt();
         if (len > 0) {
             for (int i = 0; i < len; i++) {
-                TransactionLog txLog = in.readObject();
+                TransactionRecord txLog = in.readObject();
                 txLogs.add(txLog);
             }
         }

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/PutRemoteTransactionOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/PutRemoteTransactionOperation.java
@@ -21,7 +21,7 @@ import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.spi.BackupAwareOperation;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.Operation;
-import com.hazelcast.transaction.impl.TransactionLog;
+import com.hazelcast.transaction.impl.TransactionRecord;
 
 import java.io.IOException;
 import java.util.LinkedList;
@@ -29,7 +29,7 @@ import java.util.List;
 
 public class PutRemoteTransactionOperation extends Operation implements BackupAwareOperation {
 
-    private final List<TransactionLog> txLogs = new LinkedList<TransactionLog>();
+    private final List<TransactionRecord> txLogs = new LinkedList<TransactionRecord>();
 
     private SerializableXID xid;
     private String txnId;
@@ -40,7 +40,7 @@ public class PutRemoteTransactionOperation extends Operation implements BackupAw
     public PutRemoteTransactionOperation() {
     }
 
-    public PutRemoteTransactionOperation(List<TransactionLog> logs, String txnId, SerializableXID xid,
+    public PutRemoteTransactionOperation(List<TransactionRecord> logs, String txnId, SerializableXID xid,
                                          String txOwnerUuid, long timeoutMillis, long startTime) {
         txLogs.addAll(logs);
         this.txnId = txnId;
@@ -112,7 +112,7 @@ public class PutRemoteTransactionOperation extends Operation implements BackupAw
         int len = txLogs.size();
         out.writeInt(len);
         if (len > 0) {
-            for (TransactionLog txLog : txLogs) {
+            for (TransactionRecord txLog : txLogs) {
                 out.writeObject(txLog);
             }
         }
@@ -128,7 +128,7 @@ public class PutRemoteTransactionOperation extends Operation implements BackupAw
         int len = in.readInt();
         if (len > 0) {
             for (int i = 0; i < len; i++) {
-                TransactionLog txLog = in.readObject();
+                TransactionRecord txLog = in.readObject();
                 txLogs.add(txLog);
             }
         }

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/XATransactionHolder.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/XATransactionHolder.java
@@ -19,7 +19,7 @@ package com.hazelcast.transaction.impl.xa;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.DataSerializable;
-import com.hazelcast.transaction.impl.TransactionLog;
+import com.hazelcast.transaction.impl.TransactionRecord;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -31,7 +31,7 @@ public class XATransactionHolder implements DataSerializable {
     String ownerUuid;
     long timeoutMilis;
     long startTime;
-    List<TransactionLog> txLogs;
+    List<TransactionRecord> txLogs;
 
     public XATransactionHolder() {
 
@@ -47,7 +47,7 @@ public class XATransactionHolder implements DataSerializable {
     }
 
     public XATransactionHolder(String txnId, SerializableXID xid, String ownerUuid, long timeoutMilis,
-                               long startTime, List<TransactionLog> txLogs) {
+                               long startTime, List<TransactionRecord> txLogs) {
         this.txnId = txnId;
         this.xid = xid;
         this.ownerUuid = ownerUuid;
@@ -66,7 +66,7 @@ public class XATransactionHolder implements DataSerializable {
         int len = txLogs.size();
         out.writeInt(len);
         if (len > 0) {
-            for (TransactionLog txLog : txLogs) {
+            for (TransactionRecord txLog : txLogs) {
                 out.writeObject(txLog);
             }
         }
@@ -80,9 +80,9 @@ public class XATransactionHolder implements DataSerializable {
         timeoutMilis = in.readLong();
         startTime = in.readLong();
         int size = in.readInt();
-        txLogs = new ArrayList<TransactionLog>(size);
+        txLogs = new ArrayList<TransactionRecord>(size);
         for (int i = 0; i < size; i++) {
-            TransactionLog txLog = in.readObject();
+            TransactionRecord txLog = in.readObject();
             txLogs.add(txLog);
         }
     }

--- a/hazelcast/src/test/java/com/hazelcast/map/MapTransactionStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapTransactionStressTest.java
@@ -25,8 +25,8 @@ import com.hazelcast.transaction.TransactionException;
 import com.hazelcast.transaction.TransactionalObject;
 import com.hazelcast.transaction.TransactionalTask;
 import com.hazelcast.transaction.TransactionalTaskContext;
-import com.hazelcast.transaction.impl.TransactionLog;
-import com.hazelcast.transaction.impl.TransactionSupport;
+import com.hazelcast.transaction.impl.TransactionRecord;
+import com.hazelcast.transaction.impl.InternalTransaction;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -263,7 +263,7 @@ public class MapTransactionStressTest extends HazelcastTestSupport {
 
         @Override
         public TransactionalObject createTransactionalObject(String name,
-                                                             TransactionSupport transaction) {
+                                                             InternalTransaction transaction) {
             return new DummyTransactionalObject(serviceName, name, transaction);
         }
 
@@ -285,16 +285,16 @@ public class MapTransactionStressTest extends HazelcastTestSupport {
 
         final String serviceName;
         final String name;
-        final TransactionSupport transaction;
+        final InternalTransaction transaction;
 
-        DummyTransactionalObject(String serviceName, String name, TransactionSupport transaction) {
+        DummyTransactionalObject(String serviceName, String name, InternalTransaction transaction) {
             this.serviceName = serviceName;
             this.name = name;
             this.transaction = transaction;
         }
 
         public void doSomethingTxnal() {
-            transaction.addTransactionLog(new SleepyTransactionLog());
+            transaction.add(new SleepyTransactionRecord());
         }
 
         @Override
@@ -318,7 +318,7 @@ public class MapTransactionStressTest extends HazelcastTestSupport {
         }
     }
 
-    public static class SleepyTransactionLog implements TransactionLog {
+    public static class SleepyTransactionRecord implements TransactionRecord {
         @Override
         public Future prepare(NodeEngine nodeEngine) {
             return new EmptyFuture();

--- a/hazelcast/src/test/java/com/hazelcast/transaction/impl/TransactionImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/transaction/impl/TransactionImplTest.java
@@ -94,7 +94,7 @@ public class TransactionImplTest {
         TransactionOptions options = new TransactionOptions().setTransactionType(TransactionType.LOCAL);
         transaction = new TransactionImpl(transactionManagerService, nodeEngine, options, "dummy-uuid");
         transaction.begin();
-        transaction.addTransactionLog(new FailingTransactionLog(false, true, false));
+        transaction.add(new FailingTransactionRecord(false, true, false));
         transaction.commit();
     }
 
@@ -112,7 +112,7 @@ public class TransactionImplTest {
         transaction = new TransactionImpl(transactionManagerService, nodeEngine, options, "dummy-uuid");
 
         transaction.begin();
-        transaction.addTransactionLog(new FailingTransactionLog(true, true, false));
+        transaction.add(new FailingTransactionRecord(true, true, false));
         transaction.prepare();
     }
 
@@ -129,17 +129,17 @@ public class TransactionImplTest {
                 .setTransactionType(TransactionType.TWO_PHASE).setDurability(0);
         transaction = new TransactionImpl(transactionManagerService, nodeEngine, options, "dummy-uuid");
         transaction.begin();
-        transaction.addTransactionLog(new FailingTransactionLog(false, true, false));
+        transaction.add(new FailingTransactionRecord(false, true, false));
         transaction.prepare();
         transaction.commit();
     }
 
-    private static class FailingTransactionLog implements TransactionLog {
+    private static class FailingTransactionRecord implements TransactionRecord {
         final boolean failPrepare;
         final boolean failCommit;
         final boolean failRollback;
 
-        public FailingTransactionLog(boolean failPrepare, boolean failCommit, boolean failRollback) {
+        public FailingTransactionRecord(boolean failPrepare, boolean failCommit, boolean failRollback) {
             this.failPrepare = failPrepare;
             this.failCommit = failCommit;
             this.failRollback = failRollback;


### PR DESCRIPTION
The TransactionLog is not a log for transactions, it is a single record in the transaction. So a single map.put is a single record within the transaction. That is why it has been renamed to TransactionRecord.

I also renamed the TransactionSupport to InternalTransaction and have it extend the Transaction interface.  