### PR TITLE
NodeEngine: removed dependency on MemberImpl

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/core/Member.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/Member.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.core;
 
+import com.hazelcast.nio.Address;
 import com.hazelcast.nio.serialization.DataSerializable;
 
 import java.net.InetSocketAddress;
@@ -38,6 +39,14 @@ public interface Member extends DataSerializable, Endpoint {
      *         local member, <tt>false</tt> otherwise.
      */
     boolean localMember();
+
+    /**
+     * Returns the Address of this Member.
+     *
+     * @return the address.
+     * @since 3.6
+     */
+    Address getAddress();
 
     /**
      * Returns the InetSocketAddress of this member.

--- a/hazelcast/src/main/java/com/hazelcast/partition/impl/PromoteFromBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/impl/PromoteFromBackupOperation.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.partition.impl;
 
+import com.hazelcast.core.Member;
 import com.hazelcast.core.MigrationEvent;
 import com.hazelcast.core.MigrationEvent.MigrationStatus;
 import com.hazelcast.instance.MemberImpl;
@@ -96,7 +97,7 @@ final class PromoteFromBackupOperation
     private void sendMigrationEvent(final MigrationStatus status) {
         final int partitionId = getPartitionId();
         final NodeEngine nodeEngine = getNodeEngine();
-        final MemberImpl localMember = nodeEngine.getLocalMember();
+        final Member localMember = nodeEngine.getLocalMember();
         final MemberImpl deadMember = new MemberImpl(oldAddress, false);
         final MigrationEvent event = new MigrationEvent(partitionId, deadMember, localMember, status);
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/NodeEngine.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/NodeEngine.java
@@ -19,15 +19,15 @@ package com.hazelcast.spi;
 import com.hazelcast.cluster.ClusterService;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.Member;
 import com.hazelcast.instance.GroupProperties;
-import com.hazelcast.instance.MemberImpl;
+import com.hazelcast.internal.storage.DataRef;
+import com.hazelcast.internal.storage.Storage;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.SerializationService;
 import com.hazelcast.partition.InternalPartitionService;
-import com.hazelcast.internal.storage.DataRef;
-import com.hazelcast.internal.storage.Storage;
 import com.hazelcast.quorum.impl.QuorumServiceImpl;
 import com.hazelcast.transaction.TransactionManagerService;
 import com.hazelcast.wan.WanReplicationService;
@@ -139,7 +139,7 @@ public interface NodeEngine {
      *
      * @return the local member.
      */
-    MemberImpl getLocalMember();
+    Member getLocalMember();
 
     /**
      * Returns the Config that was used to create the HazelcastInstance.

--- a/hazelcast/src/main/java/com/hazelcast/topic/impl/TopicProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/impl/TopicProxySupport.java
@@ -19,8 +19,8 @@ package com.hazelcast.topic.impl;
 import com.hazelcast.config.ListenerConfig;
 import com.hazelcast.config.TopicConfig;
 import com.hazelcast.core.HazelcastInstanceAware;
+import com.hazelcast.core.Member;
 import com.hazelcast.core.MessageListener;
-import com.hazelcast.instance.MemberImpl;
 import com.hazelcast.monitor.LocalTopicStats;
 import com.hazelcast.monitor.impl.LocalTopicStatsImpl;
 import com.hazelcast.nio.ClassLoaderUtil;
@@ -36,7 +36,7 @@ public abstract class TopicProxySupport extends AbstractDistributedObject<TopicS
     private final ClassLoader configClassLoader;
     private final TopicService topicService;
     private final LocalTopicStatsImpl topicStats;
-    private final MemberImpl localMember;
+    private final Member localMember;
 
     public TopicProxySupport(String name, NodeEngine nodeEngine, TopicService service) {
         super(nodeEngine, service);

--- a/hazelcast/src/test/java/com/hazelcast/instance/SimpleMemberImpl.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/SimpleMemberImpl.java
@@ -17,6 +17,7 @@
 package com.hazelcast.instance;
 
 import com.hazelcast.core.Member;
+import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 
@@ -38,6 +39,11 @@ public class SimpleMemberImpl implements Member {
     public SimpleMemberImpl(String uuid, InetSocketAddress address) {
         this.uuid = uuid;
         this.address = address;
+    }
+
+    @Override
+    public Address getAddress() {
+        throw new UnsupportedOperationException();
     }
 
     @Override


### PR DESCRIPTION
MemberImpl is an implementation detail and should not be exposed as API.
This PR fixes that by returning a Member interface, not MemberImpl.

This PR breaks compatibility!