### PR TITLE
Packet bind request goes through transceiver

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/instance/DefaultNodeExtension.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/DefaultNodeExtension.java
@@ -32,9 +32,9 @@ import com.hazelcast.memory.MemoryStats;
 import com.hazelcast.nio.ClassLoaderUtil;
 import com.hazelcast.nio.IOService;
 import com.hazelcast.nio.MemberSocketInterceptor;
-import com.hazelcast.nio.serialization.impl.DefaultSerializationServiceBuilder;
 import com.hazelcast.nio.serialization.SerializationService;
 import com.hazelcast.nio.serialization.SerializationServiceBuilder;
+import com.hazelcast.nio.serialization.impl.DefaultSerializationServiceBuilder;
 import com.hazelcast.nio.tcp.DefaultPacketReader;
 import com.hazelcast.nio.tcp.DefaultPacketWriter;
 import com.hazelcast.nio.tcp.DefaultSocketChannelWrapperFactory;
@@ -163,7 +163,7 @@ public class DefaultNodeExtension implements NodeExtension {
     @Override
     public PacketReader createPacketReader(TcpIpConnection connection, IOService ioService) {
         NodeEngineImpl nodeEngine = node.nodeEngine;
-        return new DefaultPacketReader(connection, nodeEngine.getSerializationService(), nodeEngine.getPacketTransceiver());
+        return new DefaultPacketReader(connection, nodeEngine.getPacketTransceiver());
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/nio/IOService.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/IOService.java
@@ -30,7 +30,6 @@ import com.hazelcast.nio.tcp.PacketWriter;
 import com.hazelcast.nio.tcp.SocketChannelWrapperFactory;
 import com.hazelcast.nio.tcp.TcpIpConnection;
 import com.hazelcast.spi.EventService;
-import com.hazelcast.spi.impl.packettransceiver.PacketTransceiver;
 
 import java.util.Collection;
 
@@ -138,8 +137,6 @@ public interface IOService {
     SerializationService getSerializationService();
 
     SocketChannelWrapperFactory getSocketChannelWrapperFactory();
-
-    PacketTransceiver getPacketTransceiver();
 
     MemberSocketInterceptor getMemberSocketInterceptor();
 

--- a/hazelcast/src/main/java/com/hazelcast/nio/NodeIOService.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/NodeIOService.java
@@ -290,11 +290,6 @@ public class NodeIOService implements IOService {
     }
 
     @Override
-    public PacketTransceiver getPacketTransceiver() {
-        return node.nodeEngine.getPacketTransceiver();
-    }
-
-    @Override
     public MemberSocketInterceptor getMemberSocketInterceptor() {
         return node.getNodeExtension().getMemberSocketInterceptor();
     }

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/DefaultPacketReader.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/DefaultPacketReader.java
@@ -16,9 +16,7 @@
 
 package com.hazelcast.nio.tcp;
 
-import com.hazelcast.cluster.impl.BindMessage;
 import com.hazelcast.nio.Packet;
-import com.hazelcast.nio.serialization.SerializationService;
 import com.hazelcast.spi.impl.packettransceiver.PacketTransceiver;
 import com.hazelcast.util.counters.Counter;
 
@@ -27,20 +25,14 @@ import java.nio.ByteBuffer;
 public class DefaultPacketReader implements PacketReader {
 
     protected final TcpIpConnection connection;
-    protected final SerializationService serializationService;
-    protected final TcpIpConnectionManager connectionManager;
     protected Packet packet;
 
     private final PacketTransceiver packetTransceiver;
     private final Counter normalPacketsRead;
     private final Counter priorityPacketsRead;
 
-    public DefaultPacketReader(TcpIpConnection connection,
-                               SerializationService serializationService,
-                               PacketTransceiver packetTransceiver) {
+    public DefaultPacketReader(TcpIpConnection connection, PacketTransceiver packetTransceiver) {
         this.connection = connection;
-        this.connectionManager = connection.getConnectionManager();
-        this.serializationService = serializationService;
         this.packetTransceiver = packetTransceiver;
         this.normalPacketsRead = connection.getReadHandler().getNormalPacketsRead();
         this.priorityPacketsRead = connection.getReadHandler().getPriorityPacketsRead();
@@ -71,11 +63,6 @@ public class DefaultPacketReader implements PacketReader {
 
         packet.setConn(connection);
 
-        if (packet.isHeaderSet(Packet.HEADER_BIND)) {
-            BindMessage bind = serializationService.toObject(packet);
-            connectionManager.bind(connection, bind.getLocalAddress(), bind.getTargetAddress(), bind.shouldReply());
-        } else {
-            packetTransceiver.receive(packet);
-        }
+        packetTransceiver.receive(packet);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/packettransceiver/impl/PacketTransceiverImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/packettransceiver/impl/PacketTransceiverImpl.java
@@ -45,18 +45,21 @@ public class PacketTransceiverImpl implements PacketTransceiver {
     private final PacketHandler eventService;
     private final PacketHandler wanReplicationService;
     private final PacketHandler operationService;
+    private final PacketHandler connectionManager;
 
     public PacketTransceiverImpl(Node node,
                                  ILogger logger,
                                  PacketHandler operationService,
                                  PacketHandler eventService,
                                  PacketHandler wanReplicationService,
+                                 PacketHandler connectionManager,
                                  ExecutionService executionService) {
         this.node = node;
         this.executionService = executionService;
         this.operationService = operationService;
         this.eventService = eventService;
         this.wanReplicationService = wanReplicationService;
+        this.connectionManager = connectionManager;
         this.logger = logger;
     }
 
@@ -77,6 +80,8 @@ public class PacketTransceiverImpl implements PacketTransceiver {
                 eventService.handle(packet);
             } else if (packet.isHeaderSet(Packet.HEADER_WAN_REPLICATION)) {
                 wanReplicationService.handle(packet);
+            } else if (packet.isHeaderSet(Packet.HEADER_BIND)) {
+                connectionManager.handle(packet);
             } else {
                 logger.severe("Unknown packet type! Header: " + packet.getHeader());
             }


### PR DESCRIPTION
The DefaultPacketReader had too many responsibilities. 

Before:
When a bind request comes in, it deserializes it and calls the right method on the TcpIpConnectionManager.

After
Now the reader passes all packets through the PacketTransceiver and here the packet
is send tot he connection manager where the connectionmanager deals with it. So
the bind request packet now follows the same flow as other packets.