### PR TITLE
Fix #5857: Add threadId to MapExecuteOnKeyRequest

### DIFF
--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
@@ -176,7 +176,7 @@ public class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V> {
             return (T) MapRemoveAsyncCodec.decodeResponse(clientMessage).response;
         }
     };
-
+    
     private static final ClientMessageDecoder submitToKeyResponseDecoder = new ClientMessageDecoder() {
         @Override
         public <T> T decodeClientMessage(ClientMessage clientMessage) {
@@ -1086,7 +1086,9 @@ public class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V> {
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
         final Data keyData = toData(key);
         ClientMessage request = MapExecuteOnKeyCodec.encodeRequest(name, toData(entryProcessor), keyData, ThreadUtil.getThreadId());
-        return invoke(request, keyData);
+        ClientMessage response = invoke(request, keyData);
+        MapExecuteOnKeyCodec.ResponseParameters resultParameters = MapExecuteOnKeyCodec.decodeResponse(response);
+        return toObject(resultParameters.response);
     }
 
     public void submitToKey(K key, EntryProcessor entryProcessor, final ExecutionCallback callback) {

--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
@@ -1085,14 +1085,14 @@ public class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V> {
     public Object executeOnKey(K key, EntryProcessor entryProcessor) {
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
         final Data keyData = toData(key);
-        ClientMessage request = MapExecuteOnKeyCodec.encodeRequest(name, toData(entryProcessor), keyData);
+        ClientMessage request = MapExecuteOnKeyCodec.encodeRequest(name, toData(entryProcessor), keyData, ThreadUtil.getThreadId());
         return invoke(request, keyData);
     }
 
     public void submitToKey(K key, EntryProcessor entryProcessor, final ExecutionCallback callback) {
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
         final Data keyData = toData(key);
-        ClientMessage request = MapSubmitToKeyCodec.encodeRequest(name, toData(entryProcessor), keyData);
+        ClientMessage request = MapSubmitToKeyCodec.encodeRequest(name, toData(entryProcessor), keyData, ThreadUtil.getThreadId());
         try {
             final ICompletableFuture future = invokeOnKeyOwner(request, keyData);
             future.andThen(callback);
@@ -1104,7 +1104,7 @@ public class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V> {
     public Future submitToKey(K key, EntryProcessor entryProcessor) {
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
         final Data keyData = toData(key);
-        ClientMessage request = MapSubmitToKeyCodec.encodeRequest(name, toData(entryProcessor), keyData);
+        ClientMessage request = MapSubmitToKeyCodec.encodeRequest(name, toData(entryProcessor), keyData, ThreadUtil.getThreadId());
 
         try {
             final ClientInvocationFuture future = invokeOnKeyOwner(request, keyData);

--- a/hazelcast-client-new/src/test/java/com/hazelcast/client/map/ClientMapLockTest.java
+++ b/hazelcast-client-new/src/test/java/com/hazelcast/client/map/ClientMapLockTest.java
@@ -19,6 +19,8 @@ package com.hazelcast.client.map;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
+import com.hazelcast.map.EntryBackupProcessor;
+import com.hazelcast.map.EntryProcessor;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
@@ -29,7 +31,9 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import java.io.Serializable;
 import java.util.Set;
+import java.util.Map.Entry;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -629,6 +633,42 @@ public class ClientMapLockTest {
         }, 30);
     }
 
+    @Test
+    public void testExecuteOnKeyWhenLock() throws InterruptedException {
+        final IMap map = getMapForLock();
+        final String key = randomString();
+        
+        map.lock(key);
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+            	String payload = randomString();
+                Object ret = map.executeOnKey(key, new LockEntryProcessor(payload));
+                assertEquals(payload, ret);
+            }
+        }, 30);
+        map.unlock(key);
+    }
+    
+    private static class LockEntryProcessor implements EntryProcessor<Object,Object>, Serializable {
+
+    	public final String payload;
+    	public LockEntryProcessor(String payload) {
+    		this.payload = payload;
+    	}
+    	
+		@Override
+		public Object process(Entry entry) {
+			return payload;
+		}
+
+		@Override
+		public EntryBackupProcessor getBackupProcessor() {
+			return null;
+		}
+    	
+    }
+    
     private IMap getMapForLock() {
         return client.getMap(randomString());
     }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
@@ -899,14 +899,14 @@ public class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V> {
     public Object executeOnKey(K key, EntryProcessor entryProcessor) {
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
         final Data keyData = toData(key);
-        MapExecuteOnKeyRequest request = new MapExecuteOnKeyRequest(name, entryProcessor, keyData);
+        MapExecuteOnKeyRequest request = new MapExecuteOnKeyRequest(name, entryProcessor, keyData, ThreadUtil.getThreadId());
         return invoke(request, keyData);
     }
 
     public void submitToKey(K key, EntryProcessor entryProcessor, final ExecutionCallback callback) {
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
         final Data keyData = toData(key);
-        final MapExecuteOnKeyRequest request = new MapExecuteOnKeyRequest(name, entryProcessor, keyData);
+        final MapExecuteOnKeyRequest request = new MapExecuteOnKeyRequest(name, entryProcessor, keyData, ThreadUtil.getThreadId());
         request.setAsSubmitToKey();
         try {
             final ICompletableFuture future = invokeOnKeyOwner(request, keyData);
@@ -919,7 +919,7 @@ public class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V> {
     public Future submitToKey(K key, EntryProcessor entryProcessor) {
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
         final Data keyData = toData(key);
-        final MapExecuteOnKeyRequest request = new MapExecuteOnKeyRequest(name, entryProcessor, keyData);
+        final MapExecuteOnKeyRequest request = new MapExecuteOnKeyRequest(name, entryProcessor, keyData, ThreadUtil.getThreadId());
         request.setAsSubmitToKey();
         try {
             final ICompletableFuture future = invokeOnKeyOwner(request, keyData);

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapLockTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapLockTest.java
@@ -19,6 +19,8 @@ package com.hazelcast.client.map;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
+import com.hazelcast.map.EntryBackupProcessor;
+import com.hazelcast.map.EntryProcessor;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
@@ -29,6 +31,8 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import java.io.Serializable;
+import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -629,6 +633,42 @@ public class ClientMapLockTest {
         }, 30);
     }
 
+    @Test
+    public void testExecuteOnKeyWhenLock() throws InterruptedException {
+        final IMap map = getMapForLock();
+        final String key = randomString();
+        
+        map.lock(key);
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+            	String payload = randomString();
+                Object ret = map.executeOnKey(key, new LockEntryProcessor(payload));
+                assertEquals(payload, ret);
+            }
+        }, 30);
+        map.unlock(key);
+    }
+    
+    private static class LockEntryProcessor implements EntryProcessor<Object,Object>, Serializable {
+
+    	public final String payload;
+    	public LockEntryProcessor(String payload) {
+    		this.payload = payload;
+    	}
+    	
+		@Override
+		public Object process(Entry entry) {
+			return payload;
+		}
+
+		@Override
+		public EntryBackupProcessor getBackupProcessor() {
+			return null;
+		}
+    	
+    }
+    
     private IMap getMapForLock() {
         return client.getMap(randomString());
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapExecuteOnKeyMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapExecuteOnKeyMessageTask.java
@@ -40,7 +40,9 @@ public class MapExecuteOnKeyMessageTask
     @Override
     protected Operation prepareOperation() {
         final EntryProcessor processor = serializationService.toObject(parameters.entryProcessor);
-        return new EntryOperation(parameters.name, parameters.key, processor);
+        EntryOperation op = new EntryOperation(parameters.name, parameters.key, processor);
+        op.setThreadId(parameters.threadId);
+        return op;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapSubmitToKeyMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapSubmitToKeyMessageTask.java
@@ -41,7 +41,9 @@ public class MapSubmitToKeyMessageTask
     @Override
     protected Operation prepareOperation() {
         final EntryProcessor processor = serializationService.toObject(parameters.entryProcessor);
-        return new EntryOperation(parameters.name, parameters.key, processor);
+        EntryOperation op = new EntryOperation(parameters.name, parameters.key, processor);
+        op.setThreadId(parameters.threadId);
+        return op;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/MapCodecTemplate.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/MapCodecTemplate.java
@@ -178,10 +178,10 @@ public interface MapCodecTemplate {
     void clear(String name);
 
     @Request(id = 50, retryable = false, response = ResponseMessageConst.DATA)
-    void executeOnKey(String name, Data entryProcessor, Data key);
+    void executeOnKey(String name, Data entryProcessor, Data key, long threadId);
 
     @Request(id = 51, retryable = false, response = ResponseMessageConst.DATA)
-    void submitToKey(String name, Data entryProcessor, Data key);
+    void submitToKey(String name, Data entryProcessor, Data key, long threadId);
 
     @Request(id = 52, retryable = false, response = ResponseMessageConst.SET_ENTRY)
     void executeOnAllKeys(String name, Data entryProcessor);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/client/MapExecuteOnKeyRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/client/MapExecuteOnKeyRequest.java
@@ -40,14 +40,16 @@ public class MapExecuteOnKeyRequest extends KeyBasedClientRequest implements Por
     private Data key;
     private EntryProcessor processor;
     private boolean submitToKey;
+    private long threadId;
 
     public MapExecuteOnKeyRequest() {
     }
 
-    public MapExecuteOnKeyRequest(String name, EntryProcessor processor, Data key) {
+    public MapExecuteOnKeyRequest(String name, EntryProcessor processor, Data key, long threadId) {
         this.name = name;
         this.processor = processor;
         this.key = key;
+        this.threadId = threadId;
     }
 
     @Override
@@ -57,7 +59,9 @@ public class MapExecuteOnKeyRequest extends KeyBasedClientRequest implements Por
 
     @Override
     protected Operation prepareOperation() {
-        return new EntryOperation(name, key, processor);
+        EntryOperation op = new EntryOperation(name, key, processor);
+        op.setThreadId(threadId);
+        return op;
     }
 
     public String getServiceName() {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/client/MapExecuteOnKeyRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/client/MapExecuteOnKeyRequest.java
@@ -87,6 +87,7 @@ public class MapExecuteOnKeyRequest extends KeyBasedClientRequest implements Por
         final ObjectDataOutput out = writer.getRawDataOutput();
         out.writeData(key);
         out.writeObject(processor);
+        out.writeLong(threadId);
     }
 
     public void read(PortableReader reader) throws IOException {
@@ -95,6 +96,7 @@ public class MapExecuteOnKeyRequest extends KeyBasedClientRequest implements Por
         final ObjectDataInput in = reader.getRawDataInput();
         key = in.readData();
         processor = in.readObject();
+        threadId = in.readLong();
     }
 
     public Permission getRequiredPermission() {


### PR DESCRIPTION
* Add threadId as a long to MapExecuteOnKeyRequest, which should tag the
request as the id of the current thread, typically from ThreadUtils.getThreadId. Similarly, add threadId to the client protocol MapCodecTemplate methods relating to executeOnKey and submitToKey.

* Set threadId in the EntryOperation returned by MapExecuteOnKeyRequest.prepareOperation, MapSubmitToKeyRequest.prepareOperation and MapExecuteOnKeyMessageTask.prepareOperation.

* Supply threadId in ClientMapProxy when creating such requests.

* hazelcast-client-new/ClientMapProxy: Fix broken contract on
executeOnKey where the raw ClientMessage was being returned, by decoding
the message, retrieving the response, and deserializing the embedded
payload from Data to Object.

* provide unit-tests that prove all of the above.

Fixes #5857 and broken IMap contract, as described above.
