### PR TITLE
Removed the ordering from the TransactionLog

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionImpl.java
@@ -249,7 +249,7 @@ public class TransactionImpl implements Transaction {
             }
 
             Future f = operationService.invokeOnTarget(TransactionManagerServiceImpl.SERVICE_NAME,
-                    new ReplicateTxOperation(transactionLog.getRecordList(), txOwnerUuid, txnId, timeoutMillis, startTime),
+                    new ReplicateTxOperation(transactionLog.getRecords(), txOwnerUuid, txnId, timeoutMillis, startTime),
                     backupAddress);
             futures.add(f);
         }

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionLogRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionLogRecord.java
@@ -33,7 +33,7 @@ public interface TransactionLogRecord extends DataSerializable {
      * key, and if later on another put on that key is done, by using the same transaction-log-key, the first
      * put is overwritten.
      *
-     * If null is returned, this TransactionLogRecord can't be identified and can't be overwritten by a later change.
+     * Null should not be returned.
      *
      * @return the transaction-log-key that uniquely identifies this TransactionLogRecord.
      */

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/operations/ReplicateTxOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/operations/ReplicateTxOperation.java
@@ -25,6 +25,7 @@ import com.hazelcast.transaction.impl.TransactionManagerServiceImpl;
 import com.hazelcast.transaction.impl.TransactionLogRecord;
 
 import java.io.IOException;
+import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -43,9 +44,9 @@ public final class ReplicateTxOperation extends TxBaseOperation {
     public ReplicateTxOperation() {
     }
 
-    public ReplicateTxOperation(List<TransactionLogRecord> logs, String callerUuid, String txnId,
+    public ReplicateTxOperation(Collection<TransactionLogRecord> logRecords, String callerUuid, String txnId,
                                 long timeoutMillis, long startTime) {
-        records.addAll(logs);
+        records.addAll(logRecords);
         this.callerUuid = callerUuid;
         this.txnId = txnId;
         this.timeoutMillis = timeoutMillis;

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/PutRemoteTransactionOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/PutRemoteTransactionOperation.java
@@ -24,6 +24,7 @@ import com.hazelcast.spi.Operation;
 import com.hazelcast.transaction.impl.TransactionLogRecord;
 
 import java.io.IOException;
+import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -40,7 +41,7 @@ public class PutRemoteTransactionOperation extends Operation implements BackupAw
     public PutRemoteTransactionOperation() {
     }
 
-    public PutRemoteTransactionOperation(List<TransactionLogRecord> logs, String txnId, SerializableXID xid,
+    public PutRemoteTransactionOperation(Collection<TransactionLogRecord> logs, String txnId, SerializableXID xid,
                                          String txOwnerUuid, long timeoutMillis, long startTime) {
         records.addAll(logs);
         this.txnId = txnId;

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/XATransactionHolder.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/XATransactionHolder.java
@@ -23,6 +23,7 @@ import com.hazelcast.transaction.impl.TransactionLogRecord;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 public class XATransactionHolder implements DataSerializable {
@@ -31,7 +32,7 @@ public class XATransactionHolder implements DataSerializable {
     String ownerUuid;
     long timeoutMilis;
     long startTime;
-    List<TransactionLogRecord> records;
+    Collection<TransactionLogRecord> records;
 
     public XATransactionHolder() {
 

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/XATransactionImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/XATransactionImpl.java
@@ -34,6 +34,7 @@ import com.hazelcast.util.UuidUtil;
 
 import javax.transaction.xa.XAException;
 import javax.transaction.xa.Xid;
+import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -91,7 +92,7 @@ final class XATransactionImpl implements Transaction {
         this.rollbackExceptionHandler = logAllExceptions(logger, "Error during rollback!", Level.WARNING);
     }
 
-    XATransactionImpl(NodeEngine nodeEngine, List<TransactionLogRecord> logs,
+    XATransactionImpl(NodeEngine nodeEngine, Collection<TransactionLogRecord> logs,
                       String txnId, SerializableXID xid, String txOwnerUuid, long timeoutMillis, long startTime) {
         this.nodeEngine = nodeEngine;
         this.transactionLog = new TransactionLog(logs);
@@ -137,7 +138,7 @@ final class XATransactionImpl implements Transaction {
 
     private void putTransactionInfoRemote() throws ExecutionException, InterruptedException {
         PutRemoteTransactionOperation operation = new PutRemoteTransactionOperation(
-                transactionLog.getRecordList(), txnId, xid, txOwnerUuid, timeoutMillis, startTime);
+                transactionLog.getRecords(), txnId, xid, txOwnerUuid, timeoutMillis, startTime);
         OperationService operationService = nodeEngine.getOperationService();
         InternalPartitionService partitionService = nodeEngine.getPartitionService();
         int partitionId = partitionService.getPartitionId(xid);
@@ -213,8 +214,8 @@ final class XATransactionImpl implements Transaction {
         return startTime;
     }
 
-    public List<TransactionLogRecord> getTransactionRecords() {
-        return transactionLog.getRecordList();
+    public Collection<TransactionLogRecord> getTransactionRecords() {
+        return transactionLog.getRecords();
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/map/MapTransactionStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapTransactionStressTest.java
@@ -316,9 +316,11 @@ public class MapTransactionStressTest extends HazelcastTestSupport {
     }
 
     public static class SleepyTransactionLogRecord implements TransactionLogRecord {
+        private final String key = UUID.randomUUID().toString();
+
         @Override
         public Object getKey() {
-            return null;
+            return key;
         }
 
         @Override

--- a/hazelcast/src/test/java/com/hazelcast/transaction/impl/TransactionImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/transaction/impl/TransactionImplTest.java
@@ -38,6 +38,7 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.io.IOException;
+import java.util.UUID;
 import java.util.logging.Level;
 
 import static org.junit.Assert.assertEquals;
@@ -150,6 +151,7 @@ public class TransactionImplTest extends HazelcastTestSupport {
         final boolean failPrepare;
         final boolean failCommit;
         final boolean failRollback;
+        final String key = UUID.randomUUID().toString();
 
         public FailingTransactionLogRecord(boolean failPrepare, boolean failCommit, boolean failRollback) {
             this.failPrepare = failPrepare;
@@ -159,7 +161,7 @@ public class TransactionImplTest extends HazelcastTestSupport {
 
         @Override
         public Object getKey() {
-            return null;
+            return key;
         }
 
         @Override

--- a/hazelcast/src/test/java/com/hazelcast/transaction/impl/TransactionLogTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/transaction/impl/TransactionLogTest.java
@@ -18,7 +18,7 @@ import static org.mockito.Mockito.when;
 public class TransactionLogTest {
 
     @Test
-    public void add_whenKeyAware() {
+    public void add_whenNotExisting() {
         TransactionLog log = new TransactionLog();
         TransactionLogRecord record = mock(TransactionLogRecord.class);
         String key = "foo";
@@ -28,17 +28,6 @@ public class TransactionLogTest {
 
         assertSame(record, log.get(key));
         assertEquals(1, log.size());
-    }
-
-    @Test
-    public void add_whenNotKeyAware() {
-        TransactionLog log = new TransactionLog();
-        TransactionLogRecord record = mock(TransactionLogRecord.class);
-
-        log.add(record);
-
-        assertEquals(1, log.size());
-        assertEquals(asList(record), log.getRecordList());
     }
 
     @Test


### PR DESCRIPTION
The TransactionLogRecords were stored in a map and in a list. The list
was used to determine ordering. The ordering was only used in prepare/commit/rollback,
but these operations are executed in parallel anyway. So the current implementation
doesn't preservere ordering.

From a logical perspective I'm not convinced that these operations rely on any particular
ordering of records.