### PR TITLE
Fixed default value of `backup-count` and `async-backup-count` properties for cache definition at XSD files

### DIFF
--- a/hazelcast-spring/src/main/resources/hazelcast-spring-3.6.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-3.6.xsd
@@ -539,21 +539,25 @@
                                         </xs:documentation>
                                     </xs:annotation>
                                 </xs:attribute>
-                                <xs:attribute name="backup-count" use="optional" type="parameterized-backup-count">
+                                <xs:attribute name="backup-count" use="optional" type="parameterized-backup-count" default="1">
                                     <xs:annotation>
                                         <xs:documentation>
-                                            Number of sync backups. If 1 is set as the backup-count for example, then
-                                            all entries of the map will be copied to another JVM for fail-safety. Valid
-                                            numbers are 0 (no backup), 1, 2 ... 6.
+                                            Number of total (synchronous + asynchronous) backups.
+                                            For example, if `1` is set as the `backup-count`,
+                                            then all entries of the cache are copied to one other instance for fail-safety.
+                                            Valid numbers are 0 (no backup), 1, 2 ... 6.
                                         </xs:documentation>
                                     </xs:annotation>
                                 </xs:attribute>
-                                <xs:attribute name="async-backup-count" use="optional" type="parameterized-backup-count">
+                                <xs:attribute name="async-backup-count" use="optional" type="parameterized-backup-count" default="0">
                                     <xs:annotation>
                                         <xs:documentation>
-                                            Number of async backups. If 1 is set as the backup-count for example, then
-                                            all entries of the map will be copied to another JVM for fail-safety. Valid
-                                            numbers are 0 (no backup), 1, 2 ... 6.
+                                            Number of asynchronous backups. For example, if `1` is set as the `async-backup-count`,
+                                            then all entries of the cache are copied to one other instance as asynchronous for fail-safety.
+                                            `async-backup-count` cannot be bigger than `backup-count` and
+                                            the remaining backups are considered as synchronous backup.
+                                            So `sync-backup-count` is calculated as `backup-count - async-backup-count`.
+                                            Valid numbers are 0 (no backup), 1, 2 ... 6.
                                         </xs:documentation>
                                     </xs:annotation>
                                 </xs:attribute>

--- a/hazelcast/src/main/resources/hazelcast-config-3.6.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-3.6.xsd
@@ -411,21 +411,25 @@
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:element name="backup-count" type="backup-count" minOccurs="0" maxOccurs="1" default="0">
+            <xs:element name="backup-count" type="backup-count" minOccurs="0" maxOccurs="1" default="1">
                 <xs:annotation>
                     <xs:documentation>
-                        Number of synchronous backups. For example, if 1 is set as the backup-count,
-                        then all entries of the map are copied to one other JVM for
-                        fail-safety. Valid numbers are 0 (no backup), 1, 2 ... 6.
+                        Number of total (synchronous + asynchronous) backups.
+                        For example, if `1` is set as the `backup-count`,
+                        then all entries of the cache are copied to one other instance for fail-safety.
+                        Valid numbers are 0 (no backup), 1, 2 ... 6.
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:element name="async-backup-count" type="backup-count" minOccurs="0" maxOccurs="1" default="1">
+            <xs:element name="async-backup-count" type="backup-count" minOccurs="0" maxOccurs="1" default="0">
                 <xs:annotation>
                     <xs:documentation>
-                        Number of asynchronous backups. For example, if 1 is set as the backup-count,
-                        then all entries of the map are copied to one other JVM for
-                        fail-safety. Valid numbers are 0 (no backup), 1, 2 ... 6.
+                        Number of asynchronous backups. For example, if `1` is set as the `async-backup-count`,
+                        then all entries of the cache are copied to one other instance as asynchronous for fail-safety.
+                        `async-backup-count` cannot be bigger than `backup-count` and
+                        the remaining backups are considered as synchronous backup.
+                        So `sync-backup-count` is calculated as `backup-count - async-backup-count`.
+                        Valid numbers are 0 (no backup), 1, 2 ... 6.
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>


### PR DESCRIPTION
Currently, in the cache config bean (programmatic configuration), `backup-count`'s default value is `1` and `async-backup-count`s default is `0`. But in the XSD definitions they are not the same.
 
- In the `hazelcast-config.xsd`, `backup-count`'s default value is `0` and `async-backup-count`s default is `0`.
- In the `hazelcast-spring.xsd`, there is no default value for `backup-count` and `async-backup-count` properties. In this case, they are not set to cache config bean so the default values are used of cache config bean as in the programmatic configuration.

With this PR, in XSD definitions, `backup-count`'s default value is set to `1` and `async-backup-count`s default is set to `0`. So default values are the same for programmatic and declarative configuration. Also XSD documentations are updated as related changes. 

Fixes #5881 