### PR TITLE
TransactionLogRecord cleanup

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txncollection/TransactionLogRecordKey.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txncollection/TransactionLogRecordKey.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.collection.impl.txncollection;
 
-class TransactionRecordKey {
+class TransactionLogRecordKey {
 
     private final String name;
 
@@ -24,7 +24,7 @@ class TransactionRecordKey {
 
     private final String serviceName;
 
-    TransactionRecordKey(String name, long itemId, String serviceName) {
+    TransactionLogRecordKey(String name, long itemId, String serviceName) {
         this.name = name;
         this.itemId = itemId;
         this.serviceName = serviceName;
@@ -35,11 +35,11 @@ class TransactionRecordKey {
         if (this == o) {
             return true;
         }
-        if (!(o instanceof TransactionRecordKey)) {
+        if (!(o instanceof TransactionLogRecordKey)) {
             return false;
         }
 
-        TransactionRecordKey that = (TransactionRecordKey) o;
+        TransactionLogRecordKey that = (TransactionLogRecordKey) o;
 
         if (itemId != that.itemId) {
             return false;

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txncollection/operations/CollectionPrepareOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txncollection/operations/CollectionPrepareOperation.java
@@ -33,8 +33,11 @@ public class CollectionPrepareOperation extends CollectionBackupAwareOperation {
     public CollectionPrepareOperation() {
     }
 
-    public CollectionPrepareOperation(String name, long itemId, String transactionId, boolean removeOperation) {
+    public CollectionPrepareOperation(int partitionId, String name, String serviceName, long itemId, String transactionId,
+                                      boolean removeOperation) {
         super(name);
+        setPartitionId(partitionId);
+        setServiceName(serviceName);
         this.itemId = itemId;
         this.removeOperation = removeOperation;
         this.transactionId = transactionId;

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txncollection/operations/CollectionRollbackOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txncollection/operations/CollectionRollbackOperation.java
@@ -32,8 +32,10 @@ public class CollectionRollbackOperation extends CollectionBackupAwareOperation 
     public CollectionRollbackOperation() {
     }
 
-    public CollectionRollbackOperation(String name, long itemId, boolean removeOperation) {
+    public CollectionRollbackOperation(int partitionId, String name, String serviceName, long itemId, boolean removeOperation) {
         super(name);
+        setPartitionId(partitionId);
+        setServiceName(serviceName);
         this.itemId = itemId;
         this.removeOperation = removeOperation;
     }

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/QueueTransactionLogRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/QueueTransactionLogRecord.java
@@ -16,23 +16,15 @@
 
 package com.hazelcast.collection.impl.txnqueue;
 
-import com.hazelcast.collection.impl.queue.QueueService;
 import com.hazelcast.collection.impl.txnqueue.operations.TxnPollOperation;
 import com.hazelcast.collection.impl.txnqueue.operations.TxnPrepareOperation;
 import com.hazelcast.collection.impl.txnqueue.operations.TxnRollbackOperation;
-import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.spi.InternalCompletableFuture;
-import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.Operation;
-import com.hazelcast.spi.OperationService;
-import com.hazelcast.spi.impl.operationservice.InternalOperationService;
 import com.hazelcast.transaction.impl.KeyAwareTransactionLogRecord;
-import com.hazelcast.util.ExceptionUtil;
 
 import java.io.IOException;
-import java.util.concurrent.Future;
 
 /**
  * This class contains Transaction log for the Queue.
@@ -57,54 +49,26 @@ public class QueueTransactionLogRecord implements KeyAwareTransactionLogRecord {
     }
 
     @Override
-    public Future prepare(NodeEngine nodeEngine) {
+    public Operation newPrepareOperation() {
         boolean pollOperation = op instanceof TxnPollOperation;
-        TxnPrepareOperation operation = new TxnPrepareOperation(name, itemId, pollOperation, transactionId);
-        try {
-            return invoke(nodeEngine, operation);
-        } catch (Throwable t) {
-            throw ExceptionUtil.rethrow(t);
-        }
-    }
-
-    private InternalCompletableFuture invoke(NodeEngine nodeEngine, Operation operation) {
-        OperationService operationService = nodeEngine.getOperationService();
-        return operationService.invokeOnPartition(QueueService.SERVICE_NAME, operation, partitionId);
+        return new TxnPrepareOperation(partitionId, name, itemId, pollOperation, transactionId);
     }
 
     @Override
-    public Future commit(NodeEngine nodeEngine) {
-        try {
-            OperationService operationService = nodeEngine.getOperationService();
-            return operationService.invokeOnPartition(QueueService.SERVICE_NAME, op, partitionId);
-        } catch (Throwable t) {
-            throw ExceptionUtil.rethrow(t);
-        }
+    public Operation newCommitOperation() {
+        op.setPartitionId(partitionId);
+        return op;
     }
 
     @Override
-    public void commitAsync(NodeEngine nodeEngine, ExecutionCallback callback) {
-        InternalOperationService operationService = (InternalOperationService) nodeEngine.getOperationService();
-        operationService.asyncInvokeOnPartition(QueueService.SERVICE_NAME, op, partitionId, callback);
-    }
-
-    @Override
-    public Future rollback(NodeEngine nodeEngine) {
+    public Operation newRollbackOperation() {
         boolean pollOperation = op instanceof TxnPollOperation;
-        TxnRollbackOperation operation = new TxnRollbackOperation(name, itemId, pollOperation);
-        try {
-            return invoke(nodeEngine, operation);
-        } catch (Throwable t) {
-            throw ExceptionUtil.rethrow(t);
-        }
+        return new TxnRollbackOperation(partitionId, name, itemId, pollOperation);
     }
 
     @Override
-    public void rollbackAsync(NodeEngine nodeEngine, ExecutionCallback callback) {
-        boolean pollOperation = op instanceof TxnPollOperation;
-        TxnRollbackOperation operation = new TxnRollbackOperation(name, itemId, pollOperation);
-        InternalOperationService operationService = (InternalOperationService) nodeEngine.getOperationService();
-        operationService.asyncInvokeOnPartition(QueueService.SERVICE_NAME, operation, partitionId, callback);
+    public Object getKey() {
+        return new TransactionLogRecordKey(itemId, name);
     }
 
     @Override
@@ -123,10 +87,5 @@ public class QueueTransactionLogRecord implements KeyAwareTransactionLogRecord {
         name = in.readUTF();
         partitionId = in.readInt();
         op = in.readObject();
-    }
-
-    @Override
-    public Object getKey() {
-        return new TransactionRecordKey(itemId, name);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/TransactionLogRecordKey.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/TransactionLogRecordKey.java
@@ -16,13 +16,13 @@
 
 package com.hazelcast.collection.impl.txnqueue;
 
-class TransactionRecordKey {
+class TransactionLogRecordKey {
 
     private final long itemId;
 
     private final String name;
 
-    public TransactionRecordKey(long itemId, String name) {
+    public TransactionLogRecordKey(long itemId, String name) {
         this.itemId = itemId;
         this.name = name;
     }
@@ -31,11 +31,11 @@ class TransactionRecordKey {
         if (this == o) {
             return true;
         }
-        if (!(o instanceof TransactionRecordKey)) {
+        if (!(o instanceof TransactionLogRecordKey)) {
             return false;
         }
 
-        TransactionRecordKey that = (TransactionRecordKey) o;
+        TransactionLogRecordKey that = (TransactionLogRecordKey) o;
 
         if (itemId != that.itemId) {
             return false;

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/TransactionalQueueProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/TransactionalQueueProxySupport.java
@@ -104,7 +104,7 @@ public abstract class TransactionalQueueProxySupport extends AbstractDistributed
             if (item != null) {
                 if (reservedOffer != null && item.getItemId() == reservedOffer.getItemId()) {
                     offeredQueue.poll();
-                    tx.remove(new TransactionRecordKey(reservedOffer.getItemId(), name));
+                    tx.remove(new TransactionLogRecordKey(reservedOffer.getItemId(), name));
                     itemIdSet.remove(reservedOffer.getItemId());
                     return reservedOffer.getData();
                 }

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/operations/TxnPrepareOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/operations/TxnPrepareOperation.java
@@ -31,16 +31,15 @@ import java.io.IOException;
 public class TxnPrepareOperation extends QueueBackupAwareOperation {
 
     private long itemId;
-
     private boolean pollOperation;
-
     private String transactionId;
 
     public TxnPrepareOperation() {
     }
 
-    public TxnPrepareOperation(String name, long itemId, boolean pollOperation, String transactionId) {
+    public TxnPrepareOperation(int partitionId, String name, long itemId, boolean pollOperation, String transactionId) {
         super(name);
+        setPartitionId(partitionId);
         this.itemId = itemId;
         this.pollOperation = pollOperation;
         this.transactionId = transactionId;

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/operations/TxnRollbackOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/operations/TxnRollbackOperation.java
@@ -38,8 +38,9 @@ public class TxnRollbackOperation extends QueueBackupAwareOperation implements N
     public TxnRollbackOperation() {
     }
 
-    public TxnRollbackOperation(String name, long itemId, boolean pollOperation) {
+    public TxnRollbackOperation(int partitionId, String name, long itemId, boolean pollOperation) {
         super(name);
+        setPartitionId(partitionId);
         this.itemId = itemId;
         this.pollOperation = pollOperation;
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TransactionalMapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TransactionalMapProxySupport.java
@@ -148,7 +148,7 @@ public abstract class TransactionalMapProxySupport extends AbstractDistributedOb
     public Data putInternal(Data key, Data value) {
         VersionedValue versionedValue = lockAndGet(key, tx.getTimeoutMillis());
         final TxnSetOperation op = new TxnSetOperation(name, key, value, versionedValue.version);
-        tx.add(new MapTransactionLogRecord(name, key, op, versionedValue.version, tx.getOwnerUuid()));
+        tx.add(new MapTransactionLogRecord(name, key, getPartitionId(key), op, versionedValue.version, tx.getOwnerUuid()));
         return versionedValue.value;
     }
 
@@ -156,7 +156,7 @@ public abstract class TransactionalMapProxySupport extends AbstractDistributedOb
         VersionedValue versionedValue = lockAndGet(key, tx.getTimeoutMillis());
         final long timeInMillis = getTimeInMillis(ttl, timeUnit);
         final TxnSetOperation op = new TxnSetOperation(name, key, value, versionedValue.version, timeInMillis);
-        tx.add(new MapTransactionLogRecord(name, key, op, versionedValue.version, tx.getOwnerUuid()));
+        tx.add(new MapTransactionLogRecord(name, key, getPartitionId(key), op, versionedValue.version, tx.getOwnerUuid()));
         return versionedValue.value;
     }
 
@@ -168,7 +168,7 @@ public abstract class TransactionalMapProxySupport extends AbstractDistributedOb
         }
 
         final TxnSetOperation op = new TxnSetOperation(name, key, value, versionedValue.version);
-        tx.add(new MapTransactionLogRecord(name, key, op, versionedValue.version, tx.getOwnerUuid()));
+        tx.add(new MapTransactionLogRecord(name, key, getPartitionId(key), op, versionedValue.version, tx.getOwnerUuid()));
         return versionedValue.value;
     }
 
@@ -179,7 +179,7 @@ public abstract class TransactionalMapProxySupport extends AbstractDistributedOb
             return null;
         }
         final TxnSetOperation op = new TxnSetOperation(name, key, value, versionedValue.version);
-        tx.add(new MapTransactionLogRecord(name, key, op, versionedValue.version, tx.getOwnerUuid()));
+        tx.add(new MapTransactionLogRecord(name, key, getPartitionId(key), op, versionedValue.version, tx.getOwnerUuid()));
         return versionedValue.value;
     }
 
@@ -190,13 +190,13 @@ public abstract class TransactionalMapProxySupport extends AbstractDistributedOb
             return false;
         }
         final TxnSetOperation op = new TxnSetOperation(name, key, newValue, versionedValue.version);
-        tx.add(new MapTransactionLogRecord(name, key, op, versionedValue.version, tx.getOwnerUuid()));
+        tx.add(new MapTransactionLogRecord(name, key, getPartitionId(key), op, versionedValue.version, tx.getOwnerUuid()));
         return true;
     }
 
     public Data removeInternal(Data key) {
         VersionedValue versionedValue = lockAndGet(key, tx.getTimeoutMillis());
-        tx.add(new MapTransactionLogRecord(name, key,
+        tx.add(new MapTransactionLogRecord(name, key, getPartitionId(key),
                 new TxnDeleteOperation(name, key, versionedValue.version), versionedValue.version, tx.getOwnerUuid()));
         return versionedValue.value;
     }
@@ -207,14 +207,14 @@ public abstract class TransactionalMapProxySupport extends AbstractDistributedOb
             addUnlockTransactionRecord(key, versionedValue.version);
             return false;
         }
-        tx.add(new MapTransactionLogRecord(name, key,
+        tx.add(new MapTransactionLogRecord(name, key, getPartitionId(key),
                 new TxnDeleteOperation(name, key, versionedValue.version), versionedValue.version, tx.getOwnerUuid()));
         return true;
     }
 
     private void addUnlockTransactionRecord(Data key, long version) {
         TxnUnlockOperation operation = new TxnUnlockOperation(name, key, version);
-        tx.add(new MapTransactionLogRecord(name, key, operation, version, tx.getOwnerUuid()));
+        tx.add(new MapTransactionLogRecord(name, key, getPartitionId(key), operation, version, tx.getOwnerUuid()));
     }
 
     private VersionedValue lockAndGet(Data key, long timeout) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnPrepareOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnPrepareOperation.java
@@ -33,10 +33,12 @@ import java.io.IOException;
 public class TxnPrepareOperation extends KeyBasedMapOperation implements BackupAwareOperation, MutatingOperation {
 
     private static final long LOCK_TTL_MILLIS = 10000L;
-    String ownerUuid;
 
-    protected TxnPrepareOperation(String name, Data dataKey, String ownerUuid) {
+    private String ownerUuid;
+
+    protected TxnPrepareOperation(int partitionId, String name, Data dataKey, String ownerUuid) {
         super(name, dataKey);
+        setPartitionId(partitionId);
         this.ownerUuid = ownerUuid;
     }
 
@@ -55,25 +57,30 @@ public class TxnPrepareOperation extends KeyBasedMapOperation implements BackupA
 
     @Override
     public Object getResponse() {
-        return Boolean.TRUE;
+        return true;
     }
 
+    @Override
     public boolean shouldBackup() {
         return true;
     }
 
+    @Override
     public final Operation getBackupOperation() {
         return new TxnPrepareBackupOperation(name, dataKey, ownerUuid, getThreadId());
     }
 
+    @Override
     public final int getAsyncBackupCount() {
         return mapContainer.getAsyncBackupCount();
     }
 
+    @Override
     public final int getSyncBackupCount() {
         return mapContainer.getBackupCount();
     }
 
+    @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
         out.writeUTF(ownerUuid);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnRollbackOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnRollbackOperation.java
@@ -28,6 +28,7 @@ import com.hazelcast.spi.Notifier;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.WaitNotifyKey;
 import com.hazelcast.transaction.TransactionException;
+
 import java.io.IOException;
 
 /**
@@ -35,10 +36,11 @@ import java.io.IOException;
  */
 public class TxnRollbackOperation extends KeyBasedMapOperation implements BackupAwareOperation, Notifier {
 
-    String ownerUuid;
+    private String ownerUuid;
 
-    protected TxnRollbackOperation(String name, Data dataKey, String ownerUuid) {
+    protected TxnRollbackOperation(int partitionId, String name, Data dataKey, String ownerUuid) {
         super(name, dataKey);
+        setPartitionId(partitionId);
         this.ownerUuid = ownerUuid;
     }
 
@@ -55,21 +57,25 @@ public class TxnRollbackOperation extends KeyBasedMapOperation implements Backup
 
     @Override
     public Object getResponse() {
-        return Boolean.TRUE;
+        return true;
     }
 
+    @Override
     public boolean shouldBackup() {
         return true;
     }
 
+    @Override
     public final Operation getBackupOperation() {
         return new TxnRollbackBackupOperation(name, dataKey, ownerUuid, getThreadId());
     }
 
+    @Override
     public final int getAsyncBackupCount() {
         return mapContainer.getAsyncBackupCount();
     }
 
+    @Override
     public final int getSyncBackupCount() {
         return mapContainer.getBackupCount();
     }

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/MultiMapTransactionLogRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/MultiMapTransactionLogRecord.java
@@ -16,94 +16,58 @@
 
 package com.hazelcast.multimap.impl.txn;
 
-import com.hazelcast.core.ExecutionCallback;
-import com.hazelcast.multimap.impl.MultiMapService;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.Operation;
-import com.hazelcast.spi.OperationService;
-import com.hazelcast.spi.impl.operationservice.InternalOperationService;
 import com.hazelcast.transaction.impl.KeyAwareTransactionLogRecord;
-import com.hazelcast.util.ExceptionUtil;
 
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.concurrent.Future;
 
 public class MultiMapTransactionLogRecord implements KeyAwareTransactionLogRecord {
 
-    final List<Operation> opList = new LinkedList<Operation>();
-    String name;
-    Data key;
-    long ttl;
-    long threadId;
+    // todo: probably better to switch to an ArrayList to reduce litter.
+    private final List<Operation> opList = new LinkedList<Operation>();
+    private int partitionId;
+    private String name;
+    private Data key;
+    private long ttl;
+    private long threadId;
 
     public MultiMapTransactionLogRecord() {
     }
 
-    public MultiMapTransactionLogRecord(Data key, String name, long ttl, long threadId) {
+    public MultiMapTransactionLogRecord(int partitionId, Data key, String name, long ttl, long threadId) {
         this.key = key;
         this.name = name;
         this.ttl = ttl;
         this.threadId = threadId;
-    }
-
-    public Future prepare(NodeEngine nodeEngine) {
-        TxnPrepareOperation operation = new TxnPrepareOperation(name, key, ttl, threadId);
-        try {
-            int partitionId = nodeEngine.getPartitionService().getPartitionId(key);
-            final OperationService operationService = nodeEngine.getOperationService();
-            return operationService.invokeOnPartition(MultiMapService.SERVICE_NAME, operation, partitionId);
-        } catch (Throwable t) {
-            throw ExceptionUtil.rethrow(t);
-        }
-    }
-
-    public Future commit(NodeEngine nodeEngine) {
-        TxnCommitOperation operation = new TxnCommitOperation(name, key, threadId, opList);
-        try {
-            int partitionId = nodeEngine.getPartitionService().getPartitionId(key);
-            final OperationService operationService = nodeEngine.getOperationService();
-            return operationService.invokeOnPartition(MultiMapService.SERVICE_NAME, operation, partitionId);
-        } catch (Throwable t) {
-            throw ExceptionUtil.rethrow(t);
-        }
+        this.partitionId = partitionId;
     }
 
     @Override
-    public void commitAsync(NodeEngine nodeEngine, ExecutionCallback callback) {
-        TxnCommitOperation operation = new TxnCommitOperation(name, key, threadId, opList);
-        int partitionId = nodeEngine.getPartitionService().getPartitionId(key);
-        InternalOperationService operationService = (InternalOperationService) nodeEngine.getOperationService();
-        operationService.asyncInvokeOnPartition(MultiMapService.SERVICE_NAME, operation, partitionId, callback);
-    }
-
-    public Future rollback(NodeEngine nodeEngine) {
-        TxnRollbackOperation operation = new TxnRollbackOperation(name, key, threadId);
-        try {
-            int partitionId = nodeEngine.getPartitionService().getPartitionId(key);
-            final OperationService operationService = nodeEngine.getOperationService();
-            return operationService.invokeOnPartition(MultiMapService.SERVICE_NAME, operation, partitionId);
-        } catch (Throwable t) {
-            throw ExceptionUtil.rethrow(t);
-        }
+    public Operation newPrepareOperation() {
+        return new TxnPrepareOperation(partitionId, name, key, ttl, threadId);
     }
 
     @Override
-    public void rollbackAsync(NodeEngine nodeEngine, ExecutionCallback callback) {
-        TxnRollbackOperation operation = new TxnRollbackOperation(name, key, threadId);
-        int partitionId = nodeEngine.getPartitionService().getPartitionId(key);
-        InternalOperationService operationService = (InternalOperationService) nodeEngine.getOperationService();
-        operationService.asyncInvokeOnPartition(MultiMapService.SERVICE_NAME, operation, partitionId, callback);
+    public Operation newCommitOperation() {
+        return new TxnCommitOperation(partitionId, name, key, threadId, opList);
     }
 
+    @Override
+    public Operation newRollbackOperation() {
+        return new TxnRollbackOperation(partitionId, name, key, threadId);
+    }
+
+    @Override
     public void writeData(ObjectDataOutput out) throws IOException {
         out.writeUTF(name);
+        out.writeInt(partitionId);
         out.writeInt(opList.size());
         for (Operation op : opList) {
             out.writeObject(op);
@@ -113,8 +77,10 @@ public class MultiMapTransactionLogRecord implements KeyAwareTransactionLogRecor
         out.writeLong(threadId);
     }
 
+    @Override
     public void readData(ObjectDataInput in) throws IOException {
         name = in.readUTF();
+        partitionId = in.readInt();
         int size = in.readInt();
         for (int i = 0; i < size; i++) {
             opList.add((Operation) in.readObject());
@@ -124,6 +90,7 @@ public class MultiMapTransactionLogRecord implements KeyAwareTransactionLogRecor
         threadId = in.readLong();
     }
 
+    @Override
     public Object getKey() {
         return new TransactionRecordKey(name, key);
     }

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnCommitOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnCommitOperation.java
@@ -31,20 +31,24 @@ import java.util.List;
 
 public class TxnCommitOperation extends MultiMapBackupAwareOperation implements Notifier {
 
-    List<Operation> opList;
-    boolean notify = true;
+    private List<Operation> opList;
+    private boolean notify = true;
 
     public TxnCommitOperation() {
     }
 
-    public TxnCommitOperation(String name, Data dataKey, long threadId, List<Operation> opList) {
+    public TxnCommitOperation(int partitionId, String name, Data dataKey, long threadId, List<Operation> opList) {
         super(name, dataKey, threadId);
+        setPartitionId(partitionId);
         this.opList = opList;
     }
 
+    @Override
     public void run() throws Exception {
         for (Operation op : opList) {
-            op.setNodeEngine(getNodeEngine()).setServiceName(getServiceName()).setPartitionId(getPartitionId());
+            op.setNodeEngine(getNodeEngine())
+                    .setServiceName(getServiceName())
+                    .setPartitionId(getPartitionId());
             op.beforeRun();
             op.run();
             op.afterRun();
@@ -52,10 +56,12 @@ public class TxnCommitOperation extends MultiMapBackupAwareOperation implements 
         getOrCreateContainer().unlock(dataKey, getCallerUuid(), threadId, getCallId());
     }
 
+    @Override
     public boolean shouldBackup() {
         return notify;
     }
 
+    @Override
     public Operation getBackupOperation() {
         List<Operation> backupOpList = new ArrayList<Operation>();
         for (Operation operation : opList) {
@@ -69,14 +75,22 @@ public class TxnCommitOperation extends MultiMapBackupAwareOperation implements 
         return new TxnCommitBackupOperation(name, dataKey, backupOpList, getCallerUuid(), threadId);
     }
 
+    @Override
     public boolean shouldNotify() {
         return notify;
     }
 
+    @Override
     public WaitNotifyKey getNotifiedKey() {
         return getWaitKey();
     }
 
+    @Override
+    public int getId() {
+        return MultiMapDataSerializerHook.TXN_COMMIT;
+    }
+
+    @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
         out.writeInt(opList.size());
@@ -85,6 +99,7 @@ public class TxnCommitOperation extends MultiMapBackupAwareOperation implements 
         }
     }
 
+    @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
         int size = in.readInt();
@@ -92,9 +107,5 @@ public class TxnCommitOperation extends MultiMapBackupAwareOperation implements 
         for (int i = 0; i < size; i++) {
             opList.add((Operation) in.readObject());
         }
-    }
-
-    public int getId() {
-        return MultiMapDataSerializerHook.TXN_COMMIT;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnPrepareOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnPrepareOperation.java
@@ -29,16 +29,18 @@ import java.io.IOException;
 public class TxnPrepareOperation extends MultiMapBackupAwareOperation {
 
     private static final long LOCK_EXTENSION_TIME_IN_MILLIS = 10000L;
-    long ttl;
+    private long ttl;
 
     public TxnPrepareOperation() {
     }
 
-    public TxnPrepareOperation(String name, Data dataKey, long ttl, long threadId) {
+    public TxnPrepareOperation(int partitionId, String name, Data dataKey, long ttl, long threadId) {
         super(name, dataKey, threadId);
+        setPartitionId(partitionId);
         this.ttl = ttl;
     }
 
+    @Override
     public void run() throws Exception {
         MultiMapContainer container = getOrCreateContainer();
         if (!container.extendLock(dataKey, getCallerUuid(), threadId, LOCK_EXTENSION_TIME_IN_MILLIS)) {
@@ -49,29 +51,35 @@ public class TxnPrepareOperation extends MultiMapBackupAwareOperation {
         response = true;
     }
 
+    @Override
     public boolean shouldBackup() {
         return true;
     }
 
+    @Override
     public boolean shouldWait() {
         return false;
     }
 
+    @Override
     public Operation getBackupOperation() {
         return new TxnPrepareBackupOperation(name, dataKey, getCallerUuid(), threadId);
     }
 
+    @Override
+    public int getId() {
+        return MultiMapDataSerializerHook.TXN_PREPARE;
+    }
+
+    @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
         out.writeLong(ttl);
     }
 
+    @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
         ttl = in.readLong();
-    }
-
-    public int getId() {
-        return MultiMapDataSerializerHook.TXN_PREPARE;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnRollbackOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnRollbackOperation.java
@@ -30,10 +30,12 @@ public class TxnRollbackOperation extends MultiMapBackupAwareOperation implement
     public TxnRollbackOperation() {
     }
 
-    public TxnRollbackOperation(String name, Data dataKey, long threadId) {
+    public TxnRollbackOperation(int partitionId, String name, Data dataKey, long threadId) {
         super(name, dataKey, threadId);
+        setPartitionId(partitionId);
     }
 
+    @Override
     public void run() throws Exception {
         MultiMapContainer container = getOrCreateContainer();
         if (container.isLocked(dataKey) && !container.unlock(dataKey, getCallerUuid(), threadId, getCallId())) {
@@ -43,18 +45,22 @@ public class TxnRollbackOperation extends MultiMapBackupAwareOperation implement
         }
     }
 
+    @Override
     public Operation getBackupOperation() {
         return new TxnRollbackBackupOperation(name, dataKey, getCallerUuid(), threadId);
     }
 
+    @Override
     public boolean shouldNotify() {
         return true;
     }
 
+    @Override
     public WaitNotifyKey getNotifiedKey() {
         return getWaitKey();
     }
 
+    @Override
     public int getId() {
         return MultiMapDataSerializerHook.TXN_ROLLBACK;
     }

--- a/hazelcast/src/main/java/com/hazelcast/spi/AbstractDistributedObject.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/AbstractDistributedObject.java
@@ -56,6 +56,10 @@ public abstract class AbstractDistributedObject<S extends RemoteService> impleme
         postDestroy();
     }
 
+    protected int getPartitionId(Data key) {
+        return getNodeEngine().getPartitionService().getPartitionId(key);
+    }
+
     protected void postDestroy() {
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionImpl.java
@@ -227,7 +227,7 @@ public class TransactionImpl implements Transaction, InternalTransaction {
             final List<Future> futures = new ArrayList<Future>(transactionLog.size());
             state = PREPARING;
             for (TransactionLogRecord record : transactionLog) {
-                futures.add(record.prepare(nodeEngine));
+                futures.add(transactionLog.prepare(nodeEngine, record));
             }
             waitWithDeadline(futures, timeoutMillis, TimeUnit.MILLISECONDS, RETHROW_TRANSACTION_EXCEPTION);
             futures.clear();
@@ -270,7 +270,7 @@ public class TransactionImpl implements Transaction, InternalTransaction {
                 final List<Future> futures = new ArrayList<Future>(transactionLog.size());
                 state = COMMITTING;
                 for (TransactionLogRecord record : transactionLog) {
-                    futures.add(record.commit(nodeEngine));
+                    futures.add(transactionLog.commit(nodeEngine, record));
                 }
                 // We should rethrow exception if transaction is not TWO_PHASE
                 ExceptionHandler exceptionHandler = transactionType.equals(TransactionType.TWO_PHASE)
@@ -311,7 +311,7 @@ public class TransactionImpl implements Transaction, InternalTransaction {
                 ListIterator<TransactionLogRecord> iterator = transactionLog.getRecordList().listIterator(transactionLog.size());
                 while (iterator.hasPrevious()) {
                     TransactionLogRecord record = iterator.previous();
-                    futures.add(record.rollback(nodeEngine));
+                    futures.add(transactionLog.rollback(nodeEngine, record));
                 }
                 waitWithDeadline(futures, ROLLBACK_TIMEOUT_MINUTES, TimeUnit.MINUTES, rollbackExceptionHandler);
                 // purge tx backup

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionLogRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionLogRecord.java
@@ -16,11 +16,8 @@
 
 package com.hazelcast.transaction.impl;
 
-import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.nio.serialization.DataSerializable;
-import com.hazelcast.spi.NodeEngine;
-
-import java.util.concurrent.Future;
+import com.hazelcast.spi.Operation;
 
 /**
  * Represents a change made in a transaction e.g. a map.put.
@@ -29,13 +26,9 @@ import java.util.concurrent.Future;
  */
 public interface TransactionLogRecord extends DataSerializable {
 
-    Future prepare(NodeEngine nodeEngine);
+    Operation newPrepareOperation();
 
-    Future commit(NodeEngine nodeEngine);
+    Operation newCommitOperation();
 
-    Future rollback(NodeEngine nodeEngine);
-
-    void commitAsync(NodeEngine nodeEngine, ExecutionCallback callback);
-
-    void rollbackAsync(NodeEngine nodeEngine, ExecutionCallback callback);
+    Operation newRollbackOperation();
 }

--- a/hazelcast/src/test/java/com/hazelcast/map/MapTransactionStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapTransactionStressTest.java
@@ -13,7 +13,9 @@ import com.hazelcast.core.TransactionalMultiMap;
 import com.hazelcast.core.TransactionalQueue;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.spi.AbstractOperation;
 import com.hazelcast.spi.NodeEngine;
+import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.RemoteService;
 import com.hazelcast.spi.TransactionalService;
 import com.hazelcast.test.HazelcastParallelClassRunner;
@@ -319,28 +321,33 @@ public class MapTransactionStressTest extends HazelcastTestSupport {
     }
 
     public static class SleepyTransactionLogRecord implements TransactionLogRecord {
+
         @Override
-        public Future prepare(NodeEngine nodeEngine) {
-            return new EmptyFuture();
+        public Operation newPrepareOperation() {
+            return new AbstractOperation() {
+                @Override
+                public void run() throws Exception {
+                }
+            };
         }
 
         @Override
-        public Future commit(NodeEngine nodeEngine) {
-            LockSupport.parkNanos(10000);
-            return new EmptyFuture();
+        public Operation newCommitOperation() {
+            return new AbstractOperation() {
+                @Override
+                public void run() throws Exception {
+                    LockSupport.parkNanos(10000);
+                }
+            };
         }
 
         @Override
-        public Future rollback(NodeEngine nodeEngine) {
-            return new EmptyFuture();
-        }
-
-        @Override
-        public void commitAsync(NodeEngine nodeEngine, ExecutionCallback callback) {
-        }
-
-        @Override
-        public void rollbackAsync(NodeEngine nodeEngine, ExecutionCallback callback) {
+        public Operation newRollbackOperation() {
+            return new AbstractOperation() {
+                @Override
+                public void run() throws Exception {
+                }
+            };
         }
 
         @Override
@@ -353,35 +360,7 @@ public class MapTransactionStressTest extends HazelcastTestSupport {
 
         @Override
         public String toString() {
-            return "SleepyTransactionLog{}";
-        }
-    }
-
-    public static class EmptyFuture implements Future {
-        @Override
-        public boolean cancel(boolean mayInterruptIfRunning) {
-            return false;
-        }
-
-        @Override
-        public boolean isCancelled() {
-            return false;
-        }
-
-        @Override
-        public boolean isDone() {
-            return true;
-        }
-
-        @Override
-        public Object get() throws InterruptedException, ExecutionException {
-            return null;
-        }
-
-        @Override
-        public Object get(long timeout, TimeUnit unit)
-                throws InterruptedException, ExecutionException, TimeoutException {
-            return null;
+            return "SleepyTransactionLogRecord{}";
         }
     }
 


### PR DESCRIPTION
The LogRecords are responsible for creating operations, but not for the actual invocation.

This prevents code duplication, but it also makes it possible to do optimizations like last
cohort optimization, merging operations for a single partition etc.