### PR TITLE
Renamed TcpIpConnectionThreadingModel

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/instance/DefaultNodeContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/DefaultNodeContext.java
@@ -20,7 +20,7 @@ import com.hazelcast.cluster.Joiner;
 import com.hazelcast.nio.ConnectionManager;
 import com.hazelcast.nio.NodeIOService;
 import com.hazelcast.nio.tcp.TcpIpConnectionManager;
-import com.hazelcast.nio.tcp.nonblocking.NonBlockingTcpIpConnectionThreadingModel;
+import com.hazelcast.nio.tcp.nonblocking.NonBlockingIOThreadingModel;
 
 import java.nio.channels.ServerSocketChannel;
 
@@ -39,7 +39,7 @@ public class DefaultNodeContext implements NodeContext {
     @Override
     public ConnectionManager createConnectionManager(Node node, ServerSocketChannel serverSocketChannel) {
         NodeIOService ioService = new NodeIOService(node, node.nodeEngine);
-        NonBlockingTcpIpConnectionThreadingModel threadingModel = new NonBlockingTcpIpConnectionThreadingModel(
+        NonBlockingIOThreadingModel ioThreadingModel = new NonBlockingIOThreadingModel(
                 ioService,
                 node.loggingService,
                 node.nodeEngine.getMetricsRegistry(),
@@ -50,6 +50,6 @@ public class DefaultNodeContext implements NodeContext {
                 serverSocketChannel,
                 node.loggingService,
                 node.nodeEngine.getMetricsRegistry(),
-                threadingModel);
+                ioThreadingModel);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/IOThreadingModel.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/IOThreadingModel.java
@@ -16,17 +16,19 @@
 
 package com.hazelcast.nio.tcp;
 
+import com.hazelcast.nio.tcp.nonblocking.NonBlockingIOThreadingModel;
+
 /**
  * An abstract of the threading model used by the {@link TcpIpConnection}.
  *
- * The default implementation of this is the {@link com.hazelcast.nio.tcp.nonblocking.NonBlockingTcpIpConnectionThreadingModel}
- * that relies on selectors. But also different implementations can be added like spinning, thread per connection etc.
+ * The default implementation of this is the {@link NonBlockingIOThreadingModel} that relies on selectors. But also
+ * different implementations can be added like spinning, thread per connection etc.
  *
  * Apart from providing a hook to add new functionality, it also simplifies the {@link TcpIpConnection} and
- * {@link TcpIpConnectionManager} since a lot of complexity is moved out into a self contained module; keeping them
- * more pure.
+ * {@link TcpIpConnectionManager} since the IOThreadingModel provides a separation of concerns. The TcpIpConnectManager
+ * is responsible for managing connections, the IOThreadingModel is responsible for providing threads to the connections.
  */
-public interface TcpIpConnectionThreadingModel {
+public interface IOThreadingModel {
 
     /**
      * Tells whether or not every I/O operation on SocketChannel should block until it completes.

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/SocketAcceptorThread.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/SocketAcceptorThread.java
@@ -157,7 +157,7 @@ public class SocketAcceptorThread extends Thread {
         try {
             connectionManager.initSocket(socketChannel.socket());
             connectionManager.interceptSocket(socketChannel.socket(), true);
-            socketChannel.configureBlocking(connectionManager.getThreadingModel().isBlocking());
+            socketChannel.configureBlocking(connectionManager.getIoThreadingModel().isBlocking());
             connectionManager.newConnection(socketChannel, null);
         } catch (Exception e) {
             logger.warning(e.getClass().getName() + ": " + e.getMessage(), e);

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnection.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnection.java
@@ -63,13 +63,13 @@ public final class TcpIpConnection implements Connection {
     public TcpIpConnection(TcpIpConnectionManager connectionManager,
                            int connectionId,
                            SocketChannelWrapper socketChannel,
-                           TcpIpConnectionThreadingModel threadingModel) {
+                           IOThreadingModel ioThreadingModel) {
         this.connectionId = connectionId;
         this.logger = connectionManager.getIoService().getLogger(TcpIpConnection.class.getName());
         this.connectionManager = connectionManager;
         this.socketChannel = socketChannel;
-        this.writeHandler = threadingModel.newWriteHandler(this);
-        this.readHandler = threadingModel.newReadHandler(this);
+        this.writeHandler = ioThreadingModel.newWriteHandler(this);
+        this.readHandler = ioThreadingModel.newReadHandler(this);
     }
 
     public ReadHandler getReadHandler() {

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/AbstractSelectionHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/AbstractSelectionHandler.java
@@ -140,8 +140,8 @@ public abstract class AbstractSelectionHandler implements MigratableHandler {
     private void completeMigration(NonBlockingIOThread newOwner) {
         assert ioThread == newOwner;
 
-        NonBlockingTcpIpConnectionThreadingModel threadingModel =
-                (NonBlockingTcpIpConnectionThreadingModel) connection.getConnectionManager().getThreadingModel();
+        NonBlockingIOThreadingModel threadingModel =
+                (NonBlockingIOThreadingModel) connection.getConnectionManager().getIoThreadingModel();
         threadingModel.getIOBalancer().signalMigrationComplete();
 
         if (!socketChannel.isOpen()) {

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/IOThreadingModelFactory.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/IOThreadingModelFactory.java
@@ -1,0 +1,7 @@
+package com.hazelcast.nio.tcp;
+
+import com.hazelcast.internal.metrics.MetricsRegistry;
+
+public interface IOThreadingModelFactory {
+    IOThreadingModel create(MockIOService ioService, MetricsRegistry metricsRegistry);
+}

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/TcpIpConnectionThreadingModelFactory.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/TcpIpConnectionThreadingModelFactory.java
@@ -1,7 +1,0 @@
-package com.hazelcast.nio.tcp;
-
-import com.hazelcast.internal.metrics.MetricsRegistry;
-
-public interface TcpIpConnectionThreadingModelFactory {
-    TcpIpConnectionThreadingModel create(MockIOService ioService, MetricsRegistry metricsRegistry);
-}

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/TcpIpConnection_AbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/TcpIpConnection_AbstractTest.java
@@ -8,7 +8,7 @@ import com.hazelcast.nio.Address;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
-import com.hazelcast.nio.tcp.nonblocking.Select_NonBlockingTcpIpConnectionThreadingModelFactory;
+import com.hazelcast.nio.tcp.nonblocking.Select_NonBlockingIOThreadingModelFactory;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastTestSupport;
 import org.junit.After;
@@ -20,7 +20,7 @@ import static org.junit.Assert.assertNotNull;
 
 public abstract class TcpIpConnection_AbstractTest extends HazelcastTestSupport {
 
-    protected TcpIpConnectionThreadingModelFactory threadingModelFactory = new Select_NonBlockingTcpIpConnectionThreadingModelFactory();
+    protected IOThreadingModelFactory threadingModelFactory = new Select_NonBlockingIOThreadingModelFactory();
 
     protected ILogger logger;
     protected LoggingServiceImpl loggingService;

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/nonblocking/SelectNow_NonBlockingIOThreadingModelFactory.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/nonblocking/SelectNow_NonBlockingIOThreadingModelFactory.java
@@ -2,14 +2,14 @@ package com.hazelcast.nio.tcp.nonblocking;
 
 import com.hazelcast.internal.metrics.MetricsRegistry;
 import com.hazelcast.nio.tcp.MockIOService;
-import com.hazelcast.nio.tcp.TcpIpConnectionThreadingModelFactory;
+import com.hazelcast.nio.tcp.IOThreadingModelFactory;
 
-public class SelectNow_NonBlockingTcpIpConnectionThreadingModelFactory implements TcpIpConnectionThreadingModelFactory {
+public class SelectNow_NonBlockingIOThreadingModelFactory implements IOThreadingModelFactory {
 
     @Override
-    public NonBlockingTcpIpConnectionThreadingModel create(
+    public NonBlockingIOThreadingModel create(
             MockIOService ioService, MetricsRegistry metricsRegistry) {
-        NonBlockingTcpIpConnectionThreadingModel threadingModel = new NonBlockingTcpIpConnectionThreadingModel(
+        NonBlockingIOThreadingModel threadingModel = new NonBlockingIOThreadingModel(
                 ioService,
                 ioService.loggingService,
                 metricsRegistry,

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/nonblocking/SelectNow_TcpIpConnectionManager_ConnectTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/nonblocking/SelectNow_TcpIpConnectionManager_ConnectTest.java
@@ -13,7 +13,7 @@ public class SelectNow_TcpIpConnectionManager_ConnectTest extends TcpIpConnectio
 
     @Before
     public void setup() throws Exception {
-        threadingModelFactory = new SelectNow_NonBlockingTcpIpConnectionThreadingModelFactory();
+        threadingModelFactory = new SelectNow_NonBlockingIOThreadingModelFactory();
         super.setup();
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/nonblocking/SelectNow_TcpIpConnection_BasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/nonblocking/SelectNow_TcpIpConnection_BasicTest.java
@@ -13,7 +13,7 @@ public class SelectNow_TcpIpConnection_BasicTest extends TcpIpConnection_BasicTe
 
     @Before
     public void setup() throws Exception {
-        threadingModelFactory = new SelectNow_NonBlockingTcpIpConnectionThreadingModelFactory();
+        threadingModelFactory = new SelectNow_NonBlockingIOThreadingModelFactory();
         super.setup();
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/nonblocking/SelectNow_TcpIpConnection_TransferStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/nonblocking/SelectNow_TcpIpConnection_TransferStressTest.java
@@ -13,7 +13,7 @@ public class SelectNow_TcpIpConnection_TransferStressTest extends TcpIpConnectio
 
     @Before
     public void setup() throws Exception {
-        threadingModelFactory = new SelectNow_NonBlockingTcpIpConnectionThreadingModelFactory();
+        threadingModelFactory = new SelectNow_NonBlockingIOThreadingModelFactory();
         super.setup();
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/nonblocking/Select_NonBlockingIOThreadingModelFactory.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/nonblocking/Select_NonBlockingIOThreadingModelFactory.java
@@ -2,14 +2,14 @@ package com.hazelcast.nio.tcp.nonblocking;
 
 import com.hazelcast.internal.metrics.MetricsRegistry;
 import com.hazelcast.nio.tcp.MockIOService;
-import com.hazelcast.nio.tcp.TcpIpConnectionThreadingModelFactory;
+import com.hazelcast.nio.tcp.IOThreadingModelFactory;
 
-public class Select_NonBlockingTcpIpConnectionThreadingModelFactory implements TcpIpConnectionThreadingModelFactory {
+public class Select_NonBlockingIOThreadingModelFactory implements IOThreadingModelFactory {
 
     @Override
-    public NonBlockingTcpIpConnectionThreadingModel create(
+    public NonBlockingIOThreadingModel create(
             MockIOService ioService, MetricsRegistry metricsRegistry) {
-        NonBlockingTcpIpConnectionThreadingModel threadingModel = new NonBlockingTcpIpConnectionThreadingModel(
+        NonBlockingIOThreadingModel threadingModel = new NonBlockingIOThreadingModel(
                 ioService,
                 ioService.loggingService,
                 metricsRegistry,

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/nonblocking/Select_TcpIpConnectionManager_ConnectTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/nonblocking/Select_TcpIpConnectionManager_ConnectTest.java
@@ -13,7 +13,7 @@ public class Select_TcpIpConnectionManager_ConnectTest extends TcpIpConnectionMa
 
     @Before
     public void setup() throws Exception {
-        threadingModelFactory = new Select_NonBlockingTcpIpConnectionThreadingModelFactory();
+        threadingModelFactory = new Select_NonBlockingIOThreadingModelFactory();
         super.setup();
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/nonblocking/Select_TcpIpConnection_BasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/nonblocking/Select_TcpIpConnection_BasicTest.java
@@ -13,7 +13,7 @@ public class Select_TcpIpConnection_BasicTest extends TcpIpConnection_BasicTest 
 
     @Before
     public void setup() throws Exception {
-        threadingModelFactory = new Select_NonBlockingTcpIpConnectionThreadingModelFactory();
+        threadingModelFactory = new Select_NonBlockingIOThreadingModelFactory();
         super.setup();
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/nonblocking/Select_TcpIpConnection_TransferStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/nonblocking/Select_TcpIpConnection_TransferStressTest.java
@@ -13,7 +13,7 @@ public class Select_TcpIpConnection_TransferStressTest extends TcpIpConnection_T
 
     @Before
     public void setup() throws Exception {
-        threadingModelFactory = new Select_NonBlockingTcpIpConnectionThreadingModelFactory();
+        threadingModelFactory = new Select_NonBlockingIOThreadingModelFactory();
         super.setup();
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/nonblocking/iobalancer/IOBalancerStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/nonblocking/iobalancer/IOBalancerStressTest.java
@@ -25,7 +25,7 @@ import com.hazelcast.instance.HazelcastInstanceFactory;
 import com.hazelcast.nio.tcp.nonblocking.NonBlockingIOThread;
 import com.hazelcast.nio.tcp.nonblocking.NonBlockingInputThread;
 import com.hazelcast.nio.tcp.nonblocking.MigratableHandler;
-import com.hazelcast.nio.tcp.nonblocking.NonBlockingTcpIpConnectionThreadingModel;
+import com.hazelcast.nio.tcp.nonblocking.NonBlockingIOThreadingModel;
 import com.hazelcast.nio.tcp.nonblocking.NonBlockingOutputThread;
 import com.hazelcast.nio.tcp.nonblocking.NonBlockingReadHandler;
 import com.hazelcast.nio.tcp.TcpIpConnection;
@@ -106,7 +106,7 @@ public class IOBalancerStressTest extends HazelcastTestSupport {
     }
 
     public String debug(TcpIpConnectionManager connectionManager) {
-        NonBlockingTcpIpConnectionThreadingModel threadingModel = (NonBlockingTcpIpConnectionThreadingModel) connectionManager.getThreadingModel();
+        NonBlockingIOThreadingModel threadingModel = (NonBlockingIOThreadingModel) connectionManager.getIoThreadingModel();
 
         StringBuffer sb = new StringBuffer();
         sb.append("in selectors\n");


### PR DESCRIPTION
Renamed TcpIpConnectionThreadingModel to IOThreadingModel; the previous one was just too long and the package-context provides enough explanation what the purpose is.

Also improved javadoc of the NonBlockingIOThreadingModel