### PR TITLE
Cleanup of ClusterServiceImpl

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -54,7 +54,8 @@
     <suppress checks="JavadocMethod" files="com/hazelcast/cluster/"/>
     <suppress checks="JavadocVariable" files="com/hazelcast/cluster/"/>
     <!-- TODO: Needs to be fixed -->
-    <suppress checks="" files="com/hazelcast/cluster/impl/ClusterServiceImpl"/>
+    <suppress checks="MethodCount|FileLengthCheck|ClassDataAbstractionCoupling|ClassFanOutComplexityCheck"
+              files="com/hazelcast/cluster/impl/ClusterServiceImpl"/>
     <suppress checks="" files="com/hazelcast/cluster/impl/MulticastService"/>
     <suppress checks="" files="com/hazelcast/cluster/impl/ConfigCheck"/>
     <suppress checks="" files="com/hazelcast/cluster/impl/TcpIpJoiner"/>


### PR DESCRIPTION
This PR will be a bit more fun after the very simple cleanups before. I mostly fixed simple CheckStyle issues like magic numbers, 130 line width, trailing comments etc. I also aligned the format of comments and log messages. After that I took care about NPath and Cyclomatic complexity and pulled out some methods or adjusted the code flow to get rid of those issues.

I have quite high confidence that I didn't break anything. A lot of changes were done via IDEA refactoring tools. I ran the cluster tests 3 times including code coverage. There where no failures with 84% line coverage. The biggest untested part is the `ping()` method, which I didn't change significantly. The remaining untested parts are mostly the `toString()` method and logging branches (see https://hazelcast-l337.sonar.cloudbees.com/resource/index/11063?display_title=true&metric=coverage).

I hope I didn't do any controversial things. There maybe things which we can discuss, but I hope we can agree that the class is in better shape than before with this PR.