### PR TITLE
Fix/hibernate caching test coverage

### DIFF
--- a/hazelcast-hibernate/hazelcast-hibernate3/src/test/java/com/hazelcast/hibernate/HibernateStatisticsTestSupport.java
+++ b/hazelcast-hibernate/hazelcast-hibernate3/src/test/java/com/hazelcast/hibernate/HibernateStatisticsTestSupport.java
@@ -20,7 +20,11 @@ import com.hazelcast.config.MapConfig;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.hibernate.entity.DummyEntity;
+import com.hazelcast.hibernate.entity.DummyEntityNonStrictRW;
+import com.hazelcast.hibernate.entity.DummyEntityReadOnly;
 import com.hazelcast.hibernate.entity.DummyProperty;
+import com.hazelcast.hibernate.entity.DummyPropertyNonStrictRW;
+import com.hazelcast.hibernate.entity.DummyPropertyReadOnly;
 import com.hazelcast.hibernate.instance.HazelcastAccessor;
 import com.hazelcast.hibernate.region.HazelcastQueryResultsRegion;
 import com.hazelcast.test.annotation.NightlyTest;
@@ -99,8 +103,145 @@ public abstract class HibernateStatisticsTestSupport extends HibernateTestSuppor
         }
     }
 
+    protected void insertDummyNonStrictRWEntities(int count, int childCount) {
+        Session session = sf.openSession();
+        Transaction tx = session.beginTransaction();
+        try {
+            for (int i = 0; i < count; i++) {
+                DummyEntityNonStrictRW e = new DummyEntityNonStrictRW((long) i, "dummy:" + i, i * 123456d, new Date());
+                session.save(e);
+                for (int j = 0; j < childCount; j++) {
+                    DummyPropertyNonStrictRW p = new DummyPropertyNonStrictRW("key:" + j, e);
+                    session.save(p);
+                }
+            }
+            tx.commit();
+        } catch (Exception e) {
+            tx.rollback();
+            e.printStackTrace();
+        } finally {
+            session.close();
+        }
+    }
+
+    protected void insertDummyReadOnlyEntities(int count, int childCount) {
+        Session session = sf.openSession();
+        Transaction tx = session.beginTransaction();
+        try {
+            for (int i = 0; i < count; i++) {
+                DummyEntityReadOnly e = new DummyEntityReadOnly((long) i, "dummy:" + i, i * 123456d, new Date());
+                session.save(e);
+                for (int j = 0; j < childCount; j++) {
+                    DummyPropertyReadOnly p = new DummyPropertyReadOnly("key:" + j, e);
+                    session.save(p);
+                }
+            }
+            tx.commit();
+        } catch (Exception e) {
+            tx.rollback();
+            e.printStackTrace();
+        } finally {
+            session.close();
+        }
+    }
+
     @Test
-    public void testEntity() {
+    public void testNonStrictReadWriteEntity() {
+        Session session = null;
+        Transaction txn = null;
+
+        int entityCount = 10;
+        int childCount = 4;
+
+        insertDummyNonStrictRWEntities(entityCount, childCount);
+
+        sf.getCache().evictEntityRegions();
+        sf2.getCache().evictEntityRegions();
+
+        session = sf.openSession();
+        ArrayList<DummyEntityNonStrictRW> entities = new ArrayList<DummyEntityNonStrictRW>(entityCount);
+        for (int i=0; i<entityCount; i++) {
+            entities.add((DummyEntityNonStrictRW)session.get(DummyEntityNonStrictRW.class, (long)i));
+        }
+        assertEquals(entityCount*2, sf.getStatistics().getSecondLevelCacheMissCount());
+        assertEquals(0, sf.getStatistics().getSecondLevelCacheHitCount());
+
+        session.close();
+
+        session = sf.openSession();
+        txn = session.beginTransaction();
+        DummyEntityNonStrictRW updatedEntity = entities.get(0);
+        updatedEntity.setName("updated:" + 0);
+        session.update(updatedEntity);
+        DummyEntityNonStrictRW removedEntity = entities.get(1);
+        session.delete(removedEntity);
+        txn.commit();
+        session.close();
+        sleep(1);
+
+
+        assertEquals(0, sf2.getStatistics().getSecondLevelCacheMissCount());
+        assertEquals(0, sf2.getStatistics().getSecondLevelCacheHitCount());
+
+        session = sf2.openSession();
+        entities = new ArrayList<DummyEntityNonStrictRW>(entityCount);
+        for (int i=0; i<entityCount; i++) {
+            DummyEntityNonStrictRW ent = (DummyEntityNonStrictRW)session.get(DummyEntityNonStrictRW.class, (long)i);
+            entities.add(ent);
+        }
+        //missed entries: updated entry, children of updated entry, deleted entry
+        assertEquals(1 + 1 + childCount, sf2.getStatistics().getSecondLevelCacheMissCount());
+        //assertEquals((entityCount - 1) * (2 + childCount), sf2.getStatistics().getSecondLevelCacheHitCount());
+
+    }
+
+    @Test
+    public void testReadOnlyEntity() {
+        Session session = null;
+        Transaction txn = null;
+
+        int entityCount = 10;
+        int childCount = 4;
+
+        insertDummyReadOnlyEntities(entityCount, childCount);
+
+        sf.getCache().evictEntityRegions();
+        sf2.getCache().evictEntityRegions();
+
+        session = sf.openSession();
+        ArrayList<DummyEntityReadOnly> entities = new ArrayList<DummyEntityReadOnly>(entityCount);
+        for (int i=0; i<entityCount; i++) {
+            entities.add((DummyEntityReadOnly)session.get(DummyEntityReadOnly.class, (long)i));
+        }
+        assertEquals(entityCount * 2, sf.getStatistics().getSecondLevelCacheMissCount());
+        assertEquals(0, sf.getStatistics().getSecondLevelCacheHitCount());
+
+        session.close();
+
+        session = sf.openSession();
+        txn =session.beginTransaction();
+        DummyEntityReadOnly deletedEntity = (DummyEntityReadOnly) session.get(DummyEntityReadOnly.class, (long) 2);
+        session.delete(deletedEntity);
+        txn.commit();
+
+        assertEquals(0, sf2.getStatistics().getSecondLevelCacheMissCount());
+        assertEquals(0, sf2.getStatistics().getSecondLevelCacheHitCount());
+
+        session = sf2.openSession();
+        entities = new ArrayList<DummyEntityReadOnly>(entityCount);
+        for (int i=0; i<entityCount; i++) {
+            DummyEntityReadOnly ent = (DummyEntityReadOnly)session.get(DummyEntityReadOnly.class, (long)i);
+            entities.add(ent);
+            session.evict(ent);
+        }
+        //missed entity: deleted entity(id = 2)
+        assertEquals(1, sf2.getStatistics().getSecondLevelCacheMissCount());
+        //hit entitities: all entitties except the deleted one along with their children
+        assertEquals((entityCount-1) * (2 + childCount), sf2.getStatistics().getSecondLevelCacheHitCount());
+    }
+
+    @Test
+    public void testReadWriteEntity() {
         final HazelcastInstance hz = getHazelcastInstance(sf);
         assertNotNull(hz);
         final int count = 100;
@@ -221,6 +362,22 @@ public abstract class HibernateStatisticsTestSupport extends HibernateTestSuppor
         } finally {
             session.close();
         }
+    }
+
+    protected int executeUpdateQueryInTransaction(SessionFactory factory, String queryString) {
+        Session session = factory.openSession();
+        Transaction txn = null;
+        int res = -1;
+        try {
+            txn = session.beginTransaction();
+            Query query = session.createQuery(queryString);
+
+            res = query.executeUpdate();
+            txn.commit();
+        } finally {
+            session.close();
+        }
+        return res;
     }
 
     @Test

--- a/hazelcast-hibernate/hazelcast-hibernate3/src/test/java/com/hazelcast/hibernate/LocalRegionFactoryDefaultTest.java
+++ b/hazelcast-hibernate/hazelcast-hibernate3/src/test/java/com/hazelcast/hibernate/LocalRegionFactoryDefaultTest.java
@@ -60,19 +60,16 @@ public class LocalRegionFactoryDefaultTest extends RegionFactoryDefaultTest {
         return props;
     }
 
-
     @Test
     public void testNonStrictReadWriteEntity() {
         Session session = null;
         Transaction txn = null;
-
         int entityCount = 10;
         int childCount = 4;
 
         insertDummyNonStrictRWEntities(entityCount, childCount);
 
         sf.getCache().evictEntityRegions();
-        sf2.getCache().evictEntityRegions();
 
         session = sf.openSession();
         ArrayList<DummyEntityNonStrictRW> entities = new ArrayList<DummyEntityNonStrictRW>(entityCount);
@@ -94,18 +91,17 @@ public class LocalRegionFactoryDefaultTest extends RegionFactoryDefaultTest {
         session.delete(removedEntity);
         txn.commit();
         session.close();
-        sleep(1);
 
         session = sf.openSession();
         entities = new ArrayList<DummyEntityNonStrictRW>(entityCount);
         for (int i=0; i<entityCount; i++) {
             DummyEntityNonStrictRW ent = (DummyEntityNonStrictRW)session.get(DummyEntityNonStrictRW.class, (long)i);
-            entities.add(ent);
+            if(ent != null)
+                entities.add(ent);
         }
-        //missed entries: updated entry, children of updated entry, deleted entry
-        assertEquals(1 + 1 + childCount, sf.getStatistics().getSecondLevelCacheMissCount());
-        //assertEquals((entityCount - 1) * (2 + childCount), sf2.getStatistics().getSecondLevelCacheHitCount());
-
+        assertEquals(entityCount-1, entities.size());
+        assertEquals(2 + childCount, sf.getStatistics().getSecondLevelCacheMissCount());
+        assertEquals((entityCount - 1) * (1 + childCount) + childCount, sf.getStatistics().getSecondLevelCacheHitCount());
     }
 
     @Test

--- a/hazelcast-hibernate/hazelcast-hibernate3/src/test/java/com/hazelcast/hibernate/RegionFactoryDefaultTest.java
+++ b/hazelcast-hibernate/hazelcast-hibernate3/src/test/java/com/hazelcast/hibernate/RegionFactoryDefaultTest.java
@@ -16,11 +16,14 @@
 
 package com.hazelcast.hibernate;
 
+import com.hazelcast.hibernate.access.ReadOnlyAccessDelegate;
 import com.hazelcast.hibernate.entity.DummyEntity;
 import com.hazelcast.hibernate.entity.DummyEntityNonStrictRW;
 import com.hazelcast.hibernate.entity.DummyEntityReadOnly;
+import com.hazelcast.hibernate.region.HazelcastRegion;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
+import org.hibernate.Query;
 import org.hibernate.Session;
 import org.hibernate.Transaction;
 import org.hibernate.cfg.Environment;
@@ -31,11 +34,14 @@ import org.junit.runner.RunWith;
 
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
 import java.util.Properties;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
@@ -46,6 +52,100 @@ public class RegionFactoryDefaultTest extends HibernateStatisticsTestSupport {
         props.setProperty(Environment.CACHE_REGION_FACTORY, HazelcastCacheRegionFactory.class.getName());
         return props;
     }
+
+    @Test
+    public void testNonStrictReadWriteEntity() {
+        Session session = null;
+        Transaction txn = null;
+
+        int entityCount = 10;
+        int childCount = 4;
+
+        insertDummyNonStrictRWEntities(entityCount, childCount);
+
+        sf.getCache().evictEntityRegions();
+        sf2.getCache().evictEntityRegions();
+
+        session = sf.openSession();
+        ArrayList<DummyEntityNonStrictRW> entities = new ArrayList<DummyEntityNonStrictRW>(entityCount);
+        for (int i=0; i<entityCount; i++) {
+            entities.add((DummyEntityNonStrictRW)session.get(DummyEntityNonStrictRW.class, (long)i));
+        }
+        assertEquals(entityCount*2, sf.getStatistics().getSecondLevelCacheMissCount());
+        assertEquals(0, sf.getStatistics().getSecondLevelCacheHitCount());
+
+        session.close();
+
+        session = sf.openSession();
+        txn = session.beginTransaction();
+        DummyEntityNonStrictRW updatedEntity = entities.get(0);
+        updatedEntity.setName("updated:" + 0);
+        session.update(updatedEntity);
+        DummyEntityNonStrictRW removedEntity = entities.get(1);
+        session.delete(removedEntity);
+        txn.commit();
+        session.close();
+
+        assertEquals(0, sf2.getStatistics().getSecondLevelCacheMissCount());
+        assertEquals(0, sf2.getStatistics().getSecondLevelCacheHitCount());
+
+        session = sf2.openSession();
+        entities = new ArrayList<DummyEntityNonStrictRW>(entityCount);
+        for (int i=0; i<entityCount; i++) {
+            DummyEntityNonStrictRW ent = (DummyEntityNonStrictRW)session.get(DummyEntityNonStrictRW.class, (long)i);
+            if(ent != null)
+                entities.add(ent);
+        }
+        assertEquals(entityCount-1, entities.size());
+        assertEquals(2 + childCount, sf2.getStatistics().getSecondLevelCacheMissCount());
+        assertEquals((entityCount - 1) * (1 + childCount) + childCount, sf2.getStatistics().getSecondLevelCacheHitCount());
+    }
+
+    @Test
+    public void testReadOnlyEntity() {
+        Session session = null;
+        Transaction txn = null;
+
+        int entityCount = 10;
+        int childCount = 4;
+
+        insertDummyReadOnlyEntities(entityCount, childCount);
+
+        sf.getCache().evictEntityRegions();
+        sf2.getCache().evictEntityRegions();
+
+        session = sf.openSession();
+        ArrayList<DummyEntityReadOnly> entities = new ArrayList<DummyEntityReadOnly>(entityCount);
+        for (int i=0; i<entityCount; i++) {
+            entities.add((DummyEntityReadOnly)session.get(DummyEntityReadOnly.class, (long)i));
+        }
+        assertEquals(entityCount * 2, sf.getStatistics().getSecondLevelCacheMissCount());
+        assertEquals(0, sf.getStatistics().getSecondLevelCacheHitCount());
+
+        session.close();
+
+        session = sf.openSession();
+        txn =session.beginTransaction();
+        DummyEntityReadOnly deletedEntity = (DummyEntityReadOnly) session.get(DummyEntityReadOnly.class, (long) 2);
+        session.delete(deletedEntity);
+        txn.commit();
+
+        assertEquals(0, sf2.getStatistics().getSecondLevelCacheMissCount());
+        assertEquals(0, sf2.getStatistics().getSecondLevelCacheHitCount());
+
+        session = sf2.openSession();
+        entities = new ArrayList<DummyEntityReadOnly>(entityCount);
+        for (int i=0; i<entityCount; i++) {
+            DummyEntityReadOnly ent = (DummyEntityReadOnly)session.get(DummyEntityReadOnly.class, (long)i);
+            entities.add(ent);
+            session.evict(ent);
+        }
+        //missed entity: deleted entity(id = 2)
+        assertEquals(1, sf2.getStatistics().getSecondLevelCacheMissCount());
+        //hit entitities: all entitties except the deleted one along with their children
+        assertEquals((entityCount-1) * (2 + childCount), sf2.getStatistics().getSecondLevelCacheHitCount());
+    }
+
 
     @Test
     public void testUpdateQueryCausesInvalidationOfEntireRegion() {
@@ -75,18 +175,39 @@ public class RegionFactoryDefaultTest extends HibernateStatisticsTestSupport {
         Session session = null;
 
         int res = executeUpdateQueryInTransaction(sf, "UPDATE DummyEntityNonStrictRW set name = 'manually-updated' where id=2");
-
         assertEquals(1, res);
-
         sf.getStatistics().clear();
 
         session = sf.openSession();
         ArrayList<DummyEntityNonStrictRW> entities = new ArrayList<DummyEntityNonStrictRW>(entityCount);
         for (int i=0; i<entityCount; i++) {
-            entities.add((DummyEntityNonStrictRW)session.get(DummyEntityNonStrictRW.class, (long)i));
+            entities.add((DummyEntityNonStrictRW)session.get(DummyEntityNonStrictRW.class, (long) i));
         }
         assertEquals(entityCount * 2, sf.getStatistics().getSecondLevelCacheMissCount());
         assertEquals(0, sf.getStatistics().getSecondLevelCacheHitCount());
+    }
+
+    @Test
+    public void testQueryRegionEviction() {
+        sf.getCache().evictDefaultQueryRegion();
+        int entityCount = 10;
+        insertDummyEntities(entityCount, 0);
+        List<DummyEntity> retrievedEntities = executeListQueryInTransaction(sf);
+        assertEquals(entityCount, retrievedEntities.size());
+
+        sf.getStatistics().clear();
+        executeListQueryInTransaction(sf);
+
+        assertEquals(1, sf.getStatistics().getQueryCacheHitCount());
+        assertEquals(0, sf.getStatistics().getQueryCacheMissCount());
+
+        executeUpdateQueryInTransaction(sf, "delete from DummyEntity");
+
+        sf.getStatistics().clear();
+        executeListQueryInTransaction(sf);
+        executeListQueryInTransaction(sf);
+        assertEquals(1, sf.getStatistics().getQueryCacheHitCount());
+        assertEquals(1, sf.getStatistics().getQueryCacheMissCount());
     }
 
     @Test(expected = UnsupportedOperationException.class)
@@ -95,8 +216,6 @@ public class RegionFactoryDefaultTest extends HibernateStatisticsTestSupport {
         Transaction txn = null;
 
         insertDummyReadOnlyEntities(1, 0);
-        sleep(1);
-
         try {
             session = sf.openSession();
             DummyEntityReadOnly e = (DummyEntityReadOnly) session.get(DummyEntityReadOnly.class, (long)0);
@@ -110,6 +229,24 @@ public class RegionFactoryDefaultTest extends HibernateStatisticsTestSupport {
         } finally {
             session.close();
         }
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testAfterUpdateShouldThrowOnReadOnly() {
+        HazelcastRegion hzRegion = mock(HazelcastRegion.class);
+        when(hzRegion.getCache()).thenReturn(null);
+        when(hzRegion.getLogger()).thenReturn(null);
+        ReadOnlyAccessDelegate readOnlyAccessDelegate = new ReadOnlyAccessDelegate(hzRegion, null);
+        readOnlyAccessDelegate.afterUpdate(null, null, null, null, null);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testLockRegionShouldThrowOnReadOnly() {
+        HazelcastRegion hzRegion = mock(HazelcastRegion.class);
+        when(hzRegion.getCache()).thenReturn(null);
+        when(hzRegion.getLogger()).thenReturn(null);
+        ReadOnlyAccessDelegate readOnlyAccessDelegate = new ReadOnlyAccessDelegate(hzRegion, null);
+        readOnlyAccessDelegate.lockRegion();
     }
 
     @Test

--- a/hazelcast-hibernate/hazelcast-hibernate3/src/test/java/com/hazelcast/hibernate/entity/DummyEntityNonStrictRW.java
+++ b/hazelcast-hibernate/hazelcast-hibernate3/src/test/java/com/hazelcast/hibernate/entity/DummyEntityNonStrictRW.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate.entity;
+
+import java.util.Date;
+import java.util.Set;
+
+public class DummyEntityNonStrictRW {
+
+    private long id;
+
+    private int version;
+
+    private String name;
+
+    private double value;
+
+    private Date date;
+
+    private Set<DummyPropertyNonStrictRW> properties;
+
+    public DummyEntityNonStrictRW() {
+    }
+
+    public DummyEntityNonStrictRW(long id, String name, double value, Date date) {
+        this.id = id;
+        this.name = name;
+        this.value = value;
+        this.date = date;
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    public int getVersion() {
+        return version;
+    }
+
+    public void setVersion(int version) {
+        this.version = version;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public double getValue() {
+        return value;
+    }
+
+    public void setValue(double value) {
+        this.value = value;
+    }
+
+    public Date getDate() {
+        return date;
+    }
+
+    public void setDate(Date date) {
+        this.date = date;
+    }
+
+    public void setProperties(Set<DummyPropertyNonStrictRW> properties) {
+        this.properties = properties;
+    }
+
+    public Set<DummyPropertyNonStrictRW> getProperties() {
+        return properties;
+    }
+}

--- a/hazelcast-hibernate/hazelcast-hibernate3/src/test/java/com/hazelcast/hibernate/entity/DummyEntityReadOnly.java
+++ b/hazelcast-hibernate/hazelcast-hibernate3/src/test/java/com/hazelcast/hibernate/entity/DummyEntityReadOnly.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate.entity;
+
+import java.util.Date;
+import java.util.Set;
+
+public class DummyEntityReadOnly {
+
+    private long id;
+
+    private int version;
+
+    private String name;
+
+    private double value;
+
+    private Date date;
+
+    private Set<DummyPropertyReadOnly> properties;
+
+    public DummyEntityReadOnly() {
+    }
+
+    public DummyEntityReadOnly(long id, String name, double value, Date date) {
+        this.id = id;
+        this.name = name;
+        this.value = value;
+        this.date = date;
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    public int getVersion() {
+        return version;
+    }
+
+    public void setVersion(int version) {
+        this.version = version;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public double getValue() {
+        return value;
+    }
+
+    public void setValue(double value) {
+        this.value = value;
+    }
+
+    public Date getDate() {
+        return date;
+    }
+
+    public void setDate(Date date) {
+        this.date = date;
+    }
+
+    public void setProperties(Set<DummyPropertyReadOnly> properties) {
+        this.properties = properties;
+    }
+
+    public Set<DummyPropertyReadOnly> getProperties() {
+        return properties;
+    }
+}

--- a/hazelcast-hibernate/hazelcast-hibernate3/src/test/java/com/hazelcast/hibernate/entity/DummyPropertyNonStrictRW.java
+++ b/hazelcast-hibernate/hazelcast-hibernate3/src/test/java/com/hazelcast/hibernate/entity/DummyPropertyNonStrictRW.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate.entity;
+
+public class DummyPropertyNonStrictRW {
+
+    private long id;
+
+    private int version;
+
+    private String key;
+
+    private DummyEntityNonStrictRW entity;
+
+    public DummyPropertyNonStrictRW() {
+    }
+
+    public DummyPropertyNonStrictRW(String key) {
+        this.key = key;
+    }
+
+    public DummyPropertyNonStrictRW(String key, DummyEntityNonStrictRW entity) {
+        this.key = key;
+        this.entity = entity;
+    }
+
+    public DummyPropertyNonStrictRW(long id, String key, DummyEntityNonStrictRW entity) {
+        this.id = id;
+        this.key = key;
+        this.entity = entity;
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    public int getVersion() {
+        return version;
+    }
+
+    public void setVersion(int version) {
+        this.version = version;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    public DummyEntityNonStrictRW getEntity() {
+        return entity;
+    }
+
+    public void setEntity(DummyEntityNonStrictRW entity) {
+        this.entity = entity;
+    }
+}

--- a/hazelcast-hibernate/hazelcast-hibernate3/src/test/java/com/hazelcast/hibernate/entity/DummyPropertyReadOnly.java
+++ b/hazelcast-hibernate/hazelcast-hibernate3/src/test/java/com/hazelcast/hibernate/entity/DummyPropertyReadOnly.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate.entity;
+
+public class DummyPropertyReadOnly {
+
+    private long id;
+
+    private int version;
+
+    private String key;
+
+    private DummyEntityReadOnly entity;
+
+    public DummyPropertyReadOnly() {
+    }
+
+    public DummyPropertyReadOnly(String key) {
+        this.key = key;
+    }
+
+    public DummyPropertyReadOnly(String key, DummyEntityReadOnly entity) {
+        this.key = key;
+        this.entity = entity;
+    }
+
+    public DummyPropertyReadOnly(long id, String key, DummyEntityReadOnly entity) {
+        this.id = id;
+        this.key = key;
+        this.entity = entity;
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    public int getVersion() {
+        return version;
+    }
+
+    public void setVersion(int version) {
+        this.version = version;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    public DummyEntityReadOnly getEntity() {
+        return entity;
+    }
+
+    public void setEntity(DummyEntityReadOnly entity) {
+        this.entity = entity;
+    }
+}

--- a/hazelcast-hibernate/hazelcast-hibernate3/src/test/resources/com/hazelcast/hibernate/entity/DummyEntity.hbm.xml
+++ b/hazelcast-hibernate/hazelcast-hibernate3/src/test/resources/com/hazelcast/hibernate/entity/DummyEntity.hbm.xml
@@ -39,4 +39,39 @@
             <one-to-many class="com.hazelcast.hibernate.entity.DummyProperty"/>
         </set>
     </class>
+    <class name="DummyEntityNonStrictRW" table="dummy_entities_nonstrict_rw">
+        <cache usage="nonstrict-read-write"/>
+
+        <id name="id" column="uid" type="long" unsaved-value="null">
+            <generator class="assigned"/>
+        </id>
+        <version column="version" name="version" type="int"/>
+        <property name="name" type="string" length="100"/>
+        <property name="date" column="dummy_date" type="date"/>
+        <property name="value" column="dummy_value" type="double"/>
+
+        <set name="properties" lazy="false" cascade="all" inverse="true">
+            <cache usage="nonstrict-read-write"/>
+            <key column="parent_uid"/>
+            <one-to-many class="com.hazelcast.hibernate.entity.DummyPropertyNonStrictRW"/>
+        </set>
+    </class>
+
+    <class name="DummyEntityReadOnly" table="dummy_entities_read_only">
+        <cache usage="read-only"/>
+
+        <id name="id" column="uid" type="long" unsaved-value="null">
+            <generator class="assigned"/>
+        </id>
+        <version column="version" name="version" type="int"/>
+        <property name="name" type="string" length="100"/>
+        <property name="date" column="dummy_date" type="date"/>
+        <property name="value" column="dummy_value" type="double"/>
+
+        <set name="properties" lazy="false" cascade="all" inverse="true">
+            <cache usage="read-only"/>
+            <key column="parent_uid"/>
+            <one-to-many class="com.hazelcast.hibernate.entity.DummyPropertyReadOnly"/>
+        </set>
+    </class>
 </hibernate-mapping>

--- a/hazelcast-hibernate/hazelcast-hibernate3/src/test/resources/com/hazelcast/hibernate/entity/DummyProperty.hbm.xml
+++ b/hazelcast-hibernate/hazelcast-hibernate3/src/test/resources/com/hazelcast/hibernate/entity/DummyProperty.hbm.xml
@@ -35,4 +35,30 @@
         <many-to-one name="entity" class="com.hazelcast.hibernate.entity.DummyEntity"
                      column="parent_uid"/>
     </class>
+    <class name="DummyPropertyNonStrictRW" table="dummy_props_nonstrict_rw">
+        <cache usage="nonstrict-read-write"/>
+
+        <id name="id" column="uid" type="long" unsaved-value="null">
+            <generator class="native"/>
+            <!-- 			<generator class="assigned" /> -->
+        </id>
+        <version column="version" name="version" type="int"/>
+        <property name="key" type="string" length="100"/>
+
+        <many-to-one name="entity" class="com.hazelcast.hibernate.entity.DummyEntityNonStrictRW"
+                     column="parent_uid"/>
+    </class>
+    <class name="DummyPropertyReadOnly" table="dummy_props_read_only">
+        <cache usage="read-only"/>
+
+        <id name="id" column="uid" type="long" unsaved-value="null">
+            <generator class="native"/>
+            <!-- 			<generator class="assigned" /> -->
+        </id>
+        <version column="version" name="version" type="int"/>
+        <property name="key" type="string" length="100"/>
+
+        <many-to-one name="entity" class="com.hazelcast.hibernate.entity.DummyEntityReadOnly"
+                     column="parent_uid"/>
+    </class>
 </hibernate-mapping>

--- a/hazelcast-hibernate/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/HibernateStatisticsTestSupport.java
+++ b/hazelcast-hibernate/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/HibernateStatisticsTestSupport.java
@@ -20,7 +20,11 @@ import com.hazelcast.config.MapConfig;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.hibernate.entity.DummyEntity;
+import com.hazelcast.hibernate.entity.DummyEntityNonStrictRW;
+import com.hazelcast.hibernate.entity.DummyEntityReadOnly;
 import com.hazelcast.hibernate.entity.DummyProperty;
+import com.hazelcast.hibernate.entity.DummyPropertyNonStrictRW;
+import com.hazelcast.hibernate.entity.DummyPropertyReadOnly;
 import com.hazelcast.hibernate.instance.HazelcastAccessor;
 import com.hazelcast.hibernate.region.HazelcastQueryResultsRegion;
 import com.hazelcast.test.annotation.NightlyTest;
@@ -98,6 +102,50 @@ public abstract class HibernateStatisticsTestSupport extends HibernateTestSuppor
             session.close();
         }
     }
+
+
+    protected void insertDummyNonStrictRWEntities(int count, int childCount) {
+        Session session = sf.openSession();
+        Transaction tx = session.beginTransaction();
+        try {
+            for (int i = 0; i < count; i++) {
+                DummyEntityNonStrictRW e = new DummyEntityNonStrictRW((long) i, "dummy:" + i, i * 123456d, new Date());
+                session.save(e);
+                for (int j = 0; j < childCount; j++) {
+                    DummyPropertyNonStrictRW p = new DummyPropertyNonStrictRW("key:" + j, e);
+                    session.save(p);
+                }
+            }
+            tx.commit();
+        } catch (Exception e) {
+            tx.rollback();
+            e.printStackTrace();
+        } finally {
+            session.close();
+        }
+    }
+
+    protected void insertDummyReadOnlyEntities(int count, int childCount) {
+        Session session = sf.openSession();
+        Transaction tx = session.beginTransaction();
+        try {
+            for (int i = 0; i < count; i++) {
+                DummyEntityReadOnly e = new DummyEntityReadOnly((long) i, "dummy:" + i, i * 123456d, new Date());
+                session.save(e);
+                for (int j = 0; j < childCount; j++) {
+                    DummyPropertyReadOnly p = new DummyPropertyReadOnly("key:" + j, e);
+                    session.save(p);
+                }
+            }
+            tx.commit();
+        } catch (Exception e) {
+            tx.rollback();
+            e.printStackTrace();
+        } finally {
+            session.close();
+        }
+    }
+
 
     @Test
     public void testEntity() {
@@ -221,6 +269,41 @@ public abstract class HibernateStatisticsTestSupport extends HibernateTestSuppor
         } finally {
             session.close();
         }
+    }
+
+
+    protected List<DummyEntity> executeListQueryInTransaction(SessionFactory factory) {
+        Session session = factory.openSession();
+        Transaction txn = null;
+        List<DummyEntity> res = null;
+        try {
+            txn = session.beginTransaction();
+            Query query = session.createQuery("FROM DummyEntity");
+            query.setCacheable(true);
+
+            res= query.list();
+            txn.commit();
+        } finally {
+            session.close();
+        }
+        return res;
+    }
+
+    protected int executeUpdateQueryInTransaction(SessionFactory factory, String queryString) {
+        Session session = factory.openSession();
+        Transaction txn = null;
+        int res = -1;
+        try {
+            txn = session.beginTransaction();
+            Query query = session.createQuery(queryString);
+            query.setCacheable(true);
+
+            res = query.executeUpdate();
+            txn.commit();
+        } finally {
+            session.close();
+        }
+        return res;
     }
 
     @Test

--- a/hazelcast-hibernate/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/LocalRegionFactoryDefaultTest.java
+++ b/hazelcast-hibernate/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/LocalRegionFactoryDefaultTest.java
@@ -18,6 +18,8 @@ package com.hazelcast.hibernate;
 
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.hibernate.entity.DummyEntity;
+import com.hazelcast.hibernate.entity.DummyEntityNonStrictRW;
+import com.hazelcast.hibernate.entity.DummyEntityReadOnly;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.NightlyTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -45,6 +47,93 @@ public class LocalRegionFactoryDefaultTest extends RegionFactoryDefaultTest {
         Properties props = new Properties();
         props.setProperty(Environment.CACHE_REGION_FACTORY, HazelcastLocalCacheRegionFactory.class.getName());
         return props;
+    }
+
+    @Test
+    public void testNonStrictReadWriteEntity() {
+        Session session = null;
+        Transaction txn = null;
+        int entityCount = 10;
+        int childCount = 4;
+
+        insertDummyNonStrictRWEntities(entityCount, childCount);
+
+        sf.getCache().evictEntityRegions();
+
+        session = sf.openSession();
+        ArrayList<DummyEntityNonStrictRW> entities = new ArrayList<DummyEntityNonStrictRW>(entityCount);
+        for (int i=0; i<entityCount; i++) {
+            entities.add((DummyEntityNonStrictRW)session.get(DummyEntityNonStrictRW.class, (long)i));
+        }
+        assertEquals(entityCount*2, sf.getStatistics().getSecondLevelCacheMissCount());
+        assertEquals(0, sf.getStatistics().getSecondLevelCacheHitCount());
+
+        session.close();
+        sf.getStatistics().clear();
+
+        session = sf.openSession();
+        txn = session.beginTransaction();
+        DummyEntityNonStrictRW updatedEntity = entities.get(0);
+        updatedEntity.setName("updated:" + 0);
+        session.update(updatedEntity);
+        DummyEntityNonStrictRW removedEntity = entities.get(1);
+        session.delete(removedEntity);
+        txn.commit();
+        session.close();
+
+        session = sf.openSession();
+        entities = new ArrayList<DummyEntityNonStrictRW>(entityCount);
+        for (int i=0; i<entityCount; i++) {
+            DummyEntityNonStrictRW ent = (DummyEntityNonStrictRW)session.get(DummyEntityNonStrictRW.class, (long)i);
+            if(ent != null)
+                entities.add(ent);
+        }
+        assertEquals(entityCount-1, entities.size());
+        assertEquals(2 + childCount, sf.getStatistics().getSecondLevelCacheMissCount());
+        assertEquals((entityCount - 1) * (1 + childCount) + childCount, sf.getStatistics().getSecondLevelCacheHitCount());
+    }
+
+    @Test
+    public void testReadOnlyEntity() {
+        Session session = null;
+        Transaction txn = null;
+
+        int entityCount = 10;
+        int childCount = 4;
+
+        insertDummyReadOnlyEntities(entityCount, childCount);
+
+        sf.getCache().evictEntityRegions();
+
+        session = sf.openSession();
+        ArrayList<DummyEntityReadOnly> entities = new ArrayList<DummyEntityReadOnly>(entityCount);
+        for (int i=0; i<entityCount; i++) {
+            entities.add((DummyEntityReadOnly)session.get(DummyEntityReadOnly.class, (long)i));
+        }
+        assertEquals(entityCount * 2, sf.getStatistics().getSecondLevelCacheMissCount());
+        assertEquals(0, sf.getStatistics().getSecondLevelCacheHitCount());
+
+
+        session.close();
+
+        session = sf.openSession();
+        txn =session.beginTransaction();
+        DummyEntityReadOnly deletedEntity = (DummyEntityReadOnly) session.get(DummyEntityReadOnly.class, (long) 2);
+        session.delete(deletedEntity);
+        txn.commit();
+
+        sf.getStatistics().clear();
+
+        session = sf.openSession();
+        entities = new ArrayList<DummyEntityReadOnly>(entityCount);
+        for (int i=0; i<entityCount; i++) {
+            DummyEntityReadOnly ent = (DummyEntityReadOnly)session.get(DummyEntityReadOnly.class, (long)i);
+            entities.add(ent);
+        }
+        //missed entity: deleted entity(id = 2)
+        assertEquals(1, sf.getStatistics().getSecondLevelCacheMissCount());
+        //hit entitities: all entitties except the deleted one along with their children
+        assertEquals((entityCount-1) * (2 + childCount), sf.getStatistics().getSecondLevelCacheHitCount());
     }
 
     @Test

--- a/hazelcast-hibernate/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/RegionFactoryDefaultTest.java
+++ b/hazelcast-hibernate/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/RegionFactoryDefaultTest.java
@@ -16,7 +16,11 @@
 
 package com.hazelcast.hibernate;
 
+import com.hazelcast.hibernate.access.ReadOnlyAccessDelegate;
 import com.hazelcast.hibernate.entity.DummyEntity;
+import com.hazelcast.hibernate.entity.DummyEntityNonStrictRW;
+import com.hazelcast.hibernate.entity.DummyEntityReadOnly;
+import com.hazelcast.hibernate.region.HazelcastRegion;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.NightlyTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -28,11 +32,15 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
 import java.util.Properties;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
@@ -43,6 +51,203 @@ public class RegionFactoryDefaultTest extends HibernateStatisticsTestSupport {
         props.setProperty(Environment.CACHE_REGION_FACTORY, HazelcastCacheRegionFactory.class.getName());
         return props;
     }
+
+
+    @Test
+    public void testNonStrictReadWriteEntity() {
+        Session session = null;
+        Transaction txn = null;
+
+        int entityCount = 10;
+        int childCount = 4;
+
+        insertDummyNonStrictRWEntities(entityCount, childCount);
+
+        sf.getCache().evictEntityRegions();
+        sf2.getCache().evictEntityRegions();
+
+        session = sf.openSession();
+        ArrayList<DummyEntityNonStrictRW> entities = new ArrayList<DummyEntityNonStrictRW>(entityCount);
+        for (int i=0; i<entityCount; i++) {
+            entities.add((DummyEntityNonStrictRW)session.get(DummyEntityNonStrictRW.class, (long)i));
+        }
+        assertEquals(entityCount*2, sf.getStatistics().getSecondLevelCacheMissCount());
+        assertEquals(0, sf.getStatistics().getSecondLevelCacheHitCount());
+
+        session.close();
+
+        session = sf.openSession();
+        txn = session.beginTransaction();
+        DummyEntityNonStrictRW updatedEntity = entities.get(0);
+        updatedEntity.setName("updated:" + 0);
+        session.update(updatedEntity);
+        DummyEntityNonStrictRW removedEntity = entities.get(1);
+        session.delete(removedEntity);
+        txn.commit();
+        session.close();
+
+        assertEquals(0, sf2.getStatistics().getSecondLevelCacheMissCount());
+        assertEquals(0, sf2.getStatistics().getSecondLevelCacheHitCount());
+
+        session = sf2.openSession();
+        entities = new ArrayList<DummyEntityNonStrictRW>(entityCount);
+        for (int i=0; i<entityCount; i++) {
+            DummyEntityNonStrictRW ent = (DummyEntityNonStrictRW)session.get(DummyEntityNonStrictRW.class, (long)i);
+            if(ent != null)
+                entities.add(ent);
+        }
+        assertEquals(entityCount-1, entities.size());
+        assertEquals(2 + childCount, sf2.getStatistics().getSecondLevelCacheMissCount());
+        assertEquals((entityCount - 1) * (1 + childCount) + childCount, sf2.getStatistics().getSecondLevelCacheHitCount());
+    }
+
+    @Test
+    public void testReadOnlyEntity() {
+        Session session = null;
+        Transaction txn = null;
+
+        int entityCount = 10;
+        int childCount = 4;
+
+        insertDummyReadOnlyEntities(entityCount, childCount);
+
+        sf.getCache().evictEntityRegions();
+        sf2.getCache().evictEntityRegions();
+
+        session = sf.openSession();
+        ArrayList<DummyEntityReadOnly> entities = new ArrayList<DummyEntityReadOnly>(entityCount);
+        for (int i=0; i<entityCount; i++) {
+            entities.add((DummyEntityReadOnly)session.get(DummyEntityReadOnly.class, (long)i));
+        }
+        assertEquals(entityCount * 2, sf.getStatistics().getSecondLevelCacheMissCount());
+        assertEquals(0, sf.getStatistics().getSecondLevelCacheHitCount());
+
+        session.close();
+
+        session = sf.openSession();
+        txn =session.beginTransaction();
+        DummyEntityReadOnly deletedEntity = (DummyEntityReadOnly) session.get(DummyEntityReadOnly.class, (long) 2);
+        session.delete(deletedEntity);
+        txn.commit();
+
+        assertEquals(0, sf2.getStatistics().getSecondLevelCacheMissCount());
+        assertEquals(0, sf2.getStatistics().getSecondLevelCacheHitCount());
+
+        session = sf2.openSession();
+        entities = new ArrayList<DummyEntityReadOnly>(entityCount);
+        for (int i=0; i<entityCount; i++) {
+            DummyEntityReadOnly ent = (DummyEntityReadOnly)session.get(DummyEntityReadOnly.class, (long)i);
+            entities.add(ent);
+        }
+        //missed entity: deleted entity(id = 2)
+        assertEquals(1, sf2.getStatistics().getSecondLevelCacheMissCount());
+        //hit entitities: all entitties except the deleted one along with their children
+        assertEquals((entityCount-1) * (2 + childCount), sf2.getStatistics().getSecondLevelCacheHitCount());
+    }
+
+
+    @Test
+    public void testUpdateQueryCausesInvalidationOfEntireRegion() {
+        int entityCount = 10;
+        insertDummyEntities(entityCount);
+        Session session = null;
+
+        int res = executeUpdateQueryInTransaction(sf, "UPDATE DummyEntity set name = 'manually-updated' where id=2");
+
+        assertEquals(1, res);
+
+        sf.getStatistics().clear();
+
+        session = sf.openSession();
+        ArrayList<DummyEntity> entities = new ArrayList<DummyEntity>(entityCount);
+        for (int i=0; i<entityCount; i++) {
+            entities.add((DummyEntity)session.get(DummyEntity.class, (long)i));
+        }
+        assertEquals(entityCount * 2, sf.getStatistics().getSecondLevelCacheMissCount());
+        assertEquals(0, sf.getStatistics().getSecondLevelCacheHitCount());
+    }
+
+    @Test
+    public void testUpdateQueryOnNonStrictRWCausesInvalidationOfEntireRegion() {
+        int entityCount = 10;
+        insertDummyNonStrictRWEntities(entityCount, 0);
+        Session session = null;
+
+        int res = executeUpdateQueryInTransaction(sf, "UPDATE DummyEntityNonStrictRW set name = 'manually-updated' where id=2");
+        assertEquals(1, res);
+        sf.getStatistics().clear();
+
+        session = sf.openSession();
+        ArrayList<DummyEntityNonStrictRW> entities = new ArrayList<DummyEntityNonStrictRW>(entityCount);
+        for (int i=0; i<entityCount; i++) {
+            entities.add((DummyEntityNonStrictRW)session.get(DummyEntityNonStrictRW.class, (long) i));
+        }
+        assertEquals(entityCount * 2, sf.getStatistics().getSecondLevelCacheMissCount());
+        assertEquals(0, sf.getStatistics().getSecondLevelCacheHitCount());
+    }
+
+    @Test
+    public void testQueryRegionEviction() {
+        sf.getCache().evictDefaultQueryRegion();
+        int entityCount = 10;
+        insertDummyEntities(entityCount, 0);
+        List<DummyEntity> retrievedEntities = executeListQueryInTransaction(sf);
+        assertEquals(entityCount, retrievedEntities.size());
+
+        sf.getStatistics().clear();
+        executeListQueryInTransaction(sf);
+
+        assertEquals(1, sf.getStatistics().getQueryCacheHitCount());
+        assertEquals(0, sf.getStatistics().getQueryCacheMissCount());
+
+        executeUpdateQueryInTransaction(sf, "delete from DummyEntity");
+
+        sf.getStatistics().clear();
+        executeListQueryInTransaction(sf);
+        executeListQueryInTransaction(sf);
+        assertEquals(1, sf.getStatistics().getQueryCacheHitCount());
+        assertEquals(1, sf.getStatistics().getQueryCacheMissCount());
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testReadOnlyUpdate() throws Exception{
+        Session session = null;
+        Transaction txn = null;
+
+        insertDummyReadOnlyEntities(1, 0);
+        try {
+            session = sf.openSession();
+            DummyEntityReadOnly e = (DummyEntityReadOnly) session.get(DummyEntityReadOnly.class, (long)0);
+            txn = session.beginTransaction();
+            e.setName("updated");
+            session.update(e);
+            txn.commit();
+        } catch (Exception e) {
+            txn.rollback();
+            throw e;
+        } finally {
+            session.close();
+        }
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testAfterUpdateShouldThrowOnReadOnly() {
+        HazelcastRegion hzRegion = mock(HazelcastRegion.class);
+        when(hzRegion.getCache()).thenReturn(null);
+        when(hzRegion.getLogger()).thenReturn(null);
+        ReadOnlyAccessDelegate readOnlyAccessDelegate = new ReadOnlyAccessDelegate(hzRegion, null);
+        readOnlyAccessDelegate.afterUpdate(null, null, null, null, null);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testLockRegionShouldThrowOnReadOnly() {
+        HazelcastRegion hzRegion = mock(HazelcastRegion.class);
+        when(hzRegion.getCache()).thenReturn(null);
+        when(hzRegion.getLogger()).thenReturn(null);
+        ReadOnlyAccessDelegate readOnlyAccessDelegate = new ReadOnlyAccessDelegate(hzRegion, null);
+        readOnlyAccessDelegate.lockRegion();
+    }
+
 
     @Test
     public void testInsertGetUpdateGet() {

--- a/hazelcast-hibernate/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/entity/DummyEntityNonStrictRW.java
+++ b/hazelcast-hibernate/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/entity/DummyEntityNonStrictRW.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate.entity;
+
+import java.util.Date;
+import java.util.Set;
+
+public class DummyEntityNonStrictRW {
+
+    private long id;
+
+    private int version;
+
+    private String name;
+
+    private double value;
+
+    private Date date;
+
+    private Set<DummyPropertyNonStrictRW> properties;
+
+    public DummyEntityNonStrictRW() {
+    }
+
+    public DummyEntityNonStrictRW(long id, String name, double value, Date date) {
+        this.id = id;
+        this.name = name;
+        this.value = value;
+        this.date = date;
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    public int getVersion() {
+        return version;
+    }
+
+    public void setVersion(int version) {
+        this.version = version;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public double getValue() {
+        return value;
+    }
+
+    public void setValue(double value) {
+        this.value = value;
+    }
+
+    public Date getDate() {
+        return date;
+    }
+
+    public void setDate(Date date) {
+        this.date = date;
+    }
+
+    public void setProperties(Set<DummyPropertyNonStrictRW> properties) {
+        this.properties = properties;
+    }
+
+    public Set<DummyPropertyNonStrictRW> getProperties() {
+        return properties;
+    }
+}

--- a/hazelcast-hibernate/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/entity/DummyEntityReadOnly.java
+++ b/hazelcast-hibernate/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/entity/DummyEntityReadOnly.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate.entity;
+
+import java.util.Date;
+import java.util.Set;
+
+public class DummyEntityReadOnly {
+
+    private long id;
+
+    private int version;
+
+    private String name;
+
+    private double value;
+
+    private Date date;
+
+    private Set<DummyPropertyReadOnly> properties;
+
+    public DummyEntityReadOnly() {
+    }
+
+    public DummyEntityReadOnly(long id, String name, double value, Date date) {
+        this.id = id;
+        this.name = name;
+        this.value = value;
+        this.date = date;
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    public int getVersion() {
+        return version;
+    }
+
+    public void setVersion(int version) {
+        this.version = version;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public double getValue() {
+        return value;
+    }
+
+    public void setValue(double value) {
+        this.value = value;
+    }
+
+    public Date getDate() {
+        return date;
+    }
+
+    public void setDate(Date date) {
+        this.date = date;
+    }
+
+    public void setProperties(Set<DummyPropertyReadOnly> properties) {
+        this.properties = properties;
+    }
+
+    public Set<DummyPropertyReadOnly> getProperties() {
+        return properties;
+    }
+}

--- a/hazelcast-hibernate/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/entity/DummyPropertyNonStrictRW.java
+++ b/hazelcast-hibernate/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/entity/DummyPropertyNonStrictRW.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate.entity;
+
+public class DummyPropertyNonStrictRW {
+
+    private long id;
+
+    private int version;
+
+    private String key;
+
+    private DummyEntityNonStrictRW entity;
+
+    public DummyPropertyNonStrictRW() {
+    }
+
+    public DummyPropertyNonStrictRW(String key) {
+        this.key = key;
+    }
+
+    public DummyPropertyNonStrictRW(String key, DummyEntityNonStrictRW entity) {
+        this.key = key;
+        this.entity = entity;
+    }
+
+    public DummyPropertyNonStrictRW(long id, String key, DummyEntityNonStrictRW entity) {
+        this.id = id;
+        this.key = key;
+        this.entity = entity;
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    public int getVersion() {
+        return version;
+    }
+
+    public void setVersion(int version) {
+        this.version = version;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    public DummyEntityNonStrictRW getEntity() {
+        return entity;
+    }
+
+    public void setEntity(DummyEntityNonStrictRW entity) {
+        this.entity = entity;
+    }
+}

--- a/hazelcast-hibernate/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/entity/DummyPropertyReadOnly.java
+++ b/hazelcast-hibernate/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/entity/DummyPropertyReadOnly.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate.entity;
+
+public class DummyPropertyReadOnly {
+
+    private long id;
+
+    private int version;
+
+    private String key;
+
+    private DummyEntityReadOnly entity;
+
+    public DummyPropertyReadOnly() {
+    }
+
+    public DummyPropertyReadOnly(String key) {
+        this.key = key;
+    }
+
+    public DummyPropertyReadOnly(String key, DummyEntityReadOnly entity) {
+        this.key = key;
+        this.entity = entity;
+    }
+
+    public DummyPropertyReadOnly(long id, String key, DummyEntityReadOnly entity) {
+        this.id = id;
+        this.key = key;
+        this.entity = entity;
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    public int getVersion() {
+        return version;
+    }
+
+    public void setVersion(int version) {
+        this.version = version;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    public DummyEntityReadOnly getEntity() {
+        return entity;
+    }
+
+    public void setEntity(DummyEntityReadOnly entity) {
+        this.entity = entity;
+    }
+}

--- a/hazelcast-hibernate/hazelcast-hibernate4/src/test/resources/com/hazelcast/hibernate/entity/DummyEntity.hbm.xml
+++ b/hazelcast-hibernate/hazelcast-hibernate4/src/test/resources/com/hazelcast/hibernate/entity/DummyEntity.hbm.xml
@@ -39,4 +39,39 @@
             <one-to-many class="com.hazelcast.hibernate.entity.DummyProperty"/>
         </set>
     </class>
+    <class name="DummyEntityNonStrictRW" table="dummy_entities_nonstrict_rw">
+        <cache usage="nonstrict-read-write"/>
+
+        <id name="id" column="uid" type="long" unsaved-value="null">
+            <generator class="assigned"/>
+        </id>
+        <version column="version" name="version" type="int"/>
+        <property name="name" type="string" length="100"/>
+        <property name="date" column="dummy_date" type="date"/>
+        <property name="value" column="dummy_value" type="double"/>
+
+        <set name="properties" lazy="false" cascade="all" inverse="true">
+            <cache usage="nonstrict-read-write"/>
+            <key column="parent_uid"/>
+            <one-to-many class="com.hazelcast.hibernate.entity.DummyPropertyNonStrictRW"/>
+        </set>
+    </class>
+
+    <class name="DummyEntityReadOnly" table="dummy_entities_read_only">
+        <cache usage="read-only"/>
+
+        <id name="id" column="uid" type="long" unsaved-value="null">
+            <generator class="assigned"/>
+        </id>
+        <version column="version" name="version" type="int"/>
+        <property name="name" type="string" length="100"/>
+        <property name="date" column="dummy_date" type="date"/>
+        <property name="value" column="dummy_value" type="double"/>
+
+        <set name="properties" lazy="false" cascade="all" inverse="true">
+            <cache usage="read-only"/>
+            <key column="parent_uid"/>
+            <one-to-many class="com.hazelcast.hibernate.entity.DummyPropertyReadOnly"/>
+        </set>
+    </class>
 </hibernate-mapping>

--- a/hazelcast-hibernate/hazelcast-hibernate4/src/test/resources/com/hazelcast/hibernate/entity/DummyProperty.hbm.xml
+++ b/hazelcast-hibernate/hazelcast-hibernate4/src/test/resources/com/hazelcast/hibernate/entity/DummyProperty.hbm.xml
@@ -35,4 +35,30 @@
         <many-to-one name="entity" class="com.hazelcast.hibernate.entity.DummyEntity"
                      column="parent_uid"/>
     </class>
+    <class name="DummyPropertyNonStrictRW" table="dummy_props_nonstrict_rw">
+        <cache usage="nonstrict-read-write"/>
+
+        <id name="id" column="uid" type="long" unsaved-value="null">
+            <generator class="native"/>
+            <!-- 			<generator class="assigned" /> -->
+        </id>
+        <version column="version" name="version" type="int"/>
+        <property name="key" type="string" length="100"/>
+
+        <many-to-one name="entity" class="com.hazelcast.hibernate.entity.DummyEntityNonStrictRW"
+                     column="parent_uid"/>
+    </class>
+    <class name="DummyPropertyReadOnly" table="dummy_props_read_only">
+        <cache usage="read-only"/>
+
+        <id name="id" column="uid" type="long" unsaved-value="null">
+            <generator class="native"/>
+            <!-- 			<generator class="assigned" /> -->
+        </id>
+        <version column="version" name="version" type="int"/>
+        <property name="key" type="string" length="100"/>
+
+        <many-to-one name="entity" class="com.hazelcast.hibernate.entity.DummyEntityReadOnly"
+                     column="parent_uid"/>
+    </class>
 </hibernate-mapping>


### PR DESCRIPTION
adds tests for NonStrictReadWrite and ReadOnly cache access strategies
adds tests for query cache eviction on customer query execution

note: hibernate4 tests are identical to hibernate3 tests.