### PR TITLE
Do not downgrade a transactional lock to a non-transactional lock after unsuccessful lock attempt

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockResourceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockResourceImpl.java
@@ -94,7 +94,6 @@ final class LockResourceImpl implements DataSerializable, LockResource {
             this.transactional = transactional;
             return true;
         }
-        this.transactional = false;
         return false;
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/lock/LockStoreImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/lock/LockStoreImplTest.java
@@ -385,6 +385,43 @@ public class LockStoreImplTest extends HazelcastTestSupport {
         assertFalse(locked);
     }
 
+    @Test
+    public void testIsTransactionallyLocked_whenLockDoesNotExist_thenReturnFalse() {
+        boolean locked = lockStore.isTransactionallyLocked(key);
+        assertFalse(locked);
+    }
+
+    @Test
+    public void testIsTransactionallyLocked_whenNonTxnLocked_thenReturnFalse() {
+        lock();
+        boolean locked = lockStore.isTransactionallyLocked(key);
+        assertFalse(locked);
+    }
+
+    @Test
+    public void testIsTransactionallyLocked_whenTxnLocked_thenReturnTrue() {
+        txnLock();
+        boolean locked = lockStore.isTransactionallyLocked(key);
+        assertTrue(locked);
+    }
+
+    @Test
+    public void testIsTransactionallyLocked_whenTxnLockedAndUnlocked_thenReturnFalse() {
+        txnLockAndIncreaseReferenceId();
+        unlock();
+        boolean locked = lockStore.isTransactionallyLocked(key);
+        assertFalse(locked);
+    }
+
+    @Test
+    public void testIsTransactionallyLocked_whenTxnLockedAndAttemptedToLockFromAnotherThread_thenReturnTrue() {
+        txnLockAndIncreaseReferenceId();
+        threadId++;
+        lockAndIncreaseReferenceId();
+        boolean locked = lockStore.isTransactionallyLocked(key);
+        assertTrue(locked);
+    }
+
 
     private boolean lock() {
         return lockStore.lock(key, callerId, threadId, referenceId, leaseTime);


### PR DESCRIPTION
Do not downgrade a transactional lock to a non-transactional lock after unsuccessful lock attempt

It seems like a left-over. We should not change state of a lock after unsuccessful lock-attempt.
It can result in premature lock release and jeopardize transaction recovery.

This PR is based on #5954 it should be merged only after #5954 is merged. 