### PR TITLE
Reduce Selector litter

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/SelectorOptimizer.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/SelectorOptimizer.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.nio.tcp.nonblocking;
+
+import com.hazelcast.logging.ILogger;
+
+import java.lang.reflect.Field;
+import java.nio.channels.SelectionKey;
+import java.nio.channels.Selector;
+import java.util.AbstractSet;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+import static com.hazelcast.util.Preconditions.checkNotNull;
+import static java.lang.Class.forName;
+import static java.lang.System.arraycopy;
+
+/**
+ * The SelectorOptimizer optimizes the Selector so less litter is being created. The Selector uses a HashSet, but this creates
+ * an object for every add of a selection key. With this SelectorOptimizer a SelectionKeysSet, which contains an  an array,
+ * is being used since every key is going to be inserted only once.
+ *
+ * This trick comes from Netty.
+ */
+public final class SelectorOptimizer {
+    static final String SELECTOR_IMPL = "sun.nio.ch.SelectorImpl";
+
+    private SelectorOptimizer() {
+    }
+
+    /**
+     * Tries to optimize the provided Selector.
+     *
+     * @param selector the selector to optimize
+     * @return an FastSelectionKeySet if the optimization was a success, null otherwise.
+     * @throws NullPointerException if selector or logger is null.
+     */
+    public static SelectionKeysSet optimize(Selector selector, ILogger logger) {
+        checkNotNull(selector, "selector");
+        checkNotNull(logger, "logger");
+
+        try {
+            SelectionKeysSet set = new SelectionKeysSet();
+
+            Class<?> selectorImplClass = findOptimizableSelectorClass(selector);
+            if (selectorImplClass == null) {
+                return null;
+            }
+
+            Field selectedKeysField = selectorImplClass.getDeclaredField("selectedKeys");
+            selectedKeysField.setAccessible(true);
+
+            Field publicSelectedKeysField = selectorImplClass.getDeclaredField("publicSelectedKeys");
+            publicSelectedKeysField.setAccessible(true);
+
+            selectedKeysField.set(selector, set);
+            publicSelectedKeysField.set(selector, set);
+
+            logger.info("Optimized Selector: " + selector.getClass().getName());
+            return set;
+        } catch (Throwable t) {
+            // we don't want to print at warning level because it could very well be that the target JVM doesn't
+            // support this optimization. That is why we print on finest
+            logger.finest("Failed to optimize Selector: " + selector.getClass().getName(), t);
+            return null;
+        }
+    }
+
+    static Class<?> findOptimizableSelectorClass(Selector selector) throws ClassNotFoundException {
+        Class<?> selectorImplClass = forName(SELECTOR_IMPL, false, SelectorOptimizer.class.getClassLoader());
+
+        // Ensure the current selector implementation is what we can instrument.
+        if (!selectorImplClass.isAssignableFrom(selector.getClass())) {
+            return null;
+        }
+        return selectorImplClass;
+    }
+
+    static class SelectionKeysSet extends AbstractSet<SelectionKey> {
+        // the active SelectionKeys is the one where is being added to.
+        SelectionKeys activeKeys = new SelectionKeys();
+        // the passive SelectionKeys is one that is being read using the iterator.
+        SelectionKeys passiveKeys = new SelectionKeys();
+
+        // the iterator is recycled.
+        private final IteratorImpl iterator = new IteratorImpl();
+
+        SelectionKeysSet() {
+        }
+
+        @Override
+        public boolean add(SelectionKey o) {
+            return activeKeys.add(o);
+        }
+
+        @Override
+        public int size() {
+            return activeKeys.size;
+        }
+
+        @Override
+        public Iterator<SelectionKey> iterator() {
+            iterator.init(flip());
+            return iterator;
+        }
+
+        private SelectionKey[] flip() {
+            SelectionKeys tmp = activeKeys;
+            activeKeys = passiveKeys;
+            passiveKeys = tmp;
+
+            activeKeys.size = 0;
+            return passiveKeys.keys;
+        }
+
+        @Override
+        public boolean remove(Object o) {
+            return false;
+        }
+
+        @Override
+        public boolean contains(Object o) {
+            return false;
+        }
+    }
+
+     static final class SelectionKeys {
+        static final int INITIAL_CAPACITY = 32;
+
+        SelectionKey[] keys = new SelectionKey[INITIAL_CAPACITY];
+        int size;
+
+        private boolean add(SelectionKey key) {
+            if (key == null) {
+                return false;
+            }
+
+            ensureCapacity();
+            keys[size] = key;
+            size++;
+            return true;
+        }
+
+        private void ensureCapacity() {
+            if (size < keys.length) {
+                return;
+            }
+
+            SelectionKey[] newKeys = new SelectionKey[keys.length * 2];
+            arraycopy(keys, 0, newKeys, 0, size);
+            keys = newKeys;
+        }
+    }
+
+    static final class IteratorImpl implements Iterator<SelectionKey> {
+
+        SelectionKey[] keys;
+        int index;
+
+        private void init(SelectionKey[] keys) {
+            this.keys = keys;
+            this.index = -1;
+        }
+
+        @Override
+        public boolean hasNext() {
+            if (index >= keys.length - 1) {
+                return false;
+            }
+
+            return keys[index + 1] != null;
+        }
+
+        @Override
+        public SelectionKey next() {
+            if (!hasNext()) {
+                throw new NoSuchElementException();
+            }
+
+            index++;
+            return keys[index];
+        }
+
+        @Override
+        public void remove() {
+            if (index == -1 || index >= keys.length - 1 || keys[index] == null) {
+                throw new IllegalStateException();
+            }
+
+            keys[index] = null;
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/nonblocking/SelectionKeysSetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/nonblocking/SelectionKeysSetTest.java
@@ -1,0 +1,132 @@
+package com.hazelcast.nio.tcp.nonblocking;
+
+import com.hazelcast.nio.tcp.nonblocking.SelectorOptimizer.IteratorImpl;
+import com.hazelcast.nio.tcp.nonblocking.SelectorOptimizer.SelectionKeys;
+import com.hazelcast.nio.tcp.nonblocking.SelectorOptimizer.SelectionKeysSet;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.nio.channels.SelectionKey;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class SelectionKeysSetTest extends HazelcastTestSupport {
+
+    private final SelectionKey key1 = mock(SelectionKey.class);
+    private final SelectionKey key2 = mock(SelectionKey.class);
+    private final SelectionKey key3 = mock(SelectionKey.class);
+    private SelectionKeysSet selectionKeysSet;
+
+    @Before
+    public void setup() {
+        selectionKeysSet = new SelectionKeysSet();
+    }
+
+    @Test
+    public void remove_doesNothing() {
+        assertFalse(selectionKeysSet.remove(key1));
+    }
+
+    @Test
+    public void contains_doesNothing() {
+        assertFalse(selectionKeysSet.contains(key1));
+    }
+
+    @Test
+    public void iteratorRecycled() {
+        Iterator it1 = selectionKeysSet.iterator();
+        Iterator it2 = selectionKeysSet.iterator();
+        assertSame(it1, it2);
+    }
+
+    @Test
+    public void add_whenCapacityNotSufficient() {
+        List<SelectionKey> expectedKeys = new LinkedList<SelectionKey>();
+        for (int k = 0; k < SelectionKeys.INITIAL_CAPACITY * 4; k++) {
+            SelectionKey key = mock(SelectionKey.class);
+            expectedKeys.add(key);
+
+            selectionKeysSet.add(key);
+            assertEquals(expectedKeys.size(), selectionKeysSet.size());
+        }
+
+        SelectionKeys active = selectionKeysSet.activeKeys;
+        assertEquals(active.size, expectedKeys.size());
+        for (int k = 0; k < expectedKeys.size(); k++) {
+            SelectionKey expected = expectedKeys.get(k);
+            SelectionKey found = active.keys[k];
+            assertSame(expected, found);
+        }
+    }
+
+    @Test
+    public void add_whenNull() {
+        boolean result = selectionKeysSet.add(null);
+
+        assertFalse(result);
+        SelectionKeys active = selectionKeysSet.activeKeys;
+        assertEquals(0, active.size);
+    }
+
+    // tests the regular nio loop; hasNext, next, remove.
+    @Test
+    public void testLoop() {
+        List<SelectionKey> addedKeys = Arrays.asList(key1, key2, key3);
+
+        for (SelectionKey selectionKey : addedKeys) {
+            selectionKeysSet.add(selectionKey);
+        }
+
+        IteratorImpl it = (IteratorImpl) selectionKeysSet.iterator();
+        int k = 0;
+        for (SelectionKey expected : addedKeys) {
+            // check if the hasNext returns true
+            boolean hasNext = it.hasNext();
+            assertTrue(hasNext);
+
+            // check if the key is correct.
+            SelectionKey next = it.next();
+            assertSame(expected, next);
+            assertEquals(k, it.index);
+
+            // do the remove and check if the slot is nulled
+            it.remove();
+            assertNull(it.keys[it.index]);
+            k++;
+        }
+
+        assertFalse(it.hasNext());
+    }
+
+    @Test(expected = NoSuchElementException.class)
+    public void next_whenNoItem() {
+        IteratorImpl it = (IteratorImpl) selectionKeysSet.iterator();
+
+        it.next();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void remove_whenNoItem() {
+        IteratorImpl it = (IteratorImpl) selectionKeysSet.iterator();
+
+        it.remove();
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/nonblocking/SelectorOptimizerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/nonblocking/SelectorOptimizerTest.java
@@ -1,0 +1,35 @@
+package com.hazelcast.nio.tcp.nonblocking;
+
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.nio.channels.Selector;
+
+import static com.hazelcast.nio.tcp.nonblocking.SelectorOptimizer.findOptimizableSelectorClass;
+import static com.hazelcast.test.HazelcastTestSupport.assertUtilityConstructor;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assume.assumeTrue;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category(QuickTest.class)
+public class SelectorOptimizerTest {
+    private ILogger logger = Logger.getLogger(SelectionKeysSetTest.class);
+
+    @Test
+    public void testConstructor() {
+        assertUtilityConstructor(SelectorOptimizer.class);
+    }
+
+    @Test
+    public void optimize() throws Exception {
+        Selector selector = Selector.open();
+        assumeTrue(findOptimizableSelectorClass(selector) != null);
+        SelectorOptimizer.SelectionKeysSet keys = SelectorOptimizer.optimize(selector, logger);
+        assertNotNull(keys);
+    }
+}


### PR DESCRIPTION
This is done by replacing the HashSet inside of the Selector by an optimized version that doesn't generate litter.

This is an experimental feature and disabled by default.

The behavior of remove/contains is in line with netty implementation and the NioSelectedKeySet from the Agrona project.

I wish I could open a closed pr; but if you force push to a closed pr.. you can't reopen. This is the old PR:
https://github.com/hazelcast/hazelcast/pull/5582