### PR TITLE
Surefire version updated

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
         <maven.jar.plugin.version>2.4</maven.jar.plugin.version>
         <maven.source.plugin.version>2.2.1</maven.source.plugin.version>
         <maven.antrun.plugin.version>1.7</maven.antrun.plugin.version>
-        <maven.surefire.plugin.version>2.17</maven.surefire.plugin.version>
+        <maven.surefire.plugin.version>2.18.1</maven.surefire.plugin.version>
         <maven.assembly.plugin.version>2.4</maven.assembly.plugin.version>
         <maven.gpg.plugin.version>1.4</maven.gpg.plugin.version>
         <maven.javadoc.plugin.version>2.9</maven.javadoc.plugin.version>


### PR DESCRIPTION
`WebFilterSessionCleanupTest` was executed during a regular build even when the test belongs to the SlowTest category.
It's a known bug in a Surefire Maven Plugin - https://issues.apache.org/jira/browse/SUREFIRE-1036

A big thanks to @frant-hartm for finding the Surefire bug.