### PR TITLE
Removed unnecessary SoftLock reference in hibernate EntryProcesors

### DIFF
--- a/hazelcast-hibernate/hazelcast-hibernate3/src/main/java/com/hazelcast/hibernate/distributed/UnlockEntryProcessor.java
+++ b/hazelcast-hibernate/hazelcast-hibernate3/src/main/java/com/hazelcast/hibernate/distributed/UnlockEntryProcessor.java
@@ -21,7 +21,6 @@ import com.hazelcast.hibernate.serialization.ExpiryMarker;
 import com.hazelcast.hibernate.serialization.HibernateDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import org.hibernate.cache.access.SoftLock;
 
 import java.io.IOException;
 import java.util.Map;
@@ -32,14 +31,14 @@ import java.util.Map;
  */
 public class UnlockEntryProcessor extends AbstractRegionCacheEntryProcessor {
 
-    private SoftLock lock;
+    private ExpiryMarker lock;
     private String nextMarkerId;
     private long timestamp;
 
     public UnlockEntryProcessor() {
     }
 
-    public UnlockEntryProcessor(SoftLock lock, String nextMarkerId, long timestamp) {
+    public UnlockEntryProcessor(ExpiryMarker lock, String nextMarkerId, long timestamp) {
         this.lock = lock;
         this.nextMarkerId = nextMarkerId;
         this.timestamp = timestamp;

--- a/hazelcast-hibernate/hazelcast-hibernate3/src/main/java/com/hazelcast/hibernate/distributed/UpdateEntryProcessor.java
+++ b/hazelcast-hibernate/hazelcast-hibernate3/src/main/java/com/hazelcast/hibernate/distributed/UpdateEntryProcessor.java
@@ -22,7 +22,6 @@ import com.hazelcast.hibernate.serialization.HibernateDataSerializerHook;
 import com.hazelcast.hibernate.serialization.Value;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import org.hibernate.cache.access.SoftLock;
 
 
 import java.io.IOException;
@@ -34,7 +33,7 @@ import java.util.Map;
  */
 public class UpdateEntryProcessor extends AbstractRegionCacheEntryProcessor {
 
-    private SoftLock lock;
+    private ExpiryMarker lock;
     private Object newValue;
     private Object newVersion;
     private String nextMarkerId;
@@ -43,7 +42,7 @@ public class UpdateEntryProcessor extends AbstractRegionCacheEntryProcessor {
     public UpdateEntryProcessor() {
     }
 
-    public UpdateEntryProcessor(SoftLock lock, Object newValue, Object newVersion, String nextMarkerId, long timestamp) {
+    public UpdateEntryProcessor(ExpiryMarker lock, Object newValue, Object newVersion, String nextMarkerId, long timestamp) {
         this.lock = lock;
         this.nextMarkerId = nextMarkerId;
         this.newValue = newValue;

--- a/hazelcast-hibernate/hazelcast-hibernate3/src/main/java/com/hazelcast/hibernate/serialization/Expirable.java
+++ b/hazelcast-hibernate/hazelcast-hibernate3/src/main/java/com/hazelcast/hibernate/serialization/Expirable.java
@@ -19,7 +19,6 @@ package com.hazelcast.hibernate.serialization;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import org.hibernate.cache.access.SoftLock;
 
 
 import java.io.IOException;
@@ -72,13 +71,13 @@ public abstract class Expirable implements IdentifiedDataSerializable {
      * @return {@code true} if the {@link Expirable} matches using the specified lock, {@code false} otherwise
      * @see ExpiryMarker#expire(long)
      */
-    public abstract boolean matches(SoftLock lock);
+    public abstract boolean matches(ExpiryMarker lock);
 
     /**
      * Mark the entry for expiration with the given timeout and marker id.
      * <p/>
      * For every invocation a corresponding call to {@link ExpiryMarker#expire(long)} should be made, provided that
-     * the returned marker {@link #matches(SoftLock) matches}
+     * the returned marker {@link #matches(ExpiryMarker) matches}
      *
      * @param timeout      the timestamp in which the lock times out
      * @param nextMarkerId the next lock id to use if creating a new lock

--- a/hazelcast-hibernate/hazelcast-hibernate3/src/main/java/com/hazelcast/hibernate/serialization/ExpiryMarker.java
+++ b/hazelcast-hibernate/hazelcast-hibernate3/src/main/java/com/hazelcast/hibernate/serialization/ExpiryMarker.java
@@ -18,10 +18,8 @@ package com.hazelcast.hibernate.serialization;
 
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import org.hibernate.cache.access.SoftLock;
-
-
 import java.io.IOException;
+import java.io.Serializable;
 import java.util.Comparator;
 
 /**
@@ -33,10 +31,10 @@ import java.util.Comparator;
  *     <li>It will always return a null value, resulting in a cache miss</li>
  *     <li>It is only replaceable when it is completely expired</li>
  *     <li>It can be marked by multiple transactions at the same time and will not expire until all transactions complete</li>
- *     <li>It should not be expired unless {@link #matches(SoftLock)} is true</li>
+ *     <li>It should not be expired unless {@link #matches(ExpiryMarker) matches} is true</li>
  * </ul>
  */
-public class ExpiryMarker extends Expirable implements SoftLock {
+public class ExpiryMarker extends Expirable implements Serializable {
 
     private static final long NOT_COMPLETELY_EXPIRED = -1;
 
@@ -95,13 +93,8 @@ public class ExpiryMarker extends Expirable implements SoftLock {
     }
 
     @Override
-    public boolean matches(SoftLock lock) {
-        if (lock instanceof ExpiryMarker) {
-            ExpiryMarker other = (ExpiryMarker) lock;
-            return markerId.equals(other.markerId);
-        }
-
-        return false;
+    public boolean matches(ExpiryMarker lock) {
+        return markerId.equals(lock.markerId);
     }
 
     /**

--- a/hazelcast-hibernate/hazelcast-hibernate3/src/main/java/com/hazelcast/hibernate/serialization/MarkerWrapper.java
+++ b/hazelcast-hibernate/hazelcast-hibernate3/src/main/java/com/hazelcast/hibernate/serialization/MarkerWrapper.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate.serialization;
+
+
+import org.hibernate.cache.access.SoftLock;
+
+/**
+ * A wrapper class for ExpiryMarker for returning copy of marker object with
+ * {@link org.hibernate.cache.access.SoftLock} marker interface.
+ */
+
+public class MarkerWrapper implements SoftLock {
+
+    private final ExpiryMarker marker;
+
+    public MarkerWrapper(ExpiryMarker marker) {
+        this.marker = marker;
+    }
+
+    public ExpiryMarker getMarker() {
+        return marker;
+    }
+}
+

--- a/hazelcast-hibernate/hazelcast-hibernate3/src/main/java/com/hazelcast/hibernate/serialization/Value.java
+++ b/hazelcast-hibernate/hazelcast-hibernate3/src/main/java/com/hazelcast/hibernate/serialization/Value.java
@@ -18,7 +18,6 @@ package com.hazelcast.hibernate.serialization;
 
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import org.hibernate.cache.access.SoftLock;
 
 import java.io.IOException;
 import java.util.Comparator;
@@ -62,7 +61,7 @@ public class Value extends Expirable {
     }
 
     @Override
-    public boolean matches(SoftLock lock) {
+    public boolean matches(ExpiryMarker lock) {
         return false;
     }
 

--- a/hazelcast-hibernate/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/distributed/IMapRegionCache.java
+++ b/hazelcast-hibernate/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/distributed/IMapRegionCache.java
@@ -23,6 +23,8 @@ import com.hazelcast.hibernate.CacheEnvironment;
 import com.hazelcast.hibernate.HazelcastTimestamper;
 import com.hazelcast.hibernate.RegionCache;
 import com.hazelcast.hibernate.serialization.Expirable;
+import com.hazelcast.hibernate.serialization.MarkerWrapper;
+import com.hazelcast.hibernate.serialization.ExpiryMarker;
 import com.hazelcast.hibernate.serialization.Value;
 import org.hibernate.cache.spi.CacheDataDescription;
 import org.hibernate.cache.spi.access.SoftLock;
@@ -110,8 +112,13 @@ public class IMapRegionCache implements RegionCache {
     }
 
     public boolean update(final Object key, final Object newValue, final Object newVersion, final SoftLock lock) {
-        return (Boolean) map.executeOnKey(key, new UpdateEntryProcessor(lock, newValue, newVersion,
-                nextMarkerId(), nextTimestamp(hazelcastInstance)));
+        if (lock instanceof MarkerWrapper) {
+            final ExpiryMarker unwrappedMarker = ((MarkerWrapper) lock).getMarker();
+            return (Boolean) map.executeOnKey(key, new UpdateEntryProcessor(unwrappedMarker, newValue, newVersion,
+                    nextMarkerId(), nextTimestamp(hazelcastInstance)));
+        } else {
+            return false;
+        }
     }
 
     public boolean remove(final Object key) {
@@ -120,12 +127,17 @@ public class IMapRegionCache implements RegionCache {
 
     public SoftLock tryLock(final Object key, final Object version) {
         long timeout = nextTimestamp(hazelcastInstance) + lockTimeout;
-
-        return (SoftLock) map.executeOnKey(key, new LockEntryProcessor(nextMarkerId(), timeout, version));
+        final ExpiryMarker marker = (ExpiryMarker) map.executeOnKey(key,
+                new LockEntryProcessor(nextMarkerId(), timeout, version));
+        return new MarkerWrapper(marker);
     }
 
     public void unlock(final Object key, SoftLock lock) {
-        map.executeOnKey(key, new UnlockEntryProcessor(lock, nextMarkerId(), nextTimestamp(hazelcastInstance)));
+        if (lock instanceof MarkerWrapper) {
+            final ExpiryMarker unwrappedMarker = ((MarkerWrapper) lock).getMarker();
+            map.executeOnKey(key, new UnlockEntryProcessor(unwrappedMarker, nextMarkerId(),
+                    nextTimestamp(hazelcastInstance)));
+        }
     }
 
     public boolean contains(final Object key) {

--- a/hazelcast-hibernate/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/distributed/UnlockEntryProcessor.java
+++ b/hazelcast-hibernate/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/distributed/UnlockEntryProcessor.java
@@ -21,7 +21,6 @@ import com.hazelcast.hibernate.serialization.ExpiryMarker;
 import com.hazelcast.hibernate.serialization.HibernateDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import org.hibernate.cache.spi.access.SoftLock;
 
 import java.io.IOException;
 import java.util.Map;
@@ -32,14 +31,14 @@ import java.util.Map;
  */
 public class UnlockEntryProcessor extends AbstractRegionCacheEntryProcessor {
 
-    private SoftLock lock;
+    private ExpiryMarker lock;
     private String nextMarkerId;
     private long timestamp;
 
     public UnlockEntryProcessor() {
     }
 
-    public UnlockEntryProcessor(SoftLock lock, String nextMarkerId, long timestamp) {
+    public UnlockEntryProcessor(ExpiryMarker lock, String nextMarkerId, long timestamp) {
         this.lock = lock;
         this.nextMarkerId = nextMarkerId;
         this.timestamp = timestamp;

--- a/hazelcast-hibernate/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/distributed/UpdateEntryProcessor.java
+++ b/hazelcast-hibernate/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/distributed/UpdateEntryProcessor.java
@@ -22,7 +22,6 @@ import com.hazelcast.hibernate.serialization.HibernateDataSerializerHook;
 import com.hazelcast.hibernate.serialization.Value;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import org.hibernate.cache.spi.access.SoftLock;
 
 import java.io.IOException;
 import java.util.Map;
@@ -33,7 +32,7 @@ import java.util.Map;
  */
 public class UpdateEntryProcessor extends AbstractRegionCacheEntryProcessor {
 
-    private SoftLock lock;
+    private ExpiryMarker lock;
     private Object newValue;
     private Object newVersion;
     private String nextMarkerId;
@@ -42,7 +41,7 @@ public class UpdateEntryProcessor extends AbstractRegionCacheEntryProcessor {
     public UpdateEntryProcessor() {
     }
 
-    public UpdateEntryProcessor(SoftLock lock, Object newValue, Object newVersion, String nextMarkerId, long timestamp) {
+    public UpdateEntryProcessor(ExpiryMarker lock, Object newValue, Object newVersion, String nextMarkerId, long timestamp) {
         this.lock = lock;
         this.nextMarkerId = nextMarkerId;
         this.newValue = newValue;

--- a/hazelcast-hibernate/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/serialization/Expirable.java
+++ b/hazelcast-hibernate/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/serialization/Expirable.java
@@ -19,7 +19,6 @@ package com.hazelcast.hibernate.serialization;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import org.hibernate.cache.spi.access.SoftLock;
 
 import java.io.IOException;
 import java.util.Comparator;
@@ -71,13 +70,13 @@ public abstract class Expirable implements IdentifiedDataSerializable {
      * @return {@code true} if the {@link Expirable} matches using the specified lock, {@code false} otherwise
      * @see ExpiryMarker#expire(long)
      */
-    public abstract boolean matches(SoftLock lock);
+    public abstract boolean matches(ExpiryMarker lock);
 
     /**
      * Mark the entry for expiration with the given timeout and marker id.
      * <p/>
      * For every invocation a corresponding call to {@link ExpiryMarker#expire(long)} should be made, provided that
-     * the returned marker {@link #matches(SoftLock) matches}
+     * the returned marker {@link #matches(ExpiryMarker)}
      *
      * @param timeout      the timestamp in which the lock times out
      * @param nextMarkerId the next lock id to use if creating a new lock

--- a/hazelcast-hibernate/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/serialization/ExpiryMarker.java
+++ b/hazelcast-hibernate/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/serialization/ExpiryMarker.java
@@ -18,9 +18,9 @@ package com.hazelcast.hibernate.serialization;
 
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import org.hibernate.cache.spi.access.SoftLock;
 
 import java.io.IOException;
+import java.io.Serializable;
 import java.util.Comparator;
 
 /**
@@ -32,13 +32,12 @@ import java.util.Comparator;
  *     <li>It will always return a null value, resulting in a cache miss</li>
  *     <li>It is only replaceable when it is completely expired</li>
  *     <li>It can be marked by multiple transactions at the same time and will not expire until all transactions complete</li>
- *     <li>It should not be expired unless {@link #matches(SoftLock)} is true</li>
+ *     <li>It should not be expired unless {@link #matches(ExpiryMarker)} is true</li>
  * </ul>
  */
-public class ExpiryMarker extends Expirable implements SoftLock {
+public class ExpiryMarker extends Expirable implements Serializable {
 
     private static final long NOT_COMPLETELY_EXPIRED = -1;
-
     private boolean concurrent;
     private long expiredTimestamp;
     private String markerId;
@@ -94,13 +93,8 @@ public class ExpiryMarker extends Expirable implements SoftLock {
     }
 
     @Override
-    public boolean matches(SoftLock lock) {
-        if (lock instanceof ExpiryMarker) {
-            ExpiryMarker other = (ExpiryMarker) lock;
-            return markerId.equals(other.markerId);
-        }
-
-        return false;
+    public boolean matches(ExpiryMarker lock) {
+        return markerId.equals(lock.markerId);
     }
 
     /**

--- a/hazelcast-hibernate/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/serialization/MarkerWrapper.java
+++ b/hazelcast-hibernate/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/serialization/MarkerWrapper.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate.serialization;
+
+import org.hibernate.cache.spi.access.SoftLock;
+
+/**
+ * A wrapper class for ExpiryMarker for returning copy of marker object with
+ * {@link org.hibernate.cache.spi.access.SoftLock} marker interface.
+ */
+
+public class MarkerWrapper implements SoftLock {
+
+    private final ExpiryMarker marker;
+
+    public MarkerWrapper(ExpiryMarker marker) {
+        this.marker = marker;
+    }
+
+    public ExpiryMarker getMarker() {
+        return marker;
+    }
+}
+

--- a/hazelcast-hibernate/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/serialization/Value.java
+++ b/hazelcast-hibernate/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/serialization/Value.java
@@ -18,8 +18,6 @@ package com.hazelcast.hibernate.serialization;
 
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import org.hibernate.cache.spi.access.SoftLock;
-
 import java.io.IOException;
 import java.util.Comparator;
 
@@ -62,7 +60,7 @@ public class Value extends Expirable {
     }
 
     @Override
-    public boolean matches(SoftLock lock) {
+    public boolean matches(ExpiryMarker lock) {
         return false;
     }
 


### PR DESCRIPTION
Hibernate EntryProcessor were using SoftLock interface unnecessarily.
Because of this, when 2nd Level Cache is used with client only mode,
remote cluster should have hibernate-core jars in the class path. With
this PR, such requirement is not needed any more.