### PR TITLE
Client removed unnessarily when a node goes down

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEndpointImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEndpointImpl.java
@@ -115,7 +115,6 @@ public final class ClientEndpointImpl implements Client, ClientEndpoint {
     public void authenticated(ClientPrincipal principal) {
         this.principal = principal;
         this.authenticated = true;
-        clientEngine.addOwnershipMapping(principal.getUuid(), principal.getOwnerUuid());
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEndpointManagerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEndpointManagerImpl.java
@@ -18,7 +18,6 @@ package com.hazelcast.client.impl;
 
 import com.hazelcast.client.ClientEndpoint;
 import com.hazelcast.client.ClientEndpointManager;
-
 import com.hazelcast.internal.metrics.MetricsRegistry;
 import com.hazelcast.internal.metrics.Probe;
 import com.hazelcast.logging.ILogger;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/client/AuthenticationRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/client/AuthenticationRequest.java
@@ -78,8 +78,6 @@ public final class AuthenticationRequest extends CallableClientRequest {
     }
 
     private boolean authenticate() {
-        ClientEngineImpl clientEngine = getService();
-        Connection connection = endpoint.getConnection();
         ILogger logger = clientEngine.getLogger(getClass());
         boolean authenticated;
         if (credentials == null) {
@@ -97,9 +95,6 @@ public final class AuthenticationRequest extends CallableClientRequest {
                     + "Current credentials type is: " + credentials.getClass().getName());
         }
 
-
-        logger.log((authenticated ? Level.INFO : Level.WARNING), "Received auth from " + connection
-                + ", " + (authenticated ? "successfully authenticated" : "authentication failed"));
         return authenticated;
     }
 
@@ -129,11 +124,14 @@ public final class AuthenticationRequest extends CallableClientRequest {
     }
 
     private Object handleUnauthenticated() {
+        Connection connection = endpoint.getConnection();
+        ILogger logger = clientEngine.getLogger(getClass());
+        logger.log(Level.WARNING, "Received auth from " + connection
+                + " with principal " + principal + " , authentication failed");
         return new AuthenticationException("Invalid credentials!");
     }
 
     private Object handleAuthenticated() {
-        ClientEngineImpl clientEngine = getService();
 
         if (ownerConnection) {
             final String uuid = getUuid();
@@ -153,6 +151,12 @@ public final class AuthenticationRequest extends CallableClientRequest {
             return new AuthenticationException("Invalid owner-uuid: " + principal.getOwnerUuid()
                     + ", it's not member of this cluster!");
         }
+
+
+        Connection connection = endpoint.getConnection();
+        ILogger logger = clientEngine.getLogger(getClass());
+        logger.log(Level.INFO, "Received auth from " + connection + ", successfully authenticated"
+                + ", principal : " + principal + ", owner connection : " + ownerConnection);
 
         endpoint.authenticated(principal, credentials, ownerConnection);
         clientEngine.getEndpointManager().registerEndpoint(endpoint);
@@ -176,6 +180,7 @@ public final class AuthenticationRequest extends CallableClientRequest {
         for (ClientEndpoint endpoint : endpoints) {
             endpoint.authenticated(principal);
         }
+        clientEngine.addOwnershipMapping(principal.getUuid(), principal.getOwnerUuid());
     }
 
     @Override


### PR DESCRIPTION
Since client ownership map is not updated when it should,
client was being destroyed unncessarily. In the failing case
adding ownership code inside ClientEndpointImpl.authenticated,
because there is no endpoint registered to call this function on.
Adding ownership is moved from ClientEndpointImpl.authenticated
to it`s callers to make sure adding ownership is called always.

issue #4647 was failing because client is removed and its locks are
cleaned up, even tought lock should be still there.

fixes #4647