### PR TITLE
Exception send to new client via old protocol

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractMessageTask.java
@@ -129,7 +129,7 @@ public abstract class AbstractMessageTask<P>
         } else {
             exception = new HazelcastInstanceNotActiveException();
         }
-        endpoint.sendResponse(exception, clientMessage.getCorrelationId());
+        sendClientMessage(exception);
         endpointManager.removeEndpoint(endpoint);
     }
 


### PR DESCRIPTION
In case there is a authentication failure, exception is send as
packet, but rather it should be send as client message.

fixes #5976