### PR TITLE
Moved iobalancer to nonblocking package

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/instance/GroupProperties.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/GroupProperties.java
@@ -121,10 +121,10 @@ public class GroupProperties {
     public static final String PROP_IO_OUTPUT_THREAD_COUNT = "hazelcast.io.output.thread.count";
 
     /**
-     * The interval in seconds between {@link com.hazelcast.nio.tcp.iobalancer.IOBalancer IOBalancer}
+     * The interval in seconds between {@link com.hazelcast.nio.tcp.nonblocking.iobalancer.IOBalancer IOBalancer}
      * executions. The shorter intervals will catch I/O Imbalance faster, but they will cause higher overhead.
      *
-     * Please see the documentation of {@link com.hazelcast.nio.tcp.iobalancer.IOBalancer IOBalancer} for a
+     * Please see the documentation of {@link com.hazelcast.nio.tcp.nonblocking.iobalancer.IOBalancer IOBalancer} for a
      * detailed explanation of the problem.
      *
      * Default value is 20 seconds. A value smaller than 1 disables the balancer.

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/MigratableHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/MigratableHandler.java
@@ -18,7 +18,7 @@ package com.hazelcast.nio.tcp.nonblocking;
 
 /**
  * A {@link SelectionHandler} that supports migration between {@link IOSelector} instances.
- * This API is called by the {@link com.hazelcast.nio.tcp.iobalancer.IOBalancer}.
+ * This API is called by the {@link com.hazelcast.nio.tcp.nonblocking.iobalancer.IOBalancer}.
  */
 public interface MigratableHandler extends SelectionHandler {
 
@@ -27,7 +27,7 @@ public interface MigratableHandler extends SelectionHandler {
      * migration to complete.
      *
      * This method can be called by any thread, and will probably be called by the
-     * {@link com.hazelcast.nio.tcp.iobalancer.IOBalancer}.
+     * {@link com.hazelcast.nio.tcp.nonblocking.iobalancer.IOBalancer}.
      *
      * Call is ignored when handler is moving to the same IOSelector.
      *
@@ -37,7 +37,7 @@ public interface MigratableHandler extends SelectionHandler {
 
     /**
      * Get IOSelector currently owning this handler. Handler owner is a thread running this handler.
-     * {@link com.hazelcast.nio.tcp.iobalancer.IOBalancer IOBalancer} can decide to migrate
+     * {@link com.hazelcast.nio.tcp.nonblocking.iobalancer.IOBalancer IOBalancer} can decide to migrate
      * a handler to another owner.
      *
      * @return current owner

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/NonBlockingTcpIpConnectionThreadingModel.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/NonBlockingTcpIpConnectionThreadingModel.java
@@ -25,7 +25,7 @@ import com.hazelcast.nio.tcp.TcpIpConnectionThreadingModel;
 import com.hazelcast.nio.tcp.ReadHandler;
 import com.hazelcast.nio.tcp.TcpIpConnection;
 import com.hazelcast.nio.tcp.WriteHandler;
-import com.hazelcast.nio.tcp.iobalancer.IOBalancer;
+import com.hazelcast.nio.tcp.nonblocking.iobalancer.IOBalancer;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.util.concurrent.atomic.AtomicInteger;

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/iobalancer/EventCountBasicMigrationStrategy.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/iobalancer/EventCountBasicMigrationStrategy.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.hazelcast.nio.tcp.iobalancer;
+package com.hazelcast.nio.tcp.nonblocking.iobalancer;
 
 import com.hazelcast.nio.tcp.nonblocking.MigratableHandler;
 import java.util.Set;

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/iobalancer/IOBalancer.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/iobalancer/IOBalancer.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.hazelcast.nio.tcp.iobalancer;
+package com.hazelcast.nio.tcp.nonblocking.iobalancer;
 
 import com.hazelcast.instance.HazelcastThreadGroup;
 import com.hazelcast.internal.metrics.Probe;
@@ -48,7 +48,7 @@ import static com.hazelcast.util.counters.SwCounter.newSwCounter;
  *
  * It measures number of events serviced by each handler in a given interval and if imbalance is detected then it
  * schedules handler migration to fix the situation. The exact migration strategy can be customized via
- * {@link com.hazelcast.nio.tcp.iobalancer.MigrationStrategy}.
+ * {@link com.hazelcast.nio.tcp.nonblocking.iobalancer.MigrationStrategy}.
  *
  * Measuring interval can be customized via {@link com.hazelcast.instance.GroupProperties#IO_BALANCER_INTERVAL_SECONDS}
  *

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/iobalancer/IOBalancerThread.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/iobalancer/IOBalancerThread.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.hazelcast.nio.tcp.iobalancer;
+package com.hazelcast.nio.tcp.nonblocking.iobalancer;
 
 import com.hazelcast.instance.HazelcastThreadGroup;
 import com.hazelcast.logging.ILogger;

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/iobalancer/LoadImbalance.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/iobalancer/LoadImbalance.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.hazelcast.nio.tcp.iobalancer;
+package com.hazelcast.nio.tcp.nonblocking.iobalancer;
 
 import com.hazelcast.nio.tcp.nonblocking.IOSelector;
 import com.hazelcast.nio.tcp.nonblocking.MigratableHandler;

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/iobalancer/LoadTracker.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/iobalancer/LoadTracker.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.hazelcast.nio.tcp.iobalancer;
+package com.hazelcast.nio.tcp.nonblocking.iobalancer;
 
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.tcp.nonblocking.AbstractIOSelector;

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/iobalancer/MigrationStrategy.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/iobalancer/MigrationStrategy.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.hazelcast.nio.tcp.iobalancer;
+package com.hazelcast.nio.tcp.nonblocking.iobalancer;
 
 import com.hazelcast.nio.tcp.nonblocking.MigratableHandler;
 import com.hazelcast.nio.tcp.nonblocking.IOSelector;

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/iobalancer/MonkeyMigrationStrategy.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/iobalancer/MonkeyMigrationStrategy.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.hazelcast.nio.tcp.iobalancer;
+package com.hazelcast.nio.tcp.nonblocking.iobalancer;
 
 import com.hazelcast.nio.tcp.nonblocking.MigratableHandler;
 

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/iobalancer/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/iobalancer/package-info.java
@@ -17,4 +17,4 @@
 /**
  * Contains Handler Migration classes
  */
-package com.hazelcast.nio.tcp.iobalancer;
+package com.hazelcast.nio.tcp.nonblocking.iobalancer;

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/nonblocking/iobalancer/EventCountBasicMigrationStrategyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/nonblocking/iobalancer/EventCountBasicMigrationStrategyTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.hazelcast.nio.tcp.iobalancer;
+package com.hazelcast.nio.tcp.nonblocking.iobalancer;
 
 import com.hazelcast.nio.tcp.nonblocking.IOSelector;
 import com.hazelcast.nio.tcp.nonblocking.MigratableHandler;

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/nonblocking/iobalancer/IOBalancerStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/nonblocking/iobalancer/IOBalancerStressTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.hazelcast.nio.tcp.iobalancer;
+package com.hazelcast.nio.tcp.nonblocking.iobalancer;
 
 import com.hazelcast.config.Config;
 import com.hazelcast.core.Hazelcast;

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/nonblocking/iobalancer/LoadTrackerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/nonblocking/iobalancer/LoadTrackerTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.hazelcast.nio.tcp.iobalancer;
+package com.hazelcast.nio.tcp.nonblocking.iobalancer;
 
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.tcp.nonblocking.AbstractIOSelector;
@@ -26,7 +26,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/nonblocking/iobalancer/MonkeyMigrationStrategyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/nonblocking/iobalancer/MonkeyMigrationStrategyTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.hazelcast.nio.tcp.iobalancer;
+package com.hazelcast.nio.tcp.nonblocking.iobalancer;
 
 import com.hazelcast.nio.tcp.nonblocking.IOSelector;
 import com.hazelcast.nio.tcp.nonblocking.MigratableHandler;


### PR DESCRIPTION
The io balancer only has meaning for the non blocking threading model. So it is moved into that package.