### PR TITLE
Don't use new Config() as default test HZ config

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/map/IssuesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/IssuesTest.java
@@ -57,7 +57,7 @@ public class IssuesTest extends HazelcastTestSupport {
         int n = 1;
         TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(n);
 
-        final IMap<Integer, Integer> imap = factory.newHazelcastInstance(null).getMap("testIssue321_1");
+        final IMap<Integer, Integer> imap = factory.newHazelcastInstance().getMap("testIssue321_1");
         final BlockingQueue<com.hazelcast.core.EntryEvent<Integer, Integer>> events1 = new LinkedBlockingQueue<com.hazelcast.core.EntryEvent<Integer, Integer>>();
         final BlockingQueue<com.hazelcast.core.EntryEvent<Integer, Integer>> events2 = new LinkedBlockingQueue<com.hazelcast.core.EntryEvent<Integer, Integer>>();
         imap.addEntryListener(new EntryAdapter<Integer, Integer>() {
@@ -86,7 +86,7 @@ public class IssuesTest extends HazelcastTestSupport {
         int n = 1;
         TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(n);
 
-        final IMap<Integer, Integer> imap = factory.newHazelcastInstance(null).getMap("testIssue321_2");
+        final IMap<Integer, Integer> imap = factory.newHazelcastInstance().getMap("testIssue321_2");
         final BlockingQueue<com.hazelcast.core.EntryEvent<Integer, Integer>> events1 = new LinkedBlockingQueue<com.hazelcast.core.EntryEvent<Integer, Integer>>();
         final BlockingQueue<com.hazelcast.core.EntryEvent<Integer, Integer>> events2 = new LinkedBlockingQueue<com.hazelcast.core.EntryEvent<Integer, Integer>>();
         imap.addEntryListener(new EntryAdapter<Integer, Integer>() {
@@ -116,7 +116,7 @@ public class IssuesTest extends HazelcastTestSupport {
         int n = 1;
         TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(n);
 
-        final IMap<Integer, Integer> imap = factory.newHazelcastInstance(null).getMap("testIssue321_3");
+        final IMap<Integer, Integer> imap = factory.newHazelcastInstance().getMap("testIssue321_3");
         final BlockingQueue<com.hazelcast.core.EntryEvent<Integer, Integer>> events = new LinkedBlockingQueue<com.hazelcast.core.EntryEvent<Integer, Integer>>();
         final EntryAdapter<Integer, Integer> listener = new EntryAdapter<Integer, Integer>() {
             @Override
@@ -140,7 +140,7 @@ public class IssuesTest extends HazelcastTestSupport {
     public void testIssue304() {
         int n = 1;
         TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(n);
-        IMap<String, String> map = factory.newHazelcastInstance(null).getMap("testIssue304");
+        IMap<String, String> map = factory.newHazelcastInstance().getMap("testIssue304");
         map.lock("1");
         assertEquals(0, map.size());
         assertEquals(0, map.entrySet().size());

--- a/hazelcast/src/test/java/com/hazelcast/test/TestHazelcastInstanceFactory.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/TestHazelcastInstanceFactory.java
@@ -69,14 +69,15 @@ public class TestHazelcastInstanceFactory {
     }
 
     public HazelcastInstance newHazelcastInstance() {
-        return newHazelcastInstance(new Config());
+        return newHazelcastInstance(null);
     }
 
     public HazelcastInstance newHazelcastInstance(Config config) {
+        final String instanceName = config != null? config.getInstanceName() : null;
         if (mockNetwork) {
             init(config);
             NodeContext nodeContext = registry.createNodeContext(pickAddress());
-            return HazelcastInstanceFactory.newHazelcastInstance(config, null, nodeContext);
+            return HazelcastInstanceFactory.newHazelcastInstance(config, instanceName, nodeContext);
         }
         return HazelcastInstanceFactory.newHazelcastInstance(config);
     }


### PR DESCRIPTION
This small PR fixes the behavior of the nullary `newHazelcastInstance()` in the test factory, such that it doesn't insert a `new Config()`; instead it passes `null` to the production factory, letting it construct the default in the usual way (which complies with the XML Schema defaults).

At the same time the behavior is fixed regarding the creation of named HZ instances: where previously `null` was passed as the name, triggering automatic name generation, now the setting in the supplied configuration is honored (if present).