### PR TITLE
Fix #5900: call GZIPOutputStream.finish at end of serializer.write if gzipEnabled

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/impl/DefaultSerializers.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/impl/DefaultSerializers.java
@@ -172,15 +172,21 @@ public final class DefaultSerializers {
             out.writeUTF(obj.getClass().getName());
             final ObjectOutputStream objectOutputStream;
             final OutputStream outputStream = (OutputStream) out;
+            GZIPOutputStream gzip = null;
             if (gzipEnabled) {
-                objectOutputStream = new ObjectOutputStream(new GZIPOutputStream(outputStream));
+                gzip = new GZIPOutputStream(outputStream);
+                objectOutputStream = new ObjectOutputStream(gzip);
             } else {
                 objectOutputStream = new ObjectOutputStream(outputStream);
             }
             obj.writeExternal(objectOutputStream);
             // Force flush if not yet written due to internal behavior if pos < 1024
             objectOutputStream.flush();
+            if (gzipEnabled) {
+                gzip.finish();
+            }
         }
+    
     }
 
     public static final class ObjectSerializer extends SingletonSerializer<Object> {
@@ -226,8 +232,10 @@ public final class DefaultSerializers {
         public void write(final ObjectDataOutput out, final Object obj) throws IOException {
             final ObjectOutputStream objectOutputStream;
             final OutputStream outputStream = (OutputStream) out;
+            GZIPOutputStream gzip = null;
             if (gzipEnabled) {
-                objectOutputStream = new ObjectOutputStream(new GZIPOutputStream(outputStream));
+                gzip = new GZIPOutputStream(outputStream);
+                objectOutputStream = new ObjectOutputStream(gzip);
             } else {
                 objectOutputStream = new ObjectOutputStream(outputStream);
             }
@@ -238,6 +246,9 @@ public final class DefaultSerializers {
             }
             // Force flush if not yet written due to internal behavior if pos < 1024
             objectOutputStream.flush();
+            if (gzipEnabled) {
+                gzip.finish();
+            }
         }
     }
 


### PR DESCRIPTION
* Create two tests that demonstrate compression in ObjectSerializer and Externalizer. The tests will serialize an object, deserialize the resulting Data, and compare the original object with the deserialized one to ensure no loss of fidelity.

* Ensure that GZIPOutputStream.finish is called at the end of serializer.write if gzipEnabled, to ensure that everything in the gzip buffer gets flushed out.

Fixes #5900 