### PR TITLE
At most, poll from the cache invalidation queue as the current size of the queue before start to polling

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheService.java
@@ -200,7 +200,14 @@ public class CacheService extends AbstractCacheService {
                  CacheBatchInvalidationMessage batchInvalidationMessage =
                          new CacheBatchInvalidationMessage(cacheName, invalidationMessageQueue.size());
                  CacheSingleInvalidationMessage invalidationMessage;
-                 while ((invalidationMessage = invalidationMessageQueue.poll()) != null) {
+                 final int size = invalidationMessageQueue.size();
+                 // At most, poll from the invalidation queue as the current size of the queue before start to polling.
+                 // So skip new invalidation queue items offered while the polling in progress in this round.
+                 for (int i = 0; i < size; i++) {
+                     invalidationMessage = invalidationMessageQueue.poll();
+                     if (invalidationMessage == null) {
+                         break;
+                     }
                      batchInvalidationMessage.addInvalidationMessage(invalidationMessage);
                  }
                  EventService eventService = nodeEngine.getEventService();


### PR DESCRIPTION
If there are so many cache invalidation events offered to invalidation queue and the `CacheService::CacheBatchInvalidationMessageSender` task is polling from the queue until it is empty, this may cause `CacheService::CacheBatchInvalidationMessageSender` task polls infinitely from the queue without publishing them. This may occur if the producing invalidation events are too high from the consuming invalidation events. 