### PR TITLE
Independent sizing of buffers for connections opened by clients

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/io/IndependentBufferSizingTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/io/IndependentBufferSizingTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.io;
+
+import com.hazelcast.client.HazelcastClient;
+import com.hazelcast.config.Config;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.instance.Node;
+import com.hazelcast.nio.tcp.ReadHandler;
+import com.hazelcast.nio.tcp.TcpIpConnection;
+import com.hazelcast.nio.tcp.TcpIpConnectionManager;
+import com.hazelcast.nio.tcp.WriteHandler;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.lang.reflect.Field;
+import java.nio.ByteBuffer;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class IndependentBufferSizingTest extends HazelcastTestSupport {
+
+    @After
+    public void tearDown() {
+        HazelcastClient.shutdownAll();
+        Hazelcast.shutdownAll();
+    }
+
+    @Test
+    public void testClientBufferSize_SameAsForMemberMemberConnectionsByDefault() {
+        Config config = new Config();
+        HazelcastInstance server = Hazelcast.newHazelcastInstance(config);
+        HazelcastInstance client = HazelcastClient.newHazelcastClient();
+
+        TcpIpConnection clientConnection = getClientConnection(server);
+        ReadHandler readHandler = clientConnection.getReadHandler();
+        WriteHandler writeHandler = clientConnection.getWriteHandler();
+
+        int defaultReceiveBuffer = getDefaultReceiverBufferSize(server);
+        int defaultSendBuffer = getDefaultSendBufferSize(server);
+
+        assertHasByteBufferWithSize(readHandler, "inputBuffer", defaultReceiveBuffer);
+        assertHasByteBufferWithSize(writeHandler, "outputBuffer", defaultSendBuffer);
+    }
+
+    @Test
+    public void testClientBufferSize_ExplicitOverride() {
+        int receiveBufferSizeKB = 16;
+        int sendBufferSizeKB = 4;
+
+        Config config = new Config();
+        config.setProperty(GroupProperties.PROP_SOCKET_CLIENT_RECEIVE_BUFFER_SIZE, Integer.toString(receiveBufferSizeKB));
+        config.setProperty(GroupProperties.PROP_SOCKET_CLIENT_SEND_BUFFER_SIZE, Integer.toString(sendBufferSizeKB));
+
+        HazelcastInstance server = Hazelcast.newHazelcastInstance(config);
+        HazelcastInstance client = HazelcastClient.newHazelcastClient();
+
+        TcpIpConnection clientConnection = getClientConnection(server);
+        ReadHandler readHandler = clientConnection.getReadHandler();
+        WriteHandler writeHandler = clientConnection.getWriteHandler();
+
+        assertHasByteBufferWithSize(readHandler, "inputBuffer", receiveBufferSizeKB * 1024);
+        assertHasByteBufferWithSize(writeHandler, "outputBuffer", sendBufferSizeKB * 1024);
+    }
+
+    private int getDefaultSendBufferSize(HazelcastInstance instance) {
+        Node node = getNode(instance);
+        return node.getGroupProperties().SOCKET_SEND_BUFFER_SIZE.getInteger() * 1024;
+    }
+
+    private int getDefaultReceiverBufferSize(HazelcastInstance instance) {
+        Node node = getNode(instance);
+        return node.getGroupProperties().SOCKET_RECEIVE_BUFFER_SIZE.getInteger() * 1024;
+    }
+
+    private TcpIpConnection getClientConnection(HazelcastInstance server) {
+        TcpIpConnectionManager connectionManager = (TcpIpConnectionManager) getConnectionManager(server);
+        Set<TcpIpConnection> activeConnections = connectionManager.getActiveConnections();
+        return activeConnections.iterator().next();
+    }
+
+    private void assertHasByteBufferWithSize(Object object, String fieldName, int size) {
+        ByteBuffer byteBuffer = getField(object, fieldName);
+        assertEquals(size, byteBuffer.capacity());
+    }
+
+    private <T> T getField(Object object, String fieldName) {
+        try {
+            Field field = object.getClass().getDeclaredField(fieldName);
+            field.setAccessible(true);
+            return (T) field.get(object);
+        } catch (NoSuchFieldException e) {
+            throw new IllegalArgumentException("Class " + object.getClass() + " doesn't have a field " + fieldName + " declared");
+        } catch (IllegalAccessException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/instance/GroupProperties.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/GroupProperties.java
@@ -114,6 +114,33 @@ public class GroupProperties {
     public static final String PROP_CLIENT_ENGINE_THREAD_COUNT = "hazelcast.clientengine.thread.count";
     public static final String PROP_SOCKET_RECEIVE_BUFFER_SIZE = "hazelcast.socket.receive.buffer.size";
     public static final String PROP_SOCKET_SEND_BUFFER_SIZE = "hazelcast.socket.send.buffer.size";
+
+    /**
+     * Overrides receive buffer size for connections opened by clients.
+     *
+     * Hazelcast creates all connections with receive buffer size set according to #PROP_SOCKET_RECEIVE_BUFFER_SIZE.
+     * When it detects a connection was opened by a client then it adjusts receive buffer size
+     * according to this property.
+     *
+     * Size is in kilobytes.
+     * Default: -1; Same as receive buffer size for connections opened by members.
+     *
+     */
+    public static final String PROP_SOCKET_CLIENT_RECEIVE_BUFFER_SIZE = "hazelcast.socket.client.receive.buffer.size";
+
+    /**
+     * Overrides send buffer size for connections opened by clients.
+     *
+     * Hazelcast creates all connections with send buffer size set according to #PROP_SOCKET_SEND_BUFFER_SIZE.
+     * When it detects a connection was opened by a client then it adjusts send buffer size
+     * according to this property.
+     *
+     * Size is in kilobytes.
+     * Default: -1; Same as receive buffer size for connections opened by members.
+     *
+     */
+    public static final String PROP_SOCKET_CLIENT_SEND_BUFFER_SIZE = "hazelcast.socket.client.send.buffer.size";
+
     public static final String PROP_SOCKET_LINGER_SECONDS = "hazelcast.socket.linger.seconds";
     public static final String PROP_SOCKET_CONNECT_TIMEOUT_SECONDS = "hazelcast.socket.connect.timeout.seconds";
     public static final String PROP_SOCKET_KEEP_ALIVE = "hazelcast.socket.keep.alive";
@@ -464,6 +491,12 @@ public class GroupProperties {
     // number of kilobytes
     public final GroupProperty SOCKET_SEND_BUFFER_SIZE;
 
+    // number of kilobytes
+    public final GroupProperty SOCKET_CLIENT_RECEIVE_BUFFER_SIZE;
+
+    // number of kilobytes
+    public final GroupProperty SOCKET_CLIENT_SEND_BUFFER_SIZE;
+
     public final GroupProperty SOCKET_LINGER_SECONDS;
 
     public final GroupProperty SOCKET_CONNECT_TIMEOUT_SECONDS;
@@ -636,6 +669,8 @@ public class GroupProperties {
         SOCKET_CLIENT_BIND = new GroupProperty(config, PROP_SOCKET_CLIENT_BIND, "true");
         SOCKET_RECEIVE_BUFFER_SIZE = new GroupProperty(config, PROP_SOCKET_RECEIVE_BUFFER_SIZE, "32");
         SOCKET_SEND_BUFFER_SIZE = new GroupProperty(config, PROP_SOCKET_SEND_BUFFER_SIZE, "32");
+        SOCKET_CLIENT_RECEIVE_BUFFER_SIZE = new GroupProperty(config, PROP_SOCKET_CLIENT_RECEIVE_BUFFER_SIZE, "-1");
+        SOCKET_CLIENT_SEND_BUFFER_SIZE = new GroupProperty(config, PROP_SOCKET_CLIENT_SEND_BUFFER_SIZE, "-1");
         SOCKET_LINGER_SECONDS = new GroupProperty(config, PROP_SOCKET_LINGER_SECONDS, "0");
         SOCKET_CONNECT_TIMEOUT_SECONDS = new GroupProperty(config, PROP_SOCKET_CONNECT_TIMEOUT_SECONDS, "0");
         SOCKET_KEEP_ALIVE = new GroupProperty(config, PROP_SOCKET_KEEP_ALIVE, "true");

--- a/hazelcast/src/main/java/com/hazelcast/nio/IOService.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/IOService.java
@@ -84,6 +84,20 @@ public interface IOService {
 
     int getSocketSendBufferSize();
 
+    /**
+     * Size of receive buffers for connections opened by clients
+     *
+     * @return size in bytes
+     */
+    int getSocketClientReceiveBufferSize();
+
+    /**
+     * Size of send buffers for connections opened by clients
+     *
+     * @return size in bytes
+     */
+    int getSocketClientSendBufferSize();
+
     int getSocketLingerSeconds();
 
     int getSocketConnectTimeoutSeconds();

--- a/hazelcast/src/main/java/com/hazelcast/nio/NodeIOService.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/NodeIOService.java
@@ -201,6 +201,18 @@ public class NodeIOService implements IOService {
     }
 
     @Override
+    public int getSocketClientReceiveBufferSize() {
+        int clientSendBuffer = this.node.getGroupProperties().SOCKET_CLIENT_RECEIVE_BUFFER_SIZE.getInteger();
+        return clientSendBuffer != -1 ? clientSendBuffer : getSocketReceiveBufferSize();
+    }
+
+    @Override
+    public int getSocketClientSendBufferSize() {
+        int clientReceiveBuffer = this.node.getGroupProperties().SOCKET_CLIENT_SEND_BUFFER_SIZE.getInteger();
+        return clientReceiveBuffer != -1 ? clientReceiveBuffer : getSocketReceiveBufferSize();
+    }
+
+    @Override
     public int getSocketLingerSeconds() {
         return this.node.getGroupProperties().SOCKET_LINGER_SECONDS.getInteger();
     }

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnection.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnection.java
@@ -27,6 +27,7 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.net.SocketAddress;
+import java.net.SocketException;
 
 /**
  * The Tcp/Ip implementation of the {@link com.hazelcast.nio.Connection}.
@@ -235,6 +236,14 @@ public final class TcpIpConnection implements Connection {
 
     public int getConnectionId() {
         return connectionId;
+    }
+
+    public void setSendBufferSize(int size) throws SocketException {
+        socketChannel.socket().setSendBufferSize(size);
+    }
+
+    public void setReceiveBufferSize(int size) throws SocketException {
+        socketChannel.socket().setReceiveBufferSize(size);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnectionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnectionManager.java
@@ -54,9 +54,13 @@ public class TcpIpConnectionManager implements ConnectionManager {
 
     final int socketReceiveBufferSize;
 
+    final int socketClientReceiveBufferSize;
+
     final IOService ioService;
 
     final int socketSendBufferSize;
+
+    final int socketClientSendBufferSize;
 
     private final ConstructorFunction<Address, TcpIpConnectionMonitor> monitorConstructor
             = new ConstructorFunction<Address, TcpIpConnectionMonitor>() {
@@ -132,6 +136,8 @@ public class TcpIpConnectionManager implements ConnectionManager {
         this.logger = loggingService.getLogger(TcpIpConnectionManager.class.getName());
         this.socketReceiveBufferSize = ioService.getSocketReceiveBufferSize() * IOService.KILO_BYTE;
         this.socketSendBufferSize = ioService.getSocketSendBufferSize() * IOService.KILO_BYTE;
+        this.socketClientReceiveBufferSize = ioService.getSocketClientReceiveBufferSize() * IOService.KILO_BYTE;
+        this.socketClientSendBufferSize = ioService.getSocketClientSendBufferSize() * IOService.KILO_BYTE;
         this.socketLingerSeconds = ioService.getSocketLingerSeconds();
         this.socketConnectTimeoutSeconds = ioService.getSocketConnectTimeoutSeconds();
         this.socketKeepAlive = ioService.getSocketKeepAlive();


### PR DESCRIPTION
The PR introduces 2 new group properties to override buffers sizes for connections opened by clients.

It allows Hazelcast members to have large buffers for member-to-member connections and smaller buffers for connections opened by clients - as there might be 10,000's of clients, but typical cluster size is way smaller. 