### PR TITLE
Removed exception count probes in read/write-handlers

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/NonBlockingReadHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/NonBlockingReadHandler.java
@@ -57,8 +57,6 @@ public final class NonBlockingReadHandler extends AbstractSelectionHandler imple
     private final SwCounter normalPacketsRead = newSwCounter();
     @Probe(name = "in.priorityPacketsRead")
     private final SwCounter priorityPacketsRead = newSwCounter();
-    @Probe(name = "in.exceptionCount")
-    private final SwCounter exceptionCount = newSwCounter();
     private final MetricsRegistry metricRegistry;
 
     private SocketReader socketReader;
@@ -185,12 +183,6 @@ public final class NonBlockingReadHandler extends AbstractSelectionHandler imple
         } catch (Throwable t) {
             handleSocketException(t);
         }
-    }
-
-    @Override
-    public void handleSocketException(Throwable e) {
-        exceptionCount.inc();
-        super.handleSocketException(e);
     }
 
     private void initializeSocketReader() throws IOException {

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/NonBlockingWriteHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/NonBlockingWriteHandler.java
@@ -69,8 +69,6 @@ public final class NonBlockingWriteHandler extends AbstractSelectionHandler impl
     private final SwCounter normalPacketsWritten = newSwCounter();
     @Probe(name = "out.priorityPacketsWritten")
     private final SwCounter priorityPacketsWritten = newSwCounter();
-    @Probe(name = "out.exceptionCount")
-    private final SwCounter exceptionCount = newSwCounter();
     private final MetricsRegistry metricsRegistry;
 
     private volatile SocketWritable currentPacket;
@@ -345,7 +343,6 @@ public final class NonBlockingWriteHandler extends AbstractSelectionHandler impl
                 writeOutputBufferToSocket();
             }
         } catch (Throwable t) {
-            exceptionCount.inc();
             logger.severe("Fatal Error at WriteHandler for endPoint: " + connection.getEndPoint(), t);
         }
 


### PR DESCRIPTION
The NonBlockingReadHandler and writehandler have exception count probes, but since
every exception is terminal to the handler or connection there is no point in
counting them.