### PR TITLE
Refactor MemberImpl usage

### DIFF
--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/cache/impl/AbstractClientInternalCacheProxy.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/cache/impl/AbstractClientInternalCacheProxy.java
@@ -59,7 +59,6 @@ import com.hazelcast.core.Member;
 import com.hazelcast.core.MemberAttributeEvent;
 import com.hazelcast.core.MembershipEvent;
 import com.hazelcast.core.MembershipListener;
-import com.hazelcast.instance.AbstractMember;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.nio.Address;
@@ -743,7 +742,7 @@ abstract class AbstractClientInternalCacheProxy<K, V>
             Client client = clientContext.getClusterService().getLocalClient();
             EventHandler handler = new NearCacheInvalidationHandler(client);
             HazelcastClientInstanceImpl clientInstance = (HazelcastClientInstanceImpl) clientContext.getHazelcastInstance();
-            Address address = ((AbstractMember) member).getAddress();
+            Address address = member.getAddress();
             ClientInvocation invocation = new ClientInvocation(clientInstance, handler, request, address);
             Future<ClientMessage> future = invocation.invoke();
             String registrationId = CacheAddInvalidationListenerCodec.decodeResponse(future.get()).response;
@@ -761,7 +760,7 @@ abstract class AbstractClientInternalCacheProxy<K, V>
             return;
         }
 
-        Address address = ((AbstractMember) member).getAddress();
+        Address address = member.getAddress();
         if (!removeFromMemberAlso) {
             return;
         }

--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/cache/impl/ClientCacheProxy.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/cache/impl/ClientCacheProxy.java
@@ -36,7 +36,6 @@ import com.hazelcast.client.spi.impl.ListenerRemoveCodec;
 import com.hazelcast.config.CacheConfig;
 import com.hazelcast.core.ICompletableFuture;
 import com.hazelcast.core.Member;
-import com.hazelcast.instance.AbstractMember;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.util.ExceptionUtil;
@@ -353,7 +352,7 @@ public class ClientCacheProxy<K, V>
         final Collection<Future> futures = new ArrayList<Future>();
         for (Member member : members) {
             try {
-                final Address address = ((AbstractMember) member).getAddress();
+                final Address address = member.getAddress();
                 Data configData = toData(cacheEntryListenerConfiguration);
                 final ClientMessage request = CacheListenerRegistrationCodec
                         .encodeRequest(nameWithPrefix, configData, isRegister, address.getHost(), address.getPort());

--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/cache/impl/HazelcastClientCacheManager.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/cache/impl/HazelcastClientCacheManager.java
@@ -33,7 +33,6 @@ import com.hazelcast.client.spi.impl.ClientInvocation;
 import com.hazelcast.config.CacheConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.Member;
-import com.hazelcast.instance.AbstractMember;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.SerializationService;
@@ -89,7 +88,7 @@ public final class HazelcastClientCacheManager
         HazelcastClientInstanceImpl client = (HazelcastClientInstanceImpl) clientContext.getHazelcastInstance();
         for (Member member : members) {
             try {
-                Address address = ((AbstractMember) member).getAddress();
+                Address address = member.getAddress();
 
                 ClientMessage request = CacheManagementConfigCodec
                         .encodeRequest(getCacheNameWithPrefix(cacheName),

--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/proxy/ClientExecutorServiceProxy.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/proxy/ClientExecutorServiceProxy.java
@@ -37,7 +37,6 @@ import com.hazelcast.core.MemberSelector;
 import com.hazelcast.core.MultiExecutionCallback;
 import com.hazelcast.core.PartitionAware;
 import com.hazelcast.executor.impl.RunnableAdapter;
-import com.hazelcast.instance.AbstractMember;
 import com.hazelcast.monitor.LocalExecutorStats;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.serialization.Data;
@@ -183,7 +182,7 @@ public class ClientExecutorServiceProxy extends ClientProxy implements IExecutor
         final Collection<Member> memberList = getContext().getClusterService().getMemberList();
         Map<Member, Future<T>> futureMap = new HashMap<Member, Future<T>>(memberList.size());
         for (Member m : memberList) {
-            Future<T> f = submitToTargetInternal(task, ((AbstractMember) m).getAddress(), null, true);
+            Future<T> f = submitToTargetInternal(task, m.getAddress(), null, true);
             futureMap.put(m, f);
         }
         return futureMap;
@@ -639,7 +638,7 @@ public class ClientExecutorServiceProxy extends ClientProxy implements IExecutor
         if (m == null) {
             throw new HazelcastException(member + " is not available!!!");
         }
-        return ((AbstractMember) m).getAddress();
+        return m.getAddress();
     }
 
     private int getPartitionId(Object key) {

--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/spi/impl/ClientMembershipListener.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/spi/impl/ClientMembershipListener.java
@@ -171,7 +171,7 @@ class ClientMembershipListener extends ClientMembershipListenerCodec.AbstractEve
 
     private void memberRemoved(Member member) {
         members.remove(member);
-        final Connection connection = connectionManager.getConnection(((AbstractMember) member).getAddress());
+        final Connection connection = connectionManager.getConnection(member.getAddress());
         if (connection != null) {
             connectionManager.destroyConnection(connection);
         }
@@ -204,7 +204,7 @@ class ClientMembershipListener extends ClientMembershipListenerCodec.AbstractEve
         }
         for (Member member : prevMembers.values()) {
             events.add(new MembershipEvent(client.getCluster(), member, MembershipEvent.MEMBER_REMOVED, eventMembers));
-            Address address = ((AbstractMember) member).getAddress();
+            Address address = member.getAddress();
             if (clusterService.getMember(address) == null) {
                 final Connection connection = connectionManager.getConnection(address);
                 if (connection != null) {
@@ -226,7 +226,7 @@ class ClientMembershipListener extends ClientMembershipListenerCodec.AbstractEve
     private void updateMembersRef() {
         final Map<Address, Member> map = new LinkedHashMap<Address, Member>(members.size());
         for (Member member : members) {
-            map.put(((AbstractMember) member).getAddress(), member);
+            map.put(member.getAddress(), member);
         }
         clusterService.setMembersRef(Collections.unmodifiableMap(map));
     }

--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/spi/impl/ClientSmartInvocationServiceImpl.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/spi/impl/ClientSmartInvocationServiceImpl.java
@@ -23,7 +23,6 @@ import com.hazelcast.client.impl.HazelcastClientInstanceImpl;
 import com.hazelcast.client.spi.ClientClusterService;
 import com.hazelcast.core.HazelcastException;
 import com.hazelcast.core.Member;
-import com.hazelcast.instance.AbstractMember;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.Connection;
 
@@ -102,7 +101,7 @@ public final class ClientSmartInvocationServiceImpl extends ClientInvocationServ
     private Address getRandomAddress() {
         Member member = loadBalancer.next();
         if (member != null) {
-            return ((AbstractMember) member).getAddress();
+            return member.getAddress();
         }
         return null;
     }

--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/spi/impl/ClientTransactionManagerServiceImpl.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/spi/impl/ClientTransactionManagerServiceImpl.java
@@ -26,7 +26,6 @@ import com.hazelcast.client.spi.ClientTransactionManagerService;
 import com.hazelcast.config.GroupConfig;
 import com.hazelcast.core.HazelcastInstanceNotActiveException;
 import com.hazelcast.core.Member;
-import com.hazelcast.instance.AbstractMember;
 import com.hazelcast.nio.Address;
 import com.hazelcast.security.Credentials;
 import com.hazelcast.transaction.TransactionContext;
@@ -137,7 +136,7 @@ public class ClientTransactionManagerServiceImpl implements ClientTransactionMan
             throw new IllegalStateException(msg);
         }
 
-        return ((AbstractMember) member).getAddress();
+        return member.getAddress();
     }
 
 

--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/AbstractClientInternalCacheProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/AbstractClientInternalCacheProxy.java
@@ -56,7 +56,6 @@ import com.hazelcast.core.Member;
 import com.hazelcast.core.MemberAttributeEvent;
 import com.hazelcast.core.MembershipEvent;
 import com.hazelcast.core.MembershipListener;
-import com.hazelcast.instance.AbstractMember;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.nio.Address;
@@ -656,7 +655,7 @@ abstract class AbstractClientInternalCacheProxy<K, V>
             Client client = clientContext.getClusterService().getLocalClient();
             EventHandler handler = new NearCacheInvalidationHandler(client);
             HazelcastClientInstanceImpl clientInstance = (HazelcastClientInstanceImpl) clientContext.getHazelcastInstance();
-            Address address = ((AbstractMember) member).getAddress();
+            Address address = member.getAddress();
             ClientInvocation invocation = new ClientInvocation(clientInstance, handler, request, address);
             Future future = invocation.invoke();
             String registrationId = clientContext.getSerializationService().toObject(future.get());
@@ -676,7 +675,7 @@ abstract class AbstractClientInternalCacheProxy<K, V>
                     ClientRequest request = new CacheRemoveInvalidationListenerRequest(nameWithPrefix, registrationId);
                     HazelcastClientInstanceImpl clientInstance =
                             (HazelcastClientInstanceImpl) clientContext.getHazelcastInstance();
-                    Address address = ((AbstractMember) member).getAddress();
+                    Address address = member.getAddress();
                     ClientInvocation invocation = new ClientInvocation(clientInstance, request, address);
                     Future future = invocation.invoke();
                     Boolean result = clientContext.getSerializationService().toObject(future.get());

--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/ClientCacheProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/ClientCacheProxy.java
@@ -33,7 +33,6 @@ import com.hazelcast.client.spi.impl.ClientInvocation;
 import com.hazelcast.config.CacheConfig;
 import com.hazelcast.core.ICompletableFuture;
 import com.hazelcast.core.Member;
-import com.hazelcast.instance.AbstractMember;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.impl.SerializableList;
@@ -333,7 +332,7 @@ public class ClientCacheProxy<K, V>
         final Collection<Future> futures = new ArrayList<Future>();
         for (Member member : members) {
             try {
-                final Address address = ((AbstractMember) member).getAddress();
+                final Address address = member.getAddress();
                 final CacheListenerRegistrationRequest request = new CacheListenerRegistrationRequest(nameWithPrefix,
                         cacheEntryListenerConfiguration, isRegister, address);
                 final ClientInvocation invocation = new ClientInvocation(client, request, address);

--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/HazelcastClientCacheManager.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/HazelcastClientCacheManager.java
@@ -34,7 +34,6 @@ import com.hazelcast.config.CacheConfig;
 import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.Member;
-import com.hazelcast.instance.AbstractMember;
 import com.hazelcast.nio.Address;
 import com.hazelcast.spi.impl.SerializableList;
 import com.hazelcast.util.ExceptionUtil;
@@ -88,7 +87,7 @@ public final class HazelcastClientCacheManager extends AbstractHazelcastCacheMan
         HazelcastClientInstanceImpl client = (HazelcastClientInstanceImpl) clientContext.getHazelcastInstance();
         for (Member member : members) {
             try {
-                Address address = ((AbstractMember) member).getAddress();
+                Address address = member.getAddress();
                 CacheManagementConfigRequest request =
                         new CacheManagementConfigRequest(getCacheNameWithPrefix(cacheName),
                                                          statOrMan, enabled, address);

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientExecutorServiceProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientExecutorServiceProxy.java
@@ -35,7 +35,6 @@ import com.hazelcast.executor.impl.client.IsShutdownRequest;
 import com.hazelcast.executor.impl.client.PartitionTargetCallableRequest;
 import com.hazelcast.executor.impl.client.ShutdownRequest;
 import com.hazelcast.executor.impl.client.SpecificTargetCallableRequest;
-import com.hazelcast.instance.AbstractMember;
 import com.hazelcast.monitor.LocalExecutorStats;
 import com.hazelcast.nio.Address;
 import com.hazelcast.util.Clock;
@@ -165,7 +164,7 @@ public class ClientExecutorServiceProxy extends ClientProxy implements IExecutor
         final Collection<Member> memberList = getContext().getClusterService().getMemberList();
         Map<Member, Future<T>> futureMap = new HashMap<Member, Future<T>>(memberList.size());
         for (Member m : memberList) {
-            Future<T> f = submitToTargetInternal(task, ((AbstractMember) m).getAddress(), null, true);
+            Future<T> f = submitToTargetInternal(task, m.getAddress(), null, true);
             futureMap.put(m, f);
         }
         return futureMap;
@@ -584,7 +583,7 @@ public class ClientExecutorServiceProxy extends ClientProxy implements IExecutor
         if (m == null) {
             throw new HazelcastException(member + " is not available!!!");
         }
-        return ((AbstractMember) m).getAddress();
+        return m.getAddress();
     }
 
     private int getPartitionId(Object key) {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientClusterServiceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientClusterServiceImpl.java
@@ -33,7 +33,6 @@ import com.hazelcast.core.Member;
 import com.hazelcast.core.MemberAttributeEvent;
 import com.hazelcast.core.MembershipEvent;
 import com.hazelcast.core.MembershipListener;
-import com.hazelcast.instance.AbstractMember;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.nio.Address;
@@ -109,7 +108,7 @@ public class ClientClusterServiceImpl extends ClusterListenerSupport {
     public Address getMasterAddress() {
         final Collection<Member> memberList = getMemberList();
         Member member = memberList.iterator().next();
-        return !memberList.isEmpty() ? ((AbstractMember) member).getAddress() : null;
+        return !memberList.isEmpty() ? member.getAddress() : null;
     }
 
     @Override

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientMembershipListener.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientMembershipListener.java
@@ -144,7 +144,7 @@ class ClientMembershipListener implements EventHandler<ClientInitialMembershipEv
 
     private void memberRemoved(Member member) {
         members.remove(member);
-        final Connection connection = connectionManager.getConnection(((AbstractMember) member).getAddress());
+        final Connection connection = connectionManager.getConnection(member.getAddress());
         if (connection != null) {
             connectionManager.destroyConnection(connection);
         }
@@ -198,7 +198,7 @@ class ClientMembershipListener implements EventHandler<ClientInitialMembershipEv
         }
         for (Member member : prevMembers.values()) {
             events.add(new MembershipEvent(client.getCluster(), member, MembershipEvent.MEMBER_REMOVED, eventMembers));
-            Address address = ((AbstractMember) member).getAddress();
+            Address address = member.getAddress();
             if (clusterService.getMember(address) == null) {
                 final Connection connection = connectionManager.getConnection(address);
                 if (connection != null) {
@@ -221,7 +221,7 @@ class ClientMembershipListener implements EventHandler<ClientInitialMembershipEv
     private void updateMembersRef() {
         final Map<Address, Member> map = new LinkedHashMap<Address, Member>(members.size());
         for (Member member : members) {
-            map.put(((AbstractMember) member).getAddress(), member);
+            map.put(member.getAddress(), member);
         }
         clusterService.setMembersRef(Collections.unmodifiableMap(map));
     }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientSmartInvocationServiceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientSmartInvocationServiceImpl.java
@@ -23,7 +23,6 @@ import com.hazelcast.client.impl.HazelcastClientInstanceImpl;
 import com.hazelcast.client.spi.ClientClusterService;
 import com.hazelcast.core.HazelcastException;
 import com.hazelcast.core.Member;
-import com.hazelcast.instance.AbstractMember;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.Connection;
 
@@ -101,7 +100,7 @@ public final class ClientSmartInvocationServiceImpl extends ClientInvocationServ
     private Address getRandomAddress() {
         Member member = loadBalancer.next();
         if (member != null) {
-            return ((AbstractMember) member).getAddress();
+            return member.getAddress();
         }
         return null;
     }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientTransactionManagerServiceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientTransactionManagerServiceImpl.java
@@ -26,7 +26,6 @@ import com.hazelcast.client.txn.proxy.xa.XATransactionContextProxy;
 import com.hazelcast.config.GroupConfig;
 import com.hazelcast.core.HazelcastInstanceNotActiveException;
 import com.hazelcast.core.Member;
-import com.hazelcast.instance.AbstractMember;
 import com.hazelcast.nio.Address;
 import com.hazelcast.security.Credentials;
 import com.hazelcast.transaction.TransactionContext;
@@ -138,7 +137,7 @@ public class ClientTransactionManagerServiceImpl implements ClientTransactionMan
             throw new IllegalStateException(msg);
         }
 
-        return ((AbstractMember) member).getAddress();
+        return member.getAddress();
     }
 
 

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheService.java
@@ -22,7 +22,7 @@ import com.hazelcast.config.CacheConfig;
 import com.hazelcast.config.CacheSimpleConfig;
 import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.core.DistributedObject;
-import com.hazelcast.instance.MemberImpl;
+import com.hazelcast.core.Member;
 import com.hazelcast.nio.IOUtil;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.partition.MigrationEndpoint;
@@ -167,8 +167,8 @@ public abstract class AbstractCacheService
 
     protected void destroyCacheOnAllMembers(String name, String callerUuid) {
         final OperationService operationService = nodeEngine.getOperationService();
-        final Collection<MemberImpl> members = nodeEngine.getClusterService().getMemberList();
-        for (MemberImpl member : members) {
+        final Collection<Member> members = nodeEngine.getClusterService().getMembers();
+        for (Member member : members) {
             if (!member.localMember() && !member.getUuid().equals(callerUuid)) {
                 final CacheDestroyOperation op = new CacheDestroyOperation(name, true);
                 operationService.invokeOnTarget(AbstractCacheService.SERVICE_NAME, op, member.getAddress());

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheProxy.java
@@ -18,7 +18,7 @@ package com.hazelcast.cache.impl;
 
 import com.hazelcast.cache.impl.operation.CacheListenerRegistrationOperation;
 import com.hazelcast.config.CacheConfig;
-import com.hazelcast.instance.MemberImpl;
+import com.hazelcast.core.Member;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.InternalCompletableFuture;
@@ -26,15 +26,6 @@ import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.OperationService;
 import com.hazelcast.util.ExceptionUtil;
-
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.Future;
 
 import javax.cache.CacheException;
 import javax.cache.CacheManager;
@@ -45,6 +36,14 @@ import javax.cache.integration.CompletionListener;
 import javax.cache.processor.EntryProcessor;
 import javax.cache.processor.EntryProcessorException;
 import javax.cache.processor.EntryProcessorResult;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Future;
 
 import static com.hazelcast.cache.impl.CacheProxyUtil.getPartitionId;
 import static com.hazelcast.cache.impl.CacheProxyUtil.validateNotNull;
@@ -325,9 +324,9 @@ public class CacheProxy<K, V>
     protected void updateCacheListenerConfigOnOtherNodes(CacheEntryListenerConfiguration<K, V> cacheEntryListenerConfiguration,
                                                          boolean isRegister) {
         final OperationService operationService = getNodeEngine().getOperationService();
-        final Collection<MemberImpl> members = getNodeEngine().getClusterService().getMemberList();
+        final Collection<Member> members = getNodeEngine().getClusterService().getMembers();
         Collection<Future> futures = new ArrayList<Future>();
-        for (MemberImpl member : members) {
+        for (Member member : members) {
             if (!member.localMember()) {
                 final Operation op = new CacheListenerRegistrationOperation(getDistributedObjectName(),
                         cacheEntryListenerConfiguration, isRegister);

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/HazelcastServerCacheManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/HazelcastServerCacheManager.java
@@ -23,7 +23,7 @@ import com.hazelcast.cache.impl.operation.CacheManagementConfigOperation;
 import com.hazelcast.config.CacheConfig;
 import com.hazelcast.config.CacheSimpleConfig;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.instance.MemberImpl;
+import com.hazelcast.core.Member;
 import com.hazelcast.spi.InternalCompletableFuture;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.OperationService;
@@ -85,9 +85,9 @@ public class HazelcastServerCacheManager
 
     private void enableStatisticManagementOnOtherNodes(String cacheName, boolean statOrMan, boolean enabled) {
         String cacheNameWithPrefix = getCacheNameWithPrefix(cacheName);
-        Collection<MemberImpl> members = nodeEngine.getClusterService().getMemberList();
+        Collection<Member> members = nodeEngine.getClusterService().getMembers();
         Collection<Future> futures = new ArrayList<Future>();
-        for (MemberImpl member : members) {
+        for (Member member : members) {
             if (!member.localMember()) {
                 CacheManagementConfigOperation op =
                         new CacheManagementConfigOperation(cacheNameWithPrefix, statOrMan, enabled);

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheCreateConfigOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheCreateConfigOperation.java
@@ -21,7 +21,7 @@ import com.hazelcast.cache.impl.CacheDataSerializerHook;
 import com.hazelcast.cache.impl.CacheService;
 import com.hazelcast.config.CacheConfig;
 import com.hazelcast.core.ExecutionCallback;
-import com.hazelcast.instance.MemberImpl;
+import com.hazelcast.core.Member;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
@@ -88,7 +88,7 @@ public class CacheCreateConfigOperation
         }
         if (createAlsoOnOthers) {
             NodeEngine nodeEngine = getNodeEngine();
-            Collection<MemberImpl> members = nodeEngine.getClusterService().getMemberList();
+            Collection<Member> members = nodeEngine.getClusterService().getMembers();
             int remoteNodeCount = members.size() - 1;
 
             if (remoteNodeCount > 0) {
@@ -96,7 +96,7 @@ public class CacheCreateConfigOperation
 
                 ExecutionCallback<Object> callback = new CacheConfigCreateCallback(this, remoteNodeCount);
                 OperationService operationService = nodeEngine.getOperationService();
-                for (MemberImpl member : members) {
+                for (Member member : members) {
                     if (!member.localMember()) {
                         CacheCreateConfigOperation op = new CacheCreateConfigOperation(config, false);
                         operationService

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngineImpl.java
@@ -35,6 +35,7 @@ import com.hazelcast.core.Client;
 import com.hazelcast.core.ClientListener;
 import com.hazelcast.core.ClientType;
 import com.hazelcast.core.HazelcastInstanceNotActiveException;
+import com.hazelcast.core.Member;
 import com.hazelcast.instance.MemberImpl;
 import com.hazelcast.instance.Node;
 import com.hazelcast.logging.ILogger;
@@ -554,12 +555,12 @@ public class ClientEngineImpl implements ClientEngine, CoreService, PostJoinAwar
         }
 
         private void callDisconnectionOperation(ClientEndpointImpl endpoint) {
-            Collection<MemberImpl> memberList = nodeEngine.getClusterService().getMemberList();
+            Collection<Member> memberList = nodeEngine.getClusterService().getMembers();
             OperationService operationService = nodeEngine.getOperationService();
             ClientDisconnectionOperation op = createClientDisconnectionOperation(endpoint.getUuid());
             operationService.runOperationOnCallingThread(op);
 
-            for (MemberImpl member : memberList) {
+            for (Member member : memberList) {
                 if (!member.localMember()) {
                     op = createClientDisconnectionOperation(endpoint.getUuid());
                     operationService.send(op, member.getAddress());
@@ -623,7 +624,7 @@ public class ClientEngineImpl implements ClientEngine, CoreService, PostJoinAwar
         Map<ClientType, Integer> resultMap = new HashMap<ClientType, Integer>();
         Map<String, ClientType> clientsMap = new HashMap<String, ClientType>();
 
-        for (MemberImpl member : node.getClusterService().getMemberList()) {
+        for (Member member : node.getClusterService().getMembers()) {
             Address target = member.getAddress();
             Future<Map<String, ClientType>> future
                     = operationService.invokeOnTarget(SERVICE_NAME, clientInfoOperation, target);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/client/AuthenticationRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/client/AuthenticationRequest.java
@@ -22,7 +22,7 @@ import com.hazelcast.client.ClientEndpointManager;
 import com.hazelcast.client.impl.ClientEngineImpl;
 import com.hazelcast.client.impl.operations.ClientReAuthOperation;
 import com.hazelcast.config.GroupConfig;
-import com.hazelcast.instance.MemberImpl;
+import com.hazelcast.core.Member;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.serialization.Data;
@@ -139,8 +139,8 @@ public final class AuthenticationRequest extends CallableClientRequest {
             final String uuid = getUuid();
             principal = new ClientPrincipal(uuid, clientEngine.getLocalMember().getUuid());
             reAuthLocal();
-            Collection<MemberImpl> members = clientEngine.getClusterService().getMemberList();
-            for (MemberImpl member : members) {
+            Collection<Member> members = clientEngine.getClusterService().getMembers();
+            for (Member member : members) {
                 if (!member.localMember()) {
                     ClientReAuthOperation op = new ClientReAuthOperation(uuid);
                     op.setCallerUuid(clientEngine.getLocalMember().getUuid());

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/client/GetMemberListRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/client/GetMemberListRequest.java
@@ -39,9 +39,9 @@ public class GetMemberListRequest extends CallableClientRequest implements Retry
     public Object call() throws Exception {
         ClusterService service = getService();
 
-        Collection<MemberImpl> memberList = service.getMemberList();
-        List<Data> response = new ArrayList<Data>(memberList.size());
-        for (MemberImpl member : memberList) {
+        Collection<MemberImpl> members = service.getMemberImpls();
+        List<Data> response = new ArrayList<Data>(members.size());
+        for (MemberImpl member : members) {
             response.add(serializationService.toData(member));
         }
         return new SerializableList(response);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MemberCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MemberCodec.java
@@ -20,7 +20,6 @@ import com.hazelcast.annotation.Codec;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.util.ParameterUtil;
 import com.hazelcast.core.Member;
-import com.hazelcast.instance.AbstractMember;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.Bits;
 
@@ -48,7 +47,7 @@ public final class MemberCodec {
     }
 
     public static void encode(Member member, ClientMessage clientMessage) {
-        AddressCodec.encode(((AbstractMember) member).getAddress(), clientMessage);
+        AddressCodec.encode(member.getAddress(), clientMessage);
         clientMessage.set(member.getUuid());
         Map<String, Object> attributes = new HashMap<String, Object>(member.getAttributes());
         clientMessage.set(attributes.size());
@@ -61,7 +60,7 @@ public final class MemberCodec {
     }
 
     public static int calculateDataSize(Member member) {
-        int dataSize = AddressCodec.calculateDataSize(((AbstractMember) member).getAddress());
+        int dataSize = AddressCodec.calculateDataSize(member.getAddress());
         dataSize += ParameterUtil.calculateDataSize(member.getUuid());
         dataSize += Bits.INT_SIZE_IN_BYTES;
         Map<String, Object> attributes = member.getAttributes();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AuthenticationBaseMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AuthenticationBaseMessageTask.java
@@ -24,7 +24,7 @@ import com.hazelcast.client.impl.client.ClientPrincipal;
 import com.hazelcast.client.impl.operations.ClientReAuthOperation;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.config.GroupConfig;
-import com.hazelcast.instance.MemberImpl;
+import com.hazelcast.core.Member;
 import com.hazelcast.instance.Node;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Address;
@@ -144,8 +144,8 @@ public abstract class AuthenticationBaseMessageTask<P>
 
             principal = new ClientPrincipal(uuid, localMemberUUID);
             reAuthLocal();
-            Collection<MemberImpl> members = nodeEngine.getClusterService().getMemberList();
-            for (MemberImpl member : members) {
+            Collection<Member> members = nodeEngine.getClusterService().getMembers();
+            for (Member member : members) {
                 if (!member.localMember()) {
                     ClientReAuthOperation op = new ClientReAuthOperation(uuid);
                     op.setCallerUuid(localMemberUUID);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/GetPartitionsMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/GetPartitionsMessageTask.java
@@ -20,7 +20,7 @@ import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.ClientGetPartitionsCodec;
 import com.hazelcast.cluster.ClusterService;
 import com.hazelcast.cluster.impl.ClusterServiceImpl;
-import com.hazelcast.instance.MemberImpl;
+import com.hazelcast.core.Member;
 import com.hazelcast.instance.Node;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.Connection;
@@ -45,10 +45,10 @@ public class GetPartitionsMessageTask
         InternalPartitionService service = getService(InternalPartitionService.SERVICE_NAME);
         service.firstArrangement();
         ClusterService clusterService = getService(ClusterServiceImpl.SERVICE_NAME);
-        Collection<MemberImpl> memberList = clusterService.getMemberList();
+        Collection<Member> memberList = clusterService.getMembers();
 
         Map<Address, Set<Integer>> partitionsMap = new HashMap<Address, Set<Integer>>(memberList.size());
-        for (MemberImpl member : memberList) {
+        for (Member member : memberList) {
             Address address = member.getAddress();
             partitionsMap.put(address, new HashSet<Integer>());
         }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/RegisterMembershipListenerMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/RegisterMembershipListenerMessageTask.java
@@ -96,7 +96,7 @@ public class RegisterMembershipListenerMessageTask
         @Override
         public void init(InitialMembershipEvent membershipEvent) {
             ClusterService service = getService(ClusterServiceImpl.SERVICE_NAME);
-            Set members = (Set) service.getMemberList();
+            Set members = (Set) service.getMemberImpls();
             ClientMessage eventMessage = ClientMembershipListenerCodec.encodeMemberSetEvent(members);
             sendClientMessage(endpoint.getUuid(), eventMessage);
         }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/AbstractMapQueryMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/AbstractMapQueryMessageTask.java
@@ -18,7 +18,7 @@ package com.hazelcast.client.impl.protocol.task.map;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.task.AbstractCallableMessageTask;
-import com.hazelcast.instance.MemberImpl;
+import com.hazelcast.core.Member;
 import com.hazelcast.instance.Node;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.map.impl.QueryResult;
@@ -63,7 +63,7 @@ public abstract class AbstractMapQueryMessageTask<P> extends AbstractCallableMes
     protected final Object call() throws Exception {
         Collection<QueryResultEntry> result = new LinkedList<QueryResultEntry>();
 
-        Collection<MemberImpl> members = nodeEngine.getClusterService().getMemberList();
+        Collection<Member> members = nodeEngine.getClusterService().getMembers();
         List<Future> futures = new ArrayList<Future>();
         Predicate predicate = getPredicate();
         createInvocations(members, futures, predicate);
@@ -85,9 +85,9 @@ public abstract class AbstractMapQueryMessageTask<P> extends AbstractCallableMes
 
     protected abstract Object reduce(Collection<QueryResultEntry> result);
 
-    private void createInvocations(Collection<MemberImpl> members, List<Future> futures, Predicate predicate) {
+    private void createInvocations(Collection<Member> members, List<Future> futures, Predicate predicate) {
         final InternalOperationService operationService = nodeEngine.getOperationService();
-        for (MemberImpl member : members) {
+        for (Member member : members) {
             Future future = operationService.createInvocationBuilder(SERVICE_NAME,
                     new QueryOperation(getDistributedObjectName(), predicate),
                     member.getAddress()).invoke();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapAddInterceptorMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapAddInterceptorMessageTask.java
@@ -19,7 +19,7 @@ package com.hazelcast.client.impl.protocol.task.map;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.MapAddInterceptorCodec;
 import com.hazelcast.client.impl.protocol.task.AbstractMultiTargetMessageTask;
-import com.hazelcast.instance.MemberImpl;
+import com.hazelcast.core.Member;
 import com.hazelcast.instance.Node;
 import com.hazelcast.map.MapInterceptor;
 import com.hazelcast.map.impl.MapService;
@@ -67,9 +67,9 @@ public class MapAddInterceptorMessageTask
 
     @Override
     public Collection<Address> getTargets() {
-        Collection<MemberImpl> memberList = nodeEngine.getClusterService().getMemberList();
+        Collection<Member> memberList = nodeEngine.getClusterService().getMembers();
         Collection<Address> addresses = new HashSet<Address>();
-        for (MemberImpl member : memberList) {
+        for (Member member : memberList) {
             addresses.add(member.getAddress());
         }
         return addresses;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapRemoveInterceptorMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapRemoveInterceptorMessageTask.java
@@ -19,7 +19,7 @@ package com.hazelcast.client.impl.protocol.task.map;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.MapRemoveInterceptorCodec;
 import com.hazelcast.client.impl.protocol.task.AbstractMultiTargetMessageTask;
-import com.hazelcast.instance.MemberImpl;
+import com.hazelcast.core.Member;
 import com.hazelcast.instance.Node;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.map.impl.operation.RemoveInterceptorOperationFactory;
@@ -58,9 +58,9 @@ public class MapRemoveInterceptorMessageTask
 
     @Override
     public Collection<Address> getTargets() {
-        Collection<MemberImpl> memberList = nodeEngine.getClusterService().getMemberList();
+        Collection<Member> memberList = nodeEngine.getClusterService().getMembers();
         Collection<Address> addresses = new HashSet<Address>();
-        for (MemberImpl member : memberList) {
+        for (Member member : memberList) {
             addresses.add(member.getAddress());
         }
         return addresses;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/mapreduce/AbstractMapReduceTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/mapreduce/AbstractMapReduceTask.java
@@ -21,7 +21,7 @@ import com.hazelcast.client.impl.protocol.task.AbstractMessageTask;
 import com.hazelcast.cluster.ClusterService;
 import com.hazelcast.config.JobTrackerConfig;
 import com.hazelcast.core.ExecutionCallback;
-import com.hazelcast.instance.MemberImpl;
+import com.hazelcast.core.Member;
 import com.hazelcast.instance.Node;
 import com.hazelcast.mapreduce.CombinerFactory;
 import com.hazelcast.mapreduce.JobTracker;
@@ -107,7 +107,7 @@ public abstract class AbstractMapReduceTask<Parameters>
         }
 
         ClusterService cs = nodeEngine.getClusterService();
-        Collection<MemberImpl> members = cs.getMemberList();
+        Collection<Member> members = cs.getMembers();
 
         String name = getDistributedObjectName();
         String jobId = getJobId();
@@ -127,7 +127,7 @@ public abstract class AbstractMapReduceTask<Parameters>
 
         KeyPredicate predicate = getPredicate();
 
-        for (MemberImpl member : members) {
+        for (Member member : members) {
             Operation operation = new KeyValueJobOperation(name, jobId, chunkSize, keyValueSource, mapper, combinerFactory,
                     reducerFactory, communicateStats, topologyChangedStrategy);
 
@@ -135,7 +135,7 @@ public abstract class AbstractMapReduceTask<Parameters>
         }
 
         // After we prepared all the remote systems we can now start the processing
-        for (MemberImpl member : members) {
+        for (Member member : members) {
             Operation operation = new StartProcessingJobOperation(name, jobId, keyObjects, predicate);
             executeOperation(operation, member.getAddress(), mapReduceService, nodeEngine);
         }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transaction/XACollectTransactionsMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transaction/XACollectTransactionsMessageTask.java
@@ -19,7 +19,7 @@ package com.hazelcast.client.impl.protocol.task.transaction;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.XATransactionCollectTransactionsCodec;
 import com.hazelcast.client.impl.protocol.task.AbstractMultiTargetMessageTask;
-import com.hazelcast.instance.MemberImpl;
+import com.hazelcast.core.Member;
 import com.hazelcast.instance.Node;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.Connection;
@@ -27,8 +27,8 @@ import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.security.permission.TransactionPermission;
 import com.hazelcast.spi.OperationFactory;
 import com.hazelcast.spi.impl.SerializableList;
-import com.hazelcast.transaction.impl.xa.operations.CollectRemoteTransactionsOperationFactory;
 import com.hazelcast.transaction.impl.xa.XAService;
+import com.hazelcast.transaction.impl.xa.operations.CollectRemoteTransactionsOperationFactory;
 
 import java.security.Permission;
 import java.util.Collection;
@@ -70,9 +70,9 @@ public class XACollectTransactionsMessageTask
 
     @Override
     public Collection<Address> getTargets() {
-        Collection<MemberImpl> memberList = clientEngine.getClusterService().getMemberList();
+        Collection<Member> memberList = clientEngine.getClusterService().getMembers();
         Collection<Address> addresses = new HashSet<Address>();
-        for (MemberImpl member : memberList) {
+        for (Member member : memberList) {
             addresses.add(member.getAddress());
         }
         return addresses;

--- a/hazelcast/src/main/java/com/hazelcast/cluster/ClusterService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/ClusterService.java
@@ -49,13 +49,11 @@ public interface ClusterService extends CoreService {
     /**
      * Gets the collection of members.
      * <p/>
-     * TODO: The name of this method is confusing since it says that a list is returned, but a collection is returned.
-     * TODO: This method also is a bit of a duplicate since there already is getMembers. So I think this method can be dropped
      * if we take care of the generics.
      *
      * @return the collection of member. Null will never be returned.
      */
-    Collection<MemberImpl> getMemberList();
+    Collection<MemberImpl> getMemberImpls();
 
     /**
      * Returns a collection of all members part of the cluster.

--- a/hazelcast/src/main/java/com/hazelcast/cluster/client/AddMembershipListenerRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/client/AddMembershipListenerRequest.java
@@ -47,9 +47,9 @@ public final class AddMembershipListenerRequest extends CallableClientRequest im
         String name = ClusterServiceImpl.SERVICE_NAME;
         endpoint.setListenerRegistration(name, name, registrationId);
 
-        Collection<MemberImpl> memberList = service.getMemberList();
-        List<Data> response = new ArrayList<Data>(memberList.size());
-        for (MemberImpl member : memberList) {
+        Collection<MemberImpl> members = service.getMemberImpls();
+        List<Data> response = new ArrayList<Data>(members.size());
+        for (MemberImpl member : members) {
             response.add(serializationService.toData(member));
         }
         return new SerializableList(response);

--- a/hazelcast/src/main/java/com/hazelcast/cluster/client/RegisterMembershipListenerRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/client/RegisterMembershipListenerRequest.java
@@ -76,8 +76,8 @@ public final class RegisterMembershipListenerRequest extends CallableClientReque
         @Override
         public void init(InitialMembershipEvent membershipEvent) {
             ClusterService service = getService();
-            Collection<MemberImpl> memberList = service.getMemberList();
-            ClientInitialMembershipEvent event = new ClientInitialMembershipEvent(memberList);
+            Collection<MemberImpl> members = service.getMemberImpls();
+            ClientInitialMembershipEvent event = new ClientInitialMembershipEvent(members);
             endpoint.sendEvent(endpoint.getUuid(), event, getCallId());
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/operations/FinalizeJoinOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/operations/FinalizeJoinOperation.java
@@ -18,19 +18,18 @@ package com.hazelcast.cluster.impl.operations;
 
 import com.hazelcast.cluster.MemberInfo;
 import com.hazelcast.cluster.impl.ClusterServiceImpl;
-import com.hazelcast.instance.MemberImpl;
+import com.hazelcast.core.Member;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.OperationAccessor;
 import com.hazelcast.spi.OperationService;
 import com.hazelcast.spi.impl.NodeEngineImpl;
-import com.hazelcast.spi.impl.OperationResponseHandlerFactory;
 
 import java.io.IOException;
 import java.util.Collection;
 
-import static com.hazelcast.spi.impl.OperationResponseHandlerFactory.*;
+import static com.hazelcast.spi.impl.OperationResponseHandlerFactory.createEmptyResponseHandler;
 
 public class FinalizeJoinOperation extends MemberInfoUpdateOperation implements JoinOperation {
 
@@ -83,8 +82,8 @@ public class FinalizeJoinOperation extends MemberInfoUpdateOperation implements 
         clusterService.getClusterClock().setClusterStartTime(clusterStartTime);
 
         if (postJoinOperations != null && postJoinOperations.length > 0) {
-            final Collection<MemberImpl> members = clusterService.getMemberList();
-            for (MemberImpl member : members) {
+            final Collection<Member> members = clusterService.getMembers();
+            for (Member member : members) {
                 if (!member.localMember()) {
                     PostJoinOperation operation = new PostJoinOperation(postJoinOperations);
                     operationService.createInvocationBuilder(ClusterServiceImpl.SERVICE_NAME,

--- a/hazelcast/src/main/java/com/hazelcast/executor/impl/ExecutorServiceProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/executor/impl/ExecutorServiceProxy.java
@@ -550,11 +550,11 @@ public class ExecutorServiceProxy
     @Override
     public void shutdown() {
         NodeEngine nodeEngine = getNodeEngine();
-        Collection<MemberImpl> members = nodeEngine.getClusterService().getMemberList();
+        Collection<Member> members = nodeEngine.getClusterService().getMembers();
         OperationService operationService = nodeEngine.getOperationService();
         Collection<Future> calls = new LinkedList<Future>();
 
-        for (MemberImpl member : members) {
+        for (Member member : members) {
             if (member.localMember()) {
                 getService().shutdownExecutor(name);
             } else {
@@ -566,7 +566,7 @@ public class ExecutorServiceProxy
         waitWithDeadline(calls, 1, TimeUnit.SECONDS, WHILE_SHUTDOWN_EXCEPTION_HANDLER);
     }
 
-    private InternalCompletableFuture submitShutdownOperation(OperationService operationService, MemberImpl member) {
+    private InternalCompletableFuture submitShutdownOperation(OperationService operationService, Member member) {
         ShutdownOperation op = new ShutdownOperation(name);
         return operationService.invokeOnTarget(getServiceName(), op, member.getAddress());
     }
@@ -601,8 +601,8 @@ public class ExecutorServiceProxy
             throw new IllegalArgumentException("memberSelector must not be null");
         }
         List<Member> selected = new ArrayList<Member>();
-        Collection<MemberImpl> members = getNodeEngine().getClusterService().getMemberList();
-        for (MemberImpl member : members) {
+        Collection<Member> members = getNodeEngine().getClusterService().getMembers();
+        for (Member member : members) {
             if (memberSelector.select(member)) {
                 selected.add(member);
             }

--- a/hazelcast/src/main/java/com/hazelcast/instance/MemberImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/MemberImpl.java
@@ -209,7 +209,7 @@ public final class MemberImpl
         String uuid = nodeEngine.getLocalMember().getUuid();
         operation.setCallerUuid(uuid).setNodeEngine(nodeEngine);
         try {
-            for (MemberImpl member : nodeEngine.getClusterService().getMemberList()) {
+            for (Member member : nodeEngine.getClusterService().getMembers()) {
                 if (!member.localMember()) {
                     os.send(operation, member.getAddress());
                 } else {

--- a/hazelcast/src/main/java/com/hazelcast/instance/NodeShutdownLatch.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/NodeShutdownLatch.java
@@ -39,7 +39,7 @@ final class NodeShutdownLatch {
 
     NodeShutdownLatch(final Node node) {
         localMember = node.localMember;
-        Collection<MemberImpl> memberList = node.clusterService.getMemberList();
+        Collection<MemberImpl> memberList = node.clusterService.getMemberImpls();
         registrations = new HashMap<String, HazelcastInstanceImpl>(3);
         Set<MemberImpl> members = new HashSet<MemberImpl>(memberList);
         members.remove(localMember);

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/ManagementCenterService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/ManagementCenterService.java
@@ -191,8 +191,8 @@ public class ManagementCenterService {
                 return HttpCommand.RES_403;
             }
 
-            final Collection<MemberImpl> memberList = instance.node.clusterService.getMemberList();
-            for (MemberImpl member : memberList) {
+            final Collection<Member> memberList = instance.node.clusterService.getMembers();
+            for (Member member : memberList) {
                 send(member.getAddress(), new UpdateManagementCenterUrlOperation(newUrl));
             }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/monitors/PerformanceLogFile.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/monitors/PerformanceLogFile.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.internal.monitors;
 
-import com.hazelcast.instance.AbstractMember;
+import com.hazelcast.core.Member;
 import com.hazelcast.instance.BuildInfo;
 import com.hazelcast.instance.BuildInfoProvider;
 import com.hazelcast.instance.GroupProperties;
@@ -97,7 +97,7 @@ final class PerformanceLogFile {
     }
 
     private String getPathName() {
-        AbstractMember localMember = (AbstractMember) hazelcastInstance.getCluster().getLocalMember();
+        Member localMember = hazelcastInstance.getCluster().getLocalMember();
         Address address = localMember.getAddress();
         String addressString = address.getHost().replace(":", "_") + "#" + address.getPort();
         return "performance-" + addressString + "-" + currentTimeMillis() + "-%03d.log";

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/BasicMapContextQuerySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/BasicMapContextQuerySupport.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.map.impl;
 
-import com.hazelcast.instance.MemberImpl;
+import com.hazelcast.core.Member;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.map.QueryResultSizeExceededException;
 import com.hazelcast.map.impl.operation.QueryOperation;
@@ -285,9 +285,9 @@ class BasicMapContextQuerySupport implements MapContextQuerySupport {
 
     private List<Future<QueryResult>> queryOnMembers(String mapName, Predicate predicate) {
         OperationService operationService = nodeEngine.getOperationService();
-        Collection<MemberImpl> members = nodeEngine.getClusterService().getMemberList();
+        Collection<Member> members = nodeEngine.getClusterService().getMembers();
         List<Future<QueryResult>> futures = new ArrayList<Future<QueryResult>>(members.size());
-        for (MemberImpl member : members) {
+        for (Member member : members) {
             QueryOperation operation = new QueryOperation(mapName, predicate);
             Future<QueryResult> future = operationService.invokeOnTarget(MapService.SERVICE_NAME, operation, member.getAddress());
             futures.add(future);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/client/AbstractMapQueryRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/client/AbstractMapQueryRequest.java
@@ -19,7 +19,7 @@ package com.hazelcast.map.impl.client;
 import com.hazelcast.client.impl.client.InvocationClientRequest;
 import com.hazelcast.client.impl.client.RetryableRequest;
 import com.hazelcast.client.impl.client.SecureRequest;
-import com.hazelcast.instance.MemberImpl;
+import com.hazelcast.core.Member;
 import com.hazelcast.map.impl.MapPortableHook;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.map.impl.QueryResult;
@@ -68,7 +68,7 @@ abstract class AbstractMapQueryRequest extends InvocationClientRequest implement
         try {
             Predicate predicate = getPredicate();
 
-            Collection<MemberImpl> members = getClientEngine().getClusterService().getMemberList();
+            Collection<Member> members = getClientEngine().getClusterService().getMembers();
             List<Future> futures = new ArrayList<Future>();
             createInvocations(members, futures, predicate);
 
@@ -88,8 +88,8 @@ abstract class AbstractMapQueryRequest extends InvocationClientRequest implement
         getEndpoint().sendResponse(result, getCallId());
     }
 
-    private void createInvocations(Collection<MemberImpl> members, List<Future> futures, Predicate predicate) {
-        for (MemberImpl member : members) {
+    private void createInvocations(Collection<Member> members, List<Future> futures, Predicate predicate) {
+        for (Member member : members) {
             Future future = createInvocationBuilder(SERVICE_NAME, new QueryOperation(name, predicate),
                     member.getAddress()).invoke();
             futures.add(future);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/client/MapAddInterceptorRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/client/MapAddInterceptorRequest.java
@@ -18,7 +18,7 @@ package com.hazelcast.map.impl.client;
 
 import com.hazelcast.client.impl.client.MultiTargetClientRequest;
 import com.hazelcast.client.impl.client.SecureRequest;
-import com.hazelcast.instance.MemberImpl;
+import com.hazelcast.core.Member;
 import com.hazelcast.map.MapInterceptor;
 import com.hazelcast.map.impl.MapPortableHook;
 import com.hazelcast.map.impl.MapService;
@@ -33,6 +33,7 @@ import com.hazelcast.nio.serialization.PortableWriter;
 import com.hazelcast.security.permission.ActionConstants;
 import com.hazelcast.security.permission.MapPermission;
 import com.hazelcast.spi.OperationFactory;
+
 import java.io.IOException;
 import java.security.Permission;
 import java.util.Collection;
@@ -86,9 +87,9 @@ public class MapAddInterceptorRequest extends MultiTargetClientRequest implement
 
     @Override
     public Collection<Address> getTargets() {
-        Collection<MemberImpl> memberList = getClientEngine().getClusterService().getMemberList();
+        Collection<Member> memberList = getClientEngine().getClusterService().getMembers();
         Collection<Address> addresses = new HashSet<Address>();
-        for (MemberImpl member : memberList) {
+        for (Member member : memberList) {
             addresses.add(member.getAddress());
         }
         return addresses;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/client/MapRemoveInterceptorRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/client/MapRemoveInterceptorRequest.java
@@ -18,7 +18,7 @@ package com.hazelcast.map.impl.client;
 
 import com.hazelcast.client.impl.client.MultiTargetClientRequest;
 import com.hazelcast.client.impl.client.SecureRequest;
-import com.hazelcast.instance.MemberImpl;
+import com.hazelcast.core.Member;
 import com.hazelcast.map.impl.MapPortableHook;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.map.impl.operation.RemoveInterceptorOperationFactory;
@@ -29,6 +29,7 @@ import com.hazelcast.nio.serialization.PortableWriter;
 import com.hazelcast.security.permission.ActionConstants;
 import com.hazelcast.security.permission.MapPermission;
 import com.hazelcast.spi.OperationFactory;
+
 import java.io.IOException;
 import java.security.Permission;
 import java.util.Collection;
@@ -78,9 +79,9 @@ public class MapRemoveInterceptorRequest extends MultiTargetClientRequest implem
 
     @Override
     public Collection<Address> getTargets() {
-        Collection<MemberImpl> memberList = getClientEngine().getClusterService().getMemberList();
+        Collection<Member> memberList = getClientEngine().getClusterService().getMembers();
         Collection<Address> addresses = new HashSet<Address>();
-        for (MemberImpl member : memberList) {
+        for (Member member : memberList) {
             addresses.add(member.getAddress());
         }
         return addresses;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/NearCacheProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/NearCacheProvider.java
@@ -17,7 +17,7 @@
 package com.hazelcast.map.impl.nearcache;
 
 import com.hazelcast.core.HazelcastException;
-import com.hazelcast.instance.MemberImpl;
+import com.hazelcast.core.Member;
 import com.hazelcast.map.impl.MapContainer;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.map.impl.MapServiceContext;
@@ -119,8 +119,8 @@ public class NearCacheProvider {
         if (!isNearCacheEnabled(mapName)) {
             return;
         }
-        Collection<MemberImpl> members = nodeEngine.getClusterService().getMemberList();
-        for (MemberImpl member : members) {
+        Collection<Member> members = nodeEngine.getClusterService().getMembers();
+        for (Member member : members) {
             try {
                 if (member.localMember()) {
                     continue;
@@ -157,8 +157,8 @@ public class NearCacheProvider {
         //send operation.
         Operation operation = new NearCacheKeySetInvalidationOperation(mapName, keys)
                 .setServiceName(MapService.SERVICE_NAME);
-        Collection<MemberImpl> members = nodeEngine.getClusterService().getMemberList();
-        for (MemberImpl member : members) {
+        Collection<Member> members = nodeEngine.getClusterService().getMembers();
+        for (Member member : members) {
             try {
                 if (member.localMember()) {
                     continue;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TransactionalMapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TransactionalMapProxySupport.java
@@ -16,14 +16,14 @@
 
 package com.hazelcast.map.impl.tx;
 
+import com.hazelcast.core.Member;
 import com.hazelcast.core.PartitioningStrategy;
-import com.hazelcast.instance.MemberImpl;
 import com.hazelcast.map.QueryResultSizeExceededException;
 import com.hazelcast.map.impl.MapEntrySet;
 import com.hazelcast.map.impl.MapKeySet;
 import com.hazelcast.map.impl.MapService;
-import com.hazelcast.map.impl.nearcache.NearCache;
 import com.hazelcast.map.impl.QueryResult;
+import com.hazelcast.map.impl.nearcache.NearCache;
 import com.hazelcast.map.impl.operation.ContainsKeyOperation;
 import com.hazelcast.map.impl.operation.GetOperation;
 import com.hazelcast.map.impl.operation.MapEntrySetOperation;
@@ -46,6 +46,7 @@ import com.hazelcast.util.ExceptionUtil;
 import com.hazelcast.util.IterationType;
 import com.hazelcast.util.QueryResultSet;
 import com.hazelcast.util.ThreadUtil;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -282,7 +283,7 @@ public abstract class TransactionalMapProxySupport extends AbstractDistributedOb
     protected Set queryInternal(final Predicate predicate, final IterationType iterationType, final boolean dataResult) {
         NodeEngine nodeEngine = getNodeEngine();
         OperationService operationService = nodeEngine.getOperationService();
-        Collection<MemberImpl> members = nodeEngine.getClusterService().getMemberList();
+        Collection<Member> members = nodeEngine.getClusterService().getMembers();
         int partitionCount = nodeEngine.getPartitionService().getPartitionCount();
         Set<Integer> partitions = new HashSet<Integer>(partitionCount);
         QueryResultSet result = new QueryResultSet(nodeEngine.getSerializationService(), iterationType, dataResult);
@@ -314,8 +315,8 @@ public abstract class TransactionalMapProxySupport extends AbstractDistributedOb
     }
 
     private void invokeQueryOperation(Predicate predicate, OperationService operationService,
-                                      Collection<MemberImpl> members, List<Future> futures) {
-        for (MemberImpl member : members) {
+                                      Collection<Member> members, List<Future> futures) {
+        for (Member member : members) {
             Future future = operationService
                     .invokeOnTarget(SERVICE_NAME, new QueryOperation(name, predicate), member.getAddress());
             futures.add(future);

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/MapReduceService.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/MapReduceService.java
@@ -20,7 +20,7 @@ import com.hazelcast.cluster.ClusterService;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.JobTrackerConfig;
 import com.hazelcast.core.DistributedObject;
-import com.hazelcast.instance.MemberImpl;
+import com.hazelcast.core.Member;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.mapreduce.JobTracker;
@@ -106,7 +106,7 @@ public class MapReduceService
     public boolean registerJobSupervisorCancellation(String name, String jobId, Address jobOwner) {
         NodeJobTracker jobTracker = (NodeJobTracker) createDistributedObject(name);
         if (jobTracker.registerJobSupervisorCancellation(jobId) && getLocalAddress().equals(jobOwner)) {
-            for (MemberImpl member : clusterService.getMemberList()) {
+            for (Member member : clusterService.getMembers()) {
                 if (!member.getAddress().equals(jobOwner)) {
                     try {
                         ProcessingOperation operation = new CancelJobSupervisorOperation(name, jobId);
@@ -200,9 +200,9 @@ public class MapReduceService
     }
 
     public boolean checkAssignedMembersAvailable(Collection<Address> assignedMembers) {
-        Collection<MemberImpl> members = clusterService.getMemberList();
+        Collection<Member> members = clusterService.getMembers();
         List<Address> addresses = new ArrayList<Address>(members.size());
-        for (MemberImpl member : members) {
+        for (Member member : members) {
             addresses.add(member.getAddress());
         }
         for (Address address : assignedMembers) {

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/MapReduceUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/MapReduceUtil.java
@@ -18,7 +18,7 @@ package com.hazelcast.mapreduce.impl;
 
 import com.hazelcast.cluster.ClusterService;
 import com.hazelcast.core.ManagedContext;
-import com.hazelcast.instance.MemberImpl;
+import com.hazelcast.core.Member;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.mapreduce.JobPartitionState;
 import com.hazelcast.mapreduce.PartitionIdAware;
@@ -77,7 +77,7 @@ public final class MapReduceUtil {
             int partitionCount = nodeEngine.getPartitionService().getPartitionCount();
             return new JobProcessInformationImpl(partitionCount, supervisor);
         } else {
-            int partitionCount = nodeEngine.getClusterService().getMemberList().size();
+            int partitionCount = nodeEngine.getClusterService().getSize();
             return new MemberAssigningJobProcessInformationImpl(partitionCount, supervisor);
         }
     }
@@ -239,11 +239,11 @@ public final class MapReduceUtil {
         ClusterService cs = nodeEngine.getClusterService();
         OperationService os = nodeEngine.getOperationService();
 
-        Collection<MemberImpl> members = cs.getMemberList();
+        Collection<Member> members = cs.getMembers();
         List<V> results = returnsResponse ? new ArrayList<V>() : null;
 
         List<Exception> exceptions = new ArrayList<Exception>(members.size());
-        for (MemberImpl member : members) {
+        for (Member member : members) {
             try {
                 Operation operation = operationFactory.createOperation();
                 if (cs.getThisAddress().equals(member.getAddress())) {

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/client/ClientMapReduceRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/client/ClientMapReduceRequest.java
@@ -22,7 +22,7 @@ import com.hazelcast.cluster.ClusterService;
 import com.hazelcast.config.JobTrackerConfig;
 import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.core.ICompletableFuture;
-import com.hazelcast.instance.MemberImpl;
+import com.hazelcast.core.Member;
 import com.hazelcast.mapreduce.CombinerFactory;
 import com.hazelcast.mapreduce.JobTracker;
 import com.hazelcast.mapreduce.KeyPredicate;
@@ -149,8 +149,8 @@ public class ClientMapReduceRequest<KeyIn, ValueIn> extends InvocationClientRequ
         }
 
         ClusterService cs = nodeEngine.getClusterService();
-        Collection<MemberImpl> members = cs.getMemberList();
-        for (MemberImpl member : members) {
+        Collection<Member> members = cs.getMembers();
+        for (Member member : members) {
             Operation operation = new KeyValueJobOperation<KeyIn, ValueIn>(name, jobId, chunkSize, keyValueSource, mapper,
                     combinerFactory, reducerFactory, communicateStats, topologyChangedStrategy);
 
@@ -158,7 +158,7 @@ public class ClientMapReduceRequest<KeyIn, ValueIn> extends InvocationClientRequ
         }
 
         // After we prepared all the remote systems we can now start the processing
-        for (MemberImpl member : members) {
+        for (Member member : members) {
             Operation operation = new StartProcessingJobOperation<KeyIn>(name, jobId, keys, predicate);
             executeOperation(operation, member.getAddress(), mapReduceService, nodeEngine);
         }

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/KeyValueJob.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/KeyValueJob.java
@@ -18,7 +18,7 @@ package com.hazelcast.mapreduce.impl.task;
 
 import com.hazelcast.cluster.ClusterService;
 import com.hazelcast.config.JobTrackerConfig;
-import com.hazelcast.instance.MemberImpl;
+import com.hazelcast.core.Member;
 import com.hazelcast.mapreduce.Collator;
 import com.hazelcast.mapreduce.JobCompletableFuture;
 import com.hazelcast.mapreduce.KeyValueSource;
@@ -80,8 +80,8 @@ public class KeyValueJob<KeyIn, ValueIn>
         }
 
         ClusterService cs = nodeEngine.getClusterService();
-        Collection<MemberImpl> members = cs.getMemberList();
-        for (MemberImpl member : members) {
+        Collection<Member> members = cs.getMembers();
+        for (Member member : members) {
             Operation operation = new KeyValueJobOperation<KeyIn, ValueIn>(name, jobId, chunkSize, keyValueSource, mapper,
                     combinerFactory, reducerFactory, communicateStats, topologyChangedStrategy);
 
@@ -89,7 +89,7 @@ public class KeyValueJob<KeyIn, ValueIn>
         }
 
         // After we prepared all the remote systems we can now start the processing
-        for (MemberImpl member : members) {
+        for (Member member : members) {
             Operation operation = new StartProcessingJobOperation<KeyIn>(name, jobId, keys, predicate);
             executeOperation(operation, member.getAddress(), mapReduceService, nodeEngine);
         }

--- a/hazelcast/src/main/java/com/hazelcast/partition/PartitionServiceProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/PartitionServiceProxy.java
@@ -96,12 +96,12 @@ public class PartitionServiceProxy implements com.hazelcast.core.PartitionServic
     @Override
     public boolean isClusterSafe() {
         final Node node = getNode();
-        final Collection<MemberImpl> memberList = node.clusterService.getMemberList();
+        final Collection<Member> memberList = node.clusterService.getMembers();
         if (memberList == null || memberList.isEmpty() || memberList.size() < 2) {
             return true;
         }
         final Collection<Future> futures = new ArrayList<Future>(memberList.size());
-        for (MemberImpl member : memberList) {
+        for (Member member : memberList) {
             final Address target = member.getAddress();
             final Operation operation = new SafeStateCheckOperation();
             final InternalCompletableFuture future = node.getNodeEngine().getOperationService()

--- a/hazelcast/src/main/java/com/hazelcast/partition/client/GetPartitionsRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/client/GetPartitionsRequest.java
@@ -20,7 +20,7 @@ import com.hazelcast.client.impl.client.CallableClientRequest;
 import com.hazelcast.client.impl.client.ClientPortableHook;
 import com.hazelcast.client.impl.client.RetryableRequest;
 import com.hazelcast.cluster.ClusterService;
-import com.hazelcast.instance.MemberImpl;
+import com.hazelcast.core.Member;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.serialization.Portable;
 import com.hazelcast.partition.InternalPartition;
@@ -38,11 +38,11 @@ public final class GetPartitionsRequest extends CallableClientRequest implements
         InternalPartitionService service = getService();
         service.firstArrangement();
         ClusterService clusterService = getClientEngine().getClusterService();
-        Collection<MemberImpl> memberList = clusterService.getMemberList();
+        Collection<Member> memberList = clusterService.getMembers();
         Address[] addresses = new Address[memberList.size()];
         Map<Address, Integer> addressMap = new HashMap<Address, Integer>(memberList.size());
         int k = 0;
-        for (MemberImpl member : memberList) {
+        for (Member member : memberList) {
             Address address = member.getAddress();
             addresses[k] = address;
             addressMap.put(address, k);

--- a/hazelcast/src/main/java/com/hazelcast/partition/impl/InternalPartitionServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/impl/InternalPartitionServiceImpl.java
@@ -401,7 +401,7 @@ public class InternalPartitionServiceImpl implements InternalPartitionService, M
                     migrationQueue.add(new RepartitioningTask());
 
                     // send initial partition table to newly joined node.
-                    Collection<MemberImpl> members = node.clusterService.getMemberList();
+                    Collection<MemberImpl> members = node.clusterService.getMemberImpls();
                     PartitionStateOperation op = new PartitionStateOperation(createPartitionState(members));
                     nodeEngine.getOperationService().send(op, member.getAddress());
                 }
@@ -537,7 +537,7 @@ public class InternalPartitionServiceImpl implements InternalPartitionService, M
 
         lock.lock();
         try {
-            Collection<MemberImpl> members = node.clusterService.getMemberList();
+            Collection<MemberImpl> members = node.clusterService.getMemberImpls();
             PartitionRuntimeState partitionState = createPartitionState(members);
             PartitionStateOperation op = new PartitionStateOperation(partitionState);
 
@@ -557,7 +557,7 @@ public class InternalPartitionServiceImpl implements InternalPartitionService, M
     }
 
     private void syncPartitionRuntimeState() {
-        syncPartitionRuntimeState(node.clusterService.getMemberList());
+        syncPartitionRuntimeState(node.clusterService.getMemberImpls());
     }
 
     private void syncPartitionRuntimeState(Collection<MemberImpl> members) {
@@ -1664,7 +1664,7 @@ public class InternalPartitionServiceImpl implements InternalPartitionService, M
 
                     migrationQueue.clear();
                     PartitionStateGenerator psg = partitionStateGenerator;
-                    Collection<MemberImpl> members = node.getClusterService().getMemberList();
+                    Collection<MemberImpl> members = node.getClusterService().getMemberImpls();
                     Collection<MemberGroup> memberGroups = memberGroupFactory.createMemberGroups(members);
                     Address[][] newState = psg.reArrange(memberGroups, partitions);
 

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/AbstractBaseReplicatedRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/AbstractBaseReplicatedRecordStore.java
@@ -105,7 +105,7 @@ abstract class AbstractBaseReplicatedRecordStore<K, V>
     public void initialize() {
         initializeListeners();
 
-        List<MemberImpl> members = new ArrayList<MemberImpl>(nodeEngine.getClusterService().getMemberList());
+        List<MemberImpl> members = new ArrayList<MemberImpl>(nodeEngine.getClusterService().getMemberImpls());
         members.remove(localMember);
         if (members.size() == 0) {
             storage.finishLoading();

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/ReplicationPublisher.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/ReplicationPublisher.java
@@ -219,7 +219,7 @@ public class ReplicationPublisher<K, V>
     }
 
     public void retryWithDifferentReplicationNode(Member member) {
-        List<MemberImpl> members = new ArrayList<MemberImpl>(nodeEngine.getClusterService().getMemberList());
+        List<MemberImpl> members = new ArrayList<MemberImpl>(nodeEngine.getClusterService().getMemberImpls());
         members.remove(member);
 
         // If there are less than two members there is not other possible candidate to replicate from
@@ -258,7 +258,7 @@ public class ReplicationPublisher<K, V>
     }
 
     private void executeRemoteClear(boolean emptyReplicationQueue) {
-        List<MemberImpl> failedMembers = new ArrayList<MemberImpl>(clusterService.getMemberList());
+        List<MemberImpl> failedMembers = new ArrayList<MemberImpl>(clusterService.getMemberImpls());
         for (int i = 0; i < MAX_CLEAR_EXECUTION_RETRY; i++) {
             Map<MemberImpl, InternalCompletableFuture> futures = executeClearOnMembers(failedMembers, emptyReplicationQueue);
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/EventServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/EventServiceImpl.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.spi.impl.eventservice.impl;
 
+import com.hazelcast.core.Member;
 import com.hazelcast.instance.GroupProperties;
 import com.hazelcast.instance.HazelcastThreadGroup;
 import com.hazelcast.instance.MemberImpl;
@@ -216,9 +217,9 @@ public class EventServiceImpl implements InternalEventService {
 
     private void invokeRegistrationOnOtherNodes(String serviceName, Registration reg) {
         OperationService operationService = nodeEngine.getOperationService();
-        Collection<MemberImpl> members = nodeEngine.getClusterService().getMemberList();
+        Collection<Member> members = nodeEngine.getClusterService().getMembers();
         Collection<Future> calls = new ArrayList<Future>(members.size());
-        for (MemberImpl member : members) {
+        for (Member member : members) {
             if (!member.localMember()) {
                 RegistrationOperation operation = new RegistrationOperation(reg);
                 Future f = operationService.invokeOnTarget(serviceName, operation, member.getAddress());
@@ -231,9 +232,9 @@ public class EventServiceImpl implements InternalEventService {
 
     private void invokeDeregistrationOnOtherNodes(String serviceName, String topic, String id) {
         OperationService operationService = nodeEngine.getOperationService();
-        Collection<MemberImpl> members = nodeEngine.getClusterService().getMemberList();
+        Collection<Member> members = nodeEngine.getClusterService().getMembers();
         Collection<Future> calls = new ArrayList<Future>(members.size());
-        for (MemberImpl member : members) {
+        for (Member member : members) {
             if (!member.localMember()) {
                 DeregistrationOperation operation = new DeregistrationOperation(topic, id);
                 Future f = operationService.invokeOnTarget(serviceName, operation, member.getAddress());

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/ProxyServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/ProxyServiceImpl.java
@@ -19,7 +19,7 @@ package com.hazelcast.spi.impl.proxyservice.impl;
 import com.hazelcast.core.DistributedObject;
 import com.hazelcast.core.DistributedObjectListener;
 import com.hazelcast.core.HazelcastInstanceNotActiveException;
-import com.hazelcast.instance.MemberImpl;
+import com.hazelcast.core.Member;
 import com.hazelcast.internal.metrics.Probe;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.spi.EventPublishingService;
@@ -136,9 +136,9 @@ public class ProxyServiceImpl
         checkObjectNameNotNull(name);
 
         OperationService operationService = nodeEngine.getOperationService();
-        Collection<MemberImpl> members = nodeEngine.getClusterService().getMemberList();
+        Collection<Member> members = nodeEngine.getClusterService().getMembers();
         Collection<Future> calls = new ArrayList<Future>(members.size());
-        for (MemberImpl member : members) {
+        for (Member member : members) {
             if (member.localMember()) {
                 continue;
             }

--- a/hazelcast/src/main/java/com/hazelcast/transaction/client/CollectXATransactionsRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/client/CollectXATransactionsRequest.java
@@ -17,14 +17,14 @@
 package com.hazelcast.transaction.client;
 
 import com.hazelcast.client.impl.client.MultiTargetClientRequest;
-import com.hazelcast.instance.MemberImpl;
+import com.hazelcast.core.Member;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.security.permission.TransactionPermission;
 import com.hazelcast.spi.OperationFactory;
 import com.hazelcast.spi.impl.SerializableList;
-import com.hazelcast.transaction.impl.xa.operations.CollectRemoteTransactionsOperationFactory;
 import com.hazelcast.transaction.impl.xa.XAService;
+import com.hazelcast.transaction.impl.xa.operations.CollectRemoteTransactionsOperationFactory;
 
 import java.security.Permission;
 import java.util.ArrayList;
@@ -55,9 +55,9 @@ public class CollectXATransactionsRequest extends MultiTargetClientRequest {
 
     @Override
     public Collection<Address> getTargets() {
-        Collection<MemberImpl> memberList = getClientEngine().getClusterService().getMemberList();
+        Collection<Member> memberList = getClientEngine().getClusterService().getMembers();
         Collection<Address> addresses = new HashSet<Address>();
-        for (MemberImpl member : memberList) {
+        for (Member member : memberList) {
             addresses.add(member.getAddress());
         }
         return addresses;

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionManagerServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionManagerServiceImpl.java
@@ -17,6 +17,7 @@
 package com.hazelcast.transaction.impl;
 
 import com.hazelcast.cluster.ClusterService;
+import com.hazelcast.core.Member;
 import com.hazelcast.instance.MemberImpl;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Address;
@@ -155,9 +156,9 @@ public class TransactionManagerServiceImpl implements TransactionManagerService,
 
         //TODO shouldn't we remove TxBackupLog from map ?
         if (log.state == State.ACTIVE) {
-            Collection<MemberImpl> memberList = nodeEngine.getClusterService().getMemberList();
+            Collection<Member> memberList = nodeEngine.getClusterService().getMembers();
             Collection<Future> futures = new ArrayList<Future>(memberList.size());
-            for (MemberImpl member : memberList) {
+            for (Member member : memberList) {
                 Operation op = new BroadcastTxRollbackOperation(txnId);
                 Future f = operationService.invokeOnTarget(SERVICE_NAME, op, member.getAddress());
                 futures.add(f);
@@ -191,7 +192,7 @@ public class TransactionManagerServiceImpl implements TransactionManagerService,
 
     Address[] pickBackupAddresses(int durability) {
         final ClusterService clusterService = nodeEngine.getClusterService();
-        final List<MemberImpl> members = new ArrayList<MemberImpl>(clusterService.getMemberList());
+        final List<MemberImpl> members = new ArrayList<MemberImpl>(clusterService.getMemberImpls());
         members.remove(nodeEngine.getLocalMember());
         final int c = Math.min(members.size(), durability);
         Collections.shuffle(members);

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/XAResourceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/XAResourceImpl.java
@@ -18,7 +18,7 @@ package com.hazelcast.transaction.impl.xa;
 
 import com.hazelcast.cluster.ClusterService;
 import com.hazelcast.config.GroupConfig;
-import com.hazelcast.instance.MemberImpl;
+import com.hazelcast.core.Member;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.nio.Address;
@@ -232,10 +232,10 @@ public final class XAResourceImpl extends AbstractDistributedObject<XAService> i
         XAService xaService = getService();
         OperationService operationService = nodeEngine.getOperationService();
         ClusterService clusterService = nodeEngine.getClusterService();
-        Collection<MemberImpl> memberList = clusterService.getMemberList();
+        Collection<Member> memberList = clusterService.getMembers();
         List<InternalCompletableFuture<SerializableList>> futureList
                 = new ArrayList<InternalCompletableFuture<SerializableList>>();
-        for (MemberImpl member : memberList) {
+        for (Member member : memberList) {
             if (member.localMember()) {
                 continue;
             }


### PR DESCRIPTION
* Address class is exposed by adding getAddress() method to Member interface in 06f7bdd83f28dfbd1cebb734fef8cc79de5ec6c5
* Use ClusterService.getMembers() instead of ClusterService.getMemberList() where only Member.getAddress() is used
* Remove unnecessary AbstractMember casts