### PR TITLE
Remove response object litter

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -269,7 +269,7 @@
     <suppress checks="ClassFanOutComplexity" files="com/hazelcast/spi/impl/NodeEngineImpl"/>
     <!-- since this class needs to manage services, it knows about them, so it is fine to have lots of dependencies on these classes -->
     <suppress checks="ClassDataAbstractionCoupling" files="com/hazelcast/spi/impl/servicemanager/impl/ServiceManager"/>
-    <suppress checks="MethodCount|ExecutableStatementCount|ClassFanOutComplexity"
+    <suppress checks="MethodCount|ClassDataAbstractionCoupling|ExecutableStatementCount|ClassFanOutComplexity"
               files="com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl"/>
     <!-- the invocation just has many parameters because there are a lot of things to tune/ -->
     <suppress checks="ParameterNumber" files="com/hazelcast/spi/impl/operationservice/impl/InvocationImpl"/>

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheCreateConfigOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheCreateConfigOperation.java
@@ -127,7 +127,7 @@ public class CacheCreateConfigOperation
         @Override
         public void notify(Object object) {
             if (counter.decrementAndGet() == 0) {
-                operation.sendResponse(null);
+                operation.sendNormalResponse(null);
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/operations/PostJoinOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/operations/PostJoinOperation.java
@@ -17,15 +17,16 @@
 package com.hazelcast.cluster.impl.operations;
 
 import com.hazelcast.logging.ILogger;
+import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.spi.AbstractOperation;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.OperationAccessor;
-import com.hazelcast.spi.OperationResponseHandler;
 import com.hazelcast.spi.OperationService;
 import com.hazelcast.spi.UrgentSystemOperation;
+import com.hazelcast.spi.impl.OperationResponseHandlerAdapter;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -57,24 +58,16 @@ public class PostJoinOperation extends AbstractOperation implements UrgentSystem
             for (int i = 0; i < len; i++) {
                 final Operation op = operations[i];
                 op.setNodeEngine(nodeEngine);
-                op.setOperationResponseHandler(new OperationResponseHandler() {
+                op.setOperationResponseHandler(new OperationResponseHandlerAdapter() {
                     @Override
-                    public void sendResponse(Operation op, Object obj) {
-                        if (obj instanceof Throwable) {
-                            Throwable t = (Throwable) obj;
-                            ILogger logger = nodeEngine.getLogger(op.getClass());
-                            logger.warning("Error while running post-join operation: "
-                                    + t.getClass().getSimpleName() + ": " + t.getMessage());
+                    public void sendErrorResponse(Address address, long callId, boolean urgent, Operation op, Throwable cause) {
+                        ILogger logger = nodeEngine.getLogger(op.getClass());
+                        logger.warning("Error while running post-join operation: "
+                                + cause.getClass().getSimpleName() + ": " + cause.getMessage());
 
-                            if (logger.isFinestEnabled()) {
-                                logger.finest(t);
-                            }
+                        if (logger.isFinestEnabled()) {
+                            logger.finest(cause);
                         }
-                    }
-
-                    @Override
-                    public boolean isLocal() {
-                        return true;
                     }
                 });
 

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/OfferOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/OfferOperation.java
@@ -103,7 +103,7 @@ public final class OfferOperation extends QueueBackupAwareOperation
 
     @Override
     public void onWaitExpire() {
-        sendResponse(false);
+        sendNormalResponse(false);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/PollOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/PollOperation.java
@@ -94,7 +94,7 @@ public final class PollOperation extends QueueBackupAwareOperation
 
     @Override
     public void onWaitExpire() {
-        sendResponse(null);
+        sendNormalResponse(null);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/operations/TxnReserveOfferOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/operations/TxnReserveOfferOperation.java
@@ -66,7 +66,7 @@ public class TxnReserveOfferOperation extends QueueBackupAwareOperation implemen
 
     @Override
     public void onWaitExpire() {
-        sendResponse(null);
+        sendNormalResponse(null);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/operations/TxnReservePollOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/operations/TxnReservePollOperation.java
@@ -65,7 +65,7 @@ public class TxnReservePollOperation extends QueueBackupAwareOperation implement
 
     @Override
     public void onWaitExpire() {
-        sendResponse(null);
+        sendNormalResponse(null);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/countdownlatch/operations/AwaitOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/countdownlatch/operations/AwaitOperation.java
@@ -54,7 +54,7 @@ public class AwaitOperation extends BaseCountDownLatchOperation implements WaitS
 
     @Override
     public void onWaitExpire() {
-        sendResponse(false);
+        sendNormalResponse(false);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/AwaitOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/AwaitOperation.java
@@ -111,7 +111,7 @@ public class AwaitOperation extends BaseLockOperation
         boolean locked = lockStore.lock(key, getCallerUuid(), threadId, getReferenceCallId(), leaseTime);
         if (locked) {
             // expired & acquired lock, send FALSE
-            sendResponse(false);
+            sendNormalResponse(false);
         } else {
             // expired but could not acquire lock, no response atm
             lockStore.registerExpiredAwaitOp(this);

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/LockOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/LockOperation.java
@@ -73,7 +73,7 @@ public class LockOperation extends BaseLockOperation implements WaitSupport, Bac
         } else {
             response = Boolean.FALSE;
         }
-        sendResponse(response);
+        sendNormalResponse(response);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/AcquireOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/AcquireOperation.java
@@ -54,7 +54,7 @@ public class AcquireOperation extends SemaphoreBackupAwareOperation
 
     @Override
     public void onWaitExpire() {
-        sendResponse(false);
+        sendNormalResponse(false);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/executor/impl/DistributedExecutorService.java
+++ b/hazelcast/src/main/java/com/hazelcast/executor/impl/DistributedExecutorService.java
@@ -44,6 +44,9 @@ import java.util.concurrent.FutureTask;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 
+import static java.lang.Boolean.FALSE;
+import static java.lang.Boolean.TRUE;
+
 public class DistributedExecutorService implements ManagedService, RemoteService, ExecutionTracingService,
         StatisticsAwareService {
 
@@ -175,7 +178,7 @@ public class DistributedExecutorService implements ManagedService, RemoteService
 
     private final class CallableProcessor extends FutureTask implements Runnable {
         //is being used through the RESPONSE_FLAG. Can't be private due to reflection constraint.
-        volatile Boolean responseFlag = Boolean.FALSE;
+        volatile Boolean responseFlag = FALSE;
 
         private final String name;
         private final String uuid;
@@ -223,8 +226,8 @@ public class DistributedExecutorService implements ManagedService, RemoteService
         }
 
         private void sendResponse(Object result) {
-            if (RESPONSE_FLAG.compareAndSet(this, Boolean.FALSE, Boolean.TRUE)) {
-                op.sendResponse(result);
+            if (RESPONSE_FLAG.compareAndSet(this, FALSE, TRUE)) {
+                op.sendNormalResponse(result);
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/executor/impl/operations/BaseCallableTaskOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/executor/impl/operations/BaseCallableTaskOperation.java
@@ -80,7 +80,7 @@ abstract class BaseCallableTaskOperation extends Operation implements TraceableO
         try {
             return getNodeEngine().toObject(callableData);
         } catch (HazelcastSerializationException e) {
-            sendResponse(e);
+            sendErrorResponse(e);
             throw ExceptionUtil.rethrow(e);
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/BasePutOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/BasePutOperation.java
@@ -111,7 +111,7 @@ public abstract class BasePutOperation extends LockAwareOperation implements Bac
 
     @Override
     public void onWaitExpire() {
-        sendResponse(null);
+        sendNormalResponse(null);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/BaseRemoveOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/BaseRemoveOperation.java
@@ -77,7 +77,7 @@ public abstract class BaseRemoveOperation extends LockAwareOperation implements 
 
     @Override
     public void onWaitExpire() {
-        sendResponse(null);
+        sendNormalResponse(null);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ContainsKeyOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ContainsKeyOperation.java
@@ -61,7 +61,7 @@ public class ContainsKeyOperation extends KeyBasedMapOperation implements Readon
 
     @Override
     public void onWaitExpire() {
-        sendResponse(new OperationTimeoutException("Cannot read transactionally locked entry!"));
+        sendErrorResponse(new OperationTimeoutException("Cannot read transactionally locked entry!"));
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/DeleteOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/DeleteOperation.java
@@ -52,7 +52,7 @@ public class DeleteOperation extends BaseRemoveOperation {
 
     @Override
     public void onWaitExpire() {
-        sendResponse(false);
+        sendNormalResponse(false);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOperation.java
@@ -106,7 +106,7 @@ public class EntryOperation extends LockAwareOperation implements BackupAwareOpe
 
     @Override
     public void onWaitExpire() {
-        sendResponse(null);
+        sendNormalResponse(null);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EvictOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EvictOperation.java
@@ -54,7 +54,7 @@ public class EvictOperation extends LockAwareOperation implements MutatingOperat
 
     @Override
     public void onWaitExpire() {
-        sendResponse(false);
+        sendNormalResponse(false);
     }
 
     public Operation getBackupOperation() {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/GetEntryViewOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/GetEntryViewOperation.java
@@ -65,7 +65,7 @@ public class GetEntryViewOperation extends KeyBasedMapOperation implements Reado
 
     @Override
     public void onWaitExpire() {
-        sendResponse(new OperationTimeoutException("Cannot read transactionally locked entry!"));
+        sendErrorResponse(new OperationTimeoutException("Cannot read transactionally locked entry!"));
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/GetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/GetOperation.java
@@ -67,7 +67,7 @@ public final class GetOperation extends KeyBasedMapOperation
 
     @Override
     public void onWaitExpire() {
-        sendResponse(new OperationTimeoutException("Cannot read transactionally locked entry!"));
+        sendErrorResponse(new OperationTimeoutException("Cannot read transactionally locked entry!"));
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutTransientOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutTransientOperation.java
@@ -40,7 +40,7 @@ public class PutTransientOperation extends BasePutOperation {
 
     @Override
     public void onWaitExpire() {
-        sendResponse(null);
+        sendNormalResponse(null);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/RemoveIfSameOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/RemoveIfSameOperation.java
@@ -59,7 +59,7 @@ public class RemoveIfSameOperation extends BaseRemoveOperation {
 
     @Override
     public void onWaitExpire() {
-        sendResponse(null);
+        sendNormalResponse(null);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ReplaceIfSameOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ReplaceIfSameOperation.java
@@ -61,7 +61,7 @@ public class ReplaceIfSameOperation extends BasePutOperation {
 
     @Override
     public void onWaitExpire() {
-        sendResponse(false);
+        sendNormalResponse(false);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/TryPutOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/TryPutOperation.java
@@ -49,7 +49,7 @@ public class TryPutOperation extends BasePutOperation {
 
     @Override
     public void onWaitExpire() {
-        sendResponse(false);
+        sendNormalResponse(false);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/TryRemoveOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/TryRemoveOperation.java
@@ -60,7 +60,7 @@ public class TryRemoveOperation extends BaseRemoveOperation {
 
     @Override
     public void onWaitExpire() {
-        sendResponse(false);
+        sendNormalResponse(false);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/WanOriginatedDeleteOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/WanOriginatedDeleteOperation.java
@@ -62,7 +62,7 @@ public class WanOriginatedDeleteOperation extends BaseRemoveOperation {
 
     @Override
     public void onWaitExpire() {
-        sendResponse(false);
+        sendNormalResponse(false);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/BasicRecordStoreLoader.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/BasicRecordStoreLoader.java
@@ -29,8 +29,8 @@ import com.hazelcast.spi.ExecutionService;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.OperationAccessor;
-import com.hazelcast.spi.OperationResponseHandler;
 import com.hazelcast.spi.OperationService;
+import com.hazelcast.spi.impl.OperationResponseHandlerAdapter;
 import com.hazelcast.util.ExceptionUtil;
 
 import java.util.ArrayList;
@@ -222,17 +222,12 @@ class BasicRecordStoreLoader implements RecordStoreLoader {
         final NodeEngine nodeEngine = mapServiceContext.getNodeEngine();
         final Operation operation = new PutFromLoadAllOperation(name, keyValueSequence);
         operation.setNodeEngine(nodeEngine);
-        operation.setOperationResponseHandler(new OperationResponseHandler() {
+        operation.setOperationResponseHandler(new OperationResponseHandlerAdapter() {
             @Override
-            public void sendResponse(Operation op, Object obj) {
+            public void onSend() {
                 if (finishedBatchCounter.decrementAndGet() == 0) {
                     loaded.set(true);
                 }
-            }
-
-            @Override
-            public boolean isLocal() {
-                return true;
             }
         });
         operation.setPartitionId(partitionId);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnDeleteOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnDeleteOperation.java
@@ -75,7 +75,7 @@ public class TxnDeleteOperation extends BaseRemoveOperation implements MapTxnOpe
 
     @Override
     public void onWaitExpire() {
-        sendResponse(false);
+        sendNormalResponse(false);
     }
 
     public long getVersion() {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnLockAndGetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnLockAndGetOperation.java
@@ -59,7 +59,7 @@ public class TxnLockAndGetOperation extends LockAwareOperation implements Mutati
 
     @Override
     public void onWaitExpire() {
-        sendResponse(null);
+        sendNormalResponse(null);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnSetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnSetOperation.java
@@ -117,7 +117,7 @@ public class TxnSetOperation extends BasePutOperation implements MapTxnOperation
     }
 
     public void onWaitExpire() {
-        sendResponse(false);
+        sendNormalResponse(false);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnUnlockOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnUnlockOperation.java
@@ -89,7 +89,7 @@ public class TxnUnlockOperation extends LockAwareOperation implements MapTxnOper
 
     @Override
     public void onWaitExpire() {
-        sendResponse(false);
+        sendNormalResponse(false);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/ContainsEntryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/ContainsEntryOperation.java
@@ -112,6 +112,6 @@ public class ContainsEntryOperation extends MultiMapOperation implements WaitSup
 
     @Override
     public void onWaitExpire() {
-        sendResponse(new OperationTimeoutException("Cannot read transactionally locked entry!"));
+        sendErrorResponse(new OperationTimeoutException("Cannot read transactionally locked entry!"));
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/CountOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/CountOperation.java
@@ -65,7 +65,7 @@ public class CountOperation extends MultiMapKeyBasedOperation implements WaitSup
 
     @Override
     public void onWaitExpire() {
-        sendResponse(new OperationTimeoutException("Cannot read transactionally locked entry!"));
+        sendErrorResponse(new OperationTimeoutException("Cannot read transactionally locked entry!"));
     }
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/GetAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/GetAllOperation.java
@@ -45,7 +45,7 @@ public class GetAllOperation extends MultiMapKeyBasedOperation implements WaitSu
         Collection coll = null;
         if (multiMapValue != null) {
             multiMapValue.incrementHit();
-            OperationResponseHandler responseHandler = getOperationResponseHandler();
+            OperationResponseHandler responseHandler = getNotNullOperationResponseHandler();
             coll = multiMapValue.getCollection(responseHandler.isLocal());
         }
         response = new MultiMapResponse(coll, getValueCollectionType(container));
@@ -72,6 +72,6 @@ public class GetAllOperation extends MultiMapKeyBasedOperation implements WaitSu
 
     @Override
     public void onWaitExpire() {
-        sendResponse(new OperationTimeoutException("Cannot read transactionally locked entry!"));
+        sendErrorResponse(new OperationTimeoutException("Cannot read transactionally locked entry!"));
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/MultiMapBackupAwareOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/MultiMapBackupAwareOperation.java
@@ -66,6 +66,6 @@ public abstract class MultiMapBackupAwareOperation extends MultiMapKeyBasedOpera
 
     @Override
     public void onWaitExpire() {
-        sendResponse(null);
+        sendNormalResponse(null);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/PutOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/PutOperation.java
@@ -80,7 +80,7 @@ public class PutOperation extends MultiMapBackupAwareOperation {
 
     @Override
     public void onWaitExpire() {
-        sendResponse(false);
+        sendNormalResponse(false);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/RemoveAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/RemoveAllOperation.java
@@ -40,7 +40,7 @@ public class RemoveAllOperation extends MultiMapBackupAwareOperation {
     @Override
     public void run() throws Exception {
         MultiMapContainer container = getOrCreateContainer();
-        coll = remove(getOperationResponseHandler().isLocal());
+        coll = remove(getNotNullOperationResponseHandler().isLocal());
         response = new MultiMapResponse(coll, getValueCollectionType(container));
     }
 
@@ -68,7 +68,7 @@ public class RemoveAllOperation extends MultiMapBackupAwareOperation {
     public void onWaitExpire() {
         MultiMapContainer container = getOrCreateContainer();
         MultiMapConfig.ValueCollectionType valueCollectionType = getValueCollectionType(container);
-        sendResponse(new MultiMapResponse(null, valueCollectionType));
+        sendNormalResponse(new MultiMapResponse(null, valueCollectionType));
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/RemoveOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/RemoveOperation.java
@@ -85,7 +85,7 @@ public class RemoveOperation extends MultiMapBackupAwareOperation {
 
     @Override
     public void onWaitExpire() {
-        sendResponse(false);
+        sendNormalResponse(false);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnLockAndGetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnLockAndGetOperation.java
@@ -74,7 +74,7 @@ public class TxnLockAndGetOperation extends MultiMapKeyBasedOperation implements
 
     @Override
     public void onWaitExpire() {
-        sendResponse(null);
+        sendNormalResponse(null);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/partition/impl/MigrationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/impl/MigrationOperation.java
@@ -30,6 +30,7 @@ import com.hazelcast.spi.OperationAccessor;
 import com.hazelcast.spi.OperationResponseHandler;
 import com.hazelcast.spi.PartitionMigrationEvent;
 import com.hazelcast.spi.exception.RetryableHazelcastException;
+import com.hazelcast.spi.impl.OperationResponseHandlerAdapter;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.IOException;
@@ -42,15 +43,10 @@ import java.util.logging.Level;
 @SuppressFBWarnings("EI_EXPOSE_REP")
 public final class MigrationOperation extends BaseMigrationOperation {
 
-    private static final OperationResponseHandler ERROR_RESPONSE_HANDLER = new OperationResponseHandler() {
+    private static final OperationResponseHandler ERROR_RESPONSE_HANDLER = new OperationResponseHandlerAdapter() {
         @Override
-        public void sendResponse(Operation op, Object obj) {
+        public void onSend() {
             throw new HazelcastException("Migration operations can not send response!");
-        }
-
-        @Override
-        public boolean isLocal() {
-            return true;
         }
     };
 

--- a/hazelcast/src/main/java/com/hazelcast/partition/impl/MigrationRequestOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/impl/MigrationRequestOperation.java
@@ -217,7 +217,7 @@ public final class MigrationRequestOperation extends BaseMigrationOperation {
         @Override
         public void notify(Object result) {
             migrationInfo.doneProcessing();
-            op.sendResponse(result);
+            op.sendNormalResponse(result);
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/OperationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/OperationService.java
@@ -174,8 +174,7 @@ public interface OperationService {
     /**
      * Sends a response to a remote machine.
      * <p/>
-     * This methods is deprecated since 3.5. It is an implementation detail, so it is moved to the
-     * {@link com.hazelcast.spi.impl.operationservice.InternalOperationService}.
+     * This methods is deprecated since 3.5.
      *
      * @param response the response to send.
      * @param target   the address of the target machine

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/NewResponseHandlerAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/NewResponseHandlerAdapter.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi.impl;
+
+import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.OperationResponseHandler;
+import com.hazelcast.spi.ResponseHandler;
+import com.hazelcast.spi.impl.operationservice.impl.responses.CallTimeoutResponse;
+import com.hazelcast.spi.impl.operationservice.impl.responses.ErrorResponse;
+import com.hazelcast.spi.impl.operationservice.impl.responses.NormalResponse;
+import com.hazelcast.spi.impl.operationservice.impl.responses.Response;
+
+/**
+ * A {@link ResponseHandler} adapter that adapts a new {@link OperationResponseHandler} to behave like a
+ * old {@link ResponseHandler}.
+ */
+@Deprecated
+public class NewResponseHandlerAdapter implements ResponseHandler {
+
+    private final OperationResponseHandler handler;
+    private final Operation op;
+
+    public NewResponseHandlerAdapter(OperationResponseHandler handler, Operation op) {
+        this.handler = handler;
+        this.op = op;
+    }
+
+    @Override
+    public void sendResponse(Object obj) {
+        if (obj instanceof Response) {
+            if (obj instanceof NormalResponse) {
+                NormalResponse normalResponse = (NormalResponse) obj;
+                handler.sendNormalResponse(op, normalResponse.getValue(), normalResponse.getBackupCount());
+            } else if (obj instanceof ErrorResponse) {
+                ErrorResponse errorResponse = (ErrorResponse) obj;
+                handler.sendErrorResponse(op.getCallerAddress(), op.getCallId(), op.isUrgent(), op, errorResponse.getCause());
+            } else if (obj instanceof CallTimeoutResponse) {
+                handler.sendTimeoutResponse(op);
+            } else {
+                // other responses like backup response will never been send through the old response handler.
+                throw new IllegalArgumentException("Unhandled response:" + obj);
+            }
+        } else if (obj instanceof Throwable) {
+            handler.sendErrorResponse(op.getCallerAddress(), op.getCallId(), op.isUrgent(), op, (Throwable) obj);
+        } else {
+            handler.sendNormalResponse(op, obj, 0);
+        }
+    }
+
+    @Override
+    public boolean isLocal() {
+        return handler.isLocal();
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/OldResponseHandlerAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/OldResponseHandlerAdapter.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi.impl;
+
+import com.hazelcast.nio.Address;
+import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.OperationResponseHandler;
+import com.hazelcast.spi.ResponseHandler;
+import com.hazelcast.spi.impl.operationservice.impl.responses.BackupResponse;
+import com.hazelcast.spi.impl.operationservice.impl.responses.CallTimeoutResponse;
+import com.hazelcast.spi.impl.operationservice.impl.responses.ErrorResponse;
+import com.hazelcast.spi.impl.operationservice.impl.responses.NormalResponse;
+
+/**
+ * An adapter for an old {@link ResponseHandler} to act like a new OperationResponseHandler.
+ *
+ * This code will be removed as soon as the {@link ResponseHandler} is removed.
+ */
+@Deprecated
+public class OldResponseHandlerAdapter implements OperationResponseHandler {
+
+    private final ResponseHandler responseHandler;
+
+    public OldResponseHandlerAdapter(ResponseHandler responseHandler) {
+        this.responseHandler = responseHandler;
+    }
+
+    public ResponseHandler getResponseHandler() {
+        return responseHandler;
+    }
+
+    @Override
+    public void sendNormalResponse(Operation op, Object response, int syncBackupCount) {
+        if (syncBackupCount == 0) {
+            responseHandler.sendResponse(response);
+        } else {
+            responseHandler.sendResponse(new NormalResponse(response, op.getCallId(), syncBackupCount, op.isUrgent()));
+        }
+    }
+
+    @Override
+    public void sendBackupComplete(Address address, long callId, boolean urgent) {
+        responseHandler.sendResponse(new BackupResponse(callId, urgent));
+    }
+
+    @Override
+    public void sendErrorResponse(Address address, long callId, boolean urgent, Operation op, Throwable cause) {
+        responseHandler.sendResponse(new ErrorResponse(cause, callId, urgent));
+    }
+
+    @Override
+    public void sendTimeoutResponse(Operation op) {
+        responseHandler.sendResponse(new CallTimeoutResponse(op.getCallId(), op.isUrgent()));
+    }
+
+    @Override
+    public boolean isLocal() {
+        return responseHandler.isLocal();
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/OperationResponseHandlerAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/OperationResponseHandlerAdapter.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi.impl;
+
+import com.hazelcast.nio.Address;
+import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.OperationResponseHandler;
+
+/**
+ * An abstract OperationResponseHandler adapter. It doesn't adapt one interface to another; the traditional adapter design
+ * pattern. The same technique is applied in e.g. {@link java.awt.event.MouseAdapter} that implements
+ * {@link java.awt.event.MouseListener}.
+ *
+ * It implements all methods so that only methods that are interesting need to be implemented.
+ *
+ * Every implemented method forwards to the {@link #onSend()} method. So by overriding this method, any send method can be
+ * intercepted.
+ */
+public abstract class OperationResponseHandlerAdapter implements OperationResponseHandler {
+
+    @Override
+    public void sendNormalResponse(Operation op, Object response, int syncBackupCount) {
+        onSend();
+    }
+
+    @Override
+    public void sendBackupComplete(Address address, long callId, boolean urgent) {
+        onSend();
+    }
+
+    @Override
+    public void sendErrorResponse(Address address, long callId, boolean urgent, Operation op, Throwable cause) {
+        onSend();
+    }
+
+    @Override
+    public void sendTimeoutResponse(Operation op) {
+        onSend();
+    }
+
+    public void onSend() {
+    }
+
+    @Override
+    public boolean isLocal() {
+        return true;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/OperationResponseHandlerFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/OperationResponseHandlerFactory.java
@@ -17,12 +17,13 @@
 package com.hazelcast.spi.impl;
 
 import com.hazelcast.logging.ILogger;
+import com.hazelcast.nio.Address;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.OperationResponseHandler;
 
 public final class OperationResponseHandlerFactory {
 
-    private static final NoResponseHandler EMPTY_RESPONSE_HANDLER = new NoResponseHandler();
+    private static final EmptyResponseHandler EMPTY_RESPONSE_HANDLER = new EmptyResponseHandler();
 
     private OperationResponseHandlerFactory() {
     }
@@ -31,13 +32,9 @@ public final class OperationResponseHandlerFactory {
         return EMPTY_RESPONSE_HANDLER;
     }
 
-    private static class NoResponseHandler
-            implements OperationResponseHandler {
+    private static class EmptyResponseHandler extends OperationResponseHandlerAdapter {
 
-        @Override
-        public void sendResponse(Operation op, Object obj) {
-        }
-
+        // TODO: Should this not return true?
         @Override
         public boolean isLocal() {
             return false;
@@ -56,11 +53,22 @@ public final class OperationResponseHandlerFactory {
         }
 
         @Override
-        public void sendResponse(Operation op, Object obj) {
-            if (obj instanceof Throwable) {
-                Throwable t = (Throwable) obj;
-                logger.severe(t);
-            }
+        public void sendNormalResponse(Operation op, Object response, int syncBackupCount) {
+        }
+
+        @Override
+        public void sendBackupComplete(Address address, long callId, boolean urgent) {
+        }
+
+        @Override
+        public void sendErrorResponse(Address address, long callId, boolean urgent, Operation op, Throwable cause) {
+            //todo: should we not include operation information?
+            logger.severe(cause);
+        }
+
+        @Override
+        public void sendTimeoutResponse(Operation op) {
+            //todo: should we not log the timeout?
         }
 
         @Override

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/AsyncResponsePacketHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/AsyncResponsePacketHandler.java
@@ -123,7 +123,7 @@ public class AsyncResponsePacketHandler implements PacketHandler {
             }
         }
 
-        @SuppressFBWarnings({"VO_VOLATILE_INCREMENT" })
+        @SuppressFBWarnings(value = {"VO_VOLATILE_INCREMENT" }, justification = "Single thread does update")
         private void process(Packet responsePacket) {
             processedResponses++;
             try {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationFuture.java
@@ -179,9 +179,12 @@ final class InvocationFuture<E> implements InternalCompletableFuture<E> {
             }
             callbackChain = callbackHead;
             callbackHead = null;
-            notifyAll();
 
-            operationService.invocationsRegistry.deregister(invocation);
+            notify();
+
+            //if (registered) {
+                operationService.invocationsRegistry.deregister(invocation);
+            //}
         }
 
 
@@ -402,7 +405,7 @@ final class InvocationFuture<E> implements InternalCompletableFuture<E> {
 
     @Override
     public boolean isDone() {
-         return responseAvailable(response);
+        return responseAvailable(response);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
@@ -97,6 +97,7 @@ public final class OperationServiceImpl implements InternalOperationService, Pac
     private static final int ASYNC_QUEUE_CAPACITY = 100000;
     private static final long TERMINATION_TIMEOUT_MILLIS = TimeUnit.SECONDS.toMillis(10);
 
+    final RemoteInvocationResponseHandler remoteResponseHandler;
     final InvocationRegistry invocationsRegistry;
     final OperationExecutor operationExecutor;
     final ILogger invocationLogger;
@@ -127,6 +128,7 @@ public final class OperationServiceImpl implements InternalOperationService, Pac
     private final AsyncResponsePacketHandler responsePacketExecutor;
     private final SerializationService serializationService;
 
+    // A lot of creation logic should be moved into the DI container. So the dependencies should be injected
     public OperationServiceImpl(NodeEngineImpl nodeEngine) {
         this.nodeEngine = nodeEngine;
         this.node = nodeEngine.getNode();
@@ -151,8 +153,8 @@ public final class OperationServiceImpl implements InternalOperationService, Pac
                 logger,
                 new ResponsePacketHandlerImpl(
                         logger,
-                        node.getSerializationService(),
                         invocationsRegistry));
+        this.remoteResponseHandler = new RemoteInvocationResponseHandler(nodeEngine);
 
         this.operationExecutor = new ClassicOperationExecutor(
                 groupProperties,
@@ -192,10 +194,6 @@ public final class OperationServiceImpl implements InternalOperationService, Pac
     @Override
     public List<SlowOperationDTO> getSlowOperationDTOs() {
         return slowOperationDetector.getSlowOperationDTOs();
-    }
-
-    public InvocationRegistry getInvocationsRegistry() {
-        return invocationsRegistry;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/ResponsePacketHandlerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/ResponsePacketHandlerImpl.java
@@ -40,6 +40,8 @@ public class ResponsePacketHandlerImpl implements PacketHandler {
         try {
             long callId = packet.getResponseCallId();
             Address sender = packet.getConn().getEndPoint();
+            // since the packet is used as data, lets null the connection so we don't get any memory leaks
+            packet.setConn(null);
             switch (packet.getResponseType()) {
                 case Packet.RESPONSE_NORMAL:
                     Data response = packet.totalSize() == 0 ? null : packet;

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/operations/Backup.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/operations/Backup.java
@@ -29,10 +29,7 @@ import com.hazelcast.spi.BackupOperation;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.OperationAccessor;
-import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.impl.SpiDataSerializerHook;
-import com.hazelcast.spi.impl.operationservice.impl.OperationServiceImpl;
-import com.hazelcast.spi.impl.operationservice.impl.responses.BackupResponse;
 import com.hazelcast.util.Clock;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
@@ -130,16 +127,7 @@ public final class Backup extends Operation implements BackupOperation, Identifi
             return;
         }
 
-        NodeEngineImpl nodeEngine = (NodeEngineImpl) getNodeEngine();
-        long callId = getCallId();
-        OperationServiceImpl operationService = (OperationServiceImpl) nodeEngine.getOperationService();
-
-        if (nodeEngine.getThisAddress().equals(originalCaller)) {
-            operationService.getInvocationsRegistry().notifyBackupComplete(callId);
-        } else {
-            BackupResponse backupResponse = new BackupResponse(callId, backupOp.isUrgent());
-            operationService.send(backupResponse, originalCaller);
-        }
+        getNotNullOperationResponseHandler().sendBackupComplete(originalCaller, getCallId(), backupOp.isUrgent());
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/operations/IsStillExecutingOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/operations/IsStillExecutingOperation.java
@@ -49,7 +49,7 @@ public class IsStillExecutingOperation extends AbstractOperation implements Urge
         IsStillRunningService isStillRunningService = operationService.getIsStillRunningService();
         boolean executing = isStillRunningService.isOperationExecuting(getCallerAddress(),
                 operationPartitionId, operationCallId);
-        getOperationResponseHandler().sendResponse(this, executing);
+        sendNormalResponse(executing);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/operations/TraceableIsStillExecutingOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/operations/TraceableIsStillExecutingOperation.java
@@ -46,7 +46,7 @@ public class TraceableIsStillExecutingOperation extends AbstractOperation implem
         IsStillRunningService isStillRunningService = operationService.getIsStillRunningService();
         boolean executing = isStillRunningService.isOperationExecuting(getCallerAddress(), getCallerUuid(),
                 serviceName, identifier);
-        getOperationResponseHandler().sendResponse(this, executing);
+        sendNormalResponse(executing);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/responses/BackupResponse.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/responses/BackupResponse.java
@@ -25,6 +25,7 @@ import com.hazelcast.spi.impl.SpiDataSerializerHook;
  * but also the {@link BackupResponse} to make sure that the change
  * is written to the expected number of backups.
  */
+@Deprecated
 public final class BackupResponse extends Response {
 
     public BackupResponse() {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/responses/CallTimeoutResponse.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/responses/CallTimeoutResponse.java
@@ -22,6 +22,7 @@ import com.hazelcast.spi.impl.SpiDataSerializerHook;
 /**
  * An response that indicates that the execution of a single call ran into a timeout.
  */
+@Deprecated
 public class CallTimeoutResponse extends Response implements IdentifiedDataSerializable {
 
     public CallTimeoutResponse() {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/responses/ErrorResponse.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/responses/ErrorResponse.java
@@ -22,6 +22,7 @@ import com.hazelcast.spi.impl.SpiDataSerializerHook;
 
 import java.io.IOException;
 
+@Deprecated
 public class ErrorResponse extends Response {
     private Throwable cause;
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/responses/NormalResponse.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/responses/NormalResponse.java
@@ -37,6 +37,7 @@ import java.io.IOException;
  *
  * @author mdogan 4/10/13
  */
+@Deprecated
 public class NormalResponse extends Response {
 
     private Object value;

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/responses/Response.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/responses/Response.java
@@ -35,6 +35,7 @@ import java.io.IOException;
  * </li>
  * </ol>
  */
+@Deprecated
 public abstract class Response implements IdentifiedDataSerializable {
 
     protected long callId;

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/waitnotifyservice/impl/WaitNotifyServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/waitnotifyservice/impl/WaitNotifyServiceImpl.java
@@ -25,7 +25,6 @@ import com.hazelcast.nio.Address;
 import com.hazelcast.partition.MigrationInfo;
 import com.hazelcast.spi.Notifier;
 import com.hazelcast.spi.Operation;
-import com.hazelcast.spi.OperationResponseHandler;
 import com.hazelcast.spi.WaitNotifyKey;
 import com.hazelcast.spi.WaitNotifyService;
 import com.hazelcast.spi.WaitSupport;
@@ -201,8 +200,7 @@ public class WaitNotifyServiceImpl implements InternalWaitNotifyService {
                         waitingOp.setValid(false);
                         PartitionMigratingException pme = new PartitionMigratingException(thisAddress,
                                 partitionId, op.getClass().getName(), op.getServiceName());
-                        OperationResponseHandler responseHandler = op.getOperationResponseHandler();
-                        responseHandler.sendResponse(op, pme);
+                        op.sendErrorResponse(pme);
                         it.remove();
                     }
                 }
@@ -234,20 +232,21 @@ public class WaitNotifyServiceImpl implements InternalWaitNotifyService {
         logger.finest("Stopping tasks...");
         expirationTask.cancel(true);
         expirationService.shutdown();
-        final Object response = new HazelcastInstanceNotActiveException();
+        final Exception response = new HazelcastInstanceNotActiveException();
         final Address thisAddress = nodeEngine.getThisAddress();
         for (Queue<WaitingOperation> q : mapWaitingOps.values()) {
             for (WaitingOperation waitingOp : q) {
-                if (waitingOp.isValid()) {
-                    final Operation op = waitingOp.getOperation();
-                    // only for local invocations, remote ones will be expired via #onMemberLeft()
-                    if (thisAddress.equals(op.getCallerAddress())) {
-                        try {
-                            OperationResponseHandler responseHandler = op.getOperationResponseHandler();
-                            responseHandler.sendResponse(op, response);
-                        } catch (Exception e) {
-                            logger.finest("While sending HazelcastInstanceNotActiveException response...", e);
-                        }
+                if (!waitingOp.isValid()) {
+                    continue;
+                }
+
+                Operation op = waitingOp.getOperation();
+                // only for local invocations, remote ones will be expired via #onMemberLeft()
+                if (thisAddress.equals(op.getCallerAddress())) {
+                    try {
+                        op.sendErrorResponse(response);
+                    } catch (Exception e) {
+                        logger.finest("While sending HazelcastInstanceNotActiveException response...", e);
                     }
                 }
             }

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/operations/FinalizeRemoteTransactionOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/operations/FinalizeRemoteTransactionOperation.java
@@ -58,7 +58,7 @@ public class FinalizeRemoteTransactionOperation extends BaseXAOperation implemen
         XAService xaService = getService();
         final List<XATransaction> list = xaService.removeTransactions(xid);
         if (list == null) {
-            sendResponse(getNodeEngine().toData(XAException.XAER_NOTA));
+            sendNormalResponse(getNodeEngine().toData(XAException.XAER_NOTA));
             return;
         }
         final int size = list.size();
@@ -79,7 +79,7 @@ public class FinalizeRemoteTransactionOperation extends BaseXAOperation implemen
 
             void sendResponseIfComplete() {
                 if (size == counter.incrementAndGet()) {
-                    sendResponse(null);
+                    sendNormalResponse(null);
                 }
             }
         };

--- a/hazelcast/src/test/java/com/hazelcast/executor/ExecutorServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/executor/ExecutorServiceTest.java
@@ -36,6 +36,7 @@ import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
+import org.apache.log4j.Level;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -215,6 +216,9 @@ public class ExecutorServiceTest extends ExecutorServiceTestSupport {
 
     @Test
     public void test_registerCallback_multipleTimes_futureIsCompletedOnOtherNode() throws ExecutionException, InterruptedException {
+        setLoggingLog4j();
+        setLogLevel(Level.DEBUG);
+
         TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(2);
         HazelcastInstance instance1 = factory.newHazelcastInstance();
         HazelcastInstance instance2 = factory.newHazelcastInstance();

--- a/hazelcast/src/test/java/com/hazelcast/nio/OperationResponsePacketTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/OperationResponsePacketTest.java
@@ -1,0 +1,54 @@
+package com.hazelcast.nio;
+
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.nio.ByteBuffer;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category(QuickTest.class)
+public class OperationResponsePacketTest extends HazelcastTestSupport {
+
+    @Test
+    public void test() {
+        Packet original = new Packet(generateRandomString(100).getBytes());
+        original.setHeader(Packet.HEADER_OP);
+        original.setHeader(Packet.HEADER_RESPONSE);
+        original.setResponseType(Packet.RESPONSE_ERROR);
+        original.setResponseCallId(200);
+        original.setResponseSyncBackupCount(2);
+
+        Packet clone = clone(original);
+
+        assertEquals(original.getHeader(), clone.getHeader());
+        assertEquals(original.getResponseType(), clone.getResponseType());
+        assertEquals(original.getResponseCallId(), clone.getResponseCallId());
+        assertEquals(original.getResponseSyncBackupCount(), clone.getResponseSyncBackupCount());
+        assertArrayEquals(original.toByteArray(), clone.toByteArray());
+    }
+
+    private Packet clone(Packet originalPacket) {
+        Packet clonedPacket = new Packet();
+
+        ByteBuffer bb = ByteBuffer.allocate(20);
+        boolean writeCompleted;
+        boolean readCompleted;
+        do {
+            writeCompleted = originalPacket.writeTo(bb);
+            bb.flip();
+            readCompleted = clonedPacket.readFrom(bb);
+            bb.clear();
+        } while (!writeCompleted);
+
+        assertTrue(readCompleted);
+        return clonedPacket;
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/spi/OperationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/OperationTest.java
@@ -36,7 +36,7 @@ public class OperationTest extends HazelcastTestSupport {
         assertNotNull(found);
 
         // verify that the sendResponse is forwarded.
-        found.sendResponse(op, "foo");
+        found.sendNormalResponse(op, "foo", 0);
         verify(responseHandler).sendResponse("foo");
 
         // verify that the isLocal call is forwarded
@@ -75,7 +75,7 @@ public class OperationTest extends HazelcastTestSupport {
 
         // verify that the sendResponse is forwarded.
         found.sendResponse("foo");
-        verify(operationResponseHandler).sendResponse(op, "foo");
+        verify(operationResponseHandler).sendNormalResponse(op, "foo", 0);
 
         // verify that the isLocal call is forwarded
         found.isLocal();

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_NetworkSplitTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_NetworkSplitTest.java
@@ -207,7 +207,7 @@ public class Invocation_NetworkSplitTest extends HazelcastTestSupport {
 
         @Override
         public void onWaitExpire() {
-            sendResponse(new TimeoutException());
+            sendNormalResponse(new TimeoutException());
         }
 
         @Override

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/IsStillRunningServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/IsStillRunningServiceTest.java
@@ -244,7 +244,7 @@ public class IsStillRunningServiceTest extends HazelcastTestSupport {
         @Override
         public void run() throws Exception {
             sleepAtLeastMillis(sleepMs);
-            sendResponse(true);
+            sendNormalResponse(true);
         }
 
         @Override


### PR DESCRIPTION
The response objects are not used anymore to transfer a response. The response metadata like call id, type of response etc are directly encoded on the packet. This saves 2 object allocations per readonly operation. It also makes response deserialization faster since the response metadata is directly available on the packet. 

This work is needed to get rid of the response thread. 