### PR TITLE
Spinning IOThreadingModel

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -373,6 +373,7 @@
     <suppress checks="MethodCount" files="com/hazelcast/nio/Bits"/>
     <suppress checks="ExecutableStatementCount|ClassDataAbstractionCoupling|ClassFanOutComplexity"
               files="com/hazelcast/nio/tcp/TcpIpConnectionManager"/>
+    <suppress checks="NPathComplexity" files="com/hazelcast/nio/tcp/spinning/SpinningReadHandler"/>
     <suppress checks="MethodCount|MagicNumber" files="com/hazelcast/internal/serialization/impl/ByteArrayObjectDataInput"/>
     <suppress checks="MethodCount|MagicNumber" files="com/hazelcast/internal/serialization/impl/ByteArrayObjectDataOutput"/>
     <suppress checks="MethodCount|MagicNumber" files="com/hazelcast/internal/serialization/impl/ByteBufferObjectDataInput"/>

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/NonBlockingIOThreadingModel.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/NonBlockingIOThreadingModel.java
@@ -21,9 +21,9 @@ import com.hazelcast.internal.metrics.MetricsRegistry;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.LoggingService;
 import com.hazelcast.nio.IOService;
+import com.hazelcast.nio.tcp.IOThreadingModel;
 import com.hazelcast.nio.tcp.ReadHandler;
 import com.hazelcast.nio.tcp.TcpIpConnection;
-import com.hazelcast.nio.tcp.IOThreadingModel;
 import com.hazelcast.nio.tcp.WriteHandler;
 import com.hazelcast.nio.tcp.nonblocking.iobalancer.IOBalancer;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -102,7 +102,7 @@ public class NonBlockingIOThreadingModel implements IOThreadingModel {
 
     @Override
     public void start() {
-        logger.info("TcpIpConnection managed configured NonBlocking threading model:  "
+        logger.info("TcpIpConnectionManager configured with Non Blocking IO-threading model: "
                 + inputThreads.length + " input threads and "
                 + outputThreads.length + " output threads");
 

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/NonBlockingReadHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/NonBlockingReadHandler.java
@@ -26,6 +26,7 @@ import com.hazelcast.nio.tcp.PacketSocketReader;
 import com.hazelcast.nio.tcp.ReadHandler;
 import com.hazelcast.nio.tcp.SocketReader;
 import com.hazelcast.nio.tcp.TcpIpConnection;
+import com.hazelcast.nio.tcp.WriteHandler;
 import com.hazelcast.util.counters.Counter;
 import com.hazelcast.util.counters.SwCounter;
 
@@ -192,7 +193,7 @@ public final class NonBlockingReadHandler extends AbstractSelectionHandler imple
 
         if (!protocolBuffer.hasRemaining()) {
             String protocol = bytesToString(protocolBuffer.array());
-            NonBlockingWriteHandler writeHandler = (NonBlockingWriteHandler) connection.getWriteHandler();
+            WriteHandler writeHandler = connection.getWriteHandler();
             if (CLUSTER.equals(protocol)) {
                 configureBuffers(ioService.getSocketReceiveBufferSize() * KILO_BYTE);
                 connection.setType(MEMBER);

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/spinning/AbstractHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/spinning/AbstractHandler.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.nio.tcp.spinning;
+
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.nio.ConnectionType;
+import com.hazelcast.nio.IOService;
+import com.hazelcast.nio.tcp.TcpIpConnection;
+import com.hazelcast.nio.tcp.TcpIpConnectionManager;
+
+import java.io.IOException;
+import java.util.logging.Level;
+
+public abstract class AbstractHandler {
+
+    protected final TcpIpConnectionManager connectionManager;
+    protected final TcpIpConnection connection;
+    protected final ILogger logger;
+    protected final IOService ioService;
+
+    public AbstractHandler(TcpIpConnection connection, ILogger logger) {
+        this.connection = connection;
+        this.connectionManager = connection.getConnectionManager();
+        this.logger = logger;
+        this.ioService = connectionManager.getIoService();
+    }
+
+    public void onFailure(Throwable e) {
+        if (e instanceof OutOfMemoryError) {
+            connectionManager.getIoService().onOutOfMemory((OutOfMemoryError) e);
+        }
+
+        connection.close(e);
+        ConnectionType connectionType = connection.getType();
+        if (connectionType.isClient() && !connectionType.isBinary()) {
+            return;
+        }
+        StringBuilder sb = new StringBuilder();
+        sb.append(Thread.currentThread().getName());
+        sb.append(" Closing socket to endpoint ");
+        sb.append(connection.getEndPoint());
+        sb.append(", Cause:").append(e);
+        Level level = connectionManager.getIoService().isActive() ? Level.WARNING : Level.FINEST;
+        if (e instanceof IOException) {
+            logger.log(level, sb.toString());
+        } else {
+            logger.log(level, sb.toString(), e);
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/spinning/SpinningIOThreadingModel.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/spinning/SpinningIOThreadingModel.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.nio.tcp.spinning;
+
+import com.hazelcast.instance.HazelcastThreadGroup;
+import com.hazelcast.internal.metrics.MetricsRegistry;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.LoggingService;
+import com.hazelcast.nio.IOService;
+import com.hazelcast.nio.tcp.IOThreadingModel;
+import com.hazelcast.nio.tcp.ReadHandler;
+import com.hazelcast.nio.tcp.TcpIpConnection;
+import com.hazelcast.nio.tcp.WriteHandler;
+
+/**
+ * A {@link IOThreadingModel} that uses (busy) spinning on the SocketChannels to see if there is something
+ * to read or write.
+ *
+ * Currently there are 2 threads spinning:
+ * <ol>
+ * <li>1 thread spinning on all SocketChannels for reading</li>
+ * <li>1 thread spinning on all SocketChannels for writing</li>
+ * </ol>
+ * In the future we need to play with this a lot more. 1 thread should be able to saturate a 40GbE connection, but that
+ * currently doesn't work for us. So I guess our IO threads are doing too much stuff not relevant like writing the Packets
+ * to bytebuffers or converting the bytebuffers to Packets.
+ *
+ * This is an experimental feature and disabled by default.
+ */
+public class SpinningIOThreadingModel implements IOThreadingModel {
+
+    private final ILogger logger;
+    private final MetricsRegistry metricsRegistry;
+    private final LoggingService loggingService;
+    private final SpinningInputThread inputThread;
+    private final SpinningOutputThread outThread;
+
+    public SpinningIOThreadingModel(
+            IOService ioService,
+            LoggingService loggingService,
+            MetricsRegistry metricsRegistry,
+            HazelcastThreadGroup hazelcastThreadGroup) {
+        this.logger = loggingService.getLogger(SpinningIOThreadingModel.class);
+        this.metricsRegistry = metricsRegistry;
+        this.loggingService = loggingService;
+        this.inputThread = new SpinningInputThread(hazelcastThreadGroup, loggingService.getLogger(SpinningInputThread.class));
+        this.outThread = new SpinningOutputThread(hazelcastThreadGroup, loggingService.getLogger(SpinningOutputThread.class));
+    }
+
+    @Override
+    public boolean isBlocking() {
+        return false;
+    }
+
+    @Override
+    public WriteHandler newWriteHandler(TcpIpConnection connection) {
+        ILogger logger = loggingService.getLogger(SpinningWriteHandler.class);
+        return new SpinningWriteHandler(connection, metricsRegistry, logger);
+    }
+
+    @Override
+    public ReadHandler newReadHandler(TcpIpConnection connection) {
+        ILogger logger = loggingService.getLogger(SpinningReadHandler.class);
+        return new SpinningReadHandler(connection, metricsRegistry, logger);
+    }
+
+    @Override
+    public void onConnectionAdded(TcpIpConnection connection) {
+        inputThread.addConnection(connection);
+        outThread.addConnection(connection);
+    }
+
+    @Override
+    public void onConnectionRemoved(TcpIpConnection connection) {
+        inputThread.removeConnection(connection);
+        outThread.removeConnection(connection);
+    }
+
+    @Override
+    public void start() {
+        logger.info("TcpIpConnectionManager configured with Spinning IO-threading model: "
+                + "1 input thread and 1 output thread");
+        inputThread.start();
+        outThread.start();
+    }
+
+    @Override
+    public void shutdown() {
+        inputThread.shutdown();
+        outThread.shutdown();
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/spinning/SpinningInputThread.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/spinning/SpinningInputThread.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.nio.tcp.spinning;
+
+import com.hazelcast.instance.HazelcastThreadGroup;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.nio.tcp.TcpIpConnection;
+
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+
+import static java.lang.System.arraycopy;
+import static java.util.concurrent.atomic.AtomicReferenceFieldUpdater.newUpdater;
+
+public class SpinningInputThread extends Thread {
+
+    private static final ConnectionHandlers SHUTDOWN = new ConnectionHandlers();
+    private static final AtomicReferenceFieldUpdater<SpinningInputThread, ConnectionHandlers> CONNECTION_HANDLERS
+            = newUpdater(SpinningInputThread.class, ConnectionHandlers.class, "connectionHandlers");
+
+    private final ILogger logger;
+    private volatile ConnectionHandlers connectionHandlers;
+
+    public SpinningInputThread(HazelcastThreadGroup threadGroup, ILogger logger) {
+        super(threadGroup.getInternalThreadGroup(), "in-thread");
+        this.logger = logger;
+        this.connectionHandlers = new ConnectionHandlers();
+    }
+
+    public void addConnection(TcpIpConnection connection) {
+        SpinningReadHandler readHandler = (SpinningReadHandler) connection.getReadHandler();
+
+        for (; ; ) {
+            ConnectionHandlers current = connectionHandlers;
+            if (current == SHUTDOWN) {
+                return;
+            }
+
+            int length = current.readHandlers.length;
+            SpinningReadHandler[] newReadHandlers = new SpinningReadHandler[length + 1];
+            arraycopy(current.readHandlers, 0, newReadHandlers, 0, length);
+            newReadHandlers[length] = readHandler;
+
+            ConnectionHandlers update = new ConnectionHandlers(newReadHandlers);
+            if (CONNECTION_HANDLERS.compareAndSet(this, current, update)) {
+                return;
+            }
+        }
+    }
+
+    public void removeConnection(TcpIpConnection connection) {
+        SpinningReadHandler readHandler = (SpinningReadHandler) connection.getReadHandler();
+
+        for (; ; ) {
+            ConnectionHandlers current = connectionHandlers;
+            if (current == SHUTDOWN) {
+                return;
+            }
+
+            int indexOf = current.indexOf(readHandler);
+            if (indexOf == -1) {
+                return;
+            }
+
+            int length = current.readHandlers.length;
+            SpinningReadHandler[] newReadHandlers = new SpinningReadHandler[length - 1];
+
+            int destIndex = 0;
+            for (int sourceIndex = 0; sourceIndex < length; sourceIndex++) {
+                if (sourceIndex != indexOf) {
+                    newReadHandlers[destIndex] = current.readHandlers[sourceIndex];
+                    destIndex++;
+                }
+            }
+
+            ConnectionHandlers update = new ConnectionHandlers(newReadHandlers);
+            if (CONNECTION_HANDLERS.compareAndSet(this, current, update)) {
+                return;
+            }
+        }
+    }
+
+    public void shutdown() {
+        connectionHandlers = SHUTDOWN;
+        interrupt();
+    }
+
+    @Override
+    public void run() {
+        for (; ; ) {
+            ConnectionHandlers handlers = connectionHandlers;
+
+            if (handlers == SHUTDOWN) {
+                return;
+            }
+
+            for (SpinningReadHandler handler : handlers.readHandlers) {
+                try {
+                    handler.read();
+                } catch (Throwable t) {
+                    handler.onFailure(t);
+                }
+            }
+        }
+    }
+
+    static class ConnectionHandlers {
+        final SpinningReadHandler[] readHandlers;
+
+        public ConnectionHandlers() {
+            this(new SpinningReadHandler[0]);
+        }
+
+        public ConnectionHandlers(SpinningReadHandler[] readHandlers) {
+            this.readHandlers = readHandlers;
+        }
+
+        public int indexOf(SpinningReadHandler readHandler) {
+            for (int k = 0; k < readHandlers.length; k++) {
+                if (readHandlers[k] == readHandler) {
+                    return k;
+                }
+            }
+
+            return -1;
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/spinning/SpinningOutputThread.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/spinning/SpinningOutputThread.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.nio.tcp.spinning;
+
+import com.hazelcast.instance.HazelcastThreadGroup;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.nio.tcp.TcpIpConnection;
+
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+
+import static java.lang.System.arraycopy;
+import static java.util.concurrent.atomic.AtomicReferenceFieldUpdater.newUpdater;
+
+public class SpinningOutputThread extends Thread {
+
+    private static final ConnectionHandlers SHUTDOWN = new ConnectionHandlers();
+    private static final AtomicReferenceFieldUpdater<SpinningOutputThread, ConnectionHandlers> CONNECTION_HANDLERS
+            = newUpdater(SpinningOutputThread.class, ConnectionHandlers.class, "connectionHandlers");
+
+    private final ILogger logger;
+    private volatile ConnectionHandlers connectionHandlers;
+
+    public SpinningOutputThread(HazelcastThreadGroup threadGroup, ILogger logger) {
+        super(threadGroup.getInternalThreadGroup(), "out-thread");
+        this.logger = logger;
+        this.connectionHandlers = new ConnectionHandlers();
+    }
+
+    public void addConnection(TcpIpConnection connection) {
+        SpinningWriteHandler writeHandler = (SpinningWriteHandler) connection.getWriteHandler();
+
+        for (; ; ) {
+            ConnectionHandlers current = connectionHandlers;
+            if (current == SHUTDOWN) {
+                return;
+            }
+
+            int length = current.writeHandlers.length;
+
+            SpinningWriteHandler[] newWriteHandlers = new SpinningWriteHandler[length + 1];
+            arraycopy(current.writeHandlers, 0, newWriteHandlers, 0, length);
+            newWriteHandlers[length] = writeHandler;
+
+            ConnectionHandlers update = new ConnectionHandlers(newWriteHandlers);
+            if (CONNECTION_HANDLERS.compareAndSet(this, current, update)) {
+                return;
+            }
+        }
+    }
+
+    public void removeConnection(TcpIpConnection connection) {
+        SpinningWriteHandler writeHandlers = (SpinningWriteHandler) connection.getWriteHandler();
+
+        for (; ; ) {
+            ConnectionHandlers current = connectionHandlers;
+            if (current == SHUTDOWN) {
+                return;
+            }
+
+            int indexOf = current.indexOf(writeHandlers);
+            if (indexOf == -1) {
+                return;
+            }
+
+            int length = current.writeHandlers.length;
+            SpinningWriteHandler[] newWriteHandlers = new SpinningWriteHandler[length - 1];
+
+            int destIndex = 0;
+            for (int sourceIndex = 0; sourceIndex < length; sourceIndex++) {
+                if (sourceIndex != indexOf) {
+                    newWriteHandlers[destIndex] = current.writeHandlers[sourceIndex];
+                    destIndex++;
+                }
+            }
+
+            ConnectionHandlers update = new ConnectionHandlers(newWriteHandlers);
+            if (CONNECTION_HANDLERS.compareAndSet(this, current, update)) {
+                return;
+            }
+        }
+    }
+
+    public void shutdown() {
+        connectionHandlers = SHUTDOWN;
+        interrupt();
+    }
+
+    @Override
+    public void run() {
+        for (; ; ) {
+            ConnectionHandlers handlers = connectionHandlers;
+
+            if (handlers == SHUTDOWN) {
+                return;
+            }
+
+            for (SpinningWriteHandler handler : handlers.writeHandlers) {
+                try {
+                    handler.write();
+                } catch (Throwable t) {
+                    handler.onFailure(t);
+                }
+            }
+        }
+    }
+
+    static class ConnectionHandlers {
+        final SpinningWriteHandler[] writeHandlers;
+
+        public ConnectionHandlers() {
+            this(new SpinningWriteHandler[0]);
+        }
+
+        public ConnectionHandlers(SpinningWriteHandler[] writeHandlers) {
+            this.writeHandlers = writeHandlers;
+        }
+
+        public int indexOf(SpinningWriteHandler handler) {
+            for (int k = 0; k < writeHandlers.length; k++) {
+                if (writeHandlers[k] == handler) {
+                    return k;
+                }
+            }
+
+            return -1;
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/spinning/SpinningReadHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/spinning/SpinningReadHandler.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.nio.tcp.spinning;
+
+import com.hazelcast.internal.metrics.MetricsRegistry;
+import com.hazelcast.internal.metrics.Probe;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.nio.Protocols;
+import com.hazelcast.nio.ascii.SocketTextReader;
+import com.hazelcast.nio.tcp.ClientMessageSocketReader;
+import com.hazelcast.nio.tcp.ClientPacketSocketReader;
+import com.hazelcast.nio.tcp.PacketSocketReader;
+import com.hazelcast.nio.tcp.ReadHandler;
+import com.hazelcast.nio.tcp.SocketChannelWrapper;
+import com.hazelcast.nio.tcp.SocketReader;
+import com.hazelcast.nio.tcp.TcpIpConnection;
+import com.hazelcast.nio.tcp.WriteHandler;
+import com.hazelcast.util.counters.Counter;
+import com.hazelcast.util.counters.SwCounter;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.net.SocketException;
+import java.nio.ByteBuffer;
+
+import static com.hazelcast.nio.ConnectionType.MEMBER;
+import static com.hazelcast.nio.IOService.KILO_BYTE;
+import static com.hazelcast.nio.Protocols.CLIENT_BINARY;
+import static com.hazelcast.nio.Protocols.CLIENT_BINARY_NEW;
+import static com.hazelcast.nio.Protocols.CLUSTER;
+import static com.hazelcast.util.StringUtil.bytesToString;
+import static com.hazelcast.util.counters.SwCounter.newSwCounter;
+import static java.lang.Math.max;
+import static java.lang.System.currentTimeMillis;
+
+public class SpinningReadHandler extends AbstractHandler implements ReadHandler {
+
+    @Probe(name = "in.bytesRead")
+    private final SwCounter bytesRead = newSwCounter();
+    @Probe(name = "in.normalPacketsRead")
+    private final SwCounter normalPacketsRead = newSwCounter();
+    @Probe(name = "in.priorityPacketsRead")
+    private final SwCounter priorityPacketsRead = newSwCounter();
+    private final MetricsRegistry metricRegistry;
+    private final SocketChannelWrapper socketChannel;
+    private volatile long lastReadTime;
+    private SocketReader socketReader;
+    private ByteBuffer inputBuffer;
+    private ByteBuffer protocolBuffer = ByteBuffer.allocate(3);
+
+    public SpinningReadHandler(TcpIpConnection connection, MetricsRegistry metricsRegistry, ILogger logger) {
+        super(connection, logger);
+        this.metricRegistry = metricsRegistry;
+        this.socketChannel = connection.getSocketChannelWrapper();
+        metricRegistry.scanAndRegister(this, "tcp.connection[" + connection.getMetricsId() + "]");
+    }
+
+    @Override
+    public long getLastReadTimeMillis() {
+        return lastReadTime;
+    }
+
+    @Probe(name = "in.idleTimeMs")
+    private long idleTimeMs() {
+        return max(currentTimeMillis() - lastReadTime, 0);
+    }
+
+    @Override
+    public Counter getNormalPacketsReadCounter() {
+        return normalPacketsRead;
+    }
+
+    @Override
+    public Counter getPriorityPacketsReadCounter() {
+        return priorityPacketsRead;
+    }
+
+    @Override
+    public void start() {
+        //no-op
+    }
+
+    @Override
+    public void shutdown() {
+        metricRegistry.deregister(this);
+    }
+
+    public void read() throws Exception {
+        if (!connection.isAlive()) {
+            socketChannel.closeInbound();
+            return;
+        }
+
+        if (socketReader == null) {
+            initializeSocketReader();
+            if (socketReader == null) {
+                // when using SSL, we can read 0 bytes since data read from socket can be handshake packets.
+                return;
+            }
+        }
+
+        int readBytes = socketChannel.read(inputBuffer);
+        if (readBytes <= 0) {
+            if (readBytes == -1) {
+                throw new EOFException("Remote socket closed!");
+            }
+            return;
+        }
+
+        lastReadTime = currentTimeMillis();
+        bytesRead.inc(readBytes);
+        inputBuffer.flip();
+        socketReader.read(inputBuffer);
+        if (inputBuffer.hasRemaining()) {
+            inputBuffer.compact();
+        } else {
+            inputBuffer.clear();
+        }
+    }
+
+    private void initializeSocketReader() throws IOException {
+        if (socketReader != null) {
+            return;
+        }
+
+        int readBytes = socketChannel.read(protocolBuffer);
+        if (readBytes == -1) {
+            throw new EOFException("Could not read protocol type!");
+        }
+
+        if (readBytes == 0 && connectionManager.isSSLEnabled()) {
+            // when using SSL, we can read 0 bytes since data read from socket can be handshake packets.
+            return;
+        }
+
+        if (protocolBuffer.hasRemaining()) {
+            // we have not yet received all protocol bytes
+            return;
+        }
+
+        String protocol = bytesToString(protocolBuffer.array());
+        WriteHandler writeHandler = connection.getWriteHandler();
+        if (CLUSTER.equals(protocol)) {
+            configureBuffers(ioService.getSocketReceiveBufferSize() * KILO_BYTE);
+            connection.setType(MEMBER);
+            writeHandler.setProtocol(CLUSTER);
+            socketReader = new PacketSocketReader(ioService.createPacketReader(connection));
+        } else if (CLIENT_BINARY.equals(protocol)) {
+            configureBuffers(ioService.getSocketClientReceiveBufferSize() * KILO_BYTE);
+            writeHandler.setProtocol(CLIENT_BINARY);
+            socketReader = new ClientPacketSocketReader(connection, ioService);
+        } else if (CLIENT_BINARY_NEW.equals(protocol)) {
+            configureBuffers(ioService.getSocketClientReceiveBufferSize() * KILO_BYTE);
+            writeHandler.setProtocol(CLIENT_BINARY_NEW);
+            socketReader = new ClientMessageSocketReader(connection, ioService);
+        } else {
+            configureBuffers(ioService.getSocketReceiveBufferSize() * KILO_BYTE);
+            writeHandler.setProtocol(Protocols.TEXT);
+            inputBuffer.put(protocolBuffer.array());
+            socketReader = new SocketTextReader(connection);
+            connection.getConnectionManager().incrementTextConnections();
+        }
+    }
+
+    private void configureBuffers(int size) {
+        inputBuffer = ByteBuffer.allocate(size);
+        try {
+            connection.setReceiveBufferSize(size);
+        } catch (SocketException e) {
+            logger.finest("Failed to adjust TCP receive buffer of " + connection + " to " + size + " B.", e);
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/spinning/SpinningWriteHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/spinning/SpinningWriteHandler.java
@@ -1,0 +1,350 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.nio.tcp.spinning;
+
+import com.hazelcast.internal.metrics.MetricsRegistry;
+import com.hazelcast.internal.metrics.Probe;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.nio.Packet;
+import com.hazelcast.nio.SocketWritable;
+import com.hazelcast.nio.ascii.SocketTextWriter;
+import com.hazelcast.nio.tcp.ClientMessageSocketWriter;
+import com.hazelcast.nio.tcp.ClientPacketSocketWriter;
+import com.hazelcast.nio.tcp.MemberPacketSocketWriter;
+import com.hazelcast.nio.tcp.SocketChannelWrapper;
+import com.hazelcast.nio.tcp.SocketWriter;
+import com.hazelcast.nio.tcp.TcpIpConnection;
+import com.hazelcast.nio.tcp.WriteHandler;
+import com.hazelcast.util.EmptyStatement;
+import com.hazelcast.util.counters.SwCounter;
+
+import java.io.IOException;
+import java.net.SocketException;
+import java.nio.ByteBuffer;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+
+import static com.hazelcast.nio.IOService.KILO_BYTE;
+import static com.hazelcast.nio.Protocols.CLIENT_BINARY;
+import static com.hazelcast.nio.Protocols.CLIENT_BINARY_NEW;
+import static com.hazelcast.nio.Protocols.CLUSTER;
+import static com.hazelcast.util.StringUtil.stringToBytes;
+import static com.hazelcast.util.counters.SwCounter.newSwCounter;
+import static java.lang.System.currentTimeMillis;
+
+public class SpinningWriteHandler extends AbstractHandler implements WriteHandler {
+
+    private static final long TIMEOUT = 3;
+
+    @Probe(name = "out.writeQueueSize")
+    private final Queue<SocketWritable> writeQueue;
+    @Probe(name = "out.priorityWriteQueueSize")
+    private final Queue<SocketWritable> urgentWriteQueue;
+    private final ILogger logger;
+    private final SocketChannelWrapper socketChannel;
+    private ByteBuffer outputBuffer;
+    @Probe(name = "out.bytesWritten")
+    private final SwCounter bytesWritten = newSwCounter();
+    @Probe(name = "out.normalPacketsWritten")
+    private final SwCounter normalPacketsWritten = newSwCounter();
+    @Probe(name = "out.priorityPacketsWritten")
+    private final SwCounter priorityPacketsWritten = newSwCounter();
+    private final MetricsRegistry metricsRegistry;
+    private volatile long lastWriteTime;
+    private SocketWriter socketWriter;
+    private volatile SocketWritable currentPacket;
+
+    public SpinningWriteHandler(TcpIpConnection connection, MetricsRegistry metricsRegistry, ILogger logger) {
+        super(connection, logger);
+        this.metricsRegistry = metricsRegistry;
+        this.logger = logger;
+        this.socketChannel = connection.getSocketChannelWrapper();
+        this.writeQueue = new ConcurrentLinkedQueue<SocketWritable>();
+        this.urgentWriteQueue = new ConcurrentLinkedQueue<SocketWritable>();
+        // sensors
+        metricsRegistry.scanAndRegister(this, "tcp.connection[" + connection.getMetricsId() + "]");
+    }
+
+    @Override
+    public void offer(SocketWritable packet) {
+        if (packet.isUrgent()) {
+            urgentWriteQueue.add(packet);
+        } else {
+            writeQueue.add(packet);
+        }
+    }
+
+    @Probe(name = "out.writeQueuePendingBytes")
+    public long bytesPending() {
+        return bytesPending(writeQueue);
+    }
+
+    @Probe(name = "out.priorityWriteQueuePendingBytes")
+    public long priorityBytesPending() {
+        return bytesPending(urgentWriteQueue);
+    }
+
+    @Probe(name = "out.idleTimeMs")
+    private long idleTimeMs() {
+        return Math.max(currentTimeMillis() - lastWriteTime, 0);
+    }
+
+    @Override
+    public int totalPacketsPending() {
+        return urgentWriteQueue.size() + writeQueue.size();
+    }
+
+    private long bytesPending(Queue<SocketWritable> writeQueue) {
+        long bytesPending = 0;
+        for (SocketWritable writable : writeQueue) {
+            if (writable instanceof Packet) {
+                bytesPending += ((Packet) writable).packetSize();
+            }
+        }
+        return bytesPending;
+    }
+
+    @Override
+    public long getLastWriteTimeMillis() {
+        return lastWriteTime;
+    }
+
+    @Override
+    public SocketWriter getSocketWriter() {
+        return socketWriter;
+    }
+
+    // accessed from ReadHandler and SocketConnector
+    @Override
+    public void setProtocol(final String protocol) {
+        final CountDownLatch latch = new CountDownLatch(1);
+        urgentWriteQueue.add(new TaskPacket() {
+            @Override
+            public void run() {
+                logger.info("Setting protocol: " + protocol);
+                createWriter(protocol);
+                latch.countDown();
+            }
+        });
+
+        try {
+            latch.await(TIMEOUT, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            logger.finest("CountDownLatch::await interrupted", e);
+        }
+    }
+
+    private void createWriter(String protocol) {
+        if (socketWriter != null) {
+            return;
+        }
+
+        if (CLUSTER.equals(protocol)) {
+            configureBuffers(ioService.getSocketSendBufferSize() * KILO_BYTE);
+            socketWriter = new MemberPacketSocketWriter(ioService.createPacketWriter(connection));
+            outputBuffer.put(stringToBytes(CLUSTER));
+        } else if (CLIENT_BINARY.equals(protocol)) {
+            configureBuffers(ioService.getSocketClientSendBufferSize() * KILO_BYTE);
+            socketWriter = new ClientPacketSocketWriter();
+        } else if (CLIENT_BINARY_NEW.equals(protocol)) {
+            configureBuffers(ioService.getSocketClientReceiveBufferSize() * KILO_BYTE);
+            socketWriter = new ClientMessageSocketWriter();
+        } else {
+            configureBuffers(ioService.getSocketClientSendBufferSize() * KILO_BYTE);
+            socketWriter = new SocketTextWriter(connection);
+        }
+    }
+
+    private void configureBuffers(int size) {
+        outputBuffer = ByteBuffer.allocate(size);
+        try {
+            connection.setSendBufferSize(size);
+        } catch (SocketException e) {
+            logger.finest("Failed to adjust TCP send buffer of " + connection + " to " + size + " B.", e);
+        }
+    }
+
+    private SocketWritable poll() {
+        for (; ; ) {
+            boolean urgent = true;
+            SocketWritable packet = urgentWriteQueue.poll();
+
+            if (packet == null) {
+                urgent = false;
+                packet = writeQueue.poll();
+            }
+
+            if (packet == null) {
+                return null;
+            }
+
+            if (packet instanceof TaskPacket) {
+                ((TaskPacket) packet).run();
+                continue;
+            }
+
+            if (urgent) {
+                priorityPacketsWritten.inc();
+            } else {
+                normalPacketsWritten.inc();
+            }
+
+            return packet;
+        }
+    }
+
+    @Override
+    public void start() {
+        //no-op
+    }
+
+    @Override
+    public void shutdown() {
+        metricsRegistry.deregister(this);
+        writeQueue.clear();
+        urgentWriteQueue.clear();
+
+        ShutdownTask shutdownTask = new ShutdownTask();
+        offer(shutdownTask);
+        shutdownTask.awaitCompletion();
+    }
+
+    public void write() throws Exception {
+        if (!connection.isAlive()) {
+            return;
+        }
+
+        if (socketWriter == null) {
+            logger.log(Level.WARNING, "SocketWriter is not set, creating SocketWriter with CLUSTER protocol!");
+            createWriter(CLUSTER);
+            return;
+        }
+
+        fillOutputBuffer();
+
+        if (dirtyOutputBuffer()) {
+            writeOutputBufferToSocket();
+        }
+    }
+
+    /**
+     * Checks of the outputBuffer is dirty.
+     *
+     * @return true if dirty, false otherwise.
+     */
+    private boolean dirtyOutputBuffer() {
+        if (outputBuffer == null) {
+            return false;
+        }
+        return outputBuffer.position() > 0;
+    }
+
+    /**
+     * Fills the outBuffer with packets. This is done till there are no more packets or till there is no more space in the
+     * outputBuffer.
+     *
+     * @throws Exception
+     */
+    private void fillOutputBuffer() throws Exception {
+        for (; ; ) {
+            if (outputBuffer != null && !outputBuffer.hasRemaining()) {
+                // The buffer is completely filled, we are done.
+                return;
+            }
+
+            // If there currently is not packet sending, lets try to get one.
+            if (currentPacket == null) {
+                currentPacket = poll();
+                if (currentPacket == null) {
+                    // There is no packet to write, we are done.
+                    return;
+                }
+            }
+
+            // Lets write the currentPacket to the outputBuffer.
+            if (!socketWriter.write(currentPacket, outputBuffer)) {
+                // We are done for this round because not all data of the current packet fits in the outputBuffer
+                return;
+            }
+
+            // The current packet has been written completely. So lets null it and lets try to write another packet.
+            currentPacket = null;
+        }
+    }
+
+    /**
+     * Writes to content of the outputBuffer to the socket.
+     *
+     * @throws Exception
+     */
+    private void writeOutputBufferToSocket() throws Exception {
+        // So there is data for writing, so lets prepare the buffer for writing and then write it to the socketChannel.
+        outputBuffer.flip();
+        int result = socketChannel.write(outputBuffer);
+        if (result > 0) {
+            lastWriteTime = currentTimeMillis();
+            bytesWritten.inc(result);
+        }
+
+        if (outputBuffer.hasRemaining()) {
+            outputBuffer.compact();
+        } else {
+            outputBuffer.clear();
+        }
+    }
+
+    private abstract class TaskPacket implements SocketWritable {
+
+        abstract void run();
+
+        @Override
+        public boolean writeTo(ByteBuffer destination) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean isUrgent() {
+            return true;
+        }
+    }
+
+    private class ShutdownTask extends TaskPacket {
+        private final CountDownLatch latch = new CountDownLatch(1);
+
+        @Override
+        void run() {
+            try {
+                socketChannel.closeOutbound();
+            } catch (IOException e) {
+                logger.finest("Error while closing outbound", e);
+            } finally {
+                latch.countDown();
+            }
+        }
+
+        void awaitCompletion() {
+            try {
+                latch.await(TIMEOUT, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                EmptyStatement.ignore(e);
+            }
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/spinning/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/spinning/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Contains the implementation of the {@link com.hazelcast.nio.tcp.spinning.SpinningIOThreadingModel}.
+ */
+package com.hazelcast.nio.tcp.spinning;

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/spinning/Spinning_IOThreadingModelFactory.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/spinning/Spinning_IOThreadingModelFactory.java
@@ -1,0 +1,17 @@
+package com.hazelcast.nio.tcp.spinning;
+
+import com.hazelcast.internal.metrics.MetricsRegistry;
+import com.hazelcast.nio.tcp.IOThreadingModelFactory;
+import com.hazelcast.nio.tcp.MockIOService;
+
+public class Spinning_IOThreadingModelFactory implements IOThreadingModelFactory {
+
+    @Override
+    public SpinningIOThreadingModel create(MockIOService ioService, MetricsRegistry metricsRegistry) {
+        return new SpinningIOThreadingModel(
+                ioService,
+                ioService.loggingService,
+                metricsRegistry,
+                ioService.hazelcastThreadGroup);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/spinning/Spinning_TcpIpConnectionManager_ConnectTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/spinning/Spinning_TcpIpConnectionManager_ConnectTest.java
@@ -1,0 +1,20 @@
+package com.hazelcast.nio.tcp.spinning;
+
+import com.hazelcast.nio.tcp.TcpIpConnectionManager_ConnectTest;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class Spinning_TcpIpConnectionManager_ConnectTest extends TcpIpConnectionManager_ConnectTest {
+
+    @Before
+    public void setup() throws Exception {
+        threadingModelFactory = new Spinning_IOThreadingModelFactory();
+        super.setup();
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/spinning/Spinning_TcpIpConnection_BasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/spinning/Spinning_TcpIpConnection_BasicTest.java
@@ -1,0 +1,19 @@
+package com.hazelcast.nio.tcp.spinning;
+
+import com.hazelcast.nio.tcp.TcpIpConnection_BasicTest;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class Spinning_TcpIpConnection_BasicTest extends TcpIpConnection_BasicTest {
+
+    @Before
+    public void setup() throws Exception {
+        threadingModelFactory = new Spinning_IOThreadingModelFactory();
+        super.setup();
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/spinning/Spinning_TcpIpConnection_TransferStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/spinning/Spinning_TcpIpConnection_TransferStressTest.java
@@ -1,0 +1,19 @@
+package com.hazelcast.nio.tcp.spinning;
+
+import com.hazelcast.nio.tcp.TcpIpConnection_TransferStressTest;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.NightlyTest;
+import org.junit.Before;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(NightlyTest.class)
+public class Spinning_TcpIpConnection_TransferStressTest extends TcpIpConnection_TransferStressTest {
+
+    @Before
+    public void setup() throws Exception {
+        threadingModelFactory = new Spinning_IOThreadingModelFactory();
+        super.setup();
+    }
+}


### PR DESCRIPTION
Since the TcpIpConnection threadmodel has been pulled into its own abstraction, it is easy to swap it out by a different implementation. Hazelcast by default using non blocking (selector based) io. This PR contains a spinning IO implementation.  It spins by looping on the read/write of the SocketChannel.

It is an experimental feature to learn more about throughput and latency. And perhaps in the future can be used in production.