### PR TITLE
corrects wrong quorumtype

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/quorum/MapReadQuorumTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/MapReadQuorumTest.java
@@ -53,7 +53,7 @@ public class MapReadQuorumTest {
     public static void initialize() throws InterruptedException {
         QuorumConfig quorumConfig = new QuorumConfig();
         quorumConfig.setName(QUORUM_ID);
-        quorumConfig.setType(QuorumType.READ_WRITE);
+        quorumConfig.setType(QuorumType.READ);
         quorumConfig.setEnabled(true);
         quorumConfig.setSize(3);
         MapConfig mapConfig = new MapConfig(MAP_NAME_PREFIX + "*");


### PR DESCRIPTION
READ_WRITE quorum type is tested in MapReadWriteQuorumTest.java.
This one should have been READ