### PR TITLE
New Maven profile for parallel tests execution in multiple JVMs.

### DIFF
--- a/hazelcast-code-generator/pom.xml
+++ b/hazelcast-code-generator/pom.xml
@@ -58,6 +58,48 @@
         </plugins>
     </build>
 
+    <profiles>
+        <profile>
+            <!-- This profile is needed to override configuration from the root pom.xml.
+
+                Otherwise a build of hazelcast-code-generation module is failing as the Surefire Maven plugin
+                cannot load com.hazelcast.test.annotation.ParallelTest classes
+                -->
+            <id>parallelTest</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>${maven.surefire.plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <id>singlejvm</id>
+                                <phase>test</phase>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <configuration combine.self="override">
+                                    <redirectTestOutputToFile>true</redirectTestOutputToFile>
+                                    <argLine>
+                                        -Xms128m -Xmx1G -XX:MaxPermSize=128M
+                                        -Dhazelcast.version.check.enabled=false
+                                        -Dhazelcast.mancenter.enabled=false
+                                        -Dhazelcast.logging.type=none
+                                        -Dhazelcast.test.use.network=false
+                                    </argLine>
+                                    <includes>
+                                        <include>**/**.java</include>
+                                    </includes>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
     <dependencies>
         <dependency>
             <groupId>org.freemarker</groupId>

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastParallelClassRunner.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastParallelClassRunner.java
@@ -23,13 +23,17 @@ import org.junit.runners.model.Statement;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static java.lang.Math.max;
+import static java.lang.Runtime.getRuntime;
+
+
 /**
  * Runs the tests in parallel with multiple threads.
  */
 public class HazelcastParallelClassRunner extends AbstractHazelcastClassRunner {
 
-    private static final int MAX_THREADS = !TestEnvironment.isMockNetwork() ? 1
-                : Math.max(Runtime.getRuntime().availableProcessors()/2, 1);
+    private static final boolean SPAWN_MULTIPLE_THREADS = TestEnvironment.isMockNetwork() && !Boolean.getBoolean("multipleJVM");
+    private static final int MAX_THREADS = SPAWN_MULTIPLE_THREADS ? max(getRuntime().availableProcessors()/2, 1) : 1;
 
     private final AtomicInteger numThreads = new AtomicInteger(0);
 

--- a/hazelcast/src/test/java/com/hazelcast/test/annotation/ParallelTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/annotation/ParallelTest.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test.annotation;
+
+/**
+ * A Parallel test is a test that can run in multiple JVMs in parallel
+ */
+public class ParallelTest {
+}

--- a/pom.xml
+++ b/pom.xml
@@ -256,6 +256,87 @@
     </build>
 
     <profiles>
+        <profile>
+            <id>parallelTest</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>${maven.surefire.plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <id>default-test</id>
+                                <phase>test</phase>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <configuration combine.self="override">
+                                    <redirectTestOutputToFile>true</redirectTestOutputToFile>
+                                    <!-- 1C means 1 process per cpu core -->
+                                    <forkCount>4C</forkCount>
+                                    <reuseForks>true</reuseForks>
+
+                                    <!-- the argLine variable is needed for jacoco-->
+                                    <argLine>
+                                        -Xms128m -Xmx1G -XX:MaxPermSize=128M
+                                        -Dhazelcast.version.check.enabled=false
+                                        -Dhazelcast.mancenter.enabled=false
+                                        -Dhazelcast.logging.type=none
+                                        -Dhazelcast.test.use.network=false
+                                        -Dhazelcast.test.multiple.jvm=true
+                                    </argLine>
+                                    <includes>
+                                        <include>**/**.java</include>
+                                    </includes>
+                                    <excludes>
+                                        <exclude>**/jsr/**.java</exclude>
+                                    </excludes>
+                                    <groups>com.hazelcast.test.annotation.ParallelTest AND com.hazelcast.test.annotation.QuickTest</groups>
+                                    <excludedGroups>
+                                        com.hazelcast.test.annotation.SlowTest,com.hazelcast.test.annotation.NightlyTest
+                                    </excludedGroups>
+                                    <systemPropertyVariables>
+                                        <multipleJVM>true</multipleJVM>
+                                    </systemPropertyVariables>
+                                </configuration>
+                            </execution>
+
+
+                            <execution>
+                                <id>singlejvm</id>
+                                <phase>test</phase>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <configuration combine.self="override">
+                                    <redirectTestOutputToFile>true</redirectTestOutputToFile>
+
+                                    <!-- the argLine variable is needed for jacoco-->
+                                    <argLine>
+                                        -Xms128m -Xmx1G -XX:MaxPermSize=128M
+                                        -Dhazelcast.version.check.enabled=false
+                                        -Dhazelcast.mancenter.enabled=false
+                                        -Dhazelcast.logging.type=none
+                                        -Dhazelcast.test.use.network=false
+                                    </argLine>
+                                    <includes>
+                                        <include>**/**.java</include>
+                                    </includes>
+                                    <excludes>
+                                        <exclude>**/jsr/**.java</exclude>
+                                    </excludes>
+                                    <groups>com.hazelcast.test.annotation.QuickTest</groups>
+                                    <excludedGroups>
+                                        com.hazelcast.test.annotation.SlowTest,com.hazelcast.test.annotation.NightlyTest,com.hazelcast.test.annotation.ParallelTest
+                                    </excludedGroups>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
 
         <profile>
             <id>LOCAL</id>


### PR DESCRIPTION
This is a foundation for JVM-level parallelism.

When the parallelTest profile is activated then tests belonging to QuickTest AND ParallelTest
are executed in multiple JVMs in parallel.

This PR does NOT introduce any test belonging to the ParallelTest category. There will be extra PR with this. I'm using this approach to make it easier to review. 

This is a change from the #5866 package. 