### PR TITLE
Spurious test failure fixed

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationNetworkSplitTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationNetworkSplitTest.java
@@ -105,9 +105,9 @@ public class InvocationNetworkSplitTest extends HazelcastTestSupport {
         clusterService3.prepareToMerge(node1.address);
         clusterService3.merge(node1.address);
 
-        assertEquals(3, node1.getClusterService().getSize());
-        assertEquals(3, node2.getClusterService().getSize());
-        assertEquals(3, node3.getClusterService().getSize());
+        assertClusterSizeEventually(3, hz1);
+        assertClusterSizeEventually(3, hz2);
+        assertClusterSizeEventually(3, hz3);
 
         try {
             future.get(1, TimeUnit.MINUTES);


### PR DESCRIPTION
Fixing #5862 as discussed with @mdogan 

The test creates creates a cluster of 3 members, introduces a split-brain and then attempts to heal it.

Now the healing process has two-steps: first it calls prepareMerge() which schedules the actual merge. However the test also calls the same merge() method on its own. So at the end of the day there are 2 threads attempting to call the merge() method. The merge() is protected by a AtomicBoolean to ensure only 1 thread is doing a merge. In most cases it's the test thread which win the CAS. But if the scheduled thread wins then the test-thread will lose the CAS on and will return before the merge is completed -> Test Failure.