### PR TITLE
Fixed tcp last-read/write-time issue

### DIFF
--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/connection/nio/ClientConnection.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/connection/nio/ClientConnection.java
@@ -128,12 +128,12 @@ public class ClientConnection implements Connection, Closeable {
     }
 
     @Override
-    public long lastReadTime() {
+    public long lastReadTimeMillis() {
         return readHandler.getLastHandle();
     }
 
     @Override
-    public long lastWriteTime() {
+    public long lastWriteTimeMillis() {
         return writeHandler.getLastHandle();
     }
 

--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
@@ -326,14 +326,14 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
             }
             final long now = Clock.currentTimeMillis();
             for (ClientConnection connection : connections.values()) {
-                if (now - connection.lastReadTime() > heartBeatTimeout) {
+                if (now - connection.lastReadTimeMillis() > heartBeatTimeout) {
                     if (connection.isHeartBeating()) {
                         LOGGER.warning("Heartbeat failed to connection : " + connection);
                         connection.heartBeatingFailed();
                         fireHeartBeatStopped(connection);
                     }
                 }
-                if (now - connection.lastReadTime() > heartBeatInterval) {
+                if (now - connection.lastReadTimeMillis() > heartBeatInterval) {
                     ClientMessage request = ClientPingCodec.encodeRequest();
                     ClientInvocation clientInvocation = new ClientInvocation(client, request, connection);
                     clientInvocation.setBypassHeartbeatCheck(true);

--- a/hazelcast-client-new/src/test/java/com/hazelcast/client/test/TestClientRegistry.java
+++ b/hazelcast-client-new/src/test/java/com/hazelcast/client/test/TestClientRegistry.java
@@ -179,12 +179,12 @@ public class TestClientRegistry {
         }
 
         @Override
-        public long lastReadTime() {
+        public long lastReadTimeMillis() {
             return lastReadTime;
         }
 
         @Override
-        public long lastWriteTime() {
+        public long lastWriteTimeMillis() {
             return lastWriteTime;
         }
 

--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnection.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnection.java
@@ -130,12 +130,12 @@ public class ClientConnection implements Connection, Closeable {
     }
 
     @Override
-    public long lastReadTime() {
+    public long lastReadTimeMillis() {
         return readHandler.getLastHandle();
     }
 
     @Override
-    public long lastWriteTime() {
+    public long lastWriteTimeMillis() {
         return writeHandler.getLastHandle();
     }
 

--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
@@ -325,13 +325,13 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
             }
             final long now = Clock.currentTimeMillis();
             for (ClientConnection connection : connections.values()) {
-                if (now - connection.lastReadTime() > heartBeatTimeout) {
+                if (now - connection.lastReadTimeMillis() > heartBeatTimeout) {
                     if (connection.isHeartBeating()) {
                         connection.heartBeatingFailed();
                         fireHeartBeatStopped(connection);
                     }
                 }
-                if (now - connection.lastReadTime() > heartBeatInterval) {
+                if (now - connection.lastReadTimeMillis() > heartBeatInterval) {
                     final ClientPingRequest request = new ClientPingRequest();
                     new ClientInvocation(client, request, connection).invoke();
                 } else {

--- a/hazelcast-client/src/test/java/com/hazelcast/client/test/TestClientRegistry.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/test/TestClientRegistry.java
@@ -200,12 +200,12 @@ public class TestClientRegistry {
         }
 
         @Override
-        public long lastReadTime() {
+        public long lastReadTimeMillis() {
             return lastReadTime;
         }
 
         @Override
-        public long lastWriteTime() {
+        public long lastWriteTimeMillis() {
             return lastWriteTime;
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientHeartbeatMonitor.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientHeartbeatMonitor.java
@@ -82,7 +82,7 @@ public class ClientHeartbeatMonitor implements Runnable {
         }
 
         final Connection connection = clientEndpoint.getConnection();
-        final long lastTimePackageReceived = connection.lastReadTime();
+        final long lastTimePackageReceived = connection.lastReadTimeMillis();
         final long timeoutInMillis = TimeUnit.SECONDS.toMillis(heartbeatTimeoutSeconds);
         final long currentTimeInMillis = Clock.currentTimeMillis();
         if (lastTimePackageReceived + timeoutInMillis < currentTimeInMillis) {

--- a/hazelcast/src/main/java/com/hazelcast/nio/Connection.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/Connection.java
@@ -33,18 +33,18 @@ public interface Connection {
     boolean isAlive();
 
     /**
-     * Returns the clock time of the most recent read using this connection.
+     * Returns the clock time in milliseconds of the most recent read using this connection.
      *
      * @return the clock time of the most recent read
      */
-    long lastReadTime();
+    long lastReadTimeMillis();
 
     /**
-     * Returns the clock time of the most recent write using this connection.
+     * Returns the clock time in milliseconds of the most recent write using this connection.
      *
      * @return the clock time of the most recent write.
      */
-    long lastWriteTime();
+    long lastWriteTimeMillis();
 
     /**
      * Returns the {@link ConnectionType} of this Connection.

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/ReadHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/ReadHandler.java
@@ -19,7 +19,8 @@ package com.hazelcast.nio.tcp;
 import com.hazelcast.util.counters.Counter;
 
 /**
- * Each {@link TcpIpConnection} has a ReadHandler. It reads data from the socket of that connection.
+ * Each {@link TcpIpConnection} has a ReadHandler and it is responsible to read data from the socket on behalf of that
+ * connection.
  */
 public interface ReadHandler {
 
@@ -28,7 +29,7 @@ public interface ReadHandler {
      *
      * @return the last time a read from the network was done.
      */
-    long getLastReadTime();
+    long getLastReadTimeMillis();
 
     /**
      * Gets the Counter that counts the number of normal packets that have been read.

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnection.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnection.java
@@ -50,15 +50,15 @@ public final class TcpIpConnection implements Connection {
 
     private final AtomicBoolean alive = new AtomicBoolean(true);
 
-    private volatile ConnectionType type = ConnectionType.NONE;
-
-    private Address endPoint;
-
     private final ILogger logger;
 
     private final int connectionId;
 
+    private Address endPoint;
+
     private TcpIpConnectionMonitor monitor;
+
+    private volatile ConnectionType type = ConnectionType.NONE;
 
     public TcpIpConnection(TcpIpConnectionManager connectionManager,
                            int connectionId,
@@ -121,13 +121,13 @@ public final class TcpIpConnection implements Connection {
     }
 
     @Override
-    public long lastWriteTime() {
-        return writeHandler.getLastWriteTime();
+    public long lastWriteTimeMillis() {
+        return writeHandler.getLastWriteTimeMillis();
     }
 
     @Override
-    public long lastReadTime() {
-        return readHandler.getLastReadTime();
+    public long lastReadTimeMillis() {
+        return readHandler.getLastReadTimeMillis();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/WriteHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/WriteHandler.java
@@ -20,7 +20,7 @@ import com.hazelcast.nio.SocketWritable;
 
 
 /**
- * Each {@link TcpIpConnection} has a WriteHandler. It reads data from the network into the system.
+ * Each {@link TcpIpConnection} has a WriteHandler. It reads data from the network on behalf of a Connection.
  */
 public interface WriteHandler {
 
@@ -32,13 +32,13 @@ public interface WriteHandler {
     int totalPacketsPending();
 
     /**
-     * Returns the last {@link com.hazelcast.util.Clock#currentTimeMillis()} a write completes.
+     * Returns the last {@link com.hazelcast.util.Clock#currentTimeMillis()} that a write to the local network buffers completed.
      *
-     * Completes means that it is written to the network buffers; not that it has been offered.
+     * It is important to realize that this doesn't say anything about the remote side actually receiving any data.
      *
-     * @return the lst time a write completed.
+     * @return the last time a write completed.
      */
-    long getLastWriteTime();
+    long getLastWriteTimeMillis();
 
     /**
      * Offers a SocketWritable to be written.

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/NonBlockingReadHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/NonBlockingReadHandler.java
@@ -106,7 +106,7 @@ public final class NonBlockingReadHandler extends AbstractSelectionHandler imple
     }
 
     @Override
-    public long getLastReadTime() {
+    public long getLastReadTimeMillis() {
         return lastReadTime;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/NonBlockingWriteHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/NonBlockingWriteHandler.java
@@ -109,7 +109,7 @@ public final class NonBlockingWriteHandler extends AbstractSelectionHandler impl
     }
 
     @Override
-    public long getLastWriteTime() {
+    public long getLastWriteTimeMillis() {
         return lastWriteTime;
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/client/MockSimpleClient.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/MockSimpleClient.java
@@ -115,12 +115,12 @@ public class MockSimpleClient implements SimpleClient {
         }
 
         @Override
-        public long lastReadTime() {
+        public long lastReadTimeMillis() {
             return 0;
         }
 
         @Override
-        public long lastWriteTime() {
+        public long lastWriteTimeMillis() {
             return 0;
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/DroppingConnection.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/DroppingConnection.java
@@ -47,12 +47,12 @@ class DroppingConnection implements Connection {
     }
 
     @Override
-    public long lastReadTime() {
+    public long lastReadTimeMillis() {
         return timestamp;
     }
 
     @Override
-    public long lastWriteTime() {
+    public long lastWriteTimeMillis() {
         return timestamp;
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/test/TestNodeRegistry.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/TestNodeRegistry.java
@@ -484,11 +484,11 @@ public final class TestNodeRegistry {
             return newPacket;
         }
 
-        public long lastReadTime() {
+        public long lastReadTimeMillis() {
             return System.currentTimeMillis();
         }
 
-        public long lastWriteTime() {
+        public long lastWriteTimeMillis() {
             return System.currentTimeMillis();
         }
 


### PR DESCRIPTION
The bug was in the unit test. Instead of creating a list of packets in the
setup method, it was created in the class constructor.

Also the lastReadTime and lastWriteTime have been renamed to lastReadTimeMillis
and lastWriteTimeMillis to remove any confusion about their unit of time.