### PR TITLE
Removed InternalOperationService asyncInvokeOnTarget

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/InternalOperationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/InternalOperationService.java
@@ -18,7 +18,6 @@ package com.hazelcast.spi.impl.operationservice;
 
 import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.internal.management.dto.SlowOperationDTO;
-import com.hazelcast.nio.Address;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.OperationService;
 import com.hazelcast.spi.impl.PacketHandler;
@@ -62,6 +61,4 @@ public interface InternalOperationService extends OperationService, PacketHandle
     List<SlowOperationDTO> getSlowOperationDTOs();
 
     <V> void asyncInvokeOnPartition(String serviceName, Operation op, int partitionId, ExecutionCallback<V> callback);
-
-    <V> void asyncInvokeOnTarget(String serviceName, Operation op, Address target, ExecutionCallback<V> callback);
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
@@ -315,14 +315,6 @@ public final class OperationServiceImpl implements InternalOperationService, Pac
                 DEFAULT_CALL_TIMEOUT, callback, DEFAULT_DESERIALIZE_RESULT).invokeAsync();
     }
 
-    @Override
-    @SuppressWarnings("unchecked")
-    public <V> void asyncInvokeOnTarget(String serviceName, Operation op, Address target, ExecutionCallback<V> callback) {
-        new TargetInvocation(nodeEngine, serviceName, op, target, DEFAULT_TRY_COUNT,
-                DEFAULT_TRY_PAUSE_MILLIS,
-                DEFAULT_CALL_TIMEOUT, callback, DEFAULT_DESERIALIZE_RESULT).invokeAsync();
-    }
-
     // =============================== processing operation  ===============================
 
     @Override


### PR DESCRIPTION
Method was not used and wasn't tested. So no need to keep it in the system.