### PR TITLE
Client removed unnessarily when a node goes down

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEndpointImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEndpointImpl.java
@@ -115,7 +115,6 @@ public final class ClientEndpointImpl implements Client, ClientEndpoint {
     public void authenticated(ClientPrincipal principal) {
         this.principal = principal;
         this.authenticated = true;
-        clientEngine.addOwnershipMapping(principal.getUuid(), principal.getOwnerUuid());
     }
 
     @Override


### PR DESCRIPTION
Since client ownership map is not updated when it should,
client was being destroyed unncessarily. In the failing case
adding ownership code inside ClientEndpointImpl.authenticated,
because there is no endpoint registered to call this function on.
Adding ownership is moved from ClientEndpointImpl.authenticated
to it`s callers to make sure adding ownership is called always.

issue #4647 was failing because client is removed and its locks are
cleaned up, even tought lock should be still there.

fixes #4647

backport of #6000