### PR TITLE
Added a minimal null check to WebFilter$RequestWrapper.readSessionFromLocal

### DIFF
--- a/hazelcast-wm/src/main/java/com/hazelcast/web/WebFilter.java
+++ b/hazelcast-wm/src/main/java/com/hazelcast/web/WebFilter.java
@@ -471,8 +471,7 @@ public class WebFilter implements Filter {
                 String hazelcastSessionId = originalSessions.get(originalSession.getId());
                 if (hazelcastSessionId != null) {
                     hazelcastSession = sessions.get(hazelcastSessionId);
-
-                    if (!hazelcastSession.isStickySession()) {
+                    if (hazelcastSession != null && !hazelcastSession.isStickySession()) {
                         hazelcastSession.updateReloadFlag();
                     }
                     return hazelcastSession;


### PR DESCRIPTION
This is intended to fix observed NullPointerExceptions in Hazelcast 3.5.  See https://github.com/hazelcast/hazelcast/issues/5823.