### PR TITLE
PacketTransceiverImpl removed isAlive check

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/packettransceiver/impl/PacketTransceiverImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/packettransceiver/impl/PacketTransceiverImpl.java
@@ -62,7 +62,7 @@ public class PacketTransceiverImpl implements PacketTransceiver {
 
     @Override
     public boolean transmit(Packet packet, Connection connection) {
-        if (connection == null || !connection.isAlive()) {
+        if (connection == null) {
             return false;
         }
         return connection.write(packet);


### PR DESCRIPTION
The Connection.isAlive check is removed in the transmit method, since the same check is done by the connection when the connection.write is called. So no reason to repeat the logic.