### PR TITLE
Backport #5902: fix compression serialization

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/DefaultSerializers.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/DefaultSerializers.java
@@ -156,14 +156,19 @@ public final class DefaultSerializers {
             out.writeUTF(obj.getClass().getName());
             final ObjectOutputStream objectOutputStream;
             final OutputStream outputStream = (OutputStream) out;
+            GZIPOutputStream gzip = null;
             if (gzipEnabled) {
-                objectOutputStream = new ObjectOutputStream(new GZIPOutputStream(outputStream));
+                gzip = new GZIPOutputStream(outputStream);
+                objectOutputStream = new ObjectOutputStream(gzip);
             } else {
                 objectOutputStream = new ObjectOutputStream(outputStream);
             }
             obj.writeExternal(objectOutputStream);
             // Force flush if not yet written due to internal behavior if pos < 1024
             objectOutputStream.flush();
+            if (gzipEnabled) {
+                gzip.finish();
+            }
         }
     }
 
@@ -207,8 +212,10 @@ public final class DefaultSerializers {
         public void write(final ObjectDataOutput out, final Object obj) throws IOException {
             final ObjectOutputStream objectOutputStream;
             final OutputStream outputStream = (OutputStream) out;
+            GZIPOutputStream gzip = null;
             if (gzipEnabled) {
-                objectOutputStream = new ObjectOutputStream(new GZIPOutputStream(outputStream));
+                gzip = new GZIPOutputStream(outputStream);
+                objectOutputStream = new ObjectOutputStream(gzip);
             } else {
                 objectOutputStream = new ObjectOutputStream(outputStream);
             }
@@ -219,6 +226,9 @@ public final class DefaultSerializers {
             }
             // Force flush if not yet written due to internal behavior if pos < 1024
             objectOutputStream.flush();
+            if (gzipEnabled) {
+                gzip.finish();
+            }
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/SerializationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/SerializationTest.java
@@ -41,13 +41,17 @@ import org.junit.runner.RunWith;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.Externalizable;
 import java.io.IOException;
+import java.io.ObjectInput;
 import java.io.ObjectInputStream;
+import java.io.ObjectOutput;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.LinkedList;
+import java.util.Properties;
 import java.util.Random;
 
 import static org.junit.Assert.assertArrayEquals;
@@ -254,6 +258,61 @@ public class SerializationTest
         Assert.assertFalse("Objects should not be identical!", foo == foo.getBar().getFoo());
     }
 
+    /**
+     * Ensures that SerializationService correctly handles compressed Serializables,
+     * using a Properties object as a test case.
+     */
+    @Test
+    public void testCompressionOnSerializables() throws Exception {
+        SerializationService serializationService = new DefaultSerializationServiceBuilder().setEnableCompression(true).build();
+        long key = 1, value = 5000;
+        Properties properties = new Properties();
+        properties.put(key, value);
+        Data data = serializationService.toData(properties);
+        
+        Properties output = serializationService.toObject(data);
+        assertEquals(value, output.get(key));
+    }
+
+    /**
+     * Ensures that SerializationService correctly handles compressed Serializables,
+     * using a test-specific object as a test case.
+     */
+    @Test
+    public void testCompressionOnExternalizables() throws Exception {
+        SerializationService serializationService = new DefaultSerializationServiceBuilder().setEnableCompression(true).build();
+        String test = "test";
+        ExternalizableString ex = new ExternalizableString(test);  
+        Data data = serializationService.toData(ex);
+        
+        ExternalizableString actual = serializationService.toObject(data);
+        assertEquals(test, actual.value);
+    }
+    
+    private static class ExternalizableString implements Externalizable {
+        
+        String value; 
+        
+        public ExternalizableString() {
+            
+        }
+        
+        public ExternalizableString(String value) {
+            this.value = value;
+        }
+        
+        @Override
+        public void writeExternal(ObjectOutput out) throws IOException {
+            out.writeUTF(value);            
+        }
+
+        @Override
+        public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
+            value = in.readUTF();           
+        }
+        
+    }
+    
     private static class Foo implements Serializable {
         public Bar bar;
 


### PR DESCRIPTION
* Create two tests that demonstrate compression in ObjectSerializer and
Externalizer. The tests will serialize an object, deserialize the
resulting Data, and compare the original object with the deserialized
one to ensure no loss of fidelity.

* Ensure that GZIPOutputStream.finish is called at the end of
serializer.write if gzipEnabled, to ensure that everything in the gzip
buffer gets flushed out.

Fixes #5900 for the maintenance-3.x branch by backporting #5902