### PR TITLE
NotEquals Predicate does not use index

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/NotEqualPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/NotEqualPredicate.java
@@ -46,6 +46,11 @@ public class NotEqualPredicate extends EqualPredicate {
     }
 
     @Override
+    public boolean isIndexed(QueryContext queryContext) {
+        return false;
+    }
+
+    @Override
     public Set<QueryableEntry> filter(QueryContext queryContext) {
         Index index = getIndex(queryContext);
         if (index != null) {

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/PredicatesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/PredicatesTest.java
@@ -26,6 +26,8 @@ import com.hazelcast.query.PredicateBuilder;
 import com.hazelcast.query.Predicates;
 import com.hazelcast.query.QueryException;
 import com.hazelcast.query.impl.AttributeType;
+import com.hazelcast.query.impl.Index;
+import com.hazelcast.query.impl.IndexImpl;
 import com.hazelcast.query.impl.QueryContext;
 import com.hazelcast.query.impl.QueryEntry;
 import com.hazelcast.query.impl.QueryableEntry;
@@ -46,6 +48,8 @@ import static com.hazelcast.instance.TestUtil.toData;
 import com.hazelcast.query.impl.predicates.AndPredicate;
 
 import com.hazelcast.query.impl.predicates.EqualPredicate;
+import org.mockito.Mockito;
+
 import static com.hazelcast.query.Predicates.and;
 import static com.hazelcast.query.Predicates.between;
 import static com.hazelcast.query.Predicates.equal;
@@ -67,6 +71,9 @@ import static java.lang.Boolean.TRUE;
 import static java.util.Map.Entry;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
@@ -290,6 +297,20 @@ public class PredicatesTest extends HazelcastTestSupport {
     public void testInNullWithNullArray() {
         Predicates.in("", null);
     }
+
+    @Test
+    public void testNotEqualsPredicateDoesNotUseIndex() {
+        Index dummyIndex = new IndexImpl("foo", false);
+        QueryContext mockQueryContext = mock(QueryContext.class);
+        when(mockQueryContext.getIndex(anyString())).
+                thenReturn(dummyIndex);
+
+        NotEqualPredicate p = new NotEqualPredicate("foo", "bar");
+
+        boolean indexed = p.isIndexed(mockQueryContext);
+        assertFalse(indexed);
+    }
+
 
     private class DummyEntry extends QueryEntry {
 

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/PredicatesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/PredicatesTest.java
@@ -14,11 +14,17 @@
  * limitations under the License.
  */
 
-package com.hazelcast.query;
+package com.hazelcast.query.impl.predicates;
 
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.query.EntryObject;
+import com.hazelcast.query.IndexAwarePredicate;
+import com.hazelcast.query.Predicate;
+import com.hazelcast.query.PredicateBuilder;
+import com.hazelcast.query.Predicates;
+import com.hazelcast.query.QueryException;
 import com.hazelcast.query.impl.AttributeType;
 import com.hazelcast.query.impl.QueryContext;
 import com.hazelcast.query.impl.QueryEntry;


### PR DESCRIPTION
NotEquals predicate does not use index even when its attribute is indexed.

The `NotEqualsPredicate` has very low selectivity hence the full-map scan is better in vast majority of cases. Moreover the Index implementation is inefficient for `ComparisonType.NOT_EQUAL` as it's traversing the whole index anyway.

The same approach is used by most relation databases - a planner is usually not even trying to estimate cost of indexed access to evaluate NOT_EQUALS predicate and is simply doing a full table scan.