### PR TITLE
NodeEngine: removed hard dependency on QuorumServiceImpl

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/NodeEngine.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/NodeEngine.java
@@ -28,7 +28,7 @@ import com.hazelcast.nio.Address;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.SerializationService;
 import com.hazelcast.partition.InternalPartitionService;
-import com.hazelcast.quorum.impl.QuorumServiceImpl;
+import com.hazelcast.quorum.QuorumService;
 import com.hazelcast.transaction.TransactionManagerService;
 import com.hazelcast.wan.WanReplicationService;
 
@@ -103,7 +103,12 @@ public interface NodeEngine {
      */
     WanReplicationService getWanReplicationService();
 
-    QuorumServiceImpl getQuorumService();
+    /**
+     * Gets the QuorumService.
+     *
+     * @return the QuorumService.
+     */
+    QuorumService getQuorumService();
 
     /**
      * Gets the TransactionManagerService.


### PR DESCRIPTION
The NodeEngine returned QuorumServiceImpl and not a QuorumService. We don't
want to expose concrete implementations of services in our API.

This change breaks compatibility. So if a user has made use of this API;
he will suffer from it.