### PR TITLE
Removed getIOHandler method

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/nio/ascii/SocketTextReader.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/ascii/SocketTextReader.java
@@ -95,7 +95,7 @@ public class SocketTextReader implements SocketReader {
     private final ILogger logger;
 
     public SocketTextReader(TcpIpConnection connection) {
-        IOService ioService = connection.getConnectionManager().getIOHandler();
+        IOService ioService = connection.getConnectionManager().getIoService();
         this.textCommandService = ioService.getTextCommandService();
         this.socketTextWriter = (SocketTextWriter) connection.getWriteHandler().getSocketWriter();
         this.connection = connection;

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnectionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnectionManager.java
@@ -242,10 +242,6 @@ public class TcpIpConnectionManager implements ConnectionManager, PacketHandler 
         allTextConnections.incrementAndGet();
     }
 
-    public IOService getIOHandler() {
-        return ioService;
-    }
-
     public int getSocketConnectTimeoutSeconds() {
         return socketConnectTimeoutSeconds;
     }

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnectionMonitor.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnectionMonitor.java
@@ -33,7 +33,7 @@ public class TcpIpConnectionMonitor {
 
     public TcpIpConnectionMonitor(TcpIpConnectionManager connectionManager, Address endPoint) {
         this.endPoint = endPoint;
-        this.ioService = connectionManager.getIOHandler();
+        this.ioService = connectionManager.getIoService();
         this.minInterval = ioService.getConnectionMonitorInterval();
         this.maxFaults = ioService.getConnectionMonitorMaxFaults();
         this.logger = ioService.getLogger(getClass().getName());

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/TcpIpConnectionManager_ConnectTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/TcpIpConnectionManager_ConnectTest.java
@@ -130,7 +130,7 @@ public class TcpIpConnectionManager_ConnectTest extends TcpIpConnection_Abstract
         assertEquals(ConnectionType.MEMBER, connBA.getType());
         assertEquals(1, connManagerB.getActiveConnectionCount());
 
-        assertEquals(connManagerA.getIOHandler().getThisAddress(), connBA.getEndPoint());
-        assertEquals(connManagerB.getIOHandler().getThisAddress(), connAB.getEndPoint());
+        assertEquals(connManagerA.getIoService().getThisAddress(), connBA.getEndPoint());
+        assertEquals(connManagerB.getIoService().getThisAddress(), connAB.getEndPoint());
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/TcpIpConnection_AbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/TcpIpConnection_AbstractTest.java
@@ -45,13 +45,13 @@ public abstract class TcpIpConnection_AbstractTest extends HazelcastTestSupport 
         logger = loggingService.getLogger(TcpIpConnection_AbstractTest.class);
 
         connManagerA = newConnectionManager(addressA.getPort());
-        ioServiceA = (MockIOService) connManagerA.getIOHandler();
+        ioServiceA = (MockIOService) connManagerA.getIoService();
 
         connManagerB = newConnectionManager(addressB.getPort());
-        ioServiceB = (MockIOService) connManagerB.getIOHandler();
+        ioServiceB = (MockIOService) connManagerB.getIoService();
 
         connManagerC = newConnectionManager(addressC.getPort());
-        ioServiceC = (MockIOService) connManagerB.getIOHandler();
+        ioServiceC = (MockIOService) connManagerB.getIoService();
 
         serializationService = new DefaultSerializationServiceBuilder()
                 .addDataSerializableFactory(TestDataFactory.FACTORY_ID, new TestDataFactory())


### PR DESCRIPTION
getIoService and getIOHandler both did the same. So I removed the getIOHandler since it isn't
a logical name (the object returned is called ioservice).

HZ enterprise doesn't use this method. So no changes needed there.