### PR TITLE
Cleanup of GroupProperties

### DIFF
--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/config/ClientConfig.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/config/ClientConfig.java
@@ -27,6 +27,7 @@ import com.hazelcast.config.SerializationConfig;
 import com.hazelcast.config.SocketInterceptorConfig;
 import com.hazelcast.config.matcher.MatchingPointConfigPatternMatcher;
 import com.hazelcast.core.ManagedContext;
+import com.hazelcast.instance.HazelcastProperty;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.security.Credentials;
@@ -117,7 +118,7 @@ public class ClientConfig {
     }
 
     /**
-     * Gets a property already set or from system properties if not exists.
+     * Gets a named property already set or from system properties if not exists.
      *
      * @param name property name
      * @return value of the property
@@ -128,7 +129,7 @@ public class ClientConfig {
     }
 
     /**
-     * Sets the value of a named property
+     * Sets the value of a named property.
      *
      * @param name  property name
      * @param value value of the property
@@ -138,6 +139,28 @@ public class ClientConfig {
     public ClientConfig setProperty(String name, String value) {
         properties.put(name, value);
         return this;
+    }
+
+    /**
+     * Gets a {@link HazelcastProperty} already set or from system properties if not exists.
+     *
+     * @param property {@link HazelcastProperty} to get
+     * @return value of the property
+     */
+    public String getProperty(HazelcastProperty property) {
+        return getProperty(property.getName());
+    }
+
+    /**
+     * Sets the value of a {@link HazelcastProperty}.
+     *
+     * @param property {@link HazelcastProperty} to set
+     * @param value    value of the property
+     * @return configured {@link com.hazelcast.client.config.ClientConfig} for chaining
+     * @see {@link com.hazelcast.client.config.ClientProperties} for properties that is used to configure client
+     */
+    public ClientConfig setProperty(HazelcastProperty property, String value) {
+        return setProperty(property.getName(), value);
     }
 
     /**

--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/impl/DefaultClientExtension.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/impl/DefaultClientExtension.java
@@ -25,7 +25,7 @@ import com.hazelcast.client.spi.ClientProxy;
 import com.hazelcast.config.SerializationConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.PartitioningStrategy;
-import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.map.impl.MapService;
@@ -52,7 +52,6 @@ public class DefaultClientExtension implements ClientExtension {
 
     @Override
     public void afterStart(HazelcastClientInstanceImpl client) {
-
     }
 
     public SerializationService createSerializationService() {
@@ -80,7 +79,7 @@ public class DefaultClientExtension implements ClientExtension {
     }
 
     protected PartitioningStrategy getPartitioningStrategy(ClassLoader configClassLoader) throws Exception {
-        String partitioningStrategyClassName = System.getProperty(GroupProperties.PROP_PARTITIONING_STRATEGY_CLASS);
+        String partitioningStrategyClassName = GroupProperty.PARTITIONING_STRATEGY_CLASS.getSystemProperty();
         if (partitioningStrategyClassName != null && partitioningStrategyClassName.length() > 0) {
             return ClassLoaderUtil.newInstance(configClassLoader, partitioningStrategyClassName);
         } else {
@@ -115,5 +114,4 @@ public class DefaultClientExtension implements ClientExtension {
         // Currently "DefaultNearCacheManager" is enough.
         return new DefaultNearCacheManager();
     }
-
 }

--- a/hazelcast-client-new/src/test/java/com/hazelcast/client/ClientServiceTest.java
+++ b/hazelcast-client-new/src/test/java/com/hazelcast/client/ClientServiceTest.java
@@ -28,7 +28,7 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.core.LifecycleEvent;
 import com.hazelcast.core.LifecycleListener;
-import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
@@ -293,7 +293,7 @@ public class ClientServiceTest extends HazelcastTestSupport {
     @Test
     public void testClientListenerDisconnected() throws InterruptedException {
         Config config = new Config();
-        config.setProperty(GroupProperties.PROP_IO_THREAD_COUNT, "1");
+        config.setProperty(GroupProperty.IO_THREAD_COUNT, "1");
 
         final HazelcastInstance hz = hazelcastFactory.newHazelcastInstance(config);
         final HazelcastInstance hz2 = hazelcastFactory.newHazelcastInstance(config);

--- a/hazelcast-client-new/src/test/java/com/hazelcast/client/ClientSplitBrainTest.java
+++ b/hazelcast-client-new/src/test/java/com/hazelcast/client/ClientSplitBrainTest.java
@@ -9,7 +9,7 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.core.LifecycleEvent;
 import com.hazelcast.core.LifecycleListener;
-import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
@@ -40,8 +40,8 @@ public class ClientSplitBrainTest extends HazelcastTestSupport {
     @Test
     public void testClientListeners_InSplitBrain() throws Throwable {
         Config config = new Config();
-        config.setProperty(GroupProperties.PROP_MERGE_FIRST_RUN_DELAY_SECONDS, "5");
-        config.setProperty(GroupProperties.PROP_MERGE_NEXT_RUN_DELAY_SECONDS, "5");
+        config.setProperty(GroupProperty.MERGE_FIRST_RUN_DELAY_SECONDS, "5");
+        config.setProperty(GroupProperty.MERGE_NEXT_RUN_DELAY_SECONDS, "5");
         HazelcastInstance h1 = Hazelcast.newHazelcastInstance(config);
         HazelcastInstance h2 = Hazelcast.newHazelcastInstance(config);
 

--- a/hazelcast-client-new/src/test/java/com/hazelcast/client/SimpleMapTestFromClient.java
+++ b/hazelcast-client-new/src/test/java/com/hazelcast/client/SimpleMapTestFromClient.java
@@ -20,7 +20,7 @@ import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
-import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.instance.GroupProperty;
 import org.junit.Ignore;
 
 import java.util.Random;
@@ -32,7 +32,7 @@ import java.util.concurrent.atomic.AtomicLong;
 public class SimpleMapTestFromClient {
 
     static {
-        System.setProperty(GroupProperties.PROP_WAIT_SECONDS_BEFORE_JOIN, "0");
+        GroupProperty.WAIT_SECONDS_BEFORE_JOIN.setSystemProperty("0");
         System.setProperty("java.net.preferIPv4Stack", "true");
         System.setProperty("hazelcast.local.localAddress", "127.0.0.1");
         System.setProperty("hazelcast.version.check.enabled", "false");

--- a/hazelcast-client-new/src/test/java/com/hazelcast/client/lock/ClientLockTest.java
+++ b/hazelcast-client-new/src/test/java/com/hazelcast/client/lock/ClientLockTest.java
@@ -20,7 +20,7 @@ import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.ILock;
-import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
@@ -284,7 +284,7 @@ public class ClientLockTest extends HazelcastTestSupport {
     @Test
     public void testMaxLockLeaseTime() {
         Config config = new Config();
-        config.setProperty(GroupProperties.PROP_LOCK_MAX_LEASE_TIME_SECONDS, "1");
+        config.setProperty(GroupProperty.LOCK_MAX_LEASE_TIME_SECONDS, "1");
 
         factory.newHazelcastInstance(config);
 
@@ -304,7 +304,7 @@ public class ClientLockTest extends HazelcastTestSupport {
     @Test(expected = IllegalArgumentException.class)
     public void testLockFail_whenGreaterThanMaxLeaseTimeUsed() {
         Config config = new Config();
-        config.setProperty(GroupProperties.PROP_LOCK_MAX_LEASE_TIME_SECONDS, "1");
+        config.setProperty(GroupProperty.LOCK_MAX_LEASE_TIME_SECONDS, "1");
 
         factory.newHazelcastInstance(config);
 

--- a/hazelcast-client-new/src/test/java/com/hazelcast/client/map/ClientMapStoreTest.java
+++ b/hazelcast-client-new/src/test/java/com/hazelcast/client/map/ClientMapStoreTest.java
@@ -10,6 +10,7 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.core.MapLoader;
 import com.hazelcast.core.MapStore;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.map.ReachedMaxSizeException;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
@@ -320,9 +321,8 @@ public class ClientMapStoreTest extends HazelcastTestSupport {
     }
 
     private int getMaxCapacity(HazelcastInstance node) {
-        return getNode(node).getNodeEngine().getGroupProperties().MAP_WRITE_BEHIND_QUEUE_CAPACITY.getInteger();
+        return getNode(node).getNodeEngine().getGroupProperties().getInteger(GroupProperty.MAP_WRITE_BEHIND_QUEUE_CAPACITY);
     }
-
 
     @Test
     public void testIssue3023_testWithSubStringMapNames() throws Exception {

--- a/hazelcast-client-new/src/test/java/com/hazelcast/client/map/ClientMapUnboundReturnValuesTestSupport.java
+++ b/hazelcast-client-new/src/test/java/com/hazelcast/client/map/ClientMapUnboundReturnValuesTestSupport.java
@@ -6,7 +6,7 @@ import com.hazelcast.config.MapConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.core.TransactionalMap;
-import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.map.QueryResultSizeExceededException;
 import com.hazelcast.map.impl.QueryResultSizeLimiter;
 import com.hazelcast.query.TruePredicate;
@@ -148,9 +148,9 @@ public abstract class ClientMapUnboundReturnValuesTestSupport {
 
     private Config createConfig(int partitionCount, int limit, int preCheckTrigger) {
         Config config = new Config();
-        config.setProperty(GroupProperties.PROP_PARTITION_COUNT, String.valueOf(partitionCount));
-        config.setProperty(GroupProperties.PROP_QUERY_RESULT_SIZE_LIMIT, String.valueOf(limit));
-        config.setProperty(GroupProperties.PROP_QUERY_MAX_LOCAL_PARTITION_LIMIT_FOR_PRE_CHECK, String.valueOf(preCheckTrigger));
+        config.setProperty(GroupProperty.PARTITION_COUNT, String.valueOf(partitionCount));
+        config.setProperty(GroupProperty.QUERY_RESULT_SIZE_LIMIT, String.valueOf(limit));
+        config.setProperty(GroupProperty.QUERY_MAX_LOCAL_PARTITION_LIMIT_FOR_PRE_CHECK, String.valueOf(preCheckTrigger));
         return config;
     }
 

--- a/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientConfig.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientConfig.java
@@ -27,6 +27,7 @@ import com.hazelcast.config.SerializationConfig;
 import com.hazelcast.config.SocketInterceptorConfig;
 import com.hazelcast.config.matcher.MatchingPointConfigPatternMatcher;
 import com.hazelcast.core.ManagedContext;
+import com.hazelcast.instance.HazelcastProperty;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.security.Credentials;
@@ -116,7 +117,7 @@ public class ClientConfig {
     }
 
     /**
-     * Gets a property already set or from system properties if not exists.
+     * Gets a named property already set or from system properties if not exists.
      *
      * @param name property name
      * @return value of the property
@@ -127,7 +128,7 @@ public class ClientConfig {
     }
 
     /**
-     * Sets the value of a named property
+     * Sets the value of a named property.
      *
      * @param name  property name
      * @param value value of the property
@@ -137,6 +138,28 @@ public class ClientConfig {
     public ClientConfig setProperty(String name, String value) {
         properties.put(name, value);
         return this;
+    }
+
+    /**
+     * Gets a {@link HazelcastProperty} already set or from system properties if not exists.
+     *
+     * @param property {@link HazelcastProperty} to get
+     * @return value of the property
+     */
+    public String getProperty(HazelcastProperty property) {
+        return getProperty(property.getName());
+    }
+
+    /**
+     * Sets the value of a {@link HazelcastProperty}.
+     *
+     * @param property {@link HazelcastProperty} to set
+     * @param value    value of the property
+     * @return configured {@link com.hazelcast.client.config.ClientConfig} for chaining
+     * @see {@link com.hazelcast.client.config.ClientProperties} for properties that is used to configure client
+     */
+    public ClientConfig setProperty(HazelcastProperty property, String value) {
+        return setProperty(property.getName(), value);
     }
 
     /**

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/DefaultClientExtension.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/DefaultClientExtension.java
@@ -25,7 +25,7 @@ import com.hazelcast.client.spi.ClientProxy;
 import com.hazelcast.config.SerializationConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.PartitioningStrategy;
-import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.map.impl.MapService;
@@ -80,7 +80,7 @@ public class DefaultClientExtension implements ClientExtension {
     }
 
     protected PartitioningStrategy getPartitioningStrategy(ClassLoader configClassLoader) throws Exception {
-        String partitioningStrategyClassName = System.getProperty(GroupProperties.PROP_PARTITIONING_STRATEGY_CLASS);
+        String partitioningStrategyClassName = GroupProperty.PARTITIONING_STRATEGY_CLASS.getSystemProperty();
         if (partitioningStrategyClassName != null && partitioningStrategyClassName.length() > 0) {
             return ClassLoaderUtil.newInstance(configClassLoader, partitioningStrategyClassName);
         } else {

--- a/hazelcast-client/src/test/java/com/hazelcast/client/ClientServiceTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ClientServiceTest.java
@@ -28,7 +28,7 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.core.LifecycleEvent;
 import com.hazelcast.core.LifecycleListener;
-import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
@@ -293,7 +293,7 @@ public class ClientServiceTest extends HazelcastTestSupport {
     @Test
     public void testClientListenerDisconnected() throws InterruptedException {
         Config config = new Config();
-        config.setProperty(GroupProperties.PROP_IO_THREAD_COUNT, "1");
+        config.setProperty(GroupProperty.IO_THREAD_COUNT, "1");
 
         final HazelcastInstance hz = hazelcastFactory.newHazelcastInstance(config);
         final HazelcastInstance hz2 = hazelcastFactory.newHazelcastInstance(config);

--- a/hazelcast-client/src/test/java/com/hazelcast/client/ClientSplitBrainTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ClientSplitBrainTest.java
@@ -9,7 +9,7 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.core.LifecycleEvent;
 import com.hazelcast.core.LifecycleListener;
-import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
@@ -40,8 +40,8 @@ public class ClientSplitBrainTest extends HazelcastTestSupport {
     @Test
     public void testClientListeners_InSplitBrain() throws Throwable {
         Config config = new Config();
-        config.setProperty(GroupProperties.PROP_MERGE_FIRST_RUN_DELAY_SECONDS, "5");
-        config.setProperty(GroupProperties.PROP_MERGE_NEXT_RUN_DELAY_SECONDS, "5");
+        config.setProperty(GroupProperty.MERGE_FIRST_RUN_DELAY_SECONDS, "5");
+        config.setProperty(GroupProperty.MERGE_NEXT_RUN_DELAY_SECONDS, "5");
         HazelcastInstance h1 = Hazelcast.newHazelcastInstance(config);
         HazelcastInstance h2 = Hazelcast.newHazelcastInstance(config);
 

--- a/hazelcast-client/src/test/java/com/hazelcast/client/SimpleMapTestFromClient.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/SimpleMapTestFromClient.java
@@ -20,7 +20,7 @@ import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
-import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.instance.GroupProperty;
 import org.junit.Ignore;
 
 import java.util.Random;
@@ -32,7 +32,7 @@ import java.util.concurrent.atomic.AtomicLong;
 public class SimpleMapTestFromClient {
 
     static {
-        System.setProperty(GroupProperties.PROP_WAIT_SECONDS_BEFORE_JOIN, "0");
+        GroupProperty.WAIT_SECONDS_BEFORE_JOIN.setSystemProperty("0");
         System.setProperty("java.net.preferIPv4Stack", "true");
         System.setProperty("hazelcast.local.localAddress", "127.0.0.1");
         System.setProperty("hazelcast.version.check.enabled", "false");

--- a/hazelcast-client/src/test/java/com/hazelcast/client/io/IndependentBufferSizingTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/io/IndependentBufferSizingTest.java
@@ -20,7 +20,7 @@ import com.hazelcast.client.HazelcastClient;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.instance.Node;
 import com.hazelcast.nio.tcp.nonblocking.NonBlockingSocketReader;
 import com.hazelcast.nio.tcp.TcpIpConnection;
@@ -73,8 +73,8 @@ public class IndependentBufferSizingTest extends HazelcastTestSupport {
         int sendBufferSizeKB = 4;
 
         Config config = new Config();
-        config.setProperty(GroupProperties.PROP_SOCKET_CLIENT_RECEIVE_BUFFER_SIZE, Integer.toString(receiveBufferSizeKB));
-        config.setProperty(GroupProperties.PROP_SOCKET_CLIENT_SEND_BUFFER_SIZE, Integer.toString(sendBufferSizeKB));
+        config.setProperty(GroupProperty.SOCKET_CLIENT_RECEIVE_BUFFER_SIZE, Integer.toString(receiveBufferSizeKB));
+        config.setProperty(GroupProperty.SOCKET_CLIENT_SEND_BUFFER_SIZE, Integer.toString(sendBufferSizeKB));
 
         HazelcastInstance server = Hazelcast.newHazelcastInstance(config);
         HazelcastInstance client = HazelcastClient.newHazelcastClient();
@@ -89,12 +89,12 @@ public class IndependentBufferSizingTest extends HazelcastTestSupport {
 
     private int getDefaultSendBufferSize(HazelcastInstance instance) {
         Node node = getNode(instance);
-        return node.getGroupProperties().SOCKET_SEND_BUFFER_SIZE.getInteger() * 1024;
+        return node.getGroupProperties().getInteger(GroupProperty.SOCKET_SEND_BUFFER_SIZE) * 1024;
     }
 
     private int getDefaultReceiverBufferSize(HazelcastInstance instance) {
         Node node = getNode(instance);
-        return node.getGroupProperties().SOCKET_RECEIVE_BUFFER_SIZE.getInteger() * 1024;
+        return node.getGroupProperties().getInteger(GroupProperty.SOCKET_RECEIVE_BUFFER_SIZE) * 1024;
     }
 
     private TcpIpConnection getClientConnection(HazelcastInstance server) {

--- a/hazelcast-client/src/test/java/com/hazelcast/client/lock/ClientLockTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/lock/ClientLockTest.java
@@ -20,14 +20,13 @@ import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.ILock;
-import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -285,7 +284,7 @@ public class ClientLockTest extends HazelcastTestSupport {
     @Test
     public void testMaxLockLeaseTime() {
         Config config = new Config();
-        config.setProperty(GroupProperties.PROP_LOCK_MAX_LEASE_TIME_SECONDS, "1");
+        config.setProperty(GroupProperty.LOCK_MAX_LEASE_TIME_SECONDS, "1");
 
         factory.newHazelcastInstance(config);
 
@@ -305,7 +304,7 @@ public class ClientLockTest extends HazelcastTestSupport {
     @Test(expected = IllegalArgumentException.class)
     public void testLockFail_whenGreaterThanMaxLeaseTimeUsed() {
         Config config = new Config();
-        config.setProperty(GroupProperties.PROP_LOCK_MAX_LEASE_TIME_SECONDS, "1");
+        config.setProperty(GroupProperty.LOCK_MAX_LEASE_TIME_SECONDS, "1");
 
         factory.newHazelcastInstance(config);
 

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapStoreTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapStoreTest.java
@@ -10,6 +10,7 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.core.MapLoader;
 import com.hazelcast.core.MapStore;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.map.ReachedMaxSizeException;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
@@ -320,7 +321,7 @@ public class ClientMapStoreTest extends HazelcastTestSupport {
     }
 
     private int getMaxCapacity(HazelcastInstance node) {
-        return getNode(node).getNodeEngine().getGroupProperties().MAP_WRITE_BEHIND_QUEUE_CAPACITY.getInteger();
+        return getNode(node).getNodeEngine().getGroupProperties().getInteger(GroupProperty.MAP_WRITE_BEHIND_QUEUE_CAPACITY);
     }
 
 

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapUnboundReturnValuesTestSupport.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapUnboundReturnValuesTestSupport.java
@@ -6,7 +6,7 @@ import com.hazelcast.config.MapConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.core.TransactionalMap;
-import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.map.QueryResultSizeExceededException;
 import com.hazelcast.map.impl.QueryResultSizeLimiter;
 import com.hazelcast.query.TruePredicate;
@@ -148,9 +148,9 @@ public abstract class ClientMapUnboundReturnValuesTestSupport {
 
     private Config createConfig(int partitionCount, int limit, int preCheckTrigger) {
         Config config = new Config();
-        config.setProperty(GroupProperties.PROP_PARTITION_COUNT, String.valueOf(partitionCount));
-        config.setProperty(GroupProperties.PROP_QUERY_RESULT_SIZE_LIMIT, String.valueOf(limit));
-        config.setProperty(GroupProperties.PROP_QUERY_MAX_LOCAL_PARTITION_LIMIT_FOR_PRE_CHECK, String.valueOf(preCheckTrigger));
+        config.setProperty(GroupProperty.PARTITION_COUNT, String.valueOf(partitionCount));
+        config.setProperty(GroupProperty.QUERY_RESULT_SIZE_LIMIT, String.valueOf(limit));
+        config.setProperty(GroupProperty.QUERY_MAX_LOCAL_PARTITION_LIMIT_FOR_PRE_CHECK, String.valueOf(preCheckTrigger));
         return config;
     }
 

--- a/hazelcast-hibernate/hazelcast-hibernate3/src/main/java/com/hazelcast/hibernate/HazelcastTimestamper.java
+++ b/hazelcast-hibernate/hazelcast-hibernate3/src/main/java/com/hazelcast/hibernate/HazelcastTimestamper.java
@@ -19,7 +19,7 @@ package com.hazelcast.hibernate;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.logging.Logger;
 
 /**
@@ -56,7 +56,7 @@ public final class HazelcastTimestamper {
         String maxOpTimeoutProp = null;
         try {
             Config config = instance.getConfig();
-            maxOpTimeoutProp = config.getProperty(GroupProperties.PROP_OPERATION_CALL_TIMEOUT_MILLIS);
+            maxOpTimeoutProp = config.getProperty(GroupProperty.OPERATION_CALL_TIMEOUT_MILLIS);
         } catch (UnsupportedOperationException e) {
             // HazelcastInstance is instance of HazelcastClient.
             Logger.getLogger(HazelcastTimestamper.class).finest(e);

--- a/hazelcast-hibernate/hazelcast-hibernate3/src/main/java/com/hazelcast/hibernate/instance/HazelcastInstanceLoader.java
+++ b/hazelcast-hibernate/hazelcast-hibernate3/src/main/java/com/hazelcast/hibernate/instance/HazelcastInstanceLoader.java
@@ -23,7 +23,7 @@ import com.hazelcast.core.DuplicateInstanceNameException;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.hibernate.CacheEnvironment;
-import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 import org.hibernate.cache.CacheException;
@@ -101,7 +101,7 @@ class HazelcastInstanceLoader implements IHazelcastInstanceLoader {
         if (!shutDown) {
             LOGGER.warning(CacheEnvironment.SHUTDOWN_ON_STOP + " property is set to 'false'. "
                     + "Leaving current HazelcastInstance active! (Warning: Do not disable Hazelcast "
-                    + GroupProperties.PROP_SHUTDOWNHOOK_ENABLED + " property!)");
+                    + GroupProperty.SHUTDOWNHOOK_ENABLED + " property!)");
             return;
         }
         try {

--- a/hazelcast-hibernate/hazelcast-hibernate3/src/test/java/com/hazelcast/hibernate/instance/HazelcastMockInstanceLoader.java
+++ b/hazelcast-hibernate/hazelcast-hibernate3/src/test/java/com/hazelcast/hibernate/instance/HazelcastMockInstanceLoader.java
@@ -10,7 +10,7 @@ import com.hazelcast.config.XmlConfigBuilder;
 import com.hazelcast.core.DuplicateInstanceNameException;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.hibernate.CacheEnvironment;
-import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 import org.hibernate.cache.CacheException;
@@ -18,7 +18,6 @@ import org.hibernate.util.PropertiesHelper;
 
 import java.io.IOException;
 import java.util.Properties;
-
 
 public class HazelcastMockInstanceLoader implements IHazelcastInstanceLoader {
 
@@ -123,7 +122,7 @@ public class HazelcastMockInstanceLoader implements IHazelcastInstanceLoader {
             if (!shutDown) {
                 LOGGER.warning(CacheEnvironment.SHUTDOWN_ON_STOP + " property is set to 'false'. "
                         + "Leaving current HazelcastInstance active! (Warning: Do not disable Hazelcast "
-                        + GroupProperties.PROP_SHUTDOWNHOOK_ENABLED + " property!)");
+                        + GroupProperty.SHUTDOWNHOOK_ENABLED + " property!)");
                 return;
             }
             try {

--- a/hazelcast-hibernate/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/HazelcastTimestamper.java
+++ b/hazelcast-hibernate/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/HazelcastTimestamper.java
@@ -19,7 +19,7 @@ package com.hazelcast.hibernate;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.logging.Logger;
 
 /**
@@ -56,7 +56,7 @@ public final class HazelcastTimestamper {
         String maxOpTimeoutProp = null;
         try {
             Config config = instance.getConfig();
-            maxOpTimeoutProp = config.getProperty(GroupProperties.PROP_OPERATION_CALL_TIMEOUT_MILLIS);
+            maxOpTimeoutProp = config.getProperty(GroupProperty.OPERATION_CALL_TIMEOUT_MILLIS);
         } catch (UnsupportedOperationException e) {
             // HazelcastInstance is instance of HazelcastClient.
             Logger.getLogger(HazelcastTimestamper.class).finest(e);

--- a/hazelcast-hibernate/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/instance/HazelcastInstanceLoader.java
+++ b/hazelcast-hibernate/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/instance/HazelcastInstanceLoader.java
@@ -23,7 +23,7 @@ import com.hazelcast.core.DuplicateInstanceNameException;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.hibernate.CacheEnvironment;
-import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 import org.hibernate.cache.CacheException;
@@ -99,7 +99,7 @@ class HazelcastInstanceLoader implements IHazelcastInstanceLoader {
         if (!shutDown) {
             LOGGER.warning(CacheEnvironment.SHUTDOWN_ON_STOP + " property is set to 'false'. "
                     + "Leaving current HazelcastInstance active! (Warning: Do not disable Hazelcast "
-                    + GroupProperties.PROP_SHUTDOWNHOOK_ENABLED + " property!)");
+                    + GroupProperty.SHUTDOWNHOOK_ENABLED + " property!)");
             return;
         }
         try {

--- a/hazelcast-hibernate/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/instance/HazelcastMockInstanceLoader.java
+++ b/hazelcast-hibernate/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/instance/HazelcastMockInstanceLoader.java
@@ -10,7 +10,7 @@ import com.hazelcast.config.XmlConfigBuilder;
 import com.hazelcast.core.DuplicateInstanceNameException;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.hibernate.CacheEnvironment;
-import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 import org.hibernate.cache.CacheException;
@@ -18,7 +18,6 @@ import org.hibernate.internal.util.config.ConfigurationHelper;
 
 import java.io.IOException;
 import java.util.Properties;
-
 
 public class HazelcastMockInstanceLoader implements IHazelcastInstanceLoader {
 
@@ -123,7 +122,7 @@ public class HazelcastMockInstanceLoader implements IHazelcastInstanceLoader {
             if (!shutDown) {
                 LOGGER.warning(CacheEnvironment.SHUTDOWN_ON_STOP + " property is set to 'false'. "
                         + "Leaving current HazelcastInstance active! (Warning: Do not disable Hazelcast "
-                        + GroupProperties.PROP_SHUTDOWNHOOK_ENABLED + " property!)");
+                        + GroupProperty.SHUTDOWNHOOK_ENABLED + " property!)");
                 return;
             }
             try {

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/CustomSpringJUnit4ClassRunner.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/CustomSpringJUnit4ClassRunner.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.spring;
 
-import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.instance.GroupProperty;
 import org.junit.runners.model.InitializationError;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
@@ -27,8 +27,8 @@ public class CustomSpringJUnit4ClassRunner extends SpringJUnit4ClassRunner {
 
     static {
         System.setProperty("java.net.preferIPv4Stack", "true");
-        System.setProperty(GroupProperties.PROP_WAIT_SECONDS_BEFORE_JOIN, "1");
-        System.setProperty(GroupProperties.PROP_VERSION_CHECK_ENABLED, "false");
+        GroupProperty.WAIT_SECONDS_BEFORE_JOIN.setSystemProperty("1");
+        GroupProperty.VERSION_CHECK_ENABLED.setSystemProperty("false");
         System.setProperty("hazelcast.local.localAddress", "127.0.0.1");
     }
 

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
@@ -74,7 +74,6 @@ import com.hazelcast.core.Member;
 import com.hazelcast.core.MembershipListener;
 import com.hazelcast.core.MultiMap;
 import com.hazelcast.core.ReplicatedMap;
-import com.hazelcast.instance.GroupProperties;
 import com.hazelcast.memory.MemoryUnit;
 import com.hazelcast.nio.SocketInterceptor;
 import com.hazelcast.nio.serialization.DataSerializableFactory;
@@ -106,6 +105,8 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 
+import static com.hazelcast.instance.GroupProperty.MERGE_FIRST_RUN_DELAY_SECONDS;
+import static com.hazelcast.instance.GroupProperty.MERGE_NEXT_RUN_DELAY_SECONDS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -455,15 +456,16 @@ public class TestFullApplicationContext {
 
     @Test
     public void testProperties() {
-        final Properties properties = config.getProperties();
+        Properties properties = config.getProperties();
         assertNotNull(properties);
-        assertEquals("5", properties.get(GroupProperties.PROP_MERGE_FIRST_RUN_DELAY_SECONDS));
-        assertEquals("5", properties.get(GroupProperties.PROP_MERGE_NEXT_RUN_DELAY_SECONDS));
-        final Config config2 = instance.getConfig();
-        final Properties properties2 = config2.getProperties();
+        assertEquals("5", properties.get(MERGE_FIRST_RUN_DELAY_SECONDS.getName()));
+        assertEquals("5", properties.get(MERGE_NEXT_RUN_DELAY_SECONDS.getName()));
+
+        Config config2 = instance.getConfig();
+        Properties properties2 = config2.getProperties();
         assertNotNull(properties2);
-        assertEquals("5", properties2.get(GroupProperties.PROP_MERGE_FIRST_RUN_DELAY_SECONDS));
-        assertEquals("5", properties2.get(GroupProperties.PROP_MERGE_NEXT_RUN_DELAY_SECONDS));
+        assertEquals("5", properties2.get(MERGE_FIRST_RUN_DELAY_SECONDS.getName()));
+        assertEquals("5", properties2.get(MERGE_NEXT_RUN_DELAY_SECONDS.getName()));
     }
 
     @Test

--- a/hazelcast/src/main/java/com/hazelcast/cache/HazelcastCachingProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/HazelcastCachingProvider.java
@@ -17,7 +17,7 @@
 package com.hazelcast.cache;
 
 import com.hazelcast.cache.impl.HazelcastServerCachingProvider;
-import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.nio.ClassLoaderUtil;
@@ -73,7 +73,7 @@ public final class HazelcastCachingProvider
 
     public HazelcastCachingProvider() {
         CachingProvider cp = null;
-        String providerType = System.getProperty(GroupProperties.PROP_JCACHE_PROVIDER_TYPE);
+        String providerType = GroupProperty.JCACHE_PROVIDER_TYPE.getSystemProperty();
         if (providerType != null) {
             if ("client".equals(providerType)) {
                 cp = createClientProvider();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngineImpl.java
@@ -37,6 +37,7 @@ import com.hazelcast.core.ClientListener;
 import com.hazelcast.core.ClientType;
 import com.hazelcast.core.HazelcastInstanceNotActiveException;
 import com.hazelcast.core.Member;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.instance.MemberImpl;
 import com.hazelcast.instance.Node;
 import com.hazelcast.logging.ILogger;
@@ -144,7 +145,7 @@ public class ClientEngineImpl implements ClientEngine, CoreService, PostJoinAwar
         final ExecutionService executionService = nodeEngine.getExecutionService();
         int coreSize = Runtime.getRuntime().availableProcessors();
 
-        int threadCount = node.getGroupProperties().CLIENT_ENGINE_THREAD_COUNT.getInteger();
+        int threadCount = node.getGroupProperties().getInteger(GroupProperty.CLIENT_ENGINE_THREAD_COUNT);
         if (threadCount <= 0) {
             threadCount = coreSize * THREADS_PER_CORE;
         }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientHeartbeatMonitor.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientHeartbeatMonitor.java
@@ -19,6 +19,7 @@ package com.hazelcast.client.impl;
 import com.hazelcast.client.ClientEndpoint;
 import com.hazelcast.client.ClientEngine;
 import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.nio.Connection;
@@ -54,7 +55,7 @@ public class ClientHeartbeatMonitor implements Runnable {
     }
 
     private long getHeartBeatTimeout(GroupProperties groupProperties) {
-        long configuredTimeout = groupProperties.CLIENT_HEARTBEAT_TIMEOUT_SECONDS.getInteger();
+        long configuredTimeout = groupProperties.getSeconds(GroupProperty.CLIENT_HEARTBEAT_TIMEOUT_SECONDS);
         if (configuredTimeout > 0) {
             return configuredTimeout;
         }

--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/AbstractJoiner.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/AbstractJoiner.java
@@ -23,6 +23,7 @@ import com.hazelcast.cluster.impl.operations.MergeClustersOperation;
 import com.hazelcast.cluster.impl.operations.PrepareMergeOperation;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.Member;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.instance.Node;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Address;
@@ -133,7 +134,7 @@ public abstract class AbstractJoiner implements Joiner {
         boolean allConnected = false;
         if (node.joined()) {
             logger.finest("Waiting for all connections");
-            int connectAllWaitSeconds = node.groupProperties.CONNECT_ALL_WAIT_SECONDS.getInteger();
+            int connectAllWaitSeconds = node.groupProperties.getSeconds(GroupProperty.CONNECT_ALL_WAIT_SECONDS);
             int checkCount = 0;
             while (checkCount++ < connectAllWaitSeconds && !allConnected) {
                 try {
@@ -156,13 +157,15 @@ public abstract class AbstractJoiner implements Joiner {
         }
     }
 
-    protected final long getMaxJoinMillis() {return node.getGroupProperties().MAX_JOIN_SECONDS.getInteger() * 1000L;}
+    protected final long getMaxJoinMillis() {
+        return node.getGroupProperties().getMillis(GroupProperty.MAX_JOIN_SECONDS);
+    }
 
     protected final long getMaxJoinTimeToMasterNode() {
         // max join time to found master node,
         // this should be significantly greater than MAX_WAIT_SECONDS_BEFORE_JOIN property
         // hence we add 10 seconds more
-        return (node.getGroupProperties().MAX_WAIT_SECONDS_BEFORE_JOIN.getInteger() + 10) * 1000L;
+        return TimeUnit.SECONDS.toMillis(10) + node.getGroupProperties().getMillis(GroupProperty.MAX_WAIT_SECONDS_BEFORE_JOIN);
     }
 
     boolean shouldMerge(JoinMessage joinMessage) {

--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/ConfigCheck.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/ConfigCheck.java
@@ -27,8 +27,8 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
-import static com.hazelcast.instance.GroupProperties.PROP_APPLICATION_VALIDATION_TOKEN;
-import static com.hazelcast.instance.GroupProperties.PROP_PARTITION_COUNT;
+import static com.hazelcast.instance.GroupProperty.APPLICATION_VALIDATION_TOKEN;
+import static com.hazelcast.instance.GroupProperty.PARTITION_COUNT;
 
 /**
  * Contains enough information about Hazelcast Config, to do a validation check so that clusters with different configurations
@@ -60,11 +60,11 @@ public final class ConfigCheck implements IdentifiedDataSerializable {
     public ConfigCheck(Config config, String joinerType) {
         this.joinerType = joinerType;
 
-        // Copying all properties relevant for checking.
-        this.properties.put(PROP_PARTITION_COUNT, config.getProperty(PROP_PARTITION_COUNT));
-        this.properties.put(PROP_APPLICATION_VALIDATION_TOKEN, config.getProperty(PROP_APPLICATION_VALIDATION_TOKEN));
+        // Copying all properties relevant for checking
+        properties.put(PARTITION_COUNT.getName(), config.getProperty(PARTITION_COUNT));
+        properties.put(APPLICATION_VALIDATION_TOKEN.getName(), config.getProperty(APPLICATION_VALIDATION_TOKEN));
 
-        // Copying group-config settings/
+        // Copying group-config settings
         GroupConfig groupConfig = config.getGroupConfig();
         if (groupConfig != null) {
             this.groupName = groupConfig.getName();
@@ -84,12 +84,12 @@ public final class ConfigCheck implements IdentifiedDataSerializable {
     }
 
     /**
-     * Checks if 2 Hazelcast configurations are compatible.
+     * Checks if two Hazelcast configurations are compatible.
      *
      * @param found
      * @return true if compatible. False if part of another group.
-     * @throws ConfigMismatchException if the configuration isn't compatible. An exception is thrown so
-     *                                                       we can pass a nice message.
+     * @throws ConfigMismatchException if the configuration is not compatible.
+     * An exception is thrown so we can pass a nice message.
      */
     public boolean isCompatible(ConfigCheck found) {
         // check group-properties.
@@ -119,17 +119,17 @@ public final class ConfigCheck implements IdentifiedDataSerializable {
     }
 
     private void verifyApplicationValidationToken(ConfigCheck found) {
-        String expectedValidationToken = properties.get(PROP_APPLICATION_VALIDATION_TOKEN);
-        String foundValidationToken = found.properties.get(PROP_APPLICATION_VALIDATION_TOKEN);
+        String expectedValidationToken = properties.get(APPLICATION_VALIDATION_TOKEN.getName());
+        String foundValidationToken = found.properties.get(APPLICATION_VALIDATION_TOKEN.getName());
         if (!equals(expectedValidationToken, foundValidationToken)) {
-            throw new ConfigMismatchException("Incompatible '" + PROP_APPLICATION_VALIDATION_TOKEN + "'! expected: " +
+            throw new ConfigMismatchException("Incompatible '" + APPLICATION_VALIDATION_TOKEN + "'! expected: " +
                     expectedValidationToken + ", found: " + foundValidationToken);
         }
     }
 
     private void verifyPartitionCount(ConfigCheck found) {
-        String expectedPartitionCount = properties.get(PROP_PARTITION_COUNT);
-        String foundPartitionCount = found.properties.get(PROP_PARTITION_COUNT);
+        String expectedPartitionCount = properties.get(PARTITION_COUNT.getName());
+        String foundPartitionCount = found.properties.get(PARTITION_COUNT.getName());
         if (!equals(expectedPartitionCount, foundPartitionCount)) {
             throw new ConfigMismatchException("Incompatible partition count! expected: " + expectedPartitionCount + ", found: "
                     + foundPartitionCount);

--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/MulticastJoiner.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/MulticastJoiner.java
@@ -17,6 +17,7 @@
 package com.hazelcast.cluster.impl;
 
 import com.hazelcast.config.NetworkConfig;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.instance.Node;
 import com.hazelcast.nio.Address;
 import com.hazelcast.util.Clock;
@@ -122,10 +123,9 @@ public class MulticastJoiner extends AbstractJoiner {
                 }
 
                 if (joinInfo.getMemberCount() == 1) {
-                    // if the other cluster has just single member, that may be a newly starting node
-                    // instead of a split node.
-                    // Wait 2 times 'WAIT_SECONDS_BEFORE_JOIN' seconds before processing merge JoinRequest.
-                    Thread.sleep(node.groupProperties.WAIT_SECONDS_BEFORE_JOIN.getInteger() * 1000L * 2);
+                    // if the other cluster has just single member, that may be a newly starting node instead of a split node
+                    // wait 2 times 'WAIT_SECONDS_BEFORE_JOIN' seconds before processing merge JoinRequest
+                    Thread.sleep(2 * node.groupProperties.getMillis(GroupProperty.WAIT_SECONDS_BEFORE_JOIN));
                 }
 
                 JoinMessage response = sendSplitBrainJoinMessage(joinInfo.getAddress());

--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/TcpIpJoiner.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/TcpIpJoiner.java
@@ -21,7 +21,7 @@ import com.hazelcast.config.Config;
 import com.hazelcast.config.InterfacesConfig;
 import com.hazelcast.config.NetworkConfig;
 import com.hazelcast.config.TcpIpConfig;
-import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.instance.Node;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.Connection;
@@ -51,10 +51,10 @@ public class TcpIpJoiner extends AbstractJoiner {
 
     public TcpIpJoiner(Node node) {
         super(node);
-        int tryCount = node.groupProperties.TCP_JOIN_PORT_TRY_COUNT.getInteger();
+        int tryCount = node.groupProperties.getInteger(GroupProperty.TCP_JOIN_PORT_TRY_COUNT);
         if (tryCount <= 0) {
-            throw new IllegalArgumentException(GroupProperties.PROP_TCP_JOIN_PORT_TRY_COUNT
-                    + " should be greater than zero! Current value: " + tryCount);
+            throw new IllegalArgumentException(String.format("%s should be greater than zero! Current value: %d",
+                    GroupProperty.TCP_JOIN_PORT_TRY_COUNT, tryCount));
         }
         maxPortTryCount = tryCount;
     }
@@ -71,7 +71,7 @@ public class TcpIpJoiner extends AbstractJoiner {
     public void doJoin() {
         final Address targetAddress = getTargetAddress();
         if (targetAddress != null) {
-            long maxJoinMergeTargetMillis = node.getGroupProperties().MAX_JOIN_MERGE_TARGET_SECONDS.getInteger() * 1000L;
+            long maxJoinMergeTargetMillis = node.getGroupProperties().getMillis(GroupProperty.MAX_JOIN_MERGE_TARGET_SECONDS);
             joinViaTargetMember(targetAddress, maxJoinMergeTargetMillis);
             if (!node.joined()) {
                 joinViaPossibleMembers();

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockServiceImpl.java
@@ -21,6 +21,7 @@ import com.hazelcast.concurrent.lock.operations.LockReplicationOperation;
 import com.hazelcast.concurrent.lock.operations.UnlockOperation;
 import com.hazelcast.core.DistributedObject;
 import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.instance.MemberImpl;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.partition.MigrationEndpoint;
@@ -51,7 +52,6 @@ import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.spi.impl.OperationResponseHandlerFactory.createEmptyResponseHandler;
 import static com.hazelcast.util.ConcurrencyUtil.getOrPutSynchronized;
@@ -90,9 +90,7 @@ public final class LockServiceImpl implements InternalLockService, ManagedServic
     }
 
     public static long getMaxLeaseTimeInMillis(GroupProperties groupProperties) {
-        long maxLeaseTime = groupProperties.LOCK_MAX_LEASE_TIME_SECONDS.getLong();
-        maxLeaseTime = TimeUnit.SECONDS.toMillis(maxLeaseTime);
-        return maxLeaseTime;
+        return groupProperties.getMillis(GroupProperty.LOCK_MAX_LEASE_TIME_SECONDS);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/config/Config.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/Config.java
@@ -19,6 +19,7 @@ package com.hazelcast.config;
 import com.hazelcast.config.matcher.MatchingPointConfigPatternMatcher;
 import com.hazelcast.core.HazelcastException;
 import com.hazelcast.core.ManagedContext;
+import com.hazelcast.instance.HazelcastProperty;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 
@@ -164,14 +165,49 @@ public class Config {
         this.configPatternMatcher = configPatternMatcher;
     }
 
+    /**
+     * Gets a named property already set or from system properties if not exists.
+     *
+     * @param name property name
+     * @return value of the property
+     */
     public String getProperty(String name) {
         String value = properties.getProperty(name);
         return value != null ? value : System.getProperty(name);
     }
 
+    /**
+     * Sets the value of a named property.
+     *
+     * @param name  property name
+     * @param value value of the property
+     * @return configured {@link Config} for chaining
+     */
     public Config setProperty(String name, String value) {
         properties.put(name, value);
         return this;
+    }
+
+    /**
+     * Gets a {@link HazelcastProperty} already set or from system properties if not exists.
+     *
+     * @param property {@link HazelcastProperty} to get
+     * @return value of the property
+     */
+    public String getProperty(HazelcastProperty property) {
+        return getProperty(property.getName());
+    }
+
+    /**
+     * Sets the value of a {@link HazelcastProperty}.
+     *
+     * @param property {@link HazelcastProperty} to set
+     * @param value    value of the property
+     * @return configured {@link Config} for chaining
+     * @see {@link HazelcastProperty} for properties that is used to configure client
+     */
+    public Config setProperty(HazelcastProperty property, String value) {
+        return setProperty(property.getName(), value);
     }
 
     public MemberAttributeConfig getMemberAttributeConfig() {

--- a/hazelcast/src/main/java/com/hazelcast/core/IMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/IMap.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.core;
 
-import com.hazelcast.instance.GroupProperties;
 import com.hazelcast.map.EntryProcessor;
 import com.hazelcast.map.MapInterceptor;
 import com.hazelcast.map.QueryResultSizeExceededException;
@@ -1111,11 +1110,11 @@ public interface IMap<K, V>
      * <p/>
      * On the server side this method is executed by a distributed query
      * so it may throw a {@link QueryResultSizeExceededException}
-     * if {@link GroupProperties#PROP_QUERY_RESULT_SIZE_LIMIT} is configured.
+     * if {@link com.hazelcast.instance.GroupProperty#QUERY_RESULT_SIZE_LIMIT} is configured.
      *
      * @return a set clone of the keys contained in this map.
      * @throws QueryResultSizeExceededException on server side if query result size limit is exceeded
-     * @see GroupProperties#PROP_QUERY_RESULT_SIZE_LIMIT
+     * @see com.hazelcast.instance.GroupProperty#QUERY_RESULT_SIZE_LIMIT
      */
     Set<K> keySet();
 
@@ -1128,11 +1127,11 @@ public interface IMap<K, V>
      * <p/>
      * On the server side this method is executed by a distributed query
      * so it may throw a {@link QueryResultSizeExceededException}
-     * if {@link GroupProperties#PROP_QUERY_RESULT_SIZE_LIMIT} is configured.
+     * if {@link com.hazelcast.instance.GroupProperty#QUERY_RESULT_SIZE_LIMIT} is configured.
      *
      * @return a collection clone of the values contained in this map
      * @throws QueryResultSizeExceededException on server side if query result size limit is exceeded
-     * @see GroupProperties#PROP_QUERY_RESULT_SIZE_LIMIT
+     * @see com.hazelcast.instance.GroupProperty#QUERY_RESULT_SIZE_LIMIT
      */
     Collection<V> values();
 
@@ -1145,11 +1144,11 @@ public interface IMap<K, V>
      * <p/>
      * On the server side this method is executed by a distributed query
      * so it may throw a {@link QueryResultSizeExceededException}
-     * if {@link GroupProperties#PROP_QUERY_RESULT_SIZE_LIMIT} is configured.
+     * if {@link com.hazelcast.instance.GroupProperty#QUERY_RESULT_SIZE_LIMIT} is configured.
      *
      * @return a set clone of the keys mappings in this map
      * @throws QueryResultSizeExceededException on server side if query result size limit is exceeded
-     * @see GroupProperties#PROP_QUERY_RESULT_SIZE_LIMIT
+     * @see com.hazelcast.instance.GroupProperty#QUERY_RESULT_SIZE_LIMIT
      */
     Set<Map.Entry<K, V>> entrySet();
 
@@ -1165,12 +1164,12 @@ public interface IMap<K, V>
      * <p/>
      * This method is always executed by a distributed query
      * so it may throw a {@link QueryResultSizeExceededException}
-     * if {@link GroupProperties#PROP_QUERY_RESULT_SIZE_LIMIT} is configured.
+     * if {@link com.hazelcast.instance.GroupProperty#QUERY_RESULT_SIZE_LIMIT} is configured.
      *
      * @param predicate specified query criteria.
      * @return result key set of the query.
      * @throws QueryResultSizeExceededException if query result size limit is exceeded
-     * @see GroupProperties#PROP_QUERY_RESULT_SIZE_LIMIT
+     * @see com.hazelcast.instance.GroupProperty#QUERY_RESULT_SIZE_LIMIT
      */
     Set<K> keySet(Predicate predicate);
 
@@ -1186,12 +1185,12 @@ public interface IMap<K, V>
      * <p/>
      * This method is always executed by a distributed query
      * so it may throw a {@link QueryResultSizeExceededException}
-     * if {@link GroupProperties#PROP_QUERY_RESULT_SIZE_LIMIT} is configured.
+     * if {@link com.hazelcast.instance.GroupProperty#QUERY_RESULT_SIZE_LIMIT} is configured.
      *
      * @param predicate specified query criteria.
      * @return result entry set of the query.
      * @throws QueryResultSizeExceededException if query result size limit is exceeded
-     * @see GroupProperties#PROP_QUERY_RESULT_SIZE_LIMIT
+     * @see com.hazelcast.instance.GroupProperty#QUERY_RESULT_SIZE_LIMIT
      */
     Set<Map.Entry<K, V>> entrySet(Predicate predicate);
 
@@ -1207,12 +1206,12 @@ public interface IMap<K, V>
      * <p/>
      * This method is always executed by a distributed query
      * so it may throw a {@link QueryResultSizeExceededException}
-     * if {@link GroupProperties#PROP_QUERY_RESULT_SIZE_LIMIT} is configured.
+     * if {@link com.hazelcast.instance.GroupProperty#QUERY_RESULT_SIZE_LIMIT} is configured.
      *
      * @param predicate specified query criteria.
      * @return result value collection of the query.
      * @throws QueryResultSizeExceededException if query result size limit is exceeded
-     * @see GroupProperties#PROP_QUERY_RESULT_SIZE_LIMIT
+     * @see com.hazelcast.instance.GroupProperty#QUERY_RESULT_SIZE_LIMIT
      */
     Collection<V> values(Predicate predicate);
 
@@ -1232,11 +1231,11 @@ public interface IMap<K, V>
      * <p/>
      * On the server side this method is executed by a distributed query
      * so it may throw a {@link QueryResultSizeExceededException}
-     * if {@link GroupProperties#PROP_QUERY_RESULT_SIZE_LIMIT} is configured.
+     * if {@link com.hazelcast.instance.GroupProperty#QUERY_RESULT_SIZE_LIMIT} is configured.
      *
      * @return locally owned keys.
      * @throws QueryResultSizeExceededException on server side if query result size limit is exceeded
-     * @see GroupProperties#PROP_QUERY_RESULT_SIZE_LIMIT
+     * @see com.hazelcast.instance.GroupProperty#QUERY_RESULT_SIZE_LIMIT
      */
     Set<K> localKeySet();
 
@@ -1256,12 +1255,12 @@ public interface IMap<K, V>
      * <p/>
      * This method is always executed by a distributed query
      * so it may throw a {@link QueryResultSizeExceededException}
-     * if {@link GroupProperties#PROP_QUERY_RESULT_SIZE_LIMIT} is configured.
+     * if {@link com.hazelcast.instance.GroupProperty#QUERY_RESULT_SIZE_LIMIT} is configured.
      *
      * @param predicate specified query criteria.
      * @return keys of matching locally owned entries.
      * @throws QueryResultSizeExceededException if query result size limit is exceeded
-     * @see GroupProperties#PROP_QUERY_RESULT_SIZE_LIMIT
+     * @see com.hazelcast.instance.GroupProperty#QUERY_RESULT_SIZE_LIMIT
      */
     Set<K> localKeySet(Predicate predicate);
 

--- a/hazelcast/src/main/java/com/hazelcast/instance/DefaultAddressPicker.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/DefaultAddressPicker.java
@@ -87,7 +87,7 @@ class DefaultAddressPicker implements AddressPicker {
 
     private AddressDefinition getPublicAddressByPortSearch() throws IOException {
         NetworkConfig networkConfig = node.getConfig().getNetworkConfig();
-        boolean bindAny = node.getGroupProperties().SOCKET_SERVER_BIND_ANY.getBoolean();
+        boolean bindAny = node.getGroupProperties().getBoolean(GroupProperty.SOCKET_SERVER_BIND_ANY);
 
         Throwable error = null;
         ServerSocket serverSocket = null;
@@ -342,7 +342,7 @@ class DefaultAddressPicker implements AddressPicker {
 
     private boolean preferIPv4Stack() {
         boolean preferIPv4Stack = Boolean.getBoolean("java.net.preferIPv4Stack")
-                || node.groupProperties.PREFER_IPv4_STACK.getBoolean();
+                || node.groupProperties.getBoolean(GroupProperty.PREFER_IPv4_STACK);
         // AWS does not support IPv6
         JoinConfig join = node.getConfig().getNetworkConfig().getJoin();
         AwsConfig awsConfig = join.getAwsConfig();

--- a/hazelcast/src/main/java/com/hazelcast/instance/DefaultNodeExtension.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/DefaultNodeExtension.java
@@ -123,7 +123,7 @@ public class DefaultNodeExtension implements NodeExtension {
     }
 
     protected PartitioningStrategy getPartitioningStrategy(ClassLoader configClassLoader) throws Exception {
-        String partitioningStrategyClassName = node.groupProperties.PARTITIONING_STRATEGY_CLASS.getString();
+        String partitioningStrategyClassName = node.groupProperties.getString(GroupProperty.PARTITIONING_STRATEGY_CLASS);
         if (partitioningStrategyClassName != null && partitioningStrategyClassName.length() > 0) {
             return ClassLoaderUtil.newInstance(configClassLoader, partitioningStrategyClassName);
         } else {

--- a/hazelcast/src/main/java/com/hazelcast/instance/GroupProperties.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/GroupProperties.java
@@ -17,896 +17,377 @@
 package com.hazelcast.instance;
 
 import com.hazelcast.config.Config;
-import com.hazelcast.core.IMap;
-import com.hazelcast.internal.monitors.HealthMonitorLevel;
-import com.hazelcast.map.QueryResultSizeExceededException;
-import com.hazelcast.map.impl.QueryResultSizeLimiter;
-import com.hazelcast.query.TruePredicate;
+
+import java.util.concurrent.TimeUnit;
 
 /**
- * The GroupProperties contain the Hazelcast properties. They can be set as an environmental variable, or
- * directly on the Config using {@link Config#setProperty(String, String)} or from the XML.
+ * Container for configured Hazelcast properties ({@see GroupProperty}).
+ * <p/>
+ * A {@link GroupProperty} can be set as:
+ * <p><ul>
+ * <li>an environmental variable using {@link System#setProperty(String, String)}</li>
+ * <li>the programmatic configuration using {@link Config#setProperty(String, String)}</li>
+ * <li>the XML configuration
+ * {@see http://docs.hazelcast.org/docs/latest-dev/manual/html-single/hazelcast-documentation.html#system-properties}</li>
+ * </ul></p>
+ * <p/>
+ * The old property definitions are deprecated since Hazelcast 3.6. Please use the new {@link GroupProperty} definitions instead.
  */
+@SuppressWarnings("unused")
 public class GroupProperties {
 
-    /**
-     * Use this property to verify that Hazelcast nodes only join the cluster when their 'application' level configuration is the
-     * same.
-     * <p/>
-     * If you have multiple machines, and you want to make sure that each machine that joins the cluster
-     * has exactly the same 'application level' settings (such as settings that are not part of the Hazelcast configuration,
-     * maybe some filepath). To prevent these machines with potential different application level configuration from forming
-     * a cluster, you can set this property.
-     * <p/>
-     * You could use actual values, such as string paths, but you can also use an md5 hash. We'll give the guarantee
-     * that nodes will form a cluster (become a member) only where the token is an exact match. If this token is different, the
-     * member can't be started and therefore you will get the guarantee that all members in the cluster will have exactly the same
-     * application validation token.
-     * <p/>
-     * This validation-token will be checked before member join the cluster.
-     */
-    public static final String PROP_APPLICATION_VALIDATION_TOKEN = "hazelcast.application.validation.token";
-
-    public static final String PROP_HEALTH_MONITORING_LEVEL = "hazelcast.health.monitoring.level";
-    public static final String PROP_HEALTH_MONITORING_DELAY_SECONDS = "hazelcast.health.monitoring.delay.seconds";
-
-    /**
-     * Use the performance monitor to see internal performance metrics. Currently this is quite
-     * limited since it will only show read/write events per selector and operations executed per operation-thread. But in
-     * the future, all kinds of new metrics will be added.
-     * <p/>
-     * The performance monitor logs all metrics into the log file.
-     *
-     * The default is false.
-     */
-    public static final String PROP_PERFORMANCE_MONITOR_ENABLED = "hazelcast.performance.monitoring.enabled";
-
-    /**
-     * The delay in seconds between monitor of the performance.
-     *
-     * The default is 30 seconds.
-     */
-    public static final String PROP_PERFORMANCE_MONITOR_DELAY_SECONDS
-            = "hazelcast.performance.monitor.delay.seconds";
-
-    /**
-     * The PerformanceMonitor uses a rolling file approach to prevent eating too much disk space.
-     *
-     * This property sets the maximum size in MB for a single file.
-     *
-     * Every HazelcastInstance will get its own history of log files.
-     *
-     * The default is 10.
-     */
+    @Deprecated
+    public static final String PROP_APPLICATION_VALIDATION_TOKEN = GroupProperty.APPLICATION_VALIDATION_TOKEN.getName();
+    @Deprecated
+    public static final String PROP_HEALTH_MONITORING_LEVEL = GroupProperty.HEALTH_MONITORING_LEVEL.getName();
+    @Deprecated
+    public static final String PROP_HEALTH_MONITORING_DELAY_SECONDS = GroupProperty.HEALTH_MONITORING_DELAY_SECONDS.getName();
+    @Deprecated
+    public static final String PROP_PERFORMANCE_MONITOR_ENABLED = GroupProperty.PERFORMANCE_MONITOR_ENABLED.getName();
+    @Deprecated
+    public static final String PROP_PERFORMANCE_MONITOR_DELAY_SECONDS = GroupProperty.PERFORMANCE_MONITOR_DELAY_SECONDS.getName();
+    @Deprecated
     public static final String PROP_PERFORMANCE_MONITOR_MAX_ROLLED_FILE_SIZE_MB
-            = "hazelcast.performance.monitor.max.rolled.file.size.mb";
-
-    /**
-     * The PerformanceMonitor uses a rolling file approach to prevent eating too much disk space.
-     *
-     * This property sets the maximum number of rolling files to keep on disk.
-     *
-     * The default is 10.
-     */
+            = GroupProperty.PERFORMANCE_MONITOR_MAX_ROLLED_FILE_SIZE_MB.getName();
+    @Deprecated
     public static final String PROP_PERFORMANCE_MONITOR_MAX_ROLLED_FILE_COUNT
-            = "hazelcast.performance.monitor.max.rolled.file.count";
-
-    /**
-     * If a human friendly, but more difficult to parse, output format should be selected for dumping the metrics.
-     *
-     * The default is true.
-     */
+            = GroupProperty.PERFORMANCE_MONITOR_MAX_ROLLED_FILE_COUNT.getName();
+    @Deprecated
     public static final String PROP_PERFORMANCE_MONITOR_HUMAN_FRIENDLY_FORMAT
-            = "hazelcast.performance.monitor.human.friendly.format";
-
-    public static final String PROP_VERSION_CHECK_ENABLED = "hazelcast.version.check.enabled";
-    public static final String PROP_PREFER_IPv4_STACK = "hazelcast.prefer.ipv4.stack";
-
-    /**
-     * The number of threads doing socket input and the number of threads doing socket output.
-     *
-     * If e.g. 3 is configured, then you get 3 threads doing input and 3 doing output. For indidual control
-     * check PROP_IO_INPUT_THREAD_COUNT and PROP_IO_OUTPUT_THREAD_COUNT.
-     *
-     * Default value is 3 (so 6 threads)
-     */
-    public static final String PROP_IO_THREAD_COUNT = "hazelcast.io.thread.count";
-    /**
-     * Controls the number of socket input threads. BY default it is the same as PROP_IO_THREAD_COUNT.
-     */
-    public static final String PROP_IO_INPUT_THREAD_COUNT = "hazelcast.io.input.thread.count";
-    /**
-     * Controls the number of socket output threads. BY default it is the same as PROP_IO_THREAD_COUNT.
-     */
-    public static final String PROP_IO_OUTPUT_THREAD_COUNT = "hazelcast.io.output.thread.count";
-
-    /**
-     * The interval in seconds between {@link com.hazelcast.nio.tcp.nonblocking.iobalancer.IOBalancer IOBalancer}
-     * executions. The shorter intervals will catch I/O Imbalance faster, but they will cause higher overhead.
-     *
-     * Please see the documentation of {@link com.hazelcast.nio.tcp.nonblocking.iobalancer.IOBalancer IOBalancer} for a
-     * detailed explanation of the problem.
-     *
-     * Default value is 20 seconds. A value smaller than 1 disables the balancer.
-     */
-    public static final String PROP_IO_BALANCER_INTERVAL_SECONDS = "hazelcast.io.balancer.interval.seconds";
-    /**
-     * The number of partition threads per Member. If this is less than the number of partitions on a Member, then
-     * partition operations will queue behind other operations of different partitions. The default is 4.
-     */
-    public static final String PROP_PARTITION_OPERATION_THREAD_COUNT = "hazelcast.operation.thread.count";
-    public static final String PROP_GENERIC_OPERATION_THREAD_COUNT = "hazelcast.operation.generic.thread.count";
-    public static final String PROP_EVENT_THREAD_COUNT = "hazelcast.event.thread.count";
-    public static final String PROP_EVENT_QUEUE_CAPACITY = "hazelcast.event.queue.capacity";
-    public static final String PROP_EVENT_QUEUE_TIMEOUT_MILLIS = "hazelcast.event.queue.timeout.millis";
-    public static final String PROP_CONNECT_ALL_WAIT_SECONDS = "hazelcast.connect.all.wait.seconds";
-    public static final String PROP_MEMCACHE_ENABLED = "hazelcast.memcache.enabled";
-    public static final String PROP_REST_ENABLED = "hazelcast.rest.enabled";
-    public static final String PROP_MAP_LOAD_CHUNK_SIZE = "hazelcast.map.load.chunk.size";
-    public static final String PROP_MERGE_FIRST_RUN_DELAY_SECONDS = "hazelcast.merge.first.run.delay.seconds";
-    public static final String PROP_MERGE_NEXT_RUN_DELAY_SECONDS = "hazelcast.merge.next.run.delay.seconds";
-    public static final String PROP_OPERATION_CALL_TIMEOUT_MILLIS = "hazelcast.operation.call.timeout.millis";
-
-    /**
-     * If an operation has backups and the backups don't complete in time, then some cleanup logic can be executed. This
-     * property specifies that timeout for backups to complete.
-     */
-    public static final String PROP_OPERATION_BACKUP_TIMEOUT_MILLIS = "hazelcast.operation.backup.timeout.millis";
-
-    public static final String PROP_SOCKET_BIND_ANY = "hazelcast.socket.bind.any";
-    public static final String PROP_SOCKET_SERVER_BIND_ANY = "hazelcast.socket.server.bind.any";
-    public static final String PROP_SOCKET_CLIENT_BIND_ANY = "hazelcast.socket.client.bind.any";
-    public static final String PROP_SOCKET_CLIENT_BIND = "hazelcast.socket.client.bind";
-    /**
-     * The number of threads that the client engine has available for processing requests that are not partition specific.
-     * Most of the requests, such as map.put and map.get, are partition specific and will use a partition-operation-thread, but
-     * there are also requests that can't be executed on a partition-specific operation-thread, such as multimap.contain(value),
-     * because they need to access all partitions on a given member.
-     */
-    public static final String PROP_CLIENT_ENGINE_THREAD_COUNT = "hazelcast.clientengine.thread.count";
-    public static final String PROP_SOCKET_RECEIVE_BUFFER_SIZE = "hazelcast.socket.receive.buffer.size";
-    public static final String PROP_SOCKET_SEND_BUFFER_SIZE = "hazelcast.socket.send.buffer.size";
-
-    /**
-     * Overrides receive buffer size for connections opened by clients.
-     *
-     * Hazelcast creates all connections with receive buffer size set according to #PROP_SOCKET_RECEIVE_BUFFER_SIZE.
-     * When it detects a connection was opened by a client then it adjusts receive buffer size
-     * according to this property.
-     *
-     * Size is in kilobytes.
-     * Default: -1; Same as receive buffer size for connections opened by members.
-     *
-     */
-    public static final String PROP_SOCKET_CLIENT_RECEIVE_BUFFER_SIZE = "hazelcast.socket.client.receive.buffer.size";
-
-    /**
-     * Overrides send buffer size for connections opened by clients.
-     *
-     * Hazelcast creates all connections with send buffer size set according to #PROP_SOCKET_SEND_BUFFER_SIZE.
-     * When it detects a connection was opened by a client then it adjusts send buffer size
-     * according to this property.
-     *
-     * Size is in kilobytes.
-     * Default: -1; Same as receive buffer size for connections opened by members.
-     *
-     */
-    public static final String PROP_SOCKET_CLIENT_SEND_BUFFER_SIZE = "hazelcast.socket.client.send.buffer.size";
-
-    public static final String PROP_SOCKET_LINGER_SECONDS = "hazelcast.socket.linger.seconds";
-    public static final String PROP_SOCKET_CONNECT_TIMEOUT_SECONDS = "hazelcast.socket.connect.timeout.seconds";
-    public static final String PROP_SOCKET_KEEP_ALIVE = "hazelcast.socket.keep.alive";
-    public static final String PROP_SOCKET_NO_DELAY = "hazelcast.socket.no.delay";
-    public static final String PROP_SHUTDOWNHOOK_ENABLED = "hazelcast.shutdownhook.enabled";
-    public static final String PROP_WAIT_SECONDS_BEFORE_JOIN = "hazelcast.wait.seconds.before.join";
-    public static final String PROP_MAX_WAIT_SECONDS_BEFORE_JOIN = "hazelcast.max.wait.seconds.before.join";
-    public static final String PROP_MAX_JOIN_SECONDS = "hazelcast.max.join.seconds";
-    public static final String PROP_MAX_JOIN_MERGE_TARGET_SECONDS = "hazelcast.max.join.merge.target.seconds";
-    public static final String PROP_HEARTBEAT_INTERVAL_SECONDS = "hazelcast.heartbeat.interval.seconds";
-    public static final String PROP_MAX_NO_HEARTBEAT_SECONDS = "hazelcast.max.no.heartbeat.seconds";
-    public static final String PROP_MAX_NO_MASTER_CONFIRMATION_SECONDS = "hazelcast.max.no.master.confirmation.seconds";
+            = GroupProperty.PERFORMANCE_MONITOR_HUMAN_FRIENDLY_FORMAT.getName();
+    @Deprecated
+    public static final String PROP_VERSION_CHECK_ENABLED = GroupProperty.VERSION_CHECK_ENABLED.getName();
+    @Deprecated
+    public static final String PROP_PREFER_IPv4_STACK = GroupProperty.PREFER_IPv4_STACK.getName();
+    @Deprecated
+    public static final String PROP_IO_THREAD_COUNT = GroupProperty.IO_THREAD_COUNT.getName();
+    @Deprecated
+    public static final String PROP_IO_INPUT_THREAD_COUNT = GroupProperty.IO_INPUT_THREAD_COUNT.getName();
+    @Deprecated
+    public static final String PROP_IO_OUTPUT_THREAD_COUNT = GroupProperty.IO_OUTPUT_THREAD_COUNT.getName();
+    @Deprecated
+    public static final String PROP_IO_BALANCER_INTERVAL_SECONDS = GroupProperty.IO_BALANCER_INTERVAL_SECONDS.getName();
+    @Deprecated
+    public static final String PROP_PARTITION_OPERATION_THREAD_COUNT = GroupProperty.PARTITION_OPERATION_THREAD_COUNT.getName();
+    @Deprecated
+    public static final String PROP_GENERIC_OPERATION_THREAD_COUNT = GroupProperty.GENERIC_OPERATION_THREAD_COUNT.getName();
+    @Deprecated
+    public static final String PROP_EVENT_THREAD_COUNT = GroupProperty.EVENT_THREAD_COUNT.getName();
+    @Deprecated
+    public static final String PROP_EVENT_QUEUE_CAPACITY = GroupProperty.EVENT_QUEUE_CAPACITY.getName();
+    @Deprecated
+    public static final String PROP_EVENT_QUEUE_TIMEOUT_MILLIS = GroupProperty.EVENT_QUEUE_TIMEOUT_MILLIS.getName();
+    @Deprecated
+    public static final String PROP_CONNECT_ALL_WAIT_SECONDS = GroupProperty.CONNECT_ALL_WAIT_SECONDS.getName();
+    @Deprecated
+    public static final String PROP_MEMCACHE_ENABLED = GroupProperty.MEMCACHE_ENABLED.getName();
+    @Deprecated
+    public static final String PROP_REST_ENABLED = GroupProperty.REST_ENABLED.getName();
+    @Deprecated
+    public static final String PROP_MAP_LOAD_CHUNK_SIZE = GroupProperty.MAP_LOAD_CHUNK_SIZE.getName();
+    @Deprecated
+    public static final String PROP_MERGE_FIRST_RUN_DELAY_SECONDS = GroupProperty.MERGE_FIRST_RUN_DELAY_SECONDS.getName();
+    @Deprecated
+    public static final String PROP_MERGE_NEXT_RUN_DELAY_SECONDS = GroupProperty.MERGE_NEXT_RUN_DELAY_SECONDS.getName();
+    @Deprecated
+    public static final String PROP_OPERATION_CALL_TIMEOUT_MILLIS = GroupProperty.OPERATION_CALL_TIMEOUT_MILLIS.getName();
+    @Deprecated
+    public static final String PROP_OPERATION_BACKUP_TIMEOUT_MILLIS = GroupProperty.OPERATION_BACKUP_TIMEOUT_MILLIS.getName();
+    @Deprecated
+    public static final String PROP_SOCKET_BIND_ANY = GroupProperty.SOCKET_BIND_ANY.getName();
+    @Deprecated
+    public static final String PROP_SOCKET_SERVER_BIND_ANY = GroupProperty.SOCKET_SERVER_BIND_ANY.getName();
+    @Deprecated
+    public static final String PROP_SOCKET_CLIENT_BIND_ANY = GroupProperty.SOCKET_CLIENT_BIND_ANY.getName();
+    @Deprecated
+    public static final String PROP_SOCKET_CLIENT_BIND = GroupProperty.SOCKET_CLIENT_BIND.getName();
+    @Deprecated
+    public static final String PROP_CLIENT_ENGINE_THREAD_COUNT = GroupProperty.CLIENT_ENGINE_THREAD_COUNT.getName();
+    @Deprecated
+    public static final String PROP_SOCKET_RECEIVE_BUFFER_SIZE = GroupProperty.SOCKET_RECEIVE_BUFFER_SIZE.getName();
+    @Deprecated
+    public static final String PROP_SOCKET_SEND_BUFFER_SIZE = GroupProperty.SOCKET_SEND_BUFFER_SIZE.getName();
+    @Deprecated
+    public static final String PROP_SOCKET_CLIENT_RECEIVE_BUFFER_SIZE = GroupProperty.SOCKET_CLIENT_RECEIVE_BUFFER_SIZE.getName();
+    @Deprecated
+    public static final String PROP_SOCKET_CLIENT_SEND_BUFFER_SIZE = GroupProperty.SOCKET_CLIENT_SEND_BUFFER_SIZE.getName();
+    @Deprecated
+    public static final String PROP_SOCKET_LINGER_SECONDS = GroupProperty.SOCKET_LINGER_SECONDS.getName();
+    @Deprecated
+    public static final String PROP_SOCKET_CONNECT_TIMEOUT_SECONDS = GroupProperty.SOCKET_CONNECT_TIMEOUT_SECONDS.getName();
+    @Deprecated
+    public static final String PROP_SOCKET_KEEP_ALIVE = GroupProperty.SOCKET_KEEP_ALIVE.getName();
+    @Deprecated
+    public static final String PROP_SOCKET_NO_DELAY = GroupProperty.SOCKET_NO_DELAY.getName();
+    @Deprecated
+    public static final String PROP_SHUTDOWNHOOK_ENABLED = GroupProperty.SHUTDOWNHOOK_ENABLED.getName();
+    @Deprecated
+    public static final String PROP_WAIT_SECONDS_BEFORE_JOIN = GroupProperty.WAIT_SECONDS_BEFORE_JOIN.getName();
+    @Deprecated
+    public static final String PROP_MAX_WAIT_SECONDS_BEFORE_JOIN = GroupProperty.MAX_WAIT_SECONDS_BEFORE_JOIN.getName();
+    @Deprecated
+    public static final String PROP_MAX_JOIN_SECONDS = GroupProperty.MAX_JOIN_SECONDS.getName();
+    @Deprecated
+    public static final String PROP_MAX_JOIN_MERGE_TARGET_SECONDS = GroupProperty.MAX_JOIN_MERGE_TARGET_SECONDS.getName();
+    @Deprecated
+    public static final String PROP_HEARTBEAT_INTERVAL_SECONDS = GroupProperty.HEARTBEAT_INTERVAL_SECONDS.getName();
+    @Deprecated
+    public static final String PROP_MAX_NO_HEARTBEAT_SECONDS = GroupProperty.MAX_NO_HEARTBEAT_SECONDS.getName();
+    @Deprecated
+    public static final String PROP_MAX_NO_MASTER_CONFIRMATION_SECONDS
+            = GroupProperty.MAX_NO_MASTER_CONFIRMATION_SECONDS.getName();
+    @Deprecated
     public static final String PROP_MASTER_CONFIRMATION_INTERVAL_SECONDS
-            = "hazelcast.master.confirmation.interval.seconds";
+            = GroupProperty.MASTER_CONFIRMATION_INTERVAL_SECONDS.getName();
+    @Deprecated
     public static final String PROP_MEMBER_LIST_PUBLISH_INTERVAL_SECONDS
-            = "hazelcast.member.list.publish.interval.seconds";
-    public static final String PROP_ICMP_ENABLED = "hazelcast.icmp.enabled";
-    public static final String PROP_ICMP_TIMEOUT = "hazelcast.icmp.timeout";
-    public static final String PROP_ICMP_TTL = "hazelcast.icmp.ttl";
-    public static final String PROP_INITIAL_MIN_CLUSTER_SIZE = "hazelcast.initial.min.cluster.size";
-    public static final String PROP_INITIAL_WAIT_SECONDS = "hazelcast.initial.wait.seconds";
-
-    /**
-     * The number of incremental ports, starting with port number defined in network configuration,
-     * that will be used to connect to a host which is defined without a port in the TCP-IP member list
-     * while a node is searching for a cluster.
-     */
-    public static final String PROP_TCP_JOIN_PORT_TRY_COUNT = "hazelcast.tcp.join.port.try.count";
+            = GroupProperty.MEMBER_LIST_PUBLISH_INTERVAL_SECONDS.getName();
+    @Deprecated
+    public static final String PROP_ICMP_ENABLED = GroupProperty.ICMP_ENABLED.getName();
+    @Deprecated
+    public static final String PROP_ICMP_TIMEOUT = GroupProperty.ICMP_TIMEOUT.getName();
+    @Deprecated
+    public static final String PROP_ICMP_TTL = GroupProperty.ICMP_TTL.getName();
+    @Deprecated
+    public static final String PROP_INITIAL_MIN_CLUSTER_SIZE = GroupProperty.INITIAL_MIN_CLUSTER_SIZE.getName();
+    @Deprecated
+    public static final String PROP_INITIAL_WAIT_SECONDS = GroupProperty.INITIAL_WAIT_SECONDS.getName();
+    @Deprecated
+    public static final String PROP_TCP_JOIN_PORT_TRY_COUNT = GroupProperty.TCP_JOIN_PORT_TRY_COUNT.getName();
+    @Deprecated
     public static final String PROP_MAP_REPLICA_SCHEDULED_TASK_DELAY_SECONDS
-            = "hazelcast.map.replica.scheduled.task.delay.seconds";
-    /**
-     * YOu can use PROP_MAP_EXPIRY_DELAY_SECONDS to deal with some possible edge cases, such as using EntryProcessor.
-     * Without this delay, you may see that an EntryProcessor running on the owner partition found a key, but
-     * EntryBackupProcessor did not find it on backup, and as a result when backup promotes to owner
-     * you will end up with an unprocessed key.
-     */
-    public static final String PROP_MAP_EXPIRY_DELAY_SECONDS = "hazelcast.map.expiry.delay.seconds";
-    public static final String PROP_PARTITION_COUNT = "hazelcast.partition.count";
-    public static final String PROP_LOGGING_TYPE = "hazelcast.logging.type";
-    public static final String PROP_ENABLE_JMX = "hazelcast.jmx";
-    public static final String PROP_ENABLE_JMX_DETAILED = "hazelcast.jmx.detailed";
-    public static final String PROP_MC_MAX_VISIBLE_INSTANCE_COUNT = "hazelcast.mc.max.visible.instance.count";
-    public static final String PROP_MC_MAX_VISIBLE_SLOW_OPERATION_COUNT = "hazelcast.mc.max.visible.slow.operations.count";
-    public static final String PROP_MC_URL_CHANGE_ENABLED = "hazelcast.mc.url.change.enabled";
-    public static final String PROP_CONNECTION_MONITOR_INTERVAL = "hazelcast.connection.monitor.interval";
-    public static final String PROP_CONNECTION_MONITOR_MAX_FAULTS = "hazelcast.connection.monitor.max.faults";
-    public static final String PROP_PARTITION_MIGRATION_INTERVAL = "hazelcast.partition.migration.interval";
-    public static final String PROP_PARTITION_MIGRATION_TIMEOUT = "hazelcast.partition.migration.timeout";
-    public static final String PROP_PARTITION_MIGRATION_ZIP_ENABLED = "hazelcast.partition.migration.zip.enabled";
-    public static final String PROP_PARTITION_TABLE_SEND_INTERVAL = "hazelcast.partition.table.send.interval";
-    public static final String PROP_PARTITION_BACKUP_SYNC_INTERVAL = "hazelcast.partition.backup.sync.interval";
+            = GroupProperty.MAP_REPLICA_SCHEDULED_TASK_DELAY_SECONDS.getName();
+    @Deprecated
+    public static final String PROP_MAP_EXPIRY_DELAY_SECONDS = GroupProperty.MAP_EXPIRY_DELAY_SECONDS.getName();
+    @Deprecated
+    public static final String PROP_PARTITION_COUNT = GroupProperty.PARTITION_COUNT.getName();
+    @Deprecated
+    public static final String PROP_LOGGING_TYPE = GroupProperty.LOGGING_TYPE.getName();
+    @Deprecated
+    public static final String PROP_ENABLE_JMX = GroupProperty.ENABLE_JMX.getName();
+    @Deprecated
+    public static final String PROP_ENABLE_JMX_DETAILED = GroupProperty.ENABLE_JMX_DETAILED.getName();
+    @Deprecated
+    public static final String PROP_MC_MAX_VISIBLE_INSTANCE_COUNT = GroupProperty.MC_MAX_VISIBLE_INSTANCE_COUNT.getName();
+    @Deprecated
+    public static final String PROP_MC_MAX_VISIBLE_SLOW_OPERATION_COUNT
+            = GroupProperty.MC_MAX_VISIBLE_SLOW_OPERATION_COUNT.getName();
+    @Deprecated
+    public static final String PROP_MC_URL_CHANGE_ENABLED = GroupProperty.MC_URL_CHANGE_ENABLED.getName();
+    @Deprecated
+    public static final String PROP_CONNECTION_MONITOR_INTERVAL = GroupProperty.CONNECTION_MONITOR_INTERVAL.getName();
+    @Deprecated
+    public static final String PROP_CONNECTION_MONITOR_MAX_FAULTS = GroupProperty.CONNECTION_MONITOR_MAX_FAULTS.getName();
+    @Deprecated
+    public static final String PROP_PARTITION_MIGRATION_INTERVAL = GroupProperty.PARTITION_MIGRATION_INTERVAL.getName();
+    @Deprecated
+    public static final String PROP_PARTITION_MIGRATION_TIMEOUT = GroupProperty.PARTITION_MIGRATION_TIMEOUT.getName();
+    @Deprecated
+    public static final String PROP_PARTITION_MIGRATION_ZIP_ENABLED = GroupProperty.PARTITION_MIGRATION_ZIP_ENABLED.getName();
+    @Deprecated
+    public static final String PROP_PARTITION_TABLE_SEND_INTERVAL = GroupProperty.PARTITION_TABLE_SEND_INTERVAL.getName();
+    @Deprecated
+    public static final String PROP_PARTITION_BACKUP_SYNC_INTERVAL = GroupProperty.PARTITION_BACKUP_SYNC_INTERVAL.getName();
+    @Deprecated
     public static final String PROP_PARTITION_MAX_PARALLEL_REPLICATIONS
-            = "hazelcast.partition.max.parallel.replications";
-    public static final String PROP_PARTITIONING_STRATEGY_CLASS = "hazelcast.partitioning.strategy.class";
-    public static final String PROP_GRACEFUL_SHUTDOWN_MAX_WAIT = "hazelcast.graceful.shutdown.max.wait";
-    public static final String PROP_SYSTEM_LOG_ENABLED = "hazelcast.system.log.enabled";
-    public static final String PROP_LOCK_MAX_LEASE_TIME_SECONDS = "hazelcast.lock.max.lease.time.seconds";
-
-    /**
-     * Enables or disables the {@link com.hazelcast.spi.impl.operationexecutor.slowoperationdetector.SlowOperationDetector}.
-     */
-    public static final String PROP_SLOW_OPERATION_DETECTOR_ENABLED = "hazelcast.slow.operation.detector.enabled";
-
-    /**
-     * Defines a threshold above which a running operation in {@link com.hazelcast.spi.OperationService} is considered to be slow.
-     * These operations will log a warning and will be shown in the Management Center with detailed information, e.g. stacktrace.
-     */
+            = GroupProperty.PARTITION_MAX_PARALLEL_REPLICATIONS.getName();
+    @Deprecated
+    public static final String PROP_PARTITIONING_STRATEGY_CLASS = GroupProperty.PARTITIONING_STRATEGY_CLASS.getName();
+    @Deprecated
+    public static final String PROP_GRACEFUL_SHUTDOWN_MAX_WAIT = GroupProperty.GRACEFUL_SHUTDOWN_MAX_WAIT.getName();
+    @Deprecated
+    public static final String PROP_SYSTEM_LOG_ENABLED = GroupProperty.SYSTEM_LOG_ENABLED.getName();
+    @Deprecated
+    public static final String PROP_LOCK_MAX_LEASE_TIME_SECONDS = GroupProperty.LOCK_MAX_LEASE_TIME_SECONDS.getName();
+    @Deprecated
+    public static final String PROP_SLOW_OPERATION_DETECTOR_ENABLED = GroupProperty.SLOW_OPERATION_DETECTOR_ENABLED.getName();
+    @Deprecated
     public static final String PROP_SLOW_OPERATION_DETECTOR_THRESHOLD_MILLIS
-            = "hazelcast.slow.operation.detector.threshold.millis";
-
-
-    /**
-     * Defines a threshold above which a running invocation in {@link com.hazelcast.spi.OperationService} is considered
-     * to be slow. Any slow invocation will be logged.
-     *
-     * This is an experimental feature and we do not provide any backwards compatibility guarantees on it.
-     *
-     * The default value is -1 indicating there is no detection.
-     */
+            = GroupProperty.SLOW_OPERATION_DETECTOR_THRESHOLD_MILLIS.getName();
+    @Deprecated
     public static final String PROP_SLOW_INVOCATION_DETECTOR_THRESHOLD_MILLIS
-            = "hazelcast.slow.invocation.detector.threshold.millis";
-
-    /**
-     * This value defines the retention time of invocations in slow operation logs.
-     * <p/>
-     * If an invocation is older than this value, it will be purged from the log to prevent unlimited memory usage.
-     * When all invocations are purged from a log, the log itself will be deleted.
-     * <p/>
-     * @see com.hazelcast.instance.GroupProperties#PROP_SLOW_OPERATION_DETECTOR_LOG_PURGE_INTERVAL_SECONDS
-     */
+            = GroupProperty.SLOW_INVOCATION_DETECTOR_THRESHOLD_MILLIS.getName();
+    @Deprecated
     public static final String PROP_SLOW_OPERATION_DETECTOR_LOG_RETENTION_SECONDS
-            = "hazelcast.slow.operation.detector.log.retention.seconds";
-
-    /**
-     * Purge interval for slow operation logs.
-     * <p/>
-     * @see com.hazelcast.instance.GroupProperties#PROP_SLOW_OPERATION_DETECTOR_LOG_RETENTION_SECONDS
-     */
+            = GroupProperty.SLOW_OPERATION_DETECTOR_LOG_RETENTION_SECONDS.getName();
+    @Deprecated
     public static final String PROP_SLOW_OPERATION_DETECTOR_LOG_PURGE_INTERVAL_SECONDS
-            = "hazelcast.slow.operation.detector.log.purge.interval.seconds";
-
-    /**
-     * Defines if the stacktraces of slow operations are logged in the log file. Stacktraces will always be reported to the
-     * Management Center, but by default they are not printed to keep the log size small.
-     */
+            = GroupProperty.SLOW_OPERATION_DETECTOR_LOG_PURGE_INTERVAL_SECONDS
+            .getName();
+    @Deprecated
     public static final String PROP_SLOW_OPERATION_DETECTOR_STACK_TRACE_LOGGING_ENABLED
-            = "hazelcast.slow.operation.detector.stacktrace.logging.enabled";
-
-    // OLD ELASTIC MEMORY PROPS
-    public static final String PROP_ELASTIC_MEMORY_ENABLED = "hazelcast.elastic.memory.enabled";
-    public static final String PROP_ELASTIC_MEMORY_TOTAL_SIZE = "hazelcast.elastic.memory.total.size";
-    public static final String PROP_ELASTIC_MEMORY_CHUNK_SIZE = "hazelcast.elastic.memory.chunk.size";
-    public static final String PROP_ELASTIC_MEMORY_SHARED_STORAGE = "hazelcast.elastic.memory.shared.storage";
-    public static final String PROP_ELASTIC_MEMORY_UNSAFE_ENABLED = "hazelcast.elastic.memory.unsafe.enabled";
-    public static final String PROP_ENTERPRISE_LICENSE_KEY = "hazelcast.enterprise.license.key";
-    public static final String PROP_MAP_WRITE_BEHIND_QUEUE_CAPACITY = "hazelcast.map.write.behind.queue.capacity";
-
-    /**
-     * Defines event queue capacity for WAN replication. Replication Events are dropped when queue capacity is reached.
-     * Having too big queue capacity may lead to OOME problems,only valid for Hazelcast Enterprise
-     */
-    public static final String PROP_ENTERPRISE_WAN_REP_QUEUE_CAPACITY = "hazelcast.enterprise.wanrep.queue.capacity";
-
-    /**
-     * Defines the maximum number of WAN replication events to be drained and sent to the target cluster in a batch.
-     * Batches are sent in sequence to make sure of the order of events,
-     * only one batch of events is sent to a target wan member at a time. After the batch is sent, an acknowledgement is awaited
-     * from the target cluster.
-     * If no-ack is received, the same set of events is sent again to the target cluster until the ack is received.
-     * Until this process is complete, wan replication events are stored in the wan replication event queue.
-     * This queue's size is limited by {@link #PROP_ENTERPRISE_WAN_REP_QUEUE_CAPACITY}. If the queued event count
-     * exceeds queue capacity, no back-pressure is applied and older events in the queue will start dropping.
-     * Only valid for Hazelcast Enterprise.
-     */
-    public static final String PROP_ENTERPRISE_WAN_REP_BATCH_SIZE = "hazelcast.enterprise.wanrep.batch.size";
-
-    /**
-     * Defines batch sending frequency in seconds,
-     * When event size does not reach to {@link #PROP_ENTERPRISE_WAN_REP_BATCH_SIZE} in the given time period
-     * (which is defined by {@link #PROP_ENTERPRISE_WAN_REP_BATCH_FREQUENCY_SECONDS}),
-     * those events are gathered into a batch and sent to target.
-     * Only valid for Hazelcast Enterprise
-     */
+            = GroupProperty.SLOW_OPERATION_DETECTOR_STACK_TRACE_LOGGING_ENABLED.getName();
+    @Deprecated
+    public static final String PROP_ELASTIC_MEMORY_ENABLED = GroupProperty.ELASTIC_MEMORY_ENABLED.getName();
+    @Deprecated
+    public static final String PROP_ELASTIC_MEMORY_TOTAL_SIZE = GroupProperty.ELASTIC_MEMORY_TOTAL_SIZE.getName();
+    @Deprecated
+    public static final String PROP_ELASTIC_MEMORY_CHUNK_SIZE = GroupProperty.ELASTIC_MEMORY_CHUNK_SIZE.getName();
+    @Deprecated
+    public static final String PROP_ELASTIC_MEMORY_SHARED_STORAGE = GroupProperty.ELASTIC_MEMORY_SHARED_STORAGE.getName();
+    @Deprecated
+    public static final String PROP_ELASTIC_MEMORY_UNSAFE_ENABLED = GroupProperty.ELASTIC_MEMORY_UNSAFE_ENABLED.getName();
+    @Deprecated
+    public static final String PROP_ENTERPRISE_LICENSE_KEY = GroupProperty.ENTERPRISE_LICENSE_KEY.getName();
+    @Deprecated
+    public static final String PROP_MAP_WRITE_BEHIND_QUEUE_CAPACITY = GroupProperty.MAP_WRITE_BEHIND_QUEUE_CAPACITY.getName();
+    @Deprecated
+    public static final String PROP_ENTERPRISE_WAN_REP_QUEUE_CAPACITY = GroupProperty.ENTERPRISE_WAN_REP_QUEUE_CAPACITY.getName();
+    @Deprecated
+    public static final String PROP_ENTERPRISE_WAN_REP_BATCH_SIZE = GroupProperty.ENTERPRISE_WAN_REP_BATCH_SIZE.getName();
+    @Deprecated
     public static final String PROP_ENTERPRISE_WAN_REP_BATCH_FREQUENCY_SECONDS
-            = "hazelcast.enterprise.wanrep.batchfrequency.seconds";
-
-    /**
-     * Defines cache invalidation event batch sending is enabled or not.
-     */
+            = GroupProperty.ENTERPRISE_WAN_REP_BATCH_FREQUENCY_SECONDS.getName();
+    @Deprecated
     public static final String PROP_CACHE_INVALIDATION_MESSAGE_BATCH_ENABLED
-            = "hazelcast.cache.invalidation.batch.enabled";
-
-    /**
-     * Defines the maximum number of cache invalidation events to be drained and sent to the event listeners in a batch.
-     */
+            = GroupProperty.CACHE_INVALIDATION_MESSAGE_BATCH_ENABLED.getName();
+    @Deprecated
     public static final String PROP_CACHE_INVALIDATION_MESSAGE_BATCH_SIZE
-            = "hazelcast.cache.invalidation.batch.size";
-
-    /**
-     * Defines cache invalidation event batch sending frequency in seconds.
-     * When event size does not reach to {@link #PROP_CACHE_INVALIDATION_MESSAGE_BATCH_SIZE} in the given time period
-     * (which is defined by {@link #PROP_CACHE_INVALIDATION_MESSAGE_BATCH_FREQUENCY_SECONDS}),
-     * those events are gathered into a batch and sent to target.
-     */
+            = GroupProperty.CACHE_INVALIDATION_MESSAGE_BATCH_SIZE.getName();
+    @Deprecated
     public static final String PROP_CACHE_INVALIDATION_MESSAGE_BATCH_FREQUENCY_SECONDS
-            = "hazelcast.cache.invalidation.batchfrequency.seconds";
-
-    /**
-     * Defines timeout duration (in milliseconds) for a WAN replication event before retry.
-     * If confirmation is not received in the period of timeout duration, event is resent to target cluster.
-     * Only valid for Hazelcast Enterprise
-     */
+            = GroupProperty.CACHE_INVALIDATION_MESSAGE_BATCH_FREQUENCY_SECONDS.getName();
+    @Deprecated
     public static final String PROP_ENTERPRISE_WAN_REP_OP_TIMEOUT_MILLIS
-            = "hazelcast.enterprise.wanrep.optimeout.millis";
-
-    public static final String PROP_CLIENT_MAX_NO_HEARTBEAT_SECONDS = "hazelcast.client.max.no.heartbeat.seconds";
+            = GroupProperty.ENTERPRISE_WAN_REP_OP_TIMEOUT_MILLIS.getName();
+    @Deprecated
+    public static final String PROP_CLIENT_MAX_NO_HEARTBEAT_SECONDS = GroupProperty.CLIENT_HEARTBEAT_TIMEOUT_SECONDS.getName();
+    @Deprecated
     public static final String PROP_MIGRATION_MIN_DELAY_ON_MEMBER_REMOVED_SECONDS
-            = "hazelcast.migration.min.delay.on.member.removed.seconds";
-
-    /**
-     * Using back pressure, you can prevent an overload of pending asynchronous backups. With a map with a
-     * single asynchronous backup, producing asynchronous backups could happen at a higher rate than
-     * the consumption of the backup. This can eventually lead to an OOME (especially if the backups are slow).
-     * <p/>
-     * With back-pressure enabled, this can't happen.
-     * <p/>
-     * Back pressure is implemented by making asynchronous backups operations synchronous. This prevents the internal queues from
-     * overflowing because the invoker will wait for the primary and for the backups to complete. The frequency of this is
-     * determined by the sync-window.
-     * <p/>
-     */
-    public static final String PROP_BACKPRESSURE_ENABLED = "hazelcast.backpressure.enabled";
-
-    /**
-     * Controls the frequency of a BackupAwareOperation getting its async backups converted to a sync backups. This is needed
-     * to prevent an accumulation of asynchronous backups and eventually running into stability issues.
-     *
-     * A sync window of 10 means that 1 in 10 BackupAwareOperations get their async backups convert to sync backups.
-     *
-     * A sync window of 1 means that every BackupAwareOperation get their async backups converted to sync backups. 1
-     * is also the smallest legal value for the sync window.
-     *
-     * There is some randomization going on to prevent resonance. Therefore, with a sync window of n, not every Nth
-     * BackupAwareOperation operation gets its async backups converted to sync.
-     *
-     * This property only has meaning when backpressure is enabled.
-     */
-    public static final String PROP_BACKPRESSURE_SYNCWINDOW = "hazelcast.backpressure.syncwindow";
-
-    /**
-     * Control the maximum timeout in millis to wait for an invocation space to be available.
-     *
-     * If an invocation can't be made because there are too many pending invocations, then an exponential backoff is done
-     * to give the system time to deal with the backlog of invocations. This property controls how long an invocation is
-     * allowed to wait before getting a {@link com.hazelcast.core.HazelcastOverloadException}.
-     *
-     * The value need to be equal or larger than 0.
-     */
+            = GroupProperty.MIGRATION_MIN_DELAY_ON_MEMBER_REMOVED_SECONDS.getName();
+    @Deprecated
+    public static final String PROP_BACKPRESSURE_ENABLED = GroupProperty.BACKPRESSURE_ENABLED.getName();
+    @Deprecated
+    public static final String PROP_BACKPRESSURE_SYNCWINDOW = GroupProperty.BACKPRESSURE_SYNCWINDOW.getName();
+    @Deprecated
     public static final String PROP_BACKPRESSURE_BACKOFF_TIMEOUT_MILLIS
-            = "hazelcast.backpressure.backoff.timeout.millis";
-
-    /**
-     * The maximum number of concurrent invocations per partition.
-     *
-     * To prevent the system from overloading, HZ can apply a constraint on the number of concurrent invocations. If the maximum
-     * number of concurrent invocations has been exceeded and a new invocation comes in, then an exponential back-off is applied
-     * till eventually a timeout happens or there is room for the invocation.
-     *
-     * By default it is configured as 100. With 271 partitions, that would give (271+1)*100=27200 concurrent invocations from a
-     * single member. The +1 is for generic operations. The reasons why 100 is chosen are:
-     * - there can be concurrent operations that touch a lot of partitions which consume more than 1 invocation, and
-     * - certain methods like those from the IExecutor or ILock are also invocations and they can be very long running.
-     *
-     * No promise is made for the invocations being tracked per partition, or if there is a general pool of invocations.
-     */
+            = GroupProperty.BACKPRESSURE_BACKOFF_TIMEOUT_MILLIS.getName();
+    @Deprecated
     public static final String PROP_BACKPRESSURE_MAX_CONCURRENT_INVOCATIONS_PER_PARTITION
-            = "hazelcast.backpressure.max.concurrent.invocations.per.partition";
-
-
-    /**
-     * Run Query Evaluations for multiple partitions in parallel.
-     *
-     * Each Hazelcast member evaluates query predicates using a single thread by default. In most cases the overhead of
-     * inter-thread communication overweight benefit of parallel execution.
-     *
-     * When you have a large dataset and/or slow predicate you may benefit from parallel predicate evaluations.
-     * Set to true if you are using slow predicates or have > 100,000s entries per member.
-     *
-     * Default: false
-     *
-     */
-    public static final String PROP_QUERY_PREDICATE_PARALLEL_EVALUATION = "hazelcast.query.predicate.parallel.evaluation";
-
-
-    /**
-     * Forces the jcache provider, which can have values client or server, to force the provider type.
-     * Tf not provided, the provider will be client or server, whichever is found on the classPath first respectively.
-     */
-    public static final String PROP_JCACHE_PROVIDER_TYPE = "hazelcast.jcache.provider.type";
-
-    /**
-     * Result size limit for query operations on maps.
-     * <p/>
-     * This value defines the maximum number of returned elements for a single query result. If a query exceeds this number of
-     * elements, a {@link QueryResultSizeExceededException} will be thrown.
-     * <p/>
-     * This feature prevents an OOME if a single node is requesting the whole data set of the cluster, such as by
-     * executing a query with {@link TruePredicate}. This applies internally for the {@link IMap#values()}, {@link IMap#keySet()}
-     * and {@link IMap#entrySet()} methods, which are good candidates for OOME in large clusters.
-     * <p/>
-     * This feature depends on an equal distribution of the data on the cluster nodes to calculate the result size limit per node.
-     * Therefore, there is a minimum value of {@value QueryResultSizeLimiter#MINIMUM_MAX_RESULT_LIMIT} defined in
-     * {@link QueryResultSizeLimiter}. Configured values below the minimum will be increased to the minimum.
-     * <p/>
-     * The feature can be disabled by setting its value to <tt>-1</tt> (which is the default value).
-     */
-    public static final String PROP_QUERY_RESULT_SIZE_LIMIT = "hazelcast.query.result.size.limit";
-
-    /**
-     * Maximum value of local partitions to trigger local pre-check for {@link TruePredicate} query operations on maps.
-     * <p/>
-     * To limit the result size of a query ({@see PROP_QUERY_RESULT_SIZE_LIMIT}), a local pre-check on the requesting node can be
-     * done before the query is sent to the cluster. Since this may increase the latency, the pre-check is limited to a maximum
-     * number of local partitions.
-     * <p/>
-     * By increasing this parameter, you can prevent the execution of the query on the cluster. Increasing this parameter
-     * increases the latency due to the prolonged local pre-check.
-     * <p/>
-     * The pre-check can be disabled by setting the value to <tt>-1</tt>.
-     *
-     * @see #PROP_QUERY_RESULT_SIZE_LIMIT
-     */
+            = GroupProperty.BACKPRESSURE_MAX_CONCURRENT_INVOCATIONS_PER_PARTITION.getName();
+    @Deprecated
+    public static final String PROP_QUERY_PREDICATE_PARALLEL_EVALUATION
+            = GroupProperty.QUERY_PREDICATE_PARALLEL_EVALUATION.getName();
+    @Deprecated
+    public static final String PROP_JCACHE_PROVIDER_TYPE = GroupProperty.JCACHE_PROVIDER_TYPE.getName();
+    @Deprecated
+    public static final String PROP_QUERY_RESULT_SIZE_LIMIT = GroupProperty.QUERY_RESULT_SIZE_LIMIT.getName();
+    @Deprecated
     public static final String PROP_QUERY_MAX_LOCAL_PARTITION_LIMIT_FOR_PRE_CHECK
-            = "hazelcast.query.max.local.partition.limit.for.precheck";
+            = GroupProperty.QUERY_MAX_LOCAL_PARTITION_LIMIT_FOR_PRE_CHECK.getName();
 
-    public final GroupProperty CLIENT_ENGINE_THREAD_COUNT;
-
-    public final GroupProperty PARTITION_OPERATION_THREAD_COUNT;
-
-    public final GroupProperty GENERIC_OPERATION_THREAD_COUNT;
-
-    public final GroupProperty EVENT_THREAD_COUNT;
-
-    public final GroupProperty HEALTH_MONITORING_LEVEL;
-
-    public final GroupProperty HEALTH_MONITORING_DELAY_SECONDS;
-
-    public final GroupProperty PERFORMANCE_MONITOR_ENABLED;
-
-    public final GroupProperty PERFORMANCE_MONITOR_DELAY_SECONDS;
-
-    public final GroupProperty PERFORMANCE_MONITOR_MAX_ROLLED_FILE_SIZE;
-
-    public final GroupProperty PERFORMANCE_MONITOR_MAX_ROLLED_FILE_COUNT;
-
-    public final GroupProperty PERFORMANCE_MONITOR_HUMAN_FRIENDLY_FORMAT;
-
-    public final GroupProperty IO_THREAD_COUNT;
-    public final GroupProperty IO_INPUT_THREAD_COUNT;
-    public final GroupProperty IO_OUTPUT_THREAD_COUNT;
-
-    public final GroupProperty IO_BALANCER_INTERVAL_SECONDS;
-
-    public final GroupProperty EVENT_QUEUE_CAPACITY;
-
-    public final GroupProperty EVENT_QUEUE_TIMEOUT_MILLIS;
-
-    public final GroupProperty PREFER_IPv4_STACK;
-
-    public final GroupProperty CONNECT_ALL_WAIT_SECONDS;
-
-    public final GroupProperty VERSION_CHECK_ENABLED;
-
-    public final GroupProperty MEMCACHE_ENABLED;
-
-    public final GroupProperty REST_ENABLED;
-
-    public final GroupProperty MAP_LOAD_CHUNK_SIZE;
-
-    public final GroupProperty MERGE_FIRST_RUN_DELAY_SECONDS;
-
-    public final GroupProperty MERGE_NEXT_RUN_DELAY_SECONDS;
-
-    public final GroupProperty OPERATION_CALL_TIMEOUT_MILLIS;
-
-    public final GroupProperty OPERATION_BACKUP_TIMEOUT_MILLIS;
-
-    public final GroupProperty SOCKET_SERVER_BIND_ANY;
-
-    public final GroupProperty SOCKET_CLIENT_BIND_ANY;
-
-    public final GroupProperty SOCKET_CLIENT_BIND;
-
-    // number of kilobytes
-    public final GroupProperty SOCKET_RECEIVE_BUFFER_SIZE;
-
-    // number of kilobytes
-    public final GroupProperty SOCKET_SEND_BUFFER_SIZE;
-
-    // number of kilobytes
-    public final GroupProperty SOCKET_CLIENT_RECEIVE_BUFFER_SIZE;
-
-    // number of kilobytes
-    public final GroupProperty SOCKET_CLIENT_SEND_BUFFER_SIZE;
-
-    public final GroupProperty SOCKET_LINGER_SECONDS;
-
-    public final GroupProperty SOCKET_CONNECT_TIMEOUT_SECONDS;
-
-    public final GroupProperty SOCKET_KEEP_ALIVE;
-
-    public final GroupProperty SOCKET_NO_DELAY;
-
-    public final GroupProperty SHUTDOWNHOOK_ENABLED;
-
-    public final GroupProperty WAIT_SECONDS_BEFORE_JOIN;
-
-    public final GroupProperty MAX_WAIT_SECONDS_BEFORE_JOIN;
-
-    public final GroupProperty MAX_JOIN_SECONDS;
-
-    public final GroupProperty MAX_JOIN_MERGE_TARGET_SECONDS;
-
-    public final GroupProperty MAX_NO_HEARTBEAT_SECONDS;
-
-    public final GroupProperty HEARTBEAT_INTERVAL_SECONDS;
-
-    public final GroupProperty MASTER_CONFIRMATION_INTERVAL_SECONDS;
-
-    public final GroupProperty MAX_NO_MASTER_CONFIRMATION_SECONDS;
-
-    public final GroupProperty MEMBER_LIST_PUBLISH_INTERVAL_SECONDS;
-
-    public final GroupProperty ICMP_ENABLED;
-
-    public final GroupProperty ICMP_TIMEOUT;
-
-    public final GroupProperty ICMP_TTL;
-
-    public final GroupProperty INITIAL_WAIT_SECONDS;
-
-    public final GroupProperty INITIAL_MIN_CLUSTER_SIZE;
-
-    public final GroupProperty TCP_JOIN_PORT_TRY_COUNT;
-
-    public final GroupProperty MAP_REPLICA_SCHEDULED_TASK_DELAY_SECONDS;
-
-    public final GroupProperty MAP_EXPIRY_DELAY_SECONDS;
-
-    public final GroupProperty PARTITION_COUNT;
-
-    public final GroupProperty LOGGING_TYPE;
-
-    public final GroupProperty ENABLE_JMX;
-
-    public final GroupProperty ENABLE_JMX_DETAILED;
-
-    public final GroupProperty MC_MAX_INSTANCE_COUNT;
-
-    public final GroupProperty MC_MAX_SLOW_OPERATION_COUNT;
-
-    public final GroupProperty MC_URL_CHANGE_ENABLED;
-
-    public final GroupProperty CONNECTION_MONITOR_INTERVAL;
-
-    public final GroupProperty CONNECTION_MONITOR_MAX_FAULTS;
-
-    public final GroupProperty PARTITION_MIGRATION_INTERVAL;
-
-    public final GroupProperty PARTITION_MIGRATION_TIMEOUT;
-
-    public final GroupProperty PARTITION_MIGRATION_ZIP_ENABLED;
-
-    public final GroupProperty PARTITION_TABLE_SEND_INTERVAL;
-
-    public final GroupProperty PARTITION_BACKUP_SYNC_INTERVAL;
-
-    public final GroupProperty PARTITION_MAX_PARALLEL_REPLICATIONS;
-
-    public final GroupProperty PARTITIONING_STRATEGY_CLASS;
-
-    public final GroupProperty GRACEFUL_SHUTDOWN_MAX_WAIT;
-
-    public final GroupProperty SYSTEM_LOG_ENABLED;
-
-    public final GroupProperty SLOW_OPERATION_DETECTOR_ENABLED;
-    public final GroupProperty SLOW_OPERATION_DETECTOR_THRESHOLD_MILLIS;
-    public final GroupProperty SLOW_OPERATION_DETECTOR_LOG_RETENTION_SECONDS;
-    public final GroupProperty SLOW_OPERATION_DETECTOR_LOG_PURGE_INTERVAL_SECONDS;
-    public final GroupProperty SLOW_OPERATION_DETECTOR_STACK_TRACE_LOGGING_ENABLED;
-
-    public final GroupProperty SLOW_INVOCATION_DETECTOR_THRESHOLD_MILLIS;
-
-    public final GroupProperty LOCK_MAX_LEASE_TIME_SECONDS;
-
-    public final GroupProperty ELASTIC_MEMORY_ENABLED;
-
-    public final GroupProperty ELASTIC_MEMORY_TOTAL_SIZE;
-
-    public final GroupProperty ELASTIC_MEMORY_CHUNK_SIZE;
-
-    public final GroupProperty ELASTIC_MEMORY_SHARED_STORAGE;
-
-    public final GroupProperty ELASTIC_MEMORY_UNSAFE_ENABLED;
-
-    public final GroupProperty ENTERPRISE_LICENSE_KEY;
+    private final String[] properties = new String[GroupProperty.values().length];
 
     /**
-     * Setting this capacity is valid if you set
-     * {@link com.hazelcast.config.MapStoreConfig#writeCoalescing} to {@code false}. Otherwise
-     * its value will not be taken into account.
+     * Creates a container with configured Hazelcast properties.
      * <p/>
-     * The per node maximum write-behind queue capacity is the total of all write-behind queue sizes in a node,
-     * including backups.
-     * <p/>
-     * The maximum value which can be set is {@link Integer#MAX_VALUE}
+     * Uses the environmental value if no value is defined in the configuration.
+     * Uses the default value if no environmental value is defined.
+     *
+     * @param config {@link Config} used to configure the {@link GroupProperty} values.
      */
-    public final GroupProperty MAP_WRITE_BEHIND_QUEUE_CAPACITY;
-
-    public final GroupProperty ENTERPRISE_WAN_REP_QUEUE_CAPACITY;
-    public final GroupProperty ENTERPRISE_WAN_REP_BATCH_SIZE;
-    public final GroupProperty ENTERPRISE_WAN_REP_BATCH_FREQUENCY_SECONDS;
-    public final GroupProperty ENTERPRISE_WAN_REP_OP_TIMEOUT_MILLIS;
-
-    public final GroupProperty CACHE_INVALIDATION_MESSAGE_BATCH_ENABLED;
-    public final GroupProperty CACHE_INVALIDATION_MESSAGE_BATCH_SIZE;
-    public final GroupProperty CACHE_INVALIDATION_MESSAGE_BATCH_FREQUENCY_SECONDS;
-
-    public final GroupProperty CLIENT_HEARTBEAT_TIMEOUT_SECONDS;
-
-    public final GroupProperty MIGRATION_MIN_DELAY_ON_MEMBER_REMOVED_SECONDS;
-
-    public final GroupProperty BACKPRESSURE_ENABLED;
-    public final GroupProperty BACKPRESSURE_SYNCWINDOW;
-    public final GroupProperty BACKPRESSURE_BACKOFF_TIMEOUT_MILLIS;
-    public final GroupProperty BACKPRESSURE_MAX_CONCURRENT_INVOCATIONS_PER_PARTITION;
-
-    public final GroupProperty QUERY_RESULT_SIZE_LIMIT;
-    public final GroupProperty QUERY_MAX_LOCAL_PARTITION_LIMIT_FOR_PRE_CHECK;
-
-    public final GroupProperty QUERY_PREDICATE_PARALLEL_EVALUATION;
-
     public GroupProperties(Config config) {
-        HEALTH_MONITORING_LEVEL
-                = new GroupProperty(config, PROP_HEALTH_MONITORING_LEVEL, HealthMonitorLevel.SILENT.toString());
-        HEALTH_MONITORING_DELAY_SECONDS
-                = new GroupProperty(config, PROP_HEALTH_MONITORING_DELAY_SECONDS, "30");
-
-        PERFORMANCE_MONITOR_ENABLED
-                = new GroupProperty(config, PROP_PERFORMANCE_MONITOR_ENABLED, "false");
-        PERFORMANCE_MONITOR_DELAY_SECONDS
-                = new GroupProperty(config, PROP_PERFORMANCE_MONITOR_DELAY_SECONDS, "30");
-        PERFORMANCE_MONITOR_MAX_ROLLED_FILE_SIZE
-                = new GroupProperty(config, PROP_PERFORMANCE_MONITOR_MAX_ROLLED_FILE_SIZE_MB, "10");
-        PERFORMANCE_MONITOR_MAX_ROLLED_FILE_COUNT
-                = new GroupProperty(config, PROP_PERFORMANCE_MONITOR_MAX_ROLLED_FILE_COUNT, "10");
-        PERFORMANCE_MONITOR_HUMAN_FRIENDLY_FORMAT
-                = new GroupProperty(config, PROP_PERFORMANCE_MONITOR_HUMAN_FRIENDLY_FORMAT, "true");
-
-        VERSION_CHECK_ENABLED = new GroupProperty(config, PROP_VERSION_CHECK_ENABLED, "true");
-        PREFER_IPv4_STACK = new GroupProperty(config, PROP_PREFER_IPv4_STACK, "true");
-        IO_THREAD_COUNT = new GroupProperty(config, PROP_IO_THREAD_COUNT, "3");
-        IO_INPUT_THREAD_COUNT = new GroupProperty(config, PROP_IO_INPUT_THREAD_COUNT, IO_THREAD_COUNT.value);
-        IO_OUTPUT_THREAD_COUNT = new GroupProperty(config, PROP_IO_OUTPUT_THREAD_COUNT, IO_THREAD_COUNT.value);
-
-        IO_BALANCER_INTERVAL_SECONDS = new GroupProperty(config, PROP_IO_BALANCER_INTERVAL_SECONDS, "20");
-
-        //-1 means that the value is worked out dynamically.
-        PARTITION_OPERATION_THREAD_COUNT = new GroupProperty(config, PROP_PARTITION_OPERATION_THREAD_COUNT, "-1");
-        GENERIC_OPERATION_THREAD_COUNT = new GroupProperty(config, PROP_GENERIC_OPERATION_THREAD_COUNT, "-1");
-        EVENT_THREAD_COUNT = new GroupProperty(config, PROP_EVENT_THREAD_COUNT, "5");
-        EVENT_QUEUE_CAPACITY = new GroupProperty(config, PROP_EVENT_QUEUE_CAPACITY, "1000000");
-        EVENT_QUEUE_TIMEOUT_MILLIS = new GroupProperty(config, PROP_EVENT_QUEUE_TIMEOUT_MILLIS, "250");
-        CLIENT_ENGINE_THREAD_COUNT = new GroupProperty(config, PROP_CLIENT_ENGINE_THREAD_COUNT, "-1");
-
-        CONNECT_ALL_WAIT_SECONDS = new GroupProperty(config, PROP_CONNECT_ALL_WAIT_SECONDS, "120");
-        MEMCACHE_ENABLED = new GroupProperty(config, PROP_MEMCACHE_ENABLED, "true");
-        REST_ENABLED = new GroupProperty(config, PROP_REST_ENABLED, "true");
-        MAP_LOAD_CHUNK_SIZE = new GroupProperty(config, PROP_MAP_LOAD_CHUNK_SIZE, "1000");
-        MERGE_FIRST_RUN_DELAY_SECONDS = new GroupProperty(config, PROP_MERGE_FIRST_RUN_DELAY_SECONDS, "300");
-        MERGE_NEXT_RUN_DELAY_SECONDS = new GroupProperty(config, PROP_MERGE_NEXT_RUN_DELAY_SECONDS, "120");
-        OPERATION_CALL_TIMEOUT_MILLIS = new GroupProperty(config, PROP_OPERATION_CALL_TIMEOUT_MILLIS, "60000");
-        OPERATION_BACKUP_TIMEOUT_MILLIS = new GroupProperty(config, PROP_OPERATION_BACKUP_TIMEOUT_MILLIS, "5000");
-
-        final GroupProperty SOCKET_BIND_ANY = new GroupProperty(config, PROP_SOCKET_BIND_ANY, "true");
-        SOCKET_SERVER_BIND_ANY = new GroupProperty(config, PROP_SOCKET_SERVER_BIND_ANY, SOCKET_BIND_ANY);
-        SOCKET_CLIENT_BIND_ANY = new GroupProperty(config, PROP_SOCKET_CLIENT_BIND_ANY, SOCKET_BIND_ANY);
-        SOCKET_CLIENT_BIND = new GroupProperty(config, PROP_SOCKET_CLIENT_BIND, "true");
-        SOCKET_RECEIVE_BUFFER_SIZE = new GroupProperty(config, PROP_SOCKET_RECEIVE_BUFFER_SIZE, "32");
-        SOCKET_SEND_BUFFER_SIZE = new GroupProperty(config, PROP_SOCKET_SEND_BUFFER_SIZE, "32");
-        SOCKET_CLIENT_RECEIVE_BUFFER_SIZE = new GroupProperty(config, PROP_SOCKET_CLIENT_RECEIVE_BUFFER_SIZE, "-1");
-        SOCKET_CLIENT_SEND_BUFFER_SIZE = new GroupProperty(config, PROP_SOCKET_CLIENT_SEND_BUFFER_SIZE, "-1");
-        SOCKET_LINGER_SECONDS = new GroupProperty(config, PROP_SOCKET_LINGER_SECONDS, "0");
-        SOCKET_CONNECT_TIMEOUT_SECONDS = new GroupProperty(config, PROP_SOCKET_CONNECT_TIMEOUT_SECONDS, "0");
-        SOCKET_KEEP_ALIVE = new GroupProperty(config, PROP_SOCKET_KEEP_ALIVE, "true");
-        SOCKET_NO_DELAY = new GroupProperty(config, PROP_SOCKET_NO_DELAY, "true");
-        SHUTDOWNHOOK_ENABLED = new GroupProperty(config, PROP_SHUTDOWNHOOK_ENABLED, "true");
-        WAIT_SECONDS_BEFORE_JOIN = new GroupProperty(config, PROP_WAIT_SECONDS_BEFORE_JOIN, "5");
-        MAX_WAIT_SECONDS_BEFORE_JOIN = new GroupProperty(config, PROP_MAX_WAIT_SECONDS_BEFORE_JOIN, "20");
-        MAX_JOIN_SECONDS = new GroupProperty(config, PROP_MAX_JOIN_SECONDS, "300");
-        MAX_JOIN_MERGE_TARGET_SECONDS = new GroupProperty(config, PROP_MAX_JOIN_MERGE_TARGET_SECONDS, "20");
-        HEARTBEAT_INTERVAL_SECONDS = new GroupProperty(config, PROP_HEARTBEAT_INTERVAL_SECONDS, "5");
-        MAX_NO_HEARTBEAT_SECONDS = new GroupProperty(config, PROP_MAX_NO_HEARTBEAT_SECONDS, "300");
-        MASTER_CONFIRMATION_INTERVAL_SECONDS
-                = new GroupProperty(config, PROP_MASTER_CONFIRMATION_INTERVAL_SECONDS, "30");
-        MAX_NO_MASTER_CONFIRMATION_SECONDS = new GroupProperty(config, PROP_MAX_NO_MASTER_CONFIRMATION_SECONDS, "350");
-        MEMBER_LIST_PUBLISH_INTERVAL_SECONDS
-                = new GroupProperty(config, PROP_MEMBER_LIST_PUBLISH_INTERVAL_SECONDS, "300");
-        ICMP_ENABLED = new GroupProperty(config, PROP_ICMP_ENABLED, "false");
-        ICMP_TIMEOUT = new GroupProperty(config, PROP_ICMP_TIMEOUT, "1000");
-        ICMP_TTL = new GroupProperty(config, PROP_ICMP_TTL, "0");
-        INITIAL_MIN_CLUSTER_SIZE = new GroupProperty(config, PROP_INITIAL_MIN_CLUSTER_SIZE, "0");
-        INITIAL_WAIT_SECONDS = new GroupProperty(config, PROP_INITIAL_WAIT_SECONDS, "0");
-        TCP_JOIN_PORT_TRY_COUNT = new GroupProperty(config, PROP_TCP_JOIN_PORT_TRY_COUNT, "3");
-        MAP_REPLICA_SCHEDULED_TASK_DELAY_SECONDS
-                = new GroupProperty(config, PROP_MAP_REPLICA_SCHEDULED_TASK_DELAY_SECONDS, "10");
-        MAP_EXPIRY_DELAY_SECONDS = new GroupProperty(config, PROP_MAP_EXPIRY_DELAY_SECONDS, "10");
-        PARTITION_COUNT = new GroupProperty(config, PROP_PARTITION_COUNT, "271");
-        LOGGING_TYPE = new GroupProperty(config, PROP_LOGGING_TYPE, "jdk");
-        ENABLE_JMX = new GroupProperty(config, PROP_ENABLE_JMX, "false");
-        ENABLE_JMX_DETAILED = new GroupProperty(config, PROP_ENABLE_JMX_DETAILED, "false");
-        MC_MAX_INSTANCE_COUNT = new GroupProperty(config, PROP_MC_MAX_VISIBLE_INSTANCE_COUNT, "100");
-        MC_MAX_SLOW_OPERATION_COUNT = new GroupProperty(config, PROP_MC_MAX_VISIBLE_SLOW_OPERATION_COUNT, "10");
-        MC_URL_CHANGE_ENABLED = new GroupProperty(config, PROP_MC_URL_CHANGE_ENABLED, "true");
-        CONNECTION_MONITOR_INTERVAL = new GroupProperty(config, PROP_CONNECTION_MONITOR_INTERVAL, "100");
-        CONNECTION_MONITOR_MAX_FAULTS = new GroupProperty(config, PROP_CONNECTION_MONITOR_MAX_FAULTS, "3");
-        PARTITION_MIGRATION_INTERVAL = new GroupProperty(config, PROP_PARTITION_MIGRATION_INTERVAL, "0");
-        PARTITION_MIGRATION_TIMEOUT = new GroupProperty(config, PROP_PARTITION_MIGRATION_TIMEOUT, "300");
-        PARTITION_MIGRATION_ZIP_ENABLED = new GroupProperty(config, PROP_PARTITION_MIGRATION_ZIP_ENABLED, "true");
-        PARTITION_TABLE_SEND_INTERVAL = new GroupProperty(config, PROP_PARTITION_TABLE_SEND_INTERVAL, "15");
-        PARTITION_BACKUP_SYNC_INTERVAL = new GroupProperty(config, PROP_PARTITION_BACKUP_SYNC_INTERVAL, "30");
-        PARTITION_MAX_PARALLEL_REPLICATIONS = new GroupProperty(config, PROP_PARTITION_MAX_PARALLEL_REPLICATIONS, "5");
-        PARTITIONING_STRATEGY_CLASS = new GroupProperty(config, PROP_PARTITIONING_STRATEGY_CLASS, "");
-        GRACEFUL_SHUTDOWN_MAX_WAIT = new GroupProperty(config, PROP_GRACEFUL_SHUTDOWN_MAX_WAIT, "600");
-        SYSTEM_LOG_ENABLED = new GroupProperty(config, PROP_SYSTEM_LOG_ENABLED, "true");
-
-        SLOW_OPERATION_DETECTOR_ENABLED
-                = new GroupProperty(config, PROP_SLOW_OPERATION_DETECTOR_ENABLED, "true");
-        SLOW_OPERATION_DETECTOR_THRESHOLD_MILLIS
-                = new GroupProperty(config, PROP_SLOW_OPERATION_DETECTOR_THRESHOLD_MILLIS, "10000");
-        SLOW_OPERATION_DETECTOR_LOG_RETENTION_SECONDS
-                = new GroupProperty(config, PROP_SLOW_OPERATION_DETECTOR_LOG_RETENTION_SECONDS, "3600");
-        SLOW_OPERATION_DETECTOR_LOG_PURGE_INTERVAL_SECONDS
-                = new GroupProperty(config, PROP_SLOW_OPERATION_DETECTOR_LOG_PURGE_INTERVAL_SECONDS, "300");
-        SLOW_OPERATION_DETECTOR_STACK_TRACE_LOGGING_ENABLED
-                = new GroupProperty(config, PROP_SLOW_OPERATION_DETECTOR_STACK_TRACE_LOGGING_ENABLED, "false");
-        SLOW_INVOCATION_DETECTOR_THRESHOLD_MILLIS
-                = new GroupProperty(config, PROP_SLOW_INVOCATION_DETECTOR_THRESHOLD_MILLIS, "-1");
-
-        LOCK_MAX_LEASE_TIME_SECONDS = new GroupProperty(config, PROP_LOCK_MAX_LEASE_TIME_SECONDS,
-                Long.toString(Long.MAX_VALUE));
-
-        ELASTIC_MEMORY_ENABLED = new GroupProperty(config, PROP_ELASTIC_MEMORY_ENABLED, "false");
-        ELASTIC_MEMORY_TOTAL_SIZE = new GroupProperty(config, PROP_ELASTIC_MEMORY_TOTAL_SIZE, "128M");
-        ELASTIC_MEMORY_CHUNK_SIZE = new GroupProperty(config, PROP_ELASTIC_MEMORY_CHUNK_SIZE, "1K");
-        ELASTIC_MEMORY_SHARED_STORAGE = new GroupProperty(config, PROP_ELASTIC_MEMORY_SHARED_STORAGE, "false");
-        ELASTIC_MEMORY_UNSAFE_ENABLED = new GroupProperty(config, PROP_ELASTIC_MEMORY_UNSAFE_ENABLED, "false");
-        ENTERPRISE_LICENSE_KEY = new GroupProperty(config, PROP_ENTERPRISE_LICENSE_KEY);
-        MAP_WRITE_BEHIND_QUEUE_CAPACITY
-                = new GroupProperty(config, PROP_MAP_WRITE_BEHIND_QUEUE_CAPACITY, "50000");
-
-        ENTERPRISE_WAN_REP_QUEUE_CAPACITY = new GroupProperty(config, PROP_ENTERPRISE_WAN_REP_QUEUE_CAPACITY, "100000");
-        ENTERPRISE_WAN_REP_BATCH_SIZE = new GroupProperty(config, PROP_ENTERPRISE_WAN_REP_BATCH_SIZE, "50");
-        ENTERPRISE_WAN_REP_BATCH_FREQUENCY_SECONDS
-                = new GroupProperty(config, PROP_ENTERPRISE_WAN_REP_BATCH_FREQUENCY_SECONDS, "5");
-        ENTERPRISE_WAN_REP_OP_TIMEOUT_MILLIS = new GroupProperty(config, PROP_ENTERPRISE_WAN_REP_OP_TIMEOUT_MILLIS, "60000");
-
-        CACHE_INVALIDATION_MESSAGE_BATCH_ENABLED
-                = new GroupProperty(config, PROP_CACHE_INVALIDATION_MESSAGE_BATCH_ENABLED, "true");
-        CACHE_INVALIDATION_MESSAGE_BATCH_SIZE
-                = new GroupProperty(config, PROP_CACHE_INVALIDATION_MESSAGE_BATCH_SIZE, "100");
-        CACHE_INVALIDATION_MESSAGE_BATCH_FREQUENCY_SECONDS
-                = new GroupProperty(config, PROP_CACHE_INVALIDATION_MESSAGE_BATCH_FREQUENCY_SECONDS, "10");
-
-        CLIENT_HEARTBEAT_TIMEOUT_SECONDS = new GroupProperty(config, PROP_CLIENT_MAX_NO_HEARTBEAT_SECONDS, "300");
-        MIGRATION_MIN_DELAY_ON_MEMBER_REMOVED_SECONDS
-                = new GroupProperty(config, PROP_MIGRATION_MIN_DELAY_ON_MEMBER_REMOVED_SECONDS, "5");
-        BACKPRESSURE_ENABLED
-                = new GroupProperty(config, PROP_BACKPRESSURE_ENABLED, "false");
-        BACKPRESSURE_SYNCWINDOW
-                = new GroupProperty(config, PROP_BACKPRESSURE_SYNCWINDOW, "100");
-        BACKPRESSURE_MAX_CONCURRENT_INVOCATIONS_PER_PARTITION
-                = new GroupProperty(config, PROP_BACKPRESSURE_MAX_CONCURRENT_INVOCATIONS_PER_PARTITION, "100");
-        BACKPRESSURE_BACKOFF_TIMEOUT_MILLIS
-                = new GroupProperty(config, PROP_BACKPRESSURE_BACKOFF_TIMEOUT_MILLIS, "60000");
-
-        QUERY_RESULT_SIZE_LIMIT = new GroupProperty(config, PROP_QUERY_RESULT_SIZE_LIMIT, "-1");
-        QUERY_MAX_LOCAL_PARTITION_LIMIT_FOR_PRE_CHECK
-                = new GroupProperty(config, PROP_QUERY_MAX_LOCAL_PARTITION_LIMIT_FOR_PRE_CHECK, "3");
-
-        QUERY_PREDICATE_PARALLEL_EVALUATION
-                = new GroupProperty(config, PROP_QUERY_PREDICATE_PARALLEL_EVALUATION, "false");
+        for (GroupProperty groupProperty : GroupProperty.values()) {
+            String configValue = (config != null) ? config.getProperty(groupProperty) : null;
+            if (configValue != null) {
+                properties[groupProperty.ordinal()] = configValue;
+                continue;
+            }
+            String propertyValue = groupProperty.getSystemProperty();
+            if (propertyValue != null) {
+                properties[groupProperty.ordinal()] = propertyValue;
+                continue;
+            }
+            properties[groupProperty.ordinal()] = groupProperty.getDefaultValue();
+        }
     }
 
-    public static class GroupProperty {
+    /**
+     * Returns the configured value of a {@link GroupProperty} as String.
+     *
+     * @param groupProperty the {@link GroupProperty} to get the value from
+     * @return the value or <tt>null</tt> if nothing has been configured
+     */
+    public String getString(GroupProperty groupProperty) {
+        return properties[groupProperty.ordinal()];
+    }
 
-        private final String name;
-        private final String value;
+    /**
+     * Returns the configured boolean value of a {@link GroupProperty}.
+     *
+     * @param groupProperty the {@link GroupProperty} to get the value from
+     * @return the value as boolean
+     */
+    public boolean getBoolean(GroupProperty groupProperty) {
+        return Boolean.valueOf(properties[groupProperty.ordinal()]);
+    }
 
-        GroupProperty(Config config, String name) {
-            this(config, name, (String) null);
-        }
+    /**
+     * Returns the configured int value of a {@link GroupProperty}.
+     *
+     * @param groupProperty the {@link GroupProperty} to get the value from
+     * @return the value as int
+     * @throws NumberFormatException if the value cannot be parsed
+     */
+    public int getInteger(GroupProperty groupProperty) {
+        return Integer.parseInt(properties[groupProperty.ordinal()]);
+    }
 
-        GroupProperty(Config config, String name, GroupProperty defaultValue) {
-            this(config, name, defaultValue != null ? defaultValue.getString() : null);
-        }
+    /**
+     * Returns the configured long value of a {@link GroupProperty}.
+     *
+     * @param groupProperty the {@link GroupProperty} to get the value from
+     * @return the value as long
+     * @throws NumberFormatException if the value cannot be parsed
+     */
+    public long getLong(GroupProperty groupProperty) {
+        return Long.parseLong(properties[groupProperty.ordinal()]);
+    }
 
-        GroupProperty(Config config, String name, String defaultValue) {
-            this.name = name;
-            String configValue = (config != null) ? config.getProperty(name) : null;
-            if (configValue != null) {
-                value = configValue;
-            } else if (System.getProperty(name) != null) {
-                value = System.getProperty(name);
-            } else {
-                value = defaultValue;
-            }
-        }
+    /**
+     * Returns the configured float value of a {@link GroupProperty}.
+     *
+     * @param groupProperty the {@link GroupProperty} to get the value from
+     * @return the value as float
+     * @throws NumberFormatException if the value cannot be parsed
+     */
+    public float getFloat(GroupProperty groupProperty) {
+        return Float.valueOf(properties[groupProperty.ordinal()]);
+    }
 
-        public String getName() {
-            return this.name;
-        }
+    /**
+     * Returns the configured value of a {@link GroupProperty} converted to nanoseconds.
+     *
+     * @param groupProperty the {@link GroupProperty} to get the value from
+     * @return the value in nanoseconds
+     * @throws IllegalArgumentException if the {@link GroupProperty} has no {@link TimeUnit}
+     */
+    public long getNanos(GroupProperty groupProperty) {
+        TimeUnit timeUnit = groupProperty.getTimeUnit();
+        return timeUnit.toNanos(getLong(groupProperty));
+    }
 
-        public String getValue() {
-            return value;
-        }
+    /**
+     * Returns the configured value of a {@link GroupProperty} converted to milliseconds.
+     *
+     * @param groupProperty the {@link GroupProperty} to get the value from
+     * @return the value in milliseconds
+     * @throws IllegalArgumentException if the {@link GroupProperty} has no {@link TimeUnit}
+     */
+    public long getMillis(GroupProperty groupProperty) {
+        TimeUnit timeUnit = groupProperty.getTimeUnit();
+        return timeUnit.toMillis(getLong(groupProperty));
+    }
 
-        public int getInteger() {
-            return Integer.parseInt(this.value);
-        }
-
-        public byte getByte() {
-            return Byte.parseByte(this.value);
-        }
-
-        public boolean getBoolean() {
-            return Boolean.valueOf(this.value);
-        }
-
-        public float getFloat() {
-            return Float.valueOf(this.value);
-        }
-
-        public String getString() {
-            return value;
-        }
-
-        public long getLong() {
-            return Long.parseLong(this.value);
-        }
-
-        @Override
-        public String toString() {
-            return "GroupProperty [name=" + this.name + ", value=" + this.value + "]";
-        }
+    /**
+     * Returns the configured value of a {@link GroupProperty} converted to seconds.
+     *
+     * @param groupProperty the {@link GroupProperty} to get the value from
+     * @return the value in seconds
+     * @throws IllegalArgumentException if the {@link GroupProperty} has no {@link TimeUnit}
+     */
+    public int getSeconds(GroupProperty groupProperty) {
+        TimeUnit timeUnit = groupProperty.getTimeUnit();
+        return (int) timeUnit.toSeconds(getLong(groupProperty));
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/instance/GroupProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/GroupProperty.java
@@ -1,0 +1,629 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.instance;
+
+import com.hazelcast.core.IMap;
+import com.hazelcast.internal.monitors.HealthMonitorLevel;
+import com.hazelcast.map.QueryResultSizeExceededException;
+import com.hazelcast.map.impl.QueryResultSizeLimiter;
+import com.hazelcast.query.TruePredicate;
+
+import java.util.concurrent.TimeUnit;
+
+import static com.hazelcast.util.Preconditions.checkHasText;
+import static java.lang.String.format;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+/**
+ * Defines the name and default value for Hazelcast properties.
+ */
+public enum GroupProperty implements HazelcastProperty {
+
+    /**
+     * Use this property to verify that Hazelcast nodes only join the cluster when their 'application' level configuration is the
+     * same.
+     * <p/>
+     * If you have multiple machines, and you want to make sure that each machine that joins the cluster
+     * has exactly the same 'application level' settings (such as settings that are not part of the Hazelcast configuration,
+     * maybe some filepath). To prevent these machines with potential different application level configuration from forming
+     * a cluster, you can set this property.
+     * <p/>
+     * You could use actual values, such as string paths, but you can also use an md5 hash. We'll give the guarantee
+     * that nodes will form a cluster (become a member) only where the token is an exact match. If this token is different, the
+     * member can't be started and therefore you will get the guarantee that all members in the cluster will have exactly the same
+     * application validation token.
+     * <p/>
+     * This validation-token will be checked before member join the cluster.
+     */
+    APPLICATION_VALIDATION_TOKEN("hazelcast.application.validation.token"),
+
+    /**
+     * Total number of partitions in the Hazelcast cluster.
+     */
+    PARTITION_COUNT("hazelcast.partition.count", 271),
+
+    /**
+     * The number of partition operation handler threads per Member.
+     * <p/>
+     * If this is less than the number of partitions on a Member partition operations
+     * will queue behind other operations of different partitions.
+     * <p/>
+     * The default is -1, which means that the value is determined dynamically.
+     */
+    PARTITION_OPERATION_THREAD_COUNT("hazelcast.operation.thread.count", -1),
+
+    /**
+     * The number of generic operation handler threads per Member.
+     * <p/>
+     * The default is -1, which means that the value is determined dynamically.
+     */
+    GENERIC_OPERATION_THREAD_COUNT("hazelcast.operation.generic.thread.count", -1),
+
+    /**
+     * The number of threads that the client engine has available for processing requests that are not partition specific.
+     * Most of the requests, such as map.put and map.get, are partition specific and will use a partition-operation-thread, but
+     * there are also requests that can't be executed on a partition-specific operation-thread, such as multimap.contain(value),
+     * because they need to access all partitions on a given member.
+     */
+    CLIENT_ENGINE_THREAD_COUNT("hazelcast.clientengine.thread.count", -1),
+
+    EVENT_THREAD_COUNT("hazelcast.event.thread.count", 5),
+    EVENT_QUEUE_CAPACITY("hazelcast.event.queue.capacity", 1000000),
+    EVENT_QUEUE_TIMEOUT_MILLIS("hazelcast.event.queue.timeout.millis", 250, MILLISECONDS),
+
+    HEALTH_MONITORING_LEVEL("hazelcast.health.monitoring.level", HealthMonitorLevel.SILENT.toString()),
+    HEALTH_MONITORING_DELAY_SECONDS("hazelcast.health.monitoring.delay.seconds", 20, SECONDS),
+
+    /**
+     * Use the performance monitor to see internal performance metrics. Currently this is quite
+     * limited since it will only show read/write events per selector and operations executed per operation-thread. But in
+     * the future, all kinds of new metrics will be added.
+     * <p/>
+     * The performance monitor logs all metrics into the log file.
+     * <p/>
+     * The default is false.
+     */
+    PERFORMANCE_MONITOR_ENABLED("hazelcast.performance.monitoring.enabled", false),
+
+    /**
+     * The delay in seconds between monitor of the performance.
+     * <p/>
+     * The default is 30 seconds.
+     */
+    PERFORMANCE_MONITOR_DELAY_SECONDS("hazelcast.performance.monitor.delay.seconds", 30, SECONDS),
+
+    /**
+     * The PerformanceMonitor uses a rolling file approach to prevent eating too much disk space.
+     * <p/>
+     * This property sets the maximum size in MB for a single file.
+     * <p/>
+     * Every HazelcastInstance will get its own history of log files.
+     * <p/>
+     * The default is 10.
+     */
+    PERFORMANCE_MONITOR_MAX_ROLLED_FILE_SIZE_MB("hazelcast.performance.monitor.max.rolled.file.size.mb", 10),
+
+    /**
+     * The PerformanceMonitor uses a rolling file approach to prevent eating too much disk space.
+     * <p/>
+     * This property sets the maximum number of rolling files to keep on disk.
+     * <p/>
+     * The default is 10.
+     */
+    PERFORMANCE_MONITOR_MAX_ROLLED_FILE_COUNT("hazelcast.performance.monitor.max.rolled.file.count", 10),
+
+    /**
+     * If a human friendly, but more difficult to parse, output format should be selected for dumping the metrics.
+     * <p/>
+     * The default is true.
+     */
+    PERFORMANCE_MONITOR_HUMAN_FRIENDLY_FORMAT("hazelcast.performance.monitor.human.friendly.format", true),
+
+    /**
+     * The number of threads doing socket input and the number of threads doing socket output.
+     * <p/>
+     * If e.g. 3 is configured, then you get 3 threads doing input and 3 doing output. For individual control
+     * check {@link #IO_INPUT_THREAD_COUNT} and {@link #IO_OUTPUT_THREAD_COUNT}.
+     * <p/>
+     * The default is 3 (so 6 threads).
+     */
+    IO_THREAD_COUNT("hazelcast.io.thread.count", 3),
+
+    /**
+     * Controls the number of socket input threads. By default it is the same as {@link #IO_THREAD_COUNT}.
+     */
+    IO_INPUT_THREAD_COUNT("hazelcast.io.input.thread.count", IO_THREAD_COUNT),
+
+    /**
+     * Controls the number of socket output threads. By default it is the same as {@link #IO_THREAD_COUNT}.
+     */
+    IO_OUTPUT_THREAD_COUNT("hazelcast.io.output.thread.count", IO_THREAD_COUNT),
+
+    /**
+     * The interval in seconds between {@link com.hazelcast.nio.tcp.nonblocking.iobalancer.IOBalancer IOBalancer}
+     * executions. The shorter intervals will catch I/O Imbalance faster, but they will cause higher overhead.
+     * <p/>
+     * Please see the documentation of {@link com.hazelcast.nio.tcp.nonblocking.iobalancer.IOBalancer IOBalancer} for a
+     * detailed explanation of the problem.
+     * <p/>
+     * The default is 20 seconds. A value smaller than 1 disables the balancer.
+     */
+    IO_BALANCER_INTERVAL_SECONDS("hazelcast.io.balancer.interval.seconds", 20, SECONDS),
+
+    PREFER_IPv4_STACK("hazelcast.prefer.ipv4.stack", true),
+
+    VERSION_CHECK_ENABLED("hazelcast.version.check.enabled", true),
+
+    CONNECT_ALL_WAIT_SECONDS("hazelcast.connect.all.wait.seconds", 120, SECONDS),
+
+    MEMCACHE_ENABLED("hazelcast.memcache.enabled", true),
+    REST_ENABLED("hazelcast.rest.enabled", true),
+
+    MAP_LOAD_CHUNK_SIZE("hazelcast.map.load.chunk.size", 1000),
+
+    MERGE_FIRST_RUN_DELAY_SECONDS("hazelcast.merge.first.run.delay.seconds", 300, SECONDS),
+    MERGE_NEXT_RUN_DELAY_SECONDS("hazelcast.merge.next.run.delay.seconds", 120, SECONDS),
+
+    OPERATION_CALL_TIMEOUT_MILLIS("hazelcast.operation.call.timeout.millis", 60000, MILLISECONDS),
+
+    /**
+     * If an operation has backups and the backups don't complete in time, then some cleanup logic can be executed.
+     * This property specifies that timeout for backups to complete.
+     */
+    OPERATION_BACKUP_TIMEOUT_MILLIS("hazelcast.operation.backup.timeout.millis", 5000, MILLISECONDS),
+
+    SOCKET_BIND_ANY("hazelcast.socket.bind.any", true),
+    SOCKET_SERVER_BIND_ANY("hazelcast.socket.server.bind.any", SOCKET_BIND_ANY),
+    SOCKET_CLIENT_BIND_ANY("hazelcast.socket.client.bind.any", SOCKET_BIND_ANY),
+    SOCKET_CLIENT_BIND("hazelcast.socket.client.bind", true),
+
+    // number of kilobytes
+    SOCKET_RECEIVE_BUFFER_SIZE("hazelcast.socket.receive.buffer.size", 32),
+
+    // number of kilobytes
+    SOCKET_SEND_BUFFER_SIZE("hazelcast.socket.send.buffer.size", 32),
+
+    /**
+     * Overrides receive buffer size for connections opened by clients.
+     * <p/>
+     * Hazelcast creates all connections with receive buffer size set according to #PROP_SOCKET_RECEIVE_BUFFER_SIZE.
+     * When it detects a connection was opened by a client then it adjusts receive buffer size
+     * according to this property.
+     * <p/>
+     * Size is in kilobytes.
+     * <p/>
+     * The default is -1 (same as receive buffer size for connections opened by members).
+     */
+    SOCKET_CLIENT_RECEIVE_BUFFER_SIZE("hazelcast.socket.client.receive.buffer.size", -1),
+
+    /**
+     * Overrides send buffer size for connections opened by clients.
+     * <p/>
+     * Hazelcast creates all connections with send buffer size set according to #PROP_SOCKET_SEND_BUFFER_SIZE.
+     * When it detects a connection was opened by a client then it adjusts send buffer size
+     * according to this property.
+     * <p/>
+     * Size is in kilobytes.
+     * <p/>
+     * The default is -1 (same as receive buffer size for connections opened by members).
+     */
+    SOCKET_CLIENT_SEND_BUFFER_SIZE("hazelcast.socket.client.send.buffer.size", -1),
+
+    SOCKET_LINGER_SECONDS("hazelcast.socket.linger.seconds", 0, SECONDS),
+    SOCKET_CONNECT_TIMEOUT_SECONDS("hazelcast.socket.connect.timeout.seconds", 0, SECONDS),
+    SOCKET_KEEP_ALIVE("hazelcast.socket.keep.alive", true),
+    SOCKET_NO_DELAY("hazelcast.socket.no.delay", true),
+
+    SHUTDOWNHOOK_ENABLED("hazelcast.shutdownhook.enabled", true),
+
+    WAIT_SECONDS_BEFORE_JOIN("hazelcast.wait.seconds.before.join", 5, SECONDS),
+    MAX_WAIT_SECONDS_BEFORE_JOIN("hazelcast.max.wait.seconds.before.join", 20, SECONDS),
+    MAX_JOIN_SECONDS("hazelcast.max.join.seconds", 300, SECONDS),
+    MAX_JOIN_MERGE_TARGET_SECONDS("hazelcast.max.join.merge.target.seconds", 20, SECONDS),
+    HEARTBEAT_INTERVAL_SECONDS("hazelcast.heartbeat.interval.seconds", 5, SECONDS),
+    MAX_NO_HEARTBEAT_SECONDS("hazelcast.max.no.heartbeat.seconds", 300, SECONDS),
+    MASTER_CONFIRMATION_INTERVAL_SECONDS("hazelcast.master.confirmation.interval.seconds", 30, SECONDS),
+    MAX_NO_MASTER_CONFIRMATION_SECONDS("hazelcast.max.no.master.confirmation.seconds", 350, SECONDS),
+    MEMBER_LIST_PUBLISH_INTERVAL_SECONDS("hazelcast.member.list.publish.interval.seconds", 300, SECONDS),
+
+    CLIENT_HEARTBEAT_TIMEOUT_SECONDS("hazelcast.client.max.no.heartbeat.seconds", 300, SECONDS),
+    MIGRATION_MIN_DELAY_ON_MEMBER_REMOVED_SECONDS("hazelcast.migration.min.delay.on.member.removed.seconds", 5, SECONDS),
+
+    ICMP_ENABLED("hazelcast.icmp.enabled", false),
+    ICMP_TIMEOUT("hazelcast.icmp.timeout", 1000, MILLISECONDS),
+    ICMP_TTL("hazelcast.icmp.ttl", 0),
+
+    INITIAL_MIN_CLUSTER_SIZE("hazelcast.initial.min.cluster.size", 0),
+    INITIAL_WAIT_SECONDS("hazelcast.initial.wait.seconds", 0, SECONDS),
+
+    /**
+     * The number of incremental ports, starting with port number defined in network configuration,
+     * that will be used to connect to a host which is defined without a port in the TCP-IP member list
+     * while a node is searching for a cluster.
+     */
+    TCP_JOIN_PORT_TRY_COUNT("hazelcast.tcp.join.port.try.count", 3),
+
+    MAP_REPLICA_SCHEDULED_TASK_DELAY_SECONDS("hazelcast.map.replica.scheduled.task.delay.seconds", 10, SECONDS),
+
+    /**
+     * You can use MAP_EXPIRY_DELAY_SECONDS to deal with some possible edge cases, such as using EntryProcessor.
+     * Without this delay, you may see that an EntryProcessor running on the owner partition found a key, but
+     * EntryBackupProcessor did not find it on backup, and as a result when backup promotes to owner
+     * you will end up with an unprocessed key.
+     */
+    MAP_EXPIRY_DELAY_SECONDS("hazelcast.map.expiry.delay.seconds", 10, SECONDS),
+
+    LOGGING_TYPE("hazelcast.logging.type", "jdk"),
+
+    ENABLE_JMX("hazelcast.jmx", false),
+    ENABLE_JMX_DETAILED("hazelcast.jmx.detailed", false),
+
+    MC_MAX_VISIBLE_INSTANCE_COUNT("hazelcast.mc.max.visible.instance.count", 100),
+    MC_MAX_VISIBLE_SLOW_OPERATION_COUNT("hazelcast.mc.max.visible.slow.operations.count", 10),
+    MC_URL_CHANGE_ENABLED("hazelcast.mc.url.change.enabled", true),
+
+    CONNECTION_MONITOR_INTERVAL("hazelcast.connection.monitor.interval", 100, MILLISECONDS),
+    CONNECTION_MONITOR_MAX_FAULTS("hazelcast.connection.monitor.max.faults", 3),
+
+    PARTITION_MIGRATION_INTERVAL("hazelcast.partition.migration.interval", 0, SECONDS),
+    PARTITION_MIGRATION_TIMEOUT("hazelcast.partition.migration.timeout", 300, SECONDS),
+    PARTITION_MIGRATION_ZIP_ENABLED("hazelcast.partition.migration.zip.enabled", true),
+
+    PARTITION_TABLE_SEND_INTERVAL("hazelcast.partition.table.send.interval", 15, SECONDS),
+    PARTITION_BACKUP_SYNC_INTERVAL("hazelcast.partition.backup.sync.interval", 30, SECONDS),
+    PARTITION_MAX_PARALLEL_REPLICATIONS("hazelcast.partition.max.parallel.replications", 5),
+    PARTITIONING_STRATEGY_CLASS("hazelcast.partitioning.strategy.class", ""),
+
+    GRACEFUL_SHUTDOWN_MAX_WAIT("hazelcast.graceful.shutdown.max.wait", 600, SECONDS),
+
+    SYSTEM_LOG_ENABLED("hazelcast.system.log.enabled", true),
+
+    /**
+     * Enables or disables the {@link com.hazelcast.spi.impl.operationexecutor.slowoperationdetector.SlowOperationDetector}.
+     */
+    SLOW_OPERATION_DETECTOR_ENABLED("hazelcast.slow.operation.detector.enabled", true),
+
+    /**
+     * Defines a threshold above which a running operation in {@link com.hazelcast.spi.OperationService} is considered to be slow.
+     * These operations will log a warning and will be shown in the Management Center with detailed information, e.g. stacktrace.
+     */
+    SLOW_OPERATION_DETECTOR_THRESHOLD_MILLIS("hazelcast.slow.operation.detector.threshold.millis", 10000, MILLISECONDS),
+
+    /**
+     * This value defines the retention time of invocations in slow operation logs.
+     * <p/>
+     * If an invocation is older than this value, it will be purged from the log to prevent unlimited memory usage.
+     * When all invocations are purged from a log, the log itself will be deleted.
+     *
+     * @see #SLOW_OPERATION_DETECTOR_LOG_PURGE_INTERVAL_SECONDS
+     */
+    SLOW_OPERATION_DETECTOR_LOG_RETENTION_SECONDS("hazelcast.slow.operation.detector.log.retention.seconds", 3600, SECONDS),
+
+    /**
+     * Purge interval for slow operation logs.
+     *
+     * @see #SLOW_OPERATION_DETECTOR_LOG_RETENTION_SECONDS
+     */
+    SLOW_OPERATION_DETECTOR_LOG_PURGE_INTERVAL_SECONDS("hazelcast.slow.operation.detector.log.purge.interval.seconds",
+            300, SECONDS),
+
+    /**
+     * Defines if the stacktraces of slow operations are logged in the log file. Stacktraces will always be reported to the
+     * Management Center, but by default they are not printed to keep the log size small.
+     */
+    SLOW_OPERATION_DETECTOR_STACK_TRACE_LOGGING_ENABLED("hazelcast.slow.operation.detector.stacktrace.logging.enabled", false),
+
+    /**
+     * Defines a threshold above which a running invocation in {@link com.hazelcast.spi.OperationService} is considered
+     * to be slow. Any slow invocation will be logged.
+     * <p/>
+     * This is an experimental feature and we do not provide any backwards compatibility guarantees on it.
+     * <p/>
+     * The default is -1 indicating there is no detection.
+     */
+    SLOW_INVOCATION_DETECTOR_THRESHOLD_MILLIS("hazelcast.slow.invocation.detector.threshold.millis", -1, MILLISECONDS),
+
+    LOCK_MAX_LEASE_TIME_SECONDS("hazelcast.lock.max.lease.time.seconds", Long.MAX_VALUE, SECONDS),
+
+    // OLD ELASTIC MEMORY PROPS
+    ELASTIC_MEMORY_ENABLED("hazelcast.elastic.memory.enabled", false),
+    ELASTIC_MEMORY_TOTAL_SIZE("hazelcast.elastic.memory.total.size", "128M"),
+    ELASTIC_MEMORY_CHUNK_SIZE("hazelcast.elastic.memory.chunk.size", "1K"),
+    ELASTIC_MEMORY_SHARED_STORAGE("hazelcast.elastic.memory.shared.storage", false),
+    ELASTIC_MEMORY_UNSAFE_ENABLED("hazelcast.elastic.memory.unsafe.enabled", false),
+
+    ENTERPRISE_LICENSE_KEY("hazelcast.enterprise.license.key"),
+
+    /**
+     * Setting this capacity is valid if you set {@link com.hazelcast.config.MapStoreConfig#writeCoalescing} to {@code false}.
+     * Otherwise its value will not be taken into account.
+     * <p/>
+     * The per node maximum write-behind queue capacity is the total of all write-behind queue sizes in a node, including backups.
+     * <p/>
+     * The maximum value which can be set is {@link Integer#MAX_VALUE}
+     */
+    MAP_WRITE_BEHIND_QUEUE_CAPACITY("hazelcast.map.write.behind.queue.capacity", 50000),
+
+    /**
+     * Defines the event queue capacity for WAN replication.
+     * <p/>
+     * Replication Events are dropped when queue capacity is reached.
+     * Having too big queue capacity may lead to OOME problems.
+     * <p/>
+     * Only valid for Hazelcast Enterprise.
+     */
+    ENTERPRISE_WAN_REP_QUEUE_CAPACITY("hazelcast.enterprise.wanrep.queue.capacity", 100000),
+
+    /**
+     * Defines the maximum number of WAN replication events to be drained and sent to the target cluster in a batch.
+     * <p/>
+     * Batches are sent in sequence to make sure of the order of events. Only one batch of events is sent to a target wan member
+     * at a time. After the batch is sent, an acknowledgement is awaited from the target cluster.
+     * If no-ack is received, the same set of events is sent again to the target cluster until the ack is received. Until this
+     * process is complete, WAN replication events are stored in the wan replication event queue. This queue's size is limited by
+     * {@link #ENTERPRISE_WAN_REP_QUEUE_CAPACITY}. If the queued event count exceeds queue capacity, no back-pressure is applied
+     * and older events in the queue will start dropping.
+     * <p/>
+     * Only valid for Hazelcast Enterprise.
+     */
+    ENTERPRISE_WAN_REP_BATCH_SIZE("hazelcast.enterprise.wanrep.batch.size", 50),
+
+    /**
+     * Defines the batch sending frequency in seconds.
+     * <p/>
+     * When the number of events do not come up to {@link #ENTERPRISE_WAN_REP_BATCH_SIZE} in the given time period (which is
+     * defined by this property), those events are gathered into a batch and sent to target.
+     * <p/>
+     * Only valid for Hazelcast Enterprise.
+     */
+    ENTERPRISE_WAN_REP_BATCH_FREQUENCY_SECONDS("hazelcast.enterprise.wanrep.batchfrequency.seconds", 5, SECONDS),
+
+    /**
+     * Defines timeout duration (in milliseconds) for a WAN replication event before retry.
+     * <p/>
+     * If confirmation is not received in the period of timeout duration, event is resent to target cluster.
+     * <p/>
+     * Only valid for Hazelcast Enterprise.
+     */
+    ENTERPRISE_WAN_REP_OP_TIMEOUT_MILLIS("hazelcast.enterprise.wanrep.optimeout.millis", 60000),
+
+    /**
+     * Defines cache invalidation event batch sending is enabled or not.
+     */
+    CACHE_INVALIDATION_MESSAGE_BATCH_ENABLED("hazelcast.cache.invalidation.batch.enabled", true),
+
+    /**
+     * Defines the maximum number of cache invalidation events to be drained and sent to the event listeners in a batch.
+     */
+    CACHE_INVALIDATION_MESSAGE_BATCH_SIZE("hazelcast.cache.invalidation.batch.size", 100),
+
+    /**
+     * Defines the cache invalidation event batch sending frequency in seconds.
+     * <p/>
+     * When the number of events do not come up to {@link #CACHE_INVALIDATION_MESSAGE_BATCH_SIZE} in the given time period (which
+     * is defined by this property), those events are gathered into a batch and sent to target.
+     */
+    CACHE_INVALIDATION_MESSAGE_BATCH_FREQUENCY_SECONDS("hazelcast.cache.invalidation.batchfrequency.seconds", 10, SECONDS),
+
+    /**
+     * Using back pressure, you can prevent an overload of pending asynchronous backups. With a map with a
+     * single asynchronous backup, producing asynchronous backups could happen at a higher rate than
+     * the consumption of the backup. This can eventually lead to an OOME (especially if the backups are slow).
+     * <p/>
+     * With back-pressure enabled, this can't happen.
+     * <p/>
+     * Back pressure is implemented by making asynchronous backups operations synchronous. This prevents the internal queues from
+     * overflowing because the invoker will wait for the primary and for the backups to complete. The frequency of this is
+     * determined by the sync-window.
+     */
+    BACKPRESSURE_ENABLED("hazelcast.backpressure.enabled", false),
+
+    /**
+     * Controls the frequency of a BackupAwareOperation getting its async backups converted to a sync backups. This is needed
+     * to prevent an accumulation of asynchronous backups and eventually running into stability issues.
+     * <p/>
+     * A sync window of 10 means that 1 in 10 BackupAwareOperations get their async backups convert to sync backups.
+     * <p/>
+     * A sync window of 1 means that every BackupAwareOperation get their async backups converted to sync backups. 1
+     * is also the smallest legal value for the sync window.
+     * <p/>
+     * There is some randomization going on to prevent resonance. Therefore, with a sync window of n, not every Nth
+     * BackupAwareOperation operation gets its async backups converted to sync.
+     * <p/>
+     * This property only has meaning when backpressure is enabled.
+     */
+    BACKPRESSURE_SYNCWINDOW("hazelcast.backpressure.syncwindow", 100),
+
+    /**
+     * Control the maximum timeout in millis to wait for an invocation space to be available.
+     * <p/>
+     * If an invocation can't be made because there are too many pending invocations, then an exponential backoff is done
+     * to give the system time to deal with the backlog of invocations. This property controls how long an invocation is
+     * allowed to wait before getting a {@link com.hazelcast.core.HazelcastOverloadException}.
+     * <p/>
+     * The value needs to be equal or larger than 0.
+     */
+    BACKPRESSURE_BACKOFF_TIMEOUT_MILLIS("hazelcast.backpressure.backoff.timeout.millis", 60000, MILLISECONDS),
+
+    /**
+     * The maximum number of concurrent invocations per partition.
+     * <p/>
+     * To prevent the system from overloading, HZ can apply a constraint on the number of concurrent invocations. If the maximum
+     * number of concurrent invocations has been exceeded and a new invocation comes in, then an exponential back-off is applied
+     * till eventually a timeout happens or there is room for the invocation.
+     * <p/>
+     * By default it is configured as 100. With 271 partitions, that would give (271 + 1) * 100 = 27200 concurrent invocations
+     * from a single member. The +1 is for generic operations. The reasons why 100 is chosen are:
+     * - there can be concurrent operations that touch a lot of partitions which consume more than 1 invocation, and
+     * - certain methods like those from the IExecutor or ILock are also invocations and they can be very long running.
+     * <p/>
+     * No promise is made for the invocations being tracked per partition, or if there is a general pool of invocations.
+     */
+    BACKPRESSURE_MAX_CONCURRENT_INVOCATIONS_PER_PARTITION("hazelcast.backpressure.max.concurrent.invocations.per.partition", 100),
+
+    /**
+     * Run Query Evaluations for multiple partitions in parallel.
+     * <p/>
+     * Each Hazelcast member evaluates query predicates using a single thread by default. In most cases the overhead of
+     * inter-thread communication overweight benefit of parallel execution.
+     * <p/>
+     * When you have a large dataset and/or slow predicate you may benefit from parallel predicate evaluations.
+     * Set to true if you are using slow predicates or have > 100,000s entries per member.
+     * <p/>
+     * The default is false.
+     */
+    QUERY_PREDICATE_PARALLEL_EVALUATION("hazelcast.query.predicate.parallel.evaluation", false),
+
+    /**
+     * Result size limit for query operations on maps.
+     * <p/>
+     * This value defines the maximum number of returned elements for a single query result. If a query exceeds this number of
+     * elements, a {@link QueryResultSizeExceededException} will be thrown.
+     * <p/>
+     * This feature prevents an OOME if a single node is requesting the whole data set of the cluster, such as by
+     * executing a query with {@link TruePredicate}. This applies internally for the {@link IMap#values()}, {@link IMap#keySet()}
+     * and {@link IMap#entrySet()} methods, which are good candidates for OOME in large clusters.
+     * <p/>
+     * This feature depends on an equal distribution of the data on the cluster nodes to calculate the result size limit per node.
+     * Therefore, there is a minimum value of {@value QueryResultSizeLimiter#MINIMUM_MAX_RESULT_LIMIT} defined in
+     * {@link QueryResultSizeLimiter}. Configured values below the minimum will be increased to the minimum.
+     * <p/>
+     * The feature can be disabled by setting its value to <tt>-1</tt> (which is the default value).
+     */
+    QUERY_RESULT_SIZE_LIMIT("hazelcast.query.result.size.limit", -1),
+
+    /**
+     * Maximum value of local partitions to trigger local pre-check for {@link TruePredicate} query operations on maps.
+     * <p/>
+     * To limit the result size of a query ({@see PROP_QUERY_RESULT_SIZE_LIMIT}), a local pre-check on the requesting node can be
+     * done before the query is sent to the cluster. Since this may increase the latency, the pre-check is limited to a maximum
+     * number of local partitions.
+     * <p/>
+     * By increasing this parameter, you can prevent the execution of the query on the cluster. Increasing this parameter
+     * increases the latency due to the prolonged local pre-check.
+     * <p/>
+     * The pre-check can be disabled by setting the value to <tt>-1</tt>.
+     *
+     * @see #QUERY_RESULT_SIZE_LIMIT
+     */
+    QUERY_MAX_LOCAL_PARTITION_LIMIT_FOR_PRE_CHECK("hazelcast.query.max.local.partition.limit.for.precheck", 3),
+
+    /**
+     * Forces the JCache provider, which can have values client or server, to force the provider type.
+     * If not provided, the provider will be client or server, whichever is found on the classpath first respectively.
+     */
+    JCACHE_PROVIDER_TYPE("hazelcast.jcache.provider.type");
+
+    private final String name;
+    private final String defaultValue;
+    private final TimeUnit timeUnit;
+
+    GroupProperty(String name) {
+        this(name, (String) null);
+    }
+
+    GroupProperty(String name, boolean defaultValue) {
+        this(name, defaultValue ? "true" : "false");
+    }
+
+    GroupProperty(String name, Integer defaultValue) {
+        this(name, String.valueOf(defaultValue));
+    }
+
+    GroupProperty(String name, String defaultValue) {
+        this(name, defaultValue, null);
+    }
+
+    GroupProperty(String name, GroupProperty groupProperty) {
+        this(name, groupProperty.defaultValue, groupProperty.timeUnit);
+    }
+
+    GroupProperty(String name, Integer defaultValue, TimeUnit timeUnit) {
+        this(name, String.valueOf(defaultValue), timeUnit);
+    }
+
+    GroupProperty(String name, Long defaultValue, TimeUnit timeUnit) {
+        this(name, Long.toString(defaultValue), timeUnit);
+    }
+
+    GroupProperty(String name, String defaultValue, TimeUnit timeUnit) {
+        checkHasText(name, "The property name cannot be null or empty!");
+
+        this.name = name;
+        this.defaultValue = defaultValue;
+        this.timeUnit = timeUnit;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getDefaultValue() {
+        return defaultValue;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public TimeUnit getTimeUnit() {
+        if (timeUnit == null) {
+            throw new IllegalArgumentException(format("groupProperty %s has no TimeUnit defined!", this));
+        }
+        return timeUnit;
+    }
+
+    /**
+     * Sets the environmental value of the property.
+     *
+     * @param value the value to set
+     */
+    public void setSystemProperty(String value) {
+        System.setProperty(name, value);
+    }
+
+    /**
+     * Gets the environmental value of the property.
+     *
+     * @return the value of the property
+     */
+    public String getSystemProperty() {
+        return System.getProperty(name);
+    }
+
+    /**
+     * Clears the environmental value of the property.
+     */
+    @SuppressWarnings("unused")
+    public String clearSystemProperty() {
+        return System.clearProperty(name);
+    }
+
+    @Override
+    public String toString() {
+        return name;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/instance/HazelcastInstanceFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/HazelcastInstanceFactory.java
@@ -42,6 +42,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static com.hazelcast.core.LifecycleEvent.LifecycleState.STARTED;
 import static com.hazelcast.util.Preconditions.checkHasText;
 import static com.hazelcast.util.Preconditions.checkNotNull;
+import static java.lang.String.format;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 @SuppressWarnings("SynchronizationOnStaticField")
@@ -162,10 +163,10 @@ public final class HazelcastInstanceFactory {
             proxy = new HazelcastInstanceProxy(hazelcastInstance);
             Node node = hazelcastInstance.node;
             boolean firstMember = isFirstMember(node);
-            int initialWaitSeconds = node.groupProperties.INITIAL_WAIT_SECONDS.getInteger();
+            long initialWaitSeconds = node.groupProperties.getSeconds(GroupProperty.INITIAL_WAIT_SECONDS);
             if (initialWaitSeconds > 0) {
-                hazelcastInstance.logger.info("Waiting "
-                        + initialWaitSeconds + " seconds before completing HazelcastInstance startup...");
+                hazelcastInstance.logger.info(format("Waiting %d ms before completing HazelcastInstance startup...",
+                        initialWaitSeconds));
                 try {
                     SECONDS.sleep(initialWaitSeconds);
                     if (firstMember) {
@@ -196,7 +197,7 @@ public final class HazelcastInstanceFactory {
     private static void awaitMinimalClusterSize(HazelcastInstanceImpl hazelcastInstance, Node node, boolean firstMember)
             throws InterruptedException {
 
-        int initialMinClusterSize = node.groupProperties.INITIAL_MIN_CLUSTER_SIZE.getInteger();
+        int initialMinClusterSize = node.groupProperties.getInteger(GroupProperty.INITIAL_MIN_CLUSTER_SIZE);
         while (node.getClusterService().getSize() < initialMinClusterSize) {
             try {
                 hazelcastInstance.logger.info("HazelcastInstance waiting for cluster size of " + initialMinClusterSize);

--- a/hazelcast/src/main/java/com/hazelcast/instance/HazelcastProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/HazelcastProperty.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.instance;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Interface for Hazelcast Member and Client properties.
+ */
+public interface HazelcastProperty {
+
+    /**
+     * Returns the property name.
+     *
+     * @return the property name
+     */
+    String getName();
+
+    /**
+     * Returns the default value of the property.
+     *
+     * @return the default value or <tt>null</tt> if none is defined
+     */
+    String getDefaultValue();
+
+    /**
+     * Returns the {@link TimeUnit} of the property.
+     *
+     * @return the {@link TimeUnit}
+     * @throws IllegalArgumentException if no {@link TimeUnit} is defined
+     */
+    TimeUnit getTimeUnit();
+}

--- a/hazelcast/src/main/java/com/hazelcast/instance/LifecycleServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/LifecycleServiceImpl.java
@@ -97,7 +97,7 @@ public class LifecycleServiceImpl implements LifecycleService {
     }
 
     private static int getShutdownTimeoutSeconds(Node node) {
-        int gracefulShutdownMaxWaitSeconds = node.groupProperties.GRACEFUL_SHUTDOWN_MAX_WAIT.getInteger();
+        int gracefulShutdownMaxWaitSeconds = node.groupProperties.getSeconds(GroupProperty.GRACEFUL_SHUTDOWN_MAX_WAIT);
         return Math.min(DEFAULT_GRACEFUL_SHUTDOWN_WAIT, gracefulShutdownMaxWaitSeconds);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/instance/Node.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/Node.java
@@ -134,7 +134,7 @@ public class Node {
         this.groupProperties = new GroupProperties(config);
         this.buildInfo = BuildInfoProvider.getBuildInfo();
 
-        String loggingType = groupProperties.LOGGING_TYPE.getString();
+        String loggingType = groupProperties.getString(GroupProperty.LOGGING_TYPE);
         loggingService = new LoggingServiceImpl(config.getGroupConfig().getName(), loggingType, buildInfo);
         final AddressPicker addressPicker = nodeContext.createAddressPicker(this);
         try {
@@ -288,7 +288,7 @@ public class Node {
             multicastServiceThread.start();
         }
         setActive(true);
-        if (!completelyShutdown && groupProperties.SHUTDOWNHOOK_ENABLED.getBoolean()) {
+        if (!completelyShutdown && groupProperties.getBoolean(GroupProperty.SHUTDOWNHOOK_ENABLED)) {
             logger.finest("Adding ShutdownHook");
             Runtime.getRuntime().addShutdownHook(shutdownHookThread);
         }
@@ -319,14 +319,14 @@ public class Node {
             logger.finest("** we are being asked to shutdown when active = " + String.valueOf(active));
         }
         if (!terminate && isActive() && joined()) {
-            final int maxWaitSeconds = groupProperties.GRACEFUL_SHUTDOWN_MAX_WAIT.getInteger();
+            final int maxWaitSeconds = groupProperties.getSeconds(GroupProperty.GRACEFUL_SHUTDOWN_MAX_WAIT);
             if (!partitionService.prepareToSafeShutdown(maxWaitSeconds, TimeUnit.SECONDS)) {
                 logger.warning("Graceful shutdown could not be completed in " + maxWaitSeconds + " seconds!");
             }
         }
         if (isActive()) {
             if (!terminate) {
-                final int maxWaitSeconds = groupProperties.GRACEFUL_SHUTDOWN_MAX_WAIT.getInteger();
+                final int maxWaitSeconds = groupProperties.getSeconds(GroupProperty.GRACEFUL_SHUTDOWN_MAX_WAIT);
                 if (!partitionService.prepareToSafeShutdown(maxWaitSeconds, TimeUnit.SECONDS)) {
                     logger.warning("Graceful shutdown could not be completed in " + maxWaitSeconds + " seconds!");
                 }
@@ -341,7 +341,7 @@ public class Node {
             setActive(false);
             setMasterAddress(null);
             try {
-                if (groupProperties.SHUTDOWNHOOK_ENABLED.getBoolean())
+                if (groupProperties.getBoolean(GroupProperty.SHUTDOWNHOOK_ENABLED))
                     Runtime.getRuntime().removeShutdownHook(shutdownHookThread);
             } catch (Throwable ignored) {
             }
@@ -494,8 +494,8 @@ public class Node {
         }
 
         if (!joined()) {
-            long maxJoinTime = groupProperties.MAX_JOIN_SECONDS.getInteger() * 1000L;
-            logger.severe("Could not join cluster in " + maxJoinTime + " ms. Shutting down now!");
+            long maxJoinTimeMillis = groupProperties.getMillis(GroupProperty.MAX_JOIN_SECONDS);
+            logger.severe("Could not join cluster in " + maxJoinTimeMillis + " ms. Shutting down now!");
             shutdownNodeByFiringEvents(Node.this, true);
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpPostCommandProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpPostCommandProcessor.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.internal.ascii.rest;
 
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.internal.management.ManagementCenterService;
 import com.hazelcast.internal.ascii.TextCommandService;
 
@@ -86,7 +87,7 @@ public class HttpPostCommandProcessor extends HttpCommandProcessor<HttpPostComma
     }
 
     private void handleManagementCenterUrlChange(HttpPostCommand command) throws UnsupportedEncodingException {
-        if (textCommandService.getNode().getGroupProperties().MC_URL_CHANGE_ENABLED.getBoolean()) {
+        if (textCommandService.getNode().getGroupProperties().getBoolean(GroupProperty.MC_URL_CHANGE_ENABLED)) {
             byte[] res = HttpCommand.RES_204;
             byte[] data = command.getData();
             String[] strList = bytesToString(data).split("&");

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/TimedMemberStateFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/TimedMemberStateFactory.java
@@ -27,11 +27,11 @@ import com.hazelcast.config.GroupConfig;
 import com.hazelcast.core.Client;
 import com.hazelcast.core.Member;
 import com.hazelcast.executor.impl.DistributedExecutorService;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.instance.HazelcastInstanceImpl;
 import com.hazelcast.instance.MemberImpl;
 import com.hazelcast.instance.Node;
 import com.hazelcast.internal.management.dto.ClientEndPointDTO;
-import com.hazelcast.logging.ILogger;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.monitor.LocalExecutorStats;
 import com.hazelcast.monitor.LocalMapStats;
@@ -74,16 +74,14 @@ public class TimedMemberStateFactory {
     private final HazelcastInstanceImpl instance;
     private final int maxVisibleInstanceCount;
     private final boolean cacheServiceEnabled;
-    private final ILogger logger;
 
     private volatile boolean memberStateSafe = true;
 
     public TimedMemberStateFactory(HazelcastInstanceImpl instance) {
         this.instance = instance;
         Node node = instance.node;
-        maxVisibleInstanceCount = node.groupProperties.MC_MAX_INSTANCE_COUNT.getInteger();
+        maxVisibleInstanceCount = node.groupProperties.getInteger(GroupProperty.MC_MAX_VISIBLE_INSTANCE_COUNT);
         cacheServiceEnabled = node.nodeEngine.getService(CacheService.SERVICE_NAME) != null;
-        logger = node.getLogger(TimedMemberStateFactory.class);
     }
 
     public void init() {

--- a/hazelcast/src/main/java/com/hazelcast/internal/monitors/HealthMonitor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/monitors/HealthMonitor.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.internal.monitors;
 
-import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.instance.Node;
 import com.hazelcast.instance.OutOfMemoryErrorDispatcher;
 import com.hazelcast.internal.metrics.DoubleGauge;
@@ -76,7 +76,7 @@ public class HealthMonitor {
             return null;
         }
 
-        int delaySeconds = node.getGroupProperties().HEALTH_MONITORING_DELAY_SECONDS.getInteger();
+        int delaySeconds = node.getGroupProperties().getSeconds(GroupProperty.HEALTH_MONITORING_DELAY_SECONDS);
         return new HealthMonitorThread(delaySeconds);
     }
 
@@ -92,9 +92,8 @@ public class HealthMonitor {
     }
 
     private HealthMonitorLevel getHealthMonitorLevel() {
-        GroupProperties properties = node.getGroupProperties();
-        String healthMonitorLevelString = properties.HEALTH_MONITORING_LEVEL.getString();
-        return valueOf(healthMonitorLevelString);
+        String healthMonitorLevel = node.getGroupProperties().getString(GroupProperty.HEALTH_MONITORING_LEVEL);
+        return valueOf(healthMonitorLevel);
     }
 
     private final class HealthMonitorThread extends Thread {
@@ -106,7 +105,7 @@ public class HealthMonitor {
                     node.getHazelcastThreadGroup().getThreadNamePrefix("HealthMonitor"));
             setDaemon(true);
             this.delaySeconds = delaySeconds;
-            this.performanceLogHint = node.getGroupProperties().PERFORMANCE_MONITOR_ENABLED.getBoolean();
+            this.performanceLogHint = node.getGroupProperties().getBoolean(GroupProperty.PERFORMANCE_MONITOR_ENABLED);
         }
 
         @Override
@@ -151,11 +150,9 @@ public class HealthMonitor {
             // we only log the hint once.
             performanceLogHint = false;
 
-            logger.info(
-                    "The HealthMonitor has detected a high load on the system. For more detailed information, "
-                            + getLineSeperator()
-                            + "enable the PerformanceMonitor by adding -D" + GroupProperties.PROP_PERFORMANCE_MONITOR_ENABLED
-                            + "=true");
+            logger.info(String.format("The HealthMonitor has detected a high load on the system. For more detailed information,%s"
+                            + "enable the PerformanceMonitor by adding the property -D%s=true",
+                    getLineSeperator(), GroupProperty.PERFORMANCE_MONITOR_ENABLED));
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/monitors/PerformanceLogFile.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/monitors/PerformanceLogFile.java
@@ -20,6 +20,7 @@ import com.hazelcast.core.Member;
 import com.hazelcast.instance.BuildInfo;
 import com.hazelcast.instance.BuildInfoProvider;
 import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.instance.HazelcastInstanceImpl;
 import com.hazelcast.instance.Node;
 import com.hazelcast.internal.management.dto.SlowOperationDTO;
@@ -85,10 +86,10 @@ final class PerformanceLogFile {
         this.operationService = node.nodeEngine.getOperationService();
         this.pathname = getPathName();
         GroupProperties props = node.getGroupProperties();
-        this.maxRollingFileCount = props.PERFORMANCE_MONITOR_MAX_ROLLED_FILE_COUNT.getInteger();
+        this.maxRollingFileCount = props.getInteger(GroupProperty.PERFORMANCE_MONITOR_MAX_ROLLED_FILE_COUNT);
 
         // we accept a float so it becomes easier to testing to create a small file.
-        this.maxRollingFileSizeBytes = round(ONE_MB * props.PERFORMANCE_MONITOR_MAX_ROLLED_FILE_SIZE.getFloat());
+        this.maxRollingFileSizeBytes = round(ONE_MB * props.getFloat(GroupProperty.PERFORMANCE_MONITOR_MAX_ROLLED_FILE_SIZE_MB));
 
         if (logger.isFinestEnabled()) {
             logger.finest("max rolling file size: " + maxRollingFileSizeBytes);

--- a/hazelcast/src/main/java/com/hazelcast/jmx/ManagementService.java
+++ b/hazelcast/src/main/java/com/hazelcast/jmx/ManagementService.java
@@ -19,6 +19,7 @@ package com.hazelcast.jmx;
 import com.hazelcast.core.DistributedObject;
 import com.hazelcast.core.DistributedObjectEvent;
 import com.hazelcast.core.DistributedObjectListener;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.instance.HazelcastInstanceImpl;
 import com.hazelcast.logging.ILogger;
 
@@ -52,7 +53,7 @@ public class ManagementService implements DistributedObjectListener {
     public ManagementService(HazelcastInstanceImpl instance) {
         this.instance = instance;
         this.logger = instance.getLoggingService().getLogger(getClass());
-        this.enabled = instance.node.groupProperties.ENABLE_JMX.getBoolean();
+        this.enabled = instance.node.groupProperties.getBoolean(GroupProperty.ENABLE_JMX);
         if (!enabled) {
             this.instanceMBean = null;
             this.registrationId = null;

--- a/hazelcast/src/main/java/com/hazelcast/map/QueryResultSizeExceededException.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/QueryResultSizeExceededException.java
@@ -23,7 +23,7 @@ import static java.lang.String.format;
 /**
  * This exception is thrown when a query exceeds a configurable result size limit.
  *
- * @see com.hazelcast.instance.GroupProperties#PROP_QUERY_RESULT_SIZE_LIMIT
+ * @see com.hazelcast.instance.GroupProperty#QUERY_RESULT_SIZE_LIMIT
  */
 public class QueryResultSizeExceededException extends HazelcastException {
 
@@ -35,14 +35,14 @@ public class QueryResultSizeExceededException extends HazelcastException {
         super("This exception has been thrown to prevent an OOME on this Hazelcast instance."
                 + " An OOME might occur when a query collects large data sets from the whole cluster,"
                 + " e.g. by calling IMap.values(), IMap.keySet() or IMap.entrySet()."
-                + " See GroupProperties.PROP_QUERY_RESULT_SIZE_LIMIT for further details.");
+                + " See GroupProperty.QUERY_RESULT_SIZE_LIMIT for further details.");
     }
 
     public QueryResultSizeExceededException(int maxResultLimit, String optionalMessage) {
         super(format("This exception has been thrown to prevent an OOME on this Hazelcast instance."
                         + " An OOME might occur when a query collects large data sets from the whole cluster,"
                         + " e.g. by calling IMap.values(), IMap.keySet() or IMap.entrySet()."
-                        + " See GroupProperties.PROP_QUERY_RESULT_SIZE_LIMIT for further details."
+                        + " See GroupProperty.QUERY_RESULT_SIZE_LIMIT for further details."
                         + " The configured query result size limit is %d items.%s",
                 maxResultLimit, optionalMessage));
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/PartitionContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/PartitionContainer.java
@@ -19,6 +19,7 @@ package com.hazelcast.map.impl;
 import com.hazelcast.concurrent.lock.LockService;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.map.impl.recordstore.DefaultRecordStore;
 import com.hazelcast.map.impl.recordstore.RecordStore;
@@ -58,7 +59,7 @@ public class PartitionContainer {
             GroupProperties groupProperties = nodeEngine.getGroupProperties();
 
             MapKeyLoader keyLoader = new MapKeyLoader(name, opService, ps, execService, mapContainer.toData());
-            keyLoader.setMaxBatch(groupProperties.MAP_LOAD_CHUNK_SIZE.getInteger());
+            keyLoader.setMaxBatch(groupProperties.getInteger(GroupProperty.MAP_LOAD_CHUNK_SIZE));
             keyLoader.setMaxSize(getMaxSizePerNode(mapConfig.getMaxSizeConfig()));
             keyLoader.setHasBackup(mapConfig.getBackupCount() > 0 || mapConfig.getAsyncBackupCount() > 0);
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/QueryResultSizeLimiter.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/QueryResultSizeLimiter.java
@@ -23,6 +23,8 @@ import com.hazelcast.spi.NodeEngine;
 
 import java.util.Collection;
 
+import static com.hazelcast.instance.GroupProperty.QUERY_MAX_LOCAL_PARTITION_LIMIT_FOR_PRE_CHECK;
+import static com.hazelcast.instance.GroupProperty.QUERY_RESULT_SIZE_LIMIT;
 import static java.lang.Math.ceil;
 import static java.lang.Math.min;
 
@@ -142,13 +144,12 @@ public class QueryResultSizeLimiter {
     }
 
     private int getMaxResultLimit(GroupProperties groupProperties) {
-        int maxResultLimit = groupProperties.QUERY_RESULT_SIZE_LIMIT.getInteger();
+        int maxResultLimit = groupProperties.getInteger(QUERY_RESULT_SIZE_LIMIT);
         if (maxResultLimit == -1) {
             return DISABLED;
         }
         if (maxResultLimit <= 0) {
-            throw new IllegalArgumentException(groupProperties.QUERY_RESULT_SIZE_LIMIT.getName()
-                    + " has to be -1 (disabled) or a positive number!");
+            throw new IllegalArgumentException(QUERY_RESULT_SIZE_LIMIT + " has to be -1 (disabled) or a positive number!");
         }
         if (maxResultLimit < MINIMUM_MAX_RESULT_LIMIT) {
             log.finest("Max result limit was set to minimal value of " + MINIMUM_MAX_RESULT_LIMIT);
@@ -158,12 +159,12 @@ public class QueryResultSizeLimiter {
     }
 
     private int getMaxLocalPartitionsLimitForPreCheck(GroupProperties groupProperties) {
-        int maxLocalPartitionLimitForPreCheck = groupProperties.QUERY_MAX_LOCAL_PARTITION_LIMIT_FOR_PRE_CHECK.getInteger();
+        int maxLocalPartitionLimitForPreCheck = groupProperties.getInteger(QUERY_MAX_LOCAL_PARTITION_LIMIT_FOR_PRE_CHECK);
         if (maxLocalPartitionLimitForPreCheck == -1) {
             return DISABLED;
         }
         if (maxLocalPartitionLimitForPreCheck <= 0) {
-            throw new IllegalArgumentException(groupProperties.QUERY_MAX_LOCAL_PARTITION_LIMIT_FOR_PRE_CHECK.getName()
+            throw new IllegalArgumentException(QUERY_MAX_LOCAL_PARTITION_LIMIT_FOR_PRE_CHECK
                     + " has to be -1 (disabled) or a positive number!");
         }
         return maxLocalPartitionLimitForPreCheck;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/MapDataStores.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/MapDataStores.java
@@ -20,6 +20,8 @@ import com.hazelcast.config.Config;
 import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.config.MapStoreConfig;
+import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.map.impl.MapServiceContext;
 import com.hazelcast.map.impl.MapStoreWrapper;
 import com.hazelcast.map.impl.mapstore.writebehind.WriteBehindProcessor;
@@ -85,10 +87,10 @@ public final class MapDataStores {
     }
 
     private static WriteBehindQueue newWriteBehindQueue(MapServiceContext mapServiceContext, boolean writeCoalescing) {
-        final int capacity = mapServiceContext.getNodeEngine().getGroupProperties().MAP_WRITE_BEHIND_QUEUE_CAPACITY.getInteger();
+        GroupProperties groupProperties = mapServiceContext.getNodeEngine().getGroupProperties();
+        final int capacity = groupProperties.getInteger(GroupProperty.MAP_WRITE_BEHIND_QUEUE_CAPACITY);
         final AtomicInteger counter = mapServiceContext.getWriteBehindQueueItemCounter();
-        return writeCoalescing ? createDefaultWriteBehindQueue()
-                : createBoundedWriteBehindQueue(capacity, counter);
+        return (writeCoalescing ? createDefaultWriteBehindQueue() : createBoundedWriteBehindQueue(capacity, counter));
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/StoreWorker.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/StoreWorker.java
@@ -17,6 +17,8 @@
 package com.hazelcast.map.impl.mapstore.writebehind;
 
 import com.hazelcast.cluster.ClusterService;
+import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.map.impl.MapServiceContext;
 import com.hazelcast.map.impl.PartitionContainer;
 import com.hazelcast.map.impl.recordstore.RecordStore;
@@ -33,7 +35,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.hazelcast.util.CollectionUtil.isEmpty;
@@ -192,8 +193,8 @@ public class StoreWorker implements Runnable {
     }
 
     private long getReplicaWaitTime() {
-        return TimeUnit.SECONDS.toMillis(mapServiceContext.getNodeEngine().getGroupProperties()
-                .MAP_REPLICA_SCHEDULED_TASK_DELAY_SECONDS.getInteger());
+        GroupProperties groupProperties = mapServiceContext.getNodeEngine().getGroupProperties();
+        return groupProperties.getMillis(GroupProperty.MAP_REPLICA_SCHEDULED_TASK_DELAY_SECONDS);
     }
 
     private RecordStore getRecordStoreOrNull(String mapName, int partitionId) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/QueryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/QueryOperation.java
@@ -18,6 +18,7 @@ package com.hazelcast.map.impl.operation;
 
 import com.hazelcast.core.MemberLeftException;
 import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.map.impl.MapContextQuerySupport;
 import com.hazelcast.map.impl.MapServiceContext;
 import com.hazelcast.map.impl.QueryResult;
@@ -117,7 +118,7 @@ public class QueryOperation extends AbstractMapOperation implements ReadonlyOper
         if (pagingPredicate != null) {
             runParallelForPaging(initialPartitions);
         } else {
-            boolean parallelEvaluation = groupProperties.QUERY_PREDICATE_PARALLEL_EVALUATION.getBoolean();
+            boolean parallelEvaluation = groupProperties.getBoolean(GroupProperty.QUERY_PREDICATE_PARALLEL_EVALUATION);
             if (parallelEvaluation) {
                 runParallel(initialPartitions);
             } else {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/AbstractEvictableRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/AbstractEvictableRecordStore.java
@@ -19,7 +19,7 @@ package com.hazelcast.map.impl.recordstore;
 import com.hazelcast.config.EvictionPolicy;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.core.EntryView;
-import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.map.impl.MapContainer;
 import com.hazelcast.map.impl.MapServiceContext;
 import com.hazelcast.map.impl.eviction.EvictionOperator;
@@ -31,7 +31,6 @@ import com.hazelcast.spi.NodeEngine;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
-import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.map.impl.ExpirationTimeSetter.calculateExpirationWithDelay;
 import static com.hazelcast.map.impl.ExpirationTimeSetter.calculateMaxIdleMillis;
@@ -97,14 +96,11 @@ abstract class AbstractEvictableRecordStore extends AbstractRecordStore {
     }
 
     /**
-     * @see com.hazelcast.instance.GroupProperties#PROP_MAP_EXPIRY_DELAY_SECONDS
+     * @see com.hazelcast.instance.GroupProperty#MAP_EXPIRY_DELAY_SECONDS
      */
     private long getBackupExpiryDelayMillis() {
         NodeEngine nodeEngine = mapServiceContext.getNodeEngine();
-        GroupProperties groupProperties = nodeEngine.getGroupProperties();
-        GroupProperties.GroupProperty delaySecondsProperty = groupProperties.MAP_EXPIRY_DELAY_SECONDS;
-        int delaySeconds = delaySecondsProperty.getInteger();
-        return TimeUnit.SECONDS.toMillis(delaySeconds);
+        return nodeEngine.getGroupProperties().getMillis(GroupProperty.MAP_EXPIRY_DELAY_SECONDS);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/BasicRecordStoreLoader.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/BasicRecordStoreLoader.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.map.impl.recordstore;
 
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.map.impl.MapContainer;
 import com.hazelcast.map.impl.MapService;
@@ -269,6 +270,6 @@ class BasicRecordStoreLoader implements RecordStoreLoader {
     }
 
     private int getLoadBatchSize() {
-        return mapServiceContext.getNodeEngine().getGroupProperties().MAP_LOAD_CHUNK_SIZE.getInteger();
+        return mapServiceContext.getNodeEngine().getGroupProperties().getInteger(GroupProperty.MAP_LOAD_CHUNK_SIZE);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalOperationStatsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalOperationStatsImpl.java
@@ -19,6 +19,7 @@ package com.hazelcast.monitor.impl;
 import com.eclipsesource.json.JsonArray;
 import com.eclipsesource.json.JsonObject;
 import com.eclipsesource.json.JsonValue;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.instance.Node;
 import com.hazelcast.internal.management.dto.SlowOperationDTO;
 import com.hazelcast.monitor.LocalOperationStats;
@@ -46,7 +47,7 @@ public class LocalOperationStatsImpl implements LocalOperationStats {
     }
 
     public LocalOperationStatsImpl(Node node) {
-        this.maxVisibleSlowOperationCount = node.groupProperties.MC_MAX_SLOW_OPERATION_COUNT.getInteger();
+        this.maxVisibleSlowOperationCount = node.groupProperties.getInteger(GroupProperty.MC_MAX_VISIBLE_SLOW_OPERATION_COUNT);
         this.slowOperations = node.nodeEngine.getOperationService().getSlowOperationDTOs();
         this.creationTime = Clock.currentTimeMillis();
     }

--- a/hazelcast/src/main/java/com/hazelcast/nio/NodeIOService.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/NodeIOService.java
@@ -21,6 +21,7 @@ import com.hazelcast.config.NetworkConfig;
 import com.hazelcast.config.SSLConfig;
 import com.hazelcast.config.SocketInterceptorConfig;
 import com.hazelcast.config.SymmetricEncryptionConfig;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.instance.HazelcastThreadGroup;
 import com.hazelcast.instance.Node;
 import com.hazelcast.instance.OutOfMemoryErrorDispatcher;
@@ -116,12 +117,12 @@ public class NodeIOService implements IOService {
 
     @Override
     public boolean isMemcacheEnabled() {
-        return node.groupProperties.MEMCACHE_ENABLED.getBoolean();
+        return node.groupProperties.getBoolean(GroupProperty.MEMCACHE_ENABLED);
     }
 
     @Override
     public boolean isRestEnabled() {
-        return node.groupProperties.REST_ENABLED.getBoolean();
+        return node.groupProperties.getBoolean(GroupProperty.REST_ENABLED);
     }
 
     @Override
@@ -169,64 +170,64 @@ public class NodeIOService implements IOService {
 
     @Override
     public boolean isSocketBind() {
-        return node.groupProperties.SOCKET_CLIENT_BIND.getBoolean();
+        return node.groupProperties.getBoolean(GroupProperty.SOCKET_CLIENT_BIND);
     }
 
     @Override
     public boolean isSocketBindAny() {
-        return node.groupProperties.SOCKET_CLIENT_BIND_ANY.getBoolean();
+        return node.groupProperties.getBoolean(GroupProperty.SOCKET_CLIENT_BIND_ANY);
     }
 
     @Override
     public int getSocketReceiveBufferSize() {
-        return this.node.getGroupProperties().SOCKET_RECEIVE_BUFFER_SIZE.getInteger();
+        return node.getGroupProperties().getInteger(GroupProperty.SOCKET_RECEIVE_BUFFER_SIZE);
     }
 
     @Override
     public int getSocketSendBufferSize() {
-        return this.node.getGroupProperties().SOCKET_SEND_BUFFER_SIZE.getInteger();
+        return node.getGroupProperties().getInteger(GroupProperty.SOCKET_SEND_BUFFER_SIZE);
     }
 
     @Override
     public int getSocketClientReceiveBufferSize() {
-        int clientSendBuffer = this.node.getGroupProperties().SOCKET_CLIENT_RECEIVE_BUFFER_SIZE.getInteger();
+        int clientSendBuffer = node.getGroupProperties().getInteger(GroupProperty.SOCKET_CLIENT_RECEIVE_BUFFER_SIZE);
         return clientSendBuffer != -1 ? clientSendBuffer : getSocketReceiveBufferSize();
     }
 
     @Override
     public int getSocketClientSendBufferSize() {
-        int clientReceiveBuffer = this.node.getGroupProperties().SOCKET_CLIENT_SEND_BUFFER_SIZE.getInteger();
+        int clientReceiveBuffer = node.getGroupProperties().getInteger(GroupProperty.SOCKET_CLIENT_SEND_BUFFER_SIZE);
         return clientReceiveBuffer != -1 ? clientReceiveBuffer : getSocketReceiveBufferSize();
     }
 
     @Override
     public int getSocketLingerSeconds() {
-        return this.node.getGroupProperties().SOCKET_LINGER_SECONDS.getInteger();
+        return node.getGroupProperties().getSeconds(GroupProperty.SOCKET_LINGER_SECONDS);
     }
 
     @Override
     public int getSocketConnectTimeoutSeconds() {
-        return this.node.getGroupProperties().SOCKET_CONNECT_TIMEOUT_SECONDS.getInteger();
+        return node.getGroupProperties().getSeconds(GroupProperty.SOCKET_CONNECT_TIMEOUT_SECONDS);
     }
 
     @Override
     public boolean getSocketKeepAlive() {
-        return this.node.getGroupProperties().SOCKET_KEEP_ALIVE.getBoolean();
+        return node.getGroupProperties().getBoolean(GroupProperty.SOCKET_KEEP_ALIVE);
     }
 
     @Override
     public boolean getSocketNoDelay() {
-        return this.node.getGroupProperties().SOCKET_NO_DELAY.getBoolean();
+        return node.getGroupProperties().getBoolean(GroupProperty.SOCKET_NO_DELAY);
     }
 
     @Override
     public int getInputSelectorThreadCount() {
-        return node.groupProperties.IO_INPUT_THREAD_COUNT.getInteger();
+        return node.groupProperties.getInteger(GroupProperty.IO_INPUT_THREAD_COUNT);
     }
 
     @Override
     public int getOutputSelectorThreadCount() {
-        return node.groupProperties.IO_OUTPUT_THREAD_COUNT.getInteger();
+        return node.groupProperties.getInteger(GroupProperty.IO_OUTPUT_THREAD_COUNT);
     }
 
     @Override
@@ -240,17 +241,17 @@ public class NodeIOService implements IOService {
 
     @Override
     public long getConnectionMonitorInterval() {
-        return node.groupProperties.CONNECTION_MONITOR_INTERVAL.getLong();
+        return node.groupProperties.getMillis(GroupProperty.CONNECTION_MONITOR_INTERVAL);
     }
 
     @Override
     public int getConnectionMonitorMaxFaults() {
-        return node.groupProperties.CONNECTION_MONITOR_MAX_FAULTS.getInteger();
+        return node.groupProperties.getInteger(GroupProperty.CONNECTION_MONITOR_MAX_FAULTS);
     }
 
     @Override
     public int getBalancerIntervalSeconds() {
-        return node.groupProperties.IO_BALANCER_INTERVAL_SECONDS.getInteger();
+        return node.groupProperties.getSeconds(GroupProperty.IO_BALANCER_INTERVAL_SECONDS);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/iobalancer/IOBalancer.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/iobalancer/IOBalancer.java
@@ -29,8 +29,8 @@ import com.hazelcast.nio.tcp.nonblocking.NonBlockingSocketWriter;
 import com.hazelcast.util.counters.MwCounter;
 import com.hazelcast.util.counters.SwCounter;
 
-import static com.hazelcast.instance.GroupProperties.PROP_IO_BALANCER_INTERVAL_SECONDS;
-import static com.hazelcast.instance.GroupProperties.PROP_IO_THREAD_COUNT;
+import static com.hazelcast.instance.GroupProperty.IO_BALANCER_INTERVAL_SECONDS;
+import static com.hazelcast.instance.GroupProperty.IO_THREAD_COUNT;
 import static com.hazelcast.util.counters.MwCounter.newMwCounter;
 import static com.hazelcast.util.counters.SwCounter.newSwCounter;
 
@@ -48,7 +48,7 @@ import static com.hazelcast.util.counters.SwCounter.newSwCounter;
  * schedules handler migration to fix the situation. The exact migration strategy can be customized via
  * {@link com.hazelcast.nio.tcp.nonblocking.iobalancer.MigrationStrategy}.
  *
- * Measuring interval can be customized via {@link com.hazelcast.instance.GroupProperties#IO_BALANCER_INTERVAL_SECONDS}
+ * Measuring interval can be customized via {@link com.hazelcast.instance.GroupProperty#IO_BALANCER_INTERVAL_SECONDS}
  *
  * It doesn't leverage {@link com.hazelcast.nio.ConnectionListener} capability
  * provided by {@link com.hazelcast.nio.ConnectionManager} to observe connections as it has to be notified
@@ -178,15 +178,14 @@ public class IOBalancer {
 
     private boolean isEnabled(NonBlockingIOThread[] inputThreads, NonBlockingIOThread[] outputThreads) {
         if (balancerIntervalSeconds <= 0) {
-            logger.warning("I/O Balancer is disabled as the '"
-                    + PROP_IO_BALANCER_INTERVAL_SECONDS + "' property is set to "
+            logger.warning("I/O Balancer is disabled as the '" + IO_BALANCER_INTERVAL_SECONDS + "' property is set to "
                     + balancerIntervalSeconds + ". Set the property to a value larger than 0 to enable the I/O Balancer.");
             return false;
         }
 
         if (inputThreads.length == 1 && outputThreads.length == 1) {
             logger.finest("I/O Balancer is disabled as there is only a single a pair of I/O threads. Use the '"
-                    + PROP_IO_THREAD_COUNT + "' property to increase number of I/O Threads.");
+                    + IO_THREAD_COUNT + "' property to increase number of I/O Threads.");
             return false;
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/partition/PartitionServiceProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/PartitionServiceProxy.java
@@ -19,6 +19,7 @@ package com.hazelcast.partition;
 import com.hazelcast.core.Member;
 import com.hazelcast.core.MigrationListener;
 import com.hazelcast.core.Partition;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.instance.MemberImpl;
 import com.hazelcast.instance.Node;
 import com.hazelcast.logging.ILogger;
@@ -184,7 +185,7 @@ public class PartitionServiceProxy implements com.hazelcast.core.PartitionServic
     }
 
     private static int getMaxWaitTime(Node node) {
-        return node.getGroupProperties().GRACEFUL_SHUTDOWN_MAX_WAIT.getInteger();
+        return node.getGroupProperties().getSeconds(GroupProperty.GRACEFUL_SHUTDOWN_MAX_WAIT);
     }
 
     public PartitionProxy getPartition(int partitionId) {

--- a/hazelcast/src/main/java/com/hazelcast/spi/EventService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/EventService.java
@@ -26,7 +26,7 @@ public interface EventService {
     /**
      * Returns the event thread count.
      *
-     * @see com.hazelcast.instance.GroupProperties#PROP_EVENT_THREAD_COUNT
+     * @see com.hazelcast.instance.GroupProperty#EVENT_THREAD_COUNT
      * @return the event thread count
      */
     int getEventThreadCount();
@@ -34,7 +34,7 @@ public interface EventService {
     /**
      * Returns the queue capacity per event thread.
      *
-     * @see com.hazelcast.instance.GroupProperties#PROP_EVENT_QUEUE_CAPACITY
+     * @see com.hazelcast.instance.GroupProperty#EVENT_QUEUE_CAPACITY
      * @return the queue capacity per event thread
      */
     int getEventQueueCapacity();

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/EventServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/EventServiceImpl.java
@@ -18,6 +18,7 @@ package com.hazelcast.spi.impl.eventservice.impl;
 
 import com.hazelcast.core.Member;
 import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.instance.HazelcastThreadGroup;
 import com.hazelcast.instance.MemberImpl;
 import com.hazelcast.instance.Node;
@@ -79,7 +80,7 @@ public class EventServiceImpl implements InternalEventService {
     private final ExceptionHandler deregistrationExceptionHandler;
     private final ConcurrentMap<String, EventServiceSegment> segments;
     private final StripedExecutor eventExecutor;
-    private final int eventQueueTimeoutMs;
+    private final long eventQueueTimeoutMs;
 
     @Probe(name = "threadCount")
     private final int eventThreadCount;
@@ -97,9 +98,9 @@ public class EventServiceImpl implements InternalEventService {
         this.logger = nodeEngine.getLogger(EventService.class.getName());
         final Node node = nodeEngine.getNode();
         GroupProperties groupProperties = node.getGroupProperties();
-        this.eventThreadCount = groupProperties.EVENT_THREAD_COUNT.getInteger();
-        this.eventQueueCapacity = groupProperties.EVENT_QUEUE_CAPACITY.getInteger();
-        this.eventQueueTimeoutMs = groupProperties.EVENT_QUEUE_TIMEOUT_MILLIS.getInteger();
+        this.eventThreadCount = groupProperties.getInteger(GroupProperty.EVENT_THREAD_COUNT);
+        this.eventQueueCapacity = groupProperties.getInteger(GroupProperty.EVENT_QUEUE_CAPACITY);
+        this.eventQueueTimeoutMs = groupProperties.getMillis(GroupProperty.EVENT_QUEUE_TIMEOUT_MILLIS);
         HazelcastThreadGroup threadGroup = node.getHazelcastThreadGroup();
         this.eventExecutor = new StripedExecutor(
                 node.getLogger(EventServiceImpl.class),

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/classic/ClassicOperationExecutor.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/classic/ClassicOperationExecutor.java
@@ -17,6 +17,7 @@
 package com.hazelcast.spi.impl.operationexecutor.classic;
 
 import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.instance.HazelcastThreadGroup;
 import com.hazelcast.instance.NodeExtension;
 import com.hazelcast.internal.metrics.MetricsRegistry;
@@ -106,7 +107,7 @@ public final class ClassicOperationExecutor implements OperationExecutor {
     }
 
     private OperationRunner[] initPartitionOperationRunners(GroupProperties properties, OperationRunnerFactory handlerFactory) {
-        OperationRunner[] operationRunners = new OperationRunner[properties.PARTITION_COUNT.getInteger()];
+        OperationRunner[] operationRunners = new OperationRunner[properties.getInteger(GroupProperty.PARTITION_COUNT)];
         for (int partitionId = 0; partitionId < operationRunners.length; partitionId++) {
             operationRunners[partitionId] = handlerFactory.createPartitionRunner(partitionId);
         }
@@ -114,7 +115,7 @@ public final class ClassicOperationExecutor implements OperationExecutor {
     }
 
     private OperationRunner[] initGenericOperationRunners(GroupProperties properties, OperationRunnerFactory runnerFactory) {
-        int genericThreadCount = properties.GENERIC_OPERATION_THREAD_COUNT.getInteger();
+        int genericThreadCount = properties.getInteger(GroupProperty.GENERIC_OPERATION_THREAD_COUNT);
         if (genericThreadCount <= 0) {
             // default generic operation thread count
             int coreSize = Runtime.getRuntime().availableProcessors();
@@ -129,7 +130,7 @@ public final class ClassicOperationExecutor implements OperationExecutor {
     }
 
     private PartitionOperationThread[] initPartitionThreads(GroupProperties properties) {
-        int threadCount = properties.PARTITION_OPERATION_THREAD_COUNT.getInteger();
+        int threadCount = properties.getInteger(GroupProperty.PARTITION_OPERATION_THREAD_COUNT);
         if (threadCount <= 0) {
             // default partition operation thread count
             int coreSize = Runtime.getRuntime().availableProcessors();

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationRegistry.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationRegistry.java
@@ -19,6 +19,7 @@ package com.hazelcast.spi.impl.operationservice.impl;
 import com.hazelcast.core.HazelcastInstanceNotActiveException;
 import com.hazelcast.core.MemberLeftException;
 import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.instance.MemberImpl;
 import com.hazelcast.internal.metrics.Probe;
 import com.hazelcast.logging.ILogger;
@@ -99,7 +100,7 @@ public class InvocationRegistry {
         this.callIdSequence = backpressureRegulator.newCallIdSequence();
         GroupProperties props = nodeEngine.getGroupProperties();
         this.slowInvocationThresholdMs = initSlowInvocationThresholdMs(props);
-        this.backupTimeoutMillis = props.OPERATION_BACKUP_TIMEOUT_MILLIS.getLong();
+        this.backupTimeoutMillis = props.getMillis(GroupProperty.OPERATION_BACKUP_TIMEOUT_MILLIS);
         this.invocations = new ConcurrentHashMap<Long, Invocation>(INITIAL_CAPACITY, LOAD_FACTOR, concurrencyLevel);
 
         nodeEngine.getMetricsRegistry().scanAndRegister(this, "operation");
@@ -119,7 +120,7 @@ public class InvocationRegistry {
     }
 
     private long initSlowInvocationThresholdMs(GroupProperties props) {
-        long thresholdMs = props.SLOW_INVOCATION_DETECTOR_THRESHOLD_MILLIS.getLong();
+        long thresholdMs = props.getMillis(GroupProperty.SLOW_INVOCATION_DETECTOR_THRESHOLD_MILLIS);
         if (thresholdMs > -1) {
             logger.info("Slow invocation detector enabled, using threshold: " + thresholdMs + " ms");
         }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
@@ -19,6 +19,7 @@ package com.hazelcast.spi.impl.operationservice.impl;
 import com.hazelcast.cluster.ClusterClock;
 import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.instance.MemberImpl;
 import com.hazelcast.instance.Node;
 import com.hazelcast.internal.management.dto.SlowOperationDTO;
@@ -134,7 +135,7 @@ public final class OperationServiceImpl implements InternalOperationService, Pac
 
         this.invocationLogger = nodeEngine.getLogger(Invocation.class);
         GroupProperties groupProperties = node.getGroupProperties();
-        this.defaultCallTimeoutMillis = groupProperties.OPERATION_CALL_TIMEOUT_MILLIS.getLong();
+        this.defaultCallTimeoutMillis = groupProperties.getMillis(GroupProperty.OPERATION_CALL_TIMEOUT_MILLIS);
         this.backpressureRegulator = new BackpressureRegulator(groupProperties, logger);
 
         int coreSize = Runtime.getRuntime().availableProcessors();

--- a/hazelcast/src/main/java/com/hazelcast/util/VersionCheck.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/VersionCheck.java
@@ -19,6 +19,7 @@ package com.hazelcast.util;
 import com.hazelcast.cluster.impl.ClusterServiceImpl;
 import com.hazelcast.config.NativeMemoryConfig;
 import com.hazelcast.core.ClientType;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.instance.Node;
 import com.hazelcast.memory.MemoryUnit;
 import com.hazelcast.nio.IOUtil;
@@ -56,7 +57,7 @@ public final class VersionCheck {
     }
 
     public void check(final Node hazelcastNode, final String version, final boolean isEnterprise) {
-        if (!hazelcastNode.getGroupProperties().VERSION_CHECK_ENABLED.getBoolean()) {
+        if (!hazelcastNode.getGroupProperties().getBoolean(GroupProperty.VERSION_CHECK_ENABLED)) {
             return;
         }
         hazelcastNode.nodeEngine.getExecutionService().scheduleAtFixedRate(new Runnable() {

--- a/hazelcast/src/test/java/com/hazelcast/cluster/AbstractJoinTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/AbstractJoinTest.java
@@ -3,7 +3,7 @@ package com.hazelcast.cluster;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.test.HazelcastTestSupport;
 
 import static org.junit.Assert.assertEquals;
@@ -13,7 +13,7 @@ import static org.junit.Assert.fail;
 public class AbstractJoinTest extends HazelcastTestSupport {
 
     protected void testJoin(Config config) throws Exception {
-        config.setProperty(GroupProperties.PROP_WAIT_SECONDS_BEFORE_JOIN, "0");
+        config.setProperty(GroupProperty.WAIT_SECONDS_BEFORE_JOIN, "0");
 
         HazelcastInstance h1 = Hazelcast.newHazelcastInstance(config);
         assertEquals(1, h1.getCluster().getMembers().size());
@@ -29,7 +29,7 @@ public class AbstractJoinTest extends HazelcastTestSupport {
     }
 
     protected void testJoin_With_DifferentBuildNumber(Config config) {
-        config.setProperty(GroupProperties.PROP_WAIT_SECONDS_BEFORE_JOIN, "0");
+        config.setProperty(GroupProperty.WAIT_SECONDS_BEFORE_JOIN, "0");
 
         String buildNumberProp = "hazelcast.build";
         System.setProperty(buildNumberProp, "1");

--- a/hazelcast/src/test/java/com/hazelcast/cluster/ClusterMembershipTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/ClusterMembershipTest.java
@@ -28,7 +28,7 @@ import com.hazelcast.core.MemberAttributeEvent;
 import com.hazelcast.core.MembershipAdapter;
 import com.hazelcast.core.MembershipEvent;
 import com.hazelcast.core.MembershipListener;
-import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
@@ -175,7 +175,7 @@ public class ClusterMembershipTest extends HazelcastTestSupport {
         final int instanceCount = 6;
         final TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(instanceCount);
         final Config config = new Config();
-        config.setProperty(GroupProperties.PROP_WAIT_SECONDS_BEFORE_JOIN, "0");
+        config.setProperty(GroupProperty.WAIT_SECONDS_BEFORE_JOIN, "0");
         final String mapName = randomMapName();
         // index config is added since it was blocking post join operations.
         config.getMapConfig(mapName).addMapIndexConfig(new MapIndexConfig("name", false));

--- a/hazelcast/src/test/java/com/hazelcast/cluster/ConfigCheckTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/ConfigCheckTest.java
@@ -4,7 +4,7 @@ import com.hazelcast.cluster.impl.ConfigCheck;
 import com.hazelcast.cluster.impl.ConfigMismatchException;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.PartitionGroupConfig;
-import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -60,10 +60,10 @@ public class ConfigCheckTest {
     @Test
     public void whenDifferentPartitionCount_thenConfigationMismatchException() {
         Config config1 = new Config();
-        config1.setProperty(GroupProperties.PROP_PARTITION_COUNT, "100");
+        config1.setProperty(GroupProperty.PARTITION_COUNT, "100");
 
         Config config2 = new Config();
-        config2.setProperty(GroupProperties.PROP_PARTITION_COUNT, "200");
+        config2.setProperty(GroupProperty.PARTITION_COUNT, "200");
 
         ConfigCheck configCheck1 = new ConfigCheck(config1, "joiner");
         ConfigCheck configCheck2 = new ConfigCheck(config2, "joiner");
@@ -74,10 +74,10 @@ public class ConfigCheckTest {
     @Test
     public void whenDifferentApplicationValidationToken_thenConfigurationMismatchException() {
         Config config1 = new Config();
-        config1.setProperty(GroupProperties.PROP_APPLICATION_VALIDATION_TOKEN, "foo");
+        config1.setProperty(GroupProperty.APPLICATION_VALIDATION_TOKEN, "foo");
 
         Config config2 = new Config();
-        config2.setProperty(GroupProperties.PROP_APPLICATION_VALIDATION_TOKEN, "bar");
+        config2.setProperty(GroupProperty.APPLICATION_VALIDATION_TOKEN, "bar");
 
         ConfigCheck configCheck1 = new ConfigCheck(config1, "joiner");
         ConfigCheck configCheck2 = new ConfigCheck(config2, "joiner");

--- a/hazelcast/src/test/java/com/hazelcast/cluster/MemberListTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/MemberListTest.java
@@ -22,7 +22,7 @@ import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.Member;
 import com.hazelcast.core.MemberLeftException;
-import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.instance.HazelcastInstanceFactory;
 import com.hazelcast.instance.MemberImpl;
 import com.hazelcast.instance.Node;
@@ -312,12 +312,12 @@ public class MemberListTest {
     private static Config buildConfig(boolean multicastEnabled) {
         Config c = new Config();
         c.getGroupConfig().setName("group").setPassword("pass");
-        c.setProperty(GroupProperties.PROP_MERGE_FIRST_RUN_DELAY_SECONDS, "10");
-        c.setProperty(GroupProperties.PROP_MERGE_NEXT_RUN_DELAY_SECONDS, "5");
-        c.setProperty(GroupProperties.PROP_MAX_NO_HEARTBEAT_SECONDS, "10");
-        c.setProperty(GroupProperties.PROP_MASTER_CONFIRMATION_INTERVAL_SECONDS, "2");
-        c.setProperty(GroupProperties.PROP_MAX_NO_MASTER_CONFIRMATION_SECONDS, "10");
-        c.setProperty(GroupProperties.PROP_MEMBER_LIST_PUBLISH_INTERVAL_SECONDS, "10");
+        c.setProperty(GroupProperty.MERGE_FIRST_RUN_DELAY_SECONDS, "10");
+        c.setProperty(GroupProperty.MERGE_NEXT_RUN_DELAY_SECONDS, "5");
+        c.setProperty(GroupProperty.MAX_NO_HEARTBEAT_SECONDS, "10");
+        c.setProperty(GroupProperty.MASTER_CONFIRMATION_INTERVAL_SECONDS, "2");
+        c.setProperty(GroupProperty.MAX_NO_MASTER_CONFIRMATION_SECONDS, "10");
+        c.setProperty(GroupProperty.MEMBER_LIST_PUBLISH_INTERVAL_SECONDS, "10");
         final NetworkConfig networkConfig = c.getNetworkConfig();
         networkConfig.getJoin().getMulticastConfig().setEnabled(multicastEnabled);
         networkConfig.getJoin().getTcpIpConfig().setEnabled(!multicastEnabled);

--- a/hazelcast/src/test/java/com/hazelcast/cluster/MulticastJoinTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/MulticastJoinTest.java
@@ -9,7 +9,7 @@ import com.hazelcast.config.PartitionGroupConfig;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.Member;
-import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.instance.HazelcastInstanceFactory;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
@@ -77,16 +77,16 @@ public class MulticastJoinTest extends AbstractJoinTest {
     @Test
     public void test_whenDifferentGroupNames() throws Exception {
         Config config1 = new Config();
-        config1.setProperty(GroupProperties.PROP_WAIT_SECONDS_BEFORE_JOIN, "0");
-        config1.setProperty(GroupProperties.PROP_MAX_JOIN_SECONDS, "3");
+        config1.setProperty(GroupProperty.WAIT_SECONDS_BEFORE_JOIN, "0");
+        config1.setProperty(GroupProperty.MAX_JOIN_SECONDS, "3");
         config1.getGroupConfig().setName("group1");
         config1.getNetworkConfig().getJoin().getMulticastConfig()
                 .setEnabled(true).setMulticastTimeoutSeconds(3);
         config1.getNetworkConfig().getJoin().getTcpIpConfig().setEnabled(false);
 
         Config config2 = new Config();
-        config2.setProperty(GroupProperties.PROP_WAIT_SECONDS_BEFORE_JOIN, "0");
-        config2.setProperty(GroupProperties.PROP_MAX_JOIN_SECONDS, "3");
+        config2.setProperty(GroupProperty.WAIT_SECONDS_BEFORE_JOIN, "0");
+        config2.setProperty(GroupProperty.MAX_JOIN_SECONDS, "3");
         config2.getGroupConfig().setName("group2");
         config2.getNetworkConfig().getJoin().getMulticastConfig()
                 .setEnabled(true).setMulticastTimeoutSeconds(3);
@@ -98,16 +98,16 @@ public class MulticastJoinTest extends AbstractJoinTest {
     @Test
     public void test_whenSameGroupNamesButDifferentPassword() throws Exception {
         Config config1 = new Config();
-        config1.setProperty(GroupProperties.PROP_WAIT_SECONDS_BEFORE_JOIN, "0");
-        config1.setProperty(GroupProperties.PROP_MAX_JOIN_SECONDS, "3");
+        config1.setProperty(GroupProperty.WAIT_SECONDS_BEFORE_JOIN, "0");
+        config1.setProperty(GroupProperty.MAX_JOIN_SECONDS, "3");
         config1.getGroupConfig().setName("group").setPassword("password1");
         config1.getNetworkConfig().getJoin().getMulticastConfig()
                 .setEnabled(true).setMulticastTimeoutSeconds(3);
         config1.getNetworkConfig().getJoin().getTcpIpConfig().setEnabled(false);
 
         Config config2 = new Config();
-        config2.setProperty(GroupProperties.PROP_WAIT_SECONDS_BEFORE_JOIN, "0");
-        config2.setProperty(GroupProperties.PROP_MAX_JOIN_SECONDS, "3");
+        config2.setProperty(GroupProperty.WAIT_SECONDS_BEFORE_JOIN, "0");
+        config2.setProperty(GroupProperty.MAX_JOIN_SECONDS, "3");
         config2.getGroupConfig().setName("group").setPassword("password2");
         config2.getNetworkConfig().getJoin().getMulticastConfig()
                 .setEnabled(true).setMulticastTimeoutSeconds(3);
@@ -119,8 +119,8 @@ public class MulticastJoinTest extends AbstractJoinTest {
     @Test
     public void test_whenIncompatiblePartitionGroups() throws Exception {
         Config config1 = new Config();
-        config1.setProperty(GroupProperties.PROP_WAIT_SECONDS_BEFORE_JOIN, "0");
-        config1.setProperty(GroupProperties.PROP_MAX_JOIN_SECONDS, "3");
+        config1.setProperty(GroupProperty.WAIT_SECONDS_BEFORE_JOIN, "0");
+        config1.setProperty(GroupProperty.MAX_JOIN_SECONDS, "3");
         config1.getNetworkConfig().getJoin().getMulticastConfig().setEnabled(true);
         config1.getNetworkConfig().getJoin().getMulticastConfig().setMulticastTimeoutSeconds(3);
         config1.getNetworkConfig().getJoin().getTcpIpConfig().setEnabled(false);
@@ -128,8 +128,8 @@ public class MulticastJoinTest extends AbstractJoinTest {
                 .setGroupType(PartitionGroupConfig.MemberGroupType.HOST_AWARE);
 
         Config config2 = new Config();
-        config2.setProperty(GroupProperties.PROP_WAIT_SECONDS_BEFORE_JOIN, "0");
-        config2.setProperty(GroupProperties.PROP_MAX_JOIN_SECONDS, "3");
+        config2.setProperty(GroupProperty.WAIT_SECONDS_BEFORE_JOIN, "0");
+        config2.setProperty(GroupProperty.MAX_JOIN_SECONDS, "3");
         config2.getNetworkConfig().getJoin().getMulticastConfig().setEnabled(true);
         config2.getNetworkConfig().getJoin().getMulticastConfig().setMulticastTimeoutSeconds(3);
         config2.getNetworkConfig().getJoin().getTcpIpConfig().setEnabled(false);
@@ -144,21 +144,21 @@ public class MulticastJoinTest extends AbstractJoinTest {
     @Test
     public void test_issue247() throws Exception {
         Config c1 = new Config();
-        c1.setProperty(GroupProperties.PROP_WAIT_SECONDS_BEFORE_JOIN, "0");
+        c1.setProperty(GroupProperty.WAIT_SECONDS_BEFORE_JOIN, "0");
         c1.getNetworkConfig().setPort(5701).setPortAutoIncrement(false);
         c1.getNetworkConfig().getJoin().getMulticastConfig().setEnabled(false);
         c1.getNetworkConfig().getJoin().getTcpIpConfig()
                 .setEnabled(true).clear().addMember("127.0.0.1:5701");
 
         Config c2 = new Config();
-        c2.setProperty(GroupProperties.PROP_WAIT_SECONDS_BEFORE_JOIN, "0");
+        c2.setProperty(GroupProperty.WAIT_SECONDS_BEFORE_JOIN, "0");
         c2.getNetworkConfig().setPort(5702).setPortAutoIncrement(false);
         c2.getNetworkConfig().getJoin().getMulticastConfig().setEnabled(false);
         c2.getNetworkConfig().getJoin().getTcpIpConfig()
                 .setEnabled(true).clear().addMember("127.0.0.1:5702");
 
         Config c3 = new Config();
-        c3.setProperty(GroupProperties.PROP_WAIT_SECONDS_BEFORE_JOIN, "0");
+        c3.setProperty(GroupProperty.WAIT_SECONDS_BEFORE_JOIN, "0");
         c3.getNetworkConfig().setPort(5703).setPortAutoIncrement(false);
         c3.getNetworkConfig().getJoin().getMulticastConfig().setEnabled(false);
         c3.getNetworkConfig().getJoin().getTcpIpConfig()

--- a/hazelcast/src/test/java/com/hazelcast/cluster/NodeShutdownEventsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/NodeShutdownEventsTest.java
@@ -22,7 +22,7 @@ import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.LifecycleEvent;
 import com.hazelcast.core.LifecycleListener;
-import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -35,7 +35,6 @@ import org.junit.runner.RunWith;
 import java.util.concurrent.CountDownLatch;
 
 import static com.hazelcast.test.HazelcastTestSupport.assertOpenEventually;
-
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
@@ -60,7 +59,7 @@ public class NodeShutdownEventsTest {
 
         final Config config2 = new Config();
         // force join failure.
-        config2.setProperty(GroupProperties.PROP_MAX_JOIN_SECONDS, "-100");
+        config2.setProperty(GroupProperty.MAX_JOIN_SECONDS, "-100");
         // add lifecycle listener.
         final ListenerConfig listenerConfig = new ListenerConfig();
         listenerConfig.setImplementation(new LifecycleListener() {

--- a/hazelcast/src/test/java/com/hazelcast/cluster/SplitBrainHandlerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/SplitBrainHandlerTest.java
@@ -30,7 +30,7 @@ import com.hazelcast.core.MembershipAdapter;
 import com.hazelcast.core.MembershipEvent;
 import com.hazelcast.core.MembershipListener;
 import com.hazelcast.instance.DefaultNodeContext;
-import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.instance.HazelcastInstanceFactory;
 import com.hazelcast.instance.Node;
 import com.hazelcast.instance.TestUtil;
@@ -87,8 +87,8 @@ public class SplitBrainHandlerTest extends HazelcastTestSupport {
 
     private void testClusterMerge(boolean multicast) throws Exception {
         Config config1 = new Config();
-        config1.setProperty(GroupProperties.PROP_MERGE_FIRST_RUN_DELAY_SECONDS, "5");
-        config1.setProperty(GroupProperties.PROP_MERGE_NEXT_RUN_DELAY_SECONDS, "3");
+        config1.setProperty(GroupProperty.MERGE_FIRST_RUN_DELAY_SECONDS, "5");
+        config1.setProperty(GroupProperty.MERGE_NEXT_RUN_DELAY_SECONDS, "3");
         String firstGroupName = generateRandomString(10);
         config1.getGroupConfig().setName(firstGroupName);
 
@@ -99,8 +99,8 @@ public class SplitBrainHandlerTest extends HazelcastTestSupport {
         join1.getTcpIpConfig().addMember("127.0.0.1");
 
         Config config2 = new Config();
-        config2.setProperty(GroupProperties.PROP_MERGE_FIRST_RUN_DELAY_SECONDS, "5");
-        config2.setProperty(GroupProperties.PROP_MERGE_NEXT_RUN_DELAY_SECONDS, "3");
+        config2.setProperty(GroupProperty.MERGE_FIRST_RUN_DELAY_SECONDS, "5");
+        config2.setProperty(GroupProperty.MERGE_NEXT_RUN_DELAY_SECONDS, "3");
         String secondGroupName = generateRandomString(10);
         config2.getGroupConfig().setName(secondGroupName);
 
@@ -131,8 +131,8 @@ public class SplitBrainHandlerTest extends HazelcastTestSupport {
     @Test
     public void testClusterShouldNotMergeDifferentGroupName() throws Exception {
         Config config1 = new Config();
-        config1.setProperty(GroupProperties.PROP_MERGE_FIRST_RUN_DELAY_SECONDS, "5");
-        config1.setProperty(GroupProperties.PROP_MERGE_NEXT_RUN_DELAY_SECONDS, "3");
+        config1.setProperty(GroupProperty.MERGE_FIRST_RUN_DELAY_SECONDS, "5");
+        config1.setProperty(GroupProperty.MERGE_NEXT_RUN_DELAY_SECONDS, "3");
         String firstGroupName = generateRandomString(10);
         config1.getGroupConfig().setName(firstGroupName);
 
@@ -142,8 +142,8 @@ public class SplitBrainHandlerTest extends HazelcastTestSupport {
         join1.getTcpIpConfig().addMember("127.0.0.1");
 
         Config config2 = new Config();
-        config2.setProperty(GroupProperties.PROP_MERGE_FIRST_RUN_DELAY_SECONDS, "5");
-        config2.setProperty(GroupProperties.PROP_MERGE_NEXT_RUN_DELAY_SECONDS, "3");
+        config2.setProperty(GroupProperty.MERGE_FIRST_RUN_DELAY_SECONDS, "5");
+        config2.setProperty(GroupProperty.MERGE_NEXT_RUN_DELAY_SECONDS, "3");
         String secondGroupName = generateRandomString(10);
         config2.getGroupConfig().setName(secondGroupName);
 
@@ -218,8 +218,8 @@ public class SplitBrainHandlerTest extends HazelcastTestSupport {
 
     private void testMergeAfterSplitBrain(boolean multicast) throws InterruptedException {
         Config config = new Config();
-        config.setProperty(GroupProperties.PROP_MERGE_FIRST_RUN_DELAY_SECONDS, "5");
-        config.setProperty(GroupProperties.PROP_MERGE_NEXT_RUN_DELAY_SECONDS, "3");
+        config.setProperty(GroupProperty.MERGE_FIRST_RUN_DELAY_SECONDS, "5");
+        config.setProperty(GroupProperty.MERGE_NEXT_RUN_DELAY_SECONDS, "3");
         String groupName = generateRandomString(10);
         config.getGroupConfig().setName(groupName);
 
@@ -388,8 +388,8 @@ public class SplitBrainHandlerTest extends HazelcastTestSupport {
 
     private static Config buildConfig(boolean multicastEnabled, int port) {
         Config c = new Config();
-        c.setProperty(GroupProperties.PROP_MERGE_FIRST_RUN_DELAY_SECONDS, "5");
-        c.setProperty(GroupProperties.PROP_MERGE_NEXT_RUN_DELAY_SECONDS, "3");
+        c.setProperty(GroupProperty.MERGE_FIRST_RUN_DELAY_SECONDS, "5");
+        c.setProperty(GroupProperty.MERGE_NEXT_RUN_DELAY_SECONDS, "3");
 
         NetworkConfig networkConfig = c.getNetworkConfig();
         networkConfig.setPort(port).setPortAutoIncrement(false);
@@ -400,18 +400,15 @@ public class SplitBrainHandlerTest extends HazelcastTestSupport {
 
     @Test
     public void testMulticastJoin_DuringSplitBrainHandlerRunning() throws InterruptedException {
-        Properties props = new Properties();
-        props.setProperty(GroupProperties.PROP_WAIT_SECONDS_BEFORE_JOIN, "5");
-        props.setProperty(GroupProperties.PROP_MERGE_FIRST_RUN_DELAY_SECONDS, "0");
-        props.setProperty(GroupProperties.PROP_MERGE_NEXT_RUN_DELAY_SECONDS, "0");
-
         String groupName = generateRandomString(10);
         final CountDownLatch latch = new CountDownLatch(1);
         Config config1 = new Config();
         // bigger port to make sure address.hashCode() check pass during merge!
         config1.getNetworkConfig().setPort(5901);
         config1.getGroupConfig().setName(groupName);
-        config1.setProperties(props);
+        config1.setProperty(GroupProperty.WAIT_SECONDS_BEFORE_JOIN, "5");
+        config1.setProperty(GroupProperty.MERGE_FIRST_RUN_DELAY_SECONDS, "0");
+        config1.setProperty(GroupProperty.MERGE_NEXT_RUN_DELAY_SECONDS, "0");
         config1.addListenerConfig(new ListenerConfig(new LifecycleListener() {
             public void stateChanged(final LifecycleEvent event) {
                 switch (event.getState()) {
@@ -429,7 +426,9 @@ public class SplitBrainHandlerTest extends HazelcastTestSupport {
         Config config2 = new Config();
         config2.getGroupConfig().setName(groupName);
         config2.getNetworkConfig().setPort(5701);
-        config2.setProperties(props);
+        config2.setProperty(GroupProperty.WAIT_SECONDS_BEFORE_JOIN, "5");
+        config2.setProperty(GroupProperty.MERGE_FIRST_RUN_DELAY_SECONDS, "0");
+        config2.setProperty(GroupProperty.MERGE_NEXT_RUN_DELAY_SECONDS, "0");
         Hazelcast.newHazelcastInstance(config2);
 
         assertFalse("Latch should not be countdown!", latch.await(3, TimeUnit.SECONDS));
@@ -450,11 +449,11 @@ public class SplitBrainHandlerTest extends HazelcastTestSupport {
         Config config = new Config();
         String groupName = generateRandomString(10);
         config.getGroupConfig().setName(groupName);
-        config.setProperty(GroupProperties.PROP_MERGE_FIRST_RUN_DELAY_SECONDS, "10");
-        config.setProperty(GroupProperties.PROP_MERGE_NEXT_RUN_DELAY_SECONDS, "10");
-        config.setProperty(GroupProperties.PROP_MAX_NO_HEARTBEAT_SECONDS, "15");
-        config.setProperty(GroupProperties.PROP_MAX_JOIN_SECONDS, "10");
-        config.setProperty(GroupProperties.PROP_MAX_JOIN_MERGE_TARGET_SECONDS, "10");
+        config.setProperty(GroupProperty.MERGE_FIRST_RUN_DELAY_SECONDS, "10");
+        config.setProperty(GroupProperty.MERGE_NEXT_RUN_DELAY_SECONDS, "10");
+        config.setProperty(GroupProperty.MAX_NO_HEARTBEAT_SECONDS, "15");
+        config.setProperty(GroupProperty.MAX_JOIN_SECONDS, "10");
+        config.setProperty(GroupProperty.MAX_JOIN_MERGE_TARGET_SECONDS, "10");
 
         NetworkConfig networkConfig = config.getNetworkConfig();
         networkConfig.getJoin().getMulticastConfig().setEnabled(multicastEnabled);
@@ -533,11 +532,11 @@ public class SplitBrainHandlerTest extends HazelcastTestSupport {
         Config config = new Config();
         String groupName = generateRandomString(10);
         config.getGroupConfig().setName(groupName);
-        config.setProperty(GroupProperties.PROP_MERGE_FIRST_RUN_DELAY_SECONDS, "10");
-        config.setProperty(GroupProperties.PROP_MERGE_NEXT_RUN_DELAY_SECONDS, "10");
-        config.setProperty(GroupProperties.PROP_MAX_NO_HEARTBEAT_SECONDS, "15");
-        config.setProperty(GroupProperties.PROP_MAX_JOIN_SECONDS, "10");
-        config.setProperty(GroupProperties.PROP_MAX_JOIN_MERGE_TARGET_SECONDS, "10");
+        config.setProperty(GroupProperty.MERGE_FIRST_RUN_DELAY_SECONDS, "10");
+        config.setProperty(GroupProperty.MERGE_NEXT_RUN_DELAY_SECONDS, "10");
+        config.setProperty(GroupProperty.MAX_NO_HEARTBEAT_SECONDS, "15");
+        config.setProperty(GroupProperty.MAX_JOIN_SECONDS, "10");
+        config.setProperty(GroupProperty.MAX_JOIN_MERGE_TARGET_SECONDS, "10");
 
         NetworkConfig networkConfig = config.getNetworkConfig();
         networkConfig.getJoin().getMulticastConfig().setEnabled(false);
@@ -613,11 +612,11 @@ public class SplitBrainHandlerTest extends HazelcastTestSupport {
         Config config = new Config();
         String groupName = generateRandomString(10);
         config.getGroupConfig().setName(groupName);
-        config.setProperty(GroupProperties.PROP_MERGE_FIRST_RUN_DELAY_SECONDS, "10");
-        config.setProperty(GroupProperties.PROP_MERGE_NEXT_RUN_DELAY_SECONDS, "10");
-        config.setProperty(GroupProperties.PROP_MAX_NO_HEARTBEAT_SECONDS, "15");
-        config.setProperty(GroupProperties.PROP_MAX_JOIN_SECONDS, "40");
-        config.setProperty(GroupProperties.PROP_MAX_JOIN_MERGE_TARGET_SECONDS, "10");
+        config.setProperty(GroupProperty.MERGE_FIRST_RUN_DELAY_SECONDS, "10");
+        config.setProperty(GroupProperty.MERGE_NEXT_RUN_DELAY_SECONDS, "10");
+        config.setProperty(GroupProperty.MAX_NO_HEARTBEAT_SECONDS, "15");
+        config.setProperty(GroupProperty.MAX_JOIN_SECONDS, "40");
+        config.setProperty(GroupProperty.MAX_JOIN_MERGE_TARGET_SECONDS, "10");
 
         NetworkConfig networkConfig = config.getNetworkConfig();
         networkConfig.getJoin().getMulticastConfig().setEnabled(false);

--- a/hazelcast/src/test/java/com/hazelcast/cluster/SystemClockChangeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/SystemClockChangeTest.java
@@ -20,7 +20,7 @@ import com.hazelcast.config.Config;
 import com.hazelcast.core.Cluster;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.instance.HazelcastInstanceFactory;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
@@ -147,7 +147,7 @@ public class SystemClockChangeTest extends HazelcastTestSupport {
 
     private static HazelcastInstance startNode() throws Exception {
         Config config = new Config();
-        config.setProperty(GroupProperties.PROP_MEMBER_LIST_PUBLISH_INTERVAL_SECONDS, "10");
+        config.setProperty(GroupProperty.MEMBER_LIST_PUBLISH_INTERVAL_SECONDS, "10");
         return Hazelcast.newHazelcastInstance(config);
     }
 
@@ -155,8 +155,7 @@ public class SystemClockChangeTest extends HazelcastTestSupport {
         Thread thread = Thread.currentThread();
         ClassLoader tccl = thread.getContextClassLoader();
         try {
-            FilteringClassLoader cl = new FilteringClassLoader(Collections.<String>emptyList(),
-                    "com.hazelcast");
+            FilteringClassLoader cl = new FilteringClassLoader(Collections.<String>emptyList(), "com.hazelcast");
             thread.setContextClassLoader(cl);
 
             Class<?> configClazz = cl.loadClass("com.hazelcast.config.Config");
@@ -164,7 +163,7 @@ public class SystemClockChangeTest extends HazelcastTestSupport {
             Method setClassLoader = configClazz.getDeclaredMethod("setClassLoader", ClassLoader.class);
             setClassLoader.invoke(config, cl);
             Method setProperty = configClazz.getDeclaredMethod("setProperty", String.class, String.class);
-            setProperty.invoke(config, GroupProperties.PROP_MEMBER_LIST_PUBLISH_INTERVAL_SECONDS, "10");
+            setProperty.invoke(config, GroupProperty.MEMBER_LIST_PUBLISH_INTERVAL_SECONDS.getName(), "10");
 
             Class<?> hazelcastClazz = cl.loadClass("com.hazelcast.core.Hazelcast");
             Method newHazelcastInstance = hazelcastClazz.getDeclaredMethod("newHazelcastInstance", configClazz);
@@ -174,4 +173,3 @@ public class SystemClockChangeTest extends HazelcastTestSupport {
         }
     }
 }
-

--- a/hazelcast/src/test/java/com/hazelcast/cluster/TcpIpJoinTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/TcpIpJoinTest.java
@@ -19,19 +19,15 @@ package com.hazelcast.cluster;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.InterfacesConfig;
 import com.hazelcast.config.JoinConfig;
-import com.hazelcast.config.MulticastConfig;
 import com.hazelcast.config.NetworkConfig;
 import com.hazelcast.config.PartitionGroupConfig;
 import com.hazelcast.config.TcpIpConfig;
-import com.hazelcast.core.DuplicateInstanceNameException;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.Member;
-import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.instance.HazelcastInstanceFactory;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
-import com.hazelcast.test.annotation.SlowTest;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -39,10 +35,6 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.io.IOException;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
@@ -132,16 +124,16 @@ public class TcpIpJoinTest extends AbstractJoinTest {
     @Test
     public void test_whenIncompatibleGroups() throws Exception {
         Config config1 = new Config();
-        config1.setProperty(GroupProperties.PROP_WAIT_SECONDS_BEFORE_JOIN, "0");
-        config1.setProperty(GroupProperties.PROP_MAX_JOIN_SECONDS, "3");
+        config1.setProperty(GroupProperty.WAIT_SECONDS_BEFORE_JOIN, "0");
+        config1.setProperty(GroupProperty.MAX_JOIN_SECONDS, "3");
         config1.getGroupConfig().setName("group1");
         config1.getNetworkConfig().getJoin().getMulticastConfig().setEnabled(false);
         config1.getNetworkConfig().getJoin().getTcpIpConfig()
                 .setEnabled(true).setConnectionTimeoutSeconds(3).addMember("127.0.0.1");
 
         Config config2 = new Config();
-        config2.setProperty(GroupProperties.PROP_WAIT_SECONDS_BEFORE_JOIN, "0");
-        config2.setProperty(GroupProperties.PROP_MAX_JOIN_SECONDS, "3");
+        config2.setProperty(GroupProperty.WAIT_SECONDS_BEFORE_JOIN, "0");
+        config2.setProperty(GroupProperty.MAX_JOIN_SECONDS, "3");
         config2.getGroupConfig().setName("group2");
         config2.getNetworkConfig().getJoin().getMulticastConfig().setEnabled(false);
         config2.getNetworkConfig().getJoin().getTcpIpConfig()
@@ -153,16 +145,16 @@ public class TcpIpJoinTest extends AbstractJoinTest {
     @Test
     public void test_whenSameGroupNamesButDifferentPassword() throws Exception {
         Config config1 = new Config();
-        config1.setProperty(GroupProperties.PROP_WAIT_SECONDS_BEFORE_JOIN, "0");
-        config1.setProperty(GroupProperties.PROP_MAX_JOIN_SECONDS, "3");
+        config1.setProperty(GroupProperty.WAIT_SECONDS_BEFORE_JOIN, "0");
+        config1.setProperty(GroupProperty.MAX_JOIN_SECONDS, "3");
         config1.getGroupConfig().setPassword("pass1");
         config1.getNetworkConfig().getJoin().getMulticastConfig().setEnabled(false);
         config1.getNetworkConfig().getJoin().getTcpIpConfig()
                 .setEnabled(true).setConnectionTimeoutSeconds(3).addMember("127.0.0.1");
 
         Config config2 = new Config();
-        config2.setProperty(GroupProperties.PROP_WAIT_SECONDS_BEFORE_JOIN, "0");
-        config2.setProperty(GroupProperties.PROP_MAX_JOIN_SECONDS, "3");
+        config2.setProperty(GroupProperty.WAIT_SECONDS_BEFORE_JOIN, "0");
+        config2.setProperty(GroupProperty.MAX_JOIN_SECONDS, "3");
         config2.getGroupConfig().setPassword("pass2");
         config2.getNetworkConfig().getJoin().getMulticastConfig().setEnabled(false);
         config2.getNetworkConfig().getJoin().getTcpIpConfig()
@@ -174,8 +166,8 @@ public class TcpIpJoinTest extends AbstractJoinTest {
     @Test
     public void test_whenIncompatiblePartitionGroups() throws Exception {
         Config config1 = new Config();
-        config1.setProperty(GroupProperties.PROP_WAIT_SECONDS_BEFORE_JOIN, "0");
-        config1.setProperty(GroupProperties.PROP_MAX_JOIN_SECONDS, "3");
+        config1.setProperty(GroupProperty.WAIT_SECONDS_BEFORE_JOIN, "0");
+        config1.setProperty(GroupProperty.MAX_JOIN_SECONDS, "3");
         config1.getNetworkConfig().getJoin().getMulticastConfig().setEnabled(false);
         config1.getNetworkConfig().getJoin().getTcpIpConfig()
                 .setEnabled(true).setConnectionTimeoutSeconds(3).addMember("127.0.0.1");
@@ -183,8 +175,8 @@ public class TcpIpJoinTest extends AbstractJoinTest {
                 .setGroupType(PartitionGroupConfig.MemberGroupType.CUSTOM);
 
         Config config2 = new Config();
-        config2.setProperty(GroupProperties.PROP_WAIT_SECONDS_BEFORE_JOIN, "0");
-        config2.setProperty(GroupProperties.PROP_MAX_JOIN_SECONDS, "3");
+        config2.setProperty(GroupProperty.WAIT_SECONDS_BEFORE_JOIN, "0");
+        config2.setProperty(GroupProperty.MAX_JOIN_SECONDS, "3");
         config2.getNetworkConfig().getJoin().getMulticastConfig().setEnabled(false);
         config2.getNetworkConfig().getJoin().getTcpIpConfig()
                 .setEnabled(true).setConnectionTimeoutSeconds(3).addMember("127.0.0.1");
@@ -196,14 +188,14 @@ public class TcpIpJoinTest extends AbstractJoinTest {
     @Test
     public void test_whenIncompatibleJoiners() throws Exception {
         Config config1 = new Config();
-        config1.setProperty(GroupProperties.PROP_WAIT_SECONDS_BEFORE_JOIN, "0");
-        config1.setProperty(GroupProperties.PROP_MAX_JOIN_SECONDS, "3");
+        config1.setProperty(GroupProperty.WAIT_SECONDS_BEFORE_JOIN, "0");
+        config1.setProperty(GroupProperty.MAX_JOIN_SECONDS, "3");
         config1.getNetworkConfig().getJoin().getMulticastConfig().setMulticastTimeoutSeconds(3);
         config1.getNetworkConfig().getJoin().getTcpIpConfig().setEnabled(false);
 
         Config config2 = new Config();
-        config2.setProperty(GroupProperties.PROP_WAIT_SECONDS_BEFORE_JOIN, "0");
-        config2.setProperty(GroupProperties.PROP_MAX_JOIN_SECONDS, "3");
+        config2.setProperty(GroupProperty.WAIT_SECONDS_BEFORE_JOIN, "0");
+        config2.setProperty(GroupProperty.MAX_JOIN_SECONDS, "3");
         config2.getNetworkConfig().getJoin().getMulticastConfig().setEnabled(false);
         config2.getNetworkConfig().getJoin().getTcpIpConfig().setConnectionTimeoutSeconds(3)
                 .setEnabled(true).addMember("127.0.0.1");

--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/list/ListSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/list/ListSplitBrainTest.java
@@ -11,7 +11,7 @@ import com.hazelcast.core.LifecycleListener;
 import com.hazelcast.core.MemberAttributeEvent;
 import com.hazelcast.core.MembershipEvent;
 import com.hazelcast.core.MembershipListener;
-import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.instance.HazelcastInstanceFactory;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
@@ -106,8 +106,8 @@ public class ListSplitBrainTest extends HazelcastTestSupport {
 
     private Config getConfig(boolean multicast) {
         Config config = new Config();
-        config.setProperty(GroupProperties.PROP_MERGE_FIRST_RUN_DELAY_SECONDS, "30");
-        config.setProperty(GroupProperties.PROP_MERGE_NEXT_RUN_DELAY_SECONDS, "3");
+        config.setProperty(GroupProperty.MERGE_FIRST_RUN_DELAY_SECONDS, "30");
+        config.setProperty(GroupProperty.MERGE_NEXT_RUN_DELAY_SECONDS, "3");
 
         NetworkConfig networkConfig = config.getNetworkConfig();
         JoinConfig join = networkConfig.getJoin();

--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/QueueAdvancedTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/QueueAdvancedTest.java
@@ -24,7 +24,7 @@ import com.hazelcast.core.IQueue;
 import com.hazelcast.core.MemberAttributeEvent;
 import com.hazelcast.core.MembershipEvent;
 import com.hazelcast.core.MembershipListener;
-import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
@@ -574,7 +574,7 @@ public class QueueAdvancedTest extends HazelcastTestSupport {
     @Test
     public void testTakeInterruption() throws InterruptedException {
         Config config = new Config();
-        config.setProperty(GroupProperties.PROP_OPERATION_CALL_TIMEOUT_MILLIS, "1000");
+        config.setProperty(GroupProperty.OPERATION_CALL_TIMEOUT_MILLIS, "1000");
 
         HazelcastInstance instance = createHazelcastInstance(config);
         final IQueue<Object> queue = instance.getQueue(randomName());
@@ -602,7 +602,7 @@ public class QueueAdvancedTest extends HazelcastTestSupport {
     @Test
     public void testPutInterruption() throws InterruptedException {
         Config config = new Config();
-        config.setProperty(GroupProperties.PROP_OPERATION_CALL_TIMEOUT_MILLIS, "1000");
+        config.setProperty(GroupProperty.OPERATION_CALL_TIMEOUT_MILLIS, "1000");
         config.getQueueConfig("default").setMaxSize(1);
 
         HazelcastInstance instance = createHazelcastInstance(config);

--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/QueueSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/QueueSplitBrainTest.java
@@ -9,14 +9,11 @@ import com.hazelcast.core.LifecycleListener;
 import com.hazelcast.core.MemberAttributeEvent;
 import com.hazelcast.core.MembershipEvent;
 import com.hazelcast.core.MembershipListener;
-import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.instance.HazelcastInstanceFactory;
-import com.hazelcast.instance.Node;
-import com.hazelcast.instance.TestUtil;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.NightlyTest;
-import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -26,7 +23,6 @@ import org.junit.runner.RunWith;
 import java.io.IOException;
 import java.util.concurrent.CountDownLatch;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -93,8 +89,8 @@ public class QueueSplitBrainTest extends HazelcastTestSupport {
 
     private Config newConfig() {
         Config config = new Config();
-        config.setProperty(GroupProperties.PROP_MERGE_FIRST_RUN_DELAY_SECONDS, "30");
-        config.setProperty(GroupProperties.PROP_MERGE_NEXT_RUN_DELAY_SECONDS, "3");
+        config.setProperty(GroupProperty.MERGE_FIRST_RUN_DELAY_SECONDS, "30");
+        config.setProperty(GroupProperty.MERGE_NEXT_RUN_DELAY_SECONDS, "3");
         return config;
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/countdownlatch/CountDownLatchSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/countdownlatch/CountDownLatchSplitBrainTest.java
@@ -1,6 +1,5 @@
 package com.hazelcast.concurrent.countdownlatch;
 
-
 import com.hazelcast.config.Config;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
@@ -10,7 +9,7 @@ import com.hazelcast.core.LifecycleListener;
 import com.hazelcast.core.MemberAttributeEvent;
 import com.hazelcast.core.MembershipEvent;
 import com.hazelcast.core.MembershipListener;
-import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.instance.HazelcastInstanceFactory;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
@@ -29,7 +28,6 @@ import static org.junit.Assert.assertEquals;
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(SlowTest.class)
 public class CountDownLatchSplitBrainTest extends HazelcastTestSupport {
-
 
     @Before
     @After
@@ -79,8 +77,8 @@ public class CountDownLatchSplitBrainTest extends HazelcastTestSupport {
 
     private Config newConfig() {
         Config config = new Config();
-        config.setProperty(GroupProperties.PROP_MERGE_FIRST_RUN_DELAY_SECONDS, "30");
-        config.setProperty(GroupProperties.PROP_MERGE_NEXT_RUN_DELAY_SECONDS, "3");
+        config.setProperty(GroupProperty.MERGE_FIRST_RUN_DELAY_SECONDS, "30");
+        config.setProperty(GroupProperty.MERGE_NEXT_RUN_DELAY_SECONDS, "3");
         return config;
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/lock/ConditionAdvancedTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/lock/ConditionAdvancedTest.java
@@ -5,7 +5,7 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.HazelcastInstanceNotActiveException;
 import com.hazelcast.core.ICondition;
 import com.hazelcast.core.ILock;
-import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.spi.exception.DistributedObjectDestroyedException;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
@@ -31,7 +31,7 @@ public class ConditionAdvancedTest extends HazelcastTestSupport{
     public void testInterruptionDuringWaiting() throws InterruptedException {
         Config config = new Config();
         // the system should wait at most 5000 ms in order to determine the operation status
-        config.setProperty(GroupProperties.PROP_OPERATION_CALL_TIMEOUT_MILLIS, "5000");
+        config.setProperty(GroupProperty.OPERATION_CALL_TIMEOUT_MILLIS, "5000");
 
         HazelcastInstance instance = createHazelcastInstance(config);
 

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/lock/LockAdvancedTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/lock/LockAdvancedTest.java
@@ -4,7 +4,7 @@ import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.HazelcastInstanceNotActiveException;
 import com.hazelcast.core.ILock;
-import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -205,7 +205,7 @@ public class LockAdvancedTest extends HazelcastTestSupport {
     @Test(timeout = 60000)
     public void testLockInterruption() throws InterruptedException {
         Config config = new Config();
-        config.setProperty(GroupProperties.PROP_OPERATION_CALL_TIMEOUT_MILLIS, "5000");
+        config.setProperty(GroupProperty.OPERATION_CALL_TIMEOUT_MILLIS, "5000");
         final HazelcastInstance hz = createHazelcastInstance(config);
 
         final Lock lock = hz.getLock("testLockInterruption2");
@@ -324,7 +324,7 @@ public class LockAdvancedTest extends HazelcastTestSupport {
     @Test
     public void testLockInterruptibly() throws Exception {
         Config config = new Config();
-        config.setProperty(GroupProperties.PROP_OPERATION_CALL_TIMEOUT_MILLIS, "5000");
+        config.setProperty(GroupProperty.OPERATION_CALL_TIMEOUT_MILLIS, "5000");
         final TestHazelcastInstanceFactory nodeFactory = createHazelcastInstanceFactory(1);
         final HazelcastInstance h1 = nodeFactory.newHazelcastInstance(config);
         final ILock lock = h1.getLock(randomString());
@@ -369,7 +369,7 @@ public class LockAdvancedTest extends HazelcastTestSupport {
     @Test
     public void testMaxLockLeaseTime() {
         Config config = new Config();
-        config.setProperty(GroupProperties.PROP_LOCK_MAX_LEASE_TIME_SECONDS, "1");
+        config.setProperty(GroupProperty.LOCK_MAX_LEASE_TIME_SECONDS, "1");
 
         TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(1);
         HazelcastInstance hz = factory.newHazelcastInstance(config);
@@ -388,7 +388,7 @@ public class LockAdvancedTest extends HazelcastTestSupport {
     @Test(expected = IllegalArgumentException.class)
     public void testLockFail_whenGreaterThanMaxLeaseTimeUsed() {
         Config config = new Config();
-        config.setProperty(GroupProperties.PROP_LOCK_MAX_LEASE_TIME_SECONDS, "1");
+        config.setProperty(GroupProperty.LOCK_MAX_LEASE_TIME_SECONDS, "1");
 
         TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(1);
         HazelcastInstance hz = factory.newHazelcastInstance(config);

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/lock/LockSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/lock/LockSplitBrainTest.java
@@ -9,7 +9,7 @@ import com.hazelcast.core.LifecycleListener;
 import com.hazelcast.core.MemberAttributeEvent;
 import com.hazelcast.core.MembershipEvent;
 import com.hazelcast.core.MembershipListener;
-import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.instance.HazelcastInstanceFactory;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastSerialClassRunner;
@@ -83,8 +83,8 @@ public class LockSplitBrainTest extends HazelcastTestSupport {
 
     private Config newConfig() {
         Config config = new Config();
-        config.setProperty(GroupProperties.PROP_MERGE_FIRST_RUN_DELAY_SECONDS, "3");
-        config.setProperty(GroupProperties.PROP_MERGE_NEXT_RUN_DELAY_SECONDS, "1");
+        config.setProperty(GroupProperty.MERGE_FIRST_RUN_DELAY_SECONDS, "3");
+        config.setProperty(GroupProperty.MERGE_NEXT_RUN_DELAY_SECONDS, "1");
         return config;
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/semaphore/SemaphoreSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/semaphore/SemaphoreSplitBrainTest.java
@@ -1,6 +1,5 @@
 package com.hazelcast.concurrent.semaphore;
 
-
 import com.hazelcast.config.Config;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
@@ -10,7 +9,7 @@ import com.hazelcast.core.LifecycleListener;
 import com.hazelcast.core.MemberAttributeEvent;
 import com.hazelcast.core.MembershipEvent;
 import com.hazelcast.core.MembershipListener;
-import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.instance.HazelcastInstanceFactory;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastSerialClassRunner;
@@ -93,8 +92,8 @@ public class SemaphoreSplitBrainTest extends HazelcastTestSupport {
 
     private Config newConfig() {
         Config config = new Config();
-        config.setProperty(GroupProperties.PROP_MERGE_FIRST_RUN_DELAY_SECONDS, "3");
-        config.setProperty(GroupProperties.PROP_MERGE_NEXT_RUN_DELAY_SECONDS, "1");
+        config.setProperty(GroupProperty.MERGE_FIRST_RUN_DELAY_SECONDS, "3");
+        config.setProperty(GroupProperty.MERGE_NEXT_RUN_DELAY_SECONDS, "1");
         return config;
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/executor/ExecutorServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/executor/ExecutorServiceTest.java
@@ -29,7 +29,7 @@ import com.hazelcast.core.Member;
 import com.hazelcast.core.MemberSelector;
 import com.hazelcast.core.MultiExecutionCallback;
 import com.hazelcast.core.PartitionAware;
-import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.monitor.LocalExecutorStats;
 import com.hazelcast.spi.ExecutionService;
 import com.hazelcast.test.HazelcastParallelClassRunner;
@@ -73,8 +73,6 @@ public class ExecutorServiceTest extends ExecutorServiceTestSupport {
     public static final int NODE_COUNT = 3;
 
     public static final int TASK_COUNT = 1000;
-
-
 
     /* ############ andThen ############ */
 
@@ -247,8 +245,6 @@ public class ExecutorServiceTest extends ExecutorServiceTestSupport {
         assertOpenEventually(callback.getLatch());
         assertTrue(callback.getResult() instanceof Throwable);
     }
-
-
 
     /* ############ submit runnable ############ */
 
@@ -457,8 +453,6 @@ public class ExecutorServiceTest extends ExecutorServiceTestSupport {
         assertEquals(NODE_COUNT * NODE_COUNT, nullResponseCount.get());
     }
 
-
-
     /* ############ submit callable ############ */
 
     /**
@@ -634,8 +628,6 @@ public class ExecutorServiceTest extends ExecutorServiceTestSupport {
         assertEquals(NODE_COUNT * NODE_COUNT, count.get());
     }
 
-
-
     /* ############ cancellation ############ */
 
     @Test
@@ -696,8 +688,6 @@ public class ExecutorServiceTest extends ExecutorServiceTestSupport {
         }
     }
 
-
-
     /* ############ future ############ */
 
     /**
@@ -755,8 +745,6 @@ public class ExecutorServiceTest extends ExecutorServiceTestSupport {
         assertOpenEventually(callback.getLatch());
         assertTrue(callback.getResult() instanceof Member);
     }
-
-
 
     /**
      * Execute a task that is executing
@@ -971,28 +959,25 @@ public class ExecutorServiceTest extends ExecutorServiceTestSupport {
         }
     }
 
-
     @Test
     public void testLongRunningCallable() throws ExecutionException, InterruptedException, TimeoutException {
         TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(2);
 
         Config config = new Config();
-        long callTimeout = 3000;
-        config.setProperty(GroupProperties.PROP_OPERATION_CALL_TIMEOUT_MILLIS, String.valueOf(callTimeout));
+        long callTimeoutMillis = 3000;
+        config.setProperty(GroupProperty.OPERATION_CALL_TIMEOUT_MILLIS, String.valueOf(callTimeoutMillis));
 
         HazelcastInstance hz1 = factory.newHazelcastInstance(config);
         HazelcastInstance hz2 = factory.newHazelcastInstance(config);
 
         IExecutorService executor = hz1.getExecutorService("test");
         Future<Boolean> f = executor
-                .submitToMember(new SleepingTask(TimeUnit.MILLISECONDS.toSeconds(callTimeout) * 3),
+                .submitToMember(new SleepingTask(TimeUnit.MILLISECONDS.toSeconds(callTimeoutMillis) * 3),
                         hz2.getCluster().getLocalMember());
 
         Boolean result = f.get(1, TimeUnit.MINUTES);
         assertTrue(result);
     }
-
-
 
     static class ICountDownLatchAwaitCallable implements Callable<Boolean>, HazelcastInstanceAware, Serializable {
 
@@ -1043,6 +1028,4 @@ public class ExecutorServiceTest extends ExecutorServiceTestSupport {
             return "key";
         }
     }
-
 }
-

--- a/hazelcast/src/test/java/com/hazelcast/executor/SpecificSetupTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/executor/SpecificSetupTest.java
@@ -22,6 +22,7 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IExecutorService;
 import com.hazelcast.core.ManagedContext;
 import com.hazelcast.core.PartitionAware;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.monitor.LocalExecutorStats;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
@@ -37,7 +38,6 @@ import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import static com.hazelcast.instance.GroupProperties.PROP_OPERATION_CALL_TIMEOUT_MILLIS;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.Assert.assertEquals;
@@ -123,7 +123,7 @@ public class SpecificSetupTest extends ExecutorServiceTestSupport {
         TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(2);
         Config config = new Config();
         int timeoutSeconds = 3;
-        config.setProperty(PROP_OPERATION_CALL_TIMEOUT_MILLIS, String.valueOf(SECONDS.toMillis(timeoutSeconds)));
+        config.setProperty(GroupProperty.OPERATION_CALL_TIMEOUT_MILLIS, String.valueOf(SECONDS.toMillis(timeoutSeconds)));
         HazelcastInstance hz1 = factory.newHazelcastInstance(config);
         HazelcastInstance hz2 = factory.newHazelcastInstance(config);
         IExecutorService executor = hz1.getExecutorService(randomString());

--- a/hazelcast/src/test/java/com/hazelcast/internal/monitors/HealthMonitorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/monitors/HealthMonitorTest.java
@@ -2,6 +2,7 @@ package com.hazelcast.internal.monitors;
 
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.internal.metrics.DoubleProbeFunction;
 import com.hazelcast.internal.metrics.Metric;
 import com.hazelcast.internal.metrics.MetricsRegistry;
@@ -13,14 +14,13 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import static com.hazelcast.instance.GroupProperties.PROP_HEALTH_MONITORING_DELAY_SECONDS;
-import static com.hazelcast.instance.GroupProperties.PROP_HEALTH_MONITORING_LEVEL;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
 public class HealthMonitorTest extends HazelcastTestSupport {
+
     private HealthMonitor healthMonitor;
     private HealthMonitor.HealthMetrics metrics;
     private MetricsRegistry metricsRegistry;
@@ -28,8 +28,8 @@ public class HealthMonitorTest extends HazelcastTestSupport {
     @Before
     public void setup() {
         Config config = new Config();
-        config.setProperty(PROP_HEALTH_MONITORING_LEVEL, HealthMonitorLevel.NOISY.toString());
-        config.setProperty(PROP_HEALTH_MONITORING_DELAY_SECONDS, "1");
+        config.setProperty(GroupProperty.HEALTH_MONITORING_LEVEL, HealthMonitorLevel.NOISY.toString());
+        config.setProperty(GroupProperty.HEALTH_MONITORING_DELAY_SECONDS, "1");
 
         HazelcastInstance hz = createHazelcastInstance(config);
         healthMonitor = new HealthMonitor(getNode(hz));

--- a/hazelcast/src/test/java/com/hazelcast/internal/monitors/PerformanceMonitorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/monitors/PerformanceMonitorTest.java
@@ -3,6 +3,7 @@ package com.hazelcast.internal.monitors;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.instance.HazelcastInstanceImpl;
 import com.hazelcast.instance.Node;
 import com.hazelcast.internal.metrics.MetricsRegistry;
@@ -12,7 +13,6 @@ import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.QuickTest;
-import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Test;
@@ -25,12 +25,6 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.lang.reflect.Field;
 
-import static com.hazelcast.instance.GroupProperties.PROP_PERFORMANCE_MONITOR_DELAY_SECONDS;
-import static com.hazelcast.instance.GroupProperties.PROP_PERFORMANCE_MONITOR_ENABLED;
-import static com.hazelcast.instance.GroupProperties.PROP_PERFORMANCE_MONITOR_MAX_ROLLED_FILE_COUNT;
-import static com.hazelcast.instance.GroupProperties.PROP_PERFORMANCE_MONITOR_MAX_ROLLED_FILE_SIZE_MB;
-import static com.hazelcast.instance.GroupProperties.PROP_SLOW_OPERATION_DETECTOR_ENABLED;
-import static com.hazelcast.instance.GroupProperties.PROP_SLOW_OPERATION_DETECTOR_THRESHOLD_MILLIS;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -48,13 +42,13 @@ public class PerformanceMonitorTest extends HazelcastTestSupport {
     @Before
     public void setup() {
         Config config = new Config();
-        config.setProperty(PROP_PERFORMANCE_MONITOR_ENABLED, "true");
-        config.setProperty(PROP_PERFORMANCE_MONITOR_DELAY_SECONDS, "1");
-        config.setProperty(PROP_PERFORMANCE_MONITOR_MAX_ROLLED_FILE_SIZE_MB, "0.2");
-        config.setProperty(PROP_PERFORMANCE_MONITOR_MAX_ROLLED_FILE_COUNT, "3");
+        config.setProperty(GroupProperty.PERFORMANCE_MONITOR_ENABLED, "true");
+        config.setProperty(GroupProperty.PERFORMANCE_MONITOR_DELAY_SECONDS, "1");
+        config.setProperty(GroupProperty.PERFORMANCE_MONITOR_MAX_ROLLED_FILE_SIZE_MB, "0.2");
+        config.setProperty(GroupProperty.PERFORMANCE_MONITOR_MAX_ROLLED_FILE_COUNT, "3");
 
-        config.setProperty(PROP_SLOW_OPERATION_DETECTOR_ENABLED, "true");
-        config.setProperty(PROP_SLOW_OPERATION_DETECTOR_THRESHOLD_MILLIS, "2000");
+        config.setProperty(GroupProperty.SLOW_OPERATION_DETECTOR_ENABLED, "true");
+        config.setProperty(GroupProperty.SLOW_OPERATION_DETECTOR_THRESHOLD_MILLIS, "2000");
 
         hz = createHazelcastInstance(config);
 
@@ -80,7 +74,7 @@ public class PerformanceMonitorTest extends HazelcastTestSupport {
     @Test
     public void testDisabledByDefault() {
         GroupProperties groupProperties = new GroupProperties(new Config());
-        assertFalse(groupProperties.PERFORMANCE_MONITOR_ENABLED.getBoolean());
+        assertFalse(groupProperties.getBoolean(GroupProperty.PERFORMANCE_MONITOR_ENABLED));
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/jmx/LockMBeanTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jmx/LockMBeanTest.java
@@ -22,7 +22,7 @@ import org.junit.runner.RunWith;
 @Category({QuickTest.class, ParallelTest.class})
 public class LockMBeanTest extends HazelcastTestSupport {
 
-    private JmxTestDataHolder holder = new JmxTestDataHolder(createHazelcastInstanceFactory(1));
+    private MBeanDataHolder holder = new MBeanDataHolder(createHazelcastInstanceFactory(1));
     private ILock lock = holder.getHz().getLock("lock");
 
     @Before

--- a/hazelcast/src/test/java/com/hazelcast/jmx/MBeanDataHolder.java
+++ b/hazelcast/src/test/java/com/hazelcast/jmx/MBeanDataHolder.java
@@ -2,12 +2,9 @@ package com.hazelcast.jmx;
 
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
-
-import java.lang.management.ManagementFactory;
-import java.util.Hashtable;
 
 import javax.management.AttributeNotFoundException;
 import javax.management.InstanceNotFoundException;
@@ -16,24 +13,26 @@ import javax.management.MBeanServer;
 import javax.management.MalformedObjectNameException;
 import javax.management.ObjectName;
 import javax.management.ReflectionException;
+import java.lang.management.ManagementFactory;
+import java.util.Hashtable;
 
 import static com.hazelcast.test.HazelcastTestSupport.assertTrueEventually;
-
 import static org.junit.Assert.fail;
 
 /**
- * Holds the mbean server and hazelcast and provides some utility functions for accessing the mbeans.
+ * Holds the Hazelcast instance and MBean server and provides some utility functions for accessing the MBeans.
  */
-public final class JmxTestDataHolder {
+public final class MBeanDataHolder {
+
     private HazelcastInstance hz;
     private MBeanServer mbs;
 
     /**
-     * Initialize with new hazelcast instance and mbean server
+     * Initialize with new hazelcast instance and MBean server
      */
-    public JmxTestDataHolder(TestHazelcastInstanceFactory factory) {
+    public MBeanDataHolder(TestHazelcastInstanceFactory factory) {
         Config config = new Config();
-        config.setProperty(GroupProperties.PROP_ENABLE_JMX, "true");
+        config.setProperty(GroupProperty.ENABLE_JMX, "true");
         hz = factory.newHazelcastInstance(config);
         mbs = ManagementFactory.getPlatformMBeanServer();
     }
@@ -80,7 +79,7 @@ public final class JmxTestDataHolder {
     }
 
     /**
-     * Calls the mbean operation with given attributes
+     * Calls the MBean operation with given attributes
      *
      * @param type          Type of the Hazelcast object (first level of hierarchy), e.g. "IMap"
      * @param objectName    Name of the Hazelcast object (second level of hierarchy), e.g. "myMap"

--- a/hazelcast/src/test/java/com/hazelcast/jmx/MBeanTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jmx/MBeanTest.java
@@ -30,11 +30,11 @@ import java.io.Serializable;
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class MBeanTest extends HazelcastTestSupport {
-    private JmxTestDataHolder holder;
+    private MBeanDataHolder holder;
 
     @Before
     public void setUp() throws Exception {
-        holder = new JmxTestDataHolder(createHazelcastInstanceFactory(1));
+        holder = new MBeanDataHolder(createHazelcastInstanceFactory(1));
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/map/BackupTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/BackupTest.java
@@ -19,7 +19,7 @@ package com.hazelcast.map;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
-import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.instance.HazelcastInstanceFactory;
 import com.hazelcast.instance.TestUtil;
 import com.hazelcast.monitor.LocalMapStats;
@@ -282,7 +282,7 @@ public class BackupTest extends HazelcastTestSupport {
         TestHazelcastInstanceFactory nodeFactory = createHazelcastInstanceFactory(nodeCount);
         final String name = MAP_NAME;
         final Config config = new Config();
-        config.setProperty(GroupProperties.PROP_PARTITION_BACKUP_SYNC_INTERVAL, "5");
+        config.setProperty(GroupProperty.PARTITION_BACKUP_SYNC_INTERVAL, "5");
         config.getMapConfig(name).setBackupCount(backupCount).setStatisticsEnabled(true);
 
         final HazelcastInstance[] instances = new HazelcastInstance[nodeCount];
@@ -310,7 +310,6 @@ public class BackupTest extends HazelcastTestSupport {
             TestUtil.terminateInstance(instances[ix]);
             instances[ix] = null;
             checkMapSizes(mapSize, backupCount, instances);
-
         }
     }
 
@@ -577,7 +576,7 @@ public class BackupTest extends HazelcastTestSupport {
     @Test
     public void testGracefulShutdown_Issue2804() {
         Config config = new Config();
-        config.setProperty(GroupProperties.PROP_PARTITION_COUNT, "1111");
+        config.setProperty(GroupProperty.PARTITION_COUNT, "1111");
         TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(2);
 
         HazelcastInstance h1 = factory.newHazelcastInstance(config);

--- a/hazelcast/src/test/java/com/hazelcast/map/DynamicMapConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/DynamicMapConfigTest.java
@@ -22,7 +22,7 @@ import com.hazelcast.config.MapConfig;
 import com.hazelcast.config.MaxSizeConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
-import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.internal.management.operation.UpdateMapConfigOperation;
 import com.hazelcast.map.impl.recordstore.DefaultRecordStore;
 import com.hazelcast.map.impl.MapService;
@@ -60,7 +60,7 @@ public class DynamicMapConfigTest extends HazelcastTestSupport {
         String mapName = randomMapName();
 
         Config config = new Config();
-        config.setProperty(GroupProperties.PROP_PARTITION_COUNT, "1");
+        config.setProperty(GroupProperty.PARTITION_COUNT, "1");
 
         HazelcastInstance node = createHazelcastInstance(config);
 

--- a/hazelcast/src/test/java/com/hazelcast/map/EvictionMaxSizePolicyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/EvictionMaxSizePolicyTest.java
@@ -6,7 +6,7 @@ import com.hazelcast.config.MapConfig;
 import com.hazelcast.config.MaxSizeConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
-import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.map.impl.recordstore.DefaultRecordStore;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.map.impl.MapServiceContext;
@@ -278,7 +278,7 @@ public class EvictionMaxSizePolicyTest extends HazelcastTestSupport {
 
     private Config createConfig(MaxSizeConfig.MaxSizePolicy maxSizePolicy, int maxSize, String mapName) {
         Config config = new Config();
-        config.setProperty(GroupProperties.PROP_PARTITION_COUNT, String.valueOf(PARTITION_COUNT));
+        config.setProperty(GroupProperty.PARTITION_COUNT, String.valueOf(PARTITION_COUNT));
 
         MapConfig mapConfig = config.getMapConfig(mapName);
         mapConfig.setEvictionPolicy(EvictionPolicy.LRU);

--- a/hazelcast/src/test/java/com/hazelcast/map/EvictionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/EvictionTest.java
@@ -27,7 +27,7 @@ import com.hazelcast.core.EntryEvent;
 import com.hazelcast.core.EntryView;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
-import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
@@ -325,7 +325,7 @@ public class EvictionTest extends HazelcastTestSupport {
         final int size = 10;
         final String mapName = "testEvictionPerPartition";
         Config cfg = new Config();
-        cfg.setProperty(GroupProperties.PROP_PARTITION_COUNT, "1");
+        cfg.setProperty(GroupProperty.PARTITION_COUNT, "1");
         final MapConfig mc = cfg.getMapConfig(mapName);
         mc.setEvictionPolicy(EvictionPolicy.LRU);
         mc.setEvictionPercentage(50);
@@ -359,7 +359,7 @@ public class EvictionTest extends HazelcastTestSupport {
 
         final String mapName = randomMapName();
         Config cfg = new Config();
-        cfg.setProperty(GroupProperties.PROP_PARTITION_COUNT, "1");
+        cfg.setProperty(GroupProperty.PARTITION_COUNT, "1");
         MapConfig mc = cfg.getMapConfig(mapName);
         mc.setEvictionPolicy(EvictionPolicy.LRU);
         mc.setEvictionPercentage(20);
@@ -399,7 +399,7 @@ public class EvictionTest extends HazelcastTestSupport {
         final String mapName = randomMapName("_testEvictionLRU_statisticsDisabled_");
 
         Config cfg = new Config();
-        cfg.setProperty(GroupProperties.PROP_PARTITION_COUNT, "1");
+        cfg.setProperty(GroupProperty.PARTITION_COUNT, "1");
         MapConfig mc = cfg.getMapConfig(mapName);
         mc.setStatisticsEnabled(false);
         mc.setEvictionPolicy(EvictionPolicy.LRU);
@@ -437,7 +437,7 @@ public class EvictionTest extends HazelcastTestSupport {
         final int size = 10000;
 
         Config cfg = new Config();
-        cfg.setProperty(GroupProperties.PROP_PARTITION_COUNT, "1");
+        cfg.setProperty(GroupProperty.PARTITION_COUNT, "1");
         MapConfig mc = cfg.getMapConfig(mapName);
         mc.setStatisticsEnabled(false);
         mc.setEvictionPolicy(EvictionPolicy.LFU);
@@ -481,7 +481,7 @@ public class EvictionTest extends HazelcastTestSupport {
         final int instanceCount = 1;
         final int size = 10000;
         Config cfg = new Config();
-        cfg.setProperty(GroupProperties.PROP_PARTITION_COUNT, "1");
+        cfg.setProperty(GroupProperty.PARTITION_COUNT, "1");
         MapConfig mc = cfg.getMapConfig(mapName);
         mc.setEvictionPolicy(EvictionPolicy.LFU);
         mc.setEvictionPercentage(20);
@@ -524,7 +524,7 @@ public class EvictionTest extends HazelcastTestSupport {
             final int size = 10000;
             final String mapName = randomMapName("testEvictionLFU2");
             Config cfg = new Config();
-            cfg.setProperty(GroupProperties.PROP_PARTITION_COUNT, "1");
+            cfg.setProperty(GroupProperty.PARTITION_COUNT, "1");
             MapConfig mc = cfg.getMapConfig(mapName);
             mc.setEvictionPolicy(EvictionPolicy.LFU);
             mc.setEvictionPercentage(90);
@@ -638,7 +638,7 @@ public class EvictionTest extends HazelcastTestSupport {
     @Category(NightlyTest.class)
     public void testMapRecordIdleEvictionOnMigration() {
         Config cfg = new Config();
-        cfg.setProperty(GroupProperties.PROP_PARTITION_COUNT, "1");
+        cfg.setProperty(GroupProperty.PARTITION_COUNT, "1");
         final String name = "testMapRecordIdleEvictionOnMigration";
         MapConfig mc = cfg.getMapConfig(name);
         int maxIdleSeconds = 30;
@@ -1014,7 +1014,7 @@ public class EvictionTest extends HazelcastTestSupport {
 
         final Config config = newConfigWithTTL(mapName, ttlSeconds);
         // use a long delay for testing purposes.
-        config.setProperty(GroupProperties.PROP_MAP_EXPIRY_DELAY_SECONDS, String.valueOf(TimeUnit.HOURS.toSeconds(1)));
+        config.setProperty(GroupProperty.MAP_EXPIRY_DELAY_SECONDS, String.valueOf(TimeUnit.HOURS.toSeconds(1)));
 
         final TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(nodeCount);
         final HazelcastInstance[] instances = factory.newInstances(config);

--- a/hazelcast/src/test/java/com/hazelcast/map/MapRemoveFailingBackupTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapRemoveFailingBackupTest.java
@@ -19,7 +19,7 @@ package com.hazelcast.map;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
-import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.instance.HazelcastInstanceImpl;
 import com.hazelcast.instance.TestUtil;
 import com.hazelcast.map.impl.operation.BaseRemoveOperation;
@@ -60,7 +60,7 @@ public class MapRemoveFailingBackupTest extends HazelcastTestSupport {
         final String key = "2";
         final String value = "value2";
         Config config = new Config();
-        config.setProperty(GroupProperties.PROP_PARTITION_BACKUP_SYNC_INTERVAL, "5");
+        config.setProperty(GroupProperty.PARTITION_BACKUP_SYNC_INTERVAL, "5");
         config.getMapConfig(mapName).setReadBackupData(true);
         HazelcastInstance hz1 = factory.newHazelcastInstance(config);
         HazelcastInstance hz2 = factory.newHazelcastInstance(config);

--- a/hazelcast/src/test/java/com/hazelcast/map/MapTransactionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapTransactionTest.java
@@ -28,7 +28,7 @@ import com.hazelcast.core.HazelcastInstanceNotActiveException;
 import com.hazelcast.core.IMap;
 import com.hazelcast.core.MapStoreAdapter;
 import com.hazelcast.core.TransactionalMap;
-import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.instance.Node;
 import com.hazelcast.instance.TestUtil;
 import com.hazelcast.nio.serialization.Data;
@@ -429,7 +429,7 @@ public class MapTransactionTest extends HazelcastTestSupport {
     @Test
     public void testTxnGetForUpdateTxnFails() throws TransactionException {
         Config config = new Config();
-        config.setProperty(GroupProperties.PROP_OPERATION_CALL_TIMEOUT_MILLIS, "5000");
+        config.setProperty(GroupProperty.OPERATION_CALL_TIMEOUT_MILLIS, "5000");
         final TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(2);
         final HazelcastInstance h1 = factory.newHazelcastInstance(config);
         final HazelcastInstance h2 = factory.newHazelcastInstance(config);

--- a/hazelcast/src/test/java/com/hazelcast/map/MapUnboundedReturnValuesTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapUnboundedReturnValuesTestSupport.java
@@ -5,7 +5,7 @@ import com.hazelcast.config.MapConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.core.TransactionalMap;
-import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.map.impl.QueryResultSizeLimiter;
 import com.hazelcast.query.Predicate;
@@ -156,9 +156,9 @@ abstract class MapUnboundedReturnValuesTestSupport extends HazelcastTestSupport 
 
     private Config createConfig(int partitionCount, int limit, int preCheckTrigger) {
         Config config = new Config();
-        config.setProperty(GroupProperties.PROP_PARTITION_COUNT, String.valueOf(partitionCount));
-        config.setProperty(GroupProperties.PROP_QUERY_RESULT_SIZE_LIMIT, String.valueOf(limit));
-        config.setProperty(GroupProperties.PROP_QUERY_MAX_LOCAL_PARTITION_LIMIT_FOR_PRE_CHECK, String.valueOf(preCheckTrigger));
+        config.setProperty(GroupProperty.PARTITION_COUNT, String.valueOf(partitionCount));
+        config.setProperty(GroupProperty.QUERY_RESULT_SIZE_LIMIT, String.valueOf(limit));
+        config.setProperty(GroupProperty.QUERY_MAX_LOCAL_PARTITION_LIMIT_FOR_PRE_CHECK, String.valueOf(preCheckTrigger));
         return config;
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/map/MergePolicyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MergePolicyTest.java
@@ -1,6 +1,5 @@
 package com.hazelcast.map;
 
-
 import com.hazelcast.config.Config;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.core.Hazelcast;
@@ -11,7 +10,7 @@ import com.hazelcast.core.LifecycleListener;
 import com.hazelcast.core.MemberAttributeEvent;
 import com.hazelcast.core.MembershipEvent;
 import com.hazelcast.core.MembershipListener;
-import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.instance.HazelcastInstanceFactory;
 import com.hazelcast.map.merge.HigherHitsMapMergePolicy;
 import com.hazelcast.map.merge.LatestUpdateMapMergePolicy;
@@ -224,8 +223,8 @@ public class MergePolicyTest extends HazelcastTestSupport {
 
     private Config newConfig(String mergePolicy, String mapName) {
         Config config = new Config();
-        config.setProperty(GroupProperties.PROP_MERGE_FIRST_RUN_DELAY_SECONDS, "5");
-        config.setProperty(GroupProperties.PROP_MERGE_NEXT_RUN_DELAY_SECONDS, "3");
+        config.setProperty(GroupProperty.MERGE_FIRST_RUN_DELAY_SECONDS, "5");
+        config.setProperty(GroupProperty.MERGE_NEXT_RUN_DELAY_SECONDS, "3");
         config.getGroupConfig().setName(generateRandomString(10));
         MapConfig mapConfig = config.getMapConfig(mapName);
         mapConfig.setMergePolicy(mergePolicy);

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/QueryResultSizeLimiterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/QueryResultSizeLimiterTest.java
@@ -21,6 +21,9 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 
+import static com.hazelcast.instance.GroupProperty.PARTITION_COUNT;
+import static com.hazelcast.instance.GroupProperty.QUERY_MAX_LOCAL_PARTITION_LIMIT_FOR_PRE_CHECK;
+import static com.hazelcast.instance.GroupProperty.QUERY_RESULT_SIZE_LIMIT;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -212,10 +215,9 @@ public class QueryResultSizeLimiterTest {
 
     private void initMocksWithConfiguration(int maxResultSizeLimit, int maxLocalPartitionLimitForPreCheck, int partitionCount) {
         Config config = new Config();
-        config.setProperty(GroupProperties.PROP_QUERY_RESULT_SIZE_LIMIT, String.valueOf(maxResultSizeLimit));
-        config.setProperty(GroupProperties.PROP_QUERY_MAX_LOCAL_PARTITION_LIMIT_FOR_PRE_CHECK,
-                String.valueOf(maxLocalPartitionLimitForPreCheck));
-        config.setProperty(GroupProperties.PROP_PARTITION_COUNT, String.valueOf(partitionCount));
+        config.setProperty(QUERY_RESULT_SIZE_LIMIT, String.valueOf(maxResultSizeLimit));
+        config.setProperty(QUERY_MAX_LOCAL_PARTITION_LIMIT_FOR_PRE_CHECK, String.valueOf(maxLocalPartitionLimitForPreCheck));
+        config.setProperty(PARTITION_COUNT, String.valueOf(partitionCount));
 
         GroupProperties groupProperties = new GroupProperties(config);
 

--- a/hazelcast/src/test/java/com/hazelcast/map/mapstore/MapLoaderFailoverTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/mapstore/MapLoaderFailoverTest.java
@@ -16,14 +16,13 @@
 
 package com.hazelcast.map.mapstore;
 
-
 import com.hazelcast.config.Config;
 import com.hazelcast.config.GroupConfig;
 import com.hazelcast.config.MapStoreConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.core.MapLoader;
-import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
@@ -181,8 +180,8 @@ public class MapLoaderFailoverTest extends HazelcastTestSupport {
     private Config newConfig(String mapName, MapStoreConfig.InitialLoadMode loadMode, int backups, MapLoader loader) {
         Config cfg = new Config();
         cfg.setGroupConfig(new GroupConfig(getClass().getSimpleName()));
-        cfg.setProperty(GroupProperties.PROP_MAP_LOAD_CHUNK_SIZE, Integer.toString(BATCH_SIZE));
-        cfg.setProperty(GroupProperties.PROP_PARTITION_COUNT, "31");
+        cfg.setProperty(GroupProperty.MAP_LOAD_CHUNK_SIZE, Integer.toString(BATCH_SIZE));
+        cfg.setProperty(GroupProperty.PARTITION_COUNT, "31");
 
         MapStoreConfig mapStoreConfig = new MapStoreConfig()
                 .setImplementation(loader).setInitialLoadMode(loadMode);
@@ -191,5 +190,4 @@ public class MapLoaderFailoverTest extends HazelcastTestSupport {
 
         return cfg;
     }
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/map/mapstore/MapLoaderMultiNodeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/mapstore/MapLoaderMultiNodeTest.java
@@ -1,6 +1,5 @@
 package com.hazelcast.map.mapstore;
 
-
 import com.hazelcast.config.Config;
 import com.hazelcast.config.GroupConfig;
 import com.hazelcast.config.MapStoreConfig;
@@ -8,7 +7,7 @@ import com.hazelcast.config.MapStoreConfig.InitialLoadMode;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.core.MapLoader;
-import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
@@ -162,8 +161,8 @@ public class MapLoaderMultiNodeTest extends HazelcastTestSupport {
     private Config newConfig(String mapName, MapStoreConfig.InitialLoadMode loadMode, int backups, MapLoader loader) {
         Config cfg = new Config();
         cfg.setGroupConfig(new GroupConfig(getClass().getSimpleName()));
-        cfg.setProperty(GroupProperties.PROP_MAP_LOAD_CHUNK_SIZE, Integer.toString(BATCH_SIZE));
-        cfg.setProperty(GroupProperties.PROP_PARTITION_COUNT, "31");
+        cfg.setProperty(GroupProperty.MAP_LOAD_CHUNK_SIZE, Integer.toString(BATCH_SIZE));
+        cfg.setProperty(GroupProperty.PARTITION_COUNT, "31");
 
         MapStoreConfig mapStoreConfig = new MapStoreConfig()
                 .setImplementation(loader).setInitialLoadMode(loadMode);
@@ -172,5 +171,4 @@ public class MapLoaderMultiNodeTest extends HazelcastTestSupport {
 
         return cfg;
     }
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/map/mapstore/MapStoreTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/mapstore/MapStoreTest.java
@@ -32,7 +32,7 @@ import com.hazelcast.core.MapStore;
 import com.hazelcast.core.MapStoreAdapter;
 import com.hazelcast.core.MapStoreFactory;
 import com.hazelcast.core.PostProcessingMapStore;
-import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.instance.TestUtil;
 import com.hazelcast.map.AbstractEntryProcessor;
 import com.hazelcast.map.impl.MapContainer;
@@ -78,7 +78,6 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
-
 
 /**
  * @author enesakar 1/21/13
@@ -777,9 +776,8 @@ public class MapStoreTest extends HazelcastTestSupport {
 
     private Config createChunkedMapLoaderConfig(String mapName, int chunkSize, ChunkedLoader chunkedLoader) {
         Config cfg = new Config();
-        cfg.setProperty(GroupProperties.PROP_PARTITION_COUNT, "1");
-        cfg.setProperty(GroupProperties.PROP_MAP_LOAD_CHUNK_SIZE, String.valueOf(chunkSize));
-
+        cfg.setProperty(GroupProperty.PARTITION_COUNT, "1");
+        cfg.setProperty(GroupProperty.MAP_LOAD_CHUNK_SIZE, String.valueOf(chunkSize));
 
         MapStoreConfig mapStoreConfig = new MapStoreConfig();
         mapStoreConfig.setEnabled(true);

--- a/hazelcast/src/test/java/com/hazelcast/map/mapstore/MapStoreWriteBehindTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/mapstore/MapStoreWriteBehindTest.java
@@ -25,7 +25,7 @@ import com.hazelcast.core.IMap;
 import com.hazelcast.core.MapStore;
 import com.hazelcast.core.MapStoreAdapter;
 import com.hazelcast.core.TransactionalMap;
-import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.map.impl.MapServiceContext;
 import com.hazelcast.map.impl.recordstore.RecordStore;
@@ -75,7 +75,6 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-
 /**
  * @author enesakar 1/21/13
  */
@@ -87,7 +86,7 @@ public class MapStoreWriteBehindTest extends HazelcastTestSupport {
     public void testOneMemberWriteBehindWithMaxIdle() throws Exception {
         final TestEventBasedMapStore testMapStore = new TestEventBasedMapStore();
         Config config = newConfig(testMapStore, 5, InitialLoadMode.EAGER);
-        config.setProperty(GroupProperties.PROP_PARTITION_COUNT, "1");
+        config.setProperty(GroupProperty.PARTITION_COUNT, "1");
         config.getMapConfig("default").setMaxIdleSeconds(10);
         HazelcastInstance h1 = createHazelcastInstance(config);
         final IMap map = h1.getMap("default");
@@ -385,7 +384,7 @@ public class MapStoreWriteBehindTest extends HazelcastTestSupport {
         final int expectedStoreCount = 3;
         final int nodeCount = 3;
         Config config = new Config();
-        config.setProperty(GroupProperties.PROP_MAP_REPLICA_SCHEDULED_TASK_DELAY_SECONDS, "30");
+        config.setProperty(GroupProperty.MAP_REPLICA_SCHEDULED_TASK_DELAY_SECONDS, "30");
         MapConfig writeBehindBackupConfig = config.getMapConfig(name);
         MapStoreConfig mapStoreConfig = new MapStoreConfig();
         mapStoreConfig.setWriteDelaySeconds(5);

--- a/hazelcast/src/test/java/com/hazelcast/map/mapstore/MapStoreWriteThroughTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/mapstore/MapStoreWriteThroughTest.java
@@ -24,7 +24,7 @@ import com.hazelcast.core.EntryAdapter;
 import com.hazelcast.core.EntryEvent;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
-import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.instance.TestUtil;
 import com.hazelcast.map.mapstore.MapStoreTest.TestMapStore;
 import com.hazelcast.map.mapstore.MapStoreWriteBehindTest.FailAwareMapStore;
@@ -49,7 +49,6 @@ import static org.junit.Assert.fail;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
-
 
 /**
  * @author enesakar 1/21/13
@@ -95,7 +94,7 @@ public class MapStoreWriteThroughTest extends HazelcastTestSupport {
         TestMapStore testMapStore = new TestMapStore(size * 2, 1, 1);
         testMapStore.setLoadAllKeys(false);
         Config config = newConfig(testMapStore, 0);
-        config.setProperty(GroupProperties.PROP_PARTITION_COUNT, "1");
+        config.setProperty(GroupProperty.PARTITION_COUNT, "1");
         MaxSizeConfig maxSizeConfig = new MaxSizeConfig();
         maxSizeConfig.setSize(size);
         MapConfig mapConfig = config.getMapConfig("default");

--- a/hazelcast/src/test/java/com/hazelcast/map/mapstore/writebehind/TestMapUsingMapStoreBuilder.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/mapstore/writebehind/TestMapUsingMapStoreBuilder.java
@@ -6,7 +6,7 @@ import com.hazelcast.config.MapStoreConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.core.MapStore;
-import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 
 import static com.hazelcast.test.HazelcastTestSupport.randomMapName;
@@ -45,7 +45,6 @@ public class TestMapUsingMapStoreBuilder<K, V> {
     public static <K, V> TestMapUsingMapStoreBuilder<K, V> create() {
         return new TestMapUsingMapStoreBuilder<K, V>();
     }
-
 
     public TestMapUsingMapStoreBuilder<K, V> mapName(String mapName) {
         if (mapName == null) {
@@ -100,7 +99,6 @@ public class TestMapUsingMapStoreBuilder<K, V> {
         return this;
     }
 
-
     public TestMapUsingMapStoreBuilder<K, V> withMapStore(MapStore<K, V> mapStore) {
         this.mapStore = mapStore;
         return this;
@@ -124,12 +122,10 @@ public class TestMapUsingMapStoreBuilder<K, V> {
         return this;
     }
 
-
     public TestMapUsingMapStoreBuilder<K, V> withWriteBatchSize(int writeBatchSize) {
         this.writeBatchSize = writeBatchSize;
         return this;
     }
-
 
     public IMap<K, V> build() {
         if (backupCount != 0 && backupCount > nodeCount - 1) {
@@ -149,17 +145,15 @@ public class TestMapUsingMapStoreBuilder<K, V> {
                 .setInMemoryFormat(inMemoryFormat);
 
         if (writeBehindQueueCapacity > 0) {
-            config.setProperty(GroupProperties.PROP_MAP_WRITE_BEHIND_QUEUE_CAPACITY,
-                    String.valueOf(writeBehindQueueCapacity));
+            config.setProperty(GroupProperty.MAP_WRITE_BEHIND_QUEUE_CAPACITY, String.valueOf(writeBehindQueueCapacity));
         }
 
-
-        config.setProperty(GroupProperties.PROP_PARTITION_COUNT, String.valueOf(partitionCount));
+        config.setProperty(GroupProperty.PARTITION_COUNT, String.valueOf(partitionCount));
         if (backupDelaySeconds > 0) {
-            config.setProperty(GroupProperties.PROP_MAP_REPLICA_SCHEDULED_TASK_DELAY_SECONDS,
-                    String.valueOf(backupCount));
+            config.setProperty(GroupProperty.MAP_REPLICA_SCHEDULED_TASK_DELAY_SECONDS, String.valueOf(backupCount));
         }
-        // nodes.
+
+        // nodes
         nodes = new HazelcastInstance[nodeCount];
         for (int i = 0; i < nodeCount; i++) {
             nodes[i] = instanceFactory.newHazelcastInstance(config);

--- a/hazelcast/src/test/java/com/hazelcast/map/mapstore/writebehind/WriteBehindOnBackupsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/mapstore/writebehind/WriteBehindOnBackupsTest.java
@@ -50,7 +50,7 @@ public class WriteBehindOnBackupsTest extends HazelcastTestSupport {
 
     /**
      * {@link com.hazelcast.map.impl.mapstore.writebehind.StoreWorker} delays processing of write-behind queues (wbq) by adding
-     * delay with {@link com.hazelcast.instance.GroupProperties#PROP_MAP_REPLICA_SCHEDULED_TASK_DELAY_SECONDS} property.
+     * delay with {@link com.hazelcast.instance.GroupProperty#MAP_REPLICA_SCHEDULED_TASK_DELAY_SECONDS} property.
      * This is used to provide some extra robustness against node disaster scenarios by trying to prevent lost of entries in wbq-s.
      * Normally backup nodes don't store entries only remove them from wbq-s. Here, we are testing removal of entries occurred or not.
      */

--- a/hazelcast/src/test/java/com/hazelcast/map/query/QueryBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/query/QueryBasicTest.java
@@ -1,12 +1,12 @@
 package com.hazelcast.map.query;
 
-
 import com.hazelcast.config.Config;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.config.MapIndexConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.nio.serialization.PortableTest.ChildPortableObject;
 import com.hazelcast.nio.serialization.PortableTest.GrandParentPortableObject;
 import com.hazelcast.nio.serialization.PortableTest.ParentPortableObject;
@@ -57,7 +57,7 @@ public class QueryBasicTest extends HazelcastTestSupport {
     public void testPredicatedEvaluatedSingleThreadedByDefault() {
         Config config = new Config();
         GroupProperties properties = new GroupProperties(config);
-        boolean parallelEvaluation = properties.QUERY_PREDICATE_PARALLEL_EVALUATION.getBoolean();
+        boolean parallelEvaluation = properties.getBoolean(GroupProperty.QUERY_PREDICATE_PARALLEL_EVALUATION);
         assertEquals(false, parallelEvaluation);
     }
 
@@ -774,7 +774,7 @@ public class QueryBasicTest extends HazelcastTestSupport {
     @Test
     public void testQueryPortableObject_parallel() {
         Config config = new Config();
-        config.setProperty(GroupProperties.PROP_QUERY_PREDICATE_PARALLEL_EVALUATION, "true");
+        config.setProperty(GroupProperty.QUERY_PREDICATE_PARALLEL_EVALUATION, "true");
         testQueryUsingPortableObject(config, randomMapName());
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/map/query/QueryIndexMigrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/query/QueryIndexMigrationTest.java
@@ -20,7 +20,7 @@ import com.hazelcast.config.Config;
 import com.hazelcast.config.MapIndexConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
-import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.SampleObjects.Employee;
 import com.hazelcast.query.SampleObjects.Value;
@@ -192,7 +192,7 @@ public class QueryIndexMigrationTest extends HazelcastTestSupport {
 
     private Config newConfigWithIndex(final String mapName, String attribute) {
         final Config config = new Config();
-        config.setProperty(GroupProperties.PROP_WAIT_SECONDS_BEFORE_JOIN, "0");
+        config.setProperty(GroupProperty.WAIT_SECONDS_BEFORE_JOIN, "0");
         config.getMapConfig(mapName).addMapIndexConfig(new MapIndexConfig(attribute, false));
         return config;
     }

--- a/hazelcast/src/test/java/com/hazelcast/map/query/QueryIndexingTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/query/QueryIndexingTest.java
@@ -4,7 +4,7 @@ import com.hazelcast.config.Config;
 import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
-import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.mock.MockUtil;
 import com.hazelcast.query.EntryObject;
 import com.hazelcast.query.Predicate;
@@ -123,7 +123,7 @@ public class QueryIndexingTest extends HazelcastTestSupport {
         Config conf = new Config();
         conf.getMapConfig("employees").setInMemoryFormat(InMemoryFormat.OBJECT).setBackupCount(0);
         // disabling replication since we don't use backups in this test
-        conf.setProperty(GroupProperties.PROP_PARTITION_MAX_PARALLEL_REPLICATIONS, "0");
+        conf.setProperty(GroupProperty.PARTITION_MAX_PARALLEL_REPLICATIONS, "0");
         return conf;
     }
 
@@ -141,5 +141,4 @@ public class QueryIndexingTest extends HazelcastTestSupport {
         }
         return employees;
     }
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/map/query/QuerySlowTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/query/QuerySlowTest.java
@@ -19,7 +19,7 @@ import com.hazelcast.util.Clock;
 import java.util.Map;
 import java.util.Set;
 
-import static com.hazelcast.instance.GroupProperties.PROP_PARTITION_MAX_PARALLEL_REPLICATIONS;
+import static com.hazelcast.instance.GroupProperty.PARTITION_MAX_PARALLEL_REPLICATIONS;
 import static com.hazelcast.test.TimeConstants.MINUTE;
 
 import static org.junit.Assert.assertEquals;
@@ -60,7 +60,7 @@ public class QuerySlowTest extends HazelcastTestSupport {
         Config conf = new Config();
         conf.getMapConfig("default").setBackupCount(0);
         // disable replication so that indexes are used for queries
-        conf.setProperty(PROP_PARTITION_MAX_PARALLEL_REPLICATIONS, "0");
+        conf.setProperty(PARTITION_MAX_PARALLEL_REPLICATIONS, "0");
         return conf;
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/monitor/impl/LocalOperationStatsImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/monitor/impl/LocalOperationStatsImplTest.java
@@ -2,7 +2,7 @@ package com.hazelcast.monitor.impl;
 
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.instance.Node;
 import com.hazelcast.internal.management.dto.SlowOperationDTO;
 import com.hazelcast.internal.management.dto.SlowOperationInvocationDTO;
@@ -40,7 +40,7 @@ public class LocalOperationStatsImplTest extends HazelcastTestSupport {
     @Test
     public void testNodeConstructor() {
         Config config = new Config();
-        config.setProperty(GroupProperties.PROP_MC_MAX_VISIBLE_SLOW_OPERATION_COUNT, "139");
+        config.setProperty(GroupProperty.MC_MAX_VISIBLE_SLOW_OPERATION_COUNT, "139");
 
         HazelcastInstance hazelcastInstance = createHazelcastInstance(config);
         Node node = getNode(hazelcastInstance);
@@ -55,7 +55,7 @@ public class LocalOperationStatsImplTest extends HazelcastTestSupport {
     @Test
     public void testSerialization() {
         Config config = new Config();
-        config.setProperty(GroupProperties.PROP_MC_MAX_VISIBLE_SLOW_OPERATION_COUNT, "127");
+        config.setProperty(GroupProperty.MC_MAX_VISIBLE_SLOW_OPERATION_COUNT, "127");
 
         SlowOperationInvocationDTO slowOperationInvocationDTO = new SlowOperationInvocationDTO();
         slowOperationInvocationDTO.id = 12345;

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/nonblocking/iobalancer/IOBalancerStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/nonblocking/iobalancer/IOBalancerStressTest.java
@@ -20,7 +20,7 @@ import com.hazelcast.config.Config;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
-import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.instance.HazelcastInstanceFactory;
 import com.hazelcast.nio.tcp.nonblocking.NonBlockingIOThread;
 import com.hazelcast.nio.tcp.nonblocking.MigratableHandler;
@@ -63,8 +63,8 @@ public class IOBalancerStressTest extends HazelcastTestSupport {
     @Test
     public void testEachConnectionUseDifferentSelectorEventually() {
         Config config = new Config();
-        config.setProperty(GroupProperties.PROP_IO_BALANCER_INTERVAL_SECONDS, "1");
-        config.setProperty(GroupProperties.PROP_IO_THREAD_COUNT, "2");
+        config.setProperty(GroupProperty.IO_BALANCER_INTERVAL_SECONDS, "1");
+        config.setProperty(GroupProperty.IO_THREAD_COUNT, "2");
 
         HazelcastInstance instance1 = Hazelcast.newHazelcastInstance(config);
         HazelcastInstance instance2 = Hazelcast.newHazelcastInstance(config);

--- a/hazelcast/src/test/java/com/hazelcast/partition/PartitionDistributionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/partition/PartitionDistributionTest.java
@@ -22,7 +22,7 @@ import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.Member;
 import com.hazelcast.core.Partition;
-import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
@@ -137,7 +137,7 @@ public class PartitionDistributionTest extends HazelcastTestSupport {
     }
 
     private void testPartitionDistribution(int partitionCount, int nodeCount, Config config) throws InterruptedException {
-        config.setProperty(GroupProperties.PROP_PARTITION_COUNT, String.valueOf(partitionCount));
+        config.setProperty(GroupProperty.PARTITION_COUNT, String.valueOf(partitionCount));
         TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(nodeCount);
         final BlockingQueue<Integer> counts = new ArrayBlockingQueue<Integer>(nodeCount);
         final HazelcastInstance[] instances = new HazelcastInstance[nodeCount];

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/IndexSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/IndexSplitBrainTest.java
@@ -15,7 +15,7 @@ import com.hazelcast.core.MemberAttributeEvent;
 import com.hazelcast.core.MembershipEvent;
 import com.hazelcast.core.MembershipListener;
 import com.hazelcast.core.PartitionAwareKey;
-import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.map.merge.LatestUpdateMapMergePolicy;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
@@ -33,7 +33,6 @@ import org.junit.runner.RunWith;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Properties;
 import java.util.Random;
 import java.util.concurrent.CountDownLatch;
 
@@ -111,9 +110,9 @@ public class IndexSplitBrainTest extends HazelcastTestSupport {
 
     private Config newConfig(String mergePolicy, String mapName) {
         Config config = new Config();
-        config.setProperties(this.getCommonProperties());
-        config.setProperty(GroupProperties.PROP_MERGE_FIRST_RUN_DELAY_SECONDS, "5");
-        config.setProperty(GroupProperties.PROP_MERGE_NEXT_RUN_DELAY_SECONDS, "3");
+        setCommonProperties(config);
+        config.setProperty(GroupProperty.MERGE_FIRST_RUN_DELAY_SECONDS, "5");
+        config.setProperty(GroupProperty.MERGE_NEXT_RUN_DELAY_SECONDS, "3");
         MapConfig mapConfig = config.getMapConfig(mapName);
         mapConfig.setMergePolicy(mergePolicy);
         mapConfig.setBackupCount(1);
@@ -182,33 +181,29 @@ public class IndexSplitBrainTest extends HazelcastTestSupport {
         return networkConfig;
     }
 
-    protected Properties getCommonProperties() {
-        Properties properties = new Properties();
-        properties.setProperty(GroupProperties.PROP_LOGGING_TYPE, "log4j");
-        properties.setProperty(GroupProperties.PROP_VERSION_CHECK_ENABLED, "false");
-        properties.setProperty("hazelcast.mancenter.enabled", "false");
-        properties.setProperty(GroupProperties.PROP_WAIT_SECONDS_BEFORE_JOIN, "1");
-        properties.setProperty(GroupProperties.PROP_CONNECT_ALL_WAIT_SECONDS, "5");
-        properties.setProperty(GroupProperties.PROP_MAX_NO_HEARTBEAT_SECONDS, "2");
-        properties.setProperty(GroupProperties.PROP_HEARTBEAT_INTERVAL_SECONDS, "1");
-        properties.setProperty(GroupProperties.PROP_MASTER_CONFIRMATION_INTERVAL_SECONDS, "5");
-        properties.setProperty(GroupProperties.PROP_MAX_NO_MASTER_CONFIRMATION_SECONDS, "10");
-        properties.setProperty(GroupProperties.PROP_MEMBER_LIST_PUBLISH_INTERVAL_SECONDS, "5");
-        properties.setProperty(GroupProperties.PROP_MAX_JOIN_MERGE_TARGET_SECONDS, "10");
-        properties.setProperty("hazelcast.local.localAddress", "127.0.0.1");
-        properties.setProperty("java.net.preferIPv4Stack", "true");
-        properties.setProperty(TestEnvironment.HAZELCAST_TEST_USE_NETWORK, "false");
+    protected void setCommonProperties(Config config) {
+        config.setProperty(GroupProperty.LOGGING_TYPE, "log4j");
+        config.setProperty(GroupProperty.VERSION_CHECK_ENABLED, "false");
+        config.setProperty("hazelcast.mancenter.enabled", "false");
+        config.setProperty(GroupProperty.WAIT_SECONDS_BEFORE_JOIN, "1");
+        config.setProperty(GroupProperty.CONNECT_ALL_WAIT_SECONDS, "5");
+        config.setProperty(GroupProperty.MAX_NO_HEARTBEAT_SECONDS, "2");
+        config.setProperty(GroupProperty.HEARTBEAT_INTERVAL_SECONDS, "1");
+        config.setProperty(GroupProperty.MASTER_CONFIRMATION_INTERVAL_SECONDS, "5");
+        config.setProperty(GroupProperty.MAX_NO_MASTER_CONFIRMATION_SECONDS, "10");
+        config.setProperty(GroupProperty.MEMBER_LIST_PUBLISH_INTERVAL_SECONDS, "5");
+        config.setProperty(GroupProperty.MAX_JOIN_MERGE_TARGET_SECONDS, "10");
+        config.setProperty("hazelcast.local.localAddress", "127.0.0.1");
+        config.setProperty("java.net.preferIPv4Stack", "true");
+        config.setProperty(TestEnvironment.HAZELCAST_TEST_USE_NETWORK, "false");
 
         // randomize multicast group...
         Random rand = new Random();
         int g1 = rand.nextInt(255);
         int g2 = rand.nextInt(255);
         int g3 = rand.nextInt(255);
-        properties.setProperty("hazelcast.multicast.group", "224." + g1 + "." + g2 + "." + g3);
-
-        return properties;
+        config.setProperty("hazelcast.multicast.group", "224." + g1 + "." + g2 + "." + g3);
     }
-
 
     public static class RealtimeCall implements DataSerializable {
         private String id;

--- a/hazelcast/src/test/java/com/hazelcast/quorum/PartitionedCluster.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/PartitionedCluster.java
@@ -23,7 +23,7 @@ import com.hazelcast.config.QuorumConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.MembershipAdapter;
 import com.hazelcast.core.MembershipEvent;
-import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.instance.Node;
 import com.hazelcast.nio.tcp.FirewallingMockConnectionManager;
 import com.hazelcast.test.AssertTask;
@@ -80,8 +80,8 @@ public class PartitionedCluster {
 
     private Config createClusterConfig() {
         Config config = new Config();
-        config.setProperty(GroupProperties.PROP_MERGE_FIRST_RUN_DELAY_SECONDS, "9999");
-        config.setProperty(GroupProperties.PROP_MERGE_NEXT_RUN_DELAY_SECONDS, "9999");
+        config.setProperty(GroupProperty.MERGE_FIRST_RUN_DELAY_SECONDS, "9999");
+        config.setProperty(GroupProperty.MERGE_NEXT_RUN_DELAY_SECONDS, "9999");
         config.getGroupConfig().setName(generateRandomString(10));
         config.addQuorumConfig(createSuccessfulSplitTestQuorum());
         return config;

--- a/hazelcast/src/test/java/com/hazelcast/spi/MigrationAwareServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/MigrationAwareServiceTest.java
@@ -20,6 +20,7 @@ import com.hazelcast.config.Config;
 import com.hazelcast.config.ServiceConfig;
 import com.hazelcast.core.HazelcastException;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.instance.Node;
 import com.hazelcast.instance.TestUtil;
 import com.hazelcast.partition.MigrationEndpoint;
@@ -45,8 +46,6 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.LockSupport;
 
-import static com.hazelcast.instance.GroupProperties.PROP_PARTITION_COUNT;
-import static com.hazelcast.instance.GroupProperties.PROP_PARTITION_MAX_PARALLEL_REPLICATIONS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -236,8 +235,8 @@ public class MigrationAwareServiceTest extends HazelcastTestSupport {
                 .addProperty(BACKUP_COUNT_PROP, String.valueOf(backupCount));
 
         config.getServicesConfig().addServiceConfig(serviceConfig);
-        config.setProperty(PROP_PARTITION_COUNT, String.valueOf(PARTITION_COUNT));
-        config.setProperty(PROP_PARTITION_MAX_PARALLEL_REPLICATIONS, String.valueOf(PARALLEL_REPLICATIONS));
+        config.setProperty(GroupProperty.PARTITION_COUNT, String.valueOf(PARTITION_COUNT));
+        config.setProperty(GroupProperty.PARTITION_MAX_PARALLEL_REPLICATIONS, String.valueOf(PARALLEL_REPLICATIONS));
         return config;
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/classic/AbstractClassicOperationExecutorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/classic/AbstractClassicOperationExecutorTest.java
@@ -4,6 +4,7 @@ import com.hazelcast.config.Config;
 import com.hazelcast.instance.BuildInfo;
 import com.hazelcast.instance.DefaultNodeExtension;
 import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.instance.HazelcastThreadGroup;
 import com.hazelcast.internal.metrics.MetricsRegistry;
 import com.hazelcast.internal.metrics.impl.MetricsRegistryImpl;
@@ -62,9 +63,9 @@ public abstract class AbstractClassicOperationExecutorTest extends HazelcastTest
 
         serializationService = new DefaultSerializationServiceBuilder().build();
         config = new Config();
-        config.setProperty(GroupProperties.PROP_PARTITION_COUNT, "10");
-        config.setProperty(GroupProperties.PROP_PARTITION_OPERATION_THREAD_COUNT, "10");
-        config.setProperty(GroupProperties.PROP_GENERIC_OPERATION_THREAD_COUNT, "10");
+        config.setProperty(GroupProperty.PARTITION_COUNT, "10");
+        config.setProperty(GroupProperty.PARTITION_OPERATION_THREAD_COUNT, "10");
+        config.setProperty(GroupProperty.GENERIC_OPERATION_THREAD_COUNT, "10");
         thisAddress = new Address("localhost", 5701);
         threadGroup = new HazelcastThreadGroup(
                 "foo",

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/classic/ClassicOperationExecutorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/classic/ClassicOperationExecutorTest.java
@@ -1,5 +1,6 @@
 package com.hazelcast.spi.impl.operationexecutor.classic;
 
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastSerialClassRunner;
@@ -9,7 +10,6 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
@@ -19,13 +19,13 @@ public class ClassicOperationExecutorTest extends AbstractClassicOperationExecut
     public void testConstruction() {
         initExecutor();
 
-        assertEquals(groupProperties.PARTITION_COUNT.getInteger(), executor.getPartitionOperationRunners().length);
+        assertEquals(groupProperties.getInteger(GroupProperty.PARTITION_COUNT), executor.getPartitionOperationRunners().length);
         assertEquals(executor.getGenericOperationThreadCount(), executor.getGenericOperationRunners().length);
 
-        assertEquals(groupProperties.PARTITION_OPERATION_THREAD_COUNT.getInteger(),
+        assertEquals(groupProperties.getInteger(GroupProperty.PARTITION_OPERATION_THREAD_COUNT),
                 executor.getPartitionOperationThreadCount());
 
-        assertEquals(groupProperties.GENERIC_OPERATION_THREAD_COUNT.getInteger(),
+        assertEquals(groupProperties.getInteger(GroupProperty.GENERIC_OPERATION_THREAD_COUNT),
                 executor.getGenericOperationThreadCount());
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/classic/RunOnCallingThreadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/classic/RunOnCallingThreadTest.java
@@ -1,6 +1,6 @@
 package com.hazelcast.spi.impl.operationexecutor.classic;
 
-import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastSerialClassRunner;
@@ -39,7 +39,7 @@ public class RunOnCallingThreadTest extends AbstractClassicOperationExecutorTest
 
     @Test
     public void test_whenGenericOperation_andCallingFromGenericThread() {
-        config.setProperty(GroupProperties.PROP_GENERIC_OPERATION_THREAD_COUNT, "1");
+        config.setProperty(GroupProperty.GENERIC_OPERATION_THREAD_COUNT, "1");
         initExecutor();
 
         final DummyOperationRunner genericOperationHandler = ((DummyOperationRunnerFactory) handlerFactory).genericOperationHandlers.get(0);

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/slowoperationdetector/SlowOperationDetectorAbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/slowoperationdetector/SlowOperationDetectorAbstractTest.java
@@ -21,7 +21,7 @@ import com.eclipsesource.json.JsonObject;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
-import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.internal.management.TimedMemberStateFactory;
 import com.hazelcast.map.EntryBackupProcessor;
 import com.hazelcast.map.EntryProcessor;
@@ -54,8 +54,7 @@ abstract class SlowOperationDetectorAbstractTest extends HazelcastTestSupport {
 
     HazelcastInstance getSingleNodeCluster(int slowOperationThresholdMillis) {
         Config config = new Config();
-        config.setProperty(GroupProperties.PROP_SLOW_OPERATION_DETECTOR_THRESHOLD_MILLIS,
-                String.valueOf(slowOperationThresholdMillis));
+        config.setProperty(GroupProperty.SLOW_OPERATION_DETECTOR_THRESHOLD_MILLIS, String.valueOf(slowOperationThresholdMillis));
 
         return createHazelcastInstance(config);
     }

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/slowoperationdetector/SlowOperationDetectorBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/slowoperationdetector/SlowOperationDetectorBasicTest.java
@@ -19,7 +19,7 @@ package com.hazelcast.spi.impl.operationexecutor.slowoperationdetector;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
-import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.spi.AbstractOperation;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.impl.PartitionSpecificRunnable;
@@ -50,8 +50,8 @@ public class SlowOperationDetectorBasicTest extends SlowOperationDetectorAbstrac
     @Test
     public void testDisabled() {
         Config config = new Config();
-        config.setProperty(GroupProperties.PROP_SLOW_OPERATION_DETECTOR_ENABLED, "false");
-        config.setProperty(GroupProperties.PROP_SLOW_OPERATION_DETECTOR_THRESHOLD_MILLIS, "1000");
+        config.setProperty(GroupProperty.SLOW_OPERATION_DETECTOR_ENABLED, "false");
+        config.setProperty(GroupProperty.SLOW_OPERATION_DETECTOR_THRESHOLD_MILLIS, "1000");
 
         instance = createHazelcastInstance(config);
 
@@ -176,9 +176,9 @@ public class SlowOperationDetectorBasicTest extends SlowOperationDetectorAbstrac
         int recursionDepth = 15;
 
         Config config = new Config();
-        config.setProperty(GroupProperties.PROP_SLOW_OPERATION_DETECTOR_THRESHOLD_MILLIS, "1000");
-        config.setProperty(GroupProperties.PROP_SLOW_OPERATION_DETECTOR_LOG_RETENTION_SECONDS, String.valueOf(Integer.MAX_VALUE));
-        config.setProperty(GroupProperties.PROP_PARTITION_OPERATION_THREAD_COUNT, String.valueOf(partitionThreads));
+        config.setProperty(GroupProperty.SLOW_OPERATION_DETECTOR_THRESHOLD_MILLIS, "1000");
+        config.setProperty(GroupProperty.SLOW_OPERATION_DETECTOR_LOG_RETENTION_SECONDS, String.valueOf(Integer.MAX_VALUE));
+        config.setProperty(GroupProperty.PARTITION_OPERATION_THREAD_COUNT, String.valueOf(partitionThreads));
         instance = createHazelcastInstance(config);
 
         List<SlowRecursiveOperation> operations = new ArrayList<SlowRecursiveOperation>(numberOfOperations);

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/slowoperationdetector/SlowOperationDetector_purgeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/slowoperationdetector/SlowOperationDetector_purgeTest.java
@@ -19,7 +19,7 @@ package com.hazelcast.spi.impl.operationexecutor.slowoperationdetector;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
-import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.SlowTest;
 import org.junit.After;
@@ -40,10 +40,10 @@ public class SlowOperationDetector_purgeTest extends SlowOperationDetectorAbstra
 
     private void setup(String logRetentionSeconds) {
         Config config = new Config();
-        config.setProperty(GroupProperties.PROP_SLOW_OPERATION_DETECTOR_THRESHOLD_MILLIS, "1000");
-        config.setProperty(GroupProperties.PROP_SLOW_OPERATION_DETECTOR_LOG_RETENTION_SECONDS, logRetentionSeconds);
-        config.setProperty(GroupProperties.PROP_SLOW_OPERATION_DETECTOR_LOG_PURGE_INTERVAL_SECONDS, "1");
-        config.setProperty(GroupProperties.PROP_SLOW_OPERATION_DETECTOR_STACK_TRACE_LOGGING_ENABLED, "true");
+        config.setProperty(GroupProperty.SLOW_OPERATION_DETECTOR_THRESHOLD_MILLIS, "1000");
+        config.setProperty(GroupProperty.SLOW_OPERATION_DETECTOR_LOG_RETENTION_SECONDS, logRetentionSeconds);
+        config.setProperty(GroupProperty.SLOW_OPERATION_DETECTOR_LOG_PURGE_INTERVAL_SECONDS, "1");
+        config.setProperty(GroupProperty.SLOW_OPERATION_DETECTOR_STACK_TRACE_LOGGING_ENABLED, "true");
 
         instance = createHazelcastInstance(config);
         map = getMapWithSingleElement(instance);

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/BackpressureRegulatorStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/BackpressureRegulatorStressTest.java
@@ -22,12 +22,13 @@ import org.junit.runner.RunWith;
 
 import java.io.IOException;
 import java.util.Random;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
-import static com.hazelcast.instance.GroupProperties.*;
-import static com.hazelcast.test.HazelcastTestSupport.sleepAndStop;
+import static com.hazelcast.instance.GroupProperty.BACKPRESSURE_ENABLED;
+import static com.hazelcast.instance.GroupProperty.BACKPRESSURE_MAX_CONCURRENT_INVOCATIONS_PER_PARTITION;
+import static com.hazelcast.instance.GroupProperty.BACKPRESSURE_SYNCWINDOW;
+import static com.hazelcast.instance.GroupProperty.OPERATION_BACKUP_TIMEOUT_MILLIS;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.junit.Assert.assertEquals;
 
@@ -58,10 +59,10 @@ public class BackpressureRegulatorStressTest extends HazelcastTestSupport {
     @Before
     public void setup() {
         Config config = new Config()
-                .setProperty(PROP_OPERATION_BACKUP_TIMEOUT_MILLIS,"60000")
-                .setProperty(PROP_BACKPRESSURE_ENABLED, "true")
-                .setProperty(PROP_BACKPRESSURE_SYNCWINDOW, "10")
-                .setProperty(PROP_BACKPRESSURE_MAX_CONCURRENT_INVOCATIONS_PER_PARTITION, "2");
+                .setProperty(OPERATION_BACKUP_TIMEOUT_MILLIS, "60000")
+                .setProperty(BACKPRESSURE_ENABLED, "true")
+                .setProperty(BACKPRESSURE_SYNCWINDOW, "10")
+                .setProperty(BACKPRESSURE_MAX_CONCURRENT_INVOCATIONS_PER_PARTITION, "2");
         HazelcastInstance[] cluster = createHazelcastInstanceFactory(2).newInstances(config);
         local = cluster[0];
         remote = cluster[1];

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/BackpressureRegulatorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/BackpressureRegulatorTest.java
@@ -6,7 +6,6 @@ import com.hazelcast.logging.ILogger;
 import com.hazelcast.spi.AbstractOperation;
 import com.hazelcast.spi.BackupAwareOperation;
 import com.hazelcast.spi.Operation;
-import com.hazelcast.spi.OperationAccessor;
 import com.hazelcast.spi.PartitionAwareOperation;
 import com.hazelcast.spi.UrgentSystemOperation;
 import com.hazelcast.test.HazelcastParallelClassRunner;
@@ -18,7 +17,8 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import static com.hazelcast.instance.GroupProperties.PROP_BACKPRESSURE_ENABLED;
+import static com.hazelcast.instance.GroupProperty.BACKPRESSURE_ENABLED;
+import static com.hazelcast.instance.GroupProperty.BACKPRESSURE_SYNCWINDOW;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -48,8 +48,8 @@ public class BackpressureRegulatorTest extends HazelcastTestSupport {
     @Test(expected = IllegalArgumentException.class)
     public void testConstruction_invalidSyncWindow() {
         Config config = new Config();
-        config.setProperty(PROP_BACKPRESSURE_ENABLED, "true");
-        config.setProperty(GroupProperties.PROP_BACKPRESSURE_SYNCWINDOW, "" + 0);
+        config.setProperty(BACKPRESSURE_ENABLED, "true");
+        config.setProperty(BACKPRESSURE_SYNCWINDOW, "" + 0);
         GroupProperties groupProperties = new GroupProperties(config);
 
         new BackpressureRegulator(groupProperties, logger);
@@ -58,8 +58,8 @@ public class BackpressureRegulatorTest extends HazelcastTestSupport {
     @Test
     public void testConstruction_OneSyncWindow_syncOnEveryCall() {
         Config config = new Config();
-        config.setProperty(PROP_BACKPRESSURE_ENABLED, "true");
-        config.setProperty(GroupProperties.PROP_BACKPRESSURE_SYNCWINDOW, "1");
+        config.setProperty(BACKPRESSURE_ENABLED, "true");
+        config.setProperty(BACKPRESSURE_SYNCWINDOW, "1");
         GroupProperties groupProperties = new GroupProperties(config);
         BackpressureRegulator regulator = new BackpressureRegulator(groupProperties, logger);
         for (int k = 0; k < 1000; k++) {
@@ -73,7 +73,7 @@ public class BackpressureRegulatorTest extends HazelcastTestSupport {
     @Test
     public void newCallIdSequence_whenBackPressureEnabled() {
         Config config = new Config();
-        config.setProperty(PROP_BACKPRESSURE_ENABLED, "true");
+        config.setProperty(BACKPRESSURE_ENABLED, "true");
         GroupProperties groupProperties = new GroupProperties(config);
         BackpressureRegulator backpressureRegulator = new BackpressureRegulator(groupProperties, logger);
 
@@ -86,7 +86,7 @@ public class BackpressureRegulatorTest extends HazelcastTestSupport {
     @Test
     public void newCallIdSequence_whenBackPressureDisabled() {
         Config config = new Config();
-        config.setProperty(PROP_BACKPRESSURE_ENABLED, "false");
+        config.setProperty(BACKPRESSURE_ENABLED, "false");
         GroupProperties groupProperties = new GroupProperties(config);
         BackpressureRegulator backpressureRegulator = new BackpressureRegulator(groupProperties, logger);
 
@@ -94,7 +94,6 @@ public class BackpressureRegulatorTest extends HazelcastTestSupport {
 
         assertInstanceOf(CallIdSequence.CallIdSequenceWithoutBackpressure.class, callIdSequence);
     }
-
 
     // ========================== isSyncForced =================
 
@@ -269,15 +268,15 @@ public class BackpressureRegulatorTest extends HazelcastTestSupport {
 
     private BackpressureRegulator newEnabledBackPressureService() {
         Config config = new Config();
-        config.setProperty(PROP_BACKPRESSURE_ENABLED, "true");
-        config.setProperty(GroupProperties.PROP_BACKPRESSURE_SYNCWINDOW, "" + SYNC_WINDOW);
+        config.setProperty(BACKPRESSURE_ENABLED, "true");
+        config.setProperty(BACKPRESSURE_SYNCWINDOW, "" + SYNC_WINDOW);
         GroupProperties groupProperties = new GroupProperties(config);
         return new BackpressureRegulator(groupProperties, logger);
     }
 
     private BackpressureRegulator newDisabledBackPressureService() {
         Config config = new Config();
-        config.setProperty(PROP_BACKPRESSURE_ENABLED, "false");
+        config.setProperty(BACKPRESSURE_ENABLED, "false");
         GroupProperties groupProperties = new GroupProperties(config);
         return new BackpressureRegulator(groupProperties, logger);
     }

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationNestedLocalTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationNestedLocalTest.java
@@ -2,7 +2,7 @@ package com.hazelcast.spi.impl.operationservice.impl;
 
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.spi.InternalCompletableFuture;
 import com.hazelcast.spi.OperationService;
 import com.hazelcast.test.HazelcastParallelClassRunner;
@@ -79,8 +79,8 @@ public class InvocationNestedLocalTest extends InvocationNestedTest {
     @Test
     public void whenPartition_callsDifferentPartition_butMappedToSameThread() throws ExecutionException, InterruptedException {
         Config config = new Config();
-        config.setProperty(GroupProperties.PROP_PARTITION_COUNT, "2");
-        config.setProperty(GroupProperties.PROP_PARTITION_OPERATION_THREAD_COUNT, "1");
+        config.setProperty(GroupProperty.PARTITION_COUNT, "2");
+        config.setProperty(GroupProperty.PARTITION_OPERATION_THREAD_COUNT, "1");
         HazelcastInstance hz = createHazelcastInstance(config);
         final OperationService operationService = getOperationService(hz);
 

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationNetworkSplitTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationNetworkSplitTest.java
@@ -20,7 +20,7 @@ import com.hazelcast.cluster.impl.ClusterServiceImpl;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.MemberLeftException;
-import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.instance.Node;
 import com.hazelcast.instance.TestUtil;
 import com.hazelcast.spi.AbstractOperation;
@@ -186,7 +186,7 @@ public class InvocationNetworkSplitTest extends HazelcastTestSupport {
     private Config createConfig() {
         Config config = new Config();
         config.getGroupConfig().setName(generateRandomString(10));
-        config.setProperty(GroupProperties.PROP_MASTER_CONFIRMATION_INTERVAL_SECONDS, "1");
+        config.setProperty(GroupProperty.MASTER_CONFIRMATION_INTERVAL_SECONDS, "1");
         return config;
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationRegistryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationRegistryTest.java
@@ -10,19 +10,17 @@ import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.util.concurrent.ExecutionException;
 
-import static com.hazelcast.instance.GroupProperties.*;
+import static com.hazelcast.instance.GroupProperty.BACKPRESSURE_ENABLED;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.fail;
-
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
@@ -36,7 +34,7 @@ public class InvocationRegistryTest extends HazelcastTestSupport {
     @Before
     public void setup() {
         Config config = new Config();
-        config.setProperty(PROP_BACKPRESSURE_ENABLED, "false");
+        config.setProperty(BACKPRESSURE_ENABLED, "false");
         local = createHazelcastInstance(config);
         warmUpPartitions(local);
         nodeEngine = getNodeEngineImpl(local);

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationRegistry_notifyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationRegistry_notifyTest.java
@@ -21,8 +21,8 @@ import org.junit.runner.RunWith;
 
 import java.util.concurrent.TimeUnit;
 
-import static com.hazelcast.instance.GroupProperties.PROP_BACKPRESSURE_ENABLED;
-import static com.hazelcast.instance.GroupProperties.PROP_OPERATION_CALL_TIMEOUT_MILLIS;
+import static com.hazelcast.instance.GroupProperty.BACKPRESSURE_ENABLED;
+import static com.hazelcast.instance.GroupProperty.OPERATION_CALL_TIMEOUT_MILLIS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
@@ -40,8 +40,8 @@ public class InvocationRegistry_notifyTest extends HazelcastTestSupport {
     @Before
     public void setup() {
         Config config = new Config();
-        config.setProperty(PROP_BACKPRESSURE_ENABLED, "false");
-        config.setProperty(PROP_OPERATION_CALL_TIMEOUT_MILLIS, "20000");
+        config.setProperty(BACKPRESSURE_ENABLED, "false");
+        config.setProperty(OPERATION_CALL_TIMEOUT_MILLIS, "20000");
         local = createHazelcastInstance(config);
         warmUpPartitions(local);
         nodeEngine = getNodeEngineImpl(local);
@@ -123,7 +123,6 @@ public class InvocationRegistry_notifyTest extends HazelcastTestSupport {
     @Test
     @Ignore
     public void normalResponse_whenOnlyBackupInThenRetry(){
-
     }
 
     // ==================== backupResponse ======================

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationTimeoutTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationTimeoutTest.java
@@ -9,7 +9,7 @@ import com.hazelcast.core.ILock;
 import com.hazelcast.core.IQueue;
 import com.hazelcast.core.OperationTimeoutException;
 import com.hazelcast.core.Partition;
-import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
@@ -79,7 +79,7 @@ public class InvocationTimeoutTest extends HazelcastTestSupport {
     @Test
     public void testWaitingIndefinitely() throws InterruptedException {
         final Config config = new Config();
-        config.setProperty(GroupProperties.PROP_OPERATION_CALL_TIMEOUT_MILLIS, "3000");
+        config.setProperty(GroupProperty.OPERATION_CALL_TIMEOUT_MILLIS, "3000");
 
         TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(2);
         final HazelcastInstance[] instances = factory.newInstances(config);
@@ -116,7 +116,7 @@ public class InvocationTimeoutTest extends HazelcastTestSupport {
     @Test
     public void testWaitingInfinitelyForTryLock() throws InterruptedException {
         final Config config = new Config();
-        config.setProperty(GroupProperties.PROP_OPERATION_CALL_TIMEOUT_MILLIS, "3000");
+        config.setProperty(GroupProperty.OPERATION_CALL_TIMEOUT_MILLIS, "3000");
         final HazelcastInstance hz = createHazelcastInstance(config);
         final CountDownLatch latch = new CountDownLatch(1);
 
@@ -170,11 +170,10 @@ public class InvocationTimeoutTest extends HazelcastTestSupport {
         }
     }
 
-
     @Test(expected = ExecutionException.class)
     public void testInvocationThrowsOperationTimeoutExceptionWhenTimeout() throws Exception {
         final Config config = new Config();
-        config.setProperty(GroupProperties.PROP_OPERATION_CALL_TIMEOUT_MILLIS, "300");
+        config.setProperty(GroupProperty.OPERATION_CALL_TIMEOUT_MILLIS, "300");
         TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(2);
         HazelcastInstance local = factory.newHazelcastInstance(config);
         HazelcastInstance remote = factory.newHazelcastInstance(config);

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/IsStillRunningServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/IsStillRunningServiceTest.java
@@ -2,7 +2,7 @@ package com.hazelcast.spi.impl.operationservice.impl;
 
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
@@ -161,7 +161,7 @@ public class IsStillRunningServiceTest extends HazelcastTestSupport {
     public void testTimeoutInvocationIfRemoteInvocationIsRunning() throws Exception {
         int callTimeoutMillis = 500;
         Config config = new Config();
-        config.setProperty(GroupProperties.PROP_OPERATION_CALL_TIMEOUT_MILLIS, String.valueOf(callTimeoutMillis));
+        config.setProperty(GroupProperty.OPERATION_CALL_TIMEOUT_MILLIS, String.valueOf(callTimeoutMillis));
 
         TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(2);
         HazelcastInstance hz1 = factory.newHazelcastInstance(config);
@@ -202,7 +202,7 @@ public class IsStillRunningServiceTest extends HazelcastTestSupport {
     public void testTimeoutInvocationIfRemoteInvocationIsCompleted() throws Exception {
         int callTimeoutMillis = 500;
         Config config = new Config();
-        config.setProperty(GroupProperties.PROP_OPERATION_CALL_TIMEOUT_MILLIS, String.valueOf(callTimeoutMillis));
+        config.setProperty(GroupProperty.OPERATION_CALL_TIMEOUT_MILLIS, String.valueOf(callTimeoutMillis));
 
         TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(2);
         HazelcastInstance hz1 = factory.newHazelcastInstance(config);

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OperationBackupHandlerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OperationBackupHandlerTest.java
@@ -2,30 +2,24 @@ package com.hazelcast.spi.impl.operationservice.impl;
 
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.spi.BackupAwareOperation;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
-import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
-import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import java.util.UUID;
-
-import static com.hazelcast.instance.GroupProperties.*;
 import static com.hazelcast.partition.InternalPartition.MAX_BACKUP_COUNT;
 import static com.hazelcast.spi.OperationAccessor.setCallerAddress;
 import static com.hazelcast.spi.impl.operationservice.impl.DummyBackupAwareOperation.backupCompletedMap;
 import static java.lang.Math.min;
-import static java.util.UUID.*;
+import static java.util.UUID.randomUUID;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastParallelClassRunner.class)
@@ -50,8 +44,8 @@ public class OperationBackupHandlerTest extends HazelcastTestSupport {
 
     public void setup(boolean backPressureEnabled) {
         Config config = new Config()
-                .setProperty(PROP_BACKPRESSURE_ENABLED, ""+backPressureEnabled)
-                .setProperty(PROP_BACKPRESSURE_SYNCWINDOW, "1");
+                .setProperty(GroupProperty.BACKPRESSURE_ENABLED, String.valueOf(backPressureEnabled))
+                .setProperty(GroupProperty.BACKPRESSURE_SYNCWINDOW, "1");
 
         // we create a nice big cluster so that we have enough backups.
         HazelcastInstance[] cluster = createHazelcastInstanceFactory(BACKUPS + 1).newInstances(config);
@@ -101,7 +95,7 @@ public class OperationBackupHandlerTest extends HazelcastTestSupport {
     public void asyncBackups_whenForceSyncDisabled() {
         setup(BACKPRESSURE_ENABLED);
 
-         // when forceSync disabled, only the async matters
+        // when forceSync disabled, only the async matters
         assertEquals(0, backupHandler.asyncBackups(0, 0, FORCE_SYNC_DISABLED));
         assertEquals(1, backupHandler.asyncBackups(0, 1, FORCE_SYNC_DISABLED));
         assertEquals(0, backupHandler.asyncBackups(2, 0, FORCE_SYNC_DISABLED));

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl_timeoutTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl_timeoutTest.java
@@ -6,7 +6,7 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.ICompletableFuture;
 import com.hazelcast.core.IQueue;
 import com.hazelcast.core.OperationTimeoutException;
-import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.instance.Node;
 import com.hazelcast.instance.TestUtil;
 import com.hazelcast.nio.Address;
@@ -35,7 +35,6 @@ import java.util.concurrent.locks.LockSupport;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
@@ -95,7 +94,7 @@ public class OperationServiceImpl_timeoutTest extends HazelcastTestSupport {
     private void testOperationTimeout(int memberCount, boolean async) {
         assertTrue(memberCount > 0);
         Config config = new Config();
-        config.setProperty(GroupProperties.PROP_OPERATION_CALL_TIMEOUT_MILLIS, "3000");
+        config.setProperty(GroupProperty.OPERATION_CALL_TIMEOUT_MILLIS, "3000");
 
         TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(memberCount);
         HazelcastInstance[] instances = factory.newInstances(config);
@@ -178,7 +177,7 @@ public class OperationServiceImpl_timeoutTest extends HazelcastTestSupport {
     public void testOperationTimeoutForLongRunningRemoteOperation() throws Exception {
         int callTimeoutMillis = 500;
         Config config = new Config();
-        config.setProperty(GroupProperties.PROP_OPERATION_CALL_TIMEOUT_MILLIS, String.valueOf(callTimeoutMillis));
+        config.setProperty(GroupProperty.OPERATION_CALL_TIMEOUT_MILLIS, String.valueOf(callTimeoutMillis));
 
         TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(2);
         HazelcastInstance hz1 = factory.newHazelcastInstance(config);
@@ -199,7 +198,7 @@ public class OperationServiceImpl_timeoutTest extends HazelcastTestSupport {
     public void testOperationTimeoutForLongRunningLocalOperation() throws Exception {
         int callTimeoutMillis = 500;
         Config config = new Config();
-        config.setProperty(GroupProperties.PROP_OPERATION_CALL_TIMEOUT_MILLIS, String.valueOf(callTimeoutMillis));
+        config.setProperty(GroupProperty.OPERATION_CALL_TIMEOUT_MILLIS, String.valueOf(callTimeoutMillis));
 
         TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(1);
         HazelcastInstance hz1 = factory.newHazelcastInstance(config);

--- a/hazelcast/src/test/java/com/hazelcast/test/TestHazelcastInstanceFactory.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/TestHazelcastInstanceFactory.java
@@ -20,7 +20,7 @@ import com.hazelcast.config.Config;
 import com.hazelcast.config.XmlConfigBuilder;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.instance.HazelcastInstanceFactory;
 import com.hazelcast.instance.NodeContext;
 import com.hazelcast.nio.Address;
@@ -177,9 +177,9 @@ public class TestHazelcastInstanceFactory {
         if (config == null) {
             config = new XmlConfigBuilder().build();
         }
-        config.setProperty(GroupProperties.PROP_WAIT_SECONDS_BEFORE_JOIN, "0");
-        config.setProperty(GroupProperties.PROP_GRACEFUL_SHUTDOWN_MAX_WAIT, "120");
-        config.setProperty(GroupProperties.PROP_PARTITION_BACKUP_SYNC_INTERVAL, "1");
+        config.setProperty(GroupProperty.WAIT_SECONDS_BEFORE_JOIN, "0");
+        config.setProperty(GroupProperty.GRACEFUL_SHUTDOWN_MAX_WAIT, "120");
+        config.setProperty(GroupProperty.PARTITION_BACKUP_SYNC_INTERVAL, "1");
         config.getNetworkConfig().getJoin().getMulticastConfig().setEnabled(false);
         return config;
     }


### PR DESCRIPTION
This PR is an attempt to cleanup the `GroupProperties`, which are not in a good maintainable state. One of the symptoms I see in the code are rogue properties (which are just in the code, not in the `GroupProperties`) or even defined properties which are not used, e.g.:
```java
System.setProperty("hazelcast.local.localAddress", "127.0.0.1"); // not defined
System.setProperty("hazelcast.version.check.enabled", "false"); // defined, but not used
System.setProperty("hazelcast.socket.bind.any", "false"); // defined, but not used
```

The solution I came up with should make the definition way easier and the usage not much different than the old approach. It also adds methods to convert time-based properties to the wanted time unit. The new class `GroupProperty` contains all definitions and default values as well as the JavaDoc. The old class `GroupProperties` is just a container for the configured properties.

## Property definition

At the moment you have to add at least 3 lines of code to add a new property:
```java
/**
 * Maybe some JavaDoc here.
 */
public static final String PROP_PARTITION_COUNT = "hazelcast.partition.count";

public final GroupProperty PARTITION_COUNT;

public GroupProperties(Config config) {
    PARTITION_COUNT = new GroupProperty(config, PROP_PARTITION_COUNT, "271");
}
```
And this is one of the best readable examples, because of the short names and single lines.

A new definition in the class `GroupProperty` looks like this:
```java
/**
 * Total number of partitions in the Hazelcast cluster.
 */
PARTITION_COUNT("hazelcast.partition.count", 271),
```
For a time-based property you should add the time unit to the definition:
```java
EVENT_QUEUE_TIMEOUT_MILLIS("hazelcast.event.queue.timeout.millis", 250, MILLISECONDS),
```

## Usage with `Config`

```java
Config config = new Config();

// old definition
config.setProperty(GroupProperties.PROP_PARTITION_COUNT, "1");
String value = config.getProperty(GroupProperties.PROP_PARTITION_COUNT);

// new definition
config.setProperty(GroupProperty.PARTITION_COUNT, "1");
value = config.getProperty(GroupProperty.PARTITION_COUNT);
```
As you can see there is almost no difference.

## Usage with `System`

```java
// old definition
System.setProperty(GroupProperties.PROP_WAIT_SECONDS_BEFORE_JOIN, "0");
String value = System.getProperty(GroupProperties.PROP_WAIT_SECONDS_BEFORE_JOIN);

// new definition
System.setProperty(GroupProperty.WAIT_SECONDS_BEFORE_JOIN.getName(), "0");
value = System.getProperty(GroupProperty.WAIT_SECONDS_BEFORE_JOIN.getName());

GroupProperty.WAIT_SECONDS_BEFORE_JOIN.setSystemProperty("0");
value = GroupProperty.WAIT_SECONDS_BEFORE_JOIN.getSystemProperty();
```
You can either use the `getName()` or the built-in methods `setSystemProperty()` and `getSystemProperty()`.

## Usage with `GroupProperties`

### Normal properties

```java
// old definition
int threadCount = groupProperties.CLIENT_ENGINE_THREAD_COUNT.getInteger();

// new definition
int threadCount = groupProperties.getInteger(GroupProperty.CLIENT_ENGINE_THREAD_COUNT);
```
I'm not super happy with this "reverse" conversion, but I couldn't find a better solution.

### Time-based properties

As promised I could at least add some syntactic sugar to get rid of manual time conversions:
```java
// old definition
Thread.sleep(groupProperties.WAIT_SECONDS_BEFORE_JOIN.getInteger() * 1000L * 2);		

// new definition
Thread.sleep(2 * groupProperties.getMillis(GroupProperty.WAIT_SECONDS_BEFORE_JOIN));
```
This is again one of the better readable examples, there were much worse parts in the code regarding time conversions. This will also reduce magic numbers and `TimeUnit.SECONDS.toMillis()` boilerplate code.

## Todo

If you like this PR the next steps would be
* Enterprise PR to fix usage in that project (already prepared)
* convert the ClientProperties to the same structure
* add missing rogue properties to the `GroupProperty` class
