### PR TITLE
Fix naming of some internal cache API methods

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheService.java
@@ -125,13 +125,13 @@ public abstract class AbstractCacheService
     }
 
     @Override
-    public ICacheRecordStore getOrCreateCache(String name, int partitionId) {
-        return segments[partitionId].getOrCreateCache(name);
+    public ICacheRecordStore getOrCreateRecordStore(String name, int partitionId) {
+        return segments[partitionId].getOrCreateRecordStore(name);
     }
 
     @Override
-    public ICacheRecordStore getCacheRecordStore(String name, int partitionId) {
-        return segments[partitionId].getCache(name);
+    public ICacheRecordStore getRecordStore(String name, int partitionId) {
+        return segments[partitionId].getRecordStore(name);
     }
 
     @Override
@@ -141,7 +141,7 @@ public abstract class AbstractCacheService
 
     protected void destroySegments(String name) {
         for (CachePartitionSegment segment : segments) {
-            segment.deleteCache(name);
+            segment.deleteRecordStore(name);
         }
     }
 
@@ -177,7 +177,7 @@ public abstract class AbstractCacheService
     }
 
     @Override
-    public CacheConfig createCacheConfigIfAbsent(CacheConfig config) {
+    public CacheConfig putCacheConfigIfAbsent(CacheConfig config) {
         final CacheConfig localConfig = configs.putIfAbsent(config.getNameWithPrefix(), config);
         if (localConfig == null) {
             if (config.isStatisticsEnabled()) {

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/HazelcastServerCacheManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/HazelcastServerCacheManager.java
@@ -117,7 +117,7 @@ public class HazelcastServerCacheManager
 
     @Override
     protected <K, V> void addCacheConfigIfAbsent(CacheConfig<K, V> cacheConfig) {
-        cacheService.createCacheConfigIfAbsent(cacheConfig);
+        cacheService.putCacheConfigIfAbsent(cacheConfig);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/ICacheService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/ICacheService.java
@@ -37,31 +37,31 @@ public interface ICacheService extends ManagedService, RemoteService, MigrationA
      */
     String SERVICE_NAME = "hz:impl:cacheService";
 
-    ICacheRecordStore getOrCreateCache(String name, int partitionId);
+    ICacheRecordStore getOrCreateRecordStore(String name, int partitionId);
 
-    ICacheRecordStore getCacheRecordStore(String name, int partitionId);
+    ICacheRecordStore getRecordStore(String name, int partitionId);
 
     CachePartitionSegment getSegment(int partitionId);
 
-    void destroyCache(String objectName, boolean isLocal, String callerUuid);
+    CacheConfig putCacheConfigIfAbsent(CacheConfig config);
+
+    CacheConfig getCacheConfig(String name);
 
     CacheSimpleConfig findCacheConfig(String simpleName);
 
-    CacheConfig createCacheConfigIfAbsent(CacheConfig config);
+    Collection<CacheConfig> getCacheConfigs();
 
     CacheConfig deleteCacheConfig(String name);
 
     CacheStatisticsImpl createCacheStatIfAbsent(String name);
+
+    void destroyCache(String objectName, boolean isLocal, String callerUuid);
 
     void deleteCacheStat(String name);
 
     void setStatisticsEnabled(CacheConfig cacheConfig, String cacheNameWithPrefix, boolean enabled);
 
     void setManagementEnabled(CacheConfig cacheConfig, String cacheNameWithPrefix, boolean enabled);
-
-    CacheConfig getCacheConfig(String name);
-
-    Collection<CacheConfig> getCacheConfigs();
 
     void publishEvent(CacheEventContext cacheEventContext);
 
@@ -85,6 +85,4 @@ public interface ICacheService extends ManagedService, RemoteService, MigrationA
     CacheOperationProvider getCacheOperationProvider(String nameWithPrefix, InMemoryFormat storageType);
 
     void sendInvalidationEvent(String name, Data key, String sourceUuid);
-
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/AbstractCacheOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/AbstractCacheOperation.java
@@ -65,7 +65,7 @@ abstract class AbstractCacheOperation
     public final void beforeRun()
             throws Exception {
         AbstractCacheService service = getService();
-        cache = service.getOrCreateCache(name, getPartitionId());
+        cache = service.getOrCreateRecordStore(name, getPartitionId());
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheClearBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheClearBackupOperation.java
@@ -43,7 +43,7 @@ public class CacheClearBackupOperation extends AbstractNamedOperation
     public void beforeRun()
             throws Exception {
         CacheService service = getService();
-        cache = service.getOrCreateCache(name, getPartitionId());
+        cache = service.getOrCreateRecordStore(name, getPartitionId());
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheClearOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheClearOperation.java
@@ -44,7 +44,7 @@ public class CacheClearOperation
     @Override
     public void beforeRun() throws Exception {
         ICacheService service = getService();
-        cache = service.getCacheRecordStore(name, getPartitionId());
+        cache = service.getRecordStore(name, getPartitionId());
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheCreateConfigOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheCreateConfigOperation.java
@@ -41,10 +41,10 @@ import java.util.concurrent.atomic.AtomicInteger;
  * <li>Find partition id using the distributed object name of cache as a key.</li>
  * <li>Send the <code>CacheCreateConfigOperation</code> operation to the calculated partition which will force all
  * clusters to be single threaded.</li>
- * <li>{@link CacheService#createCacheConfigIfAbsent(com.hazelcast.config.CacheConfig)} is called.</li>
+ * <li>{@link CacheService#putCacheConfigIfAbsent(com.hazelcast.config.CacheConfig)} is called.</li>
  * </ul></p>
  * <p>This operation's purpose is to pass the required parameters into
- * {@link CacheService#createCacheConfigIfAbsent(com.hazelcast.config.CacheConfig)}.</p>
+ * {@link CacheService#putCacheConfigIfAbsent(com.hazelcast.config.CacheConfig)}.</p>
  */
 public class CacheCreateConfigOperation
         extends AbstractNamedOperation
@@ -84,7 +84,7 @@ public class CacheCreateConfigOperation
     public void run() throws Exception {
         AbstractCacheService service = getService();
         if (!ignoreLocal) {
-            response = service.createCacheConfigIfAbsent(config);
+            response = service.putCacheConfigIfAbsent(config);
         }
         if (createAlsoOnOthers) {
             NodeEngine nodeEngine = getNodeEngine();

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheGetAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheGetAllOperation.java
@@ -53,7 +53,7 @@ public class CacheGetAllOperation
 
     public void run() {
         CacheService service = getService();
-        ICacheRecordStore cache = service.getOrCreateCache(name, getPartitionId());
+        ICacheRecordStore cache = service.getOrCreateRecordStore(name, getPartitionId());
 
         int partitionId = getPartitionId();
         Set<Data> partitionKeySet = new HashSet<Data>();

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheGetConfigOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheGetConfigOperation.java
@@ -58,7 +58,7 @@ public class CacheGetConfigOperation
                     CacheConfig cacheConfigFromSimpleConfig = new CacheConfig(simpleConfig);
                     cacheConfigFromSimpleConfig.setName(simpleName);
                     cacheConfigFromSimpleConfig.setManagerPrefix(name.substring(0, name.lastIndexOf(simpleName)));
-                    if (service.createCacheConfigIfAbsent(cacheConfigFromSimpleConfig) == null) {
+                    if (service.putCacheConfigIfAbsent(cacheConfigFromSimpleConfig) == null) {
                         response = cacheConfigFromSimpleConfig;
                         return;
                     }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheLoadAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheLoadAllOperation.java
@@ -87,7 +87,7 @@ public class CacheLoadAllOperation
 
         try {
             final CacheService service = getService();
-            cache = service.getOrCreateCache(name, partitionId);
+            cache = service.getOrCreateRecordStore(name, partitionId);
             final Set<Data> keysLoaded = cache.loadAll(filteredKeys, replaceExistingValues);
             shouldBackup = !keysLoaded.isEmpty();
             if (shouldBackup) {

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CachePutAllBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CachePutAllBackupOperation.java
@@ -55,7 +55,7 @@ public class CachePutAllBackupOperation
     public void beforeRun()
             throws Exception {
         CacheService service = getService();
-        cache = service.getOrCreateCache(name, getPartitionId());
+        cache = service.getOrCreateRecordStore(name, getPartitionId());
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CachePutBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CachePutBackupOperation.java
@@ -53,7 +53,7 @@ public class CachePutBackupOperation
     public void run()
             throws Exception {
         CacheService service = getService();
-        ICacheRecordStore cache = service.getOrCreateCache(name, getPartitionId());
+        ICacheRecordStore cache = service.getOrCreateRecordStore(name, getPartitionId());
         cache.putRecord(key, cacheRecord);
         response = Boolean.TRUE;
     }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheRemoveAllBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheRemoveAllBackupOperation.java
@@ -69,7 +69,7 @@ public class CacheRemoveAllBackupOperation
     public void beforeRun()
             throws Exception {
         CacheService service = getService();
-        cache = service.getOrCreateCache(name, getPartitionId());
+        cache = service.getOrCreateRecordStore(name, getPartitionId());
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheRemoveAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheRemoveAllOperation.java
@@ -80,7 +80,7 @@ public class CacheRemoveAllOperation extends PartitionWideCacheOperation impleme
     @Override
     public void beforeRun() throws Exception {
         ICacheService service = getService();
-        cache = service.getCacheRecordStore(name, getPartitionId());
+        cache = service.getRecordStore(name, getPartitionId());
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheReplicationOperation.java
@@ -64,7 +64,7 @@ public class CacheReplicationOperation extends AbstractOperation {
     public CacheReplicationOperation(CachePartitionSegment segment, int replicaIndex) {
         data = new HashMap<String, Map<Data, CacheRecord>>();
 
-        Iterator<ICacheRecordStore> iter = segment.cacheIterator();
+        Iterator<ICacheRecordStore> iter = segment.recordStoreIterator();
         while (iter.hasNext()) {
             ICacheRecordStore cacheRecordStore = iter.next();
             CacheConfig cacheConfig = cacheRecordStore.getConfig();
@@ -81,7 +81,7 @@ public class CacheReplicationOperation extends AbstractOperation {
         //        //migrate CacheConfigs first
         CacheService service = getService();
         for (CacheConfig config : configs) {
-            service.createCacheConfigIfAbsent(config);
+            service.putCacheConfigIfAbsent(config);
         }
     }
 
@@ -90,7 +90,7 @@ public class CacheReplicationOperation extends AbstractOperation {
             throws Exception {
         CacheService service = getService();
         for (Map.Entry<String, Map<Data, CacheRecord>> entry : data.entrySet()) {
-            ICacheRecordStore cache = service.getOrCreateCache(entry.getKey(), getPartitionId());
+            ICacheRecordStore cache = service.getOrCreateRecordStore(entry.getKey(), getPartitionId());
             Map<Data, CacheRecord> map = entry.getValue();
 
             Iterator<Map.Entry<Data, CacheRecord>> iter = map.entrySet().iterator();

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheSizeOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheSizeOperation.java
@@ -40,7 +40,7 @@ public class CacheSizeOperation
     public void run()
             throws Exception {
         CacheService service = getService();
-        ICacheRecordStore cache = service.getCacheRecordStore(name, getPartitionId());
+        ICacheRecordStore cache = service.getRecordStore(name, getPartitionId());
         response = cache != null ? cache.size() : 0;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/PostJoinCacheOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/PostJoinCacheOperation.java
@@ -43,7 +43,7 @@ public class PostJoinCacheOperation extends AbstractOperation {
     public void run() throws Exception {
         CacheService cacheService = getService();
         for (CacheConfig cacheConfig : configs) {
-            cacheService.createCacheConfigIfAbsent(cacheConfig);
+            cacheService.putCacheConfigIfAbsent(cacheConfig);
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/cache/CacheConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CacheConfigTest.java
@@ -449,7 +449,7 @@ public class CacheConfigTest extends HazelcastTestSupport {
 
         assertNull(cacheService1.getCacheConfig(fullCacheName));
 
-        cacheService1.createCacheConfigIfAbsent(cacheConfig);
+        cacheService1.putCacheConfigIfAbsent(cacheConfig);
 
         assertNotNull(cacheService1.getCacheConfig(fullCacheName));
 

--- a/hazelcast/src/test/java/com/hazelcast/cache/entryprocessor/JCacheEntryProcessorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/entryprocessor/JCacheEntryProcessorTest.java
@@ -17,7 +17,6 @@
 package com.hazelcast.cache.entryprocessor;
 
 import com.hazelcast.cache.BackupAwareEntryProcessor;
-import com.hazelcast.cache.HazelcastCachingProvider;
 import com.hazelcast.cache.ICache;
 import com.hazelcast.cache.impl.CacheService;
 import com.hazelcast.cache.impl.HazelcastServerCachingProvider;
@@ -45,15 +44,12 @@ import javax.cache.Cache;
 import javax.cache.CacheManager;
 import javax.cache.configuration.CompleteConfiguration;
 import javax.cache.configuration.MutableConfiguration;
-import javax.cache.expiry.CreatedExpiryPolicy;
-import javax.cache.expiry.Duration;
 import javax.cache.processor.EntryProcessor;
 import javax.cache.processor.EntryProcessorException;
 import javax.cache.processor.MutableEntry;
 import javax.cache.spi.CachingProvider;
 import java.io.Serializable;
 import java.lang.reflect.Field;
-import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -282,7 +278,7 @@ public class JCacheEntryProcessorTest extends HazelcastTestSupport {
 
     private ICacheRecordStore getRecordStore(CacheService cacheService, String cacheName, int partitionId) {
         try {
-            return cacheService.getOrCreateCache("/hz/" + cacheName, partitionId);
+            return cacheService.getOrCreateRecordStore("/hz/" + cacheName, partitionId);
         } catch (Exception e) {
             fail("CacheRecordStore not yet initialized!!!");
         }

--- a/hazelcast/src/test/java/com/hazelcast/cache/recordstore/CacheRecordStoreTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/recordstore/CacheRecordStoreTestSupport.java
@@ -85,7 +85,7 @@ public abstract class CacheRecordStoreTestSupport
         NodeEngine nodeEngine = getNodeEngine(instance);
         ICacheService cacheService = getCacheService(instance);
         CacheConfig cacheConfig = createCacheConfig(cacheName, inMemoryFormat);
-        cacheService.createCacheConfigIfAbsent(cacheConfig);
+        cacheService.putCacheConfigIfAbsent(cacheConfig);
         return new CacheRecordStore(CACHE_NAME_PREFIX + cacheName, partitionId, nodeEngine, (AbstractCacheService) cacheService);
     }
 


### PR DESCRIPTION
Although this looks like a large commit, the changes are strictly method renaming/reordering and some improvement in Javadoc.

The names of some methods in the internal cache API seem to be a leftover from an earlier design. They tend to confuse new people studying the codebase (like Serkan and myself). This PR aligns the method names with the current state of things.