### PR TITLE
Queue.addAll in new client should not use Set in the codec

### DIFF
--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/proxy/ClientQueueProxy.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/proxy/ClientQueueProxy.java
@@ -55,9 +55,11 @@ import com.hazelcast.monitor.LocalQueueStats;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.SerializationService;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -334,7 +336,7 @@ public final class ClientQueueProxy<E> extends ClientProxy implements IQueue<E> 
     }
 
     public boolean addAll(Collection<? extends E> c) {
-        ClientMessage request = QueueAddAllCodec.encodeRequest(name, getDataSet(c));
+        ClientMessage request = QueueAddAllCodec.encodeRequest(name, getDataList(c));
         ClientMessage response = invoke(request);
         QueueAddAllCodec.ResponseParameters resultParameters = QueueAddAllCodec.decodeResponse(response);
         return resultParameters.response;
@@ -373,6 +375,14 @@ public final class ClientQueueProxy<E> extends ClientProxy implements IQueue<E> 
             dataSet.add(toData(o));
         }
         return dataSet;
+    }
+
+    private List<Data> getDataList(Collection<?> objects) {
+        List<Data> dataList = new ArrayList<Data>(objects.size());
+        for (Object o : objects) {
+            dataList.add(toData(o));
+        }
+        return dataList;
     }
 
     @Override

--- a/hazelcast-client-new/src/test/java/com/hazelcast/client/queue/ClientQueueTest.java
+++ b/hazelcast-client-new/src/test/java/com/hazelcast/client/queue/ClientQueueTest.java
@@ -340,9 +340,16 @@ public class ClientQueueTest {
         for (int i = 0; i < maxItems; i++) {
             coll.add(i);
         }
-
         assertTrue(q.addAll(coll));
         assertEquals(coll.size(), q.size());
+
+        // assert queue is same
+        ArrayList actual = new ArrayList();
+        for (Object item : q) {
+            actual.add(item);
+        }
+
+        assertEquals(coll, actual);
     }
 
     @Test

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/QueueCodecTemplate.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/QueueCodecTemplate.java
@@ -22,6 +22,7 @@ import com.hazelcast.client.impl.protocol.EventMessageConst;
 import com.hazelcast.client.impl.protocol.ResponseMessageConst;
 import com.hazelcast.nio.serialization.Data;
 
+import java.util.List;
 import java.util.Set;
 
 @GenerateCodec(id = TemplateConstants.QUEUE_TEMPLATE_ID, name = "Queue", ns = "Hazelcast.Client.Protocol.Queue")
@@ -73,7 +74,7 @@ public interface QueueCodecTemplate {
     void clear(String name);
 
     @Request(id = 16, retryable = false, response = ResponseMessageConst.BOOLEAN)
-    void addAll(String name, Set<Data> dataList);
+    void addAll(String name, List<Data> dataList);
 
     @Request(id = 17, retryable = true, response = ResponseMessageConst.STRING,
              event = {EventMessageConst.EVENT_ITEM})


### PR DESCRIPTION
Currently `Queue.addAll()` in new client uses `Set` in the codec, which causes items to be de duplicated and also lose the ordering when added. This has been changed to use `List`. We can further discuss if we want to change the other methods (`removeAll`, `retainAll` etc.) to use `List` as well.