### PR TITLE
[Backport] Fixed null portable array field serialization.

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/PortableContextImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/PortableContextImpl.java
@@ -124,14 +124,14 @@ final class PortableContextImpl implements PortableContext {
                 }
             } else if (type == FieldType.PORTABLE_ARRAY) {
                 int k = in.readInt();
-                if (k > 0) {
-                    fieldFactoryId = in.readInt();
-                    fieldClassId = in.readInt();
+                fieldFactoryId = in.readInt();
+                fieldClassId = in.readInt();
 
+                // TODO: what there's a null inner Portable field
+                if (k > 0) {
                     int p = in.readInt();
                     in.position(p);
 
-                    // TODO: what there's a null inner Portable field
                     int fieldVersion = in.readInt();
                     readClassDefinition(in, fieldFactoryId, fieldClassId, fieldVersion);
                 } else {

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/PortableTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/PortableTest.java
@@ -29,6 +29,7 @@ import java.nio.ByteOrder;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 /**
@@ -197,8 +198,7 @@ public class PortableTest {
                                 .addLongField("l").addCharArrayField("c").addPortableField("p", createNamedPortableClassDefinition()).build())
                 .addClassDefinition(
                         new ClassDefinitionBuilder(PORTABLE_FACTORY_ID, TestSerializationConstants.NAMED_PORTABLE)
-                                .addUTFField("name").addIntField("myint").build()
-                );
+                                .addUTFField("name").addIntField("myint").build());
 
         SerializationService serializationService = new DefaultSerializationServiceBuilder().setConfig(serializationConfig).build();
         RawDataPortable p = new RawDataPortable(System.currentTimeMillis(), "test chars".toCharArray(),
@@ -235,8 +235,9 @@ public class PortableTest {
         assertRepeatedSerialisationGivesSameByteArrays(ss, new InnerPortable(new byte[3], new char[5], new short[2],
                 new int[10], new long[7], new float[9], new double[1], new NamedPortable[]{new NamedPortable("issue-1096", 1096)}));
 
-        assertRepeatedSerialisationGivesSameByteArrays(ss, new RawDataPortable(1096L, "issue-1096".toCharArray(),
-                new NamedPortable("issue-1096", 1096), 1096, "issue-1096", new ByteArrayDataSerializable(new byte[1])));
+        assertRepeatedSerialisationGivesSameByteArrays(ss,
+                new RawDataPortable(1096L, "issue-1096".toCharArray(), new NamedPortable("issue-1096", 1096), 1096,
+                        "issue-1096", new ByteArrayDataSerializable(new byte[1])));
     }
 
     private static void assertRepeatedSerialisationGivesSameByteArrays(SerializationService ss, Portable p) {
@@ -343,6 +344,39 @@ public class PortableTest {
         assertNotNull(fd);
         assertEquals(FieldType.LONG, fd.getType());
 
+    }
+
+    @Test
+    public void testWriteRead_withNullPortableArray() {
+        ClassDefinitionBuilder builder0 = new ClassDefinitionBuilder(PORTABLE_FACTORY_ID, 1);
+        ClassDefinitionBuilder builder1 = new ClassDefinitionBuilder(PORTABLE_FACTORY_ID, 2);
+        builder0.addPortableArrayField("list", builder1.build());
+
+        SerializationService ss = new DefaultSerializationServiceBuilder()
+                .addClassDefinition(builder0.build())
+                .addClassDefinition(builder1.build())
+                .build();
+
+        Data data = ss.toData(new TestObject1());
+
+        SerializationService ss2 = new DefaultSerializationServiceBuilder()
+                .addPortableFactory(1, new PortableFactory() {
+                    @Override
+                    public Portable create(int classId) {
+                        switch (classId) {
+                            case 1:
+                                return new TestObject1();
+                            case 2:
+                                return new TestObject2();
+                        }
+                        return null;
+                    }
+                })
+                .build();
+
+        Object object = ss2.toObject(data);
+        assertNotNull(object);
+        assertTrue(object instanceof TestObject1);
     }
 
     public static class GrandParentPortableObject implements Portable {
@@ -478,10 +512,8 @@ public class PortableTest {
 
         @Override
         public void readPortable(PortableReader reader) throws IOException {
-            throw new UnsupportedOperationException();
+            portables = reader.readPortableArray("list");
         }
-
-
     }
 
     static class TestObject2 implements Portable {


### PR DESCRIPTION
`fieldFactoryId` and `fieldClassId` should be read regardless or array size.

See Zendesk ticket: 1055

Backport of https://github.com/hazelcast/hazelcast/pull/5889