### PR TITLE
Minor dependency cleanup

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/instance/DefaultNodeExtension.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/DefaultNodeExtension.java
@@ -162,7 +162,8 @@ public class DefaultNodeExtension implements NodeExtension {
 
     @Override
     public PacketReader createPacketReader(TcpIpConnection connection, IOService ioService) {
-        return new DefaultPacketReader(connection, ioService);
+        NodeEngineImpl nodeEngine = node.nodeEngine;
+        return new DefaultPacketReader(connection, nodeEngine.getSerializationService(), nodeEngine.getPacketTransceiver());
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/nio/IOService.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/IOService.java
@@ -30,6 +30,7 @@ import com.hazelcast.nio.tcp.PacketWriter;
 import com.hazelcast.nio.tcp.SocketChannelWrapperFactory;
 import com.hazelcast.nio.tcp.TcpIpConnection;
 import com.hazelcast.spi.EventService;
+import com.hazelcast.spi.impl.packettransceiver.PacketTransceiver;
 
 import java.util.Collection;
 
@@ -54,8 +55,6 @@ public interface IOService {
     SymmetricEncryptionConfig getSymmetricEncryptionConfig();
 
     SSLConfig getSSLConfig();
-
-    void handleMemberPacket(Packet p);
 
     void handleClientPacket(Packet p);
 
@@ -139,6 +138,8 @@ public interface IOService {
     SerializationService getSerializationService();
 
     SocketChannelWrapperFactory getSocketChannelWrapperFactory();
+
+    PacketTransceiver getPacketTransceiver();
 
     MemberSocketInterceptor getMemberSocketInterceptor();
 

--- a/hazelcast/src/main/java/com/hazelcast/nio/NodeIOService.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/NodeIOService.java
@@ -106,11 +106,6 @@ public class NodeIOService implements IOService {
     }
 
     @Override
-    public void handleMemberPacket(final Packet packet) {
-        packetTransceiver.receive(packet);
-    }
-
-    @Override
     public void handleClientPacket(Packet p) {
         node.clientEngine.handlePacket(p);
     }
@@ -292,6 +287,11 @@ public class NodeIOService implements IOService {
     @Override
     public SocketChannelWrapperFactory getSocketChannelWrapperFactory() {
         return node.getNodeExtension().getSocketChannelWrapperFactory();
+    }
+
+    @Override
+    public PacketTransceiver getPacketTransceiver() {
+        return node.nodeEngine.getPacketTransceiver();
     }
 
     @Override


### PR DESCRIPTION
Immediately making use of correct services instead of going through the IOService.

It simplifies the flow of a normal packet entering the system. Instead of going through the IOService, it is immediately being pushed into the PacketTransceiver.