### PR TITLE
Writehandler handle method cleanup

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/NonBlockingWriteHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/NonBlockingWriteHandler.java
@@ -21,8 +21,8 @@ import com.hazelcast.internal.metrics.Probe;
 import com.hazelcast.nio.Packet;
 import com.hazelcast.nio.SocketWritable;
 import com.hazelcast.nio.ascii.SocketTextWriter;
-import com.hazelcast.nio.tcp.ClientPacketSocketWriter;
 import com.hazelcast.nio.tcp.ClientMessageSocketWriter;
+import com.hazelcast.nio.tcp.ClientPacketSocketWriter;
 import com.hazelcast.nio.tcp.MemberPacketSocketWriter;
 import com.hazelcast.nio.tcp.SocketWriter;
 import com.hazelcast.nio.tcp.TcpIpConnection;
@@ -30,7 +30,6 @@ import com.hazelcast.nio.tcp.WriteHandler;
 import com.hazelcast.util.Clock;
 import com.hazelcast.util.EmptyStatement;
 import com.hazelcast.util.counters.SwCounter;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.IOException;
 import java.net.SocketException;
@@ -69,16 +68,15 @@ public final class NonBlockingWriteHandler extends AbstractSelectionHandler impl
     private final SwCounter normalPacketsWritten = newSwCounter();
     @Probe(name = "out.priorityPacketsWritten")
     private final SwCounter priorityPacketsWritten = newSwCounter();
-    @Probe(name = "out.exceptionCount")
-    private final SwCounter exceptionCount = newSwCounter();
     private final MetricsRegistry metricsRegistry;
 
     private volatile SocketWritable currentPacket;
     private SocketWriter socketWriter;
     private volatile long lastWriteTime;
-    //This field will be incremented by a single thread. It can be read by multiple threads.
     @Probe(name = "out.eventCount")
-    private volatile long eventCount;
+    //This field will be incremented by a single thread. It can be read by multiple threads.
+    private final SwCounter eventCount = newSwCounter();
+
     private boolean shutdown;
     // this field will be accessed by the NonBlockingIOThread or
     // it is accessed by any other thread but only that thread managed to cas the scheduled flag to true.
@@ -319,43 +317,46 @@ public final class NonBlockingWriteHandler extends AbstractSelectionHandler impl
 
     @Override
     public long getEventCount() {
-        return eventCount;
+        return eventCount.get();
     }
 
     @Override
     @SuppressWarnings("unchecked")
-    @SuppressFBWarnings(value = "VO_VOLATILE_INCREMENT",
-            justification = "eventCount is accessed by a single thread only.")
     public void handle() {
-        eventCount++;
-        lastWriteTime = Clock.currentTimeMillis();
-        if (shutdown) {
-            return;
-        }
-
-        if (socketWriter == null) {
-            logger.log(Level.WARNING, "SocketWriter is not set, creating SocketWriter with CLUSTER protocol!");
-            createWriter(CLUSTER);
-        }
-
         try {
+            eventCount.inc();
+            lastWriteTime = Clock.currentTimeMillis();
+
+            if (shutdown) {
+                return;
+            }
+
+            if (socketWriter == null) {
+                logger.log(Level.WARNING, "SocketWriter is not set, creating SocketWriter with CLUSTER protocol!");
+                createWriter(CLUSTER);
+            }
+
             fillOutputBuffer();
 
             if (dirtyOutputBuffer()) {
                 writeOutputBufferToSocket();
             }
-        } catch (Throwable t) {
-            exceptionCount.inc();
-            logger.severe("Fatal Error at WriteHandler for endPoint: " + connection.getEndPoint(), t);
-        }
 
-        if (newOwner == null) {
-            unschedule();
-        } else {
-            NonBlockingIOThread newOwner = this.newOwner;
-            this.newOwner = null;
-            startMigration(newOwner);
+            if (newOwner == null) {
+                unschedule();
+            } else {
+                startMigration();
+            }
+        } catch (Throwable t) {
+            logger.severe("Fatal Error at WriteHandler for endPoint: " + connection.getEndPoint(), t);
+            handleSocketException(t);
         }
+    }
+
+    private void startMigration() {
+        NonBlockingIOThread newOwner = this.newOwner;
+        this.newOwner = null;
+        startMigration(newOwner);
     }
 
     /**
@@ -375,23 +376,18 @@ public final class NonBlockingWriteHandler extends AbstractSelectionHandler impl
     private void writeOutputBufferToSocket() throws Exception {
         // So there is data for writing, so lets prepare the buffer for writing and then write it to the socketChannel.
         outputBuffer.flip();
-        try {
-            int result = socketChannel.write(outputBuffer);
-            this.bytesWritten.inc(result);
-        } catch (Exception e) {
-            currentPacket = null;
-            handleSocketException(e);
-            return;
-        }
+        int written = socketChannel.write(outputBuffer);
+
+        bytesWritten.inc(written);
+
         // Now we verify if all data is written.
-        if (!outputBuffer.hasRemaining()) {
+        if (outputBuffer.hasRemaining()) {
+            // We did not manage to write all data to the socket. So lets compact the buffer so new data can be added at the end.
+            outputBuffer.compact();
+        } else {
             // We managed to fully write the outputBuffer to the socket, so we are done.
             outputBuffer.clear();
-            return;
         }
-        // We did not manage to write all data to the socket. So lets compact the buffer so new data
-        // can be added at the end.
-        outputBuffer.compact();
     }
 
     /**


### PR DESCRIPTION
the try/catch is now around the whole handle method.
write outputbuffer doesn't catch any exceptions
pulled out startMigration method
event counter is not volatile long but a swcounter; just as with read-handler
removed findbugs supression since no volatile long increment anymore

