### PR TITLE
Default `treadCount` for parallel test runner reverted to `max(coreCount, 8)`

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastParallelClassRunner.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastParallelClassRunner.java
@@ -34,7 +34,7 @@ import static java.lang.Runtime.getRuntime;
  */
 public class HazelcastParallelClassRunner extends AbstractHazelcastClassRunner {
     private static final boolean SPAWN_MULTIPLE_THREADS = TestEnvironment.isMockNetwork() && !Boolean.getBoolean("multipleJVM");
-    private static final int MAX_THREADS = max(getRuntime().availableProcessors()/2, 1);
+    private static final int MAX_THREADS = max(getRuntime().availableProcessors(), 8);
 
     private final AtomicInteger numThreads = new AtomicInteger(0);
     private final int maxThreads;


### PR DESCRIPTION
Default `treadCount` for parallel test runner reverted back to `max(coreCount, 8)`

It was like this originally, but it was changed by #5465 to prevent spurious MapReduce tests failures.
However since #5859 we are able to customize threadCount on per-test basis and there is no need to
slow-down all other tests just because of MapReduce.