### PR TITLE
removed invalid reference

### DIFF
--- a/hazelcast-ra/hazelcast-jca-rar/pom.xml
+++ b/hazelcast-ra/hazelcast-jca-rar/pom.xml
@@ -64,7 +64,6 @@
                 <artifactId>maven-rar-plugin</artifactId>
                 <version>${maven.rar.plugin.version}</version>
                 <configuration>
-                    <raXmlFile>src/main/rar/ra.xml</raXmlFile>
                     <includeJar>false</includeJar>
                 </configuration>
             </plugin>


### PR DESCRIPTION
Removes reference to non-existent "ra.xml". It is located under "src/main/rar/META-INF/" directory
maven-rar plugin copies everything under "src/main/rar" into ".rar" archive by default. So there is no need to specify the location.

This closes https://github.com/hazelcast/hazelcast/issues/5760