### PR TITLE
Hibernate tests use TestHazelcastFactory for instance creation.

### DIFF
--- a/hazelcast-hibernate/hazelcast-hibernate3/src/test/java/com/hazelcast/hibernate/CacheHitMissNonStrictTest.java
+++ b/hazelcast-hibernate/hazelcast-hibernate3/src/test/java/com/hazelcast/hibernate/CacheHitMissNonStrictTest.java
@@ -17,6 +17,7 @@
 package com.hazelcast.hibernate;
 
 import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.hibernate.cache.access.AccessType;
 import org.hibernate.cfg.Environment;
@@ -37,7 +38,7 @@ import static org.junit.Assert.assertEquals;
  * Read through cache
  */
 @RunWith(HazelcastSerialClassRunner.class)
-@Category(QuickTest.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class CacheHitMissNonStrictTest extends HibernateStatisticsTestSupport {
 
     protected String getCacheStrategy() {
@@ -68,7 +69,6 @@ public class CacheHitMissNonStrictTest extends HibernateStatisticsTestSupport {
         //hit 1 entity and 4 properties
         updateDummyEntityName(sf, 2, "updated");
         //invalidation is not synchronized, so we have to wait
-        sleep(1);
         //entity 2 and its properties are invalidated
 
         //miss updated entity, hit 4 properties(they are still the same)

--- a/hazelcast-hibernate/hazelcast-hibernate3/src/test/java/com/hazelcast/hibernate/CacheHitMissReadOnlyTest.java
+++ b/hazelcast-hibernate/hazelcast-hibernate3/src/test/java/com/hazelcast/hibernate/CacheHitMissReadOnlyTest.java
@@ -19,6 +19,7 @@ package com.hazelcast.hibernate;
 import com.hazelcast.hibernate.access.ReadOnlyAccessDelegate;
 import com.hazelcast.hibernate.region.HazelcastRegion;
 import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.hibernate.cache.access.AccessType;
 import org.hibernate.cfg.Environment;
@@ -38,7 +39,7 @@ import static org.mockito.Mockito.when;
  * Data may be added and removed, but not mutated.
  */
 @RunWith(HazelcastSerialClassRunner.class)
-@Category(QuickTest.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class CacheHitMissReadOnlyTest extends HibernateStatisticsTestSupport {
 
     protected String getCacheStrategy() {

--- a/hazelcast-hibernate/hazelcast-hibernate3/src/test/java/com/hazelcast/hibernate/CacheHitMissReadWriteTest.java
+++ b/hazelcast-hibernate/hazelcast-hibernate3/src/test/java/com/hazelcast/hibernate/CacheHitMissReadWriteTest.java
@@ -17,6 +17,7 @@
 package com.hazelcast.hibernate;
 
 import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.hibernate.cache.access.AccessType;
 import org.hibernate.cfg.Environment;
@@ -36,7 +37,7 @@ import static org.junit.Assert.assertEquals;
  * Write through cache
  */
 @RunWith(HazelcastSerialClassRunner.class)
-@Category(QuickTest.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class CacheHitMissReadWriteTest
         extends HibernateStatisticsTestSupport {
 

--- a/hazelcast-hibernate/hazelcast-hibernate3/src/test/java/com/hazelcast/hibernate/HibernateSlowTestSupport.java
+++ b/hazelcast-hibernate/hazelcast-hibernate3/src/test/java/com/hazelcast/hibernate/HibernateSlowTestSupport.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate;
+
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.hibernate.entity.DummyEntity;
+import com.hazelcast.hibernate.entity.DummyProperty;
+import org.hibernate.Query;
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.Transaction;
+import org.junit.After;
+import org.junit.Before;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Properties;
+
+public abstract class HibernateSlowTestSupport extends HibernateTestSupport {
+
+    protected SessionFactory sf;
+    protected SessionFactory sf2;
+
+    @Before
+    public void postConstruct() {
+        sf = createSessionFactory(getCacheProperties(),null);
+        sf2 = createSessionFactory(getCacheProperties(),null);
+    }
+
+    @After
+    public void preDestroy() {
+        if (sf != null) {
+            sf.close();
+            sf = null;
+        }
+        if (sf2 != null) {
+            sf2.close();
+            sf2 = null;
+        }
+        Hazelcast.shutdownAll();
+    }
+
+    protected abstract Properties getCacheProperties();
+
+    protected void insertDummyEntities(int count) {
+        insertDummyEntities(count, 0);
+    }
+
+    protected void insertDummyEntities(int count, int childCount) {
+        Session session = sf.openSession();
+        Transaction tx = session.beginTransaction();
+        try {
+            for (int i = 0; i < count; i++) {
+                DummyEntity e = new DummyEntity((long) i, "dummy:" + i, i * 123456d, new Date());
+                session.save(e);
+                for (int j = 0; j < childCount; j++) {
+                    DummyProperty p = new DummyProperty("key:" + j, e);
+                    session.save(p);
+                }
+            }
+            tx.commit();
+        } catch (Exception e) {
+            tx.rollback();
+            e.printStackTrace();
+        } finally {
+            session.close();
+        }
+    }
+
+    protected List<DummyEntity> executeQuery(SessionFactory factory) {
+        Session session = factory.openSession();
+        try {
+            Query query = session.createQuery("from " + DummyEntity.class.getName());
+            query.setCacheable(false);
+            return query.list();
+        } finally {
+            session.close();
+        }
+    }
+
+    protected DummyEntity executeQuery(SessionFactory factory, long id) {
+        Session session = factory.openSession();
+        try {
+            Query query = session.createQuery("from " + DummyEntity.class.getName() + " where id = " + id);
+            query.setCacheable(true);
+            return (DummyEntity) query.list().get(0);
+        } finally {
+            session.close();
+        }
+    }
+}

--- a/hazelcast-hibernate/hazelcast-hibernate3/src/test/java/com/hazelcast/hibernate/LocalRegionFactoryDefaultTest.java
+++ b/hazelcast-hibernate/hazelcast-hibernate3/src/test/java/com/hazelcast/hibernate/LocalRegionFactoryDefaultTest.java
@@ -21,6 +21,7 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.hibernate.entity.DummyEntity;
 import com.hazelcast.hibernate.entity.DummyProperty;
 import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.hibernate.Session;
 import org.hibernate.Transaction;
@@ -43,7 +44,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 @RunWith(HazelcastSerialClassRunner.class)
-@Category(QuickTest.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class LocalRegionFactoryDefaultTest extends RegionFactoryDefaultTest {
 
     @BeforeClass
@@ -65,7 +66,6 @@ public class LocalRegionFactoryDefaultTest extends RegionFactoryDefaultTest {
         final int count = 100;
         final int childCount = 3;
         insertDummyEntities(count, childCount);
-        sleep(1);
         List<DummyEntity> list = new ArrayList<DummyEntity>(count);
         Session session = sf.openSession();
         try {
@@ -108,7 +108,6 @@ public class LocalRegionFactoryDefaultTest extends RegionFactoryDefaultTest {
         final int count = 100;
         final int childCount = 3;
         insertDummyEntities(count, childCount);
-        sleep(1);
         Session session = sf.openSession();
 
         DummyEntity e1 = (DummyEntity) session.get(DummyEntity.class, (long) 1);

--- a/hazelcast-hibernate/hazelcast-hibernate3/src/test/java/com/hazelcast/hibernate/LocalRegionFactorySlowTest.java
+++ b/hazelcast-hibernate/hazelcast-hibernate3/src/test/java/com/hazelcast/hibernate/LocalRegionFactorySlowTest.java
@@ -1,0 +1,62 @@
+package com.hazelcast.hibernate;
+
+import com.hazelcast.hibernate.entity.DummyEntity;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.NightlyTest;
+import org.hibernate.Session;
+import org.hibernate.Transaction;
+import org.hibernate.cfg.Environment;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.List;
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(NightlyTest.class)
+public class LocalRegionFactorySlowTest extends HibernateSlowTestSupport {
+
+    @Test
+    public void test_query_with_non_mock_network() {
+        final int entityCount = 10;
+        final int queryCount = 2;
+        insertDummyEntities(entityCount);
+        List<DummyEntity> list = null;
+        for (int i = 0; i < queryCount; i++) {
+            list = executeQuery(sf);
+            assertEquals(entityCount, list.size());
+        }
+        for (int i = 0; i < queryCount; i++) {
+            list = executeQuery(sf2);
+            assertEquals(entityCount, list.size());
+        }
+
+        assertNotNull(list);
+        DummyEntity toDelete = list.get(0);
+        Session session = sf2.openSession();
+        Transaction tx = session.beginTransaction();
+        try {
+            session.delete(toDelete);
+            tx.commit();
+        } catch (Exception e) {
+            tx.rollback();
+            e.printStackTrace();
+        } finally {
+            session.close();
+        }
+        assertEquals(entityCount - 1, executeQuery(sf).size());
+        assertEquals(entityCount - 1, executeQuery(sf2).size());
+
+    }
+
+    @Override
+    protected Properties getCacheProperties() {
+        Properties props = new Properties();
+        props.setProperty(Environment.CACHE_REGION_FACTORY, HazelcastLocalCacheRegionFactory.class.getName());
+        return props;
+    }
+}

--- a/hazelcast-hibernate/hazelcast-hibernate3/src/test/java/com/hazelcast/hibernate/RegionFactoryDefaultNightlyTest.java
+++ b/hazelcast-hibernate/hazelcast-hibernate3/src/test/java/com/hazelcast/hibernate/RegionFactoryDefaultNightlyTest.java
@@ -32,7 +32,7 @@ import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(NightlyTest.class)
-public class RegionFactoryDefaultNightlyTest extends HibernateStatisticsTestSupport {
+public class RegionFactoryDefaultNightlyTest extends HibernateSlowTestSupport {
 
     protected Properties getCacheProperties() {
         Properties props = new Properties();

--- a/hazelcast-hibernate/hazelcast-hibernate3/src/test/java/com/hazelcast/hibernate/RegionFactoryDefaultTest.java
+++ b/hazelcast-hibernate/hazelcast-hibernate3/src/test/java/com/hazelcast/hibernate/RegionFactoryDefaultTest.java
@@ -16,30 +16,23 @@
 
 package com.hazelcast.hibernate;
 
-import com.hazelcast.config.MapConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.hibernate.entity.DummyEntity;
 import com.hazelcast.hibernate.entity.DummyProperty;
-import com.hazelcast.hibernate.region.HazelcastQueryResultsRegion;
 import com.hazelcast.test.HazelcastSerialClassRunner;
-import com.hazelcast.test.annotation.NightlyTest;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.hibernate.Query;
 import org.hibernate.Session;
 import org.hibernate.Transaction;
-import org.hibernate.cache.access.AccessType;
 import org.hibernate.cfg.Environment;
-import org.hibernate.impl.SessionFactoryImpl;
 import org.hibernate.stat.Statistics;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -51,7 +44,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 
 @RunWith(HazelcastSerialClassRunner.class)
-@Category(QuickTest.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class RegionFactoryDefaultTest extends HibernateStatisticsTestSupport {
 
     protected Properties getCacheProperties() {
@@ -67,7 +60,6 @@ public class RegionFactoryDefaultTest extends HibernateStatisticsTestSupport {
         final int count = 100;
         final int childCount = 3;
         insertDummyEntities(count, childCount);
-        sleep(1);
         List<DummyEntity> list = new ArrayList<DummyEntity>(count);
         Session session = sf.openSession();
         try {
@@ -121,7 +113,6 @@ public class RegionFactoryDefaultTest extends HibernateStatisticsTestSupport {
         final int entityCount = 10;
         final int queryCount = 3;
         insertDummyEntities(entityCount);
-        sleep(2);
         List<DummyEntity> list = null;
         for (int i = 0; i < queryCount; i++) {
             list = executeQuery(sf);
@@ -163,48 +154,9 @@ public class RegionFactoryDefaultTest extends HibernateStatisticsTestSupport {
     }
 
     @Test
-    public void testQuery2() {
-        final int entityCount = 10;
-        final int queryCount = 2;
-        insertDummyEntities(entityCount);
-        sleep(1);
-        List<DummyEntity> list = null;
-        for (int i = 0; i < queryCount; i++) {
-            list = executeQuery(sf);
-            assertEquals(entityCount, list.size());
-            sleep(1);
-        }
-
-        for (int i = 0; i < queryCount; i++) {
-            list = executeQuery(sf2);
-            assertEquals(entityCount, list.size());
-            sleep(1);
-        }
-
-        assertNotNull(list);
-        DummyEntity toDelete = list.get(0);
-        Session session = sf.openSession();
-        Transaction tx = session.beginTransaction();
-        try {
-            session.delete(toDelete);
-            tx.commit();
-        } catch (Exception e) {
-            tx.rollback();
-            e.printStackTrace();
-        } finally {
-            session.close();
-        }
-        sleep(1);
-        assertEquals(entityCount - 1, executeQuery(sf).size());
-        assertEquals(entityCount - 1, executeQuery(sf2).size());
-    }
-
-    @Test
     public void testSpecificQueryRegionEviction() {
         int entityCount = 10;
         insertDummyEntities(entityCount, 0);
-        sleep(1);
-
         //miss 1 query list entities
         Session session = sf.openSession();
         Transaction txn = session.beginTransaction();

--- a/hazelcast-hibernate/hazelcast-hibernate3/src/test/java/com/hazelcast/hibernate/RegionFactoryQueryTest.java
+++ b/hazelcast-hibernate/hazelcast-hibernate3/src/test/java/com/hazelcast/hibernate/RegionFactoryQueryTest.java
@@ -1,0 +1,69 @@
+package com.hazelcast.hibernate;
+
+import com.hazelcast.hibernate.entity.DummyEntity;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.NightlyTest;
+import org.hibernate.Session;
+import org.hibernate.Transaction;
+import org.hibernate.cfg.Environment;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.List;
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(NightlyTest.class)
+public class RegionFactoryQueryTest extends HibernateSlowTestSupport{
+
+    @Before
+    @Override
+    public void postConstruct() {
+        sf = createSessionFactory(getCacheProperties(), null);
+        sf2 = createSessionFactory(getCacheProperties(), null);
+    }
+
+    @Test
+    public void test_query_with_non_mock_network() {
+        final int entityCount = 10;
+        final int queryCount = 2;
+        insertDummyEntities(entityCount);
+        List<DummyEntity> list = null;
+        for (int i = 0; i < queryCount; i++) {
+            list = executeQuery(sf);
+            assertEquals(entityCount, list.size());
+        }
+        for (int i = 0; i < queryCount; i++) {
+            list = executeQuery(sf2);
+            assertEquals(entityCount, list.size());
+        }
+
+        assertNotNull(list);
+        DummyEntity toDelete = list.get(0);
+        Session session = sf.openSession();
+        Transaction tx = session.beginTransaction();
+        try {
+            session.delete(toDelete);
+            tx.commit();
+        } catch (Exception e) {
+            tx.rollback();
+            e.printStackTrace();
+        } finally {
+            session.close();
+        }
+        assertEquals(entityCount - 1, executeQuery(sf).size());
+        assertEquals(entityCount - 1, executeQuery(sf2).size());
+
+    }
+
+    protected Properties getCacheProperties() {
+        Properties props = new Properties();
+        props.setProperty(Environment.CACHE_REGION_FACTORY, HazelcastCacheRegionFactory.class.getName());
+        return props;
+    }
+}

--- a/hazelcast-hibernate/hazelcast-hibernate3/src/test/java/com/hazelcast/hibernate/distributed/LockEntryProcessorTest.java
+++ b/hazelcast-hibernate/hazelcast-hibernate3/src/test/java/com/hazelcast/hibernate/distributed/LockEntryProcessorTest.java
@@ -4,6 +4,7 @@ import com.hazelcast.hibernate.serialization.Expirable;
 import com.hazelcast.hibernate.serialization.ExpiryMarker;
 import com.hazelcast.hibernate.serialization.Value;
 import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -21,7 +22,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(HazelcastSerialClassRunner.class)
-@Category(QuickTest.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class LockEntryProcessorTest {
 
     @Test

--- a/hazelcast-hibernate/hazelcast-hibernate3/src/test/java/com/hazelcast/hibernate/distributed/UnlockEntryProcessorTest.java
+++ b/hazelcast-hibernate/hazelcast-hibernate3/src/test/java/com/hazelcast/hibernate/distributed/UnlockEntryProcessorTest.java
@@ -4,6 +4,7 @@ import com.hazelcast.hibernate.serialization.Expirable;
 import com.hazelcast.hibernate.serialization.ExpiryMarker;
 import com.hazelcast.hibernate.serialization.Value;
 import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -24,7 +25,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(HazelcastSerialClassRunner.class)
-@Category(QuickTest.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class UnlockEntryProcessorTest {
 
     @Test

--- a/hazelcast-hibernate/hazelcast-hibernate3/src/test/java/com/hazelcast/hibernate/distributed/UpdateEntryProcessorTest.java
+++ b/hazelcast-hibernate/hazelcast-hibernate3/src/test/java/com/hazelcast/hibernate/distributed/UpdateEntryProcessorTest.java
@@ -4,6 +4,7 @@ import com.hazelcast.hibernate.serialization.Expirable;
 import com.hazelcast.hibernate.serialization.ExpiryMarker;
 import com.hazelcast.hibernate.serialization.Value;
 import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -24,7 +25,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(HazelcastSerialClassRunner.class)
-@Category(QuickTest.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class UpdateEntryProcessorTest {
 
     @Test

--- a/hazelcast-hibernate/hazelcast-hibernate3/src/test/java/com/hazelcast/hibernate/instance/HazelcastMockInstanceLoader.java
+++ b/hazelcast-hibernate/hazelcast-hibernate3/src/test/java/com/hazelcast/hibernate/instance/HazelcastMockInstanceLoader.java
@@ -1,0 +1,179 @@
+package com.hazelcast.hibernate.instance;
+
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.config.ClientNetworkConfig;
+import com.hazelcast.client.config.XmlClientConfigBuilder;
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.config.Config;
+import com.hazelcast.config.ConfigLoader;
+import com.hazelcast.config.XmlConfigBuilder;
+import com.hazelcast.core.DuplicateInstanceNameException;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.hibernate.CacheEnvironment;
+import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
+import org.hibernate.cache.CacheException;
+import org.hibernate.util.PropertiesHelper;
+
+import java.io.IOException;
+import java.util.Properties;
+
+
+public class HazelcastMockInstanceLoader implements IHazelcastInstanceLoader {
+
+    private static final ILogger LOGGER = Logger.getLogger(HazelcastMockInstanceLoader.class);
+    private static final int CONNECTION_ATTEMPT_LIMIT = 10;
+
+    private final Properties props = new Properties();
+    private String instanceName;
+    private HazelcastInstance instance;
+    private Config config;
+    private HazelcastInstance client;
+    private TestHazelcastFactory factory;
+    public void configure(Properties props) {
+        this.props.putAll(props);
+    }
+
+    public HazelcastInstance loadInstance() throws CacheException {
+        if (CacheEnvironment.isNativeClient(props)) {
+            if (client != null && client.getLifecycleService().isRunning()) {
+                LOGGER.warning("Current HazelcastClient is already active! Shutting it down...");
+                unloadInstance();
+            }
+            String address = PropertiesHelper.getString(CacheEnvironment.NATIVE_CLIENT_ADDRESS, props, null);
+            String group = PropertiesHelper.getString(CacheEnvironment.NATIVE_CLIENT_GROUP, props, null);
+            String pass = PropertiesHelper.getString(CacheEnvironment.NATIVE_CLIENT_PASSWORD, props, null);
+            String configResourcePath = CacheEnvironment.getConfigFilePath(props);
+
+            ClientConfig clientConfig = buildClientConfig(configResourcePath);
+            if (group != null) {
+                clientConfig.getGroupConfig().setName(group);
+            }
+            if (pass != null) {
+                clientConfig.getGroupConfig().setPassword(pass);
+            }
+            if (address != null) {
+                clientConfig.getNetworkConfig().addAddress(address);
+            }
+            clientConfig.getNetworkConfig().setSmartRouting(true);
+            clientConfig.getNetworkConfig().setRedoOperation(true);
+            client = factory.newHazelcastClient(clientConfig);
+            return client;
+        } else {
+            if (instance != null && instance.getLifecycleService().isRunning()) {
+                LOGGER.warning("Current HazelcastInstance is already loaded and running! "
+                        + "Returning current instance...");
+                return instance;
+            }
+            String configResourcePath = null;
+            instanceName = CacheEnvironment.getInstanceName(props);
+            configResourcePath = CacheEnvironment.getConfigFilePath(props);
+            if (!isEmpty(configResourcePath)) {
+                try {
+                    config = ConfigLoader.load(configResourcePath);
+                } catch (IOException e) {
+                    LOGGER.warning("IOException: " + e.getMessage());
+                }
+                if (config == null) {
+                    throw new CacheException("Could not find configuration file: "
+                            + configResourcePath);
+                }
+            }
+            if (instanceName != null) {
+                instance = getHazelcastInstanceByName(instanceName);
+                if (instance == null) {
+                    try {
+                        createOrGetInstance();
+                    } catch (DuplicateInstanceNameException ignored) {
+                        instance = getHazelcastInstanceByName(instanceName);
+                    }
+                }
+            } else {
+                createOrGetInstance();
+            }
+            return instance;
+        }
+    }
+
+    private void createOrGetInstance() throws DuplicateInstanceNameException {
+        if (config == null) {
+            config = new XmlConfigBuilder().build();
+        }
+        config.setInstanceName(instanceName);
+        instance = factory.newHazelcastInstance(config);
+    }
+
+    public void unloadInstance() throws CacheException {
+        if (CacheEnvironment.isNativeClient(props)) {
+            if (client == null) {
+                return;
+            }
+            try {
+                client.getLifecycleService().shutdown();
+                client = null;
+            } catch (Exception e) {
+                throw new CacheException(e);
+            }
+        } else {
+            if (instance == null) {
+                return;
+            }
+            final boolean shutDown = CacheEnvironment.shutdownOnStop(props, (instanceName == null));
+            if (!shutDown) {
+                LOGGER.warning(CacheEnvironment.SHUTDOWN_ON_STOP + " property is set to 'false'. "
+                        + "Leaving current HazelcastInstance active! (Warning: Do not disable Hazelcast "
+                        + GroupProperties.PROP_SHUTDOWNHOOK_ENABLED + " property!)");
+                return;
+            }
+            try {
+                instance.getLifecycleService().shutdown();
+                instance = null;
+                factory.shutdownAll();
+            } catch (Exception e) {
+                throw new CacheException(e);
+            }
+        }
+    }
+
+    public TestHazelcastFactory getInstanceFactory() throws CacheException {
+        return factory;
+    }
+
+    public void setInstanceFactory(TestHazelcastFactory factory) {
+        this.factory = factory;
+    }
+
+    private static boolean isEmpty(String s) {
+        return s == null || s.trim().length() == 0;
+    }
+
+    private HazelcastInstance getHazelcastInstanceByName(String instanceName) {
+        HazelcastInstance foundInstance = null;
+        for (HazelcastInstance instance : factory.getAllHazelcastInstances()) {
+            if(instanceName.equals(instance.getName())) {
+                foundInstance = instance;
+            }
+        }
+        return foundInstance;
+    }
+
+    private ClientConfig buildClientConfig(String configResourcePath) {
+        ClientConfig clientConfig = null;
+        if (configResourcePath != null) {
+            try {
+                clientConfig = new XmlClientConfigBuilder(configResourcePath).build();
+            } catch (IOException e) {
+                LOGGER.warning("Could not load client configuration: " + configResourcePath, e);
+            }
+        }
+        if (clientConfig == null) {
+            clientConfig = new ClientConfig();
+            final ClientNetworkConfig networkConfig = clientConfig.getNetworkConfig();
+            networkConfig.setSmartRouting(true);
+            networkConfig.setRedoOperation(true);
+            networkConfig.setConnectionAttemptLimit(CONNECTION_ATTEMPT_LIMIT);
+        }
+        return clientConfig;
+    }
+}

--- a/hazelcast-hibernate/hazelcast-hibernate3/src/test/java/com/hazelcast/hibernate/local/LocalRegionCacheTest.java
+++ b/hazelcast-hibernate/hazelcast-hibernate3/src/test/java/com/hazelcast/hibernate/local/LocalRegionCacheTest.java
@@ -6,6 +6,7 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.ITopic;
 import com.hazelcast.core.MessageListener;
 import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.hibernate.cache.CacheDataDescription;
 import org.junit.Test;
@@ -17,7 +18,7 @@ import java.util.Comparator;
 import static org.mockito.Mockito.*;
 
 @RunWith(HazelcastSerialClassRunner.class)
-@Category(QuickTest.class)
+@Category({QuickTest.class, ParallelTest.class})
 @SuppressWarnings("unchecked")
 public class LocalRegionCacheTest {
 

--- a/hazelcast-hibernate/hazelcast-hibernate3/src/test/java/com/hazelcast/hibernate/region/HazelcastQueryResultsRegionTest.java
+++ b/hazelcast-hibernate/hazelcast-hibernate3/src/test/java/com/hazelcast/hibernate/region/HazelcastQueryResultsRegionTest.java
@@ -8,6 +8,7 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.hibernate.local.LocalRegionCache;
 import com.hazelcast.hibernate.local.LocalRegionCacheTest;
 import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -22,7 +23,7 @@ import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 @RunWith(HazelcastSerialClassRunner.class)
-@Category(QuickTest.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class HazelcastQueryResultsRegionTest {
 
     private static final String REGION_NAME = "query.test";

--- a/hazelcast-hibernate/hazelcast-hibernate3/src/test/java/com/hazelcast/hibernate/serialization/ExpiryMarkerTest.java
+++ b/hazelcast-hibernate/hazelcast-hibernate3/src/test/java/com/hazelcast/hibernate/serialization/ExpiryMarkerTest.java
@@ -2,6 +2,7 @@ package com.hazelcast.hibernate.serialization;
 
 
 import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.hibernate.util.ComparableComparator;
 import org.junit.Test;
@@ -12,7 +13,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastSerialClassRunner.class)
-@Category(QuickTest.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class ExpiryMarkerTest {
 
     @Test

--- a/hazelcast-hibernate/hazelcast-hibernate3/src/test/java/com/hazelcast/hibernate/serialization/HibernateSerializationHookAvailableTest.java
+++ b/hazelcast-hibernate/hazelcast-hibernate3/src/test/java/com/hazelcast/hibernate/serialization/HibernateSerializationHookAvailableTest.java
@@ -23,6 +23,7 @@ import com.hazelcast.instance.HazelcastInstanceProxy;
 import com.hazelcast.nio.serialization.SerializationService;
 import com.hazelcast.nio.serialization.impl.SerializationServiceImpl;
 import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.hibernate.cache.CacheKey;
 import org.hibernate.cache.entry.CacheEntry;
@@ -37,7 +38,7 @@ import java.util.concurrent.ConcurrentMap;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastSerialClassRunner.class)
-@Category(QuickTest.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class HibernateSerializationHookAvailableTest {
 
     private static final Field ORIGINAL;

--- a/hazelcast-hibernate/hazelcast-hibernate3/src/test/java/com/hazelcast/hibernate/serialization/HibernateSerializationHookNonAvailableTest.java
+++ b/hazelcast-hibernate/hazelcast-hibernate3/src/test/java/com/hazelcast/hibernate/serialization/HibernateSerializationHookNonAvailableTest.java
@@ -17,6 +17,7 @@
 package com.hazelcast.hibernate.serialization;
 
 import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.util.FilteringClassLoader;
 import org.hibernate.cache.CacheKey;
@@ -34,7 +35,7 @@ import java.util.concurrent.ConcurrentMap;
 import static org.junit.Assert.assertFalse;
 
 @RunWith(HazelcastSerialClassRunner.class)
-@Category(QuickTest.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class HibernateSerializationHookNonAvailableTest {
 
     private static final Field ORIGINAL;

--- a/hazelcast-hibernate/hazelcast-hibernate3/src/test/java/com/hazelcast/hibernate/serialization/ValueTest.java
+++ b/hazelcast-hibernate/hazelcast-hibernate3/src/test/java/com/hazelcast/hibernate/serialization/ValueTest.java
@@ -1,6 +1,7 @@
 package com.hazelcast.hibernate.serialization;
 
 import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.hibernate.util.ComparableComparator;
 import org.junit.Test;
@@ -13,7 +14,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastSerialClassRunner.class)
-@Category(QuickTest.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class ValueTest {
 
     @Test

--- a/hazelcast-hibernate/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/CacheHitMissNonStrictTest.java
+++ b/hazelcast-hibernate/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/CacheHitMissNonStrictTest.java
@@ -17,6 +17,7 @@
 package com.hazelcast.hibernate;
 
 import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.hibernate.cache.spi.access.AccessType;
 import org.hibernate.cfg.Environment;
@@ -37,7 +38,7 @@ import static org.junit.Assert.assertEquals;
  * Read through cache
  */
 @RunWith(HazelcastSerialClassRunner.class)
-@Category(QuickTest.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class CacheHitMissNonStrictTest
         extends HibernateStatisticsTestSupport {
 
@@ -68,8 +69,7 @@ public class CacheHitMissNonStrictTest
 
         //hit 1 entity and 4 properties
         updateDummyEntityName(sf, 2, "updated");
-        //invalidation is not synchronized, so we have to wait
-        sleep(1);
+
         //entity 2 and its properties are invalidated
 
         //miss updated entity, hit 4 properties(they are still the same)

--- a/hazelcast-hibernate/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/CacheHitMissReadOnlyTest.java
+++ b/hazelcast-hibernate/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/CacheHitMissReadOnlyTest.java
@@ -19,6 +19,7 @@ package com.hazelcast.hibernate;
 import com.hazelcast.hibernate.access.ReadOnlyAccessDelegate;
 import com.hazelcast.hibernate.region.HazelcastRegion;
 import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.hibernate.cache.spi.access.AccessType;
 import org.hibernate.cfg.Environment;
@@ -38,7 +39,7 @@ import static org.mockito.Mockito.when;
  * Data may be added and removed, but not mutated.
  */
 @RunWith(HazelcastSerialClassRunner.class)
-@Category(QuickTest.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class CacheHitMissReadOnlyTest
         extends HibernateStatisticsTestSupport {
 

--- a/hazelcast-hibernate/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/CacheHitMissReadWriteTest.java
+++ b/hazelcast-hibernate/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/CacheHitMissReadWriteTest.java
@@ -17,6 +17,7 @@
 package com.hazelcast.hibernate;
 
 import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.hibernate.cache.spi.access.AccessType;
 import org.hibernate.cfg.Environment;
@@ -36,7 +37,7 @@ import static org.junit.Assert.assertEquals;
  * Write through cache
  */
 @RunWith(HazelcastSerialClassRunner.class)
-@Category(QuickTest.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class CacheHitMissReadWriteTest
         extends HibernateStatisticsTestSupport {
 

--- a/hazelcast-hibernate/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/CustomPropertiesTest.java
+++ b/hazelcast-hibernate/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/CustomPropertiesTest.java
@@ -18,15 +18,15 @@ package com.hazelcast.hibernate;
 
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.impl.HazelcastClientProxy;
+import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.ClasspathXmlConfig;
 import com.hazelcast.config.Config;
-import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.hibernate.entity.DummyEntity;
 import com.hazelcast.hibernate.instance.HazelcastAccessor;
+import com.hazelcast.hibernate.instance.HazelcastMockInstanceLoader;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.NightlyTest;
-import com.hazelcast.test.annotation.QuickTest;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.Transaction;
@@ -42,12 +42,15 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastSerialClassRunner.class)
-@Category(QuickTest.class)
+@Category(NightlyTest.class)
 public class CustomPropertiesTest extends HibernateTestSupport {
 
     @Test
     public void testNativeClient() throws Exception {
-        HazelcastInstance main = Hazelcast.newHazelcastInstance(new ClasspathXmlConfig("hazelcast-custom.xml"));
+
+        TestHazelcastFactory factory = new TestHazelcastFactory();
+        Config config = new ClasspathXmlConfig("hazelcast-custom.xml");
+        HazelcastInstance main = factory.newHazelcastInstance(config);
         Properties props = getDefaultProperties();
         props.remove(CacheEnvironment.CONFIG_FILE_PATH_LEGACY);
         props.setProperty(Environment.CACHE_REGION_FACTORY, HazelcastCacheRegionFactory.class.getName());
@@ -56,7 +59,10 @@ public class CustomPropertiesTest extends HibernateTestSupport {
         props.setProperty(CacheEnvironment.NATIVE_CLIENT_PASSWORD, "dev-pass");
         props.setProperty(CacheEnvironment.NATIVE_CLIENT_ADDRESS, "localhost");
         props.setProperty(CacheEnvironment.CONFIG_FILE_PATH,"hazelcast-client-custom.xml");
-        SessionFactory sf = createSessionFactory(props);
+        HazelcastMockInstanceLoader loader = new HazelcastMockInstanceLoader();
+        loader.configure(props);
+        loader.setInstanceFactory(factory);
+        SessionFactory sf = createSessionFactory(props, loader);
         HazelcastInstance hz = HazelcastAccessor.getHazelcastInstance(sf);
         assertTrue(hz instanceof HazelcastClientProxy);
         assertEquals(1, main.getCluster().getMembers().size());
@@ -66,37 +72,41 @@ public class CustomPropertiesTest extends HibernateTestSupport {
         assertEquals("dev-pass", clientConfig.getGroupConfig().getPassword());
         assertTrue(clientConfig.getNetworkConfig().isSmartRouting());
         assertTrue(clientConfig.getNetworkConfig().isRedoOperation());
-        Hazelcast.newHazelcastInstance(new ClasspathXmlConfig("hazelcast-custom.xml"));
+        factory.newHazelcastInstance(config);
         assertEquals(2, hz.getCluster().getMembers().size());
         main.shutdown();
-        Thread.sleep(1000 * 3); // let client to reconnect
+        Thread.sleep(1000 * 1); // let client to reconnect
         assertEquals(1, hz.getCluster().getMembers().size());
-
         Session session = sf.openSession();
         Transaction tx = session.beginTransaction();
         session.save(new DummyEntity(1L, "dummy", 0, new Date()));
         tx.commit();
         session.close();
-
         sf.close();
-        Hazelcast.shutdownAll();
+        factory.shutdownAll();
     }
 
     @Test
     public void testNamedInstance() {
+        TestHazelcastFactory factory = new TestHazelcastFactory();
         Config config = new Config();
         config.setInstanceName("hibernate");
-        HazelcastInstance hz = Hazelcast.newHazelcastInstance(config);
+        HazelcastInstance hz = factory.newHazelcastInstance(config);
         Properties props = getDefaultProperties();
         props.setProperty(Environment.CACHE_REGION_FACTORY, HazelcastCacheRegionFactory.class.getName());
         props.put(CacheEnvironment.HAZELCAST_INSTANCE_NAME, "hibernate");
         props.put(CacheEnvironment.SHUTDOWN_ON_STOP, "false");
-        final SessionFactory sf = createSessionFactory(props);
-        assertTrue(hz == HazelcastAccessor.getHazelcastInstance(sf));
+        HazelcastMockInstanceLoader instanceLoader = new HazelcastMockInstanceLoader();
+        instanceLoader.configure(props);
+        instanceLoader.setInstanceFactory(factory);
+        final SessionFactory sf = createSessionFactory(props, instanceLoader);
+        assertTrue(hz.equals(HazelcastAccessor.getHazelcastInstance(sf)));
         sf.close();
         assertTrue(hz.getLifecycleService().isRunning());
-        hz.shutdown();
+        factory.shutdownAll();
     }
+
+
 
     private Properties getDefaultProperties() {
         Properties props = new Properties();

--- a/hazelcast-hibernate/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/HibernateSlowTestSupport.java
+++ b/hazelcast-hibernate/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/HibernateSlowTestSupport.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hibernate;
+
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.hibernate.entity.DummyEntity;
+import com.hazelcast.hibernate.entity.DummyProperty;
+import org.hibernate.Query;
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.Transaction;
+import org.junit.After;
+import org.junit.Before;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Properties;
+
+public abstract class HibernateSlowTestSupport extends HibernateTestSupport {
+
+    protected SessionFactory sf;
+    protected SessionFactory sf2;
+
+    @Before
+    public void postConstruct() {
+        sf = createSessionFactory(getCacheProperties(),null);
+        sf2 = createSessionFactory(getCacheProperties(),null);
+    }
+
+    @After
+    public void preDestroy() {
+        if (sf != null) {
+            sf.close();
+            sf = null;
+        }
+        if (sf2 != null) {
+            sf2.close();
+            sf2 = null;
+        }
+        Hazelcast.shutdownAll();
+    }
+
+    protected abstract Properties getCacheProperties();
+
+    protected void insertDummyEntities(int count) {
+        insertDummyEntities(count, 0);
+    }
+
+    protected void insertDummyEntities(int count, int childCount) {
+        Session session = sf.openSession();
+        Transaction tx = session.beginTransaction();
+        try {
+            for (int i = 0; i < count; i++) {
+                DummyEntity e = new DummyEntity((long) i, "dummy:" + i, i * 123456d, new Date());
+                session.save(e);
+                for (int j = 0; j < childCount; j++) {
+                    DummyProperty p = new DummyProperty("key:" + j, e);
+                    session.save(p);
+                }
+            }
+            tx.commit();
+        } catch (Exception e) {
+            tx.rollback();
+            e.printStackTrace();
+        } finally {
+            session.close();
+        }
+    }
+
+    protected List<DummyEntity> executeQuery(SessionFactory factory) {
+        Session session = factory.openSession();
+        try {
+            Query query = session.createQuery("from " + DummyEntity.class.getName());
+            query.setCacheable(false);
+            return query.list();
+        } finally {
+            session.close();
+        }
+    }
+
+    protected DummyEntity executeQuery(SessionFactory factory, long id) {
+        Session session = factory.openSession();
+        try {
+            Query query = session.createQuery("from " + DummyEntity.class.getName() + " where id = " + id);
+            query.setCacheable(true);
+            return (DummyEntity) query.list().get(0);
+        } finally {
+            session.close();
+        }
+    }
+}

--- a/hazelcast-hibernate/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/HibernateStatisticsTestSupport.java
+++ b/hazelcast-hibernate/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/HibernateStatisticsTestSupport.java
@@ -16,35 +16,28 @@
 
 package com.hazelcast.hibernate;
 
-import com.hazelcast.config.MapConfig;
+
+import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.core.Hazelcast;
-import com.hazelcast.core.HazelcastInstance;
+
 import com.hazelcast.hibernate.entity.DummyEntity;
 import com.hazelcast.hibernate.entity.DummyProperty;
-import com.hazelcast.hibernate.instance.HazelcastAccessor;
-import com.hazelcast.hibernate.region.HazelcastQueryResultsRegion;
-import com.hazelcast.test.annotation.NightlyTest;
+import com.hazelcast.hibernate.instance.HazelcastMockInstanceLoader;
 import org.hibernate.Query;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.Transaction;
-import org.hibernate.internal.SessionFactoryImpl;
 import org.hibernate.stat.SecondLevelCacheStatistics;
-import org.hibernate.stat.Statistics;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
-import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
-
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 
 public abstract class HibernateStatisticsTestSupport extends HibernateTestSupport {
 
@@ -53,12 +46,15 @@ public abstract class HibernateStatisticsTestSupport extends HibernateTestSuppor
 
     protected final String CACHE_ENTITY = DummyEntity.class.getName();
     protected final String CACHE_PROPERTY = DummyProperty.class.getName();
-    protected final String CACHE_COLLECTION_ENTITY = DummyEntity.class.getName() + ".properties";
+    private static  TestHazelcastFactory factory;
 
     @Before
     public void postConstruct() {
-        sf = createSessionFactory(getCacheProperties());
-        sf2 = createSessionFactory(getCacheProperties());
+        HazelcastMockInstanceLoader loader = new HazelcastMockInstanceLoader();
+        factory = new TestHazelcastFactory();
+        loader.setInstanceFactory(factory);
+        sf = createSessionFactory(getCacheProperties(),  loader);
+        sf2 = createSessionFactory(getCacheProperties(), loader);
     }
 
     @After
@@ -72,6 +68,7 @@ public abstract class HibernateStatisticsTestSupport extends HibernateTestSuppor
             sf2 = null;
         }
         Hazelcast.shutdownAll();
+        factory.shutdownAll();
     }
 
     protected abstract Properties getCacheProperties();
@@ -107,17 +104,6 @@ public abstract class HibernateStatisticsTestSupport extends HibernateTestSuppor
             Query query = session.createQuery("from " + DummyEntity.class.getName());
             query.setCacheable(true);
             return query.list();
-        } finally {
-            session.close();
-        }
-    }
-
-    protected DummyEntity executeQuery(SessionFactory factory, long id) {
-        Session session = factory.openSession();
-        try {
-            Query query = session.createQuery("from " + DummyEntity.class.getName() + " where id = " + id);
-            query.setCacheable(true);
-            return (DummyEntity) query.list().get(0);
         } finally {
             session.close();
         }

--- a/hazelcast-hibernate/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/HibernateTestSupport.java
+++ b/hazelcast-hibernate/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/HibernateTestSupport.java
@@ -21,6 +21,7 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.hibernate.entity.DummyEntity;
 import com.hazelcast.hibernate.entity.DummyProperty;
 import com.hazelcast.hibernate.instance.HazelcastAccessor;
+import com.hazelcast.hibernate.instance.IHazelcastInstanceLoader;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.test.HazelcastTestSupport;
@@ -61,10 +62,16 @@ public abstract class HibernateTestSupport extends HazelcastTestSupport{
         }
     }
 
-    protected SessionFactory createSessionFactory(Properties props) {
+    protected SessionFactory createSessionFactory(Properties props, IHazelcastInstanceLoader customInstanceLoader) {
         Configuration conf = new Configuration();
         URL xml = HibernateTestSupport.class.getClassLoader().getResource("test-hibernate.cfg.xml");
         props.put(CacheEnvironment.EXPLICIT_VERSION_CHECK, "true");
+        if (customInstanceLoader != null) {
+            props.put("com.hazelcast.hibernate.instance.loader", customInstanceLoader);
+            customInstanceLoader.configure(props);
+        } else {
+            props.remove("com.hazelcast.hibernate.instance.loader");
+        }
         conf.configure(xml);
         conf.setCacheConcurrencyStrategy(DummyEntity.class.getName(), getCacheStrategy());
         conf.setCacheConcurrencyStrategy(DummyProperty.class.getName(), getCacheStrategy());

--- a/hazelcast-hibernate/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/LocalRegionFactoryDefaultTest.java
+++ b/hazelcast-hibernate/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/LocalRegionFactoryDefaultTest.java
@@ -19,6 +19,7 @@ package com.hazelcast.hibernate;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.hibernate.entity.DummyEntity;
 import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.hibernate.Session;
 import org.hibernate.Transaction;
@@ -37,7 +38,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 @RunWith(HazelcastSerialClassRunner.class)
-@Category(QuickTest.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class LocalRegionFactoryDefaultTest extends RegionFactoryDefaultTest {
 
     protected Properties getCacheProperties() {
@@ -53,7 +54,6 @@ public class LocalRegionFactoryDefaultTest extends RegionFactoryDefaultTest {
         final int count = 100;
         final int childCount = 3;
         insertDummyEntities(count, childCount);
-        sleep(1);
         List<DummyEntity> list = new ArrayList<DummyEntity>(count);
         Session session = sf.openSession();
         try {

--- a/hazelcast-hibernate/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/LocalRegionFactorySlowTest.java
+++ b/hazelcast-hibernate/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/LocalRegionFactorySlowTest.java
@@ -1,0 +1,62 @@
+package com.hazelcast.hibernate;
+
+import com.hazelcast.hibernate.entity.DummyEntity;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.NightlyTest;
+import org.hibernate.Session;
+import org.hibernate.Transaction;
+import org.hibernate.cfg.Environment;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.List;
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(NightlyTest.class)
+public class LocalRegionFactorySlowTest extends HibernateSlowTestSupport {
+
+    @Test
+    public void test_query_with_non_mock_network() {
+        final int entityCount = 10;
+        final int queryCount = 2;
+        insertDummyEntities(entityCount);
+        List<DummyEntity> list = null;
+        for (int i = 0; i < queryCount; i++) {
+            list = executeQuery(sf);
+            assertEquals(entityCount, list.size());
+        }
+        for (int i = 0; i < queryCount; i++) {
+            list = executeQuery(sf2);
+            assertEquals(entityCount, list.size());
+        }
+
+        assertNotNull(list);
+        DummyEntity toDelete = list.get(0);
+        Session session = sf2.openSession();
+        Transaction tx = session.beginTransaction();
+        try {
+            session.delete(toDelete);
+            tx.commit();
+        } catch (Exception e) {
+            tx.rollback();
+            e.printStackTrace();
+        } finally {
+            session.close();
+        }
+        assertEquals(entityCount - 1, executeQuery(sf).size());
+        assertEquals(entityCount - 1, executeQuery(sf2).size());
+
+    }
+
+    @Override
+    protected Properties getCacheProperties() {
+        Properties props = new Properties();
+        props.setProperty(Environment.CACHE_REGION_FACTORY, HazelcastLocalCacheRegionFactory.class.getName());
+        return props;
+    }
+}

--- a/hazelcast-hibernate/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/RegionFactoryDefaultNightlyTest.java
+++ b/hazelcast-hibernate/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/RegionFactoryDefaultNightlyTest.java
@@ -32,7 +32,7 @@ import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(NightlyTest.class)
-public class RegionFactoryDefaultNightlyTest extends HibernateStatisticsTestSupport {
+public class RegionFactoryDefaultNightlyTest extends HibernateSlowTestSupport {
 
     protected Properties getCacheProperties() {
         Properties props = new Properties();
@@ -50,7 +50,6 @@ public class RegionFactoryDefaultNightlyTest extends HibernateStatisticsTestSupp
         final int maxSize = mapConfig.getMaxSizeConfig().getSize();
         final int evictedItemCount = numberOfEntities - maxSize + (int) (maxSize * baseEvictionRate);
         insertDummyEntities(numberOfEntities);
-        sleep(1);
         for (int i = 0; i < numberOfEntities; i++) {
             executeQuery(sf, i);
         }

--- a/hazelcast-hibernate/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/RegionFactoryQueryTest.java
+++ b/hazelcast-hibernate/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/RegionFactoryQueryTest.java
@@ -1,0 +1,69 @@
+package com.hazelcast.hibernate;
+
+import com.hazelcast.hibernate.entity.DummyEntity;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.NightlyTest;
+import org.hibernate.Session;
+import org.hibernate.Transaction;
+import org.hibernate.cfg.Environment;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.List;
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(NightlyTest.class)
+public class RegionFactoryQueryTest extends HibernateSlowTestSupport{
+
+    @Before
+    @Override
+    public void postConstruct() {
+        sf = createSessionFactory(getCacheProperties(), null);
+        sf2 = createSessionFactory(getCacheProperties(), null);
+    }
+
+    @Test
+    public void test_query_with_non_mock_network() {
+        final int entityCount = 10;
+        final int queryCount = 2;
+        insertDummyEntities(entityCount);
+        List<DummyEntity> list = null;
+        for (int i = 0; i < queryCount; i++) {
+            list = executeQuery(sf);
+            assertEquals(entityCount, list.size());
+        }
+        for (int i = 0; i < queryCount; i++) {
+            list = executeQuery(sf2);
+            assertEquals(entityCount, list.size());
+        }
+
+        assertNotNull(list);
+        DummyEntity toDelete = list.get(0);
+        Session session = sf.openSession();
+        Transaction tx = session.beginTransaction();
+        try {
+            session.delete(toDelete);
+            tx.commit();
+        } catch (Exception e) {
+            tx.rollback();
+            e.printStackTrace();
+        } finally {
+            session.close();
+        }
+        assertEquals(entityCount - 1, executeQuery(sf).size());
+        assertEquals(entityCount - 1, executeQuery(sf2).size());
+
+    }
+
+    protected Properties getCacheProperties() {
+        Properties props = new Properties();
+        props.setProperty(Environment.CACHE_REGION_FACTORY, HazelcastCacheRegionFactory.class.getName());
+        return props;
+    }
+}

--- a/hazelcast-hibernate/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/distributed/LockEntryProcessorTest.java
+++ b/hazelcast-hibernate/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/distributed/LockEntryProcessorTest.java
@@ -4,6 +4,7 @@ import com.hazelcast.hibernate.serialization.Expirable;
 import com.hazelcast.hibernate.serialization.ExpiryMarker;
 import com.hazelcast.hibernate.serialization.Value;
 import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -21,7 +22,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(HazelcastSerialClassRunner.class)
-@Category(QuickTest.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class LockEntryProcessorTest {
 
     @Test

--- a/hazelcast-hibernate/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/distributed/UnlockEntryProcessorTest.java
+++ b/hazelcast-hibernate/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/distributed/UnlockEntryProcessorTest.java
@@ -4,6 +4,7 @@ import com.hazelcast.hibernate.serialization.Expirable;
 import com.hazelcast.hibernate.serialization.ExpiryMarker;
 import com.hazelcast.hibernate.serialization.Value;
 import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -25,7 +26,7 @@ import static org.mockito.Mockito.when;
 
 
 @RunWith(HazelcastSerialClassRunner.class)
-@Category(QuickTest.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class UnlockEntryProcessorTest {
 
     @Test

--- a/hazelcast-hibernate/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/distributed/UpdateEntryProcessorTest.java
+++ b/hazelcast-hibernate/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/distributed/UpdateEntryProcessorTest.java
@@ -4,6 +4,7 @@ import com.hazelcast.hibernate.serialization.Expirable;
 import com.hazelcast.hibernate.serialization.ExpiryMarker;
 import com.hazelcast.hibernate.serialization.Value;
 import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -24,7 +25,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(HazelcastSerialClassRunner.class)
-@Category(QuickTest.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class UpdateEntryProcessorTest {
 
     @Test

--- a/hazelcast-hibernate/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/instance/HazelcastMockInstanceLoader.java
+++ b/hazelcast-hibernate/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/instance/HazelcastMockInstanceLoader.java
@@ -1,0 +1,179 @@
+package com.hazelcast.hibernate.instance;
+
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.config.ClientNetworkConfig;
+import com.hazelcast.client.config.XmlClientConfigBuilder;
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.config.Config;
+import com.hazelcast.config.ConfigLoader;
+import com.hazelcast.config.XmlConfigBuilder;
+import com.hazelcast.core.DuplicateInstanceNameException;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.hibernate.CacheEnvironment;
+import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
+import org.hibernate.cache.CacheException;
+import org.hibernate.internal.util.config.ConfigurationHelper;
+
+import java.io.IOException;
+import java.util.Properties;
+
+
+public class HazelcastMockInstanceLoader implements IHazelcastInstanceLoader {
+
+    private static final ILogger LOGGER = Logger.getLogger(HazelcastMockInstanceLoader.class);
+    private static final int CONNECTION_ATTEMPT_LIMIT = 10;
+
+    private final Properties props = new Properties();
+    private String instanceName;
+    private HazelcastInstance instance;
+    private Config config;
+    private HazelcastInstance client;
+    private TestHazelcastFactory factory;
+    public void configure(Properties props) {
+        this.props.putAll(props);
+    }
+
+    public HazelcastInstance loadInstance() throws CacheException {
+        if (CacheEnvironment.isNativeClient(props)) {
+            if (client != null && client.getLifecycleService().isRunning()) {
+                LOGGER.warning("Current HazelcastClient is already active! Shutting it down...");
+                unloadInstance();
+            }
+            String address = ConfigurationHelper.getString(CacheEnvironment.NATIVE_CLIENT_ADDRESS, props, null);
+            String group = ConfigurationHelper.getString(CacheEnvironment.NATIVE_CLIENT_GROUP, props, null);
+            String pass = ConfigurationHelper.getString(CacheEnvironment.NATIVE_CLIENT_PASSWORD, props, null);
+            String configResourcePath = CacheEnvironment.getConfigFilePath(props);
+
+            ClientConfig clientConfig = buildClientConfig(configResourcePath);
+            if (group != null) {
+                clientConfig.getGroupConfig().setName(group);
+            }
+            if (pass != null) {
+                clientConfig.getGroupConfig().setPassword(pass);
+            }
+            if (address != null) {
+                clientConfig.getNetworkConfig().addAddress(address);
+            }
+            clientConfig.getNetworkConfig().setSmartRouting(true);
+            clientConfig.getNetworkConfig().setRedoOperation(true);
+            client = factory.newHazelcastClient(clientConfig);
+            return client;
+        } else {
+            if (instance != null && instance.getLifecycleService().isRunning()) {
+                LOGGER.warning("Current HazelcastInstance is already loaded and running! "
+                        + "Returning current instance...");
+                return instance;
+            }
+            String configResourcePath = null;
+            instanceName = CacheEnvironment.getInstanceName(props);
+            configResourcePath = CacheEnvironment.getConfigFilePath(props);
+            if (!isEmpty(configResourcePath)) {
+                try {
+                    config = ConfigLoader.load(configResourcePath);
+                } catch (IOException e) {
+                    LOGGER.warning("IOException: " + e.getMessage());
+                }
+                if (config == null) {
+                    throw new CacheException("Could not find configuration file: "
+                            + configResourcePath);
+                }
+            }
+            if (instanceName != null) {
+                instance = getHazelcastInstanceByName(instanceName);
+                if (instance == null) {
+                    try {
+                        createOrGetInstance();
+                    } catch (DuplicateInstanceNameException ignored) {
+                        instance = getHazelcastInstanceByName(instanceName);
+                    }
+                }
+            } else {
+                createOrGetInstance();
+            }
+            return instance;
+        }
+    }
+
+    private void createOrGetInstance() throws DuplicateInstanceNameException {
+        if (config == null) {
+            config = new XmlConfigBuilder().build();
+        }
+        config.setInstanceName(instanceName);
+        instance = factory.newHazelcastInstance(config);
+    }
+
+    public void unloadInstance() throws CacheException {
+        if (CacheEnvironment.isNativeClient(props)) {
+            if (client == null) {
+                return;
+            }
+            try {
+                client.getLifecycleService().shutdown();
+                client = null;
+            } catch (Exception e) {
+                throw new CacheException(e);
+            }
+        } else {
+            if (instance == null) {
+                return;
+            }
+            final boolean shutDown = CacheEnvironment.shutdownOnStop(props, (instanceName == null));
+            if (!shutDown) {
+                LOGGER.warning(CacheEnvironment.SHUTDOWN_ON_STOP + " property is set to 'false'. "
+                        + "Leaving current HazelcastInstance active! (Warning: Do not disable Hazelcast "
+                        + GroupProperties.PROP_SHUTDOWNHOOK_ENABLED + " property!)");
+                return;
+            }
+            try {
+                instance.getLifecycleService().shutdown();
+                instance = null;
+                factory.shutdownAll();
+            } catch (Exception e) {
+                throw new CacheException(e);
+            }
+        }
+    }
+
+    public TestHazelcastFactory getInstanceFactory() throws CacheException {
+        return factory;
+    }
+
+    public void setInstanceFactory(TestHazelcastFactory factory) {
+        this.factory = factory;
+    }
+
+    private static boolean isEmpty(String s) {
+        return s == null || s.trim().length() == 0;
+    }
+
+    private HazelcastInstance getHazelcastInstanceByName(String instanceName) {
+        HazelcastInstance foundInstance = null;
+        for (HazelcastInstance instance : factory.getAllHazelcastInstances()) {
+            if(instanceName.equals(instance.getName())) {
+                foundInstance = instance;
+            }
+        }
+        return foundInstance;
+    }
+
+    private ClientConfig buildClientConfig(String configResourcePath) {
+        ClientConfig clientConfig = null;
+        if (configResourcePath != null) {
+            try {
+                clientConfig = new XmlClientConfigBuilder(configResourcePath).build();
+            } catch (IOException e) {
+                LOGGER.warning("Could not load client configuration: " + configResourcePath, e);
+            }
+        }
+        if (clientConfig == null) {
+            clientConfig = new ClientConfig();
+            final ClientNetworkConfig networkConfig = clientConfig.getNetworkConfig();
+            networkConfig.setSmartRouting(true);
+            networkConfig.setRedoOperation(true);
+            networkConfig.setConnectionAttemptLimit(CONNECTION_ATTEMPT_LIMIT);
+        }
+        return clientConfig;
+    }
+}

--- a/hazelcast-hibernate/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/local/LocalRegionCacheTest.java
+++ b/hazelcast-hibernate/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/local/LocalRegionCacheTest.java
@@ -6,6 +6,7 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.ITopic;
 import com.hazelcast.core.MessageListener;
 import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.hibernate.cache.spi.CacheDataDescription;
 import org.junit.Test;
@@ -17,7 +18,7 @@ import java.util.Comparator;
 import static org.mockito.Mockito.*;
 
 @RunWith(HazelcastSerialClassRunner.class)
-@Category(QuickTest.class)
+@Category({QuickTest.class, ParallelTest.class})
 @SuppressWarnings("unchecked")
 public class LocalRegionCacheTest {
 

--- a/hazelcast-hibernate/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/region/HazelcastQueryResultsRegionTest.java
+++ b/hazelcast-hibernate/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/region/HazelcastQueryResultsRegionTest.java
@@ -8,6 +8,7 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.hibernate.local.LocalRegionCache;
 import com.hazelcast.hibernate.local.LocalRegionCacheTest;
 import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -22,7 +23,7 @@ import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 @RunWith(HazelcastSerialClassRunner.class)
-@Category(QuickTest.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class HazelcastQueryResultsRegionTest {
 
     private static final String REGION_NAME = "query.test";

--- a/hazelcast-hibernate/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/serialization/ExpiryMarkerTest.java
+++ b/hazelcast-hibernate/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/serialization/ExpiryMarkerTest.java
@@ -1,6 +1,7 @@
 package com.hazelcast.hibernate.serialization;
 
 import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.hibernate.internal.util.compare.ComparableComparator;
 import org.junit.Test;
@@ -10,7 +11,7 @@ import org.junit.runner.RunWith;
 import static org.junit.Assert.*;
 
 @RunWith(HazelcastSerialClassRunner.class)
-@Category(QuickTest.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class ExpiryMarkerTest {
 
     @Test

--- a/hazelcast-hibernate/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/serialization/HibernateSerializationHookAvailableTest.java
+++ b/hazelcast-hibernate/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/serialization/HibernateSerializationHookAvailableTest.java
@@ -23,6 +23,7 @@ import com.hazelcast.instance.HazelcastInstanceProxy;
 import com.hazelcast.nio.serialization.SerializationService;
 import com.hazelcast.nio.serialization.impl.SerializationServiceImpl;
 import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.hibernate.cache.spi.CacheKey;
 import org.hibernate.cache.spi.entry.CacheEntry;
@@ -37,7 +38,7 @@ import java.util.concurrent.ConcurrentMap;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastSerialClassRunner.class)
-@Category(QuickTest.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class HibernateSerializationHookAvailableTest {
 
     private static final Field ORIGINAL;

--- a/hazelcast-hibernate/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/serialization/HibernateSerializationHookNonAvailableTest.java
+++ b/hazelcast-hibernate/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/serialization/HibernateSerializationHookNonAvailableTest.java
@@ -17,6 +17,7 @@
 package com.hazelcast.hibernate.serialization;
 
 import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.util.FilteringClassLoader;
 import org.hibernate.cache.spi.CacheKey;
@@ -34,7 +35,7 @@ import java.util.concurrent.ConcurrentMap;
 import static org.junit.Assert.assertFalse;
 
 @RunWith(HazelcastSerialClassRunner.class)
-@Category(QuickTest.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class HibernateSerializationHookNonAvailableTest {
 
     private static final Field ORIGINAL;

--- a/hazelcast-hibernate/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/serialization/ValueTest.java
+++ b/hazelcast-hibernate/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/serialization/ValueTest.java
@@ -1,6 +1,7 @@
 package com.hazelcast.hibernate.serialization;
 
 import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.hibernate.internal.util.compare.ComparableComparator;
 import org.junit.Test;
@@ -10,7 +11,7 @@ import org.junit.runner.RunWith;
 import static org.junit.Assert.*;
 
 @RunWith(HazelcastSerialClassRunner.class)
-@Category(QuickTest.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class ValueTest {
 
     @Test

--- a/hazelcast-hibernate/pom.xml
+++ b/hazelcast-hibernate/pom.xml
@@ -144,7 +144,13 @@
             <groupId>com.hazelcast</groupId>
             <artifactId>hazelcast-client</artifactId>
             <version>${project.parent.version}</version>
-            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>com.hazelcast</groupId>
+            <artifactId>hazelcast-client</artifactId>
+            <scope>test</scope>
+            <version>${project.parent.version}</version>
+            <classifier>tests</classifier>
         </dependency>
         <dependency>
             <groupId>com.hazelcast</groupId>


### PR DESCRIPTION
Most of the hibernate tests are wired to use mock network. Removed unnecessary sleep calls in tests.
Also added ParallelTest category to all quick tests.  Splits PR https://github.com/hazelcast/hazelcast/pull/5967 into two commits. 