### PR TITLE
More logic into the TransactionLog

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/transaction/impl/TransactionLogTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/transaction/impl/TransactionLogTest.java
@@ -6,11 +6,8 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import java.util.Iterator;
-
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.mockito.Mockito.mock;
@@ -19,21 +16,6 @@ import static org.mockito.Mockito.when;
 @RunWith(HazelcastParallelClassRunner.class)
 @Category(QuickTest.class)
 public class TransactionLogTest {
-
-    @Test
-    public void iterator() {
-        TransactionLog log = new TransactionLog();
-        TransactionLogRecord record1 = mock(TransactionLogRecord.class);
-        TransactionLogRecord record2 = mock(TransactionLogRecord.class);
-
-        log.add(record1);
-        log.add(record2);
-
-        Iterator<TransactionLogRecord> it = log.iterator();
-        assertSame(record1, it.next());
-        assertSame(record2, it.next());
-        assertFalse(it.hasNext());
-    }
 
     @Test
     public void add_whenKeyAware() {


### PR DESCRIPTION
The rollback, commit and prepare logic is now moved into the TransactionLog.

This is a preparation of making the TransactionLog smarter for future optimizations
like last cohort and merging operations for single partition.