### PR TITLE
RecordStore load status checked by Query threads

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/DefaultRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/DefaultRecordStore.java
@@ -44,6 +44,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Future;
 
@@ -60,7 +61,8 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore implements 
     private final MapStoreContext mapStoreContext;
     private final RecordStoreLoader recordStoreLoader;
     private final MapKeyLoader keyLoader;
-    private final Collection<Future> loadingFutures = new ArrayList<Future>();
+    // loadingFutures are modified by partition threads and could be accessed by query threads
+    private final Collection<Future> loadingFutures = new ConcurrentLinkedQueue<Future>();
 
     public DefaultRecordStore(MapContainer mapContainer, int partitionId,
                               MapKeyLoader keyLoader, ILogger logger) {
@@ -121,15 +123,21 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore implements 
 
     @Override
     public void checkIfLoaded() {
+        if (loadingFutures.isEmpty()) {
+            return;
+        }
+
         if (isLoaded()) {
+            List<Future> doneFutures = null;
             try {
-                // check all loading futures for exceptions
-                FutureUtil.checkAllDone(loadingFutures);
+                doneFutures = FutureUtil.getAllDone(loadingFutures);
+                // check all finished loading futures for exceptions
+                FutureUtil.checkAllDone(doneFutures);
             } catch (Exception e) {
                 logger.severe("Exception while loading map " + name, e);
                 ExceptionUtil.rethrow(e);
             } finally {
-                loadingFutures.clear();
+                loadingFutures.removeAll(doneFutures);
             }
         } else {
             keyLoader.triggerLoadingWithDelay();

--- a/hazelcast/src/main/java/com/hazelcast/util/FutureUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/FutureUtil.java
@@ -347,4 +347,19 @@ public final class FutureUtil {
             }
         }
     }
+
+    /**
+     * Get all futures that are done
+     * @param futures
+     * @return list of completed futures
+     */
+    public static List<Future> getAllDone(Collection<Future> futures) {
+        List<Future> doneFutures = new ArrayList<Future>();
+        for (Future f: futures) {
+            if (f.isDone()) {
+                doneFutures.add(f);
+            }
+        }
+        return doneFutures;
+    }
 }

--- a/hazelcast/src/test/java/com/hazelcast/util/FutureUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/FutureUtilTest.java
@@ -23,9 +23,6 @@ import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.transaction.TransactionTimedOutException;
 import com.hazelcast.util.FutureUtil.ExceptionHandler;
 import com.hazelcast.util.executor.CompletedFuture;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -45,9 +42,15 @@ import java.util.logging.Level;
 import static com.hazelcast.util.FutureUtil.logAllExceptions;
 import static com.hazelcast.util.FutureUtil.returnWithDeadline;
 import static com.hazelcast.util.FutureUtil.waitWithDeadline;
+import static java.util.Arrays.asList;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category(QuickTest.class)
@@ -197,6 +200,15 @@ public class FutureUtilTest extends HazelcastTestSupport {
         InterruptedException exception = new InterruptedException();
         Collection<Future> futures = Arrays.asList((Future) new CompletedFuture(null, exception, null));
         FutureUtil.checkAllDone(futures);
+    }
+
+    @Test
+    public void testGetAllDone_whenSomeFuturesAreCompleted() {
+        Future completedFuture = new CompletedFuture(null, null, null);
+        Collection<Future> futures = asList(new UncancellableFuture(), completedFuture, new UncancellableFuture());
+
+        assertEquals(1, FutureUtil.getAllDone(futures).size());
+        assertEquals(completedFuture, FutureUtil.getAllDone(futures).get(0));
     }
 
     private static final class ExceptionCollector implements ExceptionHandler {


### PR DESCRIPTION
Queries can also check map's loading status and that can happen on non-partition threads. Changing ArrayList to ConcurrentLinkedQueue for storing loading futures.

Porting to master after merge.