### PR TITLE
Fixed lock lease backup issue - [Backported from #5603]

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/LockBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/LockBackupOperation.java
@@ -33,8 +33,9 @@ public class LockBackupOperation extends BaseLockOperation implements BackupOper
     public LockBackupOperation() {
     }
 
-    public LockBackupOperation(ObjectNamespace namespace, Data key, long threadId, String originalCallerUuid) {
+    public LockBackupOperation(ObjectNamespace namespace, Data key, long threadId, long ttl, String originalCallerUuid) {
         super(namespace, key, threadId);
+        this.ttl = ttl;
         this.originalCallerUuid = originalCallerUuid;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/LockOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/LockOperation.java
@@ -46,7 +46,7 @@ public class LockOperation extends BaseLockOperation implements WaitSupport, Bac
 
     @Override
     public Operation getBackupOperation() {
-        return new LockBackupOperation(namespace, key, threadId, getCallerUuid());
+        return new LockBackupOperation(namespace, key, threadId, ttl, getCallerUuid());
     }
 
     @Override


### PR DESCRIPTION
Fixed a bug which lease-time is not set correctly on backups and when backup is promoted, lease handling process doesn't kicks in. 

Backported from #5603.