### PR TITLE
SelectionHandler exception handling

### DIFF
--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/connection/nio/AbstractClientSelectionHandler.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/connection/nio/AbstractClientSelectionHandler.java
@@ -45,7 +45,8 @@ public abstract class AbstractClientSelectionHandler implements SelectionHandler
     protected void shutdown() {
     }
 
-    final void handleSocketException(Throwable e) {
+    @Override
+    public final void onFailure(Throwable e) {
         if (sk != null) {
             sk.cancel();
         }
@@ -75,7 +76,7 @@ public abstract class AbstractClientSelectionHandler implements SelectionHandler
                 }
             }
         } catch (Throwable e) {
-            handleSocketException(e);
+            onFailure(e);
         }
     }
 

--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/connection/nio/ClientNonBlockingOutputThread.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/connection/nio/ClientNonBlockingOutputThread.java
@@ -36,7 +36,11 @@ public final class ClientNonBlockingOutputThread extends NonBlockingIOThread {
         if (sk.isValid() && sk.isWritable()) {
             sk.interestOps(sk.interestOps() & ~SelectionKey.OP_WRITE);
             SelectionHandler handler = (SelectionHandler) sk.attachment();
-            handler.handle();
+            try {
+                handler.handle();
+            } catch (Throwable t) {
+                handler.onFailure(t);
+            }
         }
     }
 }

--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/connection/nio/ClientWriteHandler.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/connection/nio/ClientWriteHandler.java
@@ -20,6 +20,7 @@ import com.hazelcast.nio.SocketWritable;
 import com.hazelcast.nio.tcp.nonblocking.NonBlockingIOThread;
 import com.hazelcast.util.Clock;
 
+import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.SelectionKey;
 import java.util.Queue;
@@ -46,7 +47,7 @@ public class ClientWriteHandler extends AbstractClientSelectionHandler implement
     }
 
     @Override
-    public void handle() {
+    public void handle() throws Exception {
         lastHandle = Clock.currentTimeMillis();
         if (!connection.isAlive()) {
             return;
@@ -60,17 +61,13 @@ public class ClientWriteHandler extends AbstractClientSelectionHandler implement
             ready = true;
             return;
         }
-        try {
-            writeBuffer();
-        } catch (Throwable t) {
-            logger.severe("Fatal Error at WriteHandler for endPoint: " + connection.getEndPoint(), t);
-        } finally {
-            ready = false;
-            registerWrite();
-        }
+
+        writeBuffer();
+        ready = false;
+        registerWrite();
     }
 
-    private void writeBuffer() {
+    private void writeBuffer() throws IOException {
         while (buffer.hasRemaining() && lastWritable != null) {
             boolean complete = lastWritable.writeTo(buffer);
             if (complete) {
@@ -79,20 +76,19 @@ public class ClientWriteHandler extends AbstractClientSelectionHandler implement
                 break;
             }
         }
-        if (buffer.position() > 0) {
-            buffer.flip();
-            try {
-                socketChannel.write(buffer);
-            } catch (Exception e) {
-                lastWritable = null;
-                handleSocketException(e);
-                return;
-            }
-            if (buffer.hasRemaining()) {
-                buffer.compact();
-            } else {
-                buffer.clear();
-            }
+
+        if (buffer.position() == 0) {
+            // there is nothing to write, we are done
+            return;
+        }
+
+        buffer.flip();
+        socketChannel.write(buffer);
+
+        if (buffer.hasRemaining()) {
+            buffer.compact();
+        } else {
+            buffer.clear();
         }
     }
 
@@ -113,13 +109,17 @@ public class ClientWriteHandler extends AbstractClientSelectionHandler implement
 
     @Override
     public void run() {
-        informSelector.set(true);
-        if (ready) {
-            handle();
-        } else {
-            registerWrite();
+        try {
+            informSelector.set(true);
+            if (ready) {
+                handle();
+            } else {
+                registerWrite();
+            }
+            ready = false;
+        } catch (Throwable t) {
+            onFailure(t);
         }
-        ready = false;
     }
 
     private void registerWrite() {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/AbstractClientSelectionHandler.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/AbstractClientSelectionHandler.java
@@ -45,7 +45,8 @@ public abstract class AbstractClientSelectionHandler implements SelectionHandler
     protected void shutdown() {
     }
 
-    final void handleSocketException(Throwable e) {
+    @Override
+    public void onFailure(Throwable e) {
         if (sk != null) {
             sk.cancel();
         }
@@ -75,7 +76,7 @@ public abstract class AbstractClientSelectionHandler implements SelectionHandler
                 }
             }
         } catch (Throwable e) {
-            handleSocketException(e);
+            onFailure(e);
         }
     }
 

--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientNonBlockingOutputThread.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientNonBlockingOutputThread.java
@@ -36,7 +36,11 @@ public final class ClientNonBlockingOutputThread extends NonBlockingIOThread {
         if (sk.isValid() && sk.isWritable()) {
             sk.interestOps(sk.interestOps() & ~SelectionKey.OP_WRITE);
             SelectionHandler handler = (SelectionHandler) sk.attachment();
-            handler.handle();
+            try {
+                handler.handle();
+            } catch (Throwable t) {
+                handler.onFailure(t);
+            }
         }
     }
 }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientReadHandler.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientReadHandler.java
@@ -21,7 +21,6 @@ import com.hazelcast.nio.tcp.nonblocking.NonBlockingIOThread;
 import com.hazelcast.util.Clock;
 
 import java.io.EOFException;
-import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.SelectionKey;
 
@@ -45,41 +44,32 @@ public class ClientReadHandler extends AbstractClientSelectionHandler {
     }
 
     @Override
-    public void handle() {
+    public void handle() throws Exception {
         lastHandle = Clock.currentTimeMillis();
         if (!connection.isAlive()) {
             if (logger.isFinestEnabled()) {
-                String message = "We are being asked to read, but connection is not live so we won't";
-                logger.finest(message);
+                logger.finest("We are being asked to read, but connection is not live so we won't");
             }
             return;
         }
-        try {
-            int readBytes = socketChannel.read(buffer);
+
+        int readBytes = socketChannel.read(buffer);
+        if (readBytes <= 0) {
             if (readBytes == -1) {
                 throw new EOFException("Remote socket closed!");
             }
-        } catch (IOException e) {
-            handleSocketException(e);
             return;
         }
-        try {
-            if (buffer.position() == 0) {
-                return;
-            }
-            buffer.flip();
 
-            readPacket();
+        buffer.flip();
 
-            if (buffer.hasRemaining()) {
-                buffer.compact();
-            } else {
-                buffer.clear();
-            }
-        } catch (Throwable t) {
-            handleSocketException(t);
+        readPacket();
+
+        if (buffer.hasRemaining()) {
+            buffer.compact();
+        } else {
+            buffer.clear();
         }
-
     }
 
     private void readPacket() {

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/AbstractSelectionHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/AbstractSelectionHandler.java
@@ -62,13 +62,14 @@ public abstract class AbstractSelectionHandler implements MigratableHandler {
             try {
                 selectionKey = socketChannel.register(selector, initialOps, this);
             } catch (ClosedChannelException e) {
-                handleSocketException(e);
+                onFailure(e);
             }
         }
         return selectionKey;
     }
 
-    public void handleSocketException(Throwable e) {
+    @Override
+    public void onFailure(Throwable e) {
         if (e instanceof OutOfMemoryError) {
             ioService.onOutOfMemory((OutOfMemoryError) e);
         }
@@ -99,7 +100,7 @@ public abstract class AbstractSelectionHandler implements MigratableHandler {
         try {
             selectionKey.interestOps(selectionKey.interestOps() | operation);
         } catch (Throwable e) {
-            handleSocketException(e);
+            onFailure(e);
         }
     }
 
@@ -108,7 +109,7 @@ public abstract class AbstractSelectionHandler implements MigratableHandler {
         try {
             selectionKey.interestOps(selectionKey.interestOps() & ~operation);
         } catch (Throwable e) {
-            handleSocketException(e);
+            onFailure(e);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/NonBlockingInputThread.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/NonBlockingInputThread.java
@@ -62,7 +62,12 @@ public final class NonBlockingInputThread extends NonBlockingIOThread {
         if (sk.isValid() && sk.isReadable()) {
             readEvents.inc();
             SelectionHandler handler = (SelectionHandler) sk.attachment();
-            handler.handle();
+
+            try {
+                handler.handle();
+            } catch (Throwable t) {
+                handler.onFailure(t);
+            }
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/NonBlockingOutputThread.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/NonBlockingOutputThread.java
@@ -54,7 +54,12 @@ public final class NonBlockingOutputThread extends NonBlockingIOThread {
         if (sk.isValid() && sk.isWritable()) {
             writeEvents.inc();
             SelectionHandler handler = (SelectionHandler) sk.attachment();
-            handler.handle();
+
+            try {
+                handler.handle();
+            } catch (Throwable t) {
+                handler.onFailure(t);
+            }
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/NonBlockingWriteHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/NonBlockingWriteHandler.java
@@ -322,34 +322,29 @@ public final class NonBlockingWriteHandler extends AbstractSelectionHandler impl
 
     @Override
     @SuppressWarnings("unchecked")
-    public void handle() {
-        try {
-            eventCount.inc();
-            lastWriteTime = Clock.currentTimeMillis();
+    public void handle() throws Exception {
+        eventCount.inc();
+        lastWriteTime = Clock.currentTimeMillis();
 
-            if (shutdown) {
-                return;
-            }
+        if (shutdown) {
+            return;
+        }
 
-            if (socketWriter == null) {
-                logger.log(Level.WARNING, "SocketWriter is not set, creating SocketWriter with CLUSTER protocol!");
-                createWriter(CLUSTER);
-            }
+        if (socketWriter == null) {
+            logger.log(Level.WARNING, "SocketWriter is not set, creating SocketWriter with CLUSTER protocol!");
+            createWriter(CLUSTER);
+        }
 
-            fillOutputBuffer();
+        fillOutputBuffer();
 
-            if (dirtyOutputBuffer()) {
-                writeOutputBufferToSocket();
-            }
+        if (dirtyOutputBuffer()) {
+            writeOutputBufferToSocket();
+        }
 
-            if (newOwner == null) {
-                unschedule();
-            } else {
-                startMigration();
-            }
-        } catch (Throwable t) {
-            logger.severe("Fatal Error at WriteHandler for endPoint: " + connection.getEndPoint(), t);
-            handleSocketException(t);
+        if (newOwner == null) {
+            unschedule();
+        } else {
+            startMigration();
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/SelectionHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/SelectionHandler.java
@@ -16,6 +16,36 @@
 
 package com.hazelcast.nio.tcp.nonblocking;
 
+/**
+ * The SelectionHandler is a callback interface that gets called by an IO-thread when there data available to read, or space
+ * available to write.
+ */
 public interface SelectionHandler {
-    void handle();
+
+    /**
+     * Called when there are bytes available for reading, or space available to write.
+     *
+     * Any exception that leads to a termination of the connection like an IOException should not be handled in the handle method
+     * but should be propagated. The reason behind this is that the handle logic already is complicated enough and by pulling it
+     * out the flow will be easier to understand.
+     *
+     * @throws Exception
+     */
+    void handle() throws Exception;
+
+    /**
+     * Is called when the {@link #handle()} throws an exception.
+     *
+     * The idiom to use a handler is:
+     * <code>
+     *     try{
+     *         handler.handle();
+     *     } catch(Throwable t) {
+     *         handler.onFailure(t);
+     *     }
+     * </code>
+     *
+     * @param throwable
+     */
+    void onFailure(Throwable throwable);
 }


### PR DESCRIPTION
Instead of the handle method doing the exception handling on top of its primary concern, handling the event, the exception handling logic has been pulled out by adding an additional onFailure method that gets called when the handle method throws an exception.

This makes the handle logic a lot cleaner since all the exception handling logic is moved out.

In the clients an unhandled exception leads to closing the connection; just like on server. In the past only the exception was logged but the continue allowed to continue. But this doesn't make sense since an exception is fatal.