### PR TITLE
XA Transaction cleanup

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transaction/XAClearRemoteTransactionMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transaction/XAClearRemoteTransactionMessageTask.java
@@ -28,7 +28,7 @@ import com.hazelcast.security.permission.TransactionPermission;
 import com.hazelcast.spi.InvocationBuilder;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.impl.operationservice.InternalOperationService;
-import com.hazelcast.transaction.impl.xa.ClearRemoteTransactionOperation;
+import com.hazelcast.transaction.impl.xa.operations.ClearRemoteTransactionOperation;
 import com.hazelcast.transaction.impl.xa.XAService;
 
 import java.security.Permission;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transaction/XACollectTransactionsMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transaction/XACollectTransactionsMessageTask.java
@@ -27,7 +27,7 @@ import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.security.permission.TransactionPermission;
 import com.hazelcast.spi.OperationFactory;
 import com.hazelcast.spi.impl.SerializableList;
-import com.hazelcast.transaction.impl.xa.CollectRemoteTransactionsOperationFactory;
+import com.hazelcast.transaction.impl.xa.operations.CollectRemoteTransactionsOperationFactory;
 import com.hazelcast.transaction.impl.xa.XAService;
 
 import java.security.Permission;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transaction/XAFinalizeTransactionMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transaction/XAFinalizeTransactionMessageTask.java
@@ -24,7 +24,7 @@ import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.security.permission.TransactionPermission;
 import com.hazelcast.spi.Operation;
-import com.hazelcast.transaction.impl.xa.FinalizeRemoteTransactionOperation;
+import com.hazelcast.transaction.impl.xa.operations.FinalizeRemoteTransactionOperation;
 import com.hazelcast.transaction.impl.xa.XAService;
 
 import java.security.Permission;

--- a/hazelcast/src/main/java/com/hazelcast/transaction/client/ClearRemoteTransactionRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/client/ClearRemoteTransactionRequest.java
@@ -26,7 +26,7 @@ import com.hazelcast.nio.serialization.PortableWriter;
 import com.hazelcast.security.permission.TransactionPermission;
 import com.hazelcast.spi.InvocationBuilder;
 import com.hazelcast.spi.Operation;
-import com.hazelcast.transaction.impl.xa.ClearRemoteTransactionOperation;
+import com.hazelcast.transaction.impl.xa.operations.ClearRemoteTransactionOperation;
 import com.hazelcast.transaction.impl.xa.XAService;
 
 import java.io.IOException;

--- a/hazelcast/src/main/java/com/hazelcast/transaction/client/CollectXATransactionsRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/client/CollectXATransactionsRequest.java
@@ -23,7 +23,7 @@ import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.security.permission.TransactionPermission;
 import com.hazelcast.spi.OperationFactory;
 import com.hazelcast.spi.impl.SerializableList;
-import com.hazelcast.transaction.impl.xa.CollectRemoteTransactionsOperationFactory;
+import com.hazelcast.transaction.impl.xa.operations.CollectRemoteTransactionsOperationFactory;
 import com.hazelcast.transaction.impl.xa.XAService;
 
 import java.security.Permission;

--- a/hazelcast/src/main/java/com/hazelcast/transaction/client/FinalizeXATransactionRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/client/FinalizeXATransactionRequest.java
@@ -24,7 +24,7 @@ import com.hazelcast.nio.serialization.PortableReader;
 import com.hazelcast.nio.serialization.PortableWriter;
 import com.hazelcast.security.permission.TransactionPermission;
 import com.hazelcast.spi.Operation;
-import com.hazelcast.transaction.impl.xa.FinalizeRemoteTransactionOperation;
+import com.hazelcast.transaction.impl.xa.operations.FinalizeRemoteTransactionOperation;
 import com.hazelcast.transaction.impl.xa.XAService;
 
 import java.io.IOException;

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/XAResourceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/XAResourceImpl.java
@@ -33,6 +33,9 @@ import com.hazelcast.transaction.HazelcastXAResource;
 import com.hazelcast.transaction.TransactionContext;
 import com.hazelcast.transaction.TransactionOptions;
 import com.hazelcast.transaction.impl.Transaction;
+import com.hazelcast.transaction.impl.xa.operations.ClearRemoteTransactionOperation;
+import com.hazelcast.transaction.impl.xa.operations.CollectRemoteTransactionsOperation;
+import com.hazelcast.transaction.impl.xa.operations.FinalizeRemoteTransactionOperation;
 import com.hazelcast.util.ExceptionUtil;
 
 import javax.transaction.xa.XAException;

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/XAService.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/XAService.java
@@ -28,6 +28,7 @@ import com.hazelcast.spi.PartitionReplicationEvent;
 import com.hazelcast.spi.RemoteService;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.transaction.TransactionContext;
+import com.hazelcast.transaction.impl.xa.operations.XaReplicationOperation;
 
 import javax.transaction.xa.Xid;
 import java.util.ArrayList;
@@ -52,8 +53,8 @@ public class XAService implements ManagedService, RemoteService, MigrationAwareS
 
     private final XAResourceImpl xaResource;
 
-    private final ConcurrentMap<SerializableXID, List<XATransactionImpl>> transactions =
-            new ConcurrentHashMap<SerializableXID, List<XATransactionImpl>>();
+    private final ConcurrentMap<SerializableXID, List<XATransaction>> transactions =
+            new ConcurrentHashMap<SerializableXID, List<XATransaction>>();
 
     public XAService(NodeEngineImpl nodeEngine) {
         this.nodeEngine = nodeEngine;
@@ -85,17 +86,17 @@ public class XAService implements ManagedService, RemoteService, MigrationAwareS
         return new XATransactionContextImpl(nodeEngine, xid, null, timeout);
     }
 
-    public void putTransaction(XATransactionImpl transaction) {
+    public void putTransaction(XATransaction transaction) {
         SerializableXID xid = transaction.getXid();
-        List<XATransactionImpl> list = transactions.get(xid);
+        List<XATransaction> list = transactions.get(xid);
         if (list == null) {
-            list = new CopyOnWriteArrayList<XATransactionImpl>();
+            list = new CopyOnWriteArrayList<XATransaction>();
             transactions.put(xid, list);
         }
         list.add(transaction);
     }
 
-    public List<XATransactionImpl> removeTransactions(SerializableXID xid) {
+    public List<XATransaction> removeTransactions(SerializableXID xid) {
         return transactions.remove(xid);
     }
 
@@ -107,16 +108,16 @@ public class XAService implements ManagedService, RemoteService, MigrationAwareS
 
     @Override
     public Operation prepareReplicationOperation(PartitionReplicationEvent event) {
-        List<XATransactionHolder> migrationData = new ArrayList<XATransactionHolder>();
+        List<XATransactionDTO> migrationData = new ArrayList<XATransactionDTO>();
         InternalPartitionService partitionService = nodeEngine.getPartitionService();
-        for (Map.Entry<SerializableXID, List<XATransactionImpl>> entry : transactions.entrySet()) {
+        for (Map.Entry<SerializableXID, List<XATransaction>> entry : transactions.entrySet()) {
             SerializableXID xid = entry.getKey();
             int partitionId = partitionService.getPartitionId(xid);
-            List<XATransactionImpl> xaTransactionList = entry.getValue();
-            for (XATransactionImpl xaTransaction : xaTransactionList) {
+            List<XATransaction> xaTransactionList = entry.getValue();
+            for (XATransaction xaTransaction : xaTransactionList) {
                 if (partitionId == event.getPartitionId()
                         && event.getReplicaIndex() <= 1) {
-                    migrationData.add(new XATransactionHolder(xaTransaction));
+                    migrationData.add(new XATransactionDTO(xaTransaction));
                 }
             }
         }
@@ -149,9 +150,9 @@ public class XAService implements ManagedService, RemoteService, MigrationAwareS
     @Override
     public void clearPartitionReplica(int partitionId) {
         InternalPartitionService partitionService = nodeEngine.getPartitionService();
-        Iterator<Map.Entry<SerializableXID, List<XATransactionImpl>>> iterator = transactions.entrySet().iterator();
+        Iterator<Map.Entry<SerializableXID, List<XATransaction>>> iterator = transactions.entrySet().iterator();
         while (iterator.hasNext()) {
-            Map.Entry<SerializableXID, List<XATransactionImpl>> entry = iterator.next();
+            Map.Entry<SerializableXID, List<XATransaction>> entry = iterator.next();
             SerializableXID xid = entry.getKey();
             int xidPartitionId = partitionService.getPartitionId(xid);
             if (xidPartitionId == partitionId) {

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/XATransaction.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/XATransaction.java
@@ -27,6 +27,7 @@ import com.hazelcast.transaction.TransactionNotActiveException;
 import com.hazelcast.transaction.impl.Transaction;
 import com.hazelcast.transaction.impl.TransactionLog;
 import com.hazelcast.transaction.impl.TransactionLogRecord;
+import com.hazelcast.transaction.impl.xa.operations.PutRemoteTransactionOperation;
 import com.hazelcast.util.Clock;
 import com.hazelcast.util.ExceptionUtil;
 import com.hazelcast.util.FutureUtil;
@@ -57,10 +58,12 @@ import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 /**
+ * XA {@link Transaction} implementation.
+ *
  * This class does not need to be thread-safe, it is only used via XAResource
  * All visibility guarantees handled by XAResource
  */
-final class XATransactionImpl implements Transaction {
+public final class XATransaction implements Transaction {
 
     private static final int ROLLBACK_TIMEOUT_MINUTES = 5;
     private static final int COMMIT_TIMEOUT_MINUTES = 5;
@@ -78,7 +81,7 @@ final class XATransactionImpl implements Transaction {
     private State state = NO_TXN;
     private long startTime;
 
-    public XATransactionImpl(NodeEngine nodeEngine, Xid xid, String txOwnerUuid, int timeout) {
+    public XATransaction(NodeEngine nodeEngine, Xid xid, String txOwnerUuid, int timeout) {
         this.transactionLog = new TransactionLog();
         this.nodeEngine = nodeEngine;
         this.timeoutMillis = SECONDS.toMillis(timeout);
@@ -91,8 +94,8 @@ final class XATransactionImpl implements Transaction {
         this.rollbackExceptionHandler = logAllExceptions(logger, "Error during rollback!", Level.WARNING);
     }
 
-    XATransactionImpl(NodeEngine nodeEngine, List<TransactionLogRecord> logs,
-                      String txnId, SerializableXID xid, String txOwnerUuid, long timeoutMillis, long startTime) {
+    public XATransaction(NodeEngine nodeEngine, List<TransactionLogRecord> logs,
+                         String txnId, SerializableXID xid, String txOwnerUuid, long timeoutMillis, long startTime) {
         this.nodeEngine = nodeEngine;
         this.transactionLog = new TransactionLog(logs);
 

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/XATransactionContextImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/XATransactionContextImpl.java
@@ -44,13 +44,13 @@ import java.util.Map;
 public class XATransactionContextImpl implements TransactionContext {
 
     private final NodeEngineImpl nodeEngine;
-    private final XATransactionImpl transaction;
+    private final XATransaction transaction;
     private final Map<TransactionalObjectKey, TransactionalObject> txnObjectMap
             = new HashMap<TransactionalObjectKey, TransactionalObject>(2);
 
     public XATransactionContextImpl(NodeEngineImpl nodeEngine, Xid xid, String txOwnerUuid, int timeout) {
         this.nodeEngine = nodeEngine;
-        this.transaction = new XATransactionImpl(nodeEngine, xid, txOwnerUuid, timeout);
+        this.transaction = new XATransaction(nodeEngine, xid, txOwnerUuid, timeout);
     }
 
     @Override
@@ -133,7 +133,7 @@ public class XATransactionContextImpl implements TransactionContext {
         return obj;
     }
 
-    XATransactionImpl getTransaction() {
+    XATransaction getTransaction() {
         return transaction;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/XATransactionDTO.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/XATransactionDTO.java
@@ -25,19 +25,18 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-public class XATransactionHolder implements DataSerializable {
-    String txnId;
-    SerializableXID xid;
-    String ownerUuid;
-    long timeoutMilis;
-    long startTime;
-    List<TransactionLogRecord> records;
+public class XATransactionDTO implements DataSerializable {
+    private String txnId;
+    private SerializableXID xid;
+    private String ownerUuid;
+    private long timeoutMilis;
+    private long startTime;
+    private List<TransactionLogRecord> records;
 
-    public XATransactionHolder() {
-
+    public XATransactionDTO() {
     }
 
-    public XATransactionHolder(XATransactionImpl xaTransaction) {
+    public XATransactionDTO(XATransaction xaTransaction) {
         txnId = xaTransaction.getTxnId();
         xid = xaTransaction.getXid();
         ownerUuid = xaTransaction.getOwnerUuid();
@@ -46,14 +45,38 @@ public class XATransactionHolder implements DataSerializable {
         records = xaTransaction.getTransactionRecords();
     }
 
-    public XATransactionHolder(String txnId, SerializableXID xid, String ownerUuid, long timeoutMilis,
-                               long startTime, List<TransactionLogRecord> records) {
+    public XATransactionDTO(String txnId, SerializableXID xid, String ownerUuid, long timeoutMilis,
+                            long startTime, List<TransactionLogRecord> records) {
         this.txnId = txnId;
         this.xid = xid;
         this.ownerUuid = ownerUuid;
         this.timeoutMilis = timeoutMilis;
         this.startTime = startTime;
         this.records = records;
+    }
+
+    public String getTxnId() {
+        return txnId;
+    }
+
+    public SerializableXID getXid() {
+        return xid;
+    }
+
+    public String getOwnerUuid() {
+        return ownerUuid;
+    }
+
+    public long getTimeoutMilis() {
+        return timeoutMilis;
+    }
+
+    public long getStartTime() {
+        return startTime;
+    }
+
+    public List<TransactionLogRecord> getRecords() {
+        return records;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/operations/BaseXAOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/operations/BaseXAOperation.java
@@ -14,27 +14,15 @@
  * limitations under the License.
  */
 
-package com.hazelcast.transaction.impl.xa;
+package com.hazelcast.transaction.impl.xa.operations;
 
-import com.hazelcast.nio.ObjectDataInput;
-import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.spi.Operation;
-import com.hazelcast.spi.OperationFactory;
+import com.hazelcast.spi.AbstractOperation;
+import com.hazelcast.transaction.impl.xa.XAService;
 
-import java.io.IOException;
-
-public class CollectRemoteTransactionsOperationFactory implements OperationFactory {
+public abstract class BaseXAOperation extends AbstractOperation {
 
     @Override
-    public Operation createOperation() {
-        return new CollectRemoteTransactionsOperation();
-    }
-
-    @Override
-    public void writeData(ObjectDataOutput out) throws IOException {
-    }
-
-    @Override
-    public void readData(ObjectDataInput in) throws IOException {
+    public String getServiceName() {
+        return XAService.SERVICE_NAME;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/operations/ClearRemoteTransactionBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/operations/ClearRemoteTransactionBackupOperation.java
@@ -14,25 +14,27 @@
  * limitations under the License.
  */
 
-package com.hazelcast.transaction.impl.xa;
+package com.hazelcast.transaction.impl.xa.operations;
 
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.BackupOperation;
-import com.hazelcast.spi.Operation;
+import com.hazelcast.transaction.impl.xa.SerializableXID;
+import com.hazelcast.transaction.impl.xa.XAService;
 
 import java.io.IOException;
 
-public class FinalizeRemoteTransactionBackupOperation extends Operation implements BackupOperation {
+public class ClearRemoteTransactionBackupOperation extends BaseXAOperation implements BackupOperation {
 
     private Data xidData;
+
     private transient SerializableXID xid;
 
-    public FinalizeRemoteTransactionBackupOperation() {
+    public ClearRemoteTransactionBackupOperation() {
     }
 
-    public FinalizeRemoteTransactionBackupOperation(Data xidData) {
+    public ClearRemoteTransactionBackupOperation(Data xidData) {
         this.xidData = xidData;
     }
 
@@ -48,22 +50,8 @@ public class FinalizeRemoteTransactionBackupOperation extends Operation implemen
     }
 
     @Override
-    public void afterRun() throws Exception {
-    }
-
-    @Override
     public boolean returnsResponse() {
         return false;
-    }
-
-    @Override
-    public Object getResponse() {
-        return null;
-    }
-
-    @Override
-    public String getServiceName() {
-        return XAService.SERVICE_NAME;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/operations/ClearRemoteTransactionOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/operations/ClearRemoteTransactionOperation.java
@@ -14,17 +14,19 @@
  * limitations under the License.
  */
 
-package com.hazelcast.transaction.impl.xa;
+package com.hazelcast.transaction.impl.xa.operations;
 
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.BackupAwareOperation;
 import com.hazelcast.spi.Operation;
+import com.hazelcast.transaction.impl.xa.SerializableXID;
+import com.hazelcast.transaction.impl.xa.XAService;
 
 import java.io.IOException;
 
-public class ClearRemoteTransactionOperation extends Operation implements BackupAwareOperation {
+public class ClearRemoteTransactionOperation extends BaseXAOperation implements BackupAwareOperation {
 
     private Data xidData;
 
@@ -49,21 +51,6 @@ public class ClearRemoteTransactionOperation extends Operation implements Backup
     }
 
     @Override
-    public void afterRun() throws Exception {
-
-    }
-
-    @Override
-    public boolean returnsResponse() {
-        return true;
-    }
-
-    @Override
-    public Object getResponse() {
-        return null;
-    }
-
-    @Override
     public boolean shouldBackup() {
         return true;
     }
@@ -81,11 +68,6 @@ public class ClearRemoteTransactionOperation extends Operation implements Backup
     @Override
     public Operation getBackupOperation() {
         return new ClearRemoteTransactionBackupOperation(xidData);
-    }
-
-    @Override
-    public String getServiceName() {
-        return XAService.SERVICE_NAME;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/operations/CollectRemoteTransactionsOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/operations/CollectRemoteTransactionsOperation.java
@@ -14,29 +14,23 @@
  * limitations under the License.
  */
 
-package com.hazelcast.transaction.impl.xa;
+package com.hazelcast.transaction.impl.xa.operations;
 
-import com.hazelcast.nio.ObjectDataInput;
-import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.NodeEngine;
-import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.impl.SerializableList;
+import com.hazelcast.transaction.impl.xa.SerializableXID;
+import com.hazelcast.transaction.impl.xa.XAService;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
-public class CollectRemoteTransactionsOperation extends Operation {
+public class CollectRemoteTransactionsOperation extends BaseXAOperation {
 
     private transient SerializableList xidSet;
 
     public CollectRemoteTransactionsOperation() {
-    }
-
-    @Override
-    public void beforeRun() throws Exception {
     }
 
     @Override
@@ -52,29 +46,7 @@ public class CollectRemoteTransactionsOperation extends Operation {
     }
 
     @Override
-    public void afterRun() throws Exception {
-    }
-
-    @Override
-    public boolean returnsResponse() {
-        return true;
-    }
-
-    @Override
     public Object getResponse() {
         return xidSet;
-    }
-
-    @Override
-    public String getServiceName() {
-        return XAService.SERVICE_NAME;
-    }
-
-    @Override
-    protected void writeInternal(ObjectDataOutput out) throws IOException {
-    }
-
-    @Override
-    protected void readInternal(ObjectDataInput in) throws IOException {
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/operations/CollectRemoteTransactionsOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/operations/CollectRemoteTransactionsOperationFactory.java
@@ -14,21 +14,27 @@
  * limitations under the License.
  */
 
-package com.hazelcast.transaction.impl.xa;
+package com.hazelcast.transaction.impl.xa.operations;
 
-import com.hazelcast.transaction.TransactionContext;
-import com.hazelcast.transaction.impl.Transaction;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.OperationFactory;
 
-public final class TransactionAccessor {
+import java.io.IOException;
 
-    private TransactionAccessor() {
+public class CollectRemoteTransactionsOperationFactory implements OperationFactory {
+
+    @Override
+    public Operation createOperation() {
+        return new CollectRemoteTransactionsOperation();
     }
 
-    public static Transaction getTransaction(TransactionContext ctx) {
-        if (ctx instanceof XATransactionContextImpl) {
-            XATransactionContextImpl ctxImp = (XATransactionContextImpl) ctx;
-            return ctxImp.getTransaction();
-        }
-        throw new IllegalArgumentException();
+    @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) throws IOException {
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/operations/FinalizeRemoteTransactionBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/operations/FinalizeRemoteTransactionBackupOperation.java
@@ -14,26 +14,26 @@
  * limitations under the License.
  */
 
-package com.hazelcast.transaction.impl.xa;
+package com.hazelcast.transaction.impl.xa.operations;
 
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.BackupOperation;
-import com.hazelcast.spi.Operation;
+import com.hazelcast.transaction.impl.xa.SerializableXID;
+import com.hazelcast.transaction.impl.xa.XAService;
 
 import java.io.IOException;
 
-public class ClearRemoteTransactionBackupOperation extends Operation implements BackupOperation {
+public class FinalizeRemoteTransactionBackupOperation extends BaseXAOperation implements BackupOperation {
 
     private Data xidData;
-
     private transient SerializableXID xid;
 
-    public ClearRemoteTransactionBackupOperation() {
+    public FinalizeRemoteTransactionBackupOperation() {
     }
 
-    public ClearRemoteTransactionBackupOperation(Data xidData) {
+    public FinalizeRemoteTransactionBackupOperation(Data xidData) {
         this.xidData = xidData;
     }
 
@@ -49,22 +49,8 @@ public class ClearRemoteTransactionBackupOperation extends Operation implements 
     }
 
     @Override
-    public void afterRun() throws Exception {
-    }
-
-    @Override
     public boolean returnsResponse() {
         return false;
-    }
-
-    @Override
-    public Object getResponse() {
-        return null;
-    }
-
-    @Override
-    public String getServiceName() {
-        return XAService.SERVICE_NAME;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/operations/PutRemoteTransactionBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/operations/PutRemoteTransactionBackupOperation.java
@@ -14,20 +14,22 @@
  * limitations under the License.
  */
 
-package com.hazelcast.transaction.impl.xa;
+package com.hazelcast.transaction.impl.xa.operations;
 
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.spi.BackupOperation;
 import com.hazelcast.spi.NodeEngine;
-import com.hazelcast.spi.Operation;
 import com.hazelcast.transaction.impl.TransactionLogRecord;
+import com.hazelcast.transaction.impl.xa.SerializableXID;
+import com.hazelcast.transaction.impl.xa.XAService;
+import com.hazelcast.transaction.impl.xa.XATransaction;
 
 import java.io.IOException;
 import java.util.LinkedList;
 import java.util.List;
 
-public class PutRemoteTransactionBackupOperation extends Operation implements BackupOperation {
+public class PutRemoteTransactionBackupOperation extends BaseXAOperation implements BackupOperation {
 
     private final List<TransactionLogRecord> records = new LinkedList<TransactionLogRecord>();
 
@@ -51,35 +53,17 @@ public class PutRemoteTransactionBackupOperation extends Operation implements Ba
     }
 
     @Override
-    public void beforeRun() throws Exception {
-    }
-
-    @Override
     public void run() throws Exception {
         XAService xaService = getService();
         NodeEngine nodeEngine = getNodeEngine();
-        XATransactionImpl transaction =
-                new XATransactionImpl(nodeEngine, records, txnId, xid, txOwnerUuid, timeoutMillis, startTime);
+        XATransaction transaction =
+                new XATransaction(nodeEngine, records, txnId, xid, txOwnerUuid, timeoutMillis, startTime);
         xaService.putTransaction(transaction);
-    }
-
-    @Override
-    public void afterRun() throws Exception {
     }
 
     @Override
     public boolean returnsResponse() {
         return false;
-    }
-
-    @Override
-    public Object getResponse() {
-        return null;
-    }
-
-    @Override
-    public String getServiceName() {
-        return XAService.SERVICE_NAME;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/operations/PutRemoteTransactionOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/operations/PutRemoteTransactionOperation.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.hazelcast.transaction.impl.xa;
+package com.hazelcast.transaction.impl.xa.operations;
 
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
@@ -22,12 +22,15 @@ import com.hazelcast.spi.BackupAwareOperation;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.transaction.impl.TransactionLogRecord;
+import com.hazelcast.transaction.impl.xa.SerializableXID;
+import com.hazelcast.transaction.impl.xa.XAService;
+import com.hazelcast.transaction.impl.xa.XATransaction;
 
 import java.io.IOException;
 import java.util.LinkedList;
 import java.util.List;
 
-public class PutRemoteTransactionOperation extends Operation implements BackupAwareOperation {
+public class PutRemoteTransactionOperation extends BaseXAOperation implements BackupAwareOperation {
 
     private final List<TransactionLogRecord> records = new LinkedList<TransactionLogRecord>();
 
@@ -51,30 +54,12 @@ public class PutRemoteTransactionOperation extends Operation implements BackupAw
     }
 
     @Override
-    public void beforeRun() throws Exception {
-    }
-
-    @Override
     public void run() throws Exception {
         XAService xaService = getService();
         NodeEngine nodeEngine = getNodeEngine();
-        XATransactionImpl transaction =
-                new XATransactionImpl(nodeEngine, records, txnId, xid, txOwnerUuid, timeoutMillis, startTime);
+        XATransaction transaction =
+                new XATransaction(nodeEngine, records, txnId, xid, txOwnerUuid, timeoutMillis, startTime);
         xaService.putTransaction(transaction);
-    }
-
-    @Override
-    public void afterRun() throws Exception {
-    }
-
-    @Override
-    public boolean returnsResponse() {
-        return true;
-    }
-
-    @Override
-    public Object getResponse() {
-        return null;
     }
 
     @Override
@@ -95,11 +80,6 @@ public class PutRemoteTransactionOperation extends Operation implements BackupAw
     @Override
     public Operation getBackupOperation() {
         return new PutRemoteTransactionBackupOperation(records, txnId, xid, txOwnerUuid, timeoutMillis, startTime);
-    }
-
-    @Override
-    public String getServiceName() {
-        return XAService.SERVICE_NAME;
     }
 
     @Override


### PR DESCRIPTION
* Moved operations for xa transactions to operations package
* Renamed XATransactionImpl to XATransaction
* Renamed XATransactionHolder to XATransactionDTO since it doesn't hold a pointer, but
is a dto version of the XATransaction