### PR TITLE
mock reference object which equals tester fails to create

### DIFF
--- a/hazelcast-ra/hazelcast-jca/src/test/java/com/hazelcast/jca/ObjectEqualsHashcodeTests.java
+++ b/hazelcast-ra/hazelcast-jca/src/test/java/com/hazelcast/jca/ObjectEqualsHashcodeTests.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import javax.naming.Reference;
 import java.io.PrintWriter;
 
 import static org.mockito.Mockito.mock;
@@ -43,6 +44,7 @@ public class ObjectEqualsHashcodeTests {
     public void testConnectionFactoryImpl() {
         EqualsVerifier.forClass(ConnectionFactoryImpl.class).usingGetClass().withPrefabValues(ManagedConnectionFactoryImpl.class,
                 new ManagedConnectionFactoryImpl(), new ManagedConnectionFactoryImpl())
+                .withPrefabValues(Reference.class, mock(Reference.class), mock(Reference.class))
                 //using non-final fields and transient fields in equals should probably get FIXed
                 .suppress(Warning.NONFINAL_FIELDS).suppress(Warning.TRANSIENT_FIELDS).verify();
     }


### PR DESCRIPTION
Reference object this is used by application container to set JNDI reference cannot be mocked by the tester automatically.

This closes https://github.com/hazelcast/hazelcast/issues/5850