### PR TITLE
Cleanup for TransactionRecord

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txncollection/operations/CollectionPrepareOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txncollection/operations/CollectionPrepareOperation.java
@@ -18,11 +18,13 @@ package com.hazelcast.collection.impl.txncollection.operations;
 
 import com.hazelcast.collection.impl.collection.CollectionContainer;
 import com.hazelcast.collection.impl.collection.operations.CollectionBackupAwareOperation;
-import com.hazelcast.collection.impl.collection.CollectionDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.spi.Operation;
+
 import java.io.IOException;
+
+import static com.hazelcast.collection.impl.collection.CollectionDataSerializerHook.COLLECTION_PREPARE;
 
 public class CollectionPrepareOperation extends CollectionBackupAwareOperation {
 
@@ -33,8 +35,11 @@ public class CollectionPrepareOperation extends CollectionBackupAwareOperation {
     public CollectionPrepareOperation() {
     }
 
-    public CollectionPrepareOperation(String name, long itemId, String transactionId, boolean removeOperation) {
+    public CollectionPrepareOperation(int partitionId, String name, String serviceName,
+                                      long itemId, String transactionId, boolean removeOperation) {
         super(name);
+        setPartitionId(partitionId);
+        setServiceName(serviceName);
         this.itemId = itemId;
         this.removeOperation = removeOperation;
         this.transactionId = transactionId;
@@ -58,7 +63,7 @@ public class CollectionPrepareOperation extends CollectionBackupAwareOperation {
 
     @Override
     public int getId() {
-        return CollectionDataSerializerHook.COLLECTION_PREPARE;
+        return COLLECTION_PREPARE;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txncollection/operations/CollectionRollbackOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txncollection/operations/CollectionRollbackOperation.java
@@ -32,8 +32,10 @@ public class CollectionRollbackOperation extends CollectionBackupAwareOperation 
     public CollectionRollbackOperation() {
     }
 
-    public CollectionRollbackOperation(String name, long itemId, boolean removeOperation) {
+    public CollectionRollbackOperation(int partitionId, String name, String serviceName, long itemId, boolean removeOperation) {
         super(name);
+        setPartitionId(partitionId);
+        setServiceName(serviceName);
         this.itemId = itemId;
         this.removeOperation = removeOperation;
     }

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/operations/TxnPrepareOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/operations/TxnPrepareOperation.java
@@ -16,14 +16,15 @@
 
 package com.hazelcast.collection.impl.txnqueue.operations;
 
+import com.hazelcast.collection.impl.queue.QueueContainer;
+import com.hazelcast.collection.impl.queue.operations.QueueBackupAwareOperation;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.collection.impl.queue.operations.QueueBackupAwareOperation;
-import com.hazelcast.collection.impl.queue.QueueContainer;
-import com.hazelcast.collection.impl.queue.QueueDataSerializerHook;
 import com.hazelcast.spi.Operation;
 
 import java.io.IOException;
+
+import static com.hazelcast.collection.impl.queue.QueueDataSerializerHook.TXN_PREPARE;
 
 /**
  * Prepare operation for the transactional queue.
@@ -39,8 +40,9 @@ public class TxnPrepareOperation extends QueueBackupAwareOperation {
     public TxnPrepareOperation() {
     }
 
-    public TxnPrepareOperation(String name, long itemId, boolean pollOperation, String transactionId) {
+    public TxnPrepareOperation(int partitionId, String name, long itemId, boolean pollOperation, String transactionId) {
         super(name);
+        setPartitionId(partitionId);
         this.itemId = itemId;
         this.pollOperation = pollOperation;
         this.transactionId = transactionId;
@@ -64,7 +66,7 @@ public class TxnPrepareOperation extends QueueBackupAwareOperation {
 
     @Override
     public int getId() {
-        return QueueDataSerializerHook.TXN_PREPARE;
+        return TXN_PREPARE;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/operations/TxnRollbackOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/operations/TxnRollbackOperation.java
@@ -16,16 +16,17 @@
 
 package com.hazelcast.collection.impl.txnqueue.operations;
 
+import com.hazelcast.collection.impl.queue.QueueContainer;
+import com.hazelcast.collection.impl.queue.operations.QueueBackupAwareOperation;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.collection.impl.queue.operations.QueueBackupAwareOperation;
-import com.hazelcast.collection.impl.queue.QueueContainer;
-import com.hazelcast.collection.impl.queue.QueueDataSerializerHook;
 import com.hazelcast.spi.Notifier;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.WaitNotifyKey;
 
 import java.io.IOException;
+
+import static com.hazelcast.collection.impl.queue.QueueDataSerializerHook.TXN_ROLLBACK;
 
 /**
  * Rollback operation for the transactional queue.
@@ -38,8 +39,9 @@ public class TxnRollbackOperation extends QueueBackupAwareOperation implements N
     public TxnRollbackOperation() {
     }
 
-    public TxnRollbackOperation(String name, long itemId, boolean pollOperation) {
+    public TxnRollbackOperation(int partitionId, String name, long itemId, boolean pollOperation) {
         super(name);
+        setPartitionId(partitionId);
         this.itemId = itemId;
         this.pollOperation = pollOperation;
     }
@@ -80,7 +82,7 @@ public class TxnRollbackOperation extends QueueBackupAwareOperation implements N
 
     @Override
     public int getId() {
-        return QueueDataSerializerHook.TXN_ROLLBACK;
+        return TXN_ROLLBACK;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnPrepareOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnPrepareOperation.java
@@ -33,14 +33,17 @@ import java.io.IOException;
 public class TxnPrepareOperation extends KeyBasedMapOperation implements BackupAwareOperation, MutatingOperation {
 
     private static final long LOCK_TTL_MILLIS = 10000L;
-    String ownerUuid;
 
-    protected TxnPrepareOperation(String name, Data dataKey, String ownerUuid) {
-        super(name, dataKey);
-        this.ownerUuid = ownerUuid;
-    }
+    private String ownerUuid;
 
     public TxnPrepareOperation() {
+    }
+
+    protected TxnPrepareOperation(int partitionId, String name, Data dataKey, String ownerUuid, long threadId) {
+        super(name, dataKey);
+        setPartitionId(partitionId);
+        this.threadId = threadId;
+        this.ownerUuid = ownerUuid;
     }
 
     @Override
@@ -58,22 +61,27 @@ public class TxnPrepareOperation extends KeyBasedMapOperation implements BackupA
         return Boolean.TRUE;
     }
 
+    @Override
     public boolean shouldBackup() {
         return true;
     }
 
+    @Override
     public final Operation getBackupOperation() {
         return new TxnPrepareBackupOperation(name, dataKey, ownerUuid, getThreadId());
     }
 
+    @Override
     public final int getAsyncBackupCount() {
         return mapContainer.getAsyncBackupCount();
     }
 
+    @Override
     public final int getSyncBackupCount() {
         return mapContainer.getBackupCount();
     }
 
+    @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
         out.writeUTF(ownerUuid);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnRollbackOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnRollbackOperation.java
@@ -35,17 +35,19 @@ import java.io.IOException;
  */
 public class TxnRollbackOperation extends KeyBasedMapOperation implements BackupAwareOperation, Notifier {
 
-    String ownerUuid;
-
-    protected TxnRollbackOperation(String name, Data dataKey, String ownerUuid) {
-        super(name, dataKey);
-        this.ownerUuid = ownerUuid;
-    }
+    private String ownerUuid;
 
     public TxnRollbackOperation() {
     }
 
-    @Override
+    protected TxnRollbackOperation(int partitionId, String name, Data dataKey, String ownerUuid, long threadId) {
+        super(name, dataKey);
+        setPartitionId(partitionId);
+        this.ownerUuid = ownerUuid;
+        this.threadId = threadId;
+    }
+
+     @Override
     public void run() throws Exception {
         if (recordStore.isLocked(getKey()) && !recordStore.unlock(getKey(), ownerUuid, getThreadId(), getCallId())) {
             throw new TransactionException("Lock is not owned by the transaction! Owner: "

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnCommitOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnCommitOperation.java
@@ -25,20 +25,22 @@ import com.hazelcast.spi.BackupAwareOperation;
 import com.hazelcast.spi.Notifier;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.WaitNotifyKey;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
 public class TxnCommitOperation extends MultiMapBackupAwareOperation implements Notifier {
 
-    List<Operation> opList;
-    boolean notify = true;
+    private List<Operation> opList;
+    private boolean notify = true;
 
     public TxnCommitOperation() {
     }
 
-    public TxnCommitOperation(String name, Data dataKey, long threadId, List<Operation> opList) {
+    public TxnCommitOperation(int partitionId, String name, Data dataKey, long threadId, List<Operation> opList) {
         super(name, dataKey, threadId);
+        setPartitionId(partitionId);
         this.opList = opList;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnPrepareOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnPrepareOperation.java
@@ -29,13 +29,15 @@ import java.io.IOException;
 public class TxnPrepareOperation extends MultiMapBackupAwareOperation {
 
     private static final long LOCK_EXTENSION_TIME_IN_MILLIS = 10000L;
-    long ttl;
+
+    private long ttl;
 
     public TxnPrepareOperation() {
     }
 
-    public TxnPrepareOperation(String name, Data dataKey, long ttl, long threadId) {
+    public TxnPrepareOperation(int partitionId, String name, Data dataKey, long ttl, long threadId) {
         super(name, dataKey, threadId);
+        setPartitionId(partitionId);
         this.ttl = ttl;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnRollbackOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnRollbackOperation.java
@@ -30,10 +30,12 @@ public class TxnRollbackOperation extends MultiMapBackupAwareOperation implement
     public TxnRollbackOperation() {
     }
 
-    public TxnRollbackOperation(String name, Data dataKey, long threadId) {
+    public TxnRollbackOperation(int partitionId, String name, Data dataKey, long threadId) {
         super(name, dataKey, threadId);
+        setPartitionId(partitionId);
     }
 
+    @Override
     public void run() throws Exception {
         MultiMapContainer container = getOrCreateContainer();
         if (container.isLocked(dataKey) && !container.unlock(dataKey, getCallerUuid(), threadId, getCallId())) {
@@ -43,18 +45,22 @@ public class TxnRollbackOperation extends MultiMapBackupAwareOperation implement
         }
     }
 
+    @Override
     public Operation getBackupOperation() {
         return new TxnRollbackBackupOperation(name, dataKey, getCallerUuid(), threadId);
     }
 
+    @Override
     public boolean shouldNotify() {
         return true;
     }
 
+    @Override
     public WaitNotifyKey getNotifiedKey() {
         return getWaitKey();
     }
 
+    @Override
     public int getId() {
         return MultiMapDataSerializerHook.TXN_ROLLBACK;
     }

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/AbstractTransactionRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/AbstractTransactionRecord.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.transaction.impl;
+
+import com.hazelcast.core.ExecutionCallback;
+import com.hazelcast.spi.NodeEngine;
+import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.OperationService;
+import com.hazelcast.spi.impl.operationservice.InternalOperationService;
+import com.hazelcast.transaction.TransactionException;
+import com.hazelcast.util.ExceptionUtil;
+
+import java.util.concurrent.Future;
+
+public abstract class AbstractTransactionRecord implements TransactionRecord {
+
+    @Override
+    public final Future prepare(NodeEngine nodeEngine) throws TransactionException {
+        return invoke(nodeEngine, createPrepareOperation());
+    }
+
+    @Override
+    public final Future commit(NodeEngine nodeEngine) {
+        return invoke(nodeEngine, createCommitOperation());
+    }
+
+    @Override
+    public final void commitAsync(NodeEngine nodeEngine, ExecutionCallback callback) {
+        invokeAsync(nodeEngine, callback, createCommitOperation());
+    }
+
+    public final Future rollback(NodeEngine nodeEngine) {
+        return invoke(nodeEngine, createRollbackOperation());
+    }
+
+    @Override
+    public final void rollbackAsync(NodeEngine nodeEngine, ExecutionCallback callback) {
+        invokeAsync(nodeEngine, callback, createRollbackOperation());
+    }
+
+    private void invokeAsync(NodeEngine nodeEngine, ExecutionCallback callback, Operation operation) {
+        InternalOperationService operationService = (InternalOperationService) nodeEngine.getOperationService();
+        operationService.asyncInvokeOnPartition(operation.getServiceName(), operation, operation.getPartitionId(), callback);
+    }
+
+    private Future invoke(NodeEngine nodeEngine, Operation operation) {
+        OperationService operationService = nodeEngine.getOperationService();
+        try {
+            return operationService.invokeOnPartition(operation.getServiceName(), operation, operation.getPartitionId());
+        } catch (Throwable t) {
+            throw ExceptionUtil.rethrow(t);
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionRecord.java
@@ -19,6 +19,7 @@ package com.hazelcast.transaction.impl;
 import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.nio.serialization.DataSerializable;
 import com.hazelcast.spi.NodeEngine;
+import com.hazelcast.spi.Operation;
 
 import java.util.concurrent.Future;
 
@@ -28,6 +29,14 @@ import java.util.concurrent.Future;
  * @see InternalTransaction
  */
 public interface TransactionRecord extends DataSerializable {
+
+    int getPartitionId();
+
+    Operation createPrepareOperation();
+
+    Operation createCommitOperation();
+
+    Operation createRollbackOperation();
 
     Future prepare(NodeEngine nodeEngine);
 

--- a/hazelcast/src/test/java/com/hazelcast/map/MapTransactionStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapTransactionStressTest.java
@@ -14,6 +14,7 @@ import com.hazelcast.core.TransactionalQueue;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.spi.NodeEngine;
+import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.RemoteService;
 import com.hazelcast.spi.TransactionalService;
 import com.hazelcast.test.HazelcastParallelClassRunner;
@@ -319,6 +320,27 @@ public class MapTransactionStressTest extends HazelcastTestSupport {
     }
 
     public static class SleepyTransactionRecord implements TransactionRecord {
+
+        @Override
+        public int getPartitionId() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Operation createPrepareOperation() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Operation createCommitOperation() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Operation createRollbackOperation() {
+            throw new UnsupportedOperationException();
+        }
+
         @Override
         public Future prepare(NodeEngine nodeEngine) {
             return new EmptyFuture();
@@ -353,7 +375,7 @@ public class MapTransactionStressTest extends HazelcastTestSupport {
 
         @Override
         public String toString() {
-            return "SleepyTransactionLog{}";
+            return "SleepyTransactionRecord{}";
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/transaction/impl/TransactionImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/transaction/impl/TransactionImplTest.java
@@ -23,6 +23,7 @@ import com.hazelcast.logging.LogEvent;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.spi.NodeEngine;
+import com.hazelcast.spi.Operation;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.transaction.TransactionException;
@@ -143,6 +144,26 @@ public class TransactionImplTest {
             this.failPrepare = failPrepare;
             this.failCommit = failCommit;
             this.failRollback = failRollback;
+        }
+
+        @Override
+        public int getPartitionId() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Operation createPrepareOperation() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Operation createCommitOperation() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Operation createRollbackOperation() {
+            throw new UnsupportedOperationException();
         }
 
         @Override


### PR DESCRIPTION
The TransactionRecord now exposes methods for creating the Commit/Prepare/Rollback operations.

The invocation logic has been placed in the AbstractTransactionRecord since it is the same for
all implementations. This cleanup is preparation for transaction optimizations for the 3.6
release.

The idea is that eventually all the invoke methods are going to be removed from the the TransactionRecord and the transaction will take care of it. Here we can play with optimizations like:
- batching operations for a single partition (no need for an invocation per item per partition)
- last cohort optimization: no need to first send a prepare operation and then a commit operation, this can be squashed into a single preparecommit operation. This will also speed up transaction that modify a single item since number of remote calls is reduced.