### PR TITLE
SelectNow option for non-blocking tcp threading-model

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/NonBlockingInputThread.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/NonBlockingInputThread.java
@@ -30,9 +30,19 @@ public final class NonBlockingInputThread extends NonBlockingIOThread {
     @Probe
     private final SwCounter readEvents = newSwCounter();
 
-    public NonBlockingInputThread(ThreadGroup threadGroup, String threadName, ILogger logger,
+    public NonBlockingInputThread(ThreadGroup threadGroup,
+                                  String threadName,
+                                  ILogger logger,
                                   NonBlockingIOThreadOutOfMemoryHandler oomeHandler) {
-        super(threadGroup, threadName, logger, oomeHandler);
+        super(threadGroup, threadName, logger, oomeHandler, false);
+    }
+
+    public NonBlockingInputThread(ThreadGroup threadGroup,
+                                  String threadName,
+                                  ILogger logger,
+                                  NonBlockingIOThreadOutOfMemoryHandler oomeHandler,
+                                  boolean selectNow) {
+        super(threadGroup, threadName, logger, oomeHandler, selectNow);
     }
 
 

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/NonBlockingOutputThread.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/NonBlockingOutputThread.java
@@ -33,8 +33,9 @@ public final class NonBlockingOutputThread extends NonBlockingIOThread {
     public NonBlockingOutputThread(ThreadGroup threadGroup,
                                    String threadName,
                                    ILogger logger,
-                                   NonBlockingIOThreadOutOfMemoryHandler oomeHandler) {
-        super(threadGroup, threadName, logger, oomeHandler);
+                                   NonBlockingIOThreadOutOfMemoryHandler oomeHandler,
+                                   boolean selectNow) {
+        super(threadGroup, threadName, logger, oomeHandler, selectNow);
     }
 
     /**

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/TcpIpConnectionManager_ConnectTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/TcpIpConnectionManager_ConnectTest.java
@@ -3,11 +3,7 @@ package com.hazelcast.nio.tcp;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.ConnectionType;
 import com.hazelcast.test.AssertTask;
-import com.hazelcast.test.HazelcastSerialClassRunner;
-import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
 
 import java.net.UnknownHostException;
 
@@ -17,9 +13,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
-@RunWith(HazelcastSerialClassRunner.class)
-@Category(QuickTest.class)
-public class TcpIpConnectionManager_ConnectTest extends TcpIpConnection_AbstractTest {
+public abstract class TcpIpConnectionManager_ConnectTest extends TcpIpConnection_AbstractTest {
 
     @Test
     public void start() {
@@ -91,7 +85,7 @@ public class TcpIpConnectionManager_ConnectTest extends TcpIpConnection_Abstract
         });
     }
 
-     @Test
+    @Test
     public void destroyConnection_whenAlreadyDestroyed_thenCallIgnored() throws Exception {
         startAllConnectionManagers();
 

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/TcpIpConnectionManager_TransmitTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/TcpIpConnectionManager_TransmitTest.java
@@ -39,7 +39,6 @@ public class TcpIpConnectionManager_TransmitTest extends TcpIpConnection_Abstrac
                 packetsB.add(packet);
             }
         };
-
     }
 
     // =============== tests {@link TcpIpConnectionManager#write(Packet,Connection)} ===========

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/TcpIpConnectionThreadingModelFactory.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/TcpIpConnectionThreadingModelFactory.java
@@ -1,0 +1,7 @@
+package com.hazelcast.nio.tcp;
+
+import com.hazelcast.internal.metrics.MetricsRegistry;
+
+public interface TcpIpConnectionThreadingModelFactory {
+    TcpIpConnectionThreadingModel create(MockIOService ioService, MetricsRegistry metricsRegistry);
+}

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/TcpIpConnection_AbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/TcpIpConnection_AbstractTest.java
@@ -8,6 +8,7 @@ import com.hazelcast.nio.Address;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.serialization.SerializationService;
 import com.hazelcast.nio.serialization.impl.DefaultSerializationServiceBuilder;
+import com.hazelcast.nio.tcp.nonblocking.Select_NonBlockingTcpIpConnectionThreadingModelFactory;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastTestSupport;
 import org.junit.After;
@@ -18,6 +19,8 @@ import java.util.concurrent.atomic.AtomicReference;
 import static org.junit.Assert.assertNotNull;
 
 public abstract class TcpIpConnection_AbstractTest extends HazelcastTestSupport {
+
+    protected TcpIpConnectionThreadingModelFactory threadingModelFactory = new Select_NonBlockingTcpIpConnectionThreadingModelFactory();
 
     protected ILogger logger;
     protected LoggingServiceImpl loggingService;
@@ -78,9 +81,9 @@ public abstract class TcpIpConnection_AbstractTest extends HazelcastTestSupport 
         return new TcpIpConnectionManager(
                 ioService,
                 ioService.serverSocketChannel,
+                ioService.loggingService,
                 metricsRegistry,
-                ioService.hazelcastThreadGroup,
-                ioService.loggingService);
+                threadingModelFactory.create(ioService, metricsRegistry));
     }
 
     // ====================== support ========================================

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/TcpIpConnection_BasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/TcpIpConnection_BasicTest.java
@@ -21,9 +21,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
-@RunWith(HazelcastSerialClassRunner.class)
-@Category(NightlyTest.class)
-public class TcpIpConnection_BasicTest extends TcpIpConnection_AbstractTest {
+public abstract class TcpIpConnection_BasicTest extends TcpIpConnection_AbstractTest {
 
     private List<Packet> packetsB = Collections.synchronizedList(new ArrayList<Packet>());
 

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/TcpIpConnection_TransferStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/TcpIpConnection_TransferStressTest.java
@@ -2,13 +2,9 @@ package com.hazelcast.nio.tcp;
 
 import com.hazelcast.nio.Packet;
 import com.hazelcast.test.AssertTask;
-import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.TestThread;
-import com.hazelcast.test.annotation.NightlyTest;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
 
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
@@ -23,12 +19,10 @@ import static org.junit.Assert.assertEquals;
  * In the past we had some issues with packet not getting written. So this test will write various size packets (from small
  * to very large).
  */
-@RunWith(HazelcastSerialClassRunner.class)
-@Category(NightlyTest.class)
-public class TcpIpConnection_TransferStressTest extends TcpIpConnection_AbstractTest {
+public abstract class TcpIpConnection_TransferStressTest extends TcpIpConnection_AbstractTest {
 
     // total running time.
-    private static final long DURATION_SECONDS = TimeUnit.MINUTES.toSeconds(2);
+    private static final long DURATION_SECONDS = TimeUnit.SECONDS.toSeconds(1);
     // maximum number of pending packets
     private static final int maxPendingPacketCount = 10000;
     // we create the payloads up front and select randomly from them. This is the number of payloads we are creating.

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/nonblocking/SelectNow_NonBlockingTcpIpConnectionThreadingModelFactory.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/nonblocking/SelectNow_NonBlockingTcpIpConnectionThreadingModelFactory.java
@@ -1,0 +1,21 @@
+package com.hazelcast.nio.tcp.nonblocking;
+
+import com.hazelcast.internal.metrics.MetricsRegistry;
+import com.hazelcast.nio.tcp.MockIOService;
+import com.hazelcast.nio.tcp.TcpIpConnectionThreadingModelFactory;
+
+public class SelectNow_NonBlockingTcpIpConnectionThreadingModelFactory implements TcpIpConnectionThreadingModelFactory {
+
+    @Override
+    public NonBlockingTcpIpConnectionThreadingModel create(
+            MockIOService ioService, MetricsRegistry metricsRegistry) {
+        NonBlockingTcpIpConnectionThreadingModel threadingModel = new NonBlockingTcpIpConnectionThreadingModel(
+                ioService,
+                ioService.loggingService,
+                metricsRegistry,
+                ioService.hazelcastThreadGroup);
+        threadingModel.setInputSelectNow(true);
+        threadingModel.setOutputSelectNow(true);
+        return threadingModel;
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/nonblocking/SelectNow_TcpIpConnectionManager_ConnectTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/nonblocking/SelectNow_TcpIpConnectionManager_ConnectTest.java
@@ -1,0 +1,20 @@
+package com.hazelcast.nio.tcp.nonblocking;
+
+import com.hazelcast.nio.tcp.TcpIpConnectionManager_ConnectTest;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class SelectNow_TcpIpConnectionManager_ConnectTest extends TcpIpConnectionManager_ConnectTest {
+
+    @Before
+    public void setup() throws Exception {
+        threadingModelFactory = new SelectNow_NonBlockingTcpIpConnectionThreadingModelFactory();
+        super.setup();
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/nonblocking/SelectNow_TcpIpConnection_BasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/nonblocking/SelectNow_TcpIpConnection_BasicTest.java
@@ -1,0 +1,19 @@
+package com.hazelcast.nio.tcp.nonblocking;
+
+import com.hazelcast.nio.tcp.TcpIpConnection_BasicTest;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class SelectNow_TcpIpConnection_BasicTest extends TcpIpConnection_BasicTest {
+
+    @Before
+    public void setup() throws Exception {
+        threadingModelFactory = new SelectNow_NonBlockingTcpIpConnectionThreadingModelFactory();
+        super.setup();
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/nonblocking/SelectNow_TcpIpConnection_TransferStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/nonblocking/SelectNow_TcpIpConnection_TransferStressTest.java
@@ -1,0 +1,19 @@
+package com.hazelcast.nio.tcp.nonblocking;
+
+import com.hazelcast.nio.tcp.TcpIpConnection_TransferStressTest;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.NightlyTest;
+import org.junit.Before;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(NightlyTest.class)
+public class SelectNow_TcpIpConnection_TransferStressTest extends TcpIpConnection_TransferStressTest {
+
+    @Before
+    public void setup() throws Exception {
+        threadingModelFactory = new SelectNow_NonBlockingTcpIpConnectionThreadingModelFactory();
+        super.setup();
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/nonblocking/Select_NonBlockingTcpIpConnectionThreadingModelFactory.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/nonblocking/Select_NonBlockingTcpIpConnectionThreadingModelFactory.java
@@ -1,0 +1,21 @@
+package com.hazelcast.nio.tcp.nonblocking;
+
+import com.hazelcast.internal.metrics.MetricsRegistry;
+import com.hazelcast.nio.tcp.MockIOService;
+import com.hazelcast.nio.tcp.TcpIpConnectionThreadingModelFactory;
+
+public class Select_NonBlockingTcpIpConnectionThreadingModelFactory implements TcpIpConnectionThreadingModelFactory {
+
+    @Override
+    public NonBlockingTcpIpConnectionThreadingModel create(
+            MockIOService ioService, MetricsRegistry metricsRegistry) {
+        NonBlockingTcpIpConnectionThreadingModel threadingModel = new NonBlockingTcpIpConnectionThreadingModel(
+                ioService,
+                ioService.loggingService,
+                metricsRegistry,
+                ioService.hazelcastThreadGroup);
+        threadingModel.setInputSelectNow(false);
+        threadingModel.setOutputSelectNow(false);
+        return threadingModel;
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/nonblocking/Select_TcpIpConnectionManager_ConnectTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/nonblocking/Select_TcpIpConnectionManager_ConnectTest.java
@@ -1,0 +1,20 @@
+package com.hazelcast.nio.tcp.nonblocking;
+
+import com.hazelcast.nio.tcp.TcpIpConnectionManager_ConnectTest;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class Select_TcpIpConnectionManager_ConnectTest extends TcpIpConnectionManager_ConnectTest {
+
+    @Before
+    public void setup() throws Exception {
+        threadingModelFactory = new Select_NonBlockingTcpIpConnectionThreadingModelFactory();
+        super.setup();
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/nonblocking/Select_TcpIpConnection_BasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/nonblocking/Select_TcpIpConnection_BasicTest.java
@@ -1,0 +1,19 @@
+package com.hazelcast.nio.tcp.nonblocking;
+
+import com.hazelcast.nio.tcp.TcpIpConnection_BasicTest;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class Select_TcpIpConnection_BasicTest extends TcpIpConnection_BasicTest {
+
+    @Before
+    public void setup() throws Exception {
+        threadingModelFactory = new Select_NonBlockingTcpIpConnectionThreadingModelFactory();
+        super.setup();
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/nonblocking/Select_TcpIpConnection_TransferStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/nonblocking/Select_TcpIpConnection_TransferStressTest.java
@@ -1,0 +1,19 @@
+package com.hazelcast.nio.tcp.nonblocking;
+
+import com.hazelcast.nio.tcp.TcpIpConnection_TransferStressTest;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.NightlyTest;
+import org.junit.Before;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(NightlyTest.class)
+public class Select_TcpIpConnection_TransferStressTest extends TcpIpConnection_TransferStressTest {
+
+    @Before
+    public void setup() throws Exception {
+        threadingModelFactory = new Select_NonBlockingTcpIpConnectionThreadingModelFactory();
+        super.setup();
+    }
+}


### PR DESCRIPTION
The NonBlocking threading model now supports spinning based on calling selectNow instead of select. This is one of the way to spin; another way to spin is using spinning on socketchannel. Which will be part of this pr:

https://github.com/hazelcast/hazelcast/pull/5913

Spinning using selectNow is disabled by default and is enabled through a system property. It is experimental, so we don't publish it yet in the group properties.

