### PR TITLE
Add legal wording to Agrona backport

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/util/collection/BiInt2ObjectMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/collection/BiInt2ObjectMap.java
@@ -1,6 +1,6 @@
 /*
- * Copyright 2014 Real Logic Ltd.
- * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ * Original work Copyright 2014 Real Logic Ltd.
+ * Modified work Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/util/collection/Hashing.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/collection/Hashing.java
@@ -1,6 +1,6 @@
 /*
- * Copyright 2014 Real Logic Ltd.
- * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ * Original work Copyright 2014 Real Logic Ltd.
+ * Modified work Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/util/collection/Int2ObjectHashMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/collection/Int2ObjectHashMap.java
@@ -1,6 +1,6 @@
 /*
- * Copyright 2014 Real Logic Ltd.
- * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ * Original work Copyright 2014 Real Logic Ltd.
+ * Modified work Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/util/collection/IntHashSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/collection/IntHashSet.java
@@ -1,6 +1,6 @@
 /*
- * Copyright 2014 Real Logic Ltd.
- * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ * Original work Copyright 2014 Real Logic Ltd.
+ * Modified work Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/util/collection/IntIterator.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/collection/IntIterator.java
@@ -1,6 +1,6 @@
 /*
- * Copyright 2014 Real Logic Ltd.
- * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ * Original work Copyright 2014 Real Logic Ltd.
+ * Modified work Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/util/collection/Long2LongHashMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/collection/Long2LongHashMap.java
@@ -1,6 +1,6 @@
 /*
- * Copyright 2014 Real Logic Ltd.
- * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ * Original work Copyright 2014 Real Logic Ltd.
+ * Modified work Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/util/collection/Long2ObjectHashMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/collection/Long2ObjectHashMap.java
@@ -1,6 +1,6 @@
 /*
- * Copyright 2014 Real Logic Ltd.
- * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ * Original work Copyright 2014 Real Logic Ltd.
+ * Modified work Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/util/collection/LongHashSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/collection/LongHashSet.java
@@ -1,6 +1,6 @@
 /*
- * Copyright 2014 Real Logic Ltd.
- * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ * Original work Copyright 2014 Real Logic Ltd.
+ * Modified work Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/util/collection/LongIterator.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/collection/LongIterator.java
@@ -1,6 +1,6 @@
 /*
- * Copyright 2014 Real Logic Ltd.
- * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ * Original work Copyright 2014 Real Logic Ltd.
+ * Modified work Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/util/collection/MapDelegatingSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/collection/MapDelegatingSet.java
@@ -1,6 +1,6 @@
 /*
- * Copyright 2014 Real Logic Ltd.
- * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ * Original work Copyright 2014 Real Logic Ltd.
+ * Modified work Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/util/collection/BiInt2ObjectMapTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/collection/BiInt2ObjectMapTest.java
@@ -1,6 +1,6 @@
 /*
- * Copyright 2014 Real Logic Ltd.
- * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ * Original work Copyright 2014 Real Logic Ltd.
+ * Modified work Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/util/collection/Int2ObjectHashMapTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/collection/Int2ObjectHashMapTest.java
@@ -1,6 +1,6 @@
 /*
- * Copyright 2014 Real Logic Ltd.
- * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ * Original work Copyright 2014 Real Logic Ltd.
+ * Modified work Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/util/collection/IntHashSetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/collection/IntHashSetTest.java
@@ -1,6 +1,6 @@
 /*
- * Copyright 2014 Real Logic Ltd.
- * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ * Original work Copyright 2014 Real Logic Ltd.
+ * Modified work Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/util/collection/Long2LongHashMapTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/collection/Long2LongHashMapTest.java
@@ -1,6 +1,6 @@
 /*
- * Copyright 2014 Real Logic Ltd.
- * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ * Original work Copyright 2014 Real Logic Ltd.
+ * Modified work Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/util/collection/Long2ObjectHashMapTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/collection/Long2ObjectHashMapTest.java
@@ -1,6 +1,6 @@
 /*
- * Copyright 2014 Real Logic Ltd.
- * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ * Original work Copyright 2014 Real Logic Ltd.
+ * Modified work Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
In addition to the copyright notice in each file and attribution in `NOTICE`, Apache License 2.0 also has this rule (§4.b):

> You must cause any modified files to carry prominent notices stating that You changed the files

To more explicitly comply with this rule I added four words to each affected file's copyright notice.

Related: [Martin Thompson's comment on an Agrona issue](https://github.com/real-logic/Agrona/issues/16#issuecomment-121973804)