### PR TITLE
tcp: improved testing/javadoc

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/instance/DefaultNodeContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/DefaultNodeContext.java
@@ -38,6 +38,11 @@ public class DefaultNodeContext implements NodeContext {
     @Override
     public ConnectionManager createConnectionManager(Node node, ServerSocketChannel serverSocketChannel) {
         NodeIOService ioService = new NodeIOService(node, node.nodeEngine);
-        return new TcpIpConnectionManager(ioService, serverSocketChannel, node.getHazelcastThreadGroup(), node.loggingService);
+        return new TcpIpConnectionManager(
+                ioService,
+                serverSocketChannel,
+                node.getHazelcastThreadGroup(),
+                node.nodeEngine.getMetricsRegistry(),
+                node.loggingService);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/nio/Connection.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/Connection.java
@@ -26,20 +26,7 @@ import java.net.InetSocketAddress;
 public interface Connection {
 
     /**
-     * Writes a SocketWritable packet to the other side.
-     * <p>
-     * The packet could be stored in an internal queue before it actually is written, so this call
-     * doesn't need to be a synchronous call.
-     *
-     * @param packet the packet to write.
-     * @return false if the packet was not accepted to be written, e.g. because the Connection was
-     * not alive.
-     * @throws NullPointerException if packet is null.
-     */
-    boolean write(SocketWritable packet);
-
-    /**
-     * Checks if the Connection is still alive.
+     * Checks if the Connection is alive.
      *
      * @return true if alive, false otherwise.
      */
@@ -60,13 +47,11 @@ public interface Connection {
     long lastWriteTime();
 
     /**
-     * Closes this connection.
-     * <p>
-     * Pending packets on this connection are discarded
-     * <p>
-     * If the Connection already is closed, the call is ignored. So it can safely be called multiple times.
+     * Returns the {@link ConnectionType} of this Connection.
+     *
+     * @return the ConnectionType. It could be that <code>null</code> is returned.
      */
-    void close();
+    ConnectionType getType();
 
     /**
      * Sets the type of the connection
@@ -74,13 +59,6 @@ public interface Connection {
      * @param type to be set
      */
     void setType(ConnectionType type);
-
-    /**
-     * Returns the {@link ConnectionType} of this Connection.
-     *
-     * @return the ConnectionType. It could be that <code>null</code> is returned.
-     */
-    ConnectionType getType();
 
     /**
      * Checks if it is a client connection.
@@ -125,4 +103,27 @@ public interface Connection {
      * 0 if the socket is not connected yet.
      */
     int getPort();
+
+    /**
+     * Writes a SocketWritable packet to the other side. No guarantees are made that the packet is going to be
+     * received on the other side of the connection.
+     * <p>
+     * The packet could be stored in an internal queue before it actually is written, so this call
+     * doesn't need to be a synchronous call.
+     *
+     * @param packet the packet to write.
+     * @return false if the packet was not accepted to be written, e.g. because the Connection was not alive.
+     * @throws NullPointerException if packet is null.
+     */
+    boolean write(SocketWritable packet);
+
+    /**
+     * Closes this connection.
+     * <p>
+     * Pending packets on this connection are discarded
+     * <p>
+     * If the Connection already is closed, the call is ignored. So it can safely be called multiple times.
+     */
+    void close();
+
 }

--- a/hazelcast/src/main/java/com/hazelcast/nio/ConnectionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/ConnectionManager.java
@@ -21,27 +21,90 @@ package com.hazelcast.nio;
  */
 public interface ConnectionManager {
 
+    /**
+     * Gets the number of clients connections.
+     *
+     * @return number of client connections.
+     */
     int getCurrentClientConnections();
 
-    int getConnectionCount();
-
+    /**
+     * Gets the number of text connections (rest/memcache)
+     *
+     * @return the number of text connections.
+     */
     int getAllTextConnections();
 
+    /**
+     * Gets the total number of connections.
+     *
+     * @return the total number of connections.
+     */
+    int getConnectionCount();
+
+    /**
+     * Gets the number of active connections.
+     *
+     * @return the number of active connections.
+     */
     int getActiveConnectionCount();
 
+    /**
+     * Gets the connection for a given address. If the connection doesn't exists, null is returned.
+     *
+     * @param address the remote side of the connection.
+     * @return the found Connection, or none if one doesn't exist.
+     */
     Connection getConnection(Address address);
 
+    /**
+     * Gets the existing connection for a given address or connects. This call is silent.
+     *
+     * @param address the address to connect to.
+     * @return the found connection, or null if no connection exists.
+     * @see #getOrConnect(Address, boolean)
+     */
     Connection getOrConnect(Address address);
 
+    /**
+     * Gets the existing connection for a given address. If it doesn't exist, the system will try to make the connection
+     * asynchronously. In this case null is returned.
+     *
+     * When the connection is established at some point in time, it can be retrieved using the
+     * {@link #getConnection(Address)}.
+     *
+     * @param address the address to connect to.
+     * @param silent if logging should be done on debug level (silent=true) or on info level (silent=false).
+     * @return the existing connection.
+     */
     Connection getOrConnect(Address address, boolean silent);
 
     boolean registerConnection(Address address, Connection connection);
 
-    void destroyConnection(Connection conn);
+    /**
+     * Destroys a connection.
+     *
+     * If connection is null, the call is ignored.
+     *
+     * If the connection already is destroyed, the call is ignored.
+     *
+     * @param connection the Connection to destroy.
+     */
+    void destroyConnection(Connection connection);
 
     /**
-     * Starts ConnectionManager, initializes its resources, starts threads etc.
-     * After start ConnectionManager becomes fully operational.
+     * Registers a ConnectionListener.
+     *
+     * If the same listener is registered multiple times, it will be notified multiple times.
+     *
+     * @param listener the ConnectionListener to add.
+     * @throws NullPointerException if listener is null.
+     */
+    void addConnectionListener(ConnectionListener listener);
+
+    /**
+     * Starts ConnectionManager, initializes its resources, starts threads etc. After start ConnectionManager becomes fully
+     * operational.
      * <p/>
      * If it's already started, then this method has no effect.
      *
@@ -50,24 +113,20 @@ public interface ConnectionManager {
     void start();
 
     /**
-     * Stops ConnectionManager, releases its resources, stops threads etc.
-     * When stopped ConnectionManager can be started again using {@link #start()}.
+     * Stops ConnectionManager, releases its resources, stops threads etc. When stopped ConnectionManager can be started again
+     * using {@link #start()}.
      * <p/>
      * This method has no effect if it's already stopped or shutdown.
      * <p/>
-     * Currently <tt>stop</tt> is called during merge process
-     * to detach node from current cluster. After node becomes ready to join to
-     * the new cluster, <tt>start</tt> is called to re-initialize the ConnectionManager.
+     * Currently <tt>stop</tt> is called during merge process to detach node from current cluster. After node becomes ready to
+     * join to the new cluster, <tt>start</tt> is called to re-initialize the ConnectionManager.
      */
     void stop();
 
     /**
-     * Shutdowns ConnectionManager completely. ConnectionManager won't be operational anymore and
-     * cannot be restarted.
+     * Shutdowns ConnectionManager completely. ConnectionManager won't be operational anymore and cannot be restarted.
      * <p/>
      * This method has no effect if it's already shutdown.
      */
     void shutdown();
-
-    void addConnectionListener(ConnectionListener connectionListener);
 }

--- a/hazelcast/src/main/java/com/hazelcast/nio/IOService.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/IOService.java
@@ -21,7 +21,6 @@ import com.hazelcast.internal.ascii.TextCommandService;
 import com.hazelcast.config.SSLConfig;
 import com.hazelcast.config.SocketInterceptorConfig;
 import com.hazelcast.config.SymmetricEncryptionConfig;
-import com.hazelcast.internal.metrics.MetricsRegistry;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.SerializationService;
@@ -36,8 +35,6 @@ import java.util.Collection;
 public interface IOService {
 
     int KILO_BYTE = 1024;
-
-    MetricsRegistry getMetricRegistry();
 
     boolean isActive();
 

--- a/hazelcast/src/main/java/com/hazelcast/nio/NodeIOService.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/NodeIOService.java
@@ -25,7 +25,6 @@ import com.hazelcast.instance.HazelcastThreadGroup;
 import com.hazelcast.instance.Node;
 import com.hazelcast.instance.OutOfMemoryErrorDispatcher;
 import com.hazelcast.internal.ascii.TextCommandService;
-import com.hazelcast.internal.metrics.MetricsRegistry;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.SerializationService;
@@ -53,11 +52,6 @@ public class NodeIOService implements IOService {
         this.node = node;
         this.nodeEngine = nodeEngine;
         this.packetTransceiver = nodeEngine.getPacketTransceiver();
-    }
-
-    @Override
-    public MetricsRegistry getMetricRegistry() {
-        return nodeEngine.getMetricsRegistry();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/WriteHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/WriteHandler.java
@@ -104,6 +104,18 @@ public final class WriteHandler extends AbstractSelectionHandler implements Runn
         return socketWriter;
     }
 
+    public long getNormalPacketsWritten() {
+        return normalPacketsWritten.get();
+    }
+
+    public long getUrgentPacketsWritten() {
+        return priorityPacketsWritten.get();
+    }
+
+    public int totalPacketsPending() {
+        return writeQueue.size() + urgentWriteQueue.size();
+    }
+
     @Probe(name = "out.writeQueuePendingBytes")
     public long bytesPending() {
         return bytesPending(writeQueue);

--- a/hazelcast/src/test/java/com/hazelcast/cluster/SplitBrainHandlerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/SplitBrainHandlerTest.java
@@ -704,8 +704,12 @@ public class SplitBrainHandlerTest extends HazelcastTestSupport {
         @Override
         public ConnectionManager createConnectionManager(Node node, ServerSocketChannel serverSocketChannel) {
             NodeIOService ioService = new NodeIOService(node, node.nodeEngine);
-            return new FirewallingTcpIpConnectionManager(node.loggingService,
-                    node.getHazelcastThreadGroup(), ioService, serverSocketChannel);
+            return new FirewallingTcpIpConnectionManager(
+                    node.loggingService,
+                    node.getHazelcastThreadGroup(),
+                    ioService,
+                    node.nodeEngine.getMetricsRegistry(),
+                    serverSocketChannel);
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/DefaultPacketReaderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/DefaultPacketReaderTest.java
@@ -1,0 +1,129 @@
+package com.hazelcast.nio.tcp;
+
+import com.hazelcast.nio.Address;
+import com.hazelcast.nio.Connection;
+import com.hazelcast.nio.Packet;
+import com.hazelcast.spi.impl.packettransceiver.PacketTransceiver;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.nio.ByteBuffer;
+import java.util.LinkedList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class DefaultPacketReaderTest extends TcpIpConnection_AbstractTest {
+
+    private MockPacketTransceiver packetTransceiver;
+    private DefaultPacketReader reader;
+    private long oldPriorityPacketsRead;
+    private long oldNormalPacketsRead;
+    private ReadHandler readHandler;
+
+    @Before
+    public void setup() throws Exception {
+        super.setup();
+
+        connManagerA.start();
+        connManagerB.start();
+
+        // currently the tcpIpConnection relies heavily on tcpipconnectionmanager/io-service. So mocking is nightmare.
+        // we we create a real connection.
+        TcpIpConnection connection = connect(connManagerA, addressB);
+
+        packetTransceiver = new MockPacketTransceiver();
+        reader = new DefaultPacketReader(connection, packetTransceiver);
+
+        readHandler = connection.getReadHandler();
+        oldNormalPacketsRead = readHandler.getNormalPacketsRead().get();
+        oldPriorityPacketsRead = readHandler.getPriorityPacketsRead().get();
+    }
+
+    @Test
+    public void whenPriorityPacket() throws Exception {
+        ByteBuffer buffer = ByteBuffer.allocate(1000);
+        Packet packet = new Packet(serializationService.toBytes("foobar"));
+        packet.setHeader(Packet.HEADER_URGENT);
+        packet.writeTo(buffer);
+
+        buffer.flip();
+        reader.readPacket(buffer);
+
+        assertEquals(1, packetTransceiver.packets.size());
+        Packet found = packetTransceiver.packets.get(0);
+        assertEquals(packet, found);
+        assertEquals(oldNormalPacketsRead, readHandler.getNormalPacketsRead().get());
+        assertEquals(oldPriorityPacketsRead + 1, readHandler.getPriorityPacketsRead().get());
+    }
+
+    @Test
+    public void whenNormalPacket() throws Exception {
+        ByteBuffer buffer = ByteBuffer.allocate(1000);
+        Packet packet = new Packet(serializationService.toBytes("foobar"));
+        packet.writeTo(buffer);
+
+        buffer.flip();
+        reader.readPacket(buffer);
+
+        assertEquals(1, packetTransceiver.packets.size());
+        Packet found = packetTransceiver.packets.get(0);
+        assertEquals(packet, found);
+        assertEquals(oldNormalPacketsRead + 1, readHandler.getNormalPacketsRead().get());
+        assertEquals(oldPriorityPacketsRead, readHandler.getPriorityPacketsRead().get());
+    }
+
+    @Test
+    public void whenMultiplePackets() throws Exception {
+        ByteBuffer buffer = ByteBuffer.allocate(1000);
+
+        Packet packet1 = new Packet(serializationService.toBytes("packet1"));
+        packet1.writeTo(buffer);
+
+        Packet packet2 = new Packet(serializationService.toBytes("packet2"));
+        packet2.writeTo(buffer);
+
+        Packet packet3 = new Packet(serializationService.toBytes("packet3"));
+        packet3.writeTo(buffer);
+
+        Packet packet4 = new Packet(serializationService.toBytes("packet4"));
+        packet4.setHeader(Packet.HEADER_URGENT);
+        packet4.writeTo(buffer);
+
+        buffer.flip();
+        reader.readPacket(buffer);
+
+        assertEquals(4, packetTransceiver.packets.size());
+        assertEquals(packet1, packetTransceiver.packets.get(0));
+        assertEquals(packet2, packetTransceiver.packets.get(1));
+        assertEquals(packet3, packetTransceiver.packets.get(2));
+        assertEquals(packet4, packetTransceiver.packets.get(3));
+        assertEquals(oldNormalPacketsRead + 3, readHandler.getNormalPacketsRead().get());
+        assertEquals(oldPriorityPacketsRead+1, readHandler.getPriorityPacketsRead().get());
+    }
+
+    class MockPacketTransceiver implements PacketTransceiver {
+        private List<Packet> packets = new LinkedList<Packet>();
+
+        @Override
+        public boolean transmit(Packet packet, Connection connection) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean transmit(Packet packet, Address target) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void receive(Packet packet) {
+            packets.add(packet);
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/DefaultSocketChannelWrapperFactoryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/DefaultSocketChannelWrapperFactoryTest.java
@@ -1,0 +1,40 @@
+package com.hazelcast.nio.tcp;
+
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.nio.channels.SocketChannel;
+
+import static org.junit.Assert.assertFalse;
+import static org.mockito.Mockito.mock;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class DefaultSocketChannelWrapperFactoryTest extends HazelcastTestSupport{
+
+    private DefaultSocketChannelWrapperFactory factory;
+
+    @Before
+    public void setup(){
+        factory = new DefaultSocketChannelWrapperFactory();
+    }
+
+    @Test
+    public void wrapSocketChannel() throws Exception {
+        SocketChannel socketChannel = mock(SocketChannel.class);
+        SocketChannelWrapper wrapper = factory.wrapSocketChannel(socketChannel, false);
+
+        assertInstanceOf(DefaultSocketChannelWrapper.class, wrapper);
+    }
+
+    @Test
+    public void isSSlEnabled(){
+        boolean result = factory.isSSlEnabled();
+        assertFalse(result);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/DummyPayload.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/DummyPayload.java
@@ -1,0 +1,62 @@
+package com.hazelcast.nio.tcp;
+
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+
+import java.io.IOException;
+
+public class DummyPayload implements IdentifiedDataSerializable {
+    private long referenceId;
+    private boolean urgent;
+    private byte[] bytes;
+
+    public DummyPayload() {
+    }
+
+    public DummyPayload(byte[] bytes, boolean urgent) {
+        this(bytes, urgent, -1);
+    }
+
+    public DummyPayload(byte[] bytes, boolean urgent, long referenceId) {
+        this.bytes = bytes;
+        this.urgent = urgent;
+        this.referenceId = referenceId;
+    }
+
+    public boolean isUrgent() {
+        return urgent;
+    }
+
+    public byte[] getBytes() {
+        return bytes;
+    }
+
+    public long getReferenceId(){
+        return referenceId;
+    }
+
+    @Override
+    public int getFactoryId() {
+        return TestDataFactory.FACTORY_ID;
+    }
+
+    @Override
+    public int getId() {
+        return TestDataFactory.DUMMY_PAYLOAD;
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
+        out.writeByteArray(bytes);
+        out.writeBoolean(urgent);
+        out.writeLong(referenceId);
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) throws IOException {
+        bytes = in.readByteArray();
+        urgent = in.readBoolean();
+        referenceId = in.readLong();
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/FirewallingTcpIpConnectionManager.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/FirewallingTcpIpConnectionManager.java
@@ -17,6 +17,7 @@
 package com.hazelcast.nio.tcp;
 
 import com.hazelcast.instance.HazelcastThreadGroup;
+import com.hazelcast.internal.metrics.MetricsRegistry;
 import com.hazelcast.logging.LoggingService;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.Connection;
@@ -31,8 +32,13 @@ public class FirewallingTcpIpConnectionManager extends TcpIpConnectionManager {
 
     final Set<Address> blockedAddresses = Collections.newSetFromMap(new ConcurrentHashMap<Address, Boolean>());
 
-    public FirewallingTcpIpConnectionManager(LoggingService loggingService, HazelcastThreadGroup threadGroup, NodeIOService ioService, ServerSocketChannel serverSocketChannel) {
-        super(ioService, serverSocketChannel, threadGroup, loggingService);
+    public FirewallingTcpIpConnectionManager(
+            LoggingService loggingService,
+            HazelcastThreadGroup threadGroup,
+            NodeIOService ioService,
+            MetricsRegistry metricsRegistry,
+            ServerSocketChannel serverSocketChannel) {
+        super(ioService, serverSocketChannel, threadGroup, metricsRegistry,loggingService);
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/MockIOService.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/MockIOService.java
@@ -1,0 +1,414 @@
+package com.hazelcast.nio.tcp;
+
+import com.hazelcast.client.impl.protocol.ClientMessage;
+import com.hazelcast.config.SSLConfig;
+import com.hazelcast.config.SocketInterceptorConfig;
+import com.hazelcast.config.SymmetricEncryptionConfig;
+import com.hazelcast.instance.BuildInfoProvider;
+import com.hazelcast.instance.HazelcastThreadGroup;
+import com.hazelcast.internal.ascii.TextCommandService;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.LoggingServiceImpl;
+import com.hazelcast.nio.Address;
+import com.hazelcast.nio.Connection;
+import com.hazelcast.nio.IOService;
+import com.hazelcast.nio.MemberSocketInterceptor;
+import com.hazelcast.nio.Packet;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.nio.serialization.SerializationService;
+import com.hazelcast.nio.serialization.impl.DefaultSerializationServiceBuilder;
+import com.hazelcast.spi.EventFilter;
+import com.hazelcast.spi.EventRegistration;
+import com.hazelcast.spi.EventService;
+import com.hazelcast.spi.impl.PacketHandler;
+import com.hazelcast.spi.impl.packettransceiver.PacketTransceiver;
+
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.nio.channels.ServerSocketChannel;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class MockIOService implements IOService {
+
+    public final ServerSocketChannel serverSocketChannel;
+    public final Address thisAddress;
+    public final SerializationService serializationService;
+    public final LoggingServiceImpl loggingService;
+    public final HazelcastThreadGroup hazelcastThreadGroup;
+    public final ConcurrentHashMap<Long, DummyPayload> payloads = new ConcurrentHashMap<Long, DummyPayload>();
+    public volatile PacketHandler packetHandler;
+
+    public MockIOService(int port) throws Exception {
+        loggingService = new LoggingServiceImpl("somegroup", "log4j", BuildInfoProvider.getBuildInfo());
+        hazelcastThreadGroup = new HazelcastThreadGroup(
+                "hz",
+                loggingService.getLogger(HazelcastThreadGroup.class),
+                getClass().getClassLoader());
+
+        serverSocketChannel = ServerSocketChannel.open();
+        ServerSocket serverSocket = serverSocketChannel.socket();
+        serverSocket.setReuseAddress(true);
+        serverSocket.setSoTimeout(1000);
+        serverSocket.bind(new InetSocketAddress("0.0.0.0", port));
+        thisAddress = new Address("127.0.0.1", port);
+        this.serializationService = new DefaultSerializationServiceBuilder()
+                .addDataSerializableFactory(TestDataFactory.FACTORY_ID, new TestDataFactory())
+                .build();
+    }
+
+    @Override
+    public boolean isActive() {
+        return true;
+    }
+
+    @Override
+    public ILogger getLogger(String name) {
+        return loggingService.getLogger(name);
+    }
+
+    @Override
+    public void onOutOfMemory(OutOfMemoryError oom) {
+
+    }
+
+    @Override
+    public Address getThisAddress() {
+        return thisAddress;
+    }
+
+    @Override
+    public void onFatalError(Exception e) {
+
+    }
+
+    @Override
+    public SocketInterceptorConfig getSocketInterceptorConfig() {
+        return null;
+    }
+
+    @Override
+    public SymmetricEncryptionConfig getSymmetricEncryptionConfig() {
+        return null;
+    }
+
+    @Override
+    public SSLConfig getSSLConfig() {
+        return null;
+    }
+
+    @Override
+    public void handleClientPacket(Packet p) {
+
+    }
+
+    @Override
+    public void handleClientMessage(ClientMessage cm, Connection connection) {
+
+    }
+
+    @Override
+    public TextCommandService getTextCommandService() {
+        return null;
+    }
+
+    @Override
+    public boolean isMemcacheEnabled() {
+        return false;
+    }
+
+    @Override
+    public boolean isRestEnabled() {
+        return false;
+    }
+
+    @Override
+    public void removeEndpoint(Address endpoint) {
+
+    }
+
+    @Override
+    public String getThreadPrefix() {
+        return hazelcastThreadGroup.getThreadPoolNamePrefix("IO");
+    }
+
+    @Override
+    public ThreadGroup getThreadGroup() {
+        return hazelcastThreadGroup.getInternalThreadGroup();
+    }
+
+    @Override
+    public void onSuccessfulConnection(Address address) {
+
+    }
+
+    @Override
+    public void onFailedConnection(Address address) {
+
+    }
+
+    @Override
+    public void shouldConnectTo(Address address) {
+        if (thisAddress.equals(address)) {
+            throw new RuntimeException("Connecting to self! " + address);
+        }
+    }
+
+    @Override
+    public boolean isSocketBind() {
+        return true;
+    }
+
+    @Override
+    public boolean isSocketBindAny() {
+        return true;
+    }
+
+    @Override
+    public int getSocketReceiveBufferSize() {
+        return 32;
+    }
+
+    @Override
+    public int getSocketSendBufferSize() {
+        return 32;
+    }
+
+    @Override
+    public int getSocketClientReceiveBufferSize() {
+        return 32;
+    }
+
+    @Override
+    public int getSocketClientSendBufferSize() {
+        return 32;
+    }
+
+    @Override
+    public int getSocketLingerSeconds() {
+        return 0;
+    }
+
+    @Override
+    public int getSocketConnectTimeoutSeconds() {
+        return 0;
+    }
+
+    @Override
+    public boolean getSocketKeepAlive() {
+        return true;
+    }
+
+    @Override
+    public boolean getSocketNoDelay() {
+        return true;
+    }
+
+    @Override
+    public int getInputSelectorThreadCount() {
+        return 1;
+    }
+
+    @Override
+    public int getOutputSelectorThreadCount() {
+        return 1;
+    }
+
+    @Override
+    public long getConnectionMonitorInterval() {
+        return 0;
+    }
+
+    @Override
+    public int getConnectionMonitorMaxFaults() {
+        return 0;
+    }
+
+    @Override
+    public int getBalancerIntervalSeconds() {
+        return 0;
+    }
+
+    @Override
+    public void onDisconnect(Address endpoint) {
+
+    }
+
+    @Override
+    public boolean isClient() {
+        return false;
+    }
+
+    @Override
+    public void executeAsync(final Runnable runnable) {
+        new Thread() {
+            public void run() {
+                try {
+                    runnable.run();
+                } catch (Throwable t) {
+                    loggingService.getLogger(MockIOService.class).severe(t);
+                }
+            }
+        }.start();
+    }
+
+    @Override
+    public EventService getEventService() {
+        return new EventService() {
+            @Override
+            public int getEventThreadCount() {
+                return 0;
+            }
+
+            @Override
+            public int getEventQueueCapacity() {
+                return 0;
+            }
+
+            @Override
+            public int getEventQueueSize() {
+                return 0;
+            }
+
+            @Override
+            public EventRegistration registerLocalListener(String serviceName, String topic, Object listener) {
+                return null;
+            }
+
+            @Override
+            public EventRegistration registerLocalListener(String serviceName, String topic, EventFilter filter, Object listener) {
+                return null;
+            }
+
+            @Override
+            public EventRegistration registerListener(String serviceName, String topic, Object listener) {
+                return null;
+            }
+
+            @Override
+            public EventRegistration registerListener(String serviceName, String topic, EventFilter filter, Object listener) {
+                return null;
+            }
+
+            @Override
+            public boolean deregisterListener(String serviceName, String topic, Object id) {
+                return false;
+            }
+
+            @Override
+            public void deregisterAllListeners(String serviceName, String topic) {
+
+            }
+
+            @Override
+            public Collection<EventRegistration> getRegistrations(String serviceName, String topic) {
+                return null;
+            }
+
+            @Override
+            public EventRegistration[] getRegistrationsAsArray(String serviceName, String topic) {
+                return new EventRegistration[0];
+            }
+
+            @Override
+            public boolean hasEventRegistration(String serviceName, String topic) {
+                return false;
+            }
+
+            @Override
+            public void publishEvent(String serviceName, String topic, Object event, int orderKey) {
+
+            }
+
+            @Override
+            public void publishEvent(String serviceName, EventRegistration registration, Object event, int orderKey) {
+
+            }
+
+            @Override
+            public void publishEvent(String serviceName, Collection<EventRegistration> registrations, Object event, int orderKey) {
+
+            }
+
+            @Override
+            public void publishRemoteEvent(String serviceName, Collection<EventRegistration> registrations, Object event, int orderKey) {
+
+            }
+
+            @Override
+            public void executeEventCallback(Runnable callback) {
+                new Thread(callback).start();
+            }
+        };
+    }
+
+    @Override
+    public Collection<Integer> getOutboundPorts() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public Data toData(Object obj) {
+        return serializationService.toData(obj);
+    }
+
+    @Override
+    public Object toObject(Data data) {
+        return serializationService.toObject(data);
+    }
+
+    @Override
+    public SerializationService getSerializationService() {
+        return serializationService;
+    }
+
+    @Override
+    public SocketChannelWrapperFactory getSocketChannelWrapperFactory() {
+        return new DefaultSocketChannelWrapperFactory();
+    }
+
+    @Override
+    public MemberSocketInterceptor getMemberSocketInterceptor() {
+        return null;
+    }
+
+    @Override
+    public PacketReader createPacketReader(final TcpIpConnection connection) {
+        return new DefaultPacketReader(connection, new PacketTransceiver() {
+            private ILogger logger = getLogger("PacketTransceiver");
+
+            @Override
+            public boolean transmit(Packet packet, Connection connection) {
+                return false;
+            }
+
+            @Override
+            public boolean transmit(Packet packet, Address target) {
+                return false;
+            }
+
+            @Override
+            public void receive(Packet packet) {
+                try {
+                    if (packet.isHeaderSet(Packet.HEADER_BIND)) {
+                        connection.getConnectionManager().handle(packet);
+                    } else {
+                        PacketHandler handler = packetHandler;
+                        if (handler != null) {
+                            handler.handle(packet);
+                        }
+                    }
+                } catch (Exception e) {
+                    logger.severe(e);
+                }
+            }
+        });
+    }
+
+    @Override
+    public PacketWriter createPacketWriter(TcpIpConnection connection) {
+        return new DefaultPacketWriter();
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/TcpIpConnectionManager_ConnectTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/TcpIpConnectionManager_ConnectTest.java
@@ -1,0 +1,136 @@
+package com.hazelcast.nio.tcp;
+
+import com.hazelcast.nio.Connection;
+import com.hazelcast.nio.ConnectionType;
+import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.net.UnknownHostException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class TcpIpConnectionManager_ConnectTest extends TcpIpConnection_AbstractTest {
+
+    @Test
+    public void start() {
+        connManagerA.start();
+
+        assertTrue(connManagerA.isLive());
+    }
+
+    @Test
+    public void start_whenAlreadyStarted_thenCallIgnored() {
+        //first time
+        connManagerA.start();
+
+        //second time
+        connManagerA.start();
+
+        assertTrue(connManagerA.isLive());
+    }
+
+    // ================== getOrConnect ======================================================
+
+    @Test
+    public void getOrConnect_whenNotConnected_thenEventuallyConnectionAvailable() throws UnknownHostException {
+        startAllConnectionManagers();
+
+        Connection c = connManagerA.getOrConnect(addressB);
+        assertNull(c);
+
+        connect(connManagerA, addressB);
+
+        assertEquals(1, connManagerA.getActiveConnectionCount());
+        assertEquals(1, connManagerB.getActiveConnectionCount());
+    }
+
+    @Test
+    public void getOrConnect_whenAlreadyConnectedSameConnectionReturned() throws UnknownHostException {
+        startAllConnectionManagers();
+
+        Connection c1 = connect(connManagerA, addressB);
+        Connection c2 = connManagerA.getOrConnect(addressB);
+
+        assertSame(c1, c2);
+    }
+
+    // ================== destroy ======================================================
+
+    @Test
+    public void destroyConnection_whenNull_thenCallIgnored() throws Exception {
+        connManagerA.start();
+
+        connManagerA.destroyConnection(null);
+    }
+
+    @Test
+    public void destroyConnection_whenActive() throws Exception {
+        startAllConnectionManagers();
+
+        final TcpIpConnection connAB = connect(connManagerA, addressB);
+        final TcpIpConnection connBA = connect(connManagerB, addressA);
+
+        connManagerA.destroyConnection(connAB);
+
+        assertIsDestroyed(connAB);
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertIsDestroyed(connBA);
+            }
+        });
+    }
+
+     @Test
+    public void destroyConnection_whenAlreadyDestroyed_thenCallIgnored() throws Exception {
+        startAllConnectionManagers();
+
+        connManagerA.getOrConnect(addressB);
+        TcpIpConnection c = connect(connManagerA, addressB);
+
+        // first destroy
+        connManagerA.destroyConnection(c);
+
+        // second destroy
+        connManagerA.destroyConnection(c);
+
+        assertIsDestroyed(c);
+    }
+
+    public void assertIsDestroyed(TcpIpConnection connection) {
+        TcpIpConnectionManager connectionManager = connection.getConnectionManager();
+
+        assertFalse(connection.isAlive());
+        assertNull(connectionManager.getConnection(connection.getEndPoint()));
+    }
+
+    // ================== connection ======================================================
+
+    @Test
+    public void connect() throws UnknownHostException {
+        startAllConnectionManagers();
+
+        TcpIpConnection connAB = connect(connManagerA, addressB);
+        assertTrue(connAB.isAlive());
+        assertEquals(ConnectionType.MEMBER, connAB.getType());
+        assertEquals(1, connManagerA.getActiveConnectionCount());
+
+        TcpIpConnection connBA = (TcpIpConnection) connManagerB.getConnection(addressA);
+        assertTrue(connBA.isAlive());
+        assertEquals(ConnectionType.MEMBER, connBA.getType());
+        assertEquals(1, connManagerB.getActiveConnectionCount());
+
+        assertEquals(connManagerA.ioService.getThisAddress(), connBA.getEndPoint());
+        assertEquals(connManagerB.ioService.getThisAddress(), connAB.getEndPoint());
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/TcpIpConnectionManager_ConnectionListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/TcpIpConnectionManager_ConnectionListenerTest.java
@@ -1,0 +1,71 @@
+package com.hazelcast.nio.tcp;
+
+import com.hazelcast.nio.Connection;
+import com.hazelcast.nio.ConnectionListener;
+import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class TcpIpConnectionManager_ConnectionListenerTest extends TcpIpConnection_AbstractTest {
+
+    @Test(expected = NullPointerException.class)
+    public void addConnectionListener_whenNull() {
+        connManagerA.addConnectionListener(null);
+    }
+
+    @Test
+    public void whenConnectionAdded() throws Exception {
+        startAllConnectionManagers();
+
+        final ConnectionListener listener = mock(ConnectionListener.class);
+        connManagerA.addConnectionListener(listener);
+
+        final Connection c = connect(connManagerA, addressB);
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                listener.connectionAdded(c);
+            }
+        });
+    }
+
+    @Test
+    public void whenConnectionDestroyed() throws Exception {
+        startAllConnectionManagers();
+
+
+        final ConnectionListener listener = mock(ConnectionListener.class);
+        connManagerA.addConnectionListener(listener);
+
+        final Connection c = connect(connManagerA, addressB);
+        connManagerA.destroyConnection(c);
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                listener.connectionRemoved(c);
+            }
+        });
+    }
+
+    @Test
+    public void whenConnectionManagerShutdown_thenListenersRemoved() {
+        startAllConnectionManagers();
+
+        ConnectionListener listener = mock(ConnectionListener.class);
+        connManagerA.addConnectionListener(listener);
+
+        connManagerA.shutdown();
+
+        assertEquals(0, connManagerA.connectionListeners.size());
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/TcpIpConnection_AbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/TcpIpConnection_AbstractTest.java
@@ -1,0 +1,107 @@
+package com.hazelcast.nio.tcp;
+
+import com.hazelcast.instance.BuildInfoProvider;
+import com.hazelcast.internal.metrics.impl.MetricsRegistryImpl;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.LoggingServiceImpl;
+import com.hazelcast.nio.Address;
+import com.hazelcast.nio.Connection;
+import com.hazelcast.nio.serialization.SerializationService;
+import com.hazelcast.nio.serialization.impl.DefaultSerializationServiceBuilder;
+import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.HazelcastTestSupport;
+import org.junit.After;
+import org.junit.Before;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.Assert.assertNotNull;
+
+public abstract class TcpIpConnection_AbstractTest extends HazelcastTestSupport {
+
+    protected ILogger logger;
+    protected LoggingServiceImpl loggingService;
+    protected SerializationService serializationService;
+
+    protected Address addressA;
+    protected TcpIpConnectionManager connManagerA;
+    protected MockIOService ioServiceA;
+
+    protected Address addressB;
+    protected TcpIpConnectionManager connManagerB;
+    protected MockIOService ioServiceB;
+
+    protected TcpIpConnectionManager connManagerC;
+    protected Address addressC;
+    protected MockIOService ioServiceC;
+
+    @Before
+    public void setup() throws Exception {
+        addressA = new Address("127.0.0.1", 5701);
+        addressB = new Address("127.0.0.1", 5702);
+        addressC = new Address("127.0.0.1", 5703);
+
+        loggingService = new LoggingServiceImpl("somegroup", "log4j", BuildInfoProvider.getBuildInfo());
+        logger = loggingService.getLogger(TcpIpConnection_AbstractTest.class);
+
+        connManagerA = newConnectionManager(addressA.getPort());
+        ioServiceA = (MockIOService) connManagerA.getIOHandler();
+
+        connManagerB = newConnectionManager(addressB.getPort());
+        ioServiceB = (MockIOService) connManagerB.ioService;
+
+        connManagerC = newConnectionManager(addressC.getPort());
+        ioServiceC = (MockIOService) connManagerB.ioService;
+
+        serializationService = new DefaultSerializationServiceBuilder()
+                .addDataSerializableFactory(TestDataFactory.FACTORY_ID, new TestDataFactory())
+                .build();
+    }
+
+    public void startAllConnectionManagers(){
+        connManagerA.start();
+        connManagerB.start();
+        connManagerC.start();
+    }
+
+    @After
+    public void tearDown() {
+        connManagerA.shutdown();
+        connManagerB.shutdown();
+        connManagerC.shutdown();
+    }
+
+    protected TcpIpConnectionManager newConnectionManager(int port) throws Exception {
+        MetricsRegistryImpl metricsRegistry = new MetricsRegistryImpl(loggingService.getLogger(MetricsRegistryImpl.class));
+        MockIOService ioService = new MockIOService(port);
+
+        return new TcpIpConnectionManager(
+                ioService,
+                ioService.serverSocketChannel,
+                ioService.hazelcastThreadGroup,
+                metricsRegistry,
+                ioService.loggingService);
+    }
+
+    // ====================== support ========================================
+
+    protected TcpIpConnection connect(Address address) {
+        return connect(connManagerA, address);
+    }
+
+    protected TcpIpConnection connect(final TcpIpConnectionManager connectionManager, final Address address) {
+        connectionManager.getOrConnect(address);
+
+        final AtomicReference<TcpIpConnection> ref = new AtomicReference<TcpIpConnection>();
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                Connection c = connectionManager.getConnection(address);
+                assertNotNull(c);
+                ref.set((TcpIpConnection) c);
+            }
+        });
+
+        return ref.get();
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/TcpIpConnection_BasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/TcpIpConnection_BasicTest.java
@@ -1,0 +1,221 @@
+package com.hazelcast.nio.tcp;
+
+import com.hazelcast.nio.Packet;
+import com.hazelcast.spi.impl.PacketHandler;
+import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.NightlyTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(NightlyTest.class)
+public class TcpIpConnection_BasicTest extends TcpIpConnection_AbstractTest {
+
+    private List<Packet> packetsB = Collections.synchronizedList(new ArrayList<Packet>());
+
+    @Before
+    public void setup() throws Exception {
+        super.setup();
+
+        startAllConnectionManagers();
+
+        ioServiceB.packetHandler = new PacketHandler() {
+            @Override
+            public void handle(Packet packet) throws Exception {
+                packetsB.add(packet);
+            }
+        };
+    }
+
+    @Test
+    public void write_whenNonUrgent() {
+        TcpIpConnection c = connect(connManagerA, addressB);
+
+        Packet packet = new Packet(serializationService.toBytes("foo"));
+
+        boolean result = c.write(packet);
+
+        assertTrue(result);
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertEquals(1, packetsB.size());
+            }
+        });
+
+        Packet found = packetsB.get(0);
+        assertEquals(packet, found);
+    }
+
+    @Test
+    public void write_whenUrgent() {
+        TcpIpConnection c = connect(connManagerA, addressB);
+
+        Packet packet = new Packet(serializationService.toBytes("foo"));
+        packet.setHeader(Packet.HEADER_URGENT);
+
+        boolean result = c.write(packet);
+
+        assertTrue(result);
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertEquals(1, packetsB.size());
+            }
+        });
+
+        Packet found = packetsB.get(0);
+        assertEquals(packet, found);
+    }
+
+    @Test
+    public void lastWriteTime_whenPacketWritten() {
+        TcpIpConnection connAB = connect(connManagerA, addressB);
+
+        // we need to sleep some so that the lastWriteTime of the connection gets nice and old.
+        // we need this so we can determine the lastWriteTime got updated
+        sleepSeconds(5);
+
+        Packet packet = new Packet(serializationService.toBytes("foo"));
+
+        connAB.write(packet);
+
+        // wait for the packet to get written.
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertEquals(1, packetsB.size());
+            }
+        });
+
+        long result = connAB.lastWriteTime();
+
+        long current = System.currentTimeMillis();
+
+        // make sure that the lastWrite time is within the given marginOfErrorMs.
+        // if we make this marginOfError very small, there is a high chance of spurious failures
+        final int marginOfErrorMs = 1000;
+        assertTrue(current + marginOfErrorMs > result);
+        assertTrue(current - marginOfErrorMs < result);
+    }
+
+    @Test
+    public void lastWriteTime_whenNothingWritten() {
+        TcpIpConnection c = connect(connManagerA, addressB);
+
+        long result1 = c.lastWriteTime();
+        long result2 = c.lastWriteTime();
+
+        assertEquals(result1, result2);
+    }
+
+    // we check the lastReadTime by sending a packet on the local connection, and
+    // on the remote side we check the if the lastReadTime is updated
+    @Test
+    public void lastReadTime() {
+        TcpIpConnection connAB = connect(connManagerA, addressB);
+        TcpIpConnection connBA = connect(connManagerB, addressA);
+
+        // we need to sleep some so that the lastReadTime of the connection gets nice and old.
+        // we need this so we can determine the lastReadTime got updated
+        sleepSeconds(5);
+
+        Packet packet = new Packet(serializationService.toBytes("foo"));
+
+        connAB.write(packet);
+
+        // wait for the packet to get written.
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertEquals(1, packetsB.size());
+            }
+        });
+
+        long result = connBA.lastReadTime();
+
+        long current = System.currentTimeMillis();
+
+        // make sure that the lastWrite time is within the given marginOfErrorMs.
+        // if we make this marginOfError very small, there is a high chance of spurious failures
+        final int marginOfErrorMs = 1000;
+        assertTrue(current + marginOfErrorMs > result);
+        assertTrue(current - marginOfErrorMs < result);
+    }
+
+    @Test
+    public void lastReadTime_whenNothingWritten() {
+        TcpIpConnection c = connect(connManagerA, addressB);
+
+        long result1 = c.lastReadTime();
+        long result2 = c.lastReadTime();
+
+        assertEquals(result1, result2);
+    }
+
+    @Test
+    public void write_whenNotAlive() {
+        TcpIpConnection c = connect(connManagerA, addressB);
+        connManagerA.destroyConnection(c);
+
+        Packet packet = new Packet(serializationService.toBytes("foo"));
+
+        boolean result = c.write(packet);
+
+        assertFalse(result);
+    }
+
+    @Test
+    public void getInetAddress() {
+        TcpIpConnection c = connect(connManagerA, addressB);
+
+        InetAddress result = c.getInetAddress();
+
+        assertEquals(c.getSocketChannelWrapper().socket().getInetAddress(), result);
+    }
+
+    @Test
+    public void getRemoteSocketAddress() {
+        TcpIpConnection c = connect(connManagerA, addressB);
+
+        InetSocketAddress result = c.getRemoteSocketAddress();
+
+        assertEquals(new InetSocketAddress(addressB.getHost(), addressB.getPort()), result);
+    }
+
+    @Test
+    public void getPort() {
+        TcpIpConnection c = connect(connManagerA, addressB);
+
+        int result = c.getPort();
+
+        assertEquals(c.getSocketChannelWrapper().socket().getPort(), result);
+    }
+
+    @Test
+    public void test_equals() {
+        TcpIpConnection connAB = connect(connManagerA, addressB);
+        TcpIpConnection connAC = connect(connManagerA, addressC);
+
+        assertEquals(connAB, connAB);
+        assertEquals(connAC, connAC);
+        assertNotEquals(connAB, null);
+        assertNotEquals(connAB, connAC);
+        assertNotEquals(connAC, connAB);
+        assertNotEquals(connAB, "foo");
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/TcpIpConnection_TransferStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/TcpIpConnection_TransferStressTest.java
@@ -1,0 +1,209 @@
+package com.hazelcast.nio.tcp;
+
+import com.hazelcast.nio.Packet;
+import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.TestThread;
+import com.hazelcast.test.annotation.NightlyTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * This test will concurrently write to a single connection and check if all the data transmitted, is received
+ * on the other side.
+ *
+ * In the past we had some issues with packet not getting written. So this test will write various size packets (from small
+ * to very large).
+ */
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(NightlyTest.class)
+public class TcpIpConnection_TransferStressTest extends TcpIpConnection_AbstractTest {
+
+    // total running time.
+    private static final long DURATION_SECONDS = TimeUnit.MINUTES.toSeconds(2);
+    // maximum number of pending packets
+    private static final int maxPendingPacketCount = 10000;
+    // we create the payloads up front and select randomly from them. This is the number of payloads we are creating.
+    private static final int payloadCount = 10000;
+
+    private final AtomicBoolean stop = new AtomicBoolean();
+    private DummyPayload[] payloads;
+
+    @Before
+    public void setup() throws Exception {
+        super.setup();
+        startAllConnectionManagers();
+    }
+
+    @Test
+    public void testTinyPackets() throws Exception {
+        makePayloads(10);
+        test();
+    }
+
+    @Test
+    public void testSmallPackets() throws Exception {
+        makePayloads(100);
+        test();
+    }
+
+    @Test
+    public void testMediumPackets() throws Exception {
+        makePayloads(1000);
+        test();
+    }
+
+    @Test
+    public void testLargePackets() throws Exception {
+        makePayloads(10000);
+        test();
+    }
+
+    @Test
+    public void testSemiRealisticPackets() throws Exception {
+        makeSemiRealisticPayloads();
+        test();
+    }
+
+    public void test() throws Exception {
+        TcpIpConnection c = connect(connManagerA, addressB);
+
+        WriteThread thread1 = new WriteThread(1, c);
+        WriteThread thread2 = new WriteThread(2, c);
+
+        logger.info("Starting");
+        thread1.start();
+        thread2.start();
+
+        sleepAndStop(stop, DURATION_SECONDS);
+
+        logger.info("Done");
+
+        thread1.assertSucceedsEventually();
+        thread2.assertSucceedsEventually();
+
+        // there is always one packet extra for the bind-request
+        final long expectedNormalPackets = thread1.normalPackets + thread2.normalPackets + 1;
+        final long expectedUrgentPackets = thread1.urgentPackets + thread2.urgentPackets;
+
+        logger.info("expected normal packets: " + expectedNormalPackets);
+        logger.info("expected priority packets: " + expectedUrgentPackets);
+
+        final ReadHandler readHandler = ((TcpIpConnection) connManagerB.getConnection(addressA)).getReadHandler();
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertEquals(expectedNormalPackets, readHandler.getNormalPacketsRead().get());
+                assertEquals(expectedUrgentPackets, readHandler.getPriorityPacketsRead().get());
+            }
+        });
+
+    }
+
+    private void makePayloads(int maxSize) {
+        Random random = new Random();
+        payloads = new DummyPayload[payloadCount];
+
+        for (int k = 0; k < payloads.length; k++) {
+            final byte[] bytes = new byte[random.nextInt(maxSize)];
+            payloads[k] = new DummyPayload(bytes, false);
+        }
+    }
+
+    private void makeSemiRealisticPayloads() {
+        Random random = new Random();
+        payloads = new DummyPayload[payloadCount];
+
+        for (int k = 0; k < payloads.length; k++) {
+            // one in every 100 packet we make big
+            boolean largePacket = random.nextInt(100) == 1;
+            boolean ultraLarge = false;
+            if (largePacket) {
+                ultraLarge = random.nextInt(10) == 1;
+            }
+
+            int byteCount;
+            if (ultraLarge) {
+                byteCount = random.nextInt(100000);
+            } else if (largePacket) {
+                byteCount = random.nextInt(10000);
+            } else {
+                byteCount = random.nextInt(300);
+            }
+
+            // one in every 100 packet we make urgent
+            boolean urgentPacket = random.nextInt(100) == 1;
+
+            payloads[k] = new DummyPayload(new byte[byteCount], urgentPacket);
+        }
+    }
+
+    public class WriteThread extends TestThread {
+        private final Random random = new Random();
+        private final WriteHandler writeHandler;
+        private long normalPackets;
+        private long urgentPackets;
+
+        public WriteThread(int id, TcpIpConnection c) {
+            super("WriteThread-" + id);
+            this.writeHandler = c.getWriteHandler();
+        }
+
+        @Override
+        public void doRun() throws Throwable {
+            long prev = System.currentTimeMillis();
+            while (!stop.get()) {
+                Packet packet = nextPacket();
+                if (packet.isUrgent()) {
+                    urgentPackets++;
+                } else {
+                    normalPackets++;
+                }
+                writeHandler.offer(packet);
+
+
+                long now = System.currentTimeMillis();
+                if (now > prev + 2000) {
+                    prev = now;
+                    logger.info("At normal-packets:" + normalPackets + " priority-packets:" + urgentPackets);
+                }
+
+                double usage = getUsage();
+                if (usage < 90) {
+                    continue;
+                }
+
+                for (; ; ) {
+                    sleep(random.nextInt(5));
+                    if (getUsage() < 10) {
+                        //logger.info("Pausing");
+                        break;
+                    }
+                }
+            }
+
+            logger.info("Finished, normal packets written: " + normalPackets + " urgent packets written:" + urgentPackets);
+        }
+
+        private double getUsage() {
+            return 100d * writeHandler.totalPacketsPending() / maxPendingPacketCount;
+        }
+
+        public Packet nextPacket() {
+            DummyPayload payload = payloads[random.nextInt(payloads.length)];
+            Packet packet = new Packet(serializationService.toBytes(payload));
+            if (payload.isUrgent()) {
+                packet.setHeader(Packet.HEADER_URGENT);
+            }
+            return packet;
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/TestDataFactory.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/TestDataFactory.java
@@ -1,0 +1,20 @@
+package com.hazelcast.nio.tcp;
+
+import com.hazelcast.nio.serialization.DataSerializableFactory;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+
+public class TestDataFactory implements DataSerializableFactory {
+    public static final int FACTORY_ID = 1;
+
+    public static final int DUMMY_PAYLOAD = 0;
+
+    @Override
+    public IdentifiedDataSerializable create(int typeId) {
+        switch (typeId) {
+            case DUMMY_PAYLOAD:
+                return new DummyPayload();
+            default:
+                return null;
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/quorum/PartitionedCluster.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/PartitionedCluster.java
@@ -138,8 +138,12 @@ public class PartitionedCluster {
         @Override
         public ConnectionManager createConnectionManager(Node node, ServerSocketChannel serverSocketChannel) {
             NodeIOService ioService = new NodeIOService(node, node.nodeEngine);
-            return new FirewallingTcpIpConnectionManager(node.loggingService,
-                    node.getHazelcastThreadGroup(), ioService, serverSocketChannel);
+            return new FirewallingTcpIpConnectionManager(
+                    node.loggingService,
+                    node.getHazelcastThreadGroup(),
+                    ioService,
+                    node.nodeEngine.getMetricsRegistry(),
+                    serverSocketChannel);
         }
     }
 


### PR DESCRIPTION
Improvements
* explicit testing of TcpIpConnection
* explicit testing of TcpIpConnectionManager
* explicit testing of DefaultPacketReader
* explicit testing of DefaultSocketChannelWrapperFactory
* improved javadoc connection manager
* stress tests for sending packets to make sure we don't loose them
* removed MetricsRegistry from IO Service; pass it directly to TcpIpConnectionManager