### PR TITLE
Aggregations tests re-factored so they can be executed in parallel

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/mapreduce/aggregation/AbstractAggregationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/mapreduce/aggregation/AbstractAggregationTest.java
@@ -16,14 +16,10 @@
 
 package com.hazelcast.mapreduce.aggregation;
 
-import com.hazelcast.core.DistributedObject;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.IMap;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.Before;
 
 import java.io.Serializable;
 import java.lang.reflect.Array;
@@ -35,31 +31,17 @@ public class AbstractAggregationTest
     private static final int VALUES_COUNT = 10000;
     private static final Random RANDOM = new Random();
 
-    protected static HazelcastInstance HAZELCAST_INSTANCE;
-    protected static TestHazelcastInstanceFactory INSTANCE_FACTORY;
+    protected HazelcastInstance instance;
+    protected TestHazelcastInstanceFactory instanceFactory;
 
-    @BeforeClass
-    public static void startup() {
-        INSTANCE_FACTORY = new TestHazelcastInstanceFactory(2);
-        HAZELCAST_INSTANCE = INSTANCE_FACTORY.newHazelcastInstance();
-        HazelcastInstance hazelcastInstance = INSTANCE_FACTORY.newHazelcastInstance();
+    @Before
+    public void startup() {
+        instanceFactory = createHazelcastInstanceFactory(2);
+        instance = instanceFactory.newHazelcastInstance();
+        HazelcastInstance hazelcastInstance = instanceFactory.newHazelcastInstance();
 
-        assertClusterSizeEventually(2, HAZELCAST_INSTANCE);
+        assertClusterSizeEventually(2, instance);
         assertClusterSizeEventually(2, hazelcastInstance);
-    }
-
-    @AfterClass
-    public static void teardown() {
-        INSTANCE_FACTORY.shutdownAll();
-    }
-
-    @After
-    public void cleanup() {
-        for (DistributedObject object : HAZELCAST_INSTANCE.getDistributedObjects()) {
-            if (object instanceof IMap) {
-                ((IMap) object).destroy();
-            }
-        }
     }
 
     protected static int random(int min, int max) {

--- a/hazelcast/src/test/java/com/hazelcast/mapreduce/aggregation/MapAvgAggregationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/mapreduce/aggregation/MapAvgAggregationTest.java
@@ -17,7 +17,7 @@
 package com.hazelcast.mapreduce.aggregation;
 
 import com.hazelcast.core.IMap;
-import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -29,7 +29,7 @@ import java.util.Random;
 
 import static org.junit.Assert.assertEquals;
 
-@RunWith(HazelcastSerialClassRunner.class)
+@RunWith(HazelcastParallelClassRunner.class)
 @Category(QuickTest.class)
 public class MapAvgAggregationTest
         extends AbstractAggregationTest {
@@ -258,7 +258,7 @@ public class MapAvgAggregationTest
             throws Exception {
 
         String mapName = randomMapName();
-        IMap<String, T> map = HAZELCAST_INSTANCE.getMap(mapName);
+        IMap<String, T> map = instance.getMap(mapName);
 
         for (int i = 0; i < values.length; i++) {
             map.put("key-" + i, values[i]);
@@ -272,7 +272,7 @@ public class MapAvgAggregationTest
             throws Exception {
 
         String mapName = randomMapName();
-        IMap<String, Value<T>> map = HAZELCAST_INSTANCE.getMap(mapName);
+        IMap<String, Value<T>> map = instance.getMap(mapName);
 
         for (int i = 0; i < values.length; i++) {
             map.put("key-" + i, values[i]);

--- a/hazelcast/src/test/java/com/hazelcast/mapreduce/aggregation/MapBaseAggregationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/mapreduce/aggregation/MapBaseAggregationTest.java
@@ -19,7 +19,7 @@ package com.hazelcast.mapreduce.aggregation;
 import com.hazelcast.core.IMap;
 import com.hazelcast.mapreduce.KeyPredicate;
 import com.hazelcast.query.Predicate;
-import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -33,7 +33,7 @@ import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 
-@RunWith(HazelcastSerialClassRunner.class)
+@RunWith(HazelcastParallelClassRunner.class)
 @Category(QuickTest.class)
 public class MapBaseAggregationTest
         extends AbstractAggregationTest {
@@ -43,7 +43,7 @@ public class MapBaseAggregationTest
             throws Exception {
 
         String mapName = randomMapName();
-        IMap<String, Integer> map = HAZELCAST_INSTANCE.getMap(mapName);
+        IMap<String, Integer> map = instance.getMap(mapName);
 
         Integer[] values = buildPlainValues(new ValueProvider<Integer>() {
             @Override
@@ -67,7 +67,7 @@ public class MapBaseAggregationTest
             throws Exception {
 
         String mapName = randomMapName();
-        IMap<Integer, Integer> map = HAZELCAST_INSTANCE.getMap(mapName);
+        IMap<Integer, Integer> map = instance.getMap(mapName);
 
         Integer[] values = buildPlainValues(new ValueProvider<Integer>() {
             @Override
@@ -92,7 +92,7 @@ public class MapBaseAggregationTest
             throws Exception {
 
         String mapName = randomMapName();
-        IMap<Integer, Integer> map = HAZELCAST_INSTANCE.getMap(mapName);
+        IMap<Integer, Integer> map = instance.getMap(mapName);
 
         Integer[] values = buildPlainValues(new ValueProvider<Integer>() {
             @Override
@@ -118,7 +118,7 @@ public class MapBaseAggregationTest
             throws Exception {
 
         String mapName = randomMapName();
-        IMap<Integer, Integer> map = HAZELCAST_INSTANCE.getMap(mapName);
+        IMap<Integer, Integer> map = instance.getMap(mapName);
 
         Integer[] values = buildPlainValues(new ValueProvider<Integer>() {
             @Override
@@ -143,7 +143,7 @@ public class MapBaseAggregationTest
             throws Exception {
 
         String mapName = randomMapName();
-        IMap<Integer, Integer> map = HAZELCAST_INSTANCE.getMap(mapName);
+        IMap<Integer, Integer> map = instance.getMap(mapName);
 
         Integer[] values = buildPlainValues(new ValueProvider<Integer>() {
             @Override
@@ -172,7 +172,7 @@ public class MapBaseAggregationTest
         Set<String> expectation = new HashSet<String>(Arrays.asList(probes));
 
         String mapName = randomMapName();
-        IMap<String, String> map = HAZELCAST_INSTANCE.getMap(mapName);
+        IMap<String, String> map = instance.getMap(mapName);
 
         String[] values = buildPlainValues(new ValueProvider<String>() {
             @Override

--- a/hazelcast/src/test/java/com/hazelcast/mapreduce/aggregation/MapMaxAggregationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/mapreduce/aggregation/MapMaxAggregationTest.java
@@ -17,7 +17,7 @@
 package com.hazelcast.mapreduce.aggregation;
 
 import com.hazelcast.core.IMap;
-import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -29,7 +29,7 @@ import java.util.Random;
 
 import static org.junit.Assert.assertEquals;
 
-@RunWith(HazelcastSerialClassRunner.class)
+@RunWith(HazelcastParallelClassRunner.class)
 @Category(QuickTest.class)
 public class MapMaxAggregationTest
         extends AbstractAggregationTest {
@@ -292,7 +292,7 @@ public class MapMaxAggregationTest
             throws Exception {
 
         String mapName = randomMapName();
-        IMap<String, T> map = HAZELCAST_INSTANCE.getMap(mapName);
+        IMap<String, T> map = instance.getMap(mapName);
 
         for (int i = 0; i < values.length; i++) {
             map.put("key-" + i, values[i]);
@@ -306,7 +306,7 @@ public class MapMaxAggregationTest
             throws Exception {
 
         String mapName = randomMapName();
-        IMap<String, Value<T>> map = HAZELCAST_INSTANCE.getMap(mapName);
+        IMap<String, Value<T>> map = instance.getMap(mapName);
 
         for (int i = 0; i < values.length; i++) {
             map.put("key-" + i, values[i]);

--- a/hazelcast/src/test/java/com/hazelcast/mapreduce/aggregation/MapMinAggregationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/mapreduce/aggregation/MapMinAggregationTest.java
@@ -17,7 +17,7 @@
 package com.hazelcast.mapreduce.aggregation;
 
 import com.hazelcast.core.IMap;
-import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -29,7 +29,7 @@ import java.util.Random;
 
 import static org.junit.Assert.assertEquals;
 
-@RunWith(HazelcastSerialClassRunner.class)
+@RunWith(HazelcastParallelClassRunner.class)
 @Category(QuickTest.class)
 public class MapMinAggregationTest
         extends AbstractAggregationTest {
@@ -292,7 +292,7 @@ public class MapMinAggregationTest
             throws Exception {
 
         String mapName = randomMapName();
-        IMap<String, T> map = HAZELCAST_INSTANCE.getMap(mapName);
+        IMap<String, T> map = instance.getMap(mapName);
 
         for (int i = 0; i < values.length; i++) {
             map.put("key-" + i, values[i]);
@@ -306,7 +306,7 @@ public class MapMinAggregationTest
             throws Exception {
 
         String mapName = randomMapName();
-        IMap<String, Value<T>> map = HAZELCAST_INSTANCE.getMap(mapName);
+        IMap<String, Value<T>> map = instance.getMap(mapName);
 
         for (int i = 0; i < values.length; i++) {
             map.put("key-" + i, values[i]);

--- a/hazelcast/src/test/java/com/hazelcast/mapreduce/aggregation/MapSumAggregationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/mapreduce/aggregation/MapSumAggregationTest.java
@@ -17,7 +17,7 @@
 package com.hazelcast.mapreduce.aggregation;
 
 import com.hazelcast.core.IMap;
-import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -29,7 +29,7 @@ import java.util.Random;
 
 import static org.junit.Assert.assertEquals;
 
-@RunWith(HazelcastSerialClassRunner.class)
+@RunWith(HazelcastParallelClassRunner.class)
 @Category(QuickTest.class)
 public class MapSumAggregationTest
         extends AbstractAggregationTest {
@@ -248,7 +248,7 @@ public class MapSumAggregationTest
             throws Exception {
 
         String mapName = randomMapName();
-        IMap<String, T> map = HAZELCAST_INSTANCE.getMap(mapName);
+        IMap<String, T> map = instance.getMap(mapName);
 
         for (int i = 0; i < values.length; i++) {
             map.put("key-" + i, values[i]);
@@ -262,7 +262,7 @@ public class MapSumAggregationTest
             throws Exception {
 
         String mapName = randomMapName();
-        IMap<String, Value<T>> map = HAZELCAST_INSTANCE.getMap(mapName);
+        IMap<String, Value<T>> map = instance.getMap(mapName);
 
         for (int i = 0; i < values.length; i++) {
             map.put("key-" + i, values[i]);

--- a/hazelcast/src/test/java/com/hazelcast/mapreduce/aggregation/MultiMapAvgAggregationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/mapreduce/aggregation/MultiMapAvgAggregationTest.java
@@ -17,7 +17,7 @@
 package com.hazelcast.mapreduce.aggregation;
 
 import com.hazelcast.core.MultiMap;
-import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -29,7 +29,7 @@ import java.util.Random;
 
 import static org.junit.Assert.assertEquals;
 
-@RunWith(HazelcastSerialClassRunner.class)
+@RunWith(HazelcastParallelClassRunner.class)
 @Category(QuickTest.class)
 public class MultiMapAvgAggregationTest
         extends AbstractAggregationTest {
@@ -258,7 +258,7 @@ public class MultiMapAvgAggregationTest
             throws Exception {
 
         String mapName = randomMapName();
-        MultiMap<String, T> map = HAZELCAST_INSTANCE.getMultiMap(mapName);
+        MultiMap<String, T> map = instance.getMultiMap(mapName);
 
         for (int i = 0; i < values.length; i++) {
             map.put("key-" + i, values[i]);
@@ -272,7 +272,7 @@ public class MultiMapAvgAggregationTest
             throws Exception {
 
         String mapName = randomMapName();
-        MultiMap<String, Value<T>> map = HAZELCAST_INSTANCE.getMultiMap(mapName);
+        MultiMap<String, Value<T>> map = instance.getMultiMap(mapName);
 
         for (int i = 0; i < values.length; i++) {
             map.put("key-" + i, values[i]);

--- a/hazelcast/src/test/java/com/hazelcast/mapreduce/aggregation/MultiMapBaseAggregationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/mapreduce/aggregation/MultiMapBaseAggregationTest.java
@@ -19,7 +19,7 @@ package com.hazelcast.mapreduce.aggregation;
 import com.hazelcast.core.MultiMap;
 import com.hazelcast.mapreduce.KeyPredicate;
 import com.hazelcast.query.Predicate;
-import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -33,7 +33,7 @@ import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 
-@RunWith(HazelcastSerialClassRunner.class)
+@RunWith(HazelcastParallelClassRunner.class)
 @Category(QuickTest.class)
 public class MultiMapBaseAggregationTest
         extends AbstractAggregationTest {
@@ -43,7 +43,7 @@ public class MultiMapBaseAggregationTest
             throws Exception {
 
         String mapName = randomMapName();
-        MultiMap<String, Integer> map = HAZELCAST_INSTANCE.getMultiMap(mapName);
+        MultiMap<String, Integer> map = instance.getMultiMap(mapName);
 
         Integer[] values = buildPlainValues(new ValueProvider<Integer>() {
             @Override
@@ -67,7 +67,7 @@ public class MultiMapBaseAggregationTest
             throws Exception {
 
         String mapName = randomMapName();
-        MultiMap<Integer, Integer> map = HAZELCAST_INSTANCE.getMultiMap(mapName);
+        MultiMap<Integer, Integer> map = instance.getMultiMap(mapName);
 
         Integer[] values = buildPlainValues(new ValueProvider<Integer>() {
             @Override
@@ -92,7 +92,7 @@ public class MultiMapBaseAggregationTest
             throws Exception {
 
         String mapName = randomMapName();
-        MultiMap<Integer, Integer> map = HAZELCAST_INSTANCE.getMultiMap(mapName);
+        MultiMap<Integer, Integer> map = instance.getMultiMap(mapName);
 
         Integer[] values = buildPlainValues(new ValueProvider<Integer>() {
             @Override
@@ -118,7 +118,7 @@ public class MultiMapBaseAggregationTest
             throws Exception {
 
         String mapName = randomMapName();
-        MultiMap<Integer, Integer> map = HAZELCAST_INSTANCE.getMultiMap(mapName);
+        MultiMap<Integer, Integer> map = instance.getMultiMap(mapName);
 
         Integer[] values = buildPlainValues(new ValueProvider<Integer>() {
             @Override
@@ -143,7 +143,7 @@ public class MultiMapBaseAggregationTest
             throws Exception {
 
         String mapName = randomMapName();
-        MultiMap<Integer, Integer> map = HAZELCAST_INSTANCE.getMultiMap(mapName);
+        MultiMap<Integer, Integer> map = instance.getMultiMap(mapName);
 
         Integer[] values = buildPlainValues(new ValueProvider<Integer>() {
             @Override
@@ -172,7 +172,7 @@ public class MultiMapBaseAggregationTest
         Set<String> expectation = new HashSet<String>(Arrays.asList(probes));
 
         String mapName = randomMapName();
-        MultiMap<String, String> map = HAZELCAST_INSTANCE.getMultiMap(mapName);
+        MultiMap<String, String> map = instance.getMultiMap(mapName);
 
         String[] values = buildPlainValues(new ValueProvider<String>() {
             @Override

--- a/hazelcast/src/test/java/com/hazelcast/mapreduce/aggregation/MultiMapMaxAggregationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/mapreduce/aggregation/MultiMapMaxAggregationTest.java
@@ -17,7 +17,7 @@
 package com.hazelcast.mapreduce.aggregation;
 
 import com.hazelcast.core.MultiMap;
-import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -29,7 +29,7 @@ import java.util.Random;
 
 import static org.junit.Assert.assertEquals;
 
-@RunWith(HazelcastSerialClassRunner.class)
+@RunWith(HazelcastParallelClassRunner.class)
 @Category(QuickTest.class)
 public class MultiMapMaxAggregationTest
         extends AbstractAggregationTest {
@@ -292,7 +292,7 @@ public class MultiMapMaxAggregationTest
             throws Exception {
 
         String mapName = randomMapName();
-        MultiMap<String, T> map = HAZELCAST_INSTANCE.getMultiMap(mapName);
+        MultiMap<String, T> map = instance.getMultiMap(mapName);
 
         for (int i = 0; i < values.length; i++) {
             map.put("key-" + i, values[i]);
@@ -306,7 +306,7 @@ public class MultiMapMaxAggregationTest
             throws Exception {
 
         String mapName = randomMapName();
-        MultiMap<String, Value<T>> map = HAZELCAST_INSTANCE.getMultiMap(mapName);
+        MultiMap<String, Value<T>> map = instance.getMultiMap(mapName);
 
         for (int i = 0; i < values.length; i++) {
             map.put("key-" + i, values[i]);

--- a/hazelcast/src/test/java/com/hazelcast/mapreduce/aggregation/MultiMapMinAggregationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/mapreduce/aggregation/MultiMapMinAggregationTest.java
@@ -17,7 +17,7 @@
 package com.hazelcast.mapreduce.aggregation;
 
 import com.hazelcast.core.MultiMap;
-import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -29,7 +29,7 @@ import java.util.Random;
 
 import static org.junit.Assert.assertEquals;
 
-@RunWith(HazelcastSerialClassRunner.class)
+@RunWith(HazelcastParallelClassRunner.class)
 @Category(QuickTest.class)
 public class MultiMapMinAggregationTest
         extends AbstractAggregationTest {
@@ -292,7 +292,7 @@ public class MultiMapMinAggregationTest
             throws Exception {
 
         String mapName = randomMapName();
-        MultiMap<String, T> map = HAZELCAST_INSTANCE.getMultiMap(mapName);
+        MultiMap<String, T> map = instance.getMultiMap(mapName);
 
         for (int i = 0; i < values.length; i++) {
             map.put("key-" + i, values[i]);
@@ -306,7 +306,7 @@ public class MultiMapMinAggregationTest
             throws Exception {
 
         String mapName = randomMapName();
-        MultiMap<String, Value<T>> map = HAZELCAST_INSTANCE.getMultiMap(mapName);
+        MultiMap<String, Value<T>> map = instance.getMultiMap(mapName);
 
         for (int i = 0; i < values.length; i++) {
             map.put("key-" + i, values[i]);

--- a/hazelcast/src/test/java/com/hazelcast/mapreduce/aggregation/MultiMapSumAggregationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/mapreduce/aggregation/MultiMapSumAggregationTest.java
@@ -17,7 +17,7 @@
 package com.hazelcast.mapreduce.aggregation;
 
 import com.hazelcast.core.MultiMap;
-import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -29,7 +29,7 @@ import java.util.Random;
 
 import static org.junit.Assert.assertEquals;
 
-@RunWith(HazelcastSerialClassRunner.class)
+@RunWith(HazelcastParallelClassRunner.class)
 @Category(QuickTest.class)
 public class MultiMapSumAggregationTest
         extends AbstractAggregationTest {
@@ -248,7 +248,7 @@ public class MultiMapSumAggregationTest
             throws Exception {
 
         String mapName = randomMapName();
-        MultiMap<String, T> map = HAZELCAST_INSTANCE.getMultiMap(mapName);
+        MultiMap<String, T> map = instance.getMultiMap(mapName);
 
         for (int i = 0; i < values.length; i++) {
             map.put("key-" + i, values[i]);
@@ -262,7 +262,7 @@ public class MultiMapSumAggregationTest
             throws Exception {
 
         String mapName = randomMapName();
-        MultiMap<String, Value<T>> map = HAZELCAST_INSTANCE.getMultiMap(mapName);
+        MultiMap<String, Value<T>> map = instance.getMultiMap(mapName);
 
         for (int i = 0; i < values.length; i++) {
             map.put("key-" + i, values[i]);


### PR DESCRIPTION
I see no reason why Aggregations tests should be ran by SerialRunner. 

Cherry picked from #5866.
