### PR TITLE
Discovery SPI implementation for member, client, client-new

### DIFF
--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/config/ClientNetworkConfig.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/config/ClientNetworkConfig.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.client.config;
 
+import com.hazelcast.config.DiscoveryStrategiesConfig;
 import com.hazelcast.config.SSLConfig;
 import com.hazelcast.config.SocketInterceptorConfig;
 
@@ -40,7 +41,28 @@ public class ClientNetworkConfig {
     private SocketOptions socketOptions = new SocketOptions();
     private SSLConfig sslConfig;
     private ClientAwsConfig clientAwsConfig;
+    private DiscoveryStrategiesConfig discoveryStrategiesConfig;
 
+    /**
+     * Returns the configuration of the Hazelcast Discovery SPI and configured discovery providers
+     *
+     * @return Discovery Provider SPI configuration
+     */
+    public DiscoveryStrategiesConfig getDiscoveryStrategiesConfig() {
+        if (discoveryStrategiesConfig == null) {
+            discoveryStrategiesConfig = new DiscoveryStrategiesConfig();
+        }
+        return discoveryStrategiesConfig;
+    }
+
+    /**
+     * Defines the Discovery Provider SPI configuration
+     *
+     * @param discoveryStrategiesConfig the Discovery Provider SPI configuration
+     */
+    public void setDiscoveryStrategiesConfig(DiscoveryStrategiesConfig discoveryStrategiesConfig) {
+        this.discoveryStrategiesConfig = discoveryStrategiesConfig;
+    }
 
     /**
      * @return true if client is smart

--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/config/XmlClientConfigBuilder.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/config/XmlClientConfigBuilder.java
@@ -20,6 +20,8 @@ import com.hazelcast.client.util.RandomLB;
 import com.hazelcast.client.util.RoundRobinLB;
 import com.hazelcast.config.AbstractConfigBuilder;
 import com.hazelcast.config.ConfigLoader;
+import com.hazelcast.config.DiscoveryStrategyConfig;
+import com.hazelcast.config.DiscoveryStrategiesConfig;
 import com.hazelcast.config.EvictionConfig;
 import com.hazelcast.config.EvictionPolicy;
 import com.hazelcast.config.InMemoryFormat;
@@ -46,7 +48,9 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 
@@ -324,9 +328,63 @@ public class XmlClientConfigBuilder extends AbstractConfigBuilder {
                 handleSSLConfig(child, clientNetworkConfig);
             } else if ("aws".equals(nodeName)) {
                 handleAWS(child, clientNetworkConfig);
+            } else if ("discovery-strategies".equals(nodeName)) {
+                handleDiscoveryStrategies(child, clientNetworkConfig);
             }
         }
         clientConfig.setNetworkConfig(clientNetworkConfig);
+    }
+
+    private void handleDiscoveryStrategies(Node node, ClientNetworkConfig clientNetworkConfig) {
+        final DiscoveryStrategiesConfig discoveryStrategiesConfig = clientNetworkConfig.getDiscoveryStrategiesConfig();
+        for (Node child : new IterableNodeList(node.getChildNodes())) {
+            final String name = cleanNodeName(child.getNodeName());
+            if ("discovery-strategy".equals(name)) {
+                handleDiscoveryStrategy(child, discoveryStrategiesConfig);
+            } else if ("node-filter".equals(name)) {
+                handleDiscoveryNodeFilter(child, discoveryStrategiesConfig);
+            }
+        }
+    }
+
+    private void handleDiscoveryNodeFilter(Node node, DiscoveryStrategiesConfig discoveryStrategiesConfig) {
+        final NamedNodeMap atts = node.getAttributes();
+
+        final Node att = atts.getNamedItem("class");
+        if (att != null) {
+            discoveryStrategiesConfig.setNodeFilterClass(getTextContent(att).trim());
+        }
+    }
+
+    private void handleDiscoveryStrategy(Node node, DiscoveryStrategiesConfig discoveryStrategiesConfig) {
+        final NamedNodeMap atts = node.getAttributes();
+
+        boolean enabled = false;
+        String clazz = null;
+
+        for (int a = 0; a < atts.getLength(); a++) {
+            final Node att = atts.item(a);
+            final String value = getTextContent(att).trim();
+            if ("enabled".equalsIgnoreCase(att.getNodeName())) {
+                enabled = checkTrue(value);
+            } else if ("class".equals(att.getNodeName())) {
+                clazz = value;
+            }
+        }
+
+        if (!enabled || clazz == null) {
+            return;
+        }
+
+        Map<String, Comparable> properties = new HashMap<String, Comparable>();
+        for (Node child : new IterableNodeList(node.getChildNodes())) {
+            final String name = cleanNodeName(child.getNodeName());
+            if ("properties".equals(name)) {
+                fillProperties(child, properties);
+            }
+        }
+
+        discoveryStrategiesConfig.addDiscoveryProviderConfig(new DiscoveryStrategyConfig(clazz, properties));
     }
 
     private void handleAWS(Node node, ClientNetworkConfig clientNetworkConfig) {

--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/impl/ClientConnectionManagerFactory.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/impl/ClientConnectionManagerFactory.java
@@ -18,8 +18,10 @@ package com.hazelcast.client.impl;
 
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.connection.ClientConnectionManager;
+import com.hazelcast.spi.discovery.integration.DiscoveryService;
 
 public interface ClientConnectionManagerFactory {
 
-    ClientConnectionManager createConnectionManager(ClientConfig config, HazelcastClientInstanceImpl client);
+    ClientConnectionManager createConnectionManager(ClientConfig config, HazelcastClientInstanceImpl client,
+                                                    DiscoveryService discoveryService);
 }

--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/impl/DefaultClientConnectionManagerFactory.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/impl/DefaultClientConnectionManagerFactory.java
@@ -24,8 +24,10 @@ import com.hazelcast.client.connection.ClientConnectionManager;
 import com.hazelcast.client.connection.nio.ClientConnectionManagerImpl;
 import com.hazelcast.client.spi.impl.AwsAddressTranslator;
 import com.hazelcast.client.spi.impl.DefaultAddressTranslator;
+import com.hazelcast.client.spi.impl.discovery.DiscoveryAddressTranslator;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
+import com.hazelcast.spi.discovery.integration.DiscoveryService;
 
 import java.util.logging.Level;
 
@@ -37,7 +39,9 @@ public class DefaultClientConnectionManagerFactory implements ClientConnectionMa
     }
 
     @Override
-    public ClientConnectionManager createConnectionManager(ClientConfig config, HazelcastClientInstanceImpl client) {
+    public ClientConnectionManager createConnectionManager(ClientConfig config, HazelcastClientInstanceImpl client,
+                                                           DiscoveryService discoveryService) {
+
         final ClientAwsConfig awsConfig = config.getNetworkConfig().getAwsConfig();
         AddressTranslator addressTranslator;
         if (awsConfig != null && awsConfig.isEnabled()) {
@@ -47,6 +51,8 @@ public class DefaultClientConnectionManagerFactory implements ClientConnectionMa
                 LOGGER.log(Level.WARNING, "hazelcast-cloud.jar might be missing!");
                 throw e;
             }
+        } else if (discoveryService != null) {
+            addressTranslator = new DiscoveryAddressTranslator(discoveryService);
         } else {
             addressTranslator = new DefaultAddressTranslator();
         }

--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/spi/impl/discovery/DiscoveryAddressProvider.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/spi/impl/discovery/DiscoveryAddressProvider.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.spi.impl.discovery;
+
+import com.hazelcast.client.connection.AddressProvider;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
+import com.hazelcast.nio.Address;
+import com.hazelcast.spi.discovery.DiscoveredNode;
+import com.hazelcast.spi.discovery.integration.DiscoveryService;
+
+import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.Collection;
+
+public class DiscoveryAddressProvider
+        implements AddressProvider {
+
+    private static final ILogger LOGGER = Logger.getLogger(DiscoveryAddressProvider.class);
+
+    private final DiscoveryService discoveryService;
+
+    public DiscoveryAddressProvider(DiscoveryService discoveryService) {
+        this.discoveryService = discoveryService;
+    }
+
+    @Override
+    public Collection<InetSocketAddress> loadAddresses() {
+        Iterable<DiscoveredNode> discoveredNodes = discoveryService.discoverNodes();
+
+        Collection<InetSocketAddress> possibleMembers = new ArrayList<InetSocketAddress>();
+        for (DiscoveredNode discoveredNode : discoveredNodes) {
+            Address discoveredAddress = discoveredNode.getPrivateAddress();
+            try {
+                possibleMembers.add(discoveredAddress.getInetSocketAddress());
+            } catch (UnknownHostException e) {
+                LOGGER.warning("Unresolvable host exception", e);
+            }
+        }
+        return possibleMembers;
+    }
+}

--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/spi/impl/discovery/DiscoveryAddressTranslator.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/spi/impl/discovery/DiscoveryAddressTranslator.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.spi.impl.discovery;
+
+import com.hazelcast.client.connection.AddressTranslator;
+import com.hazelcast.nio.Address;
+import com.hazelcast.spi.discovery.DiscoveredNode;
+import com.hazelcast.spi.discovery.integration.DiscoveryService;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class DiscoveryAddressTranslator
+        implements AddressTranslator {
+
+    private final DiscoveryService discoveryService;
+
+    private volatile Map<Address, Address> privateToPublic;
+
+    public DiscoveryAddressTranslator(DiscoveryService discoveryService) {
+        this.discoveryService = discoveryService;
+    }
+
+    @Override
+    public Address translate(Address address) {
+        if (address == null) {
+            return null;
+        }
+
+        // Refresh only once to prevent load on service discovery
+        boolean alreadyRefreshed = false;
+
+        Map<Address, Address> privateToPublic = this.privateToPublic;
+        if (privateToPublic == null) {
+            refresh();
+            alreadyRefreshed = true;
+        }
+
+        privateToPublic = this.privateToPublic;
+        Address publicAddress = privateToPublic.get(address);
+        if (!alreadyRefreshed) {
+            refresh();
+            privateToPublic = this.privateToPublic;
+            publicAddress = privateToPublic.get(address);
+        }
+
+        // If public address available return, otherwise choose given address
+        return publicAddress != null ? publicAddress : address;
+    }
+
+    @Override
+    public void refresh() {
+        Iterable<DiscoveredNode> discoveredNodes = discoveryService.discoverNodes();
+
+        Map<Address, Address> privateToPublic = new HashMap<Address, Address>();
+        for (DiscoveredNode discoveredNode : discoveredNodes) {
+            privateToPublic.put(discoveredNode.getPrivateAddress(), discoveredNode.getPublicAddress());
+        }
+        this.privateToPublic = privateToPublic;
+    }
+}

--- a/hazelcast-client-new/src/main/resources/hazelcast-client-config-3.6.xsd
+++ b/hazelcast-client-new/src/main/resources/hazelcast-client-config-3.6.xsd
@@ -82,9 +82,26 @@
             <xs:element name="socket-interceptor" type="socket-interceptor" minOccurs="0" maxOccurs="1"/>
             <xs:element name="ssl" type="ssl" minOccurs="0" maxOccurs="1"/>
             <xs:element name="aws" type="aws" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="discovery-strategies" type="discovery-strategies" minOccurs="0" maxOccurs="1"/>
         </xs:all>
     </xs:complexType>
 
+    <xs:complexType name="discovery-strategies">
+        <xs:sequence>
+            <xs:element name="node-filter" type="discovery-node-filter" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="discovery-strategy" type="discovery-strategy" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="discovery-node-filter">
+        <xs:attribute name="class" type="xs:string" use="required"/>
+    </xs:complexType>
+    <xs:complexType name="discovery-strategy">
+        <xs:sequence>
+            <xs:element name="properties" type="properties" minOccurs="0" maxOccurs="1"/>
+        </xs:sequence>
+        <xs:attribute name="enabled" type="xs:boolean" use="optional" default="false"/>
+        <xs:attribute name="class" type="xs:string" use="required"/>
+    </xs:complexType>
     <xs:element name="cluster-members">
         <xs:complexType>
             <xs:sequence>

--- a/hazelcast-client-new/src/main/resources/hazelcast-client-full.xml
+++ b/hazelcast-client-new/src/main/resources/hazelcast-client-full.xml
@@ -15,7 +15,7 @@
   ~ limitations under the License.
   -->
 
-<hazelcast-client xsi:schemaLocation="http://www.hazelcast.com/schema/client-config hazelcast-client-config-3.5.xsd"
+<hazelcast-client xsi:schemaLocation="http://www.hazelcast.com/schema/client-config hazelcast-client-config-3.6.xsd"
                   xmlns="http://www.hazelcast.com/schema/client-config"
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 

--- a/hazelcast-client-new/src/test/java/com/hazelcast/client/config/XmlClientConfigBuilderTest.java
+++ b/hazelcast-client-new/src/test/java/com/hazelcast/client/config/XmlClientConfigBuilderTest.java
@@ -312,7 +312,7 @@ public class XmlClientConfigBuilderTest {
 
     private void testXSDConfigXML(String xmlFileName) throws SAXException, IOException {
         SchemaFactory factory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
-        URL schemaResource = XMLConfigBuilderTest.class.getClassLoader().getResource("hazelcast-client-config-3.5.xsd");
+        URL schemaResource = XMLConfigBuilderTest.class.getClassLoader().getResource("hazelcast-client-config-3.6.xsd");
         InputStream xmlResource = XMLConfigBuilderTest.class.getClassLoader().getResourceAsStream(xmlFileName);
         Schema schema = factory.newSchema(schemaResource);
         Source source = new StreamSource(xmlResource);

--- a/hazelcast-client-new/src/test/java/com/hazelcast/client/quorum/ClientMapReadWriteQuorumTest.java
+++ b/hazelcast-client-new/src/test/java/com/hazelcast/client/quorum/ClientMapReadWriteQuorumTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2014, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/hazelcast-client-new/src/test/java/com/hazelcast/client/spi/impl/discovery/ClientDiscoverySpiTest.java
+++ b/hazelcast-client-new/src/test/java/com/hazelcast/client/spi/impl/discovery/ClientDiscoverySpiTest.java
@@ -1,0 +1,256 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.spi.impl.discovery;
+
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.config.ClientNetworkConfig;
+import com.hazelcast.client.config.XmlClientConfigBuilder;
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.config.AwsConfig;
+import com.hazelcast.config.Config;
+import com.hazelcast.config.DiscoveryStrategiesConfig;
+import com.hazelcast.config.DiscoveryStrategyConfig;
+import com.hazelcast.config.InterfacesConfig;
+import com.hazelcast.config.properties.PropertyDefinition;
+import com.hazelcast.config.properties.PropertyTypeConverter;
+import com.hazelcast.config.properties.SimplePropertyDefinition;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.nio.Address;
+import com.hazelcast.spi.discovery.DiscoveredNode;
+import com.hazelcast.spi.discovery.DiscoveryMode;
+import com.hazelcast.spi.discovery.integration.DiscoveryService;
+import com.hazelcast.spi.discovery.integration.DiscoveryServiceProvider;
+import com.hazelcast.spi.discovery.DiscoveryStrategy;
+import com.hazelcast.spi.discovery.DiscoveryStrategyFactory;
+import com.hazelcast.spi.discovery.NodeFilter;
+import com.hazelcast.spi.discovery.SimpleDiscoveredNode;
+import com.hazelcast.spi.discovery.impl.DefaultDiscoveryService;
+import com.hazelcast.spi.discovery.impl.DefaultDiscoveryServiceProvider;
+import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.xml.sax.SAXException;
+
+import javax.xml.XMLConstants;
+import javax.xml.transform.Source;
+import javax.xml.transform.stream.StreamSource;
+import javax.xml.validation.Schema;
+import javax.xml.validation.SchemaFactory;
+import javax.xml.validation.Validator;
+import java.io.InputStream;
+import java.lang.reflect.Field;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class ClientDiscoverySpiTest extends HazelcastTestSupport {
+
+    @Test
+    public void testSchema() throws Exception {
+        String xmlFileName = "hazelcast-client-discovery-spi-test.xml";
+
+        SchemaFactory factory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+        URL schemaResource = ClientDiscoverySpiTest.class.getClassLoader().getResource("hazelcast-client-config-3.6.xsd");
+        Schema schema = factory.newSchema(schemaResource);
+
+        InputStream xmlResource = ClientDiscoverySpiTest.class.getClassLoader().getResourceAsStream(xmlFileName);
+        Source source = new StreamSource(xmlResource);
+        Validator validator = schema.newValidator();
+        validator.validate(source);
+    }
+
+    @Test
+    public void testParsing() throws Exception {
+        String xmlFileName = "hazelcast-client-discovery-spi-test.xml";
+        InputStream xmlResource = ClientDiscoverySpiTest.class.getClassLoader().getResourceAsStream(xmlFileName);
+        ClientConfig clientConfig = new XmlClientConfigBuilder(xmlResource).build();
+
+        ClientNetworkConfig networkConfig = clientConfig.getNetworkConfig();
+
+        AwsConfig awsConfig = networkConfig.getAwsConfig();
+        assertNull(awsConfig);
+
+        DiscoveryStrategiesConfig discoveryStrategiesConfig = networkConfig.getDiscoveryStrategiesConfig();
+        assertTrue(discoveryStrategiesConfig.isEnabled());
+
+        assertEquals(1, discoveryStrategiesConfig.getDiscoveryStrategyConfigs().size());
+
+        DiscoveryStrategyConfig providerConfig = discoveryStrategiesConfig.getDiscoveryStrategyConfigs().iterator().next();
+
+        assertEquals(3, providerConfig.getProperties().size());
+        assertEquals("foo", providerConfig.getProperties().get("key-string"));
+        assertEquals("123", providerConfig.getProperties().get("key-int"));
+        assertEquals("true", providerConfig.getProperties().get("key-boolean"));
+    }
+
+    @Test
+    public void testNodeStartup() {
+        TestHazelcastFactory factory = new TestHazelcastFactory();
+
+        Config config = new Config();
+        config.getNetworkConfig().setPort(50001);
+        InterfacesConfig interfaces = config.getNetworkConfig().getInterfaces();
+        interfaces.clear();
+        interfaces.setEnabled(true);
+        interfaces.addInterface("127.0.0.1");
+
+        final HazelcastInstance hazelcastInstance1 = factory.newHazelcastInstance(config);
+        final HazelcastInstance hazelcastInstance2 = factory.newHazelcastInstance(config);
+        final HazelcastInstance hazelcastInstance3 = factory.newHazelcastInstance(config);
+
+        try {
+            String xmlFileName = "hazelcast-client-discovery-spi-test.xml";
+            InputStream xmlResource = ClientDiscoverySpiTest.class.getClassLoader().getResourceAsStream(xmlFileName);
+
+            ClientConfig clientConfig = new XmlClientConfigBuilder(xmlResource).build();
+            final HazelcastInstance client = factory.newHazelcastClient(clientConfig);
+
+            assertNotNull(hazelcastInstance1);
+            assertNotNull(hazelcastInstance2);
+            assertNotNull(hazelcastInstance3);
+            assertNotNull(client);
+
+            assertTrueEventually(new AssertTask() {
+                @Override
+                public void run()
+                        throws Exception {
+
+                    assertEquals(3, hazelcastInstance1.getCluster().getMembers().size());
+                    assertEquals(3, hazelcastInstance2.getCluster().getMembers().size());
+                    assertEquals(3, hazelcastInstance3.getCluster().getMembers().size());
+                    assertEquals(3, client.getCluster().getMembers().size());
+                }
+            });
+        } finally {
+            factory.shutdownAll();
+        }
+    }
+
+    @Test
+    public void testNodeFilter_from_xml() throws Exception {
+        String xmlFileName = "hazelcast-client-discovery-spi-test.xml";
+        InputStream xmlResource = ClientDiscoverySpiTest.class.getClassLoader().getResourceAsStream(xmlFileName);
+        ClientConfig clientConfig = new XmlClientConfigBuilder(xmlResource).build();
+
+        ClientNetworkConfig networkConfig = clientConfig.getNetworkConfig();
+
+        DiscoveryStrategiesConfig discoveryStrategiesConfig = networkConfig.getDiscoveryStrategiesConfig();
+        assertNotNull(discoveryStrategiesConfig);
+        assertNotNull(discoveryStrategiesConfig.getNodeFilterClass());
+
+        DiscoveryServiceProvider provider = new DefaultDiscoveryServiceProvider();
+        DiscoveryService discoveryService = provider.newDiscoveryService(DiscoveryMode.Client,
+                discoveryStrategiesConfig, ClientDiscoverySpiTest.class.getClassLoader());
+
+        discoveryService.start();
+        discoveryService.discoverNodes();
+        discoveryService.destroy();
+
+        Field nodeFilterField = DefaultDiscoveryService.class.getDeclaredField("nodeFilter");
+        nodeFilterField.setAccessible(true);
+
+        TestNodeFilter nodeFilter = (TestNodeFilter) nodeFilterField.get(discoveryService);
+
+        assertEquals(4, nodeFilter.getNodes().size());
+    }
+
+    private static class TestDiscoveryStrategy implements DiscoveryStrategy {
+
+        @Override
+        public void start(DiscoveryMode discoveryMode) {
+        }
+
+        @Override
+        public Collection<DiscoveredNode> discoverNodes() {
+            try {
+                List<DiscoveredNode> discoveredNodes = new ArrayList<DiscoveredNode>(4);
+                Address privateAddress = new Address("127.0.0.1", 1);
+                Address publicAddress = new Address("127.0.0.1", 50001);
+                discoveredNodes.add(new SimpleDiscoveredNode(privateAddress, publicAddress));
+                publicAddress = new Address("127.0.0.1", 50002);
+                discoveredNodes.add(new SimpleDiscoveredNode(privateAddress, publicAddress));
+                publicAddress = new Address("127.0.0.1", 50003);
+                discoveredNodes.add(new SimpleDiscoveredNode(privateAddress, publicAddress));
+                publicAddress = new Address("127.0.0.1", 50004);
+                discoveredNodes.add(new SimpleDiscoveredNode(privateAddress, publicAddress));
+
+                return discoveredNodes;
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        @Override
+        public void destroy() {
+        }
+    }
+
+    public static class TestDiscoveryStrategyFactory implements DiscoveryStrategyFactory {
+
+        private final Collection<PropertyDefinition> propertyDefinitions;
+
+        public TestDiscoveryStrategyFactory() {
+            List<PropertyDefinition> propertyDefinitions = new ArrayList<PropertyDefinition>();
+            propertyDefinitions.add(new SimplePropertyDefinition("key-string", PropertyTypeConverter.STRING));
+            propertyDefinitions.add(new SimplePropertyDefinition("key-int", PropertyTypeConverter.INTEGER));
+            propertyDefinitions.add(new SimplePropertyDefinition("key-boolean", PropertyTypeConverter.BOOLEAN));
+            propertyDefinitions.add(new SimplePropertyDefinition("key-something", true, PropertyTypeConverter.STRING));
+            this.propertyDefinitions = Collections.unmodifiableCollection(propertyDefinitions);
+        }
+
+        @Override
+        public Class<? extends DiscoveryStrategy> getDiscoveryStrategyType() {
+            return TestDiscoveryStrategy.class;
+        }
+
+        @Override
+        public DiscoveryStrategy newDiscoveryStrategy(Map<String, Comparable> properties) {
+            return new TestDiscoveryStrategy();
+        }
+
+        @Override
+        public Collection<PropertyDefinition> getConfigurationProperties() {
+            return propertyDefinitions;
+        }
+    }
+
+    public static class TestNodeFilter implements NodeFilter {
+
+        private final List<DiscoveredNode> nodes = new ArrayList<DiscoveredNode>();
+
+        @Override
+        public boolean test(DiscoveredNode candidate) {
+            nodes.add(candidate);
+            return true;
+        }
+
+        private List<DiscoveredNode> getNodes() {
+            return nodes;
+        }
+    }
+}

--- a/hazelcast-client-new/src/test/java/com/hazelcast/client/test/TestClientRegistry.java
+++ b/hazelcast-client-new/src/test/java/com/hazelcast/client/test/TestClientRegistry.java
@@ -28,6 +28,7 @@ import com.hazelcast.client.impl.HazelcastClientInstanceImpl;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.spi.impl.AwsAddressTranslator;
 import com.hazelcast.client.spi.impl.DefaultAddressTranslator;
+import com.hazelcast.client.spi.impl.discovery.DiscoveryAddressTranslator;
 import com.hazelcast.core.HazelcastException;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.instance.Node;
@@ -38,6 +39,7 @@ import com.hazelcast.nio.Address;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.ConnectionType;
 import com.hazelcast.nio.OutboundFrame;
+import com.hazelcast.spi.discovery.integration.DiscoveryService;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.test.TestNodeRegistry;
 import com.hazelcast.util.ExceptionUtil;
@@ -71,7 +73,9 @@ public class TestClientRegistry {
         }
 
         @Override
-        public ClientConnectionManager createConnectionManager(ClientConfig config, HazelcastClientInstanceImpl client) {
+        public ClientConnectionManager createConnectionManager(ClientConfig config, HazelcastClientInstanceImpl client,
+                                                               DiscoveryService discoveryService) {
+
             final ClientAwsConfig awsConfig = config.getNetworkConfig().getAwsConfig();
             AddressTranslator addressTranslator;
             if (awsConfig != null && awsConfig.isEnabled()) {
@@ -81,6 +85,8 @@ public class TestClientRegistry {
                     LOGGER.log(Level.WARNING, "hazelcast-cloud.jar might be missing!");
                     throw e;
                 }
+            } else if (discoveryService != null) {
+                addressTranslator = new DiscoveryAddressTranslator(discoveryService);
             } else {
                 addressTranslator = new DefaultAddressTranslator();
             }

--- a/hazelcast-client-new/src/test/resources/META-INF/services/com.hazelcast.spi.discovery.DiscoveryStrategyFactory
+++ b/hazelcast-client-new/src/test/resources/META-INF/services/com.hazelcast.spi.discovery.DiscoveryStrategyFactory
@@ -1,0 +1,1 @@
+com.hazelcast.client.spi.impl.discovery.ClientDiscoverySpiTest$TestDiscoveryStrategyFactory

--- a/hazelcast-client-new/src/test/resources/hazelcast-client-discovery-spi-test.xml
+++ b/hazelcast-client-new/src/test/resources/hazelcast-client-discovery-spi-test.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<hazelcast-client xsi:schemaLocation="http://www.hazelcast.com/schema/client-config hazelcast-client-config-3.6.xsd"
+                  xmlns="http://www.hazelcast.com/schema/client-config"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+  <properties>
+    <property name="hazelcast.discovery.enabled">true</property>
+  </properties>
+
+  <network>
+    <discovery-strategies>
+      <node-filter class="com.hazelcast.client.spi.impl.discovery.ClientDiscoverySpiTest$TestNodeFilter"/>
+      <discovery-strategy enabled="true"
+                          class="com.hazelcast.client.spi.impl.discovery.ClientDiscoverySpiTest$TestDiscoveryStrategy">
+        <properties>
+          <property name="key-string">foo</property>
+          <property name="key-int">123</property>
+          <property name="key-boolean">true</property>
+        </properties>
+      </discovery-strategy>
+    </discovery-strategies>
+  </network>
+
+</hazelcast-client>

--- a/hazelcast-client-new/src/test/resources/hazelcast-client-test.xml
+++ b/hazelcast-client-new/src/test/resources/hazelcast-client-test.xml
@@ -15,7 +15,7 @@
   ~ limitations under the License.
   -->
 
-<hazelcast-client xsi:schemaLocation="http://www.hazelcast.com/schema/client-config hazelcast-client-config-3.5.xsd"
+<hazelcast-client xsi:schemaLocation="http://www.hazelcast.com/schema/client-config hazelcast-client-config-3.6.xsd"
                   xmlns="http://www.hazelcast.com/schema/client-config"
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 

--- a/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientNetworkConfig.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientNetworkConfig.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.client.config;
 
+import com.hazelcast.config.DiscoveryStrategiesConfig;
 import com.hazelcast.config.SSLConfig;
 import com.hazelcast.config.SocketInterceptorConfig;
 
@@ -40,7 +41,29 @@ public class ClientNetworkConfig {
     private SocketOptions socketOptions = new SocketOptions();
     private SSLConfig sslConfig;
     private ClientAwsConfig clientAwsConfig;
+    private DiscoveryStrategiesConfig discoveryStrategiesConfig;
 
+    /**
+     * Returns the configuration of the Hazelcast Discovery SPI and configured discovery providers
+     *
+     * @return Discovery Provider SPI configuration
+     */
+    public DiscoveryStrategiesConfig getDiscoveryStrategiesConfig() {
+        if (discoveryStrategiesConfig == null) {
+            discoveryStrategiesConfig = new DiscoveryStrategiesConfig();
+        }
+        return discoveryStrategiesConfig;
+    }
+
+    /**
+     * Defines the Discovery Provider SPI configuration. If <tt>null</tt> is given as the argument it will
+     * reset the discovery strategies to defaults.
+     *
+     * @param discoveryStrategiesConfig the Discovery Provider SPI configuration
+     */
+    public void setDiscoveryStrategiesConfig(DiscoveryStrategiesConfig discoveryStrategiesConfig) {
+        this.discoveryStrategiesConfig = discoveryStrategiesConfig;
+    }
 
     /**
      * @return true if client is smart

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/ClientConnectionManagerFactory.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/ClientConnectionManagerFactory.java
@@ -18,8 +18,10 @@ package com.hazelcast.client.impl;
 
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.connection.ClientConnectionManager;
+import com.hazelcast.spi.discovery.integration.DiscoveryService;
 
 public interface ClientConnectionManagerFactory {
 
-    ClientConnectionManager createConnectionManager(ClientConfig config, HazelcastClientInstanceImpl client);
+    ClientConnectionManager createConnectionManager(ClientConfig config, HazelcastClientInstanceImpl client,
+                                                    DiscoveryService discoveryService);
 }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/DefaultClientConnectionManagerFactory.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/DefaultClientConnectionManagerFactory.java
@@ -24,8 +24,10 @@ import com.hazelcast.client.connection.ClientConnectionManager;
 import com.hazelcast.client.connection.nio.ClientConnectionManagerImpl;
 import com.hazelcast.client.spi.impl.AwsAddressTranslator;
 import com.hazelcast.client.spi.impl.DefaultAddressTranslator;
+import com.hazelcast.client.spi.impl.discovery.DiscoveryAddressTranslator;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
+import com.hazelcast.spi.discovery.integration.DiscoveryService;
 
 import java.util.logging.Level;
 
@@ -37,7 +39,9 @@ public class DefaultClientConnectionManagerFactory implements ClientConnectionMa
     }
 
     @Override
-    public ClientConnectionManager createConnectionManager(ClientConfig config, HazelcastClientInstanceImpl client) {
+    public ClientConnectionManager createConnectionManager(ClientConfig config, HazelcastClientInstanceImpl client,
+                                                           DiscoveryService discoveryService) {
+
         final ClientAwsConfig awsConfig = config.getNetworkConfig().getAwsConfig();
         AddressTranslator addressTranslator;
         if (awsConfig != null && awsConfig.isEnabled()) {
@@ -47,6 +51,8 @@ public class DefaultClientConnectionManagerFactory implements ClientConnectionMa
                 LOGGER.log(Level.WARNING, "hazelcast-cloud.jar might be missing!");
                 throw e;
             }
+        } else if (discoveryService != null) {
+            addressTranslator = new DiscoveryAddressTranslator(discoveryService);
         } else {
             addressTranslator = new DefaultAddressTranslator();
         }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
@@ -32,6 +32,7 @@ import com.hazelcast.client.spi.impl.ClientPartitionServiceImpl;
 import com.hazelcast.client.spi.impl.ClientSmartInvocationServiceImpl;
 import com.hazelcast.client.spi.impl.ClientTransactionManagerServiceImpl;
 import com.hazelcast.client.spi.impl.DefaultAddressProvider;
+import com.hazelcast.client.spi.impl.discovery.DiscoveryAddressProvider;
 import com.hazelcast.client.util.RoundRobinLB;
 import com.hazelcast.collection.impl.list.ListService;
 import com.hazelcast.collection.impl.queue.QueueService;
@@ -43,6 +44,7 @@ import com.hazelcast.concurrent.idgen.IdGeneratorService;
 import com.hazelcast.concurrent.lock.LockServiceImpl;
 import com.hazelcast.concurrent.semaphore.SemaphoreService;
 import com.hazelcast.config.Config;
+import com.hazelcast.config.DiscoveryStrategiesConfig;
 import com.hazelcast.config.GroupConfig;
 import com.hazelcast.core.Client;
 import com.hazelcast.core.ClientService;
@@ -83,6 +85,10 @@ import com.hazelcast.ringbuffer.Ringbuffer;
 import com.hazelcast.ringbuffer.impl.RingbufferService;
 import com.hazelcast.security.Credentials;
 import com.hazelcast.security.UsernamePasswordCredentials;
+import com.hazelcast.spi.discovery.DiscoveryMode;
+import com.hazelcast.spi.discovery.integration.DiscoveryService;
+import com.hazelcast.spi.discovery.integration.DiscoveryServiceProvider;
+import com.hazelcast.spi.discovery.impl.DefaultDiscoveryServiceProvider;
 import com.hazelcast.spi.impl.SerializableList;
 import com.hazelcast.spi.impl.SerializationServiceSupport;
 import com.hazelcast.topic.impl.TopicService;
@@ -130,6 +136,7 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
     private final LoadBalancer loadBalancer;
     private final ClientExtension clientExtension;
     private final Credentials credentials;
+    private final DiscoveryService discoveryService;
 
     public HazelcastClientInstanceImpl(ClientConfig config,
                                        ClientConnectionManagerFactory clientConnectionManagerFactory,
@@ -156,7 +163,8 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
         loadBalancer = initLoadBalancer(config);
         transactionManager = new ClientTransactionManagerServiceImpl(this, loadBalancer);
         partitionService = new ClientPartitionServiceImpl(this);
-        connectionManager = clientConnectionManagerFactory.createConnectionManager(config, this);
+        discoveryService = initDiscoveryService(config);
+        connectionManager = clientConnectionManagerFactory.createConnectionManager(config, this, discoveryService);
         Collection<AddressProvider> addressProviders = createAddressProviders(externalAddressProvider);
         clusterService = new ClientClusterServiceImpl(this, addressProviders);
         invocationService = initInvocationService();
@@ -177,6 +185,10 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
             addressProviders.add(externalAddressProvider);
         }
 
+        if (discoveryService != null) {
+            addressProviders.add(new DiscoveryAddressProvider(discoveryService));
+        }
+
         if (awsConfig != null && awsConfig.isEnabled()) {
             try {
                 addressProviders.add(new AwsAddressProvider(awsConfig));
@@ -186,6 +198,19 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
             }
         }
         return addressProviders;
+    }
+
+    private DiscoveryService initDiscoveryService(ClientConfig config) {
+        ClientNetworkConfig networkConfig = config.getNetworkConfig();
+        DiscoveryStrategiesConfig discoveryStrategiesConfig = networkConfig.getDiscoveryStrategiesConfig().getAsReadOnly();
+        if (discoveryStrategiesConfig == null || !discoveryStrategiesConfig.isEnabled()) {
+            return null;
+        }
+        DiscoveryServiceProvider factory = discoveryStrategiesConfig.getDiscoveryServiceProvider();
+        if (factory == null) {
+            factory = new DefaultDiscoveryServiceProvider();
+        }
+        return factory.newDiscoveryService(DiscoveryMode.Client, discoveryStrategiesConfig, config.getClassLoader());
     }
 
     private LoadBalancer initLoadBalancer(ClientConfig config) {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/discovery/DiscoveryAddressProvider.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/discovery/DiscoveryAddressProvider.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.spi.impl.discovery;
+
+import com.hazelcast.client.connection.AddressProvider;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
+import com.hazelcast.nio.Address;
+import com.hazelcast.spi.discovery.DiscoveredNode;
+import com.hazelcast.spi.discovery.integration.DiscoveryService;
+
+import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.logging.Level;
+
+public class DiscoveryAddressProvider
+        implements AddressProvider {
+
+    private static final ILogger LOGGER = Logger.getLogger(DiscoveryAddressProvider.class);
+
+    private final DiscoveryService discoveryService;
+
+    public DiscoveryAddressProvider(DiscoveryService discoveryService) {
+        this.discoveryService = discoveryService;
+    }
+
+    @Override
+    public Collection<InetSocketAddress> loadAddresses() {
+        Collection<InetSocketAddress> possibleMembers = new ArrayList<InetSocketAddress>();
+        for (DiscoveredNode discoveredNode : discoveryService.discoverNodes()) {
+            Address discoveredAddress = discoveredNode.getPrivateAddress();
+            try {
+                possibleMembers.add(discoveredAddress.getInetSocketAddress());
+            } catch (UnknownHostException e) {
+                LOGGER.log(Level.WARNING, "Unresolvable host exception: " + discoveredAddress, e);
+            }
+        }
+        return possibleMembers;
+    }
+}

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/discovery/DiscoveryAddressTranslator.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/discovery/DiscoveryAddressTranslator.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.spi.impl.discovery;
+
+import com.hazelcast.client.connection.AddressTranslator;
+import com.hazelcast.nio.Address;
+import com.hazelcast.spi.discovery.DiscoveredNode;
+import com.hazelcast.spi.discovery.integration.DiscoveryService;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class DiscoveryAddressTranslator
+        implements AddressTranslator {
+
+    private final DiscoveryService discoveryService;
+
+    private volatile Map<Address, Address> privateToPublic;
+
+    public DiscoveryAddressTranslator(DiscoveryService discoveryService) {
+        this.discoveryService = discoveryService;
+    }
+
+    @Override
+    public Address translate(Address address) {
+        if (address == null) {
+            return null;
+        }
+
+        // Refresh only once to prevent load on service discovery
+        boolean alreadyRefreshed = false;
+
+        Map<Address, Address> privateToPublic = this.privateToPublic;
+        if (privateToPublic == null) {
+            refresh();
+            alreadyRefreshed = true;
+        }
+
+        privateToPublic = this.privateToPublic;
+        Address publicAddress = privateToPublic.get(address);
+        if (!alreadyRefreshed) {
+            refresh();
+            privateToPublic = this.privateToPublic;
+            publicAddress = privateToPublic.get(address);
+        }
+
+        // If public address available return, otherwise choose given address
+        return publicAddress != null ? publicAddress : address;
+    }
+
+    @Override
+    public void refresh() {
+        Iterable<DiscoveredNode> discoveredNodes = discoveryService.discoverNodes();
+
+        Map<Address, Address> privateToPublic = new HashMap<Address, Address>();
+        for (DiscoveredNode discoveredNode : discoveredNodes) {
+            privateToPublic.put(discoveredNode.getPrivateAddress(), discoveredNode.getPublicAddress());
+        }
+        this.privateToPublic = privateToPublic;
+    }
+}

--- a/hazelcast-client/src/main/resources/hazelcast-client-config-3.6.xsd
+++ b/hazelcast-client/src/main/resources/hazelcast-client-config-3.6.xsd
@@ -82,9 +82,26 @@
             <xs:element name="socket-interceptor" type="socket-interceptor" minOccurs="0" maxOccurs="1"/>
             <xs:element name="ssl" type="ssl" minOccurs="0" maxOccurs="1"/>
             <xs:element name="aws" type="aws" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="discovery-strategies" type="discovery-strategies" minOccurs="0" maxOccurs="1"/>
         </xs:all>
     </xs:complexType>
 
+    <xs:complexType name="discovery-strategies">
+        <xs:sequence>
+            <xs:element name="node-filter" type="discovery-node-filter" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="discovery-strategy" type="discovery-strategy" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="discovery-node-filter">
+        <xs:attribute name="class" type="xs:string" use="required"/>
+    </xs:complexType>
+    <xs:complexType name="discovery-strategy">
+        <xs:sequence>
+            <xs:element name="properties" type="properties" minOccurs="0" maxOccurs="1"/>
+        </xs:sequence>
+        <xs:attribute name="enabled" type="xs:boolean" use="optional" default="false"/>
+        <xs:attribute name="class" type="xs:string" use="required"/>
+    </xs:complexType>
     <xs:element name="cluster-members">
         <xs:complexType>
             <xs:sequence>

--- a/hazelcast-client/src/main/resources/hazelcast-client-default.xml
+++ b/hazelcast-client/src/main/resources/hazelcast-client-default.xml
@@ -15,7 +15,7 @@
   ~ limitations under the License.
   -->
 
-<hazelcast-client xsi:schemaLocation="http://www.hazelcast.com/schema/client-config hazelcast-client-config-3.5.xsd"
+<hazelcast-client xsi:schemaLocation="http://www.hazelcast.com/schema/client-config hazelcast-client-config-3.6.xsd"
            xmlns="http://www.hazelcast.com/schema/client-config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 

--- a/hazelcast-client/src/main/resources/hazelcast-client-full.xml
+++ b/hazelcast-client/src/main/resources/hazelcast-client-full.xml
@@ -15,7 +15,7 @@
   ~ limitations under the License.
   -->
 
-<hazelcast-client xsi:schemaLocation="http://www.hazelcast.com/schema/client-config hazelcast-client-config-3.5.xsd"
+<hazelcast-client xsi:schemaLocation="http://www.hazelcast.com/schema/client-config hazelcast-client-config-3.6.xsd"
                   xmlns="http://www.hazelcast.com/schema/client-config"
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 

--- a/hazelcast-client/src/test/java/com/hazelcast/client/config/XmlClientConfigBuilderTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/config/XmlClientConfigBuilderTest.java
@@ -311,7 +311,7 @@ public class XmlClientConfigBuilderTest {
 
     private void testXSDConfigXML(String xmlFileName) throws SAXException, IOException {
         SchemaFactory factory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
-        URL schemaResource = XMLConfigBuilderTest.class.getClassLoader().getResource("hazelcast-client-config-3.5.xsd");
+        URL schemaResource = XMLConfigBuilderTest.class.getClassLoader().getResource("hazelcast-client-config-3.6.xsd");
         InputStream xmlResource = XMLConfigBuilderTest.class.getClassLoader().getResourceAsStream(xmlFileName);
         Schema schema = factory.newSchema(schemaResource);
         Source source = new StreamSource(xmlResource);

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/ClientMapReadWriteQuorumTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/ClientMapReadWriteQuorumTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2014, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/spi/impl/discovery/ClientDiscoverySpiTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/spi/impl/discovery/ClientDiscoverySpiTest.java
@@ -1,0 +1,256 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.spi.impl.discovery;
+
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.config.ClientNetworkConfig;
+import com.hazelcast.client.config.XmlClientConfigBuilder;
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.config.AwsConfig;
+import com.hazelcast.config.Config;
+import com.hazelcast.config.DiscoveryStrategiesConfig;
+import com.hazelcast.config.DiscoveryStrategyConfig;
+import com.hazelcast.config.InterfacesConfig;
+import com.hazelcast.config.properties.PropertyDefinition;
+import com.hazelcast.config.properties.PropertyTypeConverter;
+import com.hazelcast.config.properties.SimplePropertyDefinition;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.nio.Address;
+import com.hazelcast.spi.discovery.DiscoveredNode;
+import com.hazelcast.spi.discovery.DiscoveryMode;
+import com.hazelcast.spi.discovery.integration.DiscoveryService;
+import com.hazelcast.spi.discovery.integration.DiscoveryServiceProvider;
+import com.hazelcast.spi.discovery.DiscoveryStrategy;
+import com.hazelcast.spi.discovery.DiscoveryStrategyFactory;
+import com.hazelcast.spi.discovery.NodeFilter;
+import com.hazelcast.spi.discovery.SimpleDiscoveredNode;
+import com.hazelcast.spi.discovery.impl.DefaultDiscoveryService;
+import com.hazelcast.spi.discovery.impl.DefaultDiscoveryServiceProvider;
+import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.xml.sax.SAXException;
+
+import javax.xml.XMLConstants;
+import javax.xml.transform.Source;
+import javax.xml.transform.stream.StreamSource;
+import javax.xml.validation.Schema;
+import javax.xml.validation.SchemaFactory;
+import javax.xml.validation.Validator;
+import java.io.InputStream;
+import java.lang.reflect.Field;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class ClientDiscoverySpiTest extends HazelcastTestSupport {
+
+    @Test
+    public void testSchema() throws Exception {
+        String xmlFileName = "hazelcast-client-discovery-spi-test.xml";
+
+        SchemaFactory factory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+        URL schemaResource = ClientDiscoverySpiTest.class.getClassLoader().getResource("hazelcast-client-config-3.6.xsd");
+        Schema schema = factory.newSchema(schemaResource);
+
+        InputStream xmlResource = ClientDiscoverySpiTest.class.getClassLoader().getResourceAsStream(xmlFileName);
+        Source source = new StreamSource(xmlResource);
+        Validator validator = schema.newValidator();
+        validator.validate(source);
+    }
+
+    @Test
+    public void testParsing() throws Exception {
+        String xmlFileName = "hazelcast-client-discovery-spi-test.xml";
+        InputStream xmlResource = ClientDiscoverySpiTest.class.getClassLoader().getResourceAsStream(xmlFileName);
+        ClientConfig clientConfig = new XmlClientConfigBuilder(xmlResource).build();
+
+        ClientNetworkConfig networkConfig = clientConfig.getNetworkConfig();
+
+        AwsConfig awsConfig = networkConfig.getAwsConfig();
+        assertNull(awsConfig);
+
+        DiscoveryStrategiesConfig discoveryStrategiesConfig = networkConfig.getDiscoveryStrategiesConfig();
+        assertTrue(discoveryStrategiesConfig.isEnabled());
+
+        assertEquals(1, discoveryStrategiesConfig.getDiscoveryStrategyConfigs().size());
+
+        DiscoveryStrategyConfig providerConfig = discoveryStrategiesConfig.getDiscoveryStrategyConfigs().iterator().next();
+
+        assertEquals(3, providerConfig.getProperties().size());
+        assertEquals("foo", providerConfig.getProperties().get("key-string"));
+        assertEquals("123", providerConfig.getProperties().get("key-int"));
+        assertEquals("true", providerConfig.getProperties().get("key-boolean"));
+    }
+
+    @Test
+    public void testNodeStartup() {
+        TestHazelcastFactory factory = new TestHazelcastFactory();
+
+        Config config = new Config();
+        config.getNetworkConfig().setPort(50001);
+        InterfacesConfig interfaces = config.getNetworkConfig().getInterfaces();
+        interfaces.clear();
+        interfaces.setEnabled(true);
+        interfaces.addInterface("127.0.0.1");
+
+        final HazelcastInstance hazelcastInstance1 = factory.newHazelcastInstance(config);
+        final HazelcastInstance hazelcastInstance2 = factory.newHazelcastInstance(config);
+        final HazelcastInstance hazelcastInstance3 = factory.newHazelcastInstance(config);
+
+        try {
+            String xmlFileName = "hazelcast-client-discovery-spi-test.xml";
+            InputStream xmlResource = ClientDiscoverySpiTest.class.getClassLoader().getResourceAsStream(xmlFileName);
+
+            ClientConfig clientConfig = new XmlClientConfigBuilder(xmlResource).build();
+            final HazelcastInstance client = factory.newHazelcastClient(clientConfig);
+
+            assertNotNull(hazelcastInstance1);
+            assertNotNull(hazelcastInstance2);
+            assertNotNull(hazelcastInstance3);
+            assertNotNull(client);
+
+            assertTrueEventually(new AssertTask() {
+                @Override
+                public void run()
+                        throws Exception {
+
+                    assertEquals(3, hazelcastInstance1.getCluster().getMembers().size());
+                    assertEquals(3, hazelcastInstance2.getCluster().getMembers().size());
+                    assertEquals(3, hazelcastInstance3.getCluster().getMembers().size());
+                    assertEquals(3, client.getCluster().getMembers().size());
+                }
+            });
+        } finally {
+            factory.shutdownAll();
+        }
+    }
+
+    @Test
+    public void testNodeFilter_from_xml() throws Exception {
+        String xmlFileName = "hazelcast-client-discovery-spi-test.xml";
+        InputStream xmlResource = ClientDiscoverySpiTest.class.getClassLoader().getResourceAsStream(xmlFileName);
+        ClientConfig clientConfig = new XmlClientConfigBuilder(xmlResource).build();
+
+        ClientNetworkConfig networkConfig = clientConfig.getNetworkConfig();
+
+        DiscoveryStrategiesConfig discoveryStrategiesConfig = networkConfig.getDiscoveryStrategiesConfig();
+        assertNotNull(discoveryStrategiesConfig);
+        assertNotNull(discoveryStrategiesConfig.getNodeFilterClass());
+
+        DiscoveryServiceProvider provider = new DefaultDiscoveryServiceProvider();
+        DiscoveryService discoveryService = provider.newDiscoveryService(DiscoveryMode.Client,
+                discoveryStrategiesConfig, ClientDiscoverySpiTest.class.getClassLoader());
+
+        discoveryService.start();
+        discoveryService.discoverNodes();
+        discoveryService.destroy();
+
+        Field nodeFilterField = DefaultDiscoveryService.class.getDeclaredField("nodeFilter");
+        nodeFilterField.setAccessible(true);
+
+        TestNodeFilter nodeFilter = (TestNodeFilter) nodeFilterField.get(discoveryService);
+
+        assertEquals(4, nodeFilter.getNodes().size());
+    }
+
+    private static class TestDiscoveryStrategy implements DiscoveryStrategy {
+
+        @Override
+        public void start(DiscoveryMode discoveryMode) {
+        }
+
+        @Override
+        public Collection<DiscoveredNode> discoverNodes() {
+            try {
+                List<DiscoveredNode> discoveredNodes = new ArrayList<DiscoveredNode>(4);
+                Address privateAddress = new Address("127.0.0.1", 1);
+                Address publicAddress = new Address("127.0.0.1", 50001);
+                discoveredNodes.add(new SimpleDiscoveredNode(privateAddress, publicAddress));
+                publicAddress = new Address("127.0.0.1", 50002);
+                discoveredNodes.add(new SimpleDiscoveredNode(privateAddress, publicAddress));
+                publicAddress = new Address("127.0.0.1", 50003);
+                discoveredNodes.add(new SimpleDiscoveredNode(privateAddress, publicAddress));
+                publicAddress = new Address("127.0.0.1", 50004);
+                discoveredNodes.add(new SimpleDiscoveredNode(privateAddress, publicAddress));
+
+                return discoveredNodes;
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        @Override
+        public void destroy() {
+        }
+    }
+
+    public static class TestDiscoveryStrategyFactory implements DiscoveryStrategyFactory {
+
+        private final Collection<PropertyDefinition> propertyDefinitions;
+
+        public TestDiscoveryStrategyFactory() {
+            List<PropertyDefinition> propertyDefinitions = new ArrayList<PropertyDefinition>();
+            propertyDefinitions.add(new SimplePropertyDefinition("key-string", PropertyTypeConverter.STRING));
+            propertyDefinitions.add(new SimplePropertyDefinition("key-int", PropertyTypeConverter.INTEGER));
+            propertyDefinitions.add(new SimplePropertyDefinition("key-boolean", PropertyTypeConverter.BOOLEAN));
+            propertyDefinitions.add(new SimplePropertyDefinition("key-something", true, PropertyTypeConverter.STRING));
+            this.propertyDefinitions = Collections.unmodifiableCollection(propertyDefinitions);
+        }
+
+        @Override
+        public Class<? extends DiscoveryStrategy> getDiscoveryStrategyType() {
+            return TestDiscoveryStrategy.class;
+        }
+
+        @Override
+        public DiscoveryStrategy newDiscoveryStrategy(Map<String, Comparable> properties) {
+            return new TestDiscoveryStrategy();
+        }
+
+        @Override
+        public Collection<PropertyDefinition> getConfigurationProperties() {
+            return propertyDefinitions;
+        }
+    }
+
+    public static class TestNodeFilter implements NodeFilter {
+
+        private final List<DiscoveredNode> nodes = new ArrayList<DiscoveredNode>();
+
+        @Override
+        public boolean test(DiscoveredNode candidate) {
+            nodes.add(candidate);
+            return true;
+        }
+
+        private List<DiscoveredNode> getNodes() {
+            return nodes;
+        }
+    }
+}

--- a/hazelcast-client/src/test/java/com/hazelcast/client/test/TestClientRegistry.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/test/TestClientRegistry.java
@@ -27,6 +27,7 @@ import com.hazelcast.client.impl.ClientConnectionManagerFactory;
 import com.hazelcast.client.impl.HazelcastClientInstanceImpl;
 import com.hazelcast.client.spi.impl.AwsAddressTranslator;
 import com.hazelcast.client.spi.impl.DefaultAddressTranslator;
+import com.hazelcast.client.spi.impl.discovery.DiscoveryAddressTranslator;
 import com.hazelcast.core.HazelcastException;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.instance.Node;
@@ -38,6 +39,7 @@ import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.ConnectionType;
 import com.hazelcast.nio.Packet;
 import com.hazelcast.nio.OutboundFrame;
+import com.hazelcast.spi.discovery.integration.DiscoveryService;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.test.TestNodeRegistry;
 import com.hazelcast.util.ExceptionUtil;
@@ -72,7 +74,9 @@ public class TestClientRegistry {
         }
 
         @Override
-        public ClientConnectionManager createConnectionManager(ClientConfig config, HazelcastClientInstanceImpl client) {
+        public ClientConnectionManager createConnectionManager(ClientConfig config, HazelcastClientInstanceImpl client,
+                                                               DiscoveryService discoveryService) {
+
             final ClientAwsConfig awsConfig = config.getNetworkConfig().getAwsConfig();
             AddressTranslator addressTranslator;
             if (awsConfig != null && awsConfig.isEnabled()) {
@@ -82,6 +86,8 @@ public class TestClientRegistry {
                     LOGGER.log(Level.WARNING, "hazelcast-cloud.jar might be missing!");
                     throw e;
                 }
+            } else if (discoveryService != null) {
+                addressTranslator = new DiscoveryAddressTranslator(discoveryService);
             } else {
                 addressTranslator = new DefaultAddressTranslator();
             }

--- a/hazelcast-client/src/test/resources/META-INF/services/com.hazelcast.spi.discovery.DiscoveryStrategyFactory
+++ b/hazelcast-client/src/test/resources/META-INF/services/com.hazelcast.spi.discovery.DiscoveryStrategyFactory
@@ -1,0 +1,1 @@
+com.hazelcast.client.spi.impl.discovery.ClientDiscoverySpiTest$TestDiscoveryStrategyFactory

--- a/hazelcast-client/src/test/resources/hazelcast-client-discovery-spi-test.xml
+++ b/hazelcast-client/src/test/resources/hazelcast-client-discovery-spi-test.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<hazelcast-client xsi:schemaLocation="http://www.hazelcast.com/schema/client-config hazelcast-client-config-3.6.xsd"
+                  xmlns="http://www.hazelcast.com/schema/client-config"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+  <properties>
+    <property name="hazelcast.discovery.enabled">true</property>
+  </properties>
+
+  <network>
+    <discovery-strategies>
+      <node-filter class="com.hazelcast.client.spi.impl.discovery.ClientDiscoverySpiTest$TestNodeFilter"/>
+      <discovery-strategy enabled="true"
+                          class="com.hazelcast.client.spi.impl.discovery.ClientDiscoverySpiTest$TestDiscoveryStrategy">
+        <properties>
+          <property name="key-string">foo</property>
+          <property name="key-int">123</property>
+          <property name="key-boolean">true</property>
+        </properties>
+      </discovery-strategy>
+    </discovery-strategies>
+  </network>
+
+</hazelcast-client>

--- a/hazelcast-client/src/test/resources/hazelcast-client-test.xml
+++ b/hazelcast-client/src/test/resources/hazelcast-client-test.xml
@@ -15,7 +15,7 @@
   ~ limitations under the License.
   -->
 
-<hazelcast-client xsi:schemaLocation="http://www.hazelcast.com/schema/client-config hazelcast-client-config-3.5.xsd"
+<hazelcast-client xsi:schemaLocation="http://www.hazelcast.com/schema/client-config hazelcast-client-config-3.6.xsd"
                   xmlns="http://www.hazelcast.com/schema/client-config"
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 		

--- a/hazelcast-hibernate/hazelcast-hibernate3/src/test/resources/hazelcast-client-custom.xml
+++ b/hazelcast-hibernate/hazelcast-hibernate3/src/test/resources/hazelcast-client-custom.xml
@@ -15,7 +15,7 @@
   ~ limitations under the License.
   -->
 
-<hazelcast-client xsi:schemaLocation="http://www.hazelcast.com/schema/client-config hazelcast-client-config-3.5.xsd"
+<hazelcast-client xsi:schemaLocation="http://www.hazelcast.com/schema/client-config hazelcast-client-config-3.6.xsd"
                   xmlns="http://www.hazelcast.com/schema/client-config"
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 

--- a/hazelcast-hibernate/hazelcast-hibernate4/src/test/resources/hazelcast-client-custom.xml
+++ b/hazelcast-hibernate/hazelcast-hibernate4/src/test/resources/hazelcast-client-custom.xml
@@ -15,7 +15,7 @@
   ~ limitations under the License.
   -->
 
-<hazelcast-client xsi:schemaLocation="http://www.hazelcast.com/schema/client-config hazelcast-client-config-3.5.xsd"
+<hazelcast-client xsi:schemaLocation="http://www.hazelcast.com/schema/client-config hazelcast-client-config-3.6.xsd"
                   xmlns="http://www.hazelcast.com/schema/client-config"
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 

--- a/hazelcast-wm/src/test/java/com/hazelcast/wm/test/AbstractWebFilterTest.java
+++ b/hazelcast-wm/src/test/java/com/hazelcast/wm/test/AbstractWebFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2014, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-wm/src/test/java/com/hazelcast/wm/test/DeferredFailoverClusterTest.java
+++ b/hazelcast-wm/src/test/java/com/hazelcast/wm/test/DeferredFailoverClusterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2014, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-wm/src/test/java/com/hazelcast/wm/test/DeferredWriteClusterTest.java
+++ b/hazelcast-wm/src/test/java/com/hazelcast/wm/test/DeferredWriteClusterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2014, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-wm/src/test/java/com/hazelcast/wm/test/DisconnectedHazelcastTest.java
+++ b/hazelcast-wm/src/test/java/com/hazelcast/wm/test/DisconnectedHazelcastTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2014, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-wm/src/test/java/com/hazelcast/wm/test/JettyWebFilterTest.java
+++ b/hazelcast-wm/src/test/java/com/hazelcast/wm/test/JettyWebFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2014, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-wm/src/test/java/com/hazelcast/wm/test/TestWebFilter.java
+++ b/hazelcast-wm/src/test/java/com/hazelcast/wm/test/TestWebFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2014, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-wm/src/test/java/com/hazelcast/wm/test/TomcatWebFilterTest.java
+++ b/hazelcast-wm/src/test/java/com/hazelcast/wm/test/TomcatWebFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2014, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-wm/src/test/java/com/hazelcast/wm/test/WebFilterSessionCleanupTest.java
+++ b/hazelcast-wm/src/test/java/com/hazelcast/wm/test/WebFilterSessionCleanupTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2014, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-wm/src/test/java/com/hazelcast/wm/test/WebTestRunner.java
+++ b/hazelcast-wm/src/test/java/com/hazelcast/wm/test/WebTestRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2014, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-wm/src/test/webapp/WEB-INF/hazelcast.xml
+++ b/hazelcast-wm/src/test/webapp/WEB-INF/hazelcast.xml
@@ -15,7 +15,7 @@
   ~ limitations under the License.
   -->
 
-<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config http://www.hazelcast.com/schema/config/hazelcast-config-3.5.xsd"
+<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config http://www.hazelcast.com/schema/config/hazelcast-config-3.6.xsd"
            xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <group>

--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/DiscoveryJoiner.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/DiscoveryJoiner.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.cluster.impl;
+
+import com.hazelcast.instance.MemberImpl;
+import com.hazelcast.instance.Node;
+import com.hazelcast.nio.Address;
+import com.hazelcast.spi.discovery.DiscoveredNode;
+import com.hazelcast.spi.discovery.integration.DiscoveryService;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+public class DiscoveryJoiner
+        extends TcpIpJoiner {
+
+    private final DiscoveryService discoveryService;
+
+    public DiscoveryJoiner(Node node, DiscoveryService discoveryService) {
+        super(node);
+        this.discoveryService = discoveryService;
+    }
+
+    @Override
+    protected Collection<Address> getPossibleAddresses() {
+        Iterable<DiscoveredNode> discoveredNodes = discoveryService.discoverNodes();
+
+        MemberImpl localMember = node.nodeEngine.getLocalMember();
+        Address localAddress = localMember.getAddress();
+
+        Collection<Address> possibleMembers = new ArrayList<Address>();
+        for (DiscoveredNode discoveredNode : discoveredNodes) {
+            Address discoveredAddress = discoveredNode.getPrivateAddress();
+            if (localAddress.equals(discoveredAddress)) {
+                continue;
+            }
+            possibleMembers.add(discoveredAddress);
+        }
+        return possibleMembers;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/TcpIpJoiner.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/TcpIpJoiner.java
@@ -396,7 +396,7 @@ public class TcpIpJoiner extends AbstractJoiner {
         return null;
     }
 
-    private Collection<Address> getPossibleAddresses() {
+    protected Collection<Address> getPossibleAddresses() {
         final Collection<String> possibleMembers = getMembers();
         final Set<Address> possibleAddresses = new HashSet<Address>();
         final NetworkConfig networkConfig = config.getNetworkConfig();

--- a/hazelcast/src/main/java/com/hazelcast/config/AbstractXmlConfigHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/AbstractXmlConfigHelper.java
@@ -52,6 +52,7 @@ import java.text.DecimalFormat;
 import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Properties;
 
@@ -370,6 +371,26 @@ public abstract class AbstractXmlConfigHelper {
         }
     }
 
+    protected void fillProperties(final org.w3c.dom.Node node, Map<String, Comparable> properties) {
+        if (properties == null) {
+            return;
+        }
+        for (org.w3c.dom.Node n : new IterableNodeList(node.getChildNodes())) {
+            if (n.getNodeType() == org.w3c.dom.Node.TEXT_NODE || n.getNodeType() == org.w3c.dom.Node.COMMENT_NODE) {
+                continue;
+            }
+            final String name = cleanNodeName(n.getNodeName());
+            final String propertyName;
+            if ("property".equals(name)) {
+                propertyName = getTextContent(n.getAttributes().getNamedItem("name")).trim();
+            } else {
+                // old way - probably should be deprecated
+                propertyName = name;
+            }
+            final String value = getTextContent(n).trim();
+            properties.put(propertyName, value);
+        }
+    }
 
     protected SerializationConfig parseSerialization(final Node node) {
         SerializationConfig serializationConfig = new SerializationConfig();

--- a/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
@@ -80,7 +80,7 @@ public class ConfigXmlGenerator {
                 .append("xmlns=\"http://www.hazelcast.com/schema/config\"\n")
                 .append("xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n")
                 .append("xsi:schemaLocation=\"http://www.hazelcast.com/schema/config ")
-                .append("http://www.hazelcast.com/schema/config/hazelcast-config-3.5.xsd\">");
+                .append("http://www.hazelcast.com/schema/config/hazelcast-config-3.6.xsd\">");
         xml.append("<group>");
         xml.append("<name>").append(config.getGroupConfig().getName()).append("</name>");
         xml.append("<password>").append("****").append("</password>");

--- a/hazelcast/src/main/java/com/hazelcast/config/DiscoveryStrategiesConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/DiscoveryStrategiesConfig.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+import com.hazelcast.spi.discovery.integration.DiscoveryServiceProvider;
+import com.hazelcast.spi.discovery.DiscoveryStrategy;
+import com.hazelcast.spi.discovery.NodeFilter;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * This configuration class describes the top-level config of the discovery
+ * SPI and its discovery strategies.
+ */
+public class DiscoveryStrategiesConfig {
+
+    private final List<DiscoveryStrategyConfig> discoveryStrategyConfigs = new ArrayList<DiscoveryStrategyConfig>();
+    private DiscoveryServiceProvider discoveryServiceProvider;
+    private NodeFilter nodeFilter;
+    private String nodeFilterClass;
+
+    private DiscoveryStrategiesConfig readonly;
+
+    public DiscoveryStrategiesConfig() {
+    }
+
+    protected DiscoveryStrategiesConfig(DiscoveryServiceProvider discoveryServiceProvider, NodeFilter nodeFilter,
+                                        String nodeFilterClass, Collection<DiscoveryStrategyConfig> discoveryStrategyConfigs) {
+        this.discoveryServiceProvider = discoveryServiceProvider;
+        this.nodeFilter = nodeFilter;
+        this.nodeFilterClass = nodeFilterClass;
+        this.discoveryStrategyConfigs.addAll(discoveryStrategyConfigs);
+    }
+
+    public DiscoveryStrategiesConfig getAsReadOnly() {
+        if (readonly != null) {
+            return readonly;
+        }
+        readonly = new DiscoveryStrategiesConfigReadOnly(this);
+        return readonly;
+    }
+
+    public void setDiscoveryServiceProvider(DiscoveryServiceProvider discoveryServiceProvider) {
+        this.discoveryServiceProvider = discoveryServiceProvider;
+    }
+
+    public DiscoveryServiceProvider getDiscoveryServiceProvider() {
+        return discoveryServiceProvider;
+    }
+
+    public NodeFilter getNodeFilter() {
+        return nodeFilter;
+    }
+
+    public void setNodeFilter(NodeFilter nodeFilter) {
+        this.nodeFilter = nodeFilter;
+    }
+
+    public String getNodeFilterClass() {
+        return nodeFilterClass;
+    }
+
+    public void setNodeFilterClass(String nodeFilterClass) {
+        this.nodeFilterClass = nodeFilterClass;
+    }
+
+    public boolean isEnabled() {
+        return discoveryStrategyConfigs.size() > 0;
+    }
+
+    /**
+     * Returns the defined {@link DiscoveryStrategy}
+     * configurations. This collection does not include deactivated configurations
+     * since those are automatically skipped while reading the configuration file.
+     * <p/>
+     * All returned configurations are expected to be active, this is to remember
+     * when building custom {@link com.hazelcast.config.Config} instances.
+     *
+     * @return all enabled {@link DiscoveryStrategy} configurations
+     */
+    public Collection<DiscoveryStrategyConfig> getDiscoveryStrategyConfigs() {
+        return Collections.unmodifiableCollection(discoveryStrategyConfigs);
+    }
+
+    /**
+     * Adds an enabled {@link DiscoveryStrategy}
+     * configuration.
+     * <p/>
+     * All added configurations are strictly meant to be enabled, this is to
+     * remember when building custom {@link com.hazelcast.config.Config} instances.
+     *
+     * @param discoveryStrategyConfig
+     */
+    public void addDiscoveryProviderConfig(DiscoveryStrategyConfig discoveryStrategyConfig) {
+        discoveryStrategyConfigs.add(discoveryStrategyConfig);
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/config/DiscoveryStrategiesConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/DiscoveryStrategiesConfigReadOnly.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+import com.hazelcast.spi.discovery.integration.DiscoveryServiceProvider;
+import com.hazelcast.spi.discovery.NodeFilter;
+
+/**
+ * Readonly version of {@link DiscoveryStrategiesConfig}
+ */
+public class DiscoveryStrategiesConfigReadOnly
+        extends DiscoveryStrategiesConfig {
+
+    DiscoveryStrategiesConfigReadOnly(DiscoveryStrategiesConfig discoveryStrategiesConfig) {
+        super(discoveryStrategiesConfig.getDiscoveryServiceProvider(), discoveryStrategiesConfig.getNodeFilter(),
+                discoveryStrategiesConfig.getNodeFilterClass(), discoveryStrategiesConfig.getDiscoveryStrategyConfigs());
+    }
+
+    @Override
+    public void setDiscoveryServiceProvider(DiscoveryServiceProvider discoveryServiceProvider) {
+        throw new UnsupportedOperationException("Configuration is readonly");
+    }
+
+    @Override
+    public void setNodeFilter(NodeFilter nodeFilter) {
+        throw new UnsupportedOperationException("Configuration is readonly");
+    }
+
+    @Override
+    public void setNodeFilterClass(String nodeFilterClass) {
+        throw new UnsupportedOperationException("Configuration is readonly");
+    }
+
+    @Override
+    public void addDiscoveryProviderConfig(DiscoveryStrategyConfig discoveryStrategyConfig) {
+        throw new UnsupportedOperationException("Configuration is readonly");
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/config/DiscoveryStrategyConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/DiscoveryStrategyConfig.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * This configuration class describes a {@link com.hazelcast.spi.discovery.DiscoveryStrategy}
+ * based on a parsed XML or configured manually using the config API
+ */
+public class DiscoveryStrategyConfig {
+
+    private final Map<String, Comparable> properties = new HashMap<String, Comparable>();
+
+    private final String className;
+
+    public DiscoveryStrategyConfig(String className) {
+        this(className, Collections.<String, Comparable>emptyMap());
+    }
+
+    public DiscoveryStrategyConfig(String className, Map<String, Comparable> properties) {
+        this.className = className;
+        this.properties.putAll(properties);
+    }
+
+    public String getClassName() {
+        return className;
+    }
+
+    public void addProperty(String key, Comparable value) {
+        properties.put(key, value);
+    }
+
+    public void removeProperty(String key) {
+        properties.remove(key);
+    }
+
+    public Map<String, Comparable> getProperties() {
+        return Collections.unmodifiableMap(properties);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/config/JoinConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/JoinConfig.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.config;
 
+import java.util.Collection;
+
 import static com.hazelcast.util.Preconditions.isNotNull;
 
 /**
@@ -28,6 +30,8 @@ public class JoinConfig {
     private TcpIpConfig tcpIpConfig = new TcpIpConfig();
 
     private AwsConfig awsConfig = new AwsConfig();
+
+    private DiscoveryStrategiesConfig discoveryStrategiesConfig = new DiscoveryStrategiesConfig();
 
     /**
      * @return the multicastConfig join configuration
@@ -78,6 +82,26 @@ public class JoinConfig {
     }
 
     /**
+     * Returns the currently defined {@link DiscoveryStrategiesConfig}
+     *
+     * @return current DiscoveryProvidersConfig instance
+     */
+    public DiscoveryStrategiesConfig getDiscoveryStrategiesConfig() {
+        return discoveryStrategiesConfig;
+    }
+
+    /**
+     * Sets a custom defined {@link DiscoveryStrategiesConfig}
+     *
+     * @param discoveryStrategiesConfig configuration to set
+     * @throws java.lang.IllegalArgumentException if discoveryProvidersConfig is null
+     */
+    public JoinConfig setDiscoveryStrategiesConfig(DiscoveryStrategiesConfig discoveryStrategiesConfig) {
+        this.discoveryStrategiesConfig = isNotNull(discoveryStrategiesConfig, "discoveryProvidersConfig");
+        return this;
+    }
+
+    /**
      * Verifies this JoinConfig is valid. At most a single joiner should be active.
      *
      * @throws IllegalStateException when the join config is not valid.
@@ -94,6 +118,17 @@ public class JoinConfig {
         if (getMulticastConfig().isEnabled() && getAwsConfig().isEnabled()) {
             throw new InvalidConfigurationException("Multicast and AWS join can't be enabled at the same time");
         }
+
+        Collection<DiscoveryStrategyConfig> discoveryStrategyConfigs = discoveryStrategiesConfig.getDiscoveryStrategyConfigs();
+        if (getMulticastConfig().isEnabled() && discoveryStrategyConfigs.size() > 0) {
+            throw new InvalidConfigurationException(
+                    "Multicast and DiscoveryProviders join can't be enabled at the same time");
+        }
+
+        if (getAwsConfig().isEnabled() && discoveryStrategyConfigs.size() > 0) {
+            throw new InvalidConfigurationException(
+                    "Multicast and DiscoveryProviders join can't be enabled at the same time");
+        }
     }
 
     @Override
@@ -102,6 +137,7 @@ public class JoinConfig {
         sb.append("multicastConfig=").append(multicastConfig);
         sb.append(", tcpIpConfig=").append(tcpIpConfig);
         sb.append(", awsConfig=").append(awsConfig);
+        sb.append(", discoveryProvidersConfig=").append(discoveryStrategiesConfig);
         sb.append('}');
         return sb.toString();
     }

--- a/hazelcast/src/main/java/com/hazelcast/config/properties/PropertyDefinition.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/properties/PropertyDefinition.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config.properties;
+
+import com.hazelcast.core.TypeConverter;
+
+/**
+ * This interface describes an extended approach of the currently available
+ * pure property based configuration inside Hazelcast and helps implementing
+ * an automatic and transparent way to verify configuration as well as converting
+ * types based on provided validators and converters.
+ * <p/>
+ * All verification is done on property level which means that the configuration
+ * overall might still be invalid and needs to be checked by the provider vendor
+ * before actually using it.
+ * <p/>
+ * All used {@link com.hazelcast.core.TypeConverter}s and
+ * {@link com.hazelcast.config.properties.ValueValidator}s need to be fully thread-safe
+ * and are recommended to be stateless to prevent any kind of unexpected concurrency
+ * issues.
+ */
+public interface PropertyDefinition {
+
+    /**
+     * The {@link com.hazelcast.core.TypeConverter} to be used to convert the
+     * string value read from XML to the expected type automatically.
+     *
+     * @return a defined type converter to convert from string to another type
+     */
+    TypeConverter typeConverter();
+
+    /**
+     * Returns the key (the name) of this property inside the configuration.
+     *
+     * @return returns the property key
+     */
+    String key();
+
+    /**
+     * Returns an optional validator to validate a value before finalizing the
+     * configuration.
+     *
+     * @return true if validation passed, otherwise false
+     */
+    ValueValidator validator();
+
+    /**
+     * Defines if this property is optional or not. Optional properties don't
+     * have to be set inside the configuration but if set they need to pass a
+     * possibly defined {@link com.hazelcast.config.properties.ValueValidator}
+     * test.
+     *
+     * @return true if this property is optional, otherwise false
+     */
+    boolean optional();
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/config/properties/PropertyTypeConverter.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/properties/PropertyTypeConverter.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config.properties;
+
+import com.hazelcast.core.TypeConverter;
+
+/**
+ * This enum class contains basic {@link TypeConverter} implementations to
+ * convert strings to all common basic Java types.
+ */
+public enum PropertyTypeConverter implements TypeConverter {
+    /**
+     * {@link TypeConverter} that bypasses a string
+     */
+    STRING {
+        @Override
+        public Comparable convert(Comparable value) {
+            return value.toString();
+        }
+    },
+
+    /**
+     * {@link TypeConverter} to convert an input string to an output short
+     */
+    SHORT {
+        @Override
+        public Comparable convert(Comparable value) {
+            if (value instanceof String) {
+                return Short.parseShort((String) value);
+            }
+            throw new IllegalArgumentException("Cannot convert to short");
+        }
+    },
+
+    /**
+     * {@link TypeConverter} to convert an input string to an output int
+     */
+    INTEGER {
+        @Override
+        public Comparable convert(Comparable value) {
+            if (value instanceof String) {
+                return Integer.parseInt((String) value);
+            }
+            throw new IllegalArgumentException("Cannot convert to integer");
+        }
+    },
+
+    /**
+     * {@link TypeConverter} to convert an input string to an output long
+     */
+    LONG {
+        @Override
+        public Comparable convert(Comparable value) {
+            if (value instanceof String) {
+                return Long.parseLong((String) value);
+            }
+            throw new IllegalArgumentException("Cannot convert to long");
+        }
+    },
+
+    /**
+     * {@link TypeConverter} to convert an input string to an output float
+     */
+    FLOAT {
+        @Override
+        public Comparable convert(Comparable value) {
+            if (value instanceof String) {
+                return Float.parseFloat((String) value);
+            }
+            throw new IllegalArgumentException("Cannot convert to float");
+        }
+    },
+
+    /**
+     * {@link TypeConverter} to convert an input string to an output double
+     */
+    DOUBLE {
+        @Override
+        public Comparable convert(Comparable value) {
+            if (value instanceof String) {
+                return Double.parseDouble((String) value);
+            }
+            throw new IllegalArgumentException("Cannot convert to double");
+        }
+    },
+
+    /**
+     * {@link TypeConverter} to convert an input string to an output boolean
+     */
+    BOOLEAN {
+        @Override
+        public Comparable convert(Comparable value) {
+            if (value instanceof String) {
+                return Boolean.parseBoolean((String) value);
+            }
+            throw new IllegalArgumentException("Cannot convert to boolean");
+        }
+    }
+    ;
+}

--- a/hazelcast/src/main/java/com/hazelcast/config/properties/SimplePropertyDefinition.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/properties/SimplePropertyDefinition.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config.properties;
+
+import com.hazelcast.core.TypeConverter;
+
+/**
+ * Simple immutable implementation of {@link PropertyDefinition} for convenience of implementors.
+ */
+public class SimplePropertyDefinition implements PropertyDefinition {
+
+    private final String key;
+    private final boolean optional;
+    private final TypeConverter typeConverter;
+    private final ValueValidator validator;
+
+    public SimplePropertyDefinition(String key, TypeConverter typeConverter) {
+        this(key, false, typeConverter, null);
+    }
+
+    public SimplePropertyDefinition(String key, boolean optional, TypeConverter typeConverter) {
+        this(key, optional, typeConverter, null);
+    }
+
+    public SimplePropertyDefinition(String key, boolean optional, TypeConverter typeConverter, ValueValidator validator) {
+        this.key = key;
+        this.optional = optional;
+        this.typeConverter = typeConverter;
+        this.validator = validator;
+    }
+
+    @Override
+    public TypeConverter typeConverter() {
+        return typeConverter;
+    }
+
+    @Override
+    public String key() {
+        return key;
+    }
+
+    @Override
+    public ValueValidator validator() {
+        return validator;
+    }
+
+    @Override
+    public boolean optional() {
+        return optional;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/config/properties/ValidationException.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/properties/ValidationException.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config.properties;
+
+import com.hazelcast.core.HazelcastException;
+
+/**
+ * This exception is thrown from {@link com.hazelcast.config.properties.ValueValidator}
+ * implementations whenever the validation has not succeed for any reason.
+ */
+public class ValidationException extends HazelcastException {
+    public ValidationException() {
+    }
+
+    public ValidationException(String message) {
+        super(message);
+    }
+
+    public ValidationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public ValidationException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/config/properties/ValueValidator.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/properties/ValueValidator.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config.properties;
+
+/**
+ * This interface defines a certain validation logic implementation
+ * to test if a given value is expected to be correct or not.
+ * <p/>
+ * All verification is done on property level which means that the
+ * configuration overall might still be invalid and needs to be checked
+ * by the provider vendor before actually using it.
+ * <p/>
+ * All <tt>ValueValidator</tt> implementations need to be fully thread-safe
+ * and are recommended to be stateless to prevent any kind of unexpected
+ * concurrency issues.
+ *
+ * @param <T> type of the element to be tested
+ */
+public interface ValueValidator<T extends Comparable<T>> {
+
+    /**
+     * Validates the given value according to the defined validation logic
+     * and throws a ValidationException if configuration does not meet the
+     * requirements or logical errors are spotted.
+     *
+     * @param value the value to be tested
+     * @throws ValidationException if validation failed
+     */
+    void validate(T value) throws ValidationException;
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/config/properties/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/properties/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * This package contains the public API for properties defined in the XML configuration.
+ * It also contains the interfaces for automatic validation and conversion.
+ */
+package com.hazelcast.config.properties;

--- a/hazelcast/src/main/java/com/hazelcast/core/TypeConverter.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/TypeConverter.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.core;
+
+/**
+ * Implementations of this interface define a certain type conversation.
+ * Conversation can happen from any kind of {@link java.lang.Comparable}
+ * type to another.
+ * <p/>
+ * Implementations of TypeConverter need to be fully thread-safe and
+ * must have no internal state as they are expected to be used by
+ * multiple threads and with shared instances.
+ */
+public interface TypeConverter {
+
+    /**
+     * Compares a {@link java.lang.Comparable} typed value to another one.
+     * Since TypeConverters are not statically typed itself the developer
+     * needs to take care of correct usage of input and output types.
+     *
+     * @param value the value to be converted
+     * @return the converted value
+     */
+    Comparable convert(Comparable value);
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/instance/GroupProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/GroupProperty.java
@@ -552,7 +552,14 @@ public enum GroupProperty implements HazelcastProperty {
      * Forces the JCache provider, which can have values client or server, to force the provider type.
      * If not provided, the provider will be client or server, whichever is found on the classpath first respectively.
      */
-    JCACHE_PROVIDER_TYPE("hazelcast.jcache.provider.type");
+    JCACHE_PROVIDER_TYPE("hazelcast.jcache.provider.type"),
+
+    /**
+     * <p>Enables the Discovery SPI lookup over the old native implementations. This property is temporary and will
+     * eventually be removed when the experimental marker is removed.</p>
+     * <p>Discovery SPI is <b>disabled</b> by default</p>
+     */
+    DISCOVERY_SPI_ENABLED("hazelcast.discovery.enabled", false);
 
     private final String name;
     private final String defaultValue;

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/AttributeType.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/AttributeType.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.query.impl;
 
+import com.hazelcast.core.TypeConverter;
+
 /**
  * Type of Attribute
  */
@@ -85,13 +87,13 @@ public enum AttributeType {
      */
     UUID(TypeConverters.UUID_CONVERTER);
 
-    private final TypeConverters.TypeConverter converter;
+    private final TypeConverter converter;
 
-    AttributeType(TypeConverters.TypeConverter converter) {
+    AttributeType(TypeConverter converter) {
         this.converter = converter;
     }
 
-    public TypeConverters.TypeConverter getConverter() {
+    public TypeConverter getConverter() {
         return converter;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/IdentityConverter.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/IdentityConverter.java
@@ -16,12 +16,12 @@
 
 package com.hazelcast.query.impl;
 
-import com.hazelcast.query.impl.TypeConverters.TypeConverter;
+import com.hazelcast.query.impl.TypeConverters.BaseTypeConverter;
 
 /**
  * Converts to the same value
  **/
-class IdentityConverter extends TypeConverter {
+class IdentityConverter extends BaseTypeConverter {
 
     @Override
     Comparable convertInternal(final Comparable value) {

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/Index.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/Index.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.query.impl;
 
+import com.hazelcast.core.TypeConverter;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.query.QueryException;
 
@@ -35,7 +36,7 @@ public interface Index {
      *
      * @return
      */
-    TypeConverters.TypeConverter getConverter();
+    TypeConverter getConverter();
 
     void removeEntryIndex(Data indexKey);
 

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/IndexImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/IndexImpl.java
@@ -16,12 +16,12 @@
 
 package com.hazelcast.query.impl;
 
+import com.hazelcast.core.TypeConverter;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.DataSerializable;
 import com.hazelcast.query.QueryException;
-import com.hazelcast.query.impl.TypeConverters.TypeConverter;
 
 import java.io.IOException;
 import java.util.HashSet;

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/TypeConverters.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/TypeConverters.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.query.impl;
 
+import com.hazelcast.core.TypeConverter;
+
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.sql.Timestamp;
@@ -43,7 +45,7 @@ public final class TypeConverters {
     private TypeConverters() {
     }
 
-    public abstract static class TypeConverter {
+    public abstract static class BaseTypeConverter implements TypeConverter {
         abstract Comparable convertInternal(Comparable value);
 
         public final Comparable convert(Comparable value) {
@@ -54,7 +56,7 @@ public final class TypeConverters {
         }
     }
 
-    static class EnumConverter extends TypeConverter {
+    static class EnumConverter extends BaseTypeConverter {
         @Override
         Comparable convertInternal(Comparable value) {
             String enumString = value.toString();
@@ -66,7 +68,7 @@ public final class TypeConverters {
         }
     }
 
-    static class SqlDateConverter extends TypeConverter {
+    static class SqlDateConverter extends BaseTypeConverter {
         @Override
         Comparable convertInternal(Comparable value) {
             if (value instanceof java.sql.Date) {
@@ -83,7 +85,7 @@ public final class TypeConverters {
         }
     }
 
-    static class SqlTimestampConverter extends TypeConverter {
+    static class SqlTimestampConverter extends BaseTypeConverter {
         @Override
         Comparable convertInternal(Comparable value) {
             if (value instanceof Timestamp) {
@@ -100,7 +102,7 @@ public final class TypeConverters {
         }
     }
 
-    static class DateConverter extends TypeConverter {
+    static class DateConverter extends BaseTypeConverter {
         @Override
         Comparable convertInternal(Comparable value) {
             if (value instanceof Date) {
@@ -117,7 +119,7 @@ public final class TypeConverters {
         }
     }
 
-    static class DoubleConverter extends TypeConverter {
+    static class DoubleConverter extends BaseTypeConverter {
         @Override
         Comparable convertInternal(Comparable value) {
             if (value instanceof Double) {
@@ -134,7 +136,7 @@ public final class TypeConverters {
         }
     }
 
-    static class LongConverter extends TypeConverter {
+    static class LongConverter extends BaseTypeConverter {
         @Override
         Comparable convertInternal(Comparable value) {
             if (value instanceof Long) {
@@ -151,7 +153,7 @@ public final class TypeConverters {
         }
     }
 
-    static class BigIntegerConverter extends TypeConverter {
+    static class BigIntegerConverter extends BaseTypeConverter {
         @Override
         Comparable convertInternal(Comparable value) {
             if (value instanceof BigInteger) {
@@ -161,7 +163,7 @@ public final class TypeConverters {
         }
     }
 
-    static class BigDecimalConverter extends TypeConverter {
+    static class BigDecimalConverter extends BaseTypeConverter {
         @Override
         Comparable convertInternal(Comparable value) {
             if (value instanceof BigDecimal) {
@@ -174,7 +176,7 @@ public final class TypeConverters {
         }
     }
 
-    static class IntegerConverter extends TypeConverter {
+    static class IntegerConverter extends BaseTypeConverter {
         @Override
         Comparable convertInternal(Comparable value) {
             if (value instanceof Integer) {
@@ -191,7 +193,7 @@ public final class TypeConverters {
         }
     }
 
-    static class StringConverter extends TypeConverter {
+    static class StringConverter extends BaseTypeConverter {
         @Override
         Comparable convertInternal(Comparable value) {
             if (value instanceof String) {
@@ -201,7 +203,7 @@ public final class TypeConverters {
         }
     }
 
-    static class FloatConverter extends TypeConverter {
+    static class FloatConverter extends BaseTypeConverter {
         @Override
         Comparable convertInternal(Comparable value) {
             if (value instanceof Float) {
@@ -218,7 +220,7 @@ public final class TypeConverters {
         }
     }
 
-    static class ShortConverter extends TypeConverter {
+    static class ShortConverter extends BaseTypeConverter {
         @Override
         Comparable convertInternal(Comparable value) {
             if (value instanceof Short) {
@@ -235,7 +237,7 @@ public final class TypeConverters {
         }
     }
 
-    static class BooleanConverter extends TypeConverter {
+    static class BooleanConverter extends BaseTypeConverter {
         @Override
         Comparable convertInternal(Comparable value) {
             if (value instanceof Boolean) {
@@ -252,7 +254,7 @@ public final class TypeConverters {
         }
     }
 
-    static class ByteConverter extends TypeConverter {
+    static class ByteConverter extends BaseTypeConverter {
         @Override
         Comparable convertInternal(Comparable value) {
             if (value instanceof Byte) {
@@ -269,7 +271,7 @@ public final class TypeConverters {
         }
     }
 
-    static class CharConverter extends TypeConverter {
+    static class CharConverter extends BaseTypeConverter {
         @Override
         Comparable convertInternal(Comparable value) {
             if (value.getClass() == char.class) {

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/UUIDConverter.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/UUIDConverter.java
@@ -21,7 +21,7 @@ import java.util.UUID;
 /**
  * TypeConverter to handle UUID
  */
-final class UUIDConverter extends TypeConverters.TypeConverter {
+final class UUIDConverter extends TypeConverters.BaseTypeConverter {
 
     @Override
     Comparable convertInternal(Comparable value) {

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/BetweenVisitor.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/BetweenVisitor.java
@@ -16,13 +16,13 @@
 
 package com.hazelcast.query.impl.predicates;
 
-import com.hazelcast.query.impl.Index;
-import com.hazelcast.query.impl.Indexes;
-import com.hazelcast.query.impl.TypeConverters;
-import com.hazelcast.util.collection.ArrayUtils;
-import com.hazelcast.util.collection.InternalMultiMap;
+import com.hazelcast.core.TypeConverter;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.impl.FalsePredicate;
+import com.hazelcast.query.impl.Index;
+import com.hazelcast.query.impl.Indexes;
+import com.hazelcast.util.collection.ArrayUtils;
+import com.hazelcast.util.collection.InternalMultiMap;
 
 import java.util.List;
 import java.util.Map;
@@ -102,7 +102,7 @@ public class BetweenVisitor extends AbstractVisitor {
         GreaterLessPredicate mostRightGreaterOrEquals = null;
         GreaterLessPredicate mostLeftLessThanOrEquals = null;
         Index index = indexes.getIndex(attributeName);
-        TypeConverters.TypeConverter converter = index.getConverter();
+        TypeConverter converter = index.getConverter();
         for (GreaterLessPredicate predicate : predicates) {
             if (predicate.less) {
                 if (mostLeftLessThanOrEquals == null || isLessThan(mostLeftLessThanOrEquals, predicate, converter)) {
@@ -198,10 +198,10 @@ public class BetweenVisitor extends AbstractVisitor {
     private class Boundaries {
         private final GreaterLessPredicate leftBoundary;
         private final GreaterLessPredicate rightBoundary;
-        private final TypeConverters.TypeConverter typeConverter;
+        private final TypeConverter typeConverter;
 
         Boundaries(GreaterLessPredicate leftBoundary, GreaterLessPredicate rightBoundary,
-                   TypeConverters.TypeConverter converter) {
+                   TypeConverter converter) {
             this.leftBoundary = leftBoundary;
             this.rightBoundary = rightBoundary;
             this.typeConverter = converter;
@@ -248,14 +248,14 @@ public class BetweenVisitor extends AbstractVisitor {
     }
 
     private boolean isGreaterThan(GreaterLessPredicate leftPredicate,
-                                  GreaterLessPredicate rightPredicate, TypeConverters.TypeConverter converter) {
+                                  GreaterLessPredicate rightPredicate, TypeConverter converter) {
         Comparable rightValue = converter.convert(rightPredicate.value);
         Comparable leftValue = converter.convert(leftPredicate.value);
         return rightValue.compareTo(leftValue) > 0;
     }
 
     private boolean isLessThan(GreaterLessPredicate leftPredicate, GreaterLessPredicate rightPredicate,
-                               TypeConverters.TypeConverter converter) {
+                               TypeConverter converter) {
         Comparable rightValue = converter.convert(rightPredicate.value);
         Comparable leftValue = converter.convert(leftPredicate.value);
         return rightValue.compareTo(leftValue) < 0;

--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/DiscoveredNode.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/DiscoveredNode.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi.discovery;
+
+import com.hazelcast.nio.Address;
+
+import java.util.Map;
+
+/**
+ * A <tt>DiscoveredNode</tt> describes a nodes addresses (private and if
+ * necessary a public one) as well as attributes assigned to this node.
+ * Private address defines the typical internal communication port, all
+ * cluster communication and also client communication inside the same
+ * network happens on this address. However in cloud environments clients
+ * might run in other sub-networks and therefore cannot access the private
+ * address. In those situations {@link DiscoveryStrategy}
+ * vendors can retrieve and assign an additional external (or public) IP
+ * address of the node for clients to connect against.
+ * <p/>
+ * Public addresses, if not necessary, can either be returned as null or
+ * may return the same address instance as the private one and will be
+ * handled internally the same way.
+ * <p/>
+ * The properties will be used to store any kind of tags or other metadata
+ * available for the node inside of the cloud environment. If a
+ * {@link com.hazelcast.spi.discovery.NodeFilter} is configured, these
+ * properties might be used for further refinement of the discovered nodes
+ * based on whatever the filter decides.
+ */
+public interface DiscoveredNode {
+
+    /**
+     * Returns the private address of the discovered node. The private address
+     * <b>must not be</b> null.
+     *
+     * @return the private address of the discovered node
+     */
+    Address getPrivateAddress();
+
+    /**
+     * Returns the public address of the discovered node if available. Public addresses
+     * are optional and this method may return null or the same address as {@link #getPrivateAddress()}.
+     *
+     * @return the public address of the discovered node if available otherwise null or {@link #getPrivateAddress()}
+     */
+    Address getPublicAddress();
+
+    /**
+     * Returns a set of unmodifiable properties that are assigned to the discovered node. These properties
+     * can be used for additional filtering based on the {@link NodeFilter} API.
+     *
+     * @return assigned properties of that node
+     */
+    Map<String, Object> getProperties();
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/DiscoveryMode.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/DiscoveryMode.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi.discovery;
+
+/**
+ * <p>The <tt>DiscoveryMode</tt> describes how the {@link DiscoveryStrategy} is going
+ * to behave on discovery requests. Depending on the current environment it will
+ * either be setup to run in client or server mode.</p>
+ * <p>Implementors of {@link DiscoveryStrategy}s are free to change behavior as necessary.
+ * One possible use case is to prevent to start a multicast service on clients when only
+ * discovery is necessary.</p>
+ */
+public enum DiscoveryMode {
+    /**
+     * The current runtime environment is a Hazelcast member node
+     */
+    Member,
+
+    /**
+     * The current runtime environment is a Hazelcast client
+     */
+    Client
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/DiscoveryStrategy.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/DiscoveryStrategy.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi.discovery;
+
+/**
+ * The <tt>DiscoveryStrategy</tt> itself is the actual implementation to discover
+ * nodes based on whatever environment is used to run the Hazelcast cloud. The
+ * internal implementation is completely vendor specific and might use external Java
+ * libraries to query APIs or send requests to a external REST service.
+ * <p/>
+ * <tt>DiscoveryStrategies</tt> are also free to define any kind of properties that might
+ * be necessary to discover eligible nodes based on configured attributes, tags or any
+ * other kind of metadata.
+ * <p/>
+ * Using the simple lifecycle management strategies like multicast discovery is able to
+ * register and destroy sockets based on Hazelcast’s lifecycle. Deactivated services will
+ * also never be started.
+ */
+public interface DiscoveryStrategy {
+
+    /**
+     * The <tt>start</tt> method is used to initialize internal state and perform any kind of
+     * startup procedure like multicast socket creation. The behavior of this method might
+     * change based on the passed {@link DiscoveredNode}.
+     *
+     * @param discoveryMode the provided discovery mode
+     */
+    void start(DiscoveryMode discoveryMode);
+
+    /**
+     * Returns a set of all discovered nodes based on the defined properties that were used
+     * to create the <tt>DiscoveryStrategy</tt> instance.
+     *
+     * @return a set of all discovered nodes
+     */
+    Iterable<DiscoveredNode> discoverNodes();
+
+    /**
+     * The <tt>stop</tt> method is used to stop internal services, sockets or to destroy any
+     * kind of internal state.
+     */
+    void destroy();
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/DiscoveryStrategyFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/DiscoveryStrategyFactory.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi.discovery;
+
+import com.hazelcast.config.properties.PropertyDefinition;
+
+import java.util.Collection;
+import java.util.Map;
+
+/**
+ * The <tt>DiscoveryStrategyFactory</tt> is the entry point for strategy vendors. Every
+ * {@link DiscoveryStrategy} should have its own factory building it. In rare cases (like
+ * multiple version support or similar) one factory might return different provider
+ * implementations based on certain criteria. It is also up to the <tt>DiscoveryStrategyFactory</tt>
+ * to cache instances and return them in some kind of a Singleton-like fashion.
+ * <p/>
+ * The defined set of configuration properties describes the existing properties inside
+ * of the Hazelcast configuration. It will be used for automatic conversion,
+ * type-checking and validation before handing them to the {@link DiscoveryStrategy}.
+ * This removes a lot of boilerplate from the provider vendor and provides some convenience as
+ * well as guarantee to execute the expected configuration checks. The later is especially
+ * important because there is no schema support for properties necessary or provided by the
+ * provider plugins. Any kind of violation while verification of any type conversion error
+ * as well as missing non-optional properties will throw an exception and prevent the node
+ * from starting up.
+ */
+public interface DiscoveryStrategyFactory {
+
+    /**
+     * Returns the type of the {@link DiscoveryStrategy} itself.
+     *
+     * @return the type of the discovery strategy
+     */
+    Class<? extends DiscoveryStrategy> getDiscoveryStrategyType();
+
+    /**
+     * Instantiates a new instance of the {@link DiscoveryStrategy} with the given configuration
+     * properties.
+     *
+     * @param properties the properties parsed from the configuration
+     * @return a new instance of the discovery strategy
+     */
+    DiscoveryStrategy newDiscoveryStrategy(Map<String, Comparable> properties);
+
+    /**
+     * Returns a set of the expected configuration properties. These properties contain
+     * information about the value type of the property, if it is required and a possible
+     * validator to automatically test and convert values from the XML configuration.
+     *
+     * @return a set of expected configuration properties
+     */
+    Collection<PropertyDefinition> getConfigurationProperties();
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/NodeFilter.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/NodeFilter.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi.discovery;
+
+/**
+ * The NodeFilter, if supplied, will retrieve all discovered nodes and might
+ * apply additional filtering based on vendor provided metadata. These metadata
+ * are expected to be provided using the {@link DiscoveredNode#getProperties()}
+ * method and may contain additional information initially setup by the user.
+ * <p/>
+ * This is useful for additional security settings, to apply a certain type of
+ * policy or to work around insufficient query languages of cloud providers.
+ * <p/>
+ * Denied {@link com.hazelcast.spi.discovery.DiscoveredNode}s will not be
+ * handed over to the Hazelcast connection framework and therefore are not
+ * known to the discovered.
+ */
+public interface NodeFilter {
+
+    /**
+     * Accepts or denies a {@link com.hazelcast.spi.discovery.DiscoveredNode}
+     * based on the implemented rules.
+     *
+     * @param candidate the candidate to be tested
+     * @return true if the DiscoveredNode is selected to be discovered, otherwise false.
+     */
+    boolean test(DiscoveredNode candidate);
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/SimpleDiscoveredNode.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/SimpleDiscoveredNode.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi.discovery;
+
+import com.hazelcast.nio.Address;
+import com.hazelcast.util.Preconditions;
+
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * Simple immutable implementation of the {@link DiscoveredNode} interface for convenience
+ * when implementing a {@link DiscoveryStrategy}.
+ */
+public class SimpleDiscoveredNode
+        implements DiscoveredNode {
+
+    private final Address privateAddress;
+    private final Address publicAddress;
+    private final Map<String, Object> properties;
+
+    /**
+     * This constructor will set private and public addresses to the same value and no properties
+     * are available.
+     *
+     * @param privateAddress the discovered node's private address
+     */
+    public SimpleDiscoveredNode(Address privateAddress) {
+        this(privateAddress, privateAddress, Collections.<String, Object>emptyMap());
+    }
+
+    /**
+     * This constructor will set private and public addresses to the same value.
+     *
+     * @param privateAddress the discovered node's private address
+     * @param properties     the discovered node's additional properties
+     */
+    public SimpleDiscoveredNode(Address privateAddress, Map<String, Object> properties) {
+        this(privateAddress, privateAddress, properties);
+    }
+
+    /**
+     * <p>This constructor will set private and public addresses separately and no properties are available.
+     * Based on the internal implementation Hazelcast will either choose private or public address to connect
+     * to the cluster.</p>
+     * <p>On members private addresses are preferred.</p>
+     *
+     * @param privateAddress the discovered node's private address
+     * @param publicAddress  the discovered node's public address
+     */
+    public SimpleDiscoveredNode(Address privateAddress, Address publicAddress) {
+        this(privateAddress, publicAddress, Collections.<String, Object>emptyMap());
+    }
+
+    /**
+     * <p>This constructor will set private and public addresses separately. Based on the internal
+     * implementation Hazelcast will either choose private or public address to connect to the cluster.</p>
+     * <p>On members private addresses are preferred.</p>
+     *
+     * @param privateAddress the discovered node's private address
+     * @param publicAddress  the discovered node's public address
+     * @param properties     the discovered node's additional properties
+     */
+    public SimpleDiscoveredNode(Address privateAddress, Address publicAddress, Map<String, Object> properties) {
+        Preconditions.checkNotNull(privateAddress, "The private address cannot be null");
+        Preconditions.checkNotNull(properties, "The properties cannot be null");
+        this.privateAddress = privateAddress;
+        this.publicAddress = publicAddress;
+        this.properties = Collections.unmodifiableMap(properties);
+    }
+
+    @Override
+    public Address getPrivateAddress() {
+        return privateAddress;
+    }
+
+    @Override
+    public Address getPublicAddress() {
+        return publicAddress;
+    }
+
+    @Override
+    public Map<String, Object> getProperties() {
+        return properties;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/impl/DefaultDiscoveryService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/impl/DefaultDiscoveryService.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi.discovery.impl;
+
+import com.hazelcast.config.DiscoveryStrategiesConfig;
+import com.hazelcast.config.DiscoveryStrategyConfig;
+import com.hazelcast.config.properties.PropertyDefinition;
+import com.hazelcast.config.properties.ValueValidator;
+import com.hazelcast.core.HazelcastException;
+import com.hazelcast.core.TypeConverter;
+import com.hazelcast.spi.discovery.DiscoveredNode;
+import com.hazelcast.spi.discovery.DiscoveryMode;
+import com.hazelcast.spi.discovery.integration.DiscoveryService;
+import com.hazelcast.spi.discovery.DiscoveryStrategy;
+import com.hazelcast.spi.discovery.DiscoveryStrategyFactory;
+import com.hazelcast.spi.discovery.NodeFilter;
+import com.hazelcast.util.ServiceLoader;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class DefaultDiscoveryService
+        implements DiscoveryService {
+
+    private static final String SERVICE_LOADER_TAG = DiscoveryStrategyFactory.class.getCanonicalName();
+
+    private final Iterable<DiscoveryStrategy> discoveryProviders;
+    private final DiscoveryMode discoveryMode;
+    private final NodeFilter nodeFilter;
+
+    public DefaultDiscoveryService(DiscoveryMode discoveryMode, DiscoveryStrategiesConfig discoveryStrategiesConfig,
+                                   ClassLoader configClassLoader) {
+
+        this.discoveryMode = discoveryMode;
+        this.nodeFilter = getNodeFilter(discoveryStrategiesConfig, configClassLoader);
+        this.discoveryProviders = loadDiscoveryProviders(discoveryStrategiesConfig, configClassLoader);
+    }
+
+    @Override
+    public void start() {
+        for (DiscoveryStrategy discoveryStrategy : discoveryProviders) {
+            discoveryStrategy.start(discoveryMode);
+        }
+    }
+
+    @Override
+    public Iterable<DiscoveredNode> discoverNodes() {
+        Set<DiscoveredNode> discoveredNodes = new HashSet<DiscoveredNode>();
+        for (DiscoveryStrategy discoveryStrategy : discoveryProviders) {
+            Iterable<DiscoveredNode> candidates = discoveryStrategy.discoverNodes();
+
+            if (candidates != null) {
+                for (DiscoveredNode candidate : candidates) {
+                    if (validateCandidate(candidate)) {
+                        discoveredNodes.add(candidate);
+                    }
+                }
+            }
+        }
+        return discoveredNodes;
+    }
+
+    @Override
+    public void destroy() {
+        for (DiscoveryStrategy discoveryStrategy : discoveryProviders) {
+            discoveryStrategy.destroy();
+        }
+    }
+
+    private NodeFilter getNodeFilter(DiscoveryStrategiesConfig discoveryStrategiesConfig, ClassLoader configClassLoader) {
+        if (discoveryStrategiesConfig.getNodeFilter() != null) {
+            return discoveryStrategiesConfig.getNodeFilter();
+        }
+        if (discoveryStrategiesConfig.getNodeFilterClass() != null) {
+            try {
+                ClassLoader cl = configClassLoader;
+                if (cl == null) {
+                    cl = DefaultDiscoveryService.class.getClassLoader();
+                }
+
+                String className = discoveryStrategiesConfig.getNodeFilterClass();
+                return (NodeFilter) cl.loadClass(className).newInstance();
+            } catch (Exception e) {
+                throw new RuntimeException("Failed to configure discovery node filter", e);
+            }
+        }
+        return null;
+    }
+
+    private boolean validateCandidate(DiscoveredNode candidate) {
+        return nodeFilter == null || nodeFilter.test(candidate);
+    }
+
+    private Iterable<DiscoveryStrategy> loadDiscoveryProviders(DiscoveryStrategiesConfig providersConfig,
+                                                               ClassLoader configClassLoader) {
+        try {
+            Collection<DiscoveryStrategyConfig> discoveryStrategyConfigs = providersConfig.getDiscoveryStrategyConfigs();
+
+            Iterator<DiscoveryStrategyFactory> iterator = ServiceLoader
+                    .iterator(DiscoveryStrategyFactory.class, SERVICE_LOADER_TAG, configClassLoader);
+
+            List<DiscoveryStrategy> discoveryStrategies = new ArrayList<DiscoveryStrategy>();
+            while (iterator.hasNext()) {
+                DiscoveryStrategyFactory factory = iterator.next();
+                DiscoveryStrategy discoveryStrategy = buildDiscoveryProvider(factory, discoveryStrategyConfigs);
+                if (discoveryStrategy != null) {
+                    discoveryStrategies.add(discoveryStrategy);
+                }
+            }
+            return discoveryStrategies;
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to configure discovery strategies", e);
+        }
+    }
+
+    private Map<String, Comparable> buildProperties(DiscoveryStrategyFactory factory, DiscoveryStrategyConfig config,
+                                                    String className) {
+        Collection<PropertyDefinition> propertyDefinitions = factory.getConfigurationProperties();
+        if (propertyDefinitions == null) {
+            return Collections.emptyMap();
+        }
+
+        Map<String, Comparable> properties = config.getProperties();
+        Map<String, Comparable> mappedProperties = new HashMap<String, Comparable>();
+
+        for (PropertyDefinition propertyDefinition : propertyDefinitions) {
+            String propertyKey = propertyDefinition.key();
+            Comparable value = properties.get(propertyKey);
+            if (value == null) {
+                if (!propertyDefinition.optional()) {
+                    throw new HazelcastException(
+                            "Missing property '" + propertyKey + "' on discovery strategy '" + className + "' configuration");
+                }
+                continue;
+            }
+
+            TypeConverter typeConverter = propertyDefinition.typeConverter();
+            Comparable mappedValue = typeConverter.convert(value);
+
+            ValueValidator validator = propertyDefinition.validator();
+            if (validator != null) {
+                validator.validate(mappedValue);
+            }
+
+            mappedProperties.put(propertyKey, mappedValue);
+        }
+
+        return mappedProperties;
+    }
+
+    private DiscoveryStrategy buildDiscoveryProvider(DiscoveryStrategyFactory factory,
+                                                     Collection<DiscoveryStrategyConfig> discoveryStrategyConfigs) {
+        Class<? extends DiscoveryStrategy> discoveryProviderType = factory.getDiscoveryStrategyType();
+        String className = discoveryProviderType.getName();
+
+        for (DiscoveryStrategyConfig config : discoveryStrategyConfigs) {
+            if (config.getClassName().equals(className)) {
+                Map<String, Comparable> properties = buildProperties(factory, config, className);
+                return factory.newDiscoveryStrategy(properties);
+            }
+        }
+        return null;
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/impl/DefaultDiscoveryServiceProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/impl/DefaultDiscoveryServiceProvider.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi.discovery.impl;
+
+import com.hazelcast.config.DiscoveryStrategiesConfig;
+import com.hazelcast.spi.discovery.DiscoveryMode;
+import com.hazelcast.spi.discovery.integration.DiscoveryService;
+import com.hazelcast.spi.discovery.integration.DiscoveryServiceProvider;
+
+public class DefaultDiscoveryServiceProvider
+        implements DiscoveryServiceProvider {
+
+    @Override
+    public DiscoveryService newDiscoveryService(DiscoveryMode discoveryMode, DiscoveryStrategiesConfig discoveryStrategiesConfig,
+                                                ClassLoader configClassLoader) {
+
+        return new DefaultDiscoveryService(discoveryMode, discoveryStrategiesConfig, configClassLoader);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/integration/DiscoveryService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/integration/DiscoveryService.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi.discovery.integration;
+
+import com.hazelcast.spi.discovery.DiscoveredNode;
+import com.hazelcast.spi.discovery.DiscoveryStrategy;
+import com.hazelcast.spi.discovery.NodeFilter;
+
+/**
+ * The <tt>DiscoveryService</tt> interface defines the basic entry point
+ * into the Discovery SPI implementation. If not overridden explicitly the Hazelcast
+ * internal {@link com.hazelcast.spi.discovery.impl.DefaultDiscoveryService}
+ * implementation is used. A <tt>DiscoveryService</tt> somehow finds available
+ * {@link DiscoveryStrategy}s inside the classpath and manages their activation
+ * or deactivation status.
+ * <p/>
+ * This interface is used by system integrators, integrating Hazelcast into their own
+ * frameworks or environments, are free to extend or exchange the default implementation
+ * based on their needs and requirements.
+ * <p/>
+ * Only enabled providers are expected to discover nodes but, depending on the
+ * <tt>DiscoveryService</tt> implementation, multiple {@link DiscoveryStrategy}s
+ * might be enabled at the same time (e.g. TCP-IP Joiner with well known addresses
+ * and Cloud discovery).
+ */
+public interface DiscoveryService {
+
+    /**
+     * The <tt>start</tt> method is called on system startup to implement simple
+     * lifecycle management. This method is expected to call
+     * {@link DiscoveryStrategy#start(com.hazelcast.spi.discovery.DiscoveryMode)} on all
+     * discovered and activated strategies.
+     */
+    void start();
+
+    /**
+     * Returns a discovered and filtered, if a {@link NodeFilter} is setup, set of
+     * discovered nodes to connect to.
+     *
+     * @return a set of discovered and filtered nodes
+     */
+    Iterable<DiscoveredNode> discoverNodes();
+
+    /**
+     * The <tt>start</tt> method is called on system startup to implement simple
+     * lifecycle management. This method is expected to call
+     * {@link DiscoveryStrategy#destroy()} on all discovered and activated strategies
+     * before the service itself will shutdown.
+     */
+    void destroy();
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/integration/DiscoveryServiceProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/integration/DiscoveryServiceProvider.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi.discovery.integration;
+
+import com.hazelcast.config.DiscoveryStrategiesConfig;
+import com.hazelcast.spi.discovery.DiscoveryMode;
+
+/**
+ * The <tt>DiscoveryServiceProvider</tt> interface provides the possibility to build {@link DiscoveryService}s.
+ * <tt>DiscoveryService</tt> implementations should be immutable and therefore the provider is introduced to
+ * provide this ability. Every service should have its own provider, however in rare cases a single provider might
+ * create different <tt>DiscoveryService</tt> implementations based on the provided {@link DiscoveryMode} or other
+ * configuration details.
+ */
+public interface DiscoveryServiceProvider {
+
+    /**
+     * Instantiates a new instance of the {@link DiscoveryService}.
+     *
+     * @param discoveryMode            the current discovery mode
+     * @param discoveryStrategiesConfig the configuration parsed from the XML or provided using the programmatic API
+     * @param configClassLoader        the classloader set in the configuration
+     * @return a new instance of the discovery service
+     */
+    DiscoveryService newDiscoveryService(DiscoveryMode discoveryMode, DiscoveryStrategiesConfig discoveryStrategiesConfig,
+                                         ClassLoader configClassLoader);
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/integration/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/integration/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * This package contains the public part of the integrators SPI and is meant for
+ * people that integrate Hazelcast into their own systems or frameworks and cannot
+ * use the default discovery service implementation (for example using a different
+ * {@link com.hazelcast.spi.discovery.DiscoveryStrategy} lookup strategy like OSGi).
+ */
+package com.hazelcast.spi.discovery.integration;

--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * This package contains the public SPI for vendors and users to implement their
+ * custom node / IP discovery strategy.
+ */
+package com.hazelcast.spi.discovery;

--- a/hazelcast/src/main/resources/hazelcast-config-3.6.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-3.6.xsd
@@ -1440,7 +1440,25 @@
             <xs:element name="multicast" type="multicast" minOccurs="0"/>
             <xs:element name="tcp-ip" type="tcp-ip" minOccurs="0"/>
             <xs:element name="aws" type="aws" minOccurs="0"/>
+            <xs:element name="discovery-strategies" type="discovery-strategies" minOccurs="0" maxOccurs="1"/>
         </xs:all>
+    </xs:complexType>
+
+    <xs:complexType name="discovery-strategies">
+        <xs:sequence>
+            <xs:element name="node-filter" type="discovery-node-filter" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="discovery-strategy" type="discovery-strategy" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="discovery-node-filter">
+        <xs:attribute name="class" type="xs:string" use="required"/>
+    </xs:complexType>
+    <xs:complexType name="discovery-strategy">
+        <xs:sequence>
+            <xs:element name="properties" type="properties" minOccurs="0" maxOccurs="1"/>
+        </xs:sequence>
+        <xs:attribute name="enabled" type="xs:boolean" use="optional" default="false"/>
+        <xs:attribute name="class" type="xs:string" use="required"/>
     </xs:complexType>
     <xs:complexType name="interfaces">
         <xs:annotation>

--- a/hazelcast/src/main/resources/hazelcast-default.xml
+++ b/hazelcast/src/main/resources/hazelcast-default.xml
@@ -21,7 +21,7 @@
     - no hazelcast.xml if present
 
 -->
-<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.5.xsd"
+<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.6.xsd"
            xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <group>
@@ -61,6 +61,8 @@
                 <tag-key>type</tag-key>
                 <tag-value>hz-nodes</tag-value>
             </aws>
+            <discovery-strategies>
+            </discovery-strategies>
         </join>
         <interfaces enabled="false">
             <interface>10.10.1.*</interface>

--- a/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
@@ -764,7 +764,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
 
     private void testXSDConfigXML(String xmlFileName) throws SAXException, IOException {
         SchemaFactory factory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
-        URL schemaResource = XMLConfigBuilderTest.class.getClassLoader().getResource("hazelcast-config-3.5.xsd");
+        URL schemaResource = XMLConfigBuilderTest.class.getClassLoader().getResource("hazelcast-config-3.6.xsd");
         InputStream xmlResource = XMLConfigBuilderTest.class.getClassLoader().getResourceAsStream(xmlFileName);
         Schema schema = factory.newSchema(schemaResource);
         Source source = new StreamSource(xmlResource);

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/TypeConverterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/TypeConverterTest.java
@@ -31,7 +31,7 @@ public class TypeConverterTest {
 
     @Test
     public void testConvert_whenPassedNullValue_thenConvertToNullObject() {
-        TypeConverters.TypeConverter converter = new TypeConverters.TypeConverter() {
+        TypeConverters.BaseTypeConverter converter = new TypeConverters.BaseTypeConverter() {
             @Override
             Comparable convertInternal(Comparable value) {
                 return value;

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/BetweenVisitorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/BetweenVisitorTest.java
@@ -1,12 +1,11 @@
 package com.hazelcast.query.impl.predicates;
 
+import com.hazelcast.core.TypeConverter;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.impl.FalsePredicate;
 import com.hazelcast.query.impl.Index;
 import com.hazelcast.query.impl.Indexes;
-import com.hazelcast.query.impl.TypeConverters;
 import com.hazelcast.test.HazelcastParallelClassRunner;
-import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
@@ -14,15 +13,20 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import static com.hazelcast.query.Predicates.*;
+import static com.hazelcast.query.Predicates.and;
+import static com.hazelcast.query.Predicates.equal;
+import static com.hazelcast.query.Predicates.greaterEqual;
+import static com.hazelcast.query.Predicates.greaterThan;
+import static com.hazelcast.query.Predicates.lessEqual;
+import static com.hazelcast.query.Predicates.notEqual;
 import static com.hazelcast.query.impl.TypeConverters.INTEGER_CONVERTER;
+import static org.hamcrest.Matchers.hasItemInArray;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.hamcrest.Matchers.*;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
@@ -180,7 +184,7 @@ public class BetweenVisitorTest {
         assertEquals(FalsePredicate.INSTANCE, result);
     }
 
-    private void useConverter(TypeConverters.TypeConverter converter) {
+    private void useConverter(TypeConverter converter) {
         when(mockIndex.getConverter()).thenReturn(converter);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/FlatteningVisitorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/FlatteningVisitorTest.java
@@ -16,10 +16,10 @@
 
 package com.hazelcast.query.impl.predicates;
 
+import com.hazelcast.core.TypeConverter;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.impl.Index;
 import com.hazelcast.query.impl.Indexes;
-import com.hazelcast.query.impl.TypeConverters;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -32,11 +32,11 @@ import static com.hazelcast.query.Predicates.and;
 import static com.hazelcast.query.Predicates.equal;
 import static com.hazelcast.query.Predicates.not;
 import static com.hazelcast.query.Predicates.or;
+import static com.hazelcast.query.impl.TypeConverters.INTEGER_CONVERTER;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static com.hazelcast.query.impl.TypeConverters.INTEGER_CONVERTER;
 import static org.mockito.Mockito.withSettings;
 
 @RunWith(HazelcastParallelClassRunner.class)
@@ -103,7 +103,7 @@ public class FlatteningVisitorTest {
         assertEquals(negated, result);
     }
 
-    private void useConverter(TypeConverters.TypeConverter converter) {
+    private void useConverter(TypeConverter converter) {
         when(mockIndex.getConverter()).thenReturn(converter);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/OrToInVisitorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/OrToInVisitorTest.java
@@ -1,9 +1,9 @@
 package com.hazelcast.query.impl.predicates;
 
+import com.hazelcast.core.TypeConverter;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.impl.Index;
 import com.hazelcast.query.impl.Indexes;
-import com.hazelcast.query.impl.TypeConverters;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -57,7 +57,7 @@ public class OrToInVisitorTest {
 
 
 
-    private void useConverter(TypeConverters.TypeConverter converter) {
+    private void useConverter(TypeConverter converter) {
         when(mockIndex.getConverter()).thenReturn(converter);
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/quorum/PartitionedCluster.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/PartitionedCluster.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2014, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/quorum/cache/CacheQuorumListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/cache/CacheQuorumListenerTest.java
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2008-2014, Hazelcast, Inc. All Rights Reserved.
+* Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
 *
 *  Licensed under the Apache License, Version 2.0 (the "License");
 *  you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/quorum/map/MapReadWriteQuorumTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/map/MapReadWriteQuorumTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2014, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/quorum/map/QuorumListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/map/QuorumListenerTest.java
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2008-2014, Hazelcast, Inc. All Rights Reserved.
+* Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
 *
 *  Licensed under the Apache License, Version 2.0 (the "License");
 *  you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/quorum/map/TransactionalMapReadWriteQuorumTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/map/TransactionalMapReadWriteQuorumTest.java
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2008-2014, Hazelcast, Inc. All Rights Reserved.
+* Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
 *
 *  Licensed under the Apache License, Version 2.0 (the "License");
 *  you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/impl/record/LazyIteratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/impl/record/LazyIteratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2014, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/spi/discovery/DiscoverySpiTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/discovery/DiscoverySpiTest.java
@@ -1,0 +1,248 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi.discovery;
+
+import com.hazelcast.config.AwsConfig;
+import com.hazelcast.config.Config;
+import com.hazelcast.config.DiscoveryStrategiesConfig;
+import com.hazelcast.config.DiscoveryStrategyConfig;
+import com.hazelcast.config.InterfacesConfig;
+import com.hazelcast.config.JoinConfig;
+import com.hazelcast.config.MulticastConfig;
+import com.hazelcast.config.TcpIpConfig;
+import com.hazelcast.config.XmlConfigBuilder;
+import com.hazelcast.config.properties.PropertyDefinition;
+import com.hazelcast.config.properties.PropertyTypeConverter;
+import com.hazelcast.config.properties.SimplePropertyDefinition;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.nio.Address;
+import com.hazelcast.spi.discovery.impl.DefaultDiscoveryService;
+import com.hazelcast.spi.discovery.impl.DefaultDiscoveryServiceProvider;
+import com.hazelcast.spi.discovery.integration.DiscoveryService;
+import com.hazelcast.spi.discovery.integration.DiscoveryServiceProvider;
+import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.xml.sax.SAXException;
+
+import javax.xml.XMLConstants;
+import javax.xml.transform.Source;
+import javax.xml.transform.stream.StreamSource;
+import javax.xml.validation.Schema;
+import javax.xml.validation.SchemaFactory;
+import javax.xml.validation.Validator;
+import java.io.InputStream;
+import java.lang.reflect.Field;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category(QuickTest.class)
+public class DiscoverySpiTest
+        extends HazelcastTestSupport {
+
+    @Test
+    public void testSchema() throws Exception {
+        String xmlFileName = "test-hazelcast-discovery-spi.xml";
+
+        SchemaFactory factory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+        URL schemaResource = DiscoverySpiTest.class.getClassLoader().getResource("hazelcast-config-3.6.xsd");
+        Schema schema = factory.newSchema(schemaResource);
+
+        InputStream xmlResource = DiscoverySpiTest.class.getClassLoader().getResourceAsStream(xmlFileName);
+        Source source = new StreamSource(xmlResource);
+        Validator validator = schema.newValidator();
+        validator.validate(source);
+    }
+
+    @Test
+    public void testParsing() throws Exception {
+        String xmlFileName = "test-hazelcast-discovery-spi.xml";
+        InputStream xmlResource = DiscoverySpiTest.class.getClassLoader().getResourceAsStream(xmlFileName);
+        Config config = new XmlConfigBuilder(xmlResource).build();
+
+        JoinConfig joinConfig = config.getNetworkConfig().getJoin();
+
+        AwsConfig awsConfig = joinConfig.getAwsConfig();
+        assertFalse(awsConfig.isEnabled());
+
+        TcpIpConfig tcpIpConfig = joinConfig.getTcpIpConfig();
+        assertFalse(tcpIpConfig.isEnabled());
+
+        MulticastConfig multicastConfig = joinConfig.getMulticastConfig();
+        assertFalse(multicastConfig.isEnabled());
+
+        DiscoveryStrategiesConfig discoveryStrategiesConfig = joinConfig.getDiscoveryStrategiesConfig();
+        assertTrue(discoveryStrategiesConfig.isEnabled());
+
+        assertEquals(1, discoveryStrategiesConfig.getDiscoveryStrategyConfigs().size());
+
+        DiscoveryStrategyConfig providerConfig = discoveryStrategiesConfig.getDiscoveryStrategyConfigs().iterator().next();
+
+        assertEquals(3, providerConfig.getProperties().size());
+        assertEquals("foo", providerConfig.getProperties().get("key-string"));
+        assertEquals("123", providerConfig.getProperties().get("key-int"));
+        assertEquals("true", providerConfig.getProperties().get("key-boolean"));
+    }
+
+    @Test
+    public void testNodeStartup() {
+        String xmlFileName = "test-hazelcast-discovery-spi.xml";
+        InputStream xmlResource = DiscoverySpiTest.class.getClassLoader().getResourceAsStream(xmlFileName);
+        Config config = new XmlConfigBuilder(xmlResource).build();
+        config.getNetworkConfig().setPort(50001);
+        InterfacesConfig interfaces = config.getNetworkConfig().getInterfaces();
+        interfaces.clear();
+        interfaces.setEnabled(true);
+        interfaces.addInterface("127.0.0.1");
+
+        String[] addresses = {"127.0.0.1", "127.0.0.1", "127.0.0.1"};
+        final TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(50001, addresses);
+
+        final HazelcastInstance hazelcastInstance1 = factory.newHazelcastInstance(config);
+        final HazelcastInstance hazelcastInstance2 = factory.newHazelcastInstance(config);
+        final HazelcastInstance hazelcastInstance3 = factory.newHazelcastInstance(config);
+
+        assertNotNull(hazelcastInstance1);
+        assertNotNull(hazelcastInstance2);
+        assertNotNull(hazelcastInstance3);
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run()
+                    throws Exception {
+
+                assertEquals(3, hazelcastInstance1.getCluster().getMembers().size());
+                assertEquals(3, hazelcastInstance2.getCluster().getMembers().size());
+                assertEquals(3, hazelcastInstance3.getCluster().getMembers().size());
+            }
+        });
+    }
+
+    @Test
+    public void testNodeFilter_from_xml() throws Exception {
+        String xmlFileName = "test-hazelcast-discovery-spi.xml";
+        InputStream xmlResource = DiscoverySpiTest.class.getClassLoader().getResourceAsStream(xmlFileName);
+        Config config = new XmlConfigBuilder(xmlResource).build();
+
+        JoinConfig joinConfig = config.getNetworkConfig().getJoin();
+
+        DiscoveryStrategiesConfig discoveryStrategiesConfig = joinConfig.getDiscoveryStrategiesConfig();
+        assertNotNull(discoveryStrategiesConfig);
+        assertNotNull(discoveryStrategiesConfig.getNodeFilterClass());
+
+        DiscoveryServiceProvider provider = new DefaultDiscoveryServiceProvider();
+        DiscoveryService discoveryService = provider.newDiscoveryService(DiscoveryMode.Client,
+                discoveryStrategiesConfig, DiscoverySpiTest.class.getClassLoader());
+
+        discoveryService.start();
+        discoveryService.discoverNodes();
+        discoveryService.destroy();
+
+        Field nodeFilterField = DefaultDiscoveryService.class.getDeclaredField("nodeFilter");
+        nodeFilterField.setAccessible(true);
+
+        TestNodeFilter nodeFilter = (TestNodeFilter) nodeFilterField.get(discoveryService);
+
+        assertEquals(4, nodeFilter.getNodes().size());
+    }
+
+    private static class TestDiscoveryStrategy implements DiscoveryStrategy {
+
+        @Override
+        public void start(DiscoveryMode discoveryMode) {
+        }
+
+        @Override
+        public Collection<DiscoveredNode> discoverNodes() {
+            try {
+                List<DiscoveredNode> discoveredNodes = new ArrayList<DiscoveredNode>(4);
+                Address address = new Address("127.0.0.1", 50001);
+                discoveredNodes.add(new SimpleDiscoveredNode(address));
+                address = new Address("127.0.0.1", 50002);
+                discoveredNodes.add(new SimpleDiscoveredNode(address));
+                address = new Address("127.0.0.1", 50003);
+                discoveredNodes.add(new SimpleDiscoveredNode(address));
+                address = new Address("127.0.0.1", 50004);
+                discoveredNodes.add(new SimpleDiscoveredNode(address));
+
+                return discoveredNodes;
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        @Override
+        public void destroy() {
+        }
+    }
+
+    public static class TestDiscoveryStrategyFactory implements DiscoveryStrategyFactory {
+
+        private final Collection<PropertyDefinition> propertyDefinitions;
+
+        public TestDiscoveryStrategyFactory() {
+            List<PropertyDefinition> propertyDefinitions = new ArrayList<PropertyDefinition>();
+            propertyDefinitions.add(new SimplePropertyDefinition("key-string", PropertyTypeConverter.STRING));
+            propertyDefinitions.add(new SimplePropertyDefinition("key-int", PropertyTypeConverter.INTEGER));
+            propertyDefinitions.add(new SimplePropertyDefinition("key-boolean", PropertyTypeConverter.BOOLEAN));
+            propertyDefinitions.add(new SimplePropertyDefinition("key-something", true, PropertyTypeConverter.STRING));
+            this.propertyDefinitions = Collections.unmodifiableCollection(propertyDefinitions);
+        }
+
+        @Override
+        public Class<? extends DiscoveryStrategy> getDiscoveryStrategyType() {
+            return TestDiscoveryStrategy.class;
+        }
+
+        @Override
+        public DiscoveryStrategy newDiscoveryStrategy(Map<String, Comparable> properties) {
+            return new TestDiscoveryStrategy();
+        }
+
+        @Override
+        public Collection<PropertyDefinition> getConfigurationProperties() {
+            return propertyDefinitions;
+        }
+    }
+
+    public static class TestNodeFilter implements NodeFilter {
+
+        private final List<DiscoveredNode> nodes = new ArrayList<DiscoveredNode>();
+
+        @Override
+        public boolean test(DiscoveredNode candidate) {
+            nodes.add(candidate);
+            return true;
+        }
+
+        private List<DiscoveredNode> getNodes() {
+            return nodes;
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
@@ -145,6 +145,13 @@ public abstract class HazelcastTestSupport {
         return factory = new TestHazelcastInstanceFactory();
     }
 
+    protected final TestHazelcastInstanceFactory createHazelcastInstanceFactory(int initialPort, String... addresses) {
+        if (factory != null) {
+            throw new IllegalStateException("Node factory is already created!");
+        }
+        return factory = new TestHazelcastInstanceFactory(initialPort, addresses);
+    }
+
     public static Future spawn(Runnable task) {
         FutureTask<Runnable> futureTask = new FutureTask<Runnable>(task, null);
         new Thread(futureTask).start();

--- a/hazelcast/src/test/java/com/hazelcast/test/TestHazelcastInstanceFactory.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/TestHazelcastInstanceFactory.java
@@ -60,11 +60,20 @@ public class TestHazelcastInstanceFactory {
         this.registry = new TestNodeRegistry(addresses);
     }
 
+    public TestHazelcastInstanceFactory(int initialPort, String... addresses) {
+        this.count = addresses.length;
+        if (mockNetwork) {
+            this.addresses = new CopyOnWriteArrayList<Address>();
+            this.addresses.addAll(createAddresses(initialPort, PORTS, addresses));
+            this.registry = new TestNodeRegistry(this.addresses);
+        }
+    }
+
     public TestHazelcastInstanceFactory(String... addresses) {
         this.count = addresses.length;
         if (mockNetwork) {
             this.addresses = new CopyOnWriteArrayList<Address>();
-            this.addresses.addAll(createAddresses(PORTS, addresses));
+            this.addresses.addAll(createAddresses(-1, PORTS, addresses));
             this.registry = new TestNodeRegistry(this.addresses);
         }
     }
@@ -148,13 +157,14 @@ public class TestHazelcastInstanceFactory {
         return addresses;
     }
 
-    private static List<Address> createAddresses(AtomicInteger ports, String... addressArray) {
+    private static List<Address> createAddresses(int initialPort, AtomicInteger ports, String... addressArray) {
         checkElementsNotNull(addressArray);
 
         int count = addressArray.length;
         List<Address> addresses = new ArrayList<Address>(count);
         for (String address : addressArray) {
-            addresses.add(createAddress(address, ports.incrementAndGet()));
+            int port = initialPort == -1 ? ports.incrementAndGet() : initialPort++;
+            addresses.add(createAddress(address, port));
         }
         return addresses;
     }

--- a/hazelcast/src/test/resources/META-INF/services/com.hazelcast.spi.discovery.DiscoveryStrategyFactory
+++ b/hazelcast/src/test/resources/META-INF/services/com.hazelcast.spi.discovery.DiscoveryStrategyFactory
@@ -1,0 +1,1 @@
+com.hazelcast.spi.discovery.DiscoverySpiTest$TestDiscoveryStrategyFactory

--- a/hazelcast/src/test/resources/hazelcast-fullconfig.xml
+++ b/hazelcast/src/test/resources/hazelcast-fullconfig.xml
@@ -33,7 +33,7 @@
     4. If a configuration cannot be found, Hazelcast will use the default hazelcast configuration
        ’hazelcast-default.xml’, which is included in the the Hazelcast jar
 -->
-<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.5.xsd"
+<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.6.xsd"
            xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <group>

--- a/hazelcast/src/test/resources/test-hazelcast-discovery-spi.xml
+++ b/hazelcast/src/test/resources/test-hazelcast-discovery-spi.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.6.xsd"
+           xmlns="http://www.hazelcast.com/schema/config"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+  <properties>
+    <property name="hazelcast.discovery.enabled">true</property>
+  </properties>
+
+  <network>
+    <join>
+      <multicast enabled="false"/>
+      <tcp-ip enabled="false" />
+      <aws enabled="false"/>
+      <discovery-strategies>
+        <node-filter class="com.hazelcast.spi.discovery.DiscoverySpiTest$TestNodeFilter"/>
+        <discovery-strategy enabled="true" class="com.hazelcast.spi.discovery.DiscoverySpiTest$TestDiscoveryStrategy">
+          <properties>
+            <property name="key-string">foo</property>
+            <property name="key-int">123</property>
+            <property name="key-boolean">true</property>
+          </properties>
+        </discovery-strategy>
+      </discovery-strategies>
+    </join>
+  </network>
+
+</hazelcast>

--- a/hazelcast/src/test/resources/test-hazelcast-jcache.xml
+++ b/hazelcast/src/test/resources/test-hazelcast-jcache.xml
@@ -15,7 +15,7 @@
   ~ limitations under the License.
   -->
 
-<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.5.xsd"
+<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.6.xsd"
            xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 

--- a/hazelcast/src/test/resources/test-hazelcast-jcache2.xml
+++ b/hazelcast/src/test/resources/test-hazelcast-jcache2.xml
@@ -15,7 +15,7 @@
   ~ limitations under the License.
   -->
 
-<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.5.xsd"
+<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.6.xsd"
            xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 

--- a/hazelcast/src/test/resources/test-hazelcast-real-jcache.xml
+++ b/hazelcast/src/test/resources/test-hazelcast-real-jcache.xml
@@ -15,7 +15,7 @@
   ~ limitations under the License.
   -->
 
-<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.5.xsd"
+<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.6.xsd"
            xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 

--- a/hazelcast/src/test/resources/test-hazelcast.xml
+++ b/hazelcast/src/test/resources/test-hazelcast.xml
@@ -15,7 +15,7 @@
   ~ limitations under the License.
   -->
 
-<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.5.xsd"
+<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.6.xsd"
            xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <group>


### PR DESCRIPTION
This pull request implements the Discovery SPI for Hazelcast members, clients and the new client. It does not yet bring reimplementation of multicast and amazon ec2 discovery.

It also does not yet provide the requested option to automatically register started Hazelcast nodes to any kind of service discovery system (like zookeeper). I would like to do this as a separate HEP.

The SPI is already successfully implemented by third parties to prove it works:
- https://github.com/lburgazzoli/lb-hazelcast-discovery
- https://github.com/decoomanj/hazelcast-consul-spi

According HEP: https://hazelcast.atlassian.net/wiki/display/COM/HEP+2+-+Hazelcast+Discovery+SPI
Specification of the Discovery SPI: https://docs.google.com/document/d/1YoNjsE_Iz96ZKzFPUTJqMu4hhU96LaqL0vdY9FXF1ts

Mayb thanks to Paulo Pires (@pires), Ray Tsang (@saturnism), Jan De Cooman (@decoomanj) and Luca Burgazzoli (@lburgazzoli) for their help on the specification as well as demo implementations against the SPI.

@ devs: please have a look at the implementation and see if something is obviously wrong