### PR TITLE
Fixed Long2LongHashMap.size()

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/util/collection/Long2LongHashMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/collection/Long2LongHashMap.java
@@ -478,6 +478,7 @@ public class Long2LongHashMap implements Map<Long, Long> {
         resizeThreshold = (int) (newCapacity * loadFactor);
         mask = (newCapacity * 2) - 1;
         entries = new long[newCapacity * 2];
+        size = 0;
         Arrays.fill(entries, missingValue);
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/util/collection/Int2ObjectHashMapTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/collection/Int2ObjectHashMapTest.java
@@ -28,8 +28,6 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Set;
 
 import static java.lang.Integer.valueOf;
 import static org.hamcrest.core.Is.is;
@@ -290,6 +288,16 @@ public class Int2ObjectHashMapTest {
 
         final String mapAsAString = "{7=7, 12=12, 19=19, 3=3, 11=11, 1=1}";
         assertThat(intToObjectMap.toString(), equalTo(mapAsAString));
+    }
+
+    @Test
+    public void sizeShouldReturnNumberOfEntries() {
+        final int count = 100;
+        for (int key = 0; key < count; key++) {
+            intToObjectMap.put(key, "value");
+        }
+
+        assertEquals(count, intToObjectMap.size());
     }
 }
 

--- a/hazelcast/src/test/java/com/hazelcast/util/collection/Long2LongHashMapTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/collection/Long2LongHashMapTest.java
@@ -17,9 +17,9 @@
 
 package com.hazelcast.util.collection;
 
-import com.hazelcast.util.function.LongLongConsumer;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.util.function.LongLongConsumer;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -27,7 +27,6 @@ import org.mockito.InOrder;
 
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -247,4 +246,13 @@ public class Long2LongHashMapTest {
         assertThat("iterator has failed to be reset", keys, hasItems(1L, 2L));
     }
 
+    @Test
+    public void sizeShouldReturnNumberOfEntries() {
+        final int count = 100;
+        for (int key = 0; key < count; key++) {
+            map.put(key, 1);
+        }
+
+        assertEquals(count, map.size());
+    }
 }

--- a/hazelcast/src/test/java/com/hazelcast/util/collection/Long2ObjectHashMapTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/collection/Long2ObjectHashMapTest.java
@@ -26,12 +26,9 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Set;
 
 import static java.lang.Long.valueOf;
 import static org.hamcrest.core.Is.is;
@@ -285,6 +282,16 @@ public class Long2ObjectHashMapTest {
 
         final String mapAsAString = "{7=7, 12=12, 19=19, 3=3, 11=11, 1=1}";
         assertThat(longToObjectMap.toString(), equalTo(mapAsAString));
+    }
+
+    @Test
+    public void sizeShouldReturnNumberOfEntries() {
+        final int count = 100;
+        for (int key = 0; key < count; key++) {
+            longToObjectMap.put(key, "value");
+        }
+
+        assertEquals(count, longToObjectMap.size());
     }
 }
 


### PR DESCRIPTION
Size field should be reset after rehash() to avoid counting current entries multiple times.

Added size checking tests for `Long2LongHashMap`, `Int2ObjectHashMapTest` and `Long2ObjectHashMapTest`.

Fix to upstream: https://github.com/real-logic/Agrona/pull/19