### PR TITLE
Fixed Client LockRequest.getParameters() method

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/client/LockRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/client/LockRequest.java
@@ -57,7 +57,7 @@ public final class LockRequest extends AbstractLockRequest {
 
     @Override
     public Object[] getParameters() {
-        if (timeout == -1 && ttl != Long.MAX_VALUE) {
+        if (timeout == -1 && ttl != -1L) {
             // lock (lease, TimeUnit)
             return new Object[]{ttl, TimeUnit.MILLISECONDS};
         } else if (timeout >= 0) {


### PR DESCRIPTION
Client LockRequest.getParameters() should return null when lease-time is -1 instead of Long.MAX.

See 

https://hazelcast-l337.ci.cloudbees.com/job/Hazelcast-EE-3x/2928/com.hazelcast$hazelcast-enterprise-client/testReport/com.hazelcast.client.security/LockSecurityInterceptorTest/test1_lock/

https://hazelcast-l337.ci.cloudbees.com/job/Hazelcast-EE-3x/2926/com.hazelcast$hazelcast-enterprise-client/testReport/com.hazelcast.client.security/LockSecurityInterceptorTest/test1_lock/

This issue is introduced by https://github.com/hazelcast/hazelcast/pull/5603