### PR TITLE
Backport: Improved compatibility with JDK9

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/nio/UTFEncoderDecoder.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/UTFEncoderDecoder.java
@@ -274,7 +274,10 @@ public final class UTFEncoderDecoder {
             long offset = -1;
             if (UnsafeHelper.UNSAFE_AVAILABLE) {
                 try {
-                    offset = UNSAFE.objectFieldOffset(String.class.getDeclaredField("value"));
+                    Field valueField = String.class.getDeclaredField("value");
+                    if (char[].class.equals(valueField.getType())) {
+                        offset = UNSAFE.objectFieldOffset(valueField);
+                    }
                 } catch (Throwable t) {
                     EmptyStatement.ignore(t);
                 }
@@ -309,7 +312,11 @@ public final class UTFEncoderDecoder {
             Field field;
             try {
                 field = String.class.getDeclaredField("value");
-                field.setAccessible(true);
+                if (char[].class.equals(field.getType())) {
+                    field.setAccessible(true);
+                } else {
+                    field = null;
+                }
             } catch (Throwable t) {
                 EmptyStatement.ignore(t);
                 field = null;


### PR DESCRIPTION
Backport of #5799

Fixed a compatibility issue with JDK9.
JEP 254 introduces compacted String. As a result the value field is no longer char[].

See https://bugs.openjdk.java.net/browse/JDK-8054307 for additional details.
(cherry picked from commit e4b998b)