### PR TITLE
Upgraded hamcrest-library version

### DIFF
--- a/hazelcast/pom.xml
+++ b/hazelcast/pom.xml
@@ -248,7 +248,7 @@
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-library</artifactId>
-            <version>1.2</version>
+            <version>1.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Upgraded hamcrest-library version to 1.3. Because `BiInt2ObjectMapTest` is not compiling with java-9-ea compiler.

```
/hazelcast/src/test/java/com/hazelcast/util/collection/BiInt2ObjectMapTest.java:[48,77] 
error: incompatible types: Matcher<CAP#1> cannot be converted to Matcher<? super CAP#2>
```

See https://hazelcast-l337.ci.cloudbees.com/view/Quality-Outreach/job/Hazelcast-3.x-OpenJDK9-Quality-Outreach/135/console