### PR TITLE
hibernate test coverage increase

### DIFF
--- a/hazelcast-hibernate/hazelcast-hibernate3/src/test/java/com/hazelcast/hibernate/CacheHitMissNonStrictTest.java
+++ b/hazelcast-hibernate/hazelcast-hibernate3/src/test/java/com/hazelcast/hibernate/CacheHitMissNonStrictTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate;
+
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.hibernate.cache.access.AccessType;
+import org.hibernate.cfg.Environment;
+import org.hibernate.stat.CollectionStatistics;
+import org.hibernate.stat.SecondLevelCacheStatistics;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class CacheHitMissNonStrictTest extends HibernateStatisticsTestSupport {
+
+    protected String getCacheStrategy() {
+        return AccessType.NONSTRICT_READ_WRITE.getName();
+    }
+
+    @Override
+    protected Properties getCacheProperties() {
+        Properties props = new Properties();
+        props.setProperty(Environment.CACHE_REGION_FACTORY, HazelcastCacheRegionFactory.class.getName());
+        return props;
+    }
+
+    @Test
+    public void testGetUpdateRemoveGet()
+            throws Exception {
+        insertDummyEntities(10, 4);
+        //all 10 entities and 40 properties are cached
+        SecondLevelCacheStatistics dummyEntityCacheStats = sf.getStatistics().getSecondLevelCacheStatistics(CACHE_ENTITY);
+        CollectionStatistics collectionCacheStats = sf.getStatistics().getCollectionStatistics(CACHE_COLLECTION_ENTITY);
+        SecondLevelCacheStatistics dummyPropertyCacheStats = sf.getStatistics().getSecondLevelCacheStatistics(CACHE_PROPERTY);
+
+        sf.getCache().evictEntityRegions();
+        sf.getCache().evictCollectionRegions();
+
+        //miss 10 entities
+        getDummyEntities(sf, 10);
+
+        //hit 1 entity and 4 properties
+        updateDummyEntityName(sf, 2, "updated");
+        //entity 2 and its properties are invalidated
+
+        //miss updated entity, hit 4 properties(they are still the same)
+        getPropertiesOfEntity(sf, 2);
+
+        //hit 1 entity and 4 properties
+        deleteDummyEntity(sf, 1);
+        sleep(1);
+
+        assertEquals(12, dummyPropertyCacheStats.getHitCount());
+        assertEquals(0, dummyPropertyCacheStats.getMissCount());
+        assertEquals(2, dummyEntityCacheStats.getHitCount());
+        assertEquals(11, dummyEntityCacheStats.getMissCount());
+    }
+}

--- a/hazelcast-hibernate/hazelcast-hibernate3/src/test/java/com/hazelcast/hibernate/CacheHitMissNonStrictTest.java
+++ b/hazelcast-hibernate/hazelcast-hibernate3/src/test/java/com/hazelcast/hibernate/CacheHitMissNonStrictTest.java
@@ -20,7 +20,6 @@ import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
 import org.hibernate.cache.access.AccessType;
 import org.hibernate.cfg.Environment;
-import org.hibernate.stat.CollectionStatistics;
 import org.hibernate.stat.SecondLevelCacheStatistics;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -30,6 +29,13 @@ import java.util.Properties;
 
 import static org.junit.Assert.assertEquals;
 
+/**
+ * Read and wr ite access (non-strict) cache concurrency strategy of Hibernate.
+ * Data may be added, removed and mutated.
+ * Nonstrict means that data integrity is not preserved as strictly as in READ_WRITE access
+ * Cache invalidations are asychrnonous
+ * Read through cache
+ */
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
 public class CacheHitMissNonStrictTest extends HibernateStatisticsTestSupport {
@@ -51,7 +57,6 @@ public class CacheHitMissNonStrictTest extends HibernateStatisticsTestSupport {
         insertDummyEntities(10, 4);
         //all 10 entities and 40 properties are cached
         SecondLevelCacheStatistics dummyEntityCacheStats = sf.getStatistics().getSecondLevelCacheStatistics(CACHE_ENTITY);
-        CollectionStatistics collectionCacheStats = sf.getStatistics().getCollectionStatistics(CACHE_COLLECTION_ENTITY);
         SecondLevelCacheStatistics dummyPropertyCacheStats = sf.getStatistics().getSecondLevelCacheStatistics(CACHE_PROPERTY);
 
         sf.getCache().evictEntityRegions();
@@ -62,6 +67,8 @@ public class CacheHitMissNonStrictTest extends HibernateStatisticsTestSupport {
 
         //hit 1 entity and 4 properties
         updateDummyEntityName(sf, 2, "updated");
+        //invalidation is not synchronized, so we have to wait
+        sleep(1);
         //entity 2 and its properties are invalidated
 
         //miss updated entity, hit 4 properties(they are still the same)
@@ -69,11 +76,28 @@ public class CacheHitMissNonStrictTest extends HibernateStatisticsTestSupport {
 
         //hit 1 entity and 4 properties
         deleteDummyEntity(sf, 1);
-        sleep(1);
 
         assertEquals(12, dummyPropertyCacheStats.getHitCount());
         assertEquals(0, dummyPropertyCacheStats.getMissCount());
         assertEquals(2, dummyEntityCacheStats.getHitCount());
         assertEquals(11, dummyEntityCacheStats.getMissCount());
+    }
+
+    @Test
+    public void testUpdateEventuallyInvalidatesObject() {
+        insertDummyEntities(10, 4);
+        //all 10 entities and 40 properties are cached
+        final SecondLevelCacheStatistics dummyEntityCacheStats = sf.getStatistics().getSecondLevelCacheStatistics(CACHE_ENTITY);
+        SecondLevelCacheStatistics dummyPropertyCacheStats = sf.getStatistics().getSecondLevelCacheStatistics(CACHE_PROPERTY);
+
+        sf.getCache().evictEntityRegions();
+        sf.getCache().evictCollectionRegions();
+
+        //miss 10 entities
+        getDummyEntities(sf, 10);
+
+        //hit 1 entity and 4 properties
+        updateDummyEntityName(sf, 2, "updated");
+        assertSizeEventually(9, dummyEntityCacheStats.getEntries());
     }
 }

--- a/hazelcast-hibernate/hazelcast-hibernate3/src/test/java/com/hazelcast/hibernate/CacheHitMissReadOnlyTest.java
+++ b/hazelcast-hibernate/hazelcast-hibernate3/src/test/java/com/hazelcast/hibernate/CacheHitMissReadOnlyTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate;
+
+import com.hazelcast.hibernate.access.ReadOnlyAccessDelegate;
+import com.hazelcast.hibernate.region.HazelcastRegion;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.hibernate.cache.access.AccessType;
+import org.hibernate.cfg.Environment;
+import org.hibernate.stat.CollectionStatistics;
+import org.hibernate.stat.SecondLevelCacheStatistics;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class CacheHitMissReadOnlyTest extends HibernateStatisticsTestSupport {
+
+    protected String getCacheStrategy() {
+        return AccessType.READ_ONLY.getName();
+    }
+
+    @Override
+    protected Properties getCacheProperties() {
+        Properties props = new Properties();
+        props.setProperty(Environment.CACHE_REGION_FACTORY, HazelcastCacheRegionFactory.class.getName());
+        return props;
+    }
+
+    @Test
+    public void testGetUpdateRemoveGet()
+            throws Exception {
+        insertDummyEntities(10, 4);
+        //all 10 entities and 40 properties are cached
+        SecondLevelCacheStatistics dummyEntityCacheStats = sf.getStatistics().getSecondLevelCacheStatistics(CACHE_ENTITY);
+        CollectionStatistics collectionCacheStats = sf.getStatistics().getCollectionStatistics(CACHE_COLLECTION_ENTITY);
+        SecondLevelCacheStatistics dummyPropertyCacheStats = sf.getStatistics().getSecondLevelCacheStatistics(CACHE_PROPERTY);
+
+        sf.getCache().evictEntityRegions();
+        sf.getCache().evictCollectionRegions();
+        //miss 10 entities
+        getDummyEntities(sf, 10);
+        //hit 1 entity and 4 properties
+        deleteDummyEntity(sf, 1);
+        sleep(1);
+
+        assertEquals(4, dummyPropertyCacheStats.getHitCount());
+        assertEquals(0, dummyPropertyCacheStats.getMissCount());
+        assertEquals(1, dummyEntityCacheStats.getHitCount());
+        assertEquals(10, dummyEntityCacheStats.getMissCount());
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testUpdateQueryCausesInvalidationOfEntireRegion() {
+        insertDummyEntities(10);
+        executeUpdateQuery(sf, "UPDATE DummyEntity set name = 'manually-updated' where id=2");
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testReadOnlyUpdate() throws Exception{
+        insertDummyEntities(1, 0);
+        updateDummyEntityName(sf, 0, "updated");
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testAfterUpdateShouldThrowOnReadOnly() {
+        HazelcastRegion hzRegion = mock(HazelcastRegion.class);
+        when(hzRegion.getCache()).thenReturn(null);
+        when(hzRegion.getLogger()).thenReturn(null);
+        ReadOnlyAccessDelegate readOnlyAccessDelegate = new ReadOnlyAccessDelegate(hzRegion, null);
+        readOnlyAccessDelegate.afterUpdate(null, null, null, null, null);
+    }
+}

--- a/hazelcast-hibernate/hazelcast-hibernate3/src/test/java/com/hazelcast/hibernate/CacheHitMissReadOnlyTest.java
+++ b/hazelcast-hibernate/hazelcast-hibernate3/src/test/java/com/hazelcast/hibernate/CacheHitMissReadOnlyTest.java
@@ -22,7 +22,6 @@ import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
 import org.hibernate.cache.access.AccessType;
 import org.hibernate.cfg.Environment;
-import org.hibernate.stat.CollectionStatistics;
 import org.hibernate.stat.SecondLevelCacheStatistics;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -34,6 +33,10 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+/**
+ * Read-only access cache concurrency strategy of Hibernate.
+ * Data may be added and removed, but not mutated.
+ */
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
 public class CacheHitMissReadOnlyTest extends HibernateStatisticsTestSupport {
@@ -55,7 +58,6 @@ public class CacheHitMissReadOnlyTest extends HibernateStatisticsTestSupport {
         insertDummyEntities(10, 4);
         //all 10 entities and 40 properties are cached
         SecondLevelCacheStatistics dummyEntityCacheStats = sf.getStatistics().getSecondLevelCacheStatistics(CACHE_ENTITY);
-        CollectionStatistics collectionCacheStats = sf.getStatistics().getCollectionStatistics(CACHE_COLLECTION_ENTITY);
         SecondLevelCacheStatistics dummyPropertyCacheStats = sf.getStatistics().getSecondLevelCacheStatistics(CACHE_PROPERTY);
 
         sf.getCache().evictEntityRegions();
@@ -64,7 +66,6 @@ public class CacheHitMissReadOnlyTest extends HibernateStatisticsTestSupport {
         getDummyEntities(sf, 10);
         //hit 1 entity and 4 properties
         deleteDummyEntity(sf, 1);
-        sleep(1);
 
         assertEquals(4, dummyPropertyCacheStats.getHitCount());
         assertEquals(0, dummyPropertyCacheStats.getMissCount());

--- a/hazelcast-hibernate/hazelcast-hibernate3/src/test/java/com/hazelcast/hibernate/CacheHitMissReadWriteTest.java
+++ b/hazelcast-hibernate/hazelcast-hibernate3/src/test/java/com/hazelcast/hibernate/CacheHitMissReadWriteTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate;
+
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.hibernate.cache.access.AccessType;
+import org.hibernate.cfg.Environment;
+import org.hibernate.stat.CollectionStatistics;
+import org.hibernate.stat.SecondLevelCacheStatistics;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class CacheHitMissReadWriteTest
+        extends HibernateStatisticsTestSupport {
+
+    protected String getCacheStrategy() {
+        return AccessType.READ_WRITE.getName();
+    }
+
+    @Override
+    protected Properties getCacheProperties() {
+        Properties props = new Properties();
+        props.setProperty(Environment.CACHE_REGION_FACTORY, HazelcastCacheRegionFactory.class.getName());
+        return props;
+    }
+
+    @Test
+    public void testGetUpdateRemoveGet()
+            throws Exception {
+        insertDummyEntities(10, 4);
+        //all 10 entities and 40 properties are cached
+        SecondLevelCacheStatistics dummyEntityCacheStats = sf.getStatistics().getSecondLevelCacheStatistics(CACHE_ENTITY);
+        CollectionStatistics collectionCacheStats = sf.getStatistics().getCollectionStatistics(CACHE_COLLECTION_ENTITY);
+        SecondLevelCacheStatistics dummyPropertyCacheStats = sf.getStatistics().getSecondLevelCacheStatistics(CACHE_PROPERTY);
+
+        sf.getCache().evictEntityRegions();
+        sf.getCache().evictCollectionRegions();
+
+        //miss 10 entities
+        getDummyEntities(sf, 10);
+
+        //hit 1 entity and 4 properties
+        updateDummyEntityName(sf, 2, "updated");
+        //entity 2 and its properties are invalidated
+
+        //hit 1 entity, hit 4 properties
+        getPropertiesOfEntity(sf, 2);
+        //hit 1 entity and 4 properties
+        deleteDummyEntity(sf, 1);
+        sleep(1);
+
+        assertEquals(12, dummyPropertyCacheStats.getHitCount());
+        assertEquals(0, dummyPropertyCacheStats.getMissCount());
+        assertEquals(3, dummyEntityCacheStats.getHitCount());
+        assertEquals(10, dummyEntityCacheStats.getMissCount());
+
+    }
+
+}

--- a/hazelcast-hibernate/hazelcast-hibernate3/src/test/java/com/hazelcast/hibernate/HibernateStatisticsTestSupport.java
+++ b/hazelcast-hibernate/hazelcast-hibernate3/src/test/java/com/hazelcast/hibernate/HibernateStatisticsTestSupport.java
@@ -16,38 +16,34 @@
 
 package com.hazelcast.hibernate;
 
-import com.hazelcast.config.MapConfig;
 import com.hazelcast.core.Hazelcast;
-import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.hibernate.entity.DummyEntity;
 import com.hazelcast.hibernate.entity.DummyProperty;
-import com.hazelcast.hibernate.instance.HazelcastAccessor;
-import com.hazelcast.hibernate.region.HazelcastQueryResultsRegion;
-import com.hazelcast.test.annotation.NightlyTest;
 import org.hibernate.Query;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.Transaction;
-import org.hibernate.impl.SessionFactoryImpl;
-import org.hibernate.stat.Statistics;
+import org.hibernate.stat.SecondLevelCacheStatistics;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
-import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 
 public abstract class HibernateStatisticsTestSupport extends HibernateTestSupport {
 
     protected SessionFactory sf;
     protected SessionFactory sf2;
+
+    protected final String CACHE_ENTITY = DummyEntity.class.getName();
+    protected final String CACHE_PROPERTY = DummyProperty.class.getName();
+    protected final String CACHE_COLLECTION_ENTITY = DummyEntity.class.getName() + ".properties";
 
     @Before
     public void postConstruct() {
@@ -66,10 +62,6 @@ public abstract class HibernateStatisticsTestSupport extends HibernateTestSuppor
             sf2 = null;
         }
         Hazelcast.shutdownAll();
-    }
-
-    protected HazelcastInstance getHazelcastInstance(SessionFactory sf) {
-        return HazelcastAccessor.getHazelcastInstance(sf);
     }
 
     protected abstract Properties getCacheProperties();
@@ -99,108 +91,6 @@ public abstract class HibernateStatisticsTestSupport extends HibernateTestSuppor
         }
     }
 
-    @Test
-    public void testEntity() {
-        final HazelcastInstance hz = getHazelcastInstance(sf);
-        assertNotNull(hz);
-        final int count = 100;
-        final int childCount = 3;
-        insertDummyEntities(count, childCount);
-        sleep(1);
-        List<DummyEntity> list = new ArrayList<DummyEntity>(count);
-        Session session = sf.openSession();
-        try {
-            for (int i = 0; i < count; i++) {
-                DummyEntity e = (DummyEntity) session.get(DummyEntity.class, (long) i);
-                session.evict(e);
-                list.add(e);
-            }
-        } finally {
-            session.close();
-        }
-        session = sf.openSession();
-        Transaction tx = session.beginTransaction();
-        try {
-            for (DummyEntity dummy : list) {
-                dummy.setDate(new Date());
-                session.update(dummy);
-            }
-            tx.commit();
-        } catch (Exception e) {
-            tx.rollback();
-            e.printStackTrace();
-        } finally {
-            session.close();
-        }
-
-        Statistics stats = sf.getStatistics();
-        Map<?, ?> cache = hz.getMap(DummyEntity.class.getName());
-        Map<?, ?> propCache = hz.getMap(DummyProperty.class.getName());
-        Map<?, ?> propCollCache = hz.getMap(DummyEntity.class.getName() + ".properties");
-        assertEquals((childCount + 1) * count, stats.getEntityInsertCount());
-        // twice put of entity and properties (on load and update) and once put of collection
-        // TODO: fix next assertion ->
-//        assertEquals((childCount + 1) * count * 2, stats.getSecondLevelCachePutCount());
-        assertEquals(childCount * count, stats.getEntityLoadCount());
-        assertEquals(count, stats.getSecondLevelCacheHitCount());
-        // collection cache miss
-        assertEquals(count, stats.getSecondLevelCacheMissCount());
-        assertEquals(count, cache.size());
-        assertEquals(count * childCount, propCache.size());
-        assertEquals(count, propCollCache.size());
-        sf.getCache().evictEntityRegion(DummyEntity.class);
-        sf.getCache().evictEntityRegion(DummyProperty.class);
-        assertEquals(0, cache.size());
-        assertEquals(0, propCache.size());
-        stats.logSummary();
-    }
-
-    @Test
-    public void testQuery() {
-        final int entityCount = 10;
-        final int queryCount = 3;
-        insertDummyEntities(entityCount);
-        sleep(2);
-        List<DummyEntity> list = null;
-        for (int i = 0; i < queryCount; i++) {
-            list = executeQuery(sf);
-            assertEquals(entityCount, list.size());
-            sleepAtLeastSeconds(1);
-        }
-
-        assertNotNull(list);
-        Session session = sf.openSession();
-        Transaction tx = session.beginTransaction();
-        try {
-            for (DummyEntity dummy : list) {
-                session.delete(dummy);
-            }
-            tx.commit();
-        } catch (Exception e) {
-            tx.rollback();
-            e.printStackTrace();
-        } finally {
-            session.close();
-        }
-
-        Statistics stats = sf.getStatistics();
-        assertEquals(1, stats.getQueryCachePutCount());
-        assertEquals(1, stats.getQueryCacheMissCount());
-        assertEquals(queryCount - 1, stats.getQueryCacheHitCount());
-        assertEquals(1, stats.getQueryExecutionCount());
-        assertEquals(entityCount, stats.getEntityInsertCount());
-//      FIXME
-//      HazelcastRegionFactory puts into L2 cache 2 times; 1 on insert, 1 on query execution 
-//      assertEquals(entityCount, stats.getSecondLevelCachePutCount());
-        assertEquals(entityCount, stats.getEntityLoadCount());
-        assertEquals(entityCount, stats.getEntityDeleteCount());
-        assertEquals(entityCount * (queryCount - 1) * 2, stats.getSecondLevelCacheHitCount());
-        // collection cache miss
-        assertEquals(entityCount, stats.getSecondLevelCacheMissCount());
-
-        stats.logSummary();
-    }
-
     protected List<DummyEntity> executeQuery(SessionFactory factory) {
         Session session = factory.openSession();
         try {
@@ -223,63 +113,101 @@ public abstract class HibernateStatisticsTestSupport extends HibernateTestSuppor
         }
     }
 
-    @Test
-    public void testQuery2() {
-        final int entityCount = 10;
-        final int queryCount = 2;
-        insertDummyEntities(entityCount);
-        sleep(1);
-        List<DummyEntity> list = null;
-        for (int i = 0; i < queryCount; i++) {
-            list = executeQuery(sf);
-            assertEquals(entityCount, list.size());
-            sleep(1);
-        }
-
-        for (int i = 0; i < queryCount; i++) {
-            list = executeQuery(sf2);
-            assertEquals(entityCount, list.size());
-            sleep(1);
-        }
-
-        assertNotNull(list);
-        DummyEntity toDelete = list.get(0);
+    protected ArrayList<DummyEntity> getDummyEntities(SessionFactory sf, long untilId) {
         Session session = sf.openSession();
-        Transaction tx = session.beginTransaction();
+        ArrayList<DummyEntity> entities = new ArrayList<DummyEntity>();
+        for (long i=0; i<untilId; i++) {
+            DummyEntity entity = (DummyEntity)session.get(DummyEntity.class, i);
+            if (entity != null) {
+                session.evict(entity);
+                entities.add(entity);
+            }
+        }
+        session.close();
+        return entities;
+    }
+
+    protected Set<DummyProperty> getPropertiesOfEntity(SessionFactory sf, long entityId) {
+        Session session = sf.openSession();
+        DummyEntity entity = (DummyEntity)session.get(DummyEntity.class, entityId);
+        if(entity != null) {
+            return entity.getProperties();
+        } else {
+            return null;
+        }
+    }
+
+    protected void updateDummyEntityName(SessionFactory sf, long id, String newName) {
+        Session session = null;
+        Transaction txn = null;
         try {
-            session.delete(toDelete);
-            tx.commit();
-        } catch (Exception e) {
-            tx.rollback();
+            session = sf.openSession();
+            txn = session.beginTransaction();
+            DummyEntity entityToUpdate = (DummyEntity)session.get(DummyEntity.class, id);
+            entityToUpdate.setName(newName);
+            session.update(entityToUpdate);
+            txn.commit();
+        } catch (RuntimeException e) {
+            txn.rollback();
             e.printStackTrace();
+            throw e;
         } finally {
             session.close();
         }
-        sleep(1);
-        assertEquals(entityCount - 1, executeQuery(sf).size());
-        assertEquals(entityCount - 1, executeQuery(sf2).size());
+    }
+
+    protected void deleteDummyEntity(SessionFactory sf, long id)
+            throws Exception {
+        Session session = null;
+        Transaction txn = null;
+        try {
+            session = sf.openSession();
+            txn = session.beginTransaction();
+            DummyEntity entityToDelete = (DummyEntity) session.get(DummyEntity.class, id);
+            session.delete(entityToDelete);
+            txn.commit();
+        } catch (Exception e) {
+            txn.rollback();
+            e.printStackTrace();
+            throw e;
+        } finally {
+            session.close();
+        }
+    }
+
+    protected void executeUpdateQuery(SessionFactory sf, String queryString)
+            throws RuntimeException {
+        Session session = null;
+        Transaction txn = null;
+        try {
+            session = sf.openSession();
+            txn = session.beginTransaction();
+            Query query = session.createQuery(queryString);
+            query.setCacheable(true);
+            session.evict(query);
+            query.executeUpdate();
+            txn.commit();
+        } catch (RuntimeException e) {
+            txn.rollback();
+            e.printStackTrace();
+            throw e;
+        } finally {
+            session.close();
+        }
     }
 
     @Test
-    @Category(NightlyTest.class)
-    public void testQueryCacheCleanup() {
+    public void testUpdateQueryCausesInvalidationOfEntireRegion() {
+        insertDummyEntities(10);
 
-        MapConfig mapConfig = getHazelcastInstance(sf).getConfig().getMapConfig("org.hibernate.cache.*");
-        final float baseEvictionRate = 0.2f;
-        final int numberOfEntities = 100;
-        final int defaultCleanupPeriod = 60;
-        final int maxSize = mapConfig.getMaxSizeConfig().getSize();
-        final int evictedItemCount = numberOfEntities - maxSize + (int) (maxSize * baseEvictionRate);
-        insertDummyEntities(numberOfEntities);
-        sleep(1);
-        for (int i = 0; i < numberOfEntities; i++) {
-            executeQuery(sf, i);
-        }
+        executeUpdateQuery(sf, "UPDATE DummyEntity set name = 'manually-updated' where id=2");
 
-        HazelcastQueryResultsRegion queryRegion = ((HazelcastQueryResultsRegion) (((SessionFactoryImpl) sf).getQueryCache()).getRegion());
-        assertEquals(numberOfEntities, queryRegion.getCache().size());
-        sleep(defaultCleanupPeriod);
+        sf.getStatistics().clear();
 
-        assertEquals(numberOfEntities - evictedItemCount, queryRegion.getCache().size());
+        getDummyEntities(sf, 10);
+
+        SecondLevelCacheStatistics dummyEntityCacheStats = sf.getStatistics().getSecondLevelCacheStatistics(CACHE_ENTITY);
+        assertEquals(10, dummyEntityCacheStats.getMissCount());
+        assertEquals(0, dummyEntityCacheStats.getHitCount());
     }
 }

--- a/hazelcast-hibernate/hazelcast-hibernate3/src/test/java/com/hazelcast/hibernate/LocalRegionFactoryDefaultTest.java
+++ b/hazelcast-hibernate/hazelcast-hibernate3/src/test/java/com/hazelcast/hibernate/LocalRegionFactoryDefaultTest.java
@@ -21,7 +21,6 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.hibernate.entity.DummyEntity;
 import com.hazelcast.hibernate.entity.DummyProperty;
 import com.hazelcast.test.HazelcastSerialClassRunner;
-import com.hazelcast.test.annotation.NightlyTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.hibernate.Session;
 import org.hibernate.Transaction;

--- a/hazelcast-hibernate/hazelcast-hibernate3/src/test/java/com/hazelcast/hibernate/RegionFactoryDefaultTest.java
+++ b/hazelcast-hibernate/hazelcast-hibernate3/src/test/java/com/hazelcast/hibernate/RegionFactoryDefaultTest.java
@@ -223,27 +223,6 @@ public class RegionFactoryDefaultTest extends HibernateStatisticsTestSupport {
     }
 
     @Test
-    public void testAutoQueryRegionEviction() {
-        int entityCount = 10;
-        insertDummyEntities(entityCount, 0);
-        sleep(1);
-
-        //miss 1 query list entities
-        executeQuery(sf);
-        //query is cached
-
-        //query cache invalidated
-        executeUpdateQuery(sf, "delete from DummyEntity");
-        //miss 1 query
-        executeQuery(sf);
-        //hit 1 query
-        executeQuery(sf);
-
-        assertEquals(1, sf.getStatistics().getQueryCacheHitCount());
-        assertEquals(2, sf.getStatistics().getQueryCacheMissCount());
-    }
-
-    @Test
     public void testSpecificQueryRegionEviction() {
         int entityCount = 10;
         insertDummyEntities(entityCount, 0);

--- a/hazelcast-hibernate/hazelcast-hibernate3/src/test/java/com/hazelcast/hibernate/RegionFactoryDefaultTest.java
+++ b/hazelcast-hibernate/hazelcast-hibernate3/src/test/java/com/hazelcast/hibernate/RegionFactoryDefaultTest.java
@@ -224,20 +224,18 @@ public class RegionFactoryDefaultTest extends HibernateStatisticsTestSupport {
 
     @Test
     public void testAutoQueryRegionEviction() {
-        sf.getCache().evictDefaultQueryRegion();
         int entityCount = 10;
         insertDummyEntities(entityCount, 0);
+        sleep(1);
 
         //miss 1 query list entities
         executeQuery(sf);
-        sleepMillis(200);
         //query is cached
 
         //query cache invalidated
         executeUpdateQuery(sf, "delete from DummyEntity");
         //miss 1 query
         executeQuery(sf);
-        sleepMillis(200);
         //hit 1 query
         executeQuery(sf);
 
@@ -247,9 +245,9 @@ public class RegionFactoryDefaultTest extends HibernateStatisticsTestSupport {
 
     @Test
     public void testSpecificQueryRegionEviction() {
-        sf.getCache().evictDefaultQueryRegion();
         int entityCount = 10;
         insertDummyEntities(entityCount, 0);
+        sleep(1);
 
         //miss 1 query list entities
         Session session = sf.openSession();

--- a/hazelcast-hibernate/hazelcast-hibernate3/src/test/java/com/hazelcast/hibernate/RegionFactoryDefaultTest.java
+++ b/hazelcast-hibernate/hazelcast-hibernate3/src/test/java/com/hazelcast/hibernate/RegionFactoryDefaultTest.java
@@ -16,22 +16,37 @@
 
 package com.hazelcast.hibernate;
 
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.hibernate.entity.DummyEntity;
+import com.hazelcast.hibernate.entity.DummyProperty;
+import com.hazelcast.hibernate.region.HazelcastQueryResultsRegion;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.NightlyTest;
 import com.hazelcast.test.annotation.QuickTest;
+import org.hibernate.Query;
 import org.hibernate.Session;
 import org.hibernate.Transaction;
+import org.hibernate.cache.access.AccessType;
 import org.hibernate.cfg.Environment;
+import org.hibernate.impl.SessionFactoryImpl;
+import org.hibernate.stat.Statistics;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Date;
+import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 
@@ -43,6 +58,223 @@ public class RegionFactoryDefaultTest extends HibernateStatisticsTestSupport {
         Properties props = new Properties();
         props.setProperty(Environment.CACHE_REGION_FACTORY, HazelcastCacheRegionFactory.class.getName());
         return props;
+    }
+
+    @Test
+    public void testEntity() {
+        final HazelcastInstance hz = getHazelcastInstance(sf);
+        assertNotNull(hz);
+        final int count = 100;
+        final int childCount = 3;
+        insertDummyEntities(count, childCount);
+        sleep(1);
+        List<DummyEntity> list = new ArrayList<DummyEntity>(count);
+        Session session = sf.openSession();
+        try {
+            for (int i = 0; i < count; i++) {
+                DummyEntity e = (DummyEntity) session.get(DummyEntity.class, (long) i);
+                session.evict(e);
+                list.add(e);
+            }
+        } finally {
+            session.close();
+        }
+        session = sf.openSession();
+        Transaction tx = session.beginTransaction();
+        try {
+            for (DummyEntity dummy : list) {
+                dummy.setDate(new Date());
+                session.update(dummy);
+            }
+            tx.commit();
+        } catch (Exception e) {
+            tx.rollback();
+            e.printStackTrace();
+        } finally {
+            session.close();
+        }
+
+        Statistics stats = sf.getStatistics();
+        Map<?, ?> cache = hz.getMap(DummyEntity.class.getName());
+        Map<?, ?> propCache = hz.getMap(DummyProperty.class.getName());
+        Map<?, ?> propCollCache = hz.getMap(DummyEntity.class.getName() + ".properties");
+        assertEquals((childCount + 1) * count, stats.getEntityInsertCount());
+        // twice put of entity and properties (on load and update) and once put of collection
+        // TODO: fix next assertion ->
+        //        assertEquals((childCount + 1) * count * 2, stats.getSecondLevelCachePutCount());
+        assertEquals(childCount * count, stats.getEntityLoadCount());
+        assertEquals(count, stats.getSecondLevelCacheHitCount());
+        // collection cache miss
+        assertEquals(count, stats.getSecondLevelCacheMissCount());
+        assertEquals(count, cache.size());
+        assertEquals(count * childCount, propCache.size());
+        assertEquals(count, propCollCache.size());
+        sf.getCache().evictEntityRegion(DummyEntity.class);
+        sf.getCache().evictEntityRegion(DummyProperty.class);
+        assertEquals(0, cache.size());
+        assertEquals(0, propCache.size());
+        stats.logSummary();
+    }
+
+    @Test
+    public void testQuery() {
+        final int entityCount = 10;
+        final int queryCount = 3;
+        insertDummyEntities(entityCount);
+        sleep(2);
+        List<DummyEntity> list = null;
+        for (int i = 0; i < queryCount; i++) {
+            list = executeQuery(sf);
+            assertEquals(entityCount, list.size());
+            sleepAtLeastSeconds(1);
+        }
+
+        assertNotNull(list);
+        Session session = sf.openSession();
+        Transaction tx = session.beginTransaction();
+        try {
+            for (DummyEntity dummy : list) {
+                session.delete(dummy);
+            }
+            tx.commit();
+        } catch (Exception e) {
+            tx.rollback();
+            e.printStackTrace();
+        } finally {
+            session.close();
+        }
+
+        Statistics stats = sf.getStatistics();
+        assertEquals(1, stats.getQueryCachePutCount());
+        assertEquals(1, stats.getQueryCacheMissCount());
+        assertEquals(queryCount - 1, stats.getQueryCacheHitCount());
+        assertEquals(1, stats.getQueryExecutionCount());
+        assertEquals(entityCount, stats.getEntityInsertCount());
+        //      FIXME
+        //      HazelcastRegionFactory puts into L2 cache 2 times; 1 on insert, 1 on query execution
+        //      assertEquals(entityCount, stats.getSecondLevelCachePutCount());
+        assertEquals(entityCount, stats.getEntityLoadCount());
+        assertEquals(entityCount, stats.getEntityDeleteCount());
+        assertEquals(entityCount * (queryCount - 1) * 2, stats.getSecondLevelCacheHitCount());
+        // collection cache miss
+        assertEquals(entityCount, stats.getSecondLevelCacheMissCount());
+
+        stats.logSummary();
+    }
+
+    @Test
+    public void testQuery2() {
+        final int entityCount = 10;
+        final int queryCount = 2;
+        insertDummyEntities(entityCount);
+        sleep(1);
+        List<DummyEntity> list = null;
+        for (int i = 0; i < queryCount; i++) {
+            list = executeQuery(sf);
+            assertEquals(entityCount, list.size());
+            sleep(1);
+        }
+
+        for (int i = 0; i < queryCount; i++) {
+            list = executeQuery(sf2);
+            assertEquals(entityCount, list.size());
+            sleep(1);
+        }
+
+        assertNotNull(list);
+        DummyEntity toDelete = list.get(0);
+        Session session = sf.openSession();
+        Transaction tx = session.beginTransaction();
+        try {
+            session.delete(toDelete);
+            tx.commit();
+        } catch (Exception e) {
+            tx.rollback();
+            e.printStackTrace();
+        } finally {
+            session.close();
+        }
+        sleep(1);
+        assertEquals(entityCount - 1, executeQuery(sf).size());
+        assertEquals(entityCount - 1, executeQuery(sf2).size());
+    }
+
+    @Test
+    @Category(NightlyTest.class)
+    public void testQueryCacheCleanup() {
+
+        MapConfig mapConfig = getHazelcastInstance(sf).getConfig().getMapConfig("org.hibernate.cache.*");
+        final float baseEvictionRate = 0.2f;
+        final int numberOfEntities = 100;
+        final int defaultCleanupPeriod = 60;
+        final int maxSize = mapConfig.getMaxSizeConfig().getSize();
+        final int evictedItemCount = numberOfEntities - maxSize + (int) (maxSize * baseEvictionRate);
+        insertDummyEntities(numberOfEntities);
+        sleep(1);
+        for (int i = 0; i < numberOfEntities; i++) {
+            executeQuery(sf, i);
+        }
+
+        HazelcastQueryResultsRegion queryRegion = ((HazelcastQueryResultsRegion) (((SessionFactoryImpl) sf).getQueryCache()).getRegion());
+        assertEquals(numberOfEntities, queryRegion.getCache().size());
+        sleep(defaultCleanupPeriod);
+
+        assertEquals(numberOfEntities - evictedItemCount, queryRegion.getCache().size());
+    }
+
+    @Test
+    public void testAutoQueryRegionEviction() {
+        sf.getCache().evictDefaultQueryRegion();
+        int entityCount = 10;
+        insertDummyEntities(entityCount, 0);
+
+        //miss 1 query list entities
+        executeQuery(sf);
+        sleepMillis(200);
+        //query is cached
+
+        //query cache invalidated
+        executeUpdateQuery(sf, "delete from DummyEntity");
+        //miss 1 query
+        executeQuery(sf);
+        sleepMillis(200);
+        //hit 1 query
+        executeQuery(sf);
+
+        assertEquals(1, sf.getStatistics().getQueryCacheHitCount());
+        assertEquals(2, sf.getStatistics().getQueryCacheMissCount());
+    }
+
+    @Test
+    public void testSpecificQueryRegionEviction() {
+        sf.getCache().evictDefaultQueryRegion();
+        int entityCount = 10;
+        insertDummyEntities(entityCount, 0);
+
+        //miss 1 query list entities
+        Session session = sf.openSession();
+        Transaction txn = session.beginTransaction();
+        Query query = session.createQuery("from " + DummyEntity.class.getName());
+        query.setCacheable(true).setCacheRegion("newregionname");
+        query.list();
+        txn.commit();
+        session.close();
+        //query is cached
+
+        //query is invalidated
+        sf.getCache().evictQueryRegion("newregionname");
+
+        //miss 1 query
+        session = sf.openSession();
+        txn = session.beginTransaction();
+        query = session.createQuery("from " + DummyEntity.class.getName());
+        query.setCacheable(true);
+        query.list();
+        txn.commit();
+        session.close();
+
+        assertEquals(0, sf.getStatistics().getQueryCacheHitCount());
+        assertEquals(2, sf.getStatistics().getQueryCacheMissCount());
     }
 
     @Test

--- a/hazelcast-hibernate/hazelcast-hibernate3/src/test/resources/com/hazelcast/hibernate/entity/DummyEntity.hbm.xml
+++ b/hazelcast-hibernate/hazelcast-hibernate3/src/test/resources/com/hazelcast/hibernate/entity/DummyEntity.hbm.xml
@@ -21,10 +21,6 @@
 
 <hibernate-mapping package="com.hazelcast.hibernate.entity">
     <class name="DummyEntity" table="dummy_entities">
-        <!--		<cache usage="read-only"/>-->
-        <!--		<cache usage="nonstrict-read-write"/>-->
-        <cache usage="read-write"/>
-
         <id name="id" column="uid" type="long" unsaved-value="null">
             <generator class="assigned"/>
         </id>
@@ -34,7 +30,6 @@
         <property name="value" column="dummy_value" type="double"/>
 
         <set name="properties" lazy="false" cascade="all" inverse="true">
-            <cache usage="read-write"/>
             <key column="parent_uid"/>
             <one-to-many class="com.hazelcast.hibernate.entity.DummyProperty"/>
         </set>

--- a/hazelcast-hibernate/hazelcast-hibernate3/src/test/resources/com/hazelcast/hibernate/entity/DummyProperty.hbm.xml
+++ b/hazelcast-hibernate/hazelcast-hibernate3/src/test/resources/com/hazelcast/hibernate/entity/DummyProperty.hbm.xml
@@ -21,10 +21,6 @@
 
 <hibernate-mapping package="com.hazelcast.hibernate.entity">
     <class name="DummyProperty" table="dummy_props">
-        <!--		<cache usage="read-only"/>-->
-        <!--		<cache usage="nonstrict-read-write"/>-->
-        <cache usage="read-write"/>
-
         <id name="id" column="uid" type="long" unsaved-value="null">
             <generator class="native"/>
             <!-- 			<generator class="assigned" /> -->

--- a/hazelcast-hibernate/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/CacheHitMissNonStrictTest.java
+++ b/hazelcast-hibernate/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/CacheHitMissNonStrictTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate;
+
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.hibernate.cache.spi.access.AccessType;
+import org.hibernate.cfg.Environment;
+import org.hibernate.stat.CollectionStatistics;
+import org.hibernate.stat.SecondLevelCacheStatistics;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class CacheHitMissNonStrictTest
+        extends HibernateStatisticsTestSupport {
+
+    protected String getCacheStrategy() {
+        return AccessType.NONSTRICT_READ_WRITE.getExternalName();
+    }
+
+    @Override
+    protected Properties getCacheProperties() {
+        Properties props = new Properties();
+        props.setProperty(Environment.CACHE_REGION_FACTORY, HazelcastCacheRegionFactory.class.getName());
+        return props;
+    }
+
+    @Test
+    public void testGetUpdateRemoveGet()
+            throws Exception {
+        insertDummyEntities(10, 4);
+        //all 10 entities and 40 properties are cached
+        SecondLevelCacheStatistics dummyEntityCacheStats = sf.getStatistics().getSecondLevelCacheStatistics(CACHE_ENTITY);
+        CollectionStatistics collectionCacheStats = sf.getStatistics().getCollectionStatistics(CACHE_COLLECTION_ENTITY);
+        SecondLevelCacheStatistics dummyPropertyCacheStats = sf.getStatistics().getSecondLevelCacheStatistics(CACHE_PROPERTY);
+
+        sf.getCache().evictEntityRegions();
+        sf.getCache().evictCollectionRegions();
+
+        //miss 10 entities
+        getDummyEntities(sf, 10);
+
+        //hit 1 entity and 4 properties
+        updateDummyEntityName(sf, 2, "updated");
+        //entity 2 and its properties are invalidated
+
+        //miss updated entity, hit 4 properties(they are still the same)
+        getPropertiesOfEntity(sf, 2);
+
+        //hit 1 entity and 4 properties
+        deleteDummyEntity(sf, 1);
+        sleep(1);
+
+        assertEquals(12, dummyPropertyCacheStats.getHitCount());
+        assertEquals(0, dummyPropertyCacheStats.getMissCount());
+        assertEquals(2, dummyEntityCacheStats.getHitCount());
+        assertEquals(11, dummyEntityCacheStats.getMissCount());
+    }
+}

--- a/hazelcast-hibernate/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/CacheHitMissReadOnlyTest.java
+++ b/hazelcast-hibernate/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/CacheHitMissReadOnlyTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate;
+
+import com.hazelcast.hibernate.access.ReadOnlyAccessDelegate;
+import com.hazelcast.hibernate.region.HazelcastRegion;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.hibernate.cache.spi.access.AccessType;
+import org.hibernate.cfg.Environment;
+import org.hibernate.stat.CollectionStatistics;
+import org.hibernate.stat.SecondLevelCacheStatistics;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class CacheHitMissReadOnlyTest
+        extends HibernateStatisticsTestSupport {
+
+    protected String getCacheStrategy() {
+        return AccessType.READ_ONLY.getExternalName();
+    }
+
+    @Override
+    protected Properties getCacheProperties() {
+        Properties props = new Properties();
+        props.setProperty(Environment.CACHE_REGION_FACTORY, HazelcastCacheRegionFactory.class.getName());
+        return props;
+    }
+
+    @Test
+    public void testGetUpdateRemoveGet()
+            throws Exception {
+        insertDummyEntities(10, 4);
+        //all 10 entities and 40 properties are cached
+        SecondLevelCacheStatistics dummyEntityCacheStats = sf.getStatistics().getSecondLevelCacheStatistics(CACHE_ENTITY);
+        CollectionStatistics collectionCacheStats = sf.getStatistics().getCollectionStatistics(CACHE_COLLECTION_ENTITY);
+        SecondLevelCacheStatistics dummyPropertyCacheStats = sf.getStatistics().getSecondLevelCacheStatistics(CACHE_PROPERTY);
+
+        sf.getCache().evictEntityRegions();
+        sf.getCache().evictCollectionRegions();
+        //miss 10 entities
+        getDummyEntities(sf, 10);
+        //hit 1 entity and 4 properties
+        deleteDummyEntity(sf, 1);
+        sleep(1);
+
+        assertEquals(4, dummyPropertyCacheStats.getHitCount());
+        assertEquals(0, dummyPropertyCacheStats.getMissCount());
+        assertEquals(1, dummyEntityCacheStats.getHitCount());
+        assertEquals(10, dummyEntityCacheStats.getMissCount());
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testUpdateQueryCausesInvalidationOfEntireRegion() {
+        insertDummyEntities(10);
+        executeUpdateQuery(sf, "UPDATE DummyEntity set name = 'manually-updated' where id=2");
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testReadOnlyUpdate() throws Exception{
+        insertDummyEntities(1, 0);
+        updateDummyEntityName(sf, 0, "updated");
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testAfterUpdateShouldThrowOnReadOnly() {
+        HazelcastRegion hzRegion = mock(HazelcastRegion.class);
+        when(hzRegion.getCache()).thenReturn(null);
+        when(hzRegion.getLogger()).thenReturn(null);
+        ReadOnlyAccessDelegate readOnlyAccessDelegate = new ReadOnlyAccessDelegate(hzRegion, null);
+        readOnlyAccessDelegate.afterUpdate(null, null, null, null, null);
+    }
+}

--- a/hazelcast-hibernate/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/CacheHitMissReadOnlyTest.java
+++ b/hazelcast-hibernate/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/CacheHitMissReadOnlyTest.java
@@ -22,7 +22,6 @@ import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
 import org.hibernate.cache.spi.access.AccessType;
 import org.hibernate.cfg.Environment;
-import org.hibernate.stat.CollectionStatistics;
 import org.hibernate.stat.SecondLevelCacheStatistics;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -34,6 +33,10 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+/**
+ * Read-only access cache concurrency strategy of Hibernate.
+ * Data may be added and removed, but not mutated.
+ */
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
 public class CacheHitMissReadOnlyTest
@@ -56,7 +59,6 @@ public class CacheHitMissReadOnlyTest
         insertDummyEntities(10, 4);
         //all 10 entities and 40 properties are cached
         SecondLevelCacheStatistics dummyEntityCacheStats = sf.getStatistics().getSecondLevelCacheStatistics(CACHE_ENTITY);
-        CollectionStatistics collectionCacheStats = sf.getStatistics().getCollectionStatistics(CACHE_COLLECTION_ENTITY);
         SecondLevelCacheStatistics dummyPropertyCacheStats = sf.getStatistics().getSecondLevelCacheStatistics(CACHE_PROPERTY);
 
         sf.getCache().evictEntityRegions();
@@ -65,7 +67,6 @@ public class CacheHitMissReadOnlyTest
         getDummyEntities(sf, 10);
         //hit 1 entity and 4 properties
         deleteDummyEntity(sf, 1);
-        sleep(1);
 
         assertEquals(4, dummyPropertyCacheStats.getHitCount());
         assertEquals(0, dummyPropertyCacheStats.getMissCount());

--- a/hazelcast-hibernate/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/CacheHitMissReadWriteTest.java
+++ b/hazelcast-hibernate/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/CacheHitMissReadWriteTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate;
+
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.hibernate.cache.spi.access.AccessType;
+import org.hibernate.cfg.Environment;
+import org.hibernate.stat.CollectionStatistics;
+import org.hibernate.stat.SecondLevelCacheStatistics;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class CacheHitMissReadWriteTest
+        extends HibernateStatisticsTestSupport {
+
+    protected String getCacheStrategy() {
+        return AccessType.READ_WRITE.getExternalName();
+    }
+
+    @Override
+    protected Properties getCacheProperties() {
+        Properties props = new Properties();
+        props.setProperty(Environment.CACHE_REGION_FACTORY, HazelcastCacheRegionFactory.class.getName());
+        return props;
+    }
+
+    @Test
+    public void testGetUpdateRemoveGet()
+            throws Exception {
+        insertDummyEntities(10, 4);
+        //all 10 entities and 40 properties are cached
+        SecondLevelCacheStatistics dummyEntityCacheStats = sf.getStatistics().getSecondLevelCacheStatistics(CACHE_ENTITY);
+        CollectionStatistics collectionCacheStats = sf.getStatistics().getCollectionStatistics(CACHE_COLLECTION_ENTITY);
+        SecondLevelCacheStatistics dummyPropertyCacheStats = sf.getStatistics().getSecondLevelCacheStatistics(CACHE_PROPERTY);
+
+        sf.getCache().evictEntityRegions();
+        sf.getCache().evictCollectionRegions();
+
+        //miss 10 entities
+        getDummyEntities(sf, 10);
+
+        //hit 1 entity and 4 properties
+        updateDummyEntityName(sf, 2, "updated");
+        //entity 2 and its properties are invalidated
+
+        //hit 1 entity, hit 4 properties
+        getPropertiesOfEntity(sf, 2);
+        //hit 1 entity and 4 properties
+        deleteDummyEntity(sf, 1);
+        sleep(1);
+
+        assertEquals(12, dummyPropertyCacheStats.getHitCount());
+        assertEquals(0, dummyPropertyCacheStats.getMissCount());
+        assertEquals(3, dummyEntityCacheStats.getHitCount());
+        assertEquals(10, dummyEntityCacheStats.getMissCount());
+
+    }
+
+}

--- a/hazelcast-hibernate/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/CacheHitMissReadWriteTest.java
+++ b/hazelcast-hibernate/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/CacheHitMissReadWriteTest.java
@@ -20,7 +20,6 @@ import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
 import org.hibernate.cache.spi.access.AccessType;
 import org.hibernate.cfg.Environment;
-import org.hibernate.stat.CollectionStatistics;
 import org.hibernate.stat.SecondLevelCacheStatistics;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -30,6 +29,12 @@ import java.util.Properties;
 
 import static org.junit.Assert.assertEquals;
 
+/**
+ * Read and write access (strict) cache concurrency strategy of Hibernate.
+ * Data may be added, removed and mutated.
+ * Strict means data integrity is preserved strictly (by locks)
+ * Write through cache
+ */
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
 public class CacheHitMissReadWriteTest
@@ -52,7 +57,6 @@ public class CacheHitMissReadWriteTest
         insertDummyEntities(10, 4);
         //all 10 entities and 40 properties are cached
         SecondLevelCacheStatistics dummyEntityCacheStats = sf.getStatistics().getSecondLevelCacheStatistics(CACHE_ENTITY);
-        CollectionStatistics collectionCacheStats = sf.getStatistics().getCollectionStatistics(CACHE_COLLECTION_ENTITY);
         SecondLevelCacheStatistics dummyPropertyCacheStats = sf.getStatistics().getSecondLevelCacheStatistics(CACHE_PROPERTY);
 
         sf.getCache().evictEntityRegions();
@@ -63,13 +67,11 @@ public class CacheHitMissReadWriteTest
 
         //hit 1 entity and 4 properties
         updateDummyEntityName(sf, 2, "updated");
-        //entity 2 and its properties are invalidated
 
         //hit 1 entity, hit 4 properties
         getPropertiesOfEntity(sf, 2);
         //hit 1 entity and 4 properties
         deleteDummyEntity(sf, 1);
-        sleep(1);
 
         assertEquals(12, dummyPropertyCacheStats.getHitCount());
         assertEquals(0, dummyPropertyCacheStats.getMissCount());
@@ -78,4 +80,21 @@ public class CacheHitMissReadWriteTest
 
     }
 
+    @Test
+    public void testUpdateShouldNotInvalidateEntryInCache() {
+        insertDummyEntities(10, 4);
+        //all 10 entities and 40 properties are cached
+        SecondLevelCacheStatistics dummyEntityCacheStats = sf.getStatistics().getSecondLevelCacheStatistics(CACHE_ENTITY);
+
+        sf.getCache().evictEntityRegions();
+        sf.getCache().evictCollectionRegions();
+
+        //miss 10 entities, 10 entities are cached
+        getDummyEntities(sf, 10);
+
+        //updates cache entity
+        updateDummyEntityName(sf, 2, "updated");
+
+        assertEquals(10, dummyEntityCacheStats.getElementCountInMemory());
+    }
 }

--- a/hazelcast-hibernate/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/HibernateTestSupport.java
+++ b/hazelcast-hibernate/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/HibernateTestSupport.java
@@ -17,10 +17,15 @@
 package com.hazelcast.hibernate;
 
 import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.hibernate.entity.DummyEntity;
+import com.hazelcast.hibernate.entity.DummyProperty;
+import com.hazelcast.hibernate.instance.HazelcastAccessor;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.test.HazelcastTestSupport;
 import org.hibernate.SessionFactory;
+import org.hibernate.cache.spi.access.AccessType;
 import org.hibernate.cfg.Configuration;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -39,6 +44,9 @@ public abstract class HibernateTestSupport extends HazelcastTestSupport{
         Hazelcast.shutdownAll();
     }
 
+    protected String getCacheStrategy() {
+        return  AccessType.READ_WRITE.getExternalName();
+    }
 
     @After
     public final void cleanup() {
@@ -53,14 +61,22 @@ public abstract class HibernateTestSupport extends HazelcastTestSupport{
         }
     }
 
-    protected static SessionFactory createSessionFactory(Properties props) {
+    protected SessionFactory createSessionFactory(Properties props) {
         Configuration conf = new Configuration();
         URL xml = HibernateTestSupport.class.getClassLoader().getResource("test-hibernate.cfg.xml");
         props.put(CacheEnvironment.EXPLICIT_VERSION_CHECK, "true");
         conf.configure(xml);
+        conf.setCacheConcurrencyStrategy(DummyEntity.class.getName(), getCacheStrategy());
+        conf.setCacheConcurrencyStrategy(DummyProperty.class.getName(), getCacheStrategy());
+        conf.setCollectionCacheConcurrencyStrategy(DummyEntity.class.getName() + ".properties", getCacheStrategy());
         conf.addProperties(props);
         final SessionFactory sf = conf.buildSessionFactory();
         sf.getStatistics().setStatisticsEnabled(true);
         return sf;
     }
+
+    protected HazelcastInstance getHazelcastInstance(SessionFactory sf) {
+        return HazelcastAccessor.getHazelcastInstance(sf);
+    }
+
 }

--- a/hazelcast-hibernate/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/LocalRegionFactoryDefaultTest.java
+++ b/hazelcast-hibernate/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/LocalRegionFactoryDefaultTest.java
@@ -19,7 +19,6 @@ package com.hazelcast.hibernate;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.hibernate.entity.DummyEntity;
 import com.hazelcast.test.HazelcastSerialClassRunner;
-import com.hazelcast.test.annotation.NightlyTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.hibernate.Session;
 import org.hibernate.Transaction;

--- a/hazelcast-hibernate/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/RegionFactoryDefaultTest.java
+++ b/hazelcast-hibernate/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/RegionFactoryDefaultTest.java
@@ -16,22 +16,33 @@
 
 package com.hazelcast.hibernate;
 
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.hibernate.entity.DummyEntity;
+import com.hazelcast.hibernate.entity.DummyProperty;
+import com.hazelcast.hibernate.region.HazelcastQueryResultsRegion;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.NightlyTest;
 import com.hazelcast.test.annotation.QuickTest;
+import org.hibernate.Query;
 import org.hibernate.Session;
 import org.hibernate.Transaction;
 import org.hibernate.cfg.Environment;
+import org.hibernate.internal.SessionFactoryImpl;
+import org.hibernate.stat.Statistics;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
 @RunWith(HazelcastSerialClassRunner.class)
@@ -42,6 +53,223 @@ public class RegionFactoryDefaultTest extends HibernateStatisticsTestSupport {
         Properties props = new Properties();
         props.setProperty(Environment.CACHE_REGION_FACTORY, HazelcastCacheRegionFactory.class.getName());
         return props;
+    }
+
+    @Test
+    public void testEntity() {
+        final HazelcastInstance hz = getHazelcastInstance(sf);
+        assertNotNull(hz);
+        final int count = 100;
+        final int childCount = 3;
+        insertDummyEntities(count, childCount);
+        sleep(1);
+        List<DummyEntity> list = new ArrayList<DummyEntity>(count);
+        Session session = sf.openSession();
+        try {
+            for (int i = 0; i < count; i++) {
+                DummyEntity e = (DummyEntity) session.get(DummyEntity.class, (long) i);
+                session.evict(e);
+                list.add(e);
+            }
+        } finally {
+            session.close();
+        }
+        session = sf.openSession();
+        Transaction tx = session.beginTransaction();
+        try {
+            for (DummyEntity dummy : list) {
+                dummy.setDate(new Date());
+                session.update(dummy);
+            }
+            tx.commit();
+        } catch (Exception e) {
+            tx.rollback();
+            e.printStackTrace();
+        } finally {
+            session.close();
+        }
+
+        Statistics stats = sf.getStatistics();
+        Map<?, ?> cache = hz.getMap(DummyEntity.class.getName());
+        Map<?, ?> propCache = hz.getMap(DummyProperty.class.getName());
+        Map<?, ?> propCollCache = hz.getMap(DummyEntity.class.getName() + ".properties");
+        assertEquals((childCount + 1) * count, stats.getEntityInsertCount());
+        // twice put of entity and properties (on load and update) and once put of collection
+        // TODO: fix next assertion ->
+        //        assertEquals((childCount + 1) * count * 2, stats.getSecondLevelCachePutCount());
+        assertEquals(childCount * count, stats.getEntityLoadCount());
+        assertEquals(count, stats.getSecondLevelCacheHitCount());
+        // collection cache miss
+        assertEquals(count, stats.getSecondLevelCacheMissCount());
+        assertEquals(count, cache.size());
+        assertEquals(count * childCount, propCache.size());
+        assertEquals(count, propCollCache.size());
+        sf.getCache().evictEntityRegion(DummyEntity.class);
+        sf.getCache().evictEntityRegion(DummyProperty.class);
+        assertEquals(0, cache.size());
+        assertEquals(0, propCache.size());
+        stats.logSummary();
+    }
+
+    @Test
+    public void testQuery() {
+        final int entityCount = 10;
+        final int queryCount = 3;
+        insertDummyEntities(entityCount);
+        sleep(2);
+        List<DummyEntity> list = null;
+        for (int i = 0; i < queryCount; i++) {
+            list = executeQuery(sf);
+            assertEquals(entityCount, list.size());
+            sleepAtLeastSeconds(1);
+        }
+
+        assertNotNull(list);
+        Session session = sf.openSession();
+        Transaction tx = session.beginTransaction();
+        try {
+            for (DummyEntity dummy : list) {
+                session.delete(dummy);
+            }
+            tx.commit();
+        } catch (Exception e) {
+            tx.rollback();
+            e.printStackTrace();
+        } finally {
+            session.close();
+        }
+
+        Statistics stats = sf.getStatistics();
+        assertEquals(1, stats.getQueryCachePutCount());
+        assertEquals(1, stats.getQueryCacheMissCount());
+        assertEquals(queryCount - 1, stats.getQueryCacheHitCount());
+        assertEquals(1, stats.getQueryExecutionCount());
+        assertEquals(entityCount, stats.getEntityInsertCount());
+        //      FIXME
+        //      HazelcastRegionFactory puts into L2 cache 2 times; 1 on insert, 1 on query execution
+        //      assertEquals(entityCount, stats.getSecondLevelCachePutCount());
+        assertEquals(entityCount, stats.getEntityLoadCount());
+        assertEquals(entityCount, stats.getEntityDeleteCount());
+        assertEquals(entityCount * (queryCount - 1) * 2, stats.getSecondLevelCacheHitCount());
+        // collection cache miss
+        assertEquals(entityCount, stats.getSecondLevelCacheMissCount());
+
+        stats.logSummary();
+    }
+
+    @Test
+    public void testQuery2() {
+        final int entityCount = 10;
+        final int queryCount = 2;
+        insertDummyEntities(entityCount);
+        sleep(1);
+        List<DummyEntity> list = null;
+        for (int i = 0; i < queryCount; i++) {
+            list = executeQuery(sf);
+            assertEquals(entityCount, list.size());
+            sleep(1);
+        }
+
+        for (int i = 0; i < queryCount; i++) {
+            list = executeQuery(sf2);
+            assertEquals(entityCount, list.size());
+            sleep(1);
+        }
+
+        assertNotNull(list);
+        DummyEntity toDelete = list.get(0);
+        Session session = sf.openSession();
+        Transaction tx = session.beginTransaction();
+        try {
+            session.delete(toDelete);
+            tx.commit();
+        } catch (Exception e) {
+            tx.rollback();
+            e.printStackTrace();
+        } finally {
+            session.close();
+        }
+        sleep(1);
+        assertEquals(entityCount - 1, executeQuery(sf).size());
+        assertEquals(entityCount - 1, executeQuery(sf2).size());
+    }
+
+    @Test
+    @Category(NightlyTest.class)
+    public void testQueryCacheCleanup() {
+
+        MapConfig mapConfig = getHazelcastInstance(sf).getConfig().getMapConfig("org.hibernate.cache.*");
+        final float baseEvictionRate = 0.2f;
+        final int numberOfEntities = 100;
+        final int defaultCleanupPeriod = 60;
+        final int maxSize = mapConfig.getMaxSizeConfig().getSize();
+        final int evictedItemCount = numberOfEntities - maxSize + (int) (maxSize * baseEvictionRate);
+        insertDummyEntities(numberOfEntities);
+        sleep(1);
+        for (int i = 0; i < numberOfEntities; i++) {
+            executeQuery(sf, i);
+        }
+
+        HazelcastQueryResultsRegion queryRegion = ((HazelcastQueryResultsRegion) (((SessionFactoryImpl) sf).getQueryCache()).getRegion());
+        assertEquals(numberOfEntities, queryRegion.getCache().size());
+        sleep(defaultCleanupPeriod);
+
+        assertEquals(numberOfEntities - evictedItemCount, queryRegion.getCache().size());
+    }
+
+    @Test
+    public void testAutoQueryRegionEviction() {
+        sf.getCache().evictDefaultQueryRegion();
+        int entityCount = 10;
+        insertDummyEntities(entityCount, 0);
+
+        //miss 1 query list entities
+        executeQuery(sf);
+        sleepMillis(200);
+        //query is cached
+
+        //query cache invalidated
+        executeUpdateQuery(sf, "delete from DummyEntity");
+        //miss 1 query
+        executeQuery(sf);
+        sleepMillis(200);
+        //hit 1 query
+        executeQuery(sf);
+
+        assertEquals(1, sf.getStatistics().getQueryCacheHitCount());
+        assertEquals(2, sf.getStatistics().getQueryCacheMissCount());
+    }
+
+    @Test
+    public void testSpecificQueryRegionEviction() {
+        sf.getCache().evictDefaultQueryRegion();
+        int entityCount = 10;
+        insertDummyEntities(entityCount, 0);
+
+        //miss 1 query list entities
+        Session session = sf.openSession();
+        Transaction txn = session.beginTransaction();
+        Query query = session.createQuery("from " + DummyEntity.class.getName());
+        query.setCacheable(true).setCacheRegion("newregionname");
+        query.list();
+        txn.commit();
+        session.close();
+        //query is cached
+
+        //query is invalidated
+        sf.getCache().evictQueryRegion("newregionname");
+
+        //miss 1 query
+        session = sf.openSession();
+        txn = session.beginTransaction();
+        query = session.createQuery("from " + DummyEntity.class.getName());
+        query.setCacheable(true);
+        query.list();
+        txn.commit();
+        session.close();
+
+        assertEquals(0, sf.getStatistics().getQueryCacheHitCount());
+        assertEquals(2, sf.getStatistics().getQueryCacheMissCount());
     }
 
     @Test

--- a/hazelcast-hibernate/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/RegionFactoryDefaultTest.java
+++ b/hazelcast-hibernate/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/RegionFactoryDefaultTest.java
@@ -219,20 +219,18 @@ public class RegionFactoryDefaultTest extends HibernateStatisticsTestSupport {
 
     @Test
     public void testAutoQueryRegionEviction() {
-        sf.getCache().evictDefaultQueryRegion();
         int entityCount = 10;
         insertDummyEntities(entityCount, 0);
+        sleep(1);
 
         //miss 1 query list entities
         executeQuery(sf);
-        sleepMillis(200);
         //query is cached
 
         //query cache invalidated
         executeUpdateQuery(sf, "delete from DummyEntity");
         //miss 1 query
         executeQuery(sf);
-        sleepMillis(200);
         //hit 1 query
         executeQuery(sf);
 
@@ -242,9 +240,9 @@ public class RegionFactoryDefaultTest extends HibernateStatisticsTestSupport {
 
     @Test
     public void testSpecificQueryRegionEviction() {
-        sf.getCache().evictDefaultQueryRegion();
         int entityCount = 10;
         insertDummyEntities(entityCount, 0);
+        sleep(1);
 
         //miss 1 query list entities
         Session session = sf.openSession();

--- a/hazelcast-hibernate/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/RegionFactoryDefaultTest.java
+++ b/hazelcast-hibernate/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/RegionFactoryDefaultTest.java
@@ -218,27 +218,6 @@ public class RegionFactoryDefaultTest extends HibernateStatisticsTestSupport {
     }
 
     @Test
-    public void testAutoQueryRegionEviction() {
-        int entityCount = 10;
-        insertDummyEntities(entityCount, 0);
-        sleep(1);
-
-        //miss 1 query list entities
-        executeQuery(sf);
-        //query is cached
-
-        //query cache invalidated
-        executeUpdateQuery(sf, "delete from DummyEntity");
-        //miss 1 query
-        executeQuery(sf);
-        //hit 1 query
-        executeQuery(sf);
-
-        assertEquals(1, sf.getStatistics().getQueryCacheHitCount());
-        assertEquals(2, sf.getStatistics().getQueryCacheMissCount());
-    }
-
-    @Test
     public void testSpecificQueryRegionEviction() {
         int entityCount = 10;
         insertDummyEntities(entityCount, 0);

--- a/hazelcast-hibernate/hazelcast-hibernate4/src/test/resources/com/hazelcast/hibernate/entity/DummyEntity.hbm.xml
+++ b/hazelcast-hibernate/hazelcast-hibernate4/src/test/resources/com/hazelcast/hibernate/entity/DummyEntity.hbm.xml
@@ -21,10 +21,6 @@
 
 <hibernate-mapping package="com.hazelcast.hibernate.entity">
     <class name="DummyEntity" table="dummy_entities">
-        <!--		<cache usage="read-only"/>-->
-        <!--		<cache usage="nonstrict-read-write"/>-->
-        <cache usage="read-write"/>
-
         <id name="id" column="uid" type="long" unsaved-value="null">
             <generator class="assigned"/>
         </id>
@@ -34,7 +30,6 @@
         <property name="value" column="dummy_value" type="double"/>
 
         <set name="properties" lazy="false" cascade="all" inverse="true">
-            <cache usage="read-write"/>
             <key column="parent_uid"/>
             <one-to-many class="com.hazelcast.hibernate.entity.DummyProperty"/>
         </set>

--- a/hazelcast-hibernate/hazelcast-hibernate4/src/test/resources/com/hazelcast/hibernate/entity/DummyProperty.hbm.xml
+++ b/hazelcast-hibernate/hazelcast-hibernate4/src/test/resources/com/hazelcast/hibernate/entity/DummyProperty.hbm.xml
@@ -21,10 +21,6 @@
 
 <hibernate-mapping package="com.hazelcast.hibernate.entity">
     <class name="DummyProperty" table="dummy_props">
-        <!--		<cache usage="read-only"/>-->
-        <!--		<cache usage="nonstrict-read-write"/>-->
-        <cache usage="read-write"/>
-
         <id name="id" column="uid" type="long" unsaved-value="null">
             <generator class="native"/>
             <!-- 			<generator class="assigned" /> -->


### PR DESCRIPTION
Adds tests for NonStrictReadWrite, ReadWrite and ReadOnly cache concurrency strategies.
Makes concurrency configuration of test entities programmatically instead of xml files so it is easier to re-use them in other tests.

Note: hibernate4 tests are identical to hibernate3 tests.