### PR TITLE
Remove Packet Data object litter

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -312,7 +312,7 @@
          of dependencies on these classes-->
     <suppress checks="ClassDataAbstractionCoupling" files="com/hazelcast/spi/impl/servicemanager/impl/ServiceManager"/>
 
-    <suppress checks="MethodCount"
+    <suppress checks="MethodCount|ExecutableStatementCount"
               files="com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl"/>
     <!-- the invocation just has many parameters because there are a lot of things to tune/-->
     <suppress checks="ParameterNumber"

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocationServiceSupport.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocationServiceSupport.java
@@ -101,8 +101,8 @@ abstract class ClientInvocationServiceSupport implements ClientInvocationService
         }
         registerInvocation(invocation);
         final SerializationService ss = client.getSerializationService();
-        final Data data = ss.toData(invocation.getRequest());
-        Packet packet = new Packet(data, invocation.getPartitionId());
+        final byte[] bytes = ss.toBytes(invocation.getRequest());
+        Packet packet = new Packet(bytes, invocation.getPartitionId());
         if (!isAllowedToSendRequest(connection, invocation.getRequest()) || !connection.write(packet)) {
             final int callId = invocation.getRequest().getCallId();
             deRegisterCallId(callId);
@@ -331,7 +331,7 @@ abstract class ClientInvocationServiceSupport implements ClientInvocationService
         private void process(Packet packet) {
             final ClientConnection conn = (ClientConnection) packet.getConn();
             try {
-                final ClientResponse clientResponse = client.getSerializationService().toObject(packet.getData());
+                final ClientResponse clientResponse = client.getSerializationService().toObject(packet);
                 final int callId = clientResponse.getCallId();
                 final Data response = clientResponse.getResponse();
                 handlePacket(response, clientResponse.isError(), callId);

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientListenerServiceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientListenerServiceImpl.java
@@ -160,7 +160,7 @@ public final class ClientListenerServiceImpl implements ClientListenerService {
         @Override
         public void run() {
             final ClientConnection conn = (ClientConnection) packet.getConn();
-            final ClientResponse clientResponse = serializationService.toObject(packet.getData());
+            final ClientResponse clientResponse = serializationService.toObject(packet);
             final int callId = clientResponse.getCallId();
             final Data response = clientResponse.getResponse();
             handleEvent(response, callId, conn);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngineImpl.java
@@ -200,9 +200,8 @@ public class ClientEngineImpl implements ClientEngine, CoreService, PostJoinAwar
     public void sendResponse(ClientEndpoint endpoint, Object key, Object response, int callId, boolean isError, boolean isEvent) {
         Data data = serializationService.toData(response);
         ClientResponse clientResponse = new ClientResponse(data, callId, isError);
-        Data responseData = serializationService.toData(clientResponse);
         int partitionId = key == null ? -1 : getPartitionService().getPartitionId(key);
-        final Packet packet = new Packet(responseData, partitionId);
+        Packet packet = new Packet(serializationService.toBytes(clientResponse), partitionId);
         if (isEvent) {
             packet.setHeader(Packet.HEADER_EVENT);
         }
@@ -383,13 +382,12 @@ public class ClientEngineImpl implements ClientEngine, CoreService, PostJoinAwar
                 }
             } catch (Throwable e) {
                 logProcessingFailure(request, e);
-                handleProcessingFailure(endpoint, request, packet.getData(), e);
+                handleProcessingFailure(endpoint, request, packet, e);
             }
         }
 
         private ClientRequest loadRequest() {
-            Data data = packet.getData();
-            return serializationService.toObject(data);
+            return serializationService.toObject(packet);
         }
 
         private void handleEndpointNotCreatedConnectionNotAlive() {

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/SerializationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/SerializationService.java
@@ -34,6 +34,10 @@ public interface SerializationService {
 
     <B extends Data> B toData(Object obj, PartitioningStrategy strategy);
 
+    byte[] toBytes(Object obj);
+
+    byte[] toBytes(Object obj, PartitioningStrategy strategy);
+
     <T> T toObject(Object data);
 
     void writeObject(ObjectDataOutput out, Object obj);

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/impl/HeapData.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/impl/HeapData.java
@@ -27,7 +27,7 @@ import java.util.Arrays;
  * A {@link Data} implementation where the content lives on the heap.
  */
 @SuppressFBWarnings("EI_EXPOSE_REP")
-public final class HeapData implements Data {
+public class HeapData implements Data {
   // type and partition_hash are always written with BIG_ENDIAN byte-order
     public static final int TYPE_OFFSET = 0;
     // will use a byte to store partition_hash bit
@@ -37,17 +37,17 @@ public final class HeapData implements Data {
     // array (12: array header, 4: length)
     private static final int ARRAY_HEADER_SIZE_IN_BYTES = 16;
 
-    private byte[] data;
+    protected byte[] payload;
 
     public HeapData() {
     }
 
-    public HeapData(byte[] data) {
-        if (data != null && data.length > 0 && data.length < DATA_OFFSET) {
+    public HeapData(byte[] payload) {
+        if (payload != null && payload.length > 0 && payload.length < DATA_OFFSET) {
             throw new IllegalArgumentException("Data should be either empty or should contain more than "
-                    + HeapData.DATA_OFFSET + " bytes! -> " + Arrays.toString(data));
+                    + HeapData.DATA_OFFSET + " bytes! -> " + Arrays.toString(payload));
         }
-        this.data = data;
+        this.payload = payload;
     }
 
     @Override
@@ -57,25 +57,25 @@ public final class HeapData implements Data {
 
     @Override
     public int totalSize() {
-        return data != null ? data.length : 0;
+        return payload != null ? payload.length : 0;
     }
 
     @Override
     public int getPartitionHash() {
         if (hasPartitionHash()) {
-            return Bits.readIntB(data, data.length - Bits.INT_SIZE_IN_BYTES);
+            return Bits.readIntB(payload, payload.length - Bits.INT_SIZE_IN_BYTES);
         }
         return hashCode();
     }
 
     @Override
     public boolean hasPartitionHash() {
-        return totalSize() != 0 && data[PARTITION_HASH_BIT_OFFSET] != 0;
+        return totalSize() != 0 && payload[PARTITION_HASH_BIT_OFFSET] != 0;
     }
 
     @Override
     public byte[] toByteArray() {
-        return data;
+        return payload;
     }
 
     @Override
@@ -83,14 +83,14 @@ public final class HeapData implements Data {
         if (totalSize() == 0) {
             return SerializationConstants.CONSTANT_TYPE_NULL;
         }
-        return Bits.readIntB(data, TYPE_OFFSET);
+        return Bits.readIntB(payload, TYPE_OFFSET);
     }
 
     @Override
     public int getHeapCost() {
         // reference (assuming compressed oops)
         int objectRef = Bits.INT_SIZE_IN_BYTES;
-        return objectRef + (data != null ? ARRAY_HEADER_SIZE_IN_BYTES + data.length : 0);
+        return objectRef + (payload != null ? ARRAY_HEADER_SIZE_IN_BYTES + payload.length : 0);
     }
 
     @Override
@@ -115,7 +115,7 @@ public final class HeapData implements Data {
             return false;
         }
 
-        return dataSize == 0 || equals(this.data, data.toByteArray());
+        return dataSize == 0 || equals(this.payload, data.toByteArray());
     }
 
     // Same as Arrays.equals(byte[] a, byte[] a2) but loop order is reversed.
@@ -140,12 +140,12 @@ public final class HeapData implements Data {
 
     @Override
     public int hashCode() {
-        return HashUtil.MurmurHash3_x86_32(data, DATA_OFFSET, dataSize());
+        return HashUtil.MurmurHash3_x86_32(payload, DATA_OFFSET, dataSize());
     }
 
     @Override
     public long hash64() {
-        return HashUtil.MurmurHash3_x64_64(data, DATA_OFFSET, dataSize());
+        return HashUtil.MurmurHash3_x64_64(payload, DATA_OFFSET, dataSize());
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/DefaultPacketReader.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/DefaultPacketReader.java
@@ -72,7 +72,7 @@ public class DefaultPacketReader implements PacketReader {
 
     protected void handleBind(Packet packet) {
         TcpIpConnectionManager connectionManager = connection.getConnectionManager();
-        BindMessage bind = (BindMessage) ioService.toObject(packet.getData());
+        BindMessage bind = (BindMessage) ioService.toObject(packet);
         connectionManager.bind(connection, bind.getLocalAddress(), bind.getTargetAddress(), bind.shouldReply());
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnectionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnectionManager.java
@@ -31,7 +31,6 @@ import com.hazelcast.nio.IOService;
 import com.hazelcast.nio.IOUtil;
 import com.hazelcast.nio.MemberSocketInterceptor;
 import com.hazelcast.nio.Packet;
-import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.tcp.iobalancer.IOBalancer;
 import com.hazelcast.util.ConcurrencyUtil;
 import com.hazelcast.util.ConstructorFunction;
@@ -350,8 +349,8 @@ public class TcpIpConnectionManager implements ConnectionManager {
             log(Level.FINEST, "Sending bind packet to " + remoteEndPoint);
         }
         BindMessage bind = new BindMessage(ioService.getThisAddress(), remoteEndPoint, replyBack);
-        Data bindData = ioService.toData(bind);
-        Packet packet = new Packet(bindData);
+        byte[] bytes = ioService.getSerializationService().toBytes(bind);
+        Packet packet = new Packet(bytes);
         packet.setHeader(Packet.HEADER_BIND);
         connection.write(packet);
         //now you can send anything...

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/WriteHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/WriteHandler.java
@@ -118,7 +118,7 @@ public final class WriteHandler extends AbstractSelectionHandler implements Runn
         long bytesPending = 0;
         for (SocketWritable writable : writeQueue) {
             if (writable instanceof Packet) {
-                bytesPending += ((Packet) writable).size();
+                bytesPending += ((Packet) writable).packetSize();
             }
         }
         return bytesPending;

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/RemoteEventPacketProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/RemoteEventPacketProcessor.java
@@ -17,7 +17,6 @@
 package com.hazelcast.spi.impl.eventservice.impl;
 
 import com.hazelcast.nio.Packet;
-import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.util.executor.StripedRunnable;
 
 public class RemoteEventPacketProcessor extends EventPacketProcessor implements StripedRunnable {
@@ -33,8 +32,7 @@ public class RemoteEventPacketProcessor extends EventPacketProcessor implements 
     @Override
     public void run() {
         try {
-            Data data = packet.getData();
-            EventPacket eventPacket = (EventPacket) eventService.nodeEngine.toObject(data);
+            EventPacket eventPacket = (EventPacket) eventService.nodeEngine.toObject(packet);
             process(eventPacket);
         } catch (Exception e) {
             eventService.logger.warning("Error while logging processing event", e);

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/AsyncResponsePacketHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/AsyncResponsePacketHandler.java
@@ -134,7 +134,7 @@ public class AsyncResponsePacketHandler implements PacketHandler {
             }
         }
 
-        public void shutdown() {
+        private void shutdown() {
             shutdown = true;
             interrupt();
         }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/ResponsePacketHandlerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/ResponsePacketHandlerImpl.java
@@ -18,7 +18,6 @@ package com.hazelcast.spi.impl.operationservice.impl;
 
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Packet;
-import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.SerializationService;
 import com.hazelcast.spi.impl.PacketHandler;
 import com.hazelcast.spi.impl.operationservice.impl.responses.Response;
@@ -42,8 +41,7 @@ final class ResponsePacketHandlerImpl implements PacketHandler {
 
     @Override
     public void handle(Packet packet) throws Exception {
-        Data data = packet.getData();
-        Response response = serializationService.toObject(data);
+        Response response = serializationService.toObject(packet);
         try {
             invocationRegistry.notify(response);
         } catch (Throwable e) {

--- a/hazelcast/src/main/java/com/hazelcast/wan/impl/WanNoDelayReplication.java
+++ b/hazelcast/src/main/java/com/hazelcast/wan/impl/WanNoDelayReplication.java
@@ -23,7 +23,6 @@ import com.hazelcast.nio.Address;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.ConnectionManager;
 import com.hazelcast.nio.Packet;
-import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.InvocationBuilder;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.OperationService;
@@ -103,8 +102,8 @@ public class WanNoDelayReplication
                     }
                 }
                 if (conn != null && conn.isAlive()) {
-                    Data data = node.nodeEngine.getSerializationService().toData(event);
-                    Packet packet = new Packet(data);
+                    byte[] bytes = node.nodeEngine.getSerializationService().toBytes(event);
+                    Packet packet = new Packet(bytes);
                     packet.setHeader(Packet.HEADER_WAN_REPLICATION);
                     node.nodeEngine.getPacketTransceiver().transmit(packet, conn);
                 } else {

--- a/hazelcast/src/main/java/com/hazelcast/wan/impl/WanReplicationServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/wan/impl/WanReplicationServiceImpl.java
@@ -24,7 +24,6 @@ import com.hazelcast.instance.Node;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.ClassLoaderUtil;
 import com.hazelcast.nio.Packet;
-import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.ReplicationSupportingService;
 import com.hazelcast.util.ExceptionUtil;
 import com.hazelcast.util.executor.StripedExecutor;
@@ -105,9 +104,8 @@ public class WanReplicationServiceImpl implements WanReplicationService {
         ex.execute(new StripedRunnable() {
             @Override
             public void run() {
-                final Data data = packet.getData();
                 try {
-                    WanReplicationEvent replicationEvent = (WanReplicationEvent) node.nodeEngine.toObject(data);
+                    WanReplicationEvent replicationEvent = (WanReplicationEvent) node.nodeEngine.toObject(packet);
                     String serviceName = replicationEvent.getServiceName();
                     ReplicationSupportingService service = node.nodeEngine.getService(serviceName);
                     service.onReplicationEvent(replicationEvent);

--- a/hazelcast/src/test/java/com/hazelcast/client/MockSimpleClient.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/MockSimpleClient.java
@@ -66,8 +66,7 @@ public class MockSimpleClient implements SimpleClient {
     }
 
     public void send(Object o) throws IOException {
-        Data data = serializationService.toData(o);
-        Packet packet = new Packet(data);
+        Packet packet = new Packet(serializationService.toBytes(o));
         packet.setConn(connection);
         clientEngine.handlePacket(packet);
     }
@@ -79,7 +78,7 @@ public class MockSimpleClient implements SimpleClient {
         } catch (InterruptedException e) {
             throw new HazelcastException(e);
         }
-        ClientResponse clientResponse = serializationService.toObject(packet.getData());
+        ClientResponse clientResponse = serializationService.toObject(packet);
         return serializationService.toObject(clientResponse.getResponse());
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/PacketTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/PacketTest.java
@@ -69,23 +69,22 @@ public class PacketTest {
         testPacketWriteRead(portablePerson);
     }
 
-    private void testPacketWriteRead(Object object) throws IOException {
+    private void testPacketWriteRead(Object originalObject) throws IOException {
         SerializationService ss = createSerializationServiceBuilder().build();
-        Data data1 = ss.toData(object);
+        byte[] originalPayload = ss.toBytes(originalObject);
 
-        ByteBuffer buffer = ByteBuffer.allocate(data1.dataSize() * 2);
-        Packet packet1 = new Packet(data1);
-        assertTrue(packet1.writeTo(buffer));
+        ByteBuffer buffer = ByteBuffer.allocate(originalPayload.length * 2);
+        Packet originalPacket = new Packet(originalPayload);
+        assertTrue(originalPacket.writeTo(buffer));
         buffer.flip();
 
         SerializationService ss2 = createSerializationServiceBuilder().build();
-        Packet packet2 = new Packet();
-        assertTrue(packet2.readFrom(buffer));
+        Packet clonedPacket = new Packet();
+        assertTrue(clonedPacket.readFrom(buffer));
 
-        Data data2 = packet2.getData();
-        Object object2 = ss2.toObject(data2);
+        Object clonedObject = ss2.toObject(clonedPacket);
 
-        assertEquals(data1, data2);
-        assertEquals(object, object2);
+        assertEquals(originalPacket, clonedPacket);
+        assertEquals(originalObject, clonedObject);
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/classic/AbstractClassicOperationExecutorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/classic/AbstractClassicOperationExecutorTest.java
@@ -102,7 +102,7 @@ public abstract class AbstractClassicOperationExecutorTest extends HazelcastTest
         @Override
         public void handle(Packet packet) throws Exception {
             packets.add(packet);
-            Response response = serializationService.toObject(packet.getData());
+            Response response = serializationService.toObject(packet);
             responses.add(response);
         }
     }
@@ -213,7 +213,7 @@ public abstract class AbstractClassicOperationExecutorTest extends HazelcastTest
         @Override
         public void run(Packet packet) throws Exception {
             packets.add(packet);
-            Operation op = serializationService.toObject(packet.getData());
+            Operation op = serializationService.toObject(packet);
             run(op);
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/classic/ExecutePacketTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/classic/ExecutePacketTest.java
@@ -33,8 +33,7 @@ public class ExecutePacketTest extends AbstractClassicOperationExecutorTest {
         initExecutor();
 
         final NormalResponse normalResponse = new NormalResponse(null, 1, 0, false);
-        Data data = serializationService.toData(normalResponse);
-        final Packet packet = new Packet(data, 0);
+        final Packet packet = new Packet(serializationService.toBytes(normalResponse), 0);
         packet.setHeader(Packet.HEADER_RESPONSE);
         packet.setHeader(Packet.HEADER_OP);
         executor.execute(packet);
@@ -54,8 +53,7 @@ public class ExecutePacketTest extends AbstractClassicOperationExecutorTest {
         initExecutor();
 
         final DummyOperation operation = new DummyOperation(0);
-        Data data = serializationService.toData(operation);
-        final Packet packet = new Packet(data, operation.getPartitionId());
+        final Packet packet = new Packet(serializationService.toBytes(operation), operation.getPartitionId());
         packet.setHeader(Packet.HEADER_OP);
         executor.execute(packet);
 
@@ -74,8 +72,7 @@ public class ExecutePacketTest extends AbstractClassicOperationExecutorTest {
         initExecutor();
 
         final DummyOperation operation = new DummyOperation(Operation.GENERIC_PARTITION_ID);
-        Data data = serializationService.toData(operation);
-        final Packet packet = new Packet(data, operation.getPartitionId());
+        final Packet packet = new Packet(serializationService.toBytes(operation), operation.getPartitionId());
         packet.setHeader(Packet.HEADER_OP);
         executor.execute(packet);
 

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/classic/OperationThreadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/classic/OperationThreadTest.java
@@ -33,9 +33,7 @@ public class OperationThreadTest extends AbstractClassicOperationExecutorTest {
         initExecutor();
 
         DummyOperation operation = new DummyOperation(Operation.GENERIC_PARTITION_ID);
-        Data data = serializationService.toData(operation);
-
-        Packet packet = new Packet(data, operation.getPartitionId());
+        Packet packet = new Packet(serializationService.toBytes(operation), operation.getPartitionId());
         packet.setHeader(Packet.HEADER_OP);
 
         doThrow(new OutOfMemoryError()).when(handler).run(packet);

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/AsyncResponsePacketHandlerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/AsyncResponsePacketHandlerTest.java
@@ -9,7 +9,9 @@ import com.hazelcast.nio.serialization.impl.DefaultSerializationServiceBuilder;
 import com.hazelcast.spi.impl.PacketHandler;
 import com.hazelcast.spi.impl.operationservice.impl.responses.NormalResponse;
 import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.ExpectedRuntimeException;
 import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
@@ -40,8 +42,8 @@ public class AsyncResponsePacketHandlerTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void test() throws Exception {
-        final Packet packet = new Packet(serializationService.toData(new NormalResponse("foo", 1, 0, false)));
+    public void whenNoProblemPacket() throws Exception {
+        final Packet packet = new Packet(serializationService.toBytes(new NormalResponse("foo", 1, 0, false)));
         packet.setHeader(Packet.HEADER_OP);
         packet.setHeader(Packet.HEADER_RESPONSE);
         asyncHandler.handle(packet);
@@ -56,15 +58,15 @@ public class AsyncResponsePacketHandlerTest extends HazelcastTestSupport {
 
     @Test
     public void whenPacketThrowsException() throws Exception {
-        final Packet badPacket = new Packet(serializationService.toData(new NormalResponse("foo", 1, 0, false)));
+        final Packet badPacket = new Packet(serializationService.toBytes(new NormalResponse("bad", 1, 0, false)));
         badPacket.setHeader(Packet.HEADER_OP);
         badPacket.setHeader(Packet.HEADER_RESPONSE);
 
-        final Packet goodPacket = new Packet(serializationService.toData(new NormalResponse("foo", 1, 0, false)));
+        final Packet goodPacket = new Packet(serializationService.toBytes(new NormalResponse("good", 1, 0, false)));
         goodPacket.setHeader(Packet.HEADER_OP);
         goodPacket.setHeader(Packet.HEADER_RESPONSE);
 
-        doThrow(new Exception()).when(responsePacketHandler).handle(badPacket);
+        doThrow(new ExpectedRuntimeException()).when(responsePacketHandler).handle(badPacket);
 
         asyncHandler.handle(badPacket);
         asyncHandler.handle(goodPacket);
@@ -81,7 +83,7 @@ public class AsyncResponsePacketHandlerTest extends HazelcastTestSupport {
     public void whenShutdown(){
         asyncHandler.shutdown();
 
-        final Packet packet = new Packet(serializationService.toData(new NormalResponse("foo", 1, 0, false)));
+        final Packet packet = new Packet(serializationService.toBytes(new NormalResponse("foo", 1, 0, false)));
         packet.setHeader(Packet.HEADER_OP);
         packet.setHeader(Packet.HEADER_RESPONSE);
         asyncHandler.handle(packet);

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImplTest.java
@@ -200,7 +200,7 @@ public class OperationRunnerImplTest extends HazelcastTestSupport {
         setCallId(op, 1000 * 1000);
 
         Packet packet = toPacket(remote, op);
-        byte[] bytes = packet.getData().toByteArray();
+        byte[] bytes = packet.toByteArray();
         for (int k = 0; k < bytes.length; k++) {
             bytes[k]++;
         }

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
@@ -163,8 +163,7 @@ public abstract class HazelcastTestSupport {
         SerializationService serializationService = getSerializationService(hz);
         ConnectionManager connectionManager = getConnectionManager(hz);
 
-        Data data = serializationService.toData(operation);
-        Packet packet = new Packet(data, operation.getPartitionId());
+        Packet packet = new Packet(serializationService.toBytes(operation), operation.getPartitionId());
         packet.setHeader(Packet.HEADER_OP);
         packet.setConn(connectionManager.getConnection(getAddress(hz)));
         return packet;


### PR DESCRIPTION
To reduce the amount of object litter, the Packet nows extends HeapData instead of encapsulating it. Normally this isn't a preferred design approach; but in this case we can remove 4 object allocations per readonly invocation:

* caller side operation data
* receiver side operation data
* receiver side response data
* caller side response data

For a update operation (and a single sync backup) it will be 8 object allocations per invocation.

All these Data instances are now merged into the Packet instance. There is no difference in what goes over the wire; it is just an internal oo modeling thing.