### PR TITLE
Removing the ignore on client queue disruption test.

### DIFF
--- a/hazelcast-client-new/src/test/java/com/hazelcast/client/queue/ClientQueueDisruptionTest.java
+++ b/hazelcast-client-new/src/test/java/com/hazelcast/client/queue/ClientQueueDisruptionTest.java
@@ -1,6 +1,5 @@
 package com.hazelcast.client.queue;
 
-import com.hazelcast.client.HazelcastClient;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.test.AssertTask;
@@ -9,7 +8,6 @@ import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.SlowTest;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -42,8 +40,8 @@ public class ClientQueueDisruptionTest extends HazelcastTestSupport {
             cluster.add(hazelcastFactory.newHazelcastInstance());
         }
 
-        client1 = HazelcastClient.newHazelcastClient();
-        client2 = HazelcastClient.newHazelcastClient();
+        client1 = hazelcastFactory.newHazelcastClient();
+        client2 = hazelcastFactory.newHazelcastClient();
     }
 
     @After
@@ -52,7 +50,6 @@ public class ClientQueueDisruptionTest extends HazelcastTestSupport {
     }
 
     @Test
-    @Ignore
     public void clientsConsume_withNodeShutdown() throws InterruptedException {
 
         final int initial = 2000, max = 8000;
@@ -111,7 +108,7 @@ public class ClientQueueDisruptionTest extends HazelcastTestSupport {
     }
 
     private HazelcastInstance getRandomNode() {
-        int index = random.nextInt(CLUSTER_SIZE);
+        int index = random.nextInt(cluster.size());
         return cluster.get(index);
     }
 

--- a/hazelcast-client/src/test/java/com/hazelcast/client/queue/ClientQueueDisruptionTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/queue/ClientQueueDisruptionTest.java
@@ -1,6 +1,5 @@
 package com.hazelcast.client.queue;
 
-import com.hazelcast.client.HazelcastClient;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.test.AssertTask;
@@ -9,7 +8,6 @@ import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.SlowTest;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -42,8 +40,8 @@ public class ClientQueueDisruptionTest extends HazelcastTestSupport {
             cluster.add(hazelcastFactory.newHazelcastInstance());
         }
 
-        client1 = HazelcastClient.newHazelcastClient();
-        client2 = HazelcastClient.newHazelcastClient();
+        client1 = hazelcastFactory.newHazelcastClient();
+        client2 = hazelcastFactory.newHazelcastClient();
     }
 
     @After
@@ -52,7 +50,6 @@ public class ClientQueueDisruptionTest extends HazelcastTestSupport {
     }
 
     @Test
-    @Ignore
     public void clientsConsume_withNodeShutdown() throws InterruptedException {
 
         final int initial = 2000, max = 8000;
@@ -111,7 +108,7 @@ public class ClientQueueDisruptionTest extends HazelcastTestSupport {
     }
 
     private HazelcastInstance getRandomNode() {
-        int index = random.nextInt(CLUSTER_SIZE);
+        int index = random.nextInt(cluster.size());
         return cluster.get(index);
     }
 


### PR DESCRIPTION
Test is possibly fixed by #6000 and #5829.
Test did not fail in local.

fixes #4549