### PR TITLE
Fixes MapListener addition issue via EntryListenerConfig 

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/EntryListenerConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/EntryListenerConfig.java
@@ -16,7 +16,22 @@
 
 package com.hazelcast.config;
 
+import com.hazelcast.core.EntryEvent;
 import com.hazelcast.core.EntryListener;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.HazelcastInstanceAware;
+import com.hazelcast.core.MapEvent;
+import com.hazelcast.map.listener.EntryAddedListener;
+import com.hazelcast.map.listener.EntryEvictedListener;
+import com.hazelcast.map.listener.EntryRemovedListener;
+import com.hazelcast.map.listener.EntryUpdatedListener;
+import com.hazelcast.map.listener.MapClearedListener;
+import com.hazelcast.map.listener.MapEvictedListener;
+import com.hazelcast.map.listener.MapListener;
+
+import java.util.EventListener;
+
+import static com.hazelcast.util.Preconditions.isNotNull;
 
 /**
  * Configuration for EntryListener
@@ -45,6 +60,12 @@ public class EntryListenerConfig extends ListenerConfig {
         this.includeValue = includeValue;
     }
 
+    public EntryListenerConfig(MapListener implementation, boolean local, boolean includeValue) {
+        super(toEntryListener(implementation));
+        this.local = local;
+        this.includeValue = includeValue;
+    }
+
     public EntryListenerConfig(EntryListenerConfig config) {
         includeValue = config.isIncludeValue();
         local = config.isLocal();
@@ -59,8 +80,104 @@ public class EntryListenerConfig extends ListenerConfig {
         return readOnly;
     }
 
+    @Override
+    public ListenerConfig setImplementation(EventListener implementation) {
+        isNotNull(implementation, "implementation");
+        this.implementation = toEntryListener(implementation);
+        this.className = null;
+        return this;
+    }
+
     public EntryListener getImplementation() {
         return (EntryListener) implementation;
+    }
+
+    /**
+     * This method provides a workaround by converting a MapListener to EntryListener
+     * when it is added via EntryListenerConfig object.
+     * <p/>
+     * With this method, we are trying to fix two problems :
+     * First, if we do not introduce the conversion in this method, {@link EntryListenerConfig#getImplementation}
+     * will give {@link ClassCastException} with a MapListener implementation.
+     * <p/>
+     * Second goal of the conversion is to preserve backward compatibility.
+     */
+    private static EventListener toEntryListener(Object implementation) {
+        if (implementation instanceof EntryListener) {
+            return (EventListener) implementation;
+        }
+
+        if (implementation instanceof MapListener) {
+            return new MapListenerToEntryListenerAdapter((MapListener) implementation);
+        }
+
+        return (EventListener) implementation;
+
+    }
+
+    /**
+     * Wraps a MapListener into an EntryListener.
+     */
+    public static class MapListenerToEntryListenerAdapter implements EntryListener, HazelcastInstanceAware {
+
+        private final MapListener mapListener;
+
+        public MapListenerToEntryListenerAdapter(MapListener mapListener) {
+            this.mapListener = mapListener;
+        }
+
+        @Override
+        public void entryAdded(EntryEvent event) {
+            if (mapListener instanceof EntryAddedListener) {
+                ((EntryAddedListener) mapListener).entryAdded(event);
+            }
+        }
+
+        @Override
+        public void entryEvicted(EntryEvent event) {
+            if (mapListener instanceof EntryEvictedListener) {
+                ((EntryEvictedListener) mapListener).entryEvicted(event);
+            }
+        }
+
+        @Override
+        public void entryRemoved(EntryEvent event) {
+            if (mapListener instanceof EntryRemovedListener) {
+                ((EntryRemovedListener) mapListener).entryRemoved(event);
+            }
+        }
+
+        @Override
+        public void entryUpdated(EntryEvent event) {
+            if (mapListener instanceof EntryUpdatedListener) {
+                ((EntryUpdatedListener) mapListener).entryUpdated(event);
+            }
+        }
+
+        @Override
+        public void mapCleared(MapEvent event) {
+            if (mapListener instanceof MapClearedListener) {
+                ((MapClearedListener) mapListener).mapCleared(event);
+            }
+        }
+
+        @Override
+        public void mapEvicted(MapEvent event) {
+            if (mapListener instanceof MapEvictedListener) {
+                ((MapEvictedListener) mapListener).mapEvicted(event);
+            }
+        }
+
+        @Override
+        public void setHazelcastInstance(HazelcastInstance hazelcastInstance) {
+            if (mapListener instanceof HazelcastInstanceAware) {
+                ((HazelcastInstanceAware) mapListener).setHazelcastInstance(hazelcastInstance);
+            }
+        }
+
+        public MapListener getMapListener() {
+            return mapListener;
+        }
     }
 
     public EntryListenerConfig setImplementation(final EntryListener implementation) {

--- a/hazelcast/src/test/java/com/hazelcast/map/EntryListenerConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/EntryListenerConfigTest.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hazelcast.map;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.EntryListenerConfig;
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Keep this test serial. It relays on static shared variables.
+ */
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class EntryListenerConfigTest extends HazelcastTestSupport {
+
+    private String mapName = randomMapName();
+    private EntryListenerConfig listenerConfig = new EntryListenerConfig();
+
+    @Before
+    public void setUp() throws Exception {
+        init();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        init();
+    }
+
+    @Test
+    public void testMapListenerAddition_withClassName() throws Exception {
+        listenerConfig.setClassName(TestMapListener.class.getCanonicalName());
+        IMap<Integer, Integer> map = getIMap();
+
+        map.put(1, 1);
+        map.remove(1);
+
+        assertReceivedEventCount(2, TestMapListener.EVENT_COUNT);
+    }
+
+    @Test
+    public void testMapListenerAddition_withImplementation() throws Exception {
+        listenerConfig.setImplementation(new TestMapListener());
+        IMap<Integer, Integer> map = getIMap();
+
+        map.put(1, 1);
+        map.remove(1);
+
+        assertReceivedEventCount(2, TestMapListener.EVENT_COUNT);
+    }
+
+    @Test
+    public void testHazelcastInstanceAwareness_whenMapListenerAdded_withImplementation() throws Exception {
+        listenerConfig.setImplementation(new TestMapListener());
+        IMap<Integer, Integer> map = getIMap();
+
+        map.put(1, 1);
+        map.remove(1);
+
+        assertInstanceSet(TestMapListener.INSTANCE_AWARE);
+    }
+
+    @Test
+    public void testHazelcastInstanceAwareness_whenMapListenerAdded_withClassName() throws Exception {
+        listenerConfig.setClassName(TestMapListener.class.getCanonicalName());
+        IMap<Integer, Integer> map = getIMap();
+
+        map.put(1, 1);
+        map.remove(1);
+
+        assertInstanceSet(TestMapListener.INSTANCE_AWARE);
+    }
+
+
+    @Test
+    public void testEntryListenerAddition_withClassName() throws Exception {
+        listenerConfig.setClassName(TestEntryListener.class.getCanonicalName());
+        IMap<Integer, Integer> map = getIMap();
+
+        map.put(1, 1);
+        map.remove(1);
+
+        assertReceivedEventCount(2, TestEntryListener.EVENT_COUNT);
+
+    }
+
+    @Test
+    public void testEntryListenerAddition_withImplementation() throws Exception {
+        listenerConfig.setImplementation(new TestEntryListener());
+        IMap<Integer, Integer> map = getIMap();
+
+        map.put(1, 1);
+        map.remove(1);
+
+        assertReceivedEventCount(2, TestEntryListener.EVENT_COUNT);
+    }
+
+    @Test
+    public void testHazelcastInstanceAwareness_whenEntryListenerAdded_withImplementation() throws Exception {
+        listenerConfig.setImplementation(new TestEntryListener());
+        IMap<Integer, Integer> map = getIMap();
+
+        map.put(1, 1);
+        map.remove(1);
+
+        assertInstanceSet(TestEntryListener.INSTANCE_AWARE);
+    }
+
+    @Test
+    public void testHazelcastInstanceAwareness_whenEntryListenerAdded_withClassName() throws Exception {
+        listenerConfig.setClassName(TestEntryListener.class.getCanonicalName());
+        IMap<Integer, Integer> map = getIMap();
+
+        map.put(1, 1);
+        map.remove(1);
+
+        assertInstanceSet(TestEntryListener.INSTANCE_AWARE);
+    }
+
+    private IMap<Integer, Integer> getIMap() {
+        MapConfig mapConfig = new MapConfig(mapName);
+        mapConfig.getEntryListenerConfigs().add(listenerConfig);
+
+        Config config = new Config().addMapConfig(mapConfig);
+
+        HazelcastInstance node = createHazelcastInstance(config);
+
+        return node.getMap(mapName);
+    }
+
+    private void assertReceivedEventCount(final int expectedEventCount, final AtomicInteger actualEventCount) {
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertEquals(expectedEventCount, actualEventCount.get());
+            }
+        });
+    }
+
+    private void assertInstanceSet(final AtomicBoolean instanceSet) {
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertTrue(instanceSet.get());
+            }
+        });
+    }
+
+    private void init() {
+        TestMapListener.EVENT_COUNT.set(0);
+        TestMapListener.INSTANCE_AWARE.set(false);
+
+        TestEntryListener.EVENT_COUNT.set(0);
+        TestEntryListener.INSTANCE_AWARE.set(false);
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/map/TestEntryListener.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/TestEntryListener.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map;
+
+import com.hazelcast.core.EntryEvent;
+import com.hazelcast.core.EntryListener;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.HazelcastInstanceAware;
+import com.hazelcast.core.MapEvent;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class TestEntryListener implements EntryListener, HazelcastInstanceAware {
+
+    public static final AtomicInteger EVENT_COUNT = new AtomicInteger();
+    public static final AtomicBoolean INSTANCE_AWARE = new AtomicBoolean();
+
+    private HazelcastInstance instance;
+
+    @Override
+    public void entryAdded(EntryEvent event) {
+        EVENT_COUNT.incrementAndGet();
+    }
+
+    @Override
+    public void entryEvicted(EntryEvent event) {
+        EVENT_COUNT.incrementAndGet();
+    }
+
+    @Override
+    public void entryRemoved(EntryEvent event) {
+        EVENT_COUNT.incrementAndGet();
+    }
+
+    @Override
+    public void entryUpdated(EntryEvent event) {
+        EVENT_COUNT.incrementAndGet();
+    }
+
+    @Override
+    public void mapCleared(MapEvent event) {
+        EVENT_COUNT.incrementAndGet();
+    }
+
+    @Override
+    public void mapEvicted(MapEvent event) {
+        EVENT_COUNT.incrementAndGet();
+    }
+
+    @Override
+    public void setHazelcastInstance(HazelcastInstance hazelcastInstance) {
+        this.instance = hazelcastInstance;
+        INSTANCE_AWARE.set(this.instance != null);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/map/TestMapListener.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/TestMapListener.java
@@ -1,0 +1,34 @@
+package com.hazelcast.map;
+
+import com.hazelcast.core.EntryEvent;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.HazelcastInstanceAware;
+import com.hazelcast.map.listener.EntryAddedListener;
+import com.hazelcast.map.listener.EntryRemovedListener;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class TestMapListener implements EntryAddedListener, EntryRemovedListener, HazelcastInstanceAware {
+
+    public static final AtomicInteger EVENT_COUNT = new AtomicInteger();
+    public static final AtomicBoolean INSTANCE_AWARE = new AtomicBoolean();
+
+    private HazelcastInstance instance;
+
+    @Override
+    public void entryAdded(EntryEvent event) {
+        EVENT_COUNT.incrementAndGet();
+    }
+
+    @Override
+    public void entryRemoved(EntryEvent event) {
+        EVENT_COUNT.incrementAndGet();
+    }
+
+    @Override
+    public void setHazelcastInstance(HazelcastInstance hazelcastInstance) {
+        this.instance = hazelcastInstance;
+        INSTANCE_AWARE.set(this.instance != null);
+    }
+}


### PR DESCRIPTION
closes #5648 

Fixed two issues: first one is addition of a MapListener impl. via EntryListenerConfig object and second one is a left-over which prevents setting of instance to HazelcastInstanceAware listeners