### PR TITLE
[Forward-Port] Introduced Operation.onFailure() to deal with failures on operation execution

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/AbstractCacheOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/AbstractCacheOperation.java
@@ -74,7 +74,7 @@ abstract class AbstractCacheOperation
     }
 
     @Override
-    public ExceptionAction onException(Throwable throwable) {
+    public ExceptionAction onInvocationException(Throwable throwable) {
         if (throwable instanceof CacheNotExistsException) {
             ICacheService cacheService = getService();
             if (cacheService.getCacheConfig(name) != null) {
@@ -82,7 +82,7 @@ abstract class AbstractCacheOperation
                 return ExceptionAction.RETRY_INVOCATION;
             }
         }
-        return super.onException(throwable);
+        return super.onInvocationException(throwable);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/executor/impl/operations/MemberCallableTaskOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/executor/impl/operations/MemberCallableTaskOperation.java
@@ -34,11 +34,11 @@ public final class MemberCallableTaskOperation extends BaseCallableTaskOperation
     }
 
     @Override
-    public ExceptionAction onException(Throwable throwable) {
+    public ExceptionAction onInvocationException(Throwable throwable) {
         if (throwable instanceof MemberLeftException || throwable instanceof TargetNotMemberException) {
             return ExceptionAction.THROW_EXCEPTION;
         }
-        return super.onException(throwable);
+        return super.onInvocationException(throwable);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/QueryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/QueryOperation.java
@@ -193,14 +193,14 @@ public class QueryOperation extends AbstractMapOperation implements ReadonlyOper
     }
 
     @Override
-    public ExceptionAction onException(Throwable throwable) {
+    public ExceptionAction onInvocationException(Throwable throwable) {
         if (throwable instanceof MemberLeftException) {
             return ExceptionAction.THROW_EXCEPTION;
         }
         if (throwable instanceof TargetNotMemberException) {
             return ExceptionAction.THROW_EXCEPTION;
         }
-        return super.onException(throwable);
+        return super.onInvocationException(throwable);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/partition/impl/BaseMigrationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/impl/BaseMigrationOperation.java
@@ -56,14 +56,14 @@ public abstract class BaseMigrationOperation extends AbstractOperation
     }
 
     @Override
-    public ExceptionAction onException(Throwable throwable) {
+    public ExceptionAction onInvocationException(Throwable throwable) {
         if (throwable instanceof MemberLeftException) {
             return ExceptionAction.THROW_EXCEPTION;
         }
         if (!migrationInfo.isValid()) {
             return ExceptionAction.THROW_EXCEPTION;
         }
-        return super.onException(throwable);
+        return super.onInvocationException(throwable);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/partition/impl/HasOngoingMigration.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/impl/HasOngoingMigration.java
@@ -33,14 +33,14 @@ public final class HasOngoingMigration extends AbstractOperation {
     }
 
     @Override
-    public ExceptionAction onException(Throwable throwable) {
+    public ExceptionAction onInvocationException(Throwable throwable) {
         if (throwable instanceof MemberLeftException) {
             return ExceptionAction.THROW_EXCEPTION;
         }
         if (throwable instanceof TargetNotMemberException) {
             return ExceptionAction.THROW_EXCEPTION;
         }
-        return super.onException(throwable);
+        return super.onInvocationException(throwable);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/partition/impl/MigrationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/impl/MigrationOperation.java
@@ -56,6 +56,8 @@ public final class MigrationOperation extends BaseMigrationOperation {
     private long[] replicaVersions;
     private Collection<Operation> tasks;
 
+    private Throwable failureReason;
+
     public MigrationOperation() {
     }
 
@@ -78,6 +80,11 @@ public final class MigrationOperation extends BaseMigrationOperation {
             doRun();
         } catch (Throwable t) {
             logMigrationFailure(t);
+            failureReason = t;
+        } finally {
+            if (!success) {
+                onExecutionFailure(failureReason);
+            }
         }
     }
 
@@ -87,11 +94,13 @@ public final class MigrationOperation extends BaseMigrationOperation {
                 migrate();
             } catch (Throwable e) {
                 success = false;
+                failureReason = e;
                 getLogger().severe("Error while processing " + migrationInfo, e);
             } finally {
                 afterMigrate();
             }
         } else {
+            success = false;
             logMigrationCancelled();
         }
     }
@@ -142,10 +151,13 @@ public final class MigrationOperation extends BaseMigrationOperation {
         addActiveMigration();
 
         for (Operation op : tasks) {
+            prepareOperation(op);
             try {
                 runMigrationTask(op);
             } catch (Throwable e) {
                 getLogger().severe("An exception occurred while executing migration operation " + op, e);
+                success = false;
+                failureReason = e;
                 return;
             }
         }
@@ -158,11 +170,6 @@ public final class MigrationOperation extends BaseMigrationOperation {
     }
 
     private void runMigrationTask(Operation op) throws Exception {
-        op.setNodeEngine(getNodeEngine())
-                .setPartitionId(getPartitionId())
-                .setReplicaIndex(getReplicaIndex());
-        op.setOperationResponseHandler(ERROR_RESPONSE_HANDLER);
-        OperationAccessor.setCallerAddress(op, migrationInfo.getSource());
         MigrationAwareService service = op.getService();
         PartitionMigrationEvent event =
                 new PartitionMigrationEvent(MigrationEndpoint.DESTINATION, migrationInfo.getPartitionId());
@@ -170,6 +177,32 @@ public final class MigrationOperation extends BaseMigrationOperation {
         op.beforeRun();
         op.run();
         op.afterRun();
+    }
+
+    private void prepareOperation(Operation op) {
+        op.setNodeEngine(getNodeEngine())
+                .setPartitionId(getPartitionId())
+                .setReplicaIndex(getReplicaIndex());
+        op.setOperationResponseHandler(ERROR_RESPONSE_HANDLER);
+        OperationAccessor.setCallerAddress(op, migrationInfo.getSource());
+    }
+
+    @Override
+    public void onExecutionFailure(Throwable e) {
+        if (tasks != null) {
+            for (Operation op : tasks) {
+                prepareOperation(op);
+                onOperationFailure(op, e);
+            }
+        }
+    }
+
+    private void onOperationFailure(Operation op, Throwable e) {
+        try {
+            op.onExecutionFailure(e);
+        } catch (Throwable t) {
+            getLogger().warning("While calling operation.onFailure(). op: " + op, t);
+        }
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/partition/impl/MigrationRequestOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/impl/MigrationRequestOperation.java
@@ -174,11 +174,11 @@ public final class MigrationRequestOperation extends BaseMigrationOperation {
     }
 
     @Override
-    public ExceptionAction onException(Throwable throwable) {
+    public ExceptionAction onInvocationException(Throwable throwable) {
         if (throwable instanceof TargetNotMemberException) {
             return ExceptionAction.THROW_EXCEPTION;
         }
-        return super.onException(throwable);
+        return super.onInvocationException(throwable);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/spi/Operation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/Operation.java
@@ -385,9 +385,27 @@ public abstract class Operation implements DataSerializable {
         setFlag(timeout != -1, BITMASK_WAIT_TIMEOUT_SET);
     }
 
+    /**
+     * @deprecated Use & override {@link #onInvocationException(Throwable)} instead.
+     */
+    @Deprecated
     public ExceptionAction onException(Throwable throwable) {
         return (throwable instanceof RetryableException)
                 ? ExceptionAction.RETRY_INVOCATION : ExceptionAction.THROW_EXCEPTION;
+    }
+
+    /**
+     * Called when an <tt>Exception</tt>/<tt>Error</tt> is thrown
+     * during an invocation. Invocation process will continue, retry
+     * or fail according to returned <tt>ExceptionAction</tt> result.
+     * <p/>
+     * This method is called on caller side of the invocation.
+     *
+     * @param throwable <tt>Exception</tt>/<tt>Error</tt> thrown during invocation
+     * @return <tt>ExceptionAction</tt>
+     */
+    public ExceptionAction onInvocationException(Throwable throwable) {
+        return onException(throwable);
     }
 
     public String getCallerUuid() {

--- a/hazelcast/src/main/java/com/hazelcast/spi/Operation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/Operation.java
@@ -421,6 +421,28 @@ public abstract class Operation implements DataSerializable {
         return flags;
     }
 
+
+    /**
+     * Called when an <tt>Exception</tt>/<tt>Error</tt> is thrown during operation execution.
+     * <p/>
+     * By default this method does nothing.
+     * Operation implementations can override this behaviour due to their needs.
+     * <p/>
+     * This method is called on node & thread that's executing the operation.
+     *
+     * @param e Exception/Error thrown during operation execution
+     */
+    public void onExecutionFailure(Throwable e) {
+    }
+
+    /**
+     * Logs <tt>Exception</tt>/<tt>Error</tt> thrown during operation execution.
+     * Operation implementations can override this behaviour due to their needs.
+     * <p/>
+     * This method is called on node & thread that's executing the operation.
+     *
+     * @param e Exception/Error thrown during operation execution
+     */
     public void logError(Throwable e) {
         final ILogger logger = getLogger();
         if (e instanceof RetryableException) {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImpl.java
@@ -291,6 +291,12 @@ class OperationRunnerImpl extends OperationRunner {
         if (e instanceof OutOfMemoryError) {
             OutOfMemoryErrorDispatcher.onOutOfMemory((OutOfMemoryError) e);
         }
+        try {
+            operation.onExecutionFailure(e);
+        } catch (Throwable t) {
+            logger.warning("While calling 'operation.onFailure(e)'... op: " + operation + ", error: " + e, t);
+        }
+
         operation.logError(e);
 
         OperationResponseHandler responseHandler = operation.getOperationResponseHandler();

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/PartitionInvocation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/PartitionInvocation.java
@@ -42,7 +42,7 @@ public final class PartitionInvocation extends Invocation {
 
     @Override
     ExceptionAction onException(Throwable t) {
-        final ExceptionAction action = op.onException(t);
+        final ExceptionAction action = op.onInvocationException(t);
         return action != null ? action : ExceptionAction.THROW_EXCEPTION;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/TargetInvocation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/TargetInvocation.java
@@ -46,6 +46,6 @@ public final class TargetInvocation extends Invocation {
 
     @Override
     ExceptionAction onException(Throwable t) {
-        return t instanceof MemberLeftException ? ExceptionAction.THROW_EXCEPTION : op.onException(t);
+        return t instanceof MemberLeftException ? ExceptionAction.THROW_EXCEPTION : op.onInvocationException(t);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/operations/Backup.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/operations/Backup.java
@@ -141,6 +141,17 @@ public final class Backup extends Operation implements BackupOperation, Identifi
     }
 
     @Override
+    public void onExecutionFailure(Throwable e) {
+        if (backupOp != null) {
+            try {
+                backupOp.onExecutionFailure(e);
+            } catch (Throwable t) {
+                getLogger().warning("While calling operation.onFailure(). op: " + backupOp, t);
+            }
+        }
+    }
+
+    @Override
     public void logError(Throwable e) {
         if (backupOp != null) {
             backupOp.logError(e);

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/operations/BeginTxBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/operations/BeginTxBackupOperation.java
@@ -53,11 +53,11 @@ public final class BeginTxBackupOperation extends TxBaseOperation {
     }
 
     @Override
-    public ExceptionAction onException(Throwable throwable) {
+    public ExceptionAction onInvocationException(Throwable throwable) {
         if (throwable instanceof MemberLeftException || throwable instanceof TargetNotMemberException) {
             return THROW_EXCEPTION;
         }
-        return super.onException(throwable);
+        return super.onInvocationException(throwable);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/operations/BroadcastTxRollbackOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/operations/BroadcastTxRollbackOperation.java
@@ -59,11 +59,11 @@ public final class BroadcastTxRollbackOperation extends TxBaseOperation {
     }
 
     @Override
-    public ExceptionAction onException(Throwable throwable) {
+    public ExceptionAction onInvocationException(Throwable throwable) {
         if (throwable instanceof MemberLeftException) {
             return THROW_EXCEPTION;
         }
-        return super.onException(throwable);
+        return super.onInvocationException(throwable);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/operations/PurgeTxBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/operations/PurgeTxBackupOperation.java
@@ -46,11 +46,11 @@ public final class PurgeTxBackupOperation extends TxBaseOperation {
     }
 
     @Override
-    public ExceptionAction onException(Throwable throwable) {
+    public ExceptionAction onInvocationException(Throwable throwable) {
         if (throwable instanceof MemberLeftException || throwable instanceof TargetNotMemberException) {
             return THROW_EXCEPTION;
         }
-        return super.onException(throwable);
+        return super.onInvocationException(throwable);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/operations/ReplicateTxOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/operations/ReplicateTxOperation.java
@@ -64,11 +64,11 @@ public final class ReplicateTxOperation extends TxBaseOperation {
     }
 
     @Override
-    public ExceptionAction onException(Throwable throwable) {
+    public ExceptionAction onInvocationException(Throwable throwable) {
         if (throwable instanceof MemberLeftException || throwable instanceof TargetNotMemberException) {
             return THROW_EXCEPTION;
         }
-        return super.onException(throwable);
+        return super.onInvocationException(throwable);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/operations/RollbackTxBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/operations/RollbackTxBackupOperation.java
@@ -51,11 +51,11 @@ public final class RollbackTxBackupOperation extends TxBaseOperation {
     }
 
     @Override
-    public ExceptionAction onException(Throwable throwable) {
+    public ExceptionAction onInvocationException(Throwable throwable) {
         if (throwable instanceof MemberLeftException || throwable instanceof TargetNotMemberException) {
             return THROW_EXCEPTION;
         }
-        return super.onException(throwable);
+        return super.onInvocationException(throwable);
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationNetworkSplitTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationNetworkSplitTest.java
@@ -218,7 +218,7 @@ public class InvocationNetworkSplitTest extends HazelcastTestSupport {
         }
 
         @Override
-        public ExceptionAction onException(Throwable throwable) {
+        public ExceptionAction onInvocationException(Throwable throwable) {
             return ExceptionAction.THROW_EXCEPTION;
         }
     }

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OperationFailureTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OperationFailureTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi.impl.operationservice.impl;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.spi.AbstractOperation;
+import com.hazelcast.spi.BackupAwareOperation;
+import com.hazelcast.spi.BackupOperation;
+import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.exception.WrongTargetException;
+import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.ExpectedRuntimeException;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.Assert.assertNotNull;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class OperationFailureTest extends HazelcastTestSupport {
+
+    // static reference to store backup operation failure
+    private static final AtomicReference<Throwable> backupOperationFailure = new AtomicReference<Throwable>();
+
+    @Test
+    public void onFailure_shouldBeCalled_whenOperationExecutionFails() {
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+        HazelcastInstance hz = factory.newHazelcastInstance();
+        NodeEngineImpl nodeEngine = getNodeEngineImpl(hz);
+
+        FailingOperation op = new FailingOperation(new CountDownLatch(1));
+        nodeEngine.getOperationService().executeOperation(op);
+
+        assertOpenEventually(op.latch);
+        assertInstanceOf(ExpectedRuntimeException.class, op.failure);
+    }
+
+    @Test
+    public void onFailure_shouldBeCalled_whenOperationIsRejected() {
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+        HazelcastInstance hz = factory.newHazelcastInstance();
+        NodeEngineImpl nodeEngine = getNodeEngineImpl(hz);
+
+        FailingOperation op = new FailingOperation(new CountDownLatch(1));
+        op.setPartitionId(1).setReplicaIndex(1);
+        nodeEngine.getOperationService().executeOperation(op);
+
+        assertOpenEventually(op.latch);
+        assertInstanceOf(WrongTargetException.class, op.failure);
+    }
+
+    @Test
+    public void onFailure_shouldBeCalled_whenBackupExecutionFails() {
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+        HazelcastInstance hz = factory.newHazelcastInstance();
+        HazelcastInstance hz2 = factory.newHazelcastInstance();
+        warmUpPartitions(hz, hz2);
+
+        NodeEngineImpl nodeEngine = getNodeEngineImpl(hz);
+
+        nodeEngine.getOperationService().invokeOnPartition(null, new EmptyBackupAwareOperation(), 0);
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertNotNull(backupOperationFailure.get());
+            }
+        });
+
+        Throwable failure = backupOperationFailure.getAndSet(null);
+        assertInstanceOf(ExpectedRuntimeException.class, failure);
+    }
+
+    private static class FailingOperation extends AbstractOperation {
+        final CountDownLatch latch;
+        volatile Throwable failure;
+
+        FailingOperation(CountDownLatch latch) {
+            this.latch = latch;
+        }
+
+        @Override
+        public void run() throws Exception {
+            throw new ExpectedRuntimeException();
+        }
+
+        @Override
+        public void onExecutionFailure(Throwable e) {
+            failure = e;
+            latch.countDown();
+        }
+    }
+
+    private static class EmptyBackupAwareOperation extends AbstractOperation implements BackupAwareOperation {
+
+        @Override
+        public void run() throws Exception {
+        }
+
+        @Override
+        public boolean shouldBackup() {
+            return true;
+        }
+
+        @Override
+        public int getSyncBackupCount() {
+            return 1;
+        }
+
+        @Override
+        public int getAsyncBackupCount() {
+            return 0;
+        }
+
+        @Override
+        public Operation getBackupOperation() {
+            return new FailingBackupOperation();
+        }
+    }
+
+    private static class FailingBackupOperation extends AbstractOperation implements BackupOperation {
+        @Override
+        public void run() throws Exception {
+            throw new ExpectedRuntimeException();
+        }
+
+        @Override
+        public void onExecutionFailure(Throwable e) {
+            backupOperationFailure.set(e);
+        }
+    }
+}


### PR DESCRIPTION
Introduced Operation.onFailure() to deal with failures on operation execution. Normally, this isn't needed for current heap based operations. But operations using/allocating native/un-managed resources require a better failure handling to be able release/clean up those resources.

forward port from https://github.com/hazelcast/hazelcast/pull/6008