### PR TITLE
Be sure that completion event is sent in all cases for `CacheRemoveAllOperation`. 

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheRecordStore.java
@@ -34,7 +34,6 @@ import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.map.impl.MapEntrySet;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.partition.InternalPartitionService;
-import com.hazelcast.internal.serialization.impl.HeapData;
 import com.hazelcast.spi.EventRegistration;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.impl.eventservice.InternalEventService;
@@ -1372,7 +1371,7 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
             int orderKey = keys.hashCode();
             publishBatchedEvents(name, CacheEventType.REMOVED, orderKey);
             if (isEventsEnabled()) {
-                publishEvent(createCacheCompleteEvent(new HeapData(), completionId));
+                publishEvent(createCacheCompleteEvent(completionId));
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheEventContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheEventContext.java
@@ -41,87 +41,99 @@ public class CacheEventContext {
         return cacheName;
     }
 
-    public void setCacheName(String cacheName) {
+    public CacheEventContext setCacheName(String cacheName) {
         this.cacheName = cacheName;
+        return this;
     }
 
     public CacheEventType getEventType() {
         return eventType;
     }
 
-    public void setEventType(CacheEventType eventType) {
+    public CacheEventContext setEventType(CacheEventType eventType) {
         this.eventType = eventType;
+        return this;
     }
 
     public Data getDataKey() {
         return dataKey;
     }
 
-    public void setDataKey(Data dataKey) {
+    public CacheEventContext setDataKey(Data dataKey) {
         this.dataKey = dataKey;
+        return this;
     }
 
     public Data getDataValue() {
         return dataValue;
     }
 
-    public void setDataValue(Data dataValue) {
+    public CacheEventContext setDataValue(Data dataValue) {
         this.dataValue = dataValue;
+        return this;
     }
 
     public Data getDataOldValue() {
         return dataOldValue;
     }
 
-    public void setDataOldValue(Data dataOldValue) {
+    public CacheEventContext setDataOldValue(Data dataOldValue) {
         this.dataOldValue = dataOldValue;
+        return this;
     }
 
     public boolean isOldValueAvailable() {
         return isOldValueAvailable;
     }
 
-    public void setIsOldValueAvailable(boolean isOldValueAvailable) {
+    public CacheEventContext setIsOldValueAvailable(boolean isOldValueAvailable) {
         this.isOldValueAvailable = isOldValueAvailable;
+        return this;
     }
 
     public long getExpirationTime() {
         return expirationTime;
     }
 
-    public void setExpirationTime(long expirationTime) {
+    public CacheEventContext setExpirationTime(long expirationTime) {
         this.expirationTime = expirationTime;
+        return this;
     }
 
     public long getAccessHit() {
         return accessHit;
     }
 
-    public void setAccessHit(long accessHit) {
+    public CacheEventContext setAccessHit(long accessHit) {
         this.accessHit = accessHit;
+        return this;
     }
 
     public String getOrigin() {
         return origin;
     }
 
-    public void setOrigin(String origin) {
+    public CacheEventContext setOrigin(String origin) {
         this.origin = origin;
+        return this;
     }
 
     public int getOrderKey() {
         return orderKey;
     }
 
-    public void setOrderKey(int orderKey) {
+    public CacheEventContext setOrderKey(int orderKey) {
         this.orderKey = orderKey;
+        return this;
     }
 
     public int getCompletionId() {
         return completionId;
     }
 
-    public void setCompletionId(int completionId) {
+    public CacheEventContext setCompletionId(int completionId) {
         this.completionId = completionId;
+        return this;
     }
+
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheEventContextUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheEventContextUtil.java
@@ -26,6 +26,13 @@ public final class CacheEventContextUtil {
     private CacheEventContextUtil() {
     }
 
+    public static CacheEventContext createCacheCompleteEvent(int completionId) {
+        CacheEventContext cacheEventContext = new CacheEventContext();
+        cacheEventContext.setEventType(CacheEventType.COMPLETED);
+        cacheEventContext.setCompletionId(completionId);
+        return cacheEventContext;
+    }
+
     public static CacheEventContext createCacheCompleteEvent(Data dataKey, int completionId) {
         CacheEventContext cacheEventContext = new CacheEventContext();
         cacheEventContext.setEventType(CacheEventType.COMPLETED);
@@ -50,24 +57,27 @@ public final class CacheEventContextUtil {
     public static CacheEventContext createCacheExpiredEvent(Data dataKey, Data dataValue,
                                                             long expirationTime, String origin,
                                                             int completionId) {
-        CacheEventContext cacheEventContext = createBaseEventContext(CacheEventType.EXPIRED,
-                dataKey, dataValue, expirationTime, origin, completionId);
+        CacheEventContext cacheEventContext =
+                createBaseEventContext(CacheEventType.EXPIRED, dataKey, dataValue,
+                                       expirationTime, origin, completionId);
         return cacheEventContext;
     }
 
     public static CacheEventContext createCacheCreatedEvent(Data dataKey, Data dataValue,
                                                             long expirationTime, String origin,
                                                             int completionId) {
-        CacheEventContext cacheEventContext = createBaseEventContext(CacheEventType.CREATED,
-                dataKey, dataValue, expirationTime, origin, completionId);
+        CacheEventContext cacheEventContext =
+                createBaseEventContext(CacheEventType.CREATED, dataKey, dataValue,
+                                       expirationTime, origin, completionId);
         return cacheEventContext;
     }
 
     public static CacheEventContext createCacheUpdatedEvent(Data dataKey, Data dataValue, Data dataOldValue,
                                                             long expirationTime, long accessHit, String origin,
                                                             int completionId) {
-        CacheEventContext cacheEventContext = createBaseEventContext(CacheEventType.UPDATED,
-                dataKey, dataValue, expirationTime, origin, completionId);
+        CacheEventContext cacheEventContext =
+                createBaseEventContext(CacheEventType.UPDATED, dataKey, dataValue,
+                                       expirationTime, origin, completionId);
         cacheEventContext.setDataOldValue(dataOldValue);
         cacheEventContext.setIsOldValueAvailable(true);
         cacheEventContext.setAccessHit(accessHit);
@@ -77,14 +87,15 @@ public final class CacheEventContextUtil {
     public static CacheEventContext createCacheRemovedEvent(Data dataKey, Data dataValue,
                                                             long expirationTime, String origin,
                                                             int completionId) {
-        CacheEventContext cacheEventContext = createBaseEventContext(CacheEventType.REMOVED,
-                dataKey, dataValue, expirationTime, origin, completionId);
+        CacheEventContext cacheEventContext =
+                createBaseEventContext(CacheEventType.REMOVED, dataKey, dataValue,
+                                       expirationTime, origin, completionId);
         return cacheEventContext;
     }
 
     public static CacheEventContext createBaseEventContext(CacheEventType eventType, Data dataKey,
-                                                            Data dataValue, long expirationTime, String origin,
-                                                            int completionId) {
+                                                           Data dataValue, long expirationTime, String origin,
+                                                           int completionId) {
         CacheEventContext cacheEventContext = new CacheEventContext();
         cacheEventContext.setEventType(eventType);
         cacheEventContext.setDataKey(dataKey);

--- a/hazelcast/src/test/java/com/hazelcast/cache/BasicCacheTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/BasicCacheTest.java
@@ -185,6 +185,7 @@ public class BasicCacheTest
         config.addCacheEntryListenerConfiguration(listenerConfiguration);
 
         Cache<Integer, String> cache = cacheManager.createCache(cacheName, config);
+
         assertNotNull(cache);
 
         Integer key1 = 1;
@@ -211,6 +212,61 @@ public class BasicCacheTest
         keys.add(key1);
         keys.add(key2);
         cache.removeAll(keys);
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertEquals(2, listener.removed.get());
+            }
+        });
+    }
+
+    // Issue https://github.com/hazelcast/hazelcast/issues/5865
+    @Test
+    public void testCompletionTestByPuttingAndRemovingFromDifferentNodes()
+            throws InterruptedException {
+        String cacheName = "simpleCache";
+
+        CacheManager cacheManager1 = cachingProvider1.getCacheManager();
+        CacheManager cacheManager2 = cachingProvider2.getCacheManager();
+
+        CacheConfig<Integer, String> config = new CacheConfig<Integer, String>();
+        final SimpleEntryListener<Integer, String> listener = new SimpleEntryListener<Integer, String>();
+        MutableCacheEntryListenerConfiguration<Integer, String> listenerConfiguration =
+                new MutableCacheEntryListenerConfiguration<Integer, String>(
+                        FactoryBuilder.factoryOf(listener), null, true, true);
+
+        config.addCacheEntryListenerConfiguration(listenerConfiguration);
+
+        Cache<Integer, String> cache1 = cacheManager1.createCache(cacheName, config);
+        Cache<Integer, String> cache2 = cacheManager2.getCache(cacheName);
+
+        assertNotNull(cache1);
+        assertNotNull(cache2);
+
+        Integer key1 = 1;
+        String value1 = "value1";
+        cache1.put(key1, value1);
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertEquals(1, listener.created.get());
+            }
+        });
+
+        Integer key2 = 2;
+        String value2 = "value2";
+        cache1.put(key2, value2);
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertEquals(2, listener.created.get());
+            }
+        });
+
+        Set<Integer> keys = new HashSet<Integer>();
+        keys.add(key1);
+        keys.add(key2);
+        cache2.removeAll(keys);
         assertTrueEventually(new AssertTask() {
             @Override
             public void run() throws Exception {


### PR DESCRIPTION
Send completion events in these cases also:
- If `CacheRecordStore` for that partition is not created yet
- If the filtered keys are empty (that partition is not owner of the any key to be removed)

Fixes #5865