### PR TITLE
Query Performance: InflatableSet Implementation

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -336,6 +336,7 @@
     <suppress checks="MethodCount" files="com/hazelcast/util/collection/\w*HashSet"/>
     <suppress checks="MethodCount" files="com/hazelcast/collection/impl/collection/CollectionContainer"/>
     <suppress checks="MagicNumber|Header" files="com/hazelcast/util/collection/"/>
+    <suppress checks="SuperClone" files="com/hazelcast/util/collection/InflatableSet"/>
 
     <!-- Queue -->
     <suppress checks="MethodCount" files="com/hazelcast/collection/impl/queue/QueueContainer"/>

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
@@ -702,13 +702,12 @@ public class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V> {
         MapKeySetRequest request = new MapKeySetRequest(name);
         MapKeySet mapKeySet = invoke(request);
         Set<Data> keySetData = mapKeySet.getKeySet();
-        InflatableSet<K> keySet = new InflatableSet<K>(keySetData.size());
+        InflatableSet.Builder<K> setBuilder = InflatableSet.newBuilder(keySetData.size());
         for (Data data : keySetData) {
             final K key = toObject(data);
-            keySet.add(key);
+            setBuilder.add(key);
         }
-        keySet.close();
-        return keySet;
+        return setBuilder.build();
     }
 
     @Override
@@ -768,16 +767,15 @@ public class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V> {
         MapEntrySet result = invoke(request);
 
         Set<Entry<Data, Data>> entries = result.getEntrySet();
-        InflatableSet<Entry<K, V>> entrySet = new InflatableSet<Entry<K, V>>(entries.size());
+        InflatableSet.Builder<Entry<K, V>> setBuilder = InflatableSet.newBuilder(entries.size());
         for (Entry<Data, Data> dataEntry : entries) {
             Data keyData = dataEntry.getKey();
             Data valueData = dataEntry.getValue();
             K key = toObject(keyData);
             V value = toObject(valueData);
-            entrySet.add(new AbstractMap.SimpleEntry<K, V>(key, value));
+            setBuilder.add(new AbstractMap.SimpleEntry<K, V>(key, value));
         }
-        entrySet.close();
-        return entrySet;
+        return setBuilder.build();
     }
 
     @Override
@@ -791,13 +789,12 @@ public class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V> {
         MapQueryRequest request = new MapQueryRequest(name, predicate, IterationType.KEY);
         QueryResultSet result = invoke(request);
         if (pagingPredicate == null) {
-            final InflatableSet<K> keySet = new InflatableSet<K>(result.size());
+            InflatableSet.Builder<K> setBuilder = InflatableSet.newBuilder(result.size());
             for (Object o : result) {
                 final K key = toObject(o);
-                keySet.add(key);
+                setBuilder.add(key);
             }
-            keySet.close();
-            return keySet;
+            return setBuilder.build();
         }
 
         Iterator<Entry> iterator = result.rawIterator();
@@ -823,14 +820,13 @@ public class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V> {
         QueryResultSet result = invoke(request);
         if (pagingPredicate == null) {
             SerializationService serializationService = getContext().getSerializationService();
-            InflatableSet<Entry<K, V>> entrySet = new InflatableSet<Entry<K, V>>(result.size());
+            InflatableSet.Builder<Entry<K, V>> setBuilder = InflatableSet.newBuilder(result.size());
             for (Object data : result) {
                 AbstractMap.SimpleImmutableEntry<Data, Data> dataEntry = (AbstractMap.SimpleImmutableEntry<Data, Data>) data;
                 LazyMapEntry lazyEntry = new LazyMapEntry(dataEntry.getKey(), dataEntry.getValue(), serializationService);
-                entrySet.add(lazyEntry);
+                setBuilder.add(lazyEntry);
             }
-            entrySet.close();
-            return entrySet;
+            return setBuilder.build();
         }
         ArrayList<Map.Entry> resultList = new ArrayList<Map.Entry>();
         for (Object data : result) {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
@@ -36,10 +36,12 @@ import com.hazelcast.core.IMap;
 import com.hazelcast.core.IMapEvent;
 import com.hazelcast.core.MapEvent;
 import com.hazelcast.core.Member;
+import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.map.EntryProcessor;
 import com.hazelcast.map.MapInterceptor;
 import com.hazelcast.map.MapPartitionLostEvent;
+import com.hazelcast.map.impl.LazyMapEntry;
 import com.hazelcast.map.impl.ListenerAdapter;
 import com.hazelcast.map.impl.MapEntrySet;
 import com.hazelcast.map.impl.MapKeySet;
@@ -114,6 +116,7 @@ import com.hazelcast.util.IterationType;
 import com.hazelcast.util.Preconditions;
 import com.hazelcast.util.QueryResultSet;
 import com.hazelcast.util.ThreadUtil;
+import com.hazelcast.util.collection.InflatableSet;
 import com.hazelcast.util.executor.CompletedFuture;
 import com.hazelcast.util.executor.DelegatingFuture;
 
@@ -699,11 +702,12 @@ public class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V> {
         MapKeySetRequest request = new MapKeySetRequest(name);
         MapKeySet mapKeySet = invoke(request);
         Set<Data> keySetData = mapKeySet.getKeySet();
-        Set<K> keySet = new HashSet<K>(keySetData.size());
+        InflatableSet<K> keySet = new InflatableSet<K>(keySetData.size());
         for (Data data : keySetData) {
             final K key = toObject(data);
             keySet.add(key);
         }
+        keySet.close();
         return keySet;
     }
 
@@ -763,8 +767,8 @@ public class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V> {
         MapEntrySetRequest request = new MapEntrySetRequest(name);
         MapEntrySet result = invoke(request);
 
-        Set<Entry<K, V>> entrySet = new HashSet<Entry<K, V>>();
         Set<Entry<Data, Data>> entries = result.getEntrySet();
+        InflatableSet<Entry<K, V>> entrySet = new InflatableSet<Entry<K, V>>(entries.size());
         for (Entry<Data, Data> dataEntry : entries) {
             Data keyData = dataEntry.getKey();
             Data valueData = dataEntry.getValue();
@@ -772,6 +776,7 @@ public class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V> {
             V value = toObject(valueData);
             entrySet.add(new AbstractMap.SimpleEntry<K, V>(key, value));
         }
+        entrySet.close();
         return entrySet;
     }
 
@@ -786,11 +791,12 @@ public class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V> {
         MapQueryRequest request = new MapQueryRequest(name, predicate, IterationType.KEY);
         QueryResultSet result = invoke(request);
         if (pagingPredicate == null) {
-            final HashSet<K> keySet = new HashSet<K>();
+            final InflatableSet<K> keySet = new InflatableSet<K>(result.size());
             for (Object o : result) {
                 final K key = toObject(o);
                 keySet.add(key);
             }
+            keySet.close();
             return keySet;
         }
 
@@ -816,13 +822,14 @@ public class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V> {
         MapQueryRequest request = new MapQueryRequest(name, predicate, IterationType.ENTRY);
         QueryResultSet result = invoke(request);
         if (pagingPredicate == null) {
-            Set<Entry<K, V>> entrySet = new HashSet<Entry<K, V>>(result.size());
+            SerializationService serializationService = getContext().getSerializationService();
+            InflatableSet<Entry<K, V>> entrySet = new InflatableSet<Entry<K, V>>(result.size());
             for (Object data : result) {
                 AbstractMap.SimpleImmutableEntry<Data, Data> dataEntry = (AbstractMap.SimpleImmutableEntry<Data, Data>) data;
-                K key = toObject(dataEntry.getKey());
-                V value = toObject(dataEntry.getValue());
-                entrySet.add(new AbstractMap.SimpleEntry<K, V>(key, value));
+                LazyMapEntry lazyEntry = new LazyMapEntry(dataEntry.getKey(), dataEntry.getValue(), serializationService);
+                entrySet.add(lazyEntry);
             }
+            entrySet.close();
             return entrySet;
         }
         ArrayList<Map.Entry> resultList = new ArrayList<Map.Entry>();

--- a/hazelcast/src/main/java/com/hazelcast/util/BitSetUtils.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/BitSetUtils.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.util;
+
+import java.util.BitSet;
+
+/**
+ * Convenient method for BitSet manipulations
+ *
+ */
+public final class BitSetUtils {
+
+    private BitSetUtils() {
+
+    }
+
+    /**
+     * Returns true if at least one bit on a given position is set
+     *
+     * @param bitSet
+     * @param indexes
+     * @return {@code true} is BitSet contains at least one bit at any position from index which is set, otherwise
+     *         return {@code false}
+     */
+    public static boolean hasAtLeastOneBitSet(BitSet bitSet, Iterable<Integer> indexes) {
+        for (Integer index : indexes) {
+            if (bitSet.get(index)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Set all bits on a given positions
+     *
+     * @param bitSet
+     * @param indexes
+     */
+    public static void setBits(BitSet bitSet, Iterable<Integer> indexes) {
+        for (Integer index : indexes) {
+            bitSet.set(index);
+        }
+    }
+
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/util/collection/InflatableSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/collection/InflatableSet.java
@@ -1,0 +1,251 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.util.collection;
+
+import java.io.Serializable;
+import java.util.AbstractSet;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Provides fast {@link Set} implementation for cases where items are known to not
+ * contain duplicates.
+ *
+ * It doesn't not call equals/hash methods on initial data insertion hence it avoids
+ * performance penalty in the case these methods are expensive. It also means it does
+ * not detect duplicates - it's a responsibility of a caller to make sure no duplicated
+ * entries are inserted.
+ *
+ * Once the initial load is done then caller should indicate it
+ * by calling {@link #close()}. It switches operational mode and if any item is
+ * inserted afterward then the Set will inflate - it copies its content into
+ * internal HashSet. This means duplicate detection is enabled, but obviously
+ * it ruins the initial performance gain. We are making a bet the Set will not be
+ * modified once it's closed. The Set will also inflate on {@link #contains(Object)}
+ * and {@link #containsAll(Collection)} calls to enable fast look-ups.
+ *
+ * Failing to call {@link #close()} means the InflatableSet is in state where
+ * a general contract of Set is broken - duplicates aren't detected. You should
+ * never pass unclosed InfltableSet to user code.
+ *
+ * It's intended to be use in cases where a contract mandates us to return Set,
+ * but we know our data contains not duplicates. It performs the best in cases
+ * biased towards sequential iterations.
+ *
+ *
+ * @param <T>
+ */
+public final class InflatableSet<T> extends AbstractSet<T> implements Set<T>, Serializable, Cloneable {
+    private static final long serialVersionUID = 0L;
+
+    private enum State {
+        //Set is still open for initial load. It's caller's responsibility to make
+        //sure no duplicates are added to this Set in this state
+        INITIAL_LOAD,
+
+        //Only array-backed representation exists
+        COMPACT,
+
+        //both array-backed & hashset-backed representation exist.
+        //this is needed as we are creating HashSet on contains()
+        //but we don't want invalidate existing iterators.
+        HYBRID,
+
+        //only hashset based representation exists
+        INFLATED
+    }
+
+    private final List<T> compactList;
+    private Set<T> inflatedSet;
+    private State state;
+
+    public InflatableSet(int initialCapacity) {
+        this.state = State.INITIAL_LOAD;
+        if (initialCapacity < 0) {
+            throw new IllegalArgumentException("Initial Capacity must be a positive number. Current capacity: "
+                    + initialCapacity);
+        }
+        compactList = new ArrayList<T>(initialCapacity);
+    }
+
+    protected InflatableSet(InflatableSet other) {
+        compactList = new ArrayList<T>(other.compactList.size());
+        compactList.addAll(other.compactList);
+        if (other.inflatedSet != null) {
+            inflatedSet = new HashSet<T>(other.inflatedSet);
+        }
+        state = other.state;
+    }
+
+
+    @Override
+    public int size() {
+        if (state == State.INFLATED) {
+            return inflatedSet.size();
+        } else {
+            return compactList.size();
+        }
+    }
+
+    @Override
+    public boolean isEmpty() {
+        if (state == State.INFLATED) {
+            return inflatedSet.isEmpty();
+        } else {
+            return compactList.isEmpty();
+        }
+    }
+
+    @Override
+    public boolean contains(Object o) {
+        if (state == State.INITIAL_LOAD) {
+            return compactList.contains(o);
+        }
+        if (state == State.COMPACT) {
+            toHybridState();
+        }
+        return inflatedSet.contains(o);
+    }
+
+    @Override
+    public Iterator<T> iterator() {
+        if (state == State.INFLATED) {
+            return inflatedSet.iterator();
+        }
+        return new HybridIterator();
+    }
+
+    @Override
+    public boolean add(T t) {
+        if (state == State.INITIAL_LOAD) {
+            return compactList.add(t);
+        }
+        toInflatedState();
+        return inflatedSet.add(t);
+    }
+
+    @Override
+    public boolean remove(Object o) {
+        switch (state) {
+            case HYBRID:
+                compactList.remove(o);
+                return inflatedSet.remove(o);
+            case INFLATED:
+                return inflatedSet.remove(o);
+            default:
+                return compactList.remove(o);
+        }
+    }
+
+    @Override
+    public void clear() {
+        switch (state) {
+            case HYBRID:
+                inflatedSet.clear();
+                compactList.clear();
+                break;
+            case INFLATED:
+                inflatedSet.clear();
+                break;
+            default:
+                compactList.clear();
+        }
+    }
+
+    public void close() {
+        if (state != State.INITIAL_LOAD) {
+            throw new IllegalStateException("InflatableSet can be only closed during InitialLoad. Current state: "
+                    + state);
+        }
+        state = State.COMPACT;
+    }
+
+    /**
+     * Returns a shallow copy of this <tt>InflatableSet</tt> instance: the keys and
+     * values themselves are not cloned.
+     *
+     * @return a shallow copy of this set
+     */
+    @Override
+    protected Object clone()  {
+        return new InflatableSet<T>(this);
+    }
+
+    private void inflateIfNeeded() {
+        if (inflatedSet == null) {
+            inflatedSet = new HashSet<T>(compactList);
+        }
+    }
+
+    private void toHybridState() {
+        if (state == State.HYBRID) {
+            return;
+        }
+
+        state = State.HYBRID;
+        inflateIfNeeded();
+    }
+
+    private void toInflatedState() {
+        if (state == State.INFLATED) {
+            return;
+        }
+
+        state = State.INFLATED;
+        inflateIfNeeded();
+        invalidateIterators();
+    }
+
+    private void invalidateIterators() {
+        if (compactList.size() == 0) {
+            compactList.clear();
+        } else {
+            compactList.remove(0);
+        }
+    }
+
+    private class HybridIterator implements Iterator<T> {
+        private Iterator<T> innerIterator;
+        private T currentValue;
+
+        public HybridIterator() {
+            innerIterator = compactList.iterator();
+        }
+
+        @Override
+        public boolean hasNext() {
+            return innerIterator.hasNext();
+        }
+
+        @Override
+        public T next() {
+            currentValue = innerIterator.next();
+            return currentValue;
+        }
+
+        @Override
+        public void remove() {
+            innerIterator.remove();
+            if (inflatedSet != null) {
+                inflatedSet.remove(currentValue);
+            }
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/LazyMapEntryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/LazyMapEntryTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.map.impl;
 
 import com.hazelcast.nio.ObjectDataInput;
@@ -8,6 +24,7 @@ import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuil
 import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestJavaSerializationUtils;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
@@ -26,6 +43,16 @@ public class LazyMapEntryTest extends HazelcastTestSupport {
 
     private LazyMapEntry entry = new LazyMapEntry();
     private SerializationService serializationService = new DefaultSerializationServiceBuilder().build();
+
+    @Test
+    public void testSerialization() throws IOException, ClassNotFoundException {
+        Data keyData = serializationService.toData("keyData");
+        Data valueData = serializationService.toData("valueData");
+        entry.init(keyData, valueData, serializationService);
+        LazyMapEntry copy = TestJavaSerializationUtils.serializeAndDeserialize(entry);
+
+        assertEquals(entry, copy);
+    }
 
     @Test
     public void test_init() throws Exception {

--- a/hazelcast/src/test/java/com/hazelcast/test/TestJavaSerializationUtils.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/TestJavaSerializationUtils.java
@@ -44,4 +44,34 @@ public final class TestJavaSerializationUtils {
         oos.writeObject(entry);
         return bos.toByteArray();
     }
+
+    public static Serializable newSerializableObject(int id) {
+        return new SerializableObject(id);
+    }
+
+
+
+    private static final class SerializableObject implements Serializable {
+        private final int id;
+
+        public SerializableObject(int id) {
+            this.id = id;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            SerializableObject that = (SerializableObject) o;
+
+            return id == that.id;
+
+        }
+
+        @Override
+        public int hashCode() {
+            return id;
+        }
+    }
 }

--- a/hazelcast/src/test/java/com/hazelcast/test/TestJavaSerializationUtils.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/TestJavaSerializationUtils.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+
+public final class TestJavaSerializationUtils {
+    private TestJavaSerializationUtils() {
+    }
+
+    public static <T extends Serializable> T serializeAndDeserialize(T object) throws IOException, ClassNotFoundException {
+        byte[] array = serialize(object);
+        return deserialize(array);
+    }
+
+    public static <T> T deserialize(byte[] array) throws IOException, ClassNotFoundException {
+        ByteArrayInputStream bais = new ByteArrayInputStream(array);
+        ObjectInputStream ois = new ObjectInputStream(bais);
+        return (T) ois.readObject();
+    }
+
+    public static byte[] serialize(Serializable entry) throws IOException {
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        ObjectOutputStream oos = new ObjectOutputStream(bos);
+        oos.writeObject(entry);
+        return bos.toByteArray();
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/util/BitSetUtilsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/BitSetUtilsTest.java
@@ -1,0 +1,64 @@
+package com.hazelcast.util;
+
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.ArrayList;
+import java.util.BitSet;
+import java.util.List;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class BitSetUtilsTest {
+    private static final int SIZE = 10;
+
+    private BitSet bitSet;
+    private List<Integer> indexes;
+
+    @Before
+    public void setUp() {
+        bitSet = new BitSet(SIZE);
+
+        indexes = new ArrayList<Integer>(SIZE);
+        for (int i = 0; i < SIZE; i++) {
+            indexes.add(i);
+        }
+    }
+
+    @Test
+    public void hasAtLeastOneBitSet_whenEmptyBitSet_thenReturnFalse() {
+        boolean isBitSet = BitSetUtils.hasAtLeastOneBitSet(bitSet, indexes);
+        assertFalse(isBitSet);
+    }
+
+    @Test
+    public void hasAtLeastOneBitSet_whenBitIsSet_thenReturnTrue() {
+        for (int position = 0; position < SIZE; position++) {
+            bitSet = new BitSet(SIZE);
+            bitSet.set(position);
+            boolean isBitSet = BitSetUtils.hasAtLeastOneBitSet(bitSet, indexes);
+            assertTrue(isBitSet);
+        }
+    }
+
+    @Test
+    public void setBits_thenSetAllBits() {
+        BitSetUtils.setBits(bitSet, indexes);
+        assertBitsAtPositionsAreSet(bitSet, indexes);
+    }
+
+    private void assertBitsAtPositionsAreSet(BitSet bitSet, List<Integer> indexes) {
+        for (int index : indexes) {
+            boolean isSet = bitSet.get(index);
+            assertTrue(isSet);
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/util/collection/InflatableSetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/collection/InflatableSetTest.java
@@ -1,0 +1,270 @@
+package com.hazelcast.util.collection;
+
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.TestJavaSerializationUtils;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.io.IOException;
+import java.util.ConcurrentModificationException;
+import java.util.Iterator;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class InflatableSetTest {
+
+    private InflatableSet<Object> set;
+
+    @Before
+    public void setUp() {
+        set = new InflatableSet<Object>(10);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void whenInitialLoadNegative_thenThrowIllegalArgumentException() {
+        new InflatableSet<Object>(-1);
+    }
+
+    @Test
+    public void serialization_whenInInitialLoadingAndEmpty() throws IOException, ClassNotFoundException {
+        InflatableSet<Object> clone = TestJavaSerializationUtils.serializeAndDeserialize(set);
+        assertEquals(set, clone);
+    }
+
+    @Test
+    public void serialization_whenInClosedState() throws IOException, ClassNotFoundException {
+        set.add(TestJavaSerializationUtils.newSerializableObject(1));
+        set.close();
+        InflatableSet<Object> clone = TestJavaSerializationUtils.serializeAndDeserialize(set);
+        assertEquals(set, clone);
+    }
+
+    @Test
+    public void serialization_whenInflated() throws IOException, ClassNotFoundException {
+        set.close();
+        set.add(TestJavaSerializationUtils.newSerializableObject(1));
+        InflatableSet<Object> clone = TestJavaSerializationUtils.serializeAndDeserialize(set);
+        assertEquals(set, clone);
+    }
+
+    @Test
+    public void clone_whenInInitialLoadAndEntryInserted_thenCloneDoesNotContainTheObject() throws CloneNotSupportedException {
+        InflatableSet<Object> clone = (InflatableSet<Object>) set.clone();
+        set.add(new Object());
+
+        assertThat(clone, is(empty()));
+    }
+
+    @Test
+    public void clone_whenInflatedAndEntryInserted_thenCloneDoesNotContainTheObject() throws CloneNotSupportedException {
+        set.close();
+        set.add(new Object()); //inflate it
+        InflatableSet<Object> clone = (InflatableSet<Object>) set.clone();
+        set.add(new Object());
+
+        assertThat(clone, hasSize(1));
+    }
+
+
+    @Test
+    public void add_whenInInitialLoad_thenDoNotCallEquals() {
+        MyObject o = new MyObject();
+        set.add(o);
+        assertThat(o.equalsCount, is(0));
+    }
+
+    @Test
+    public void add_whenInInitialLoad_thenDoNotCallHashCode() {
+        MyObject o = new MyObject();
+        set.add(o);
+        assertThat(o.hashCodeCount, is(0));
+    }
+
+    @Test
+    public void add_whenClosed_thenDetectDuplicates() {
+        MyObject o = new MyObject();
+        set.add(o);
+        set.close();
+        boolean added = set.add(o);
+        assertFalse(added);
+    }
+
+    @Test
+    public void clear_whenInInitialLoad_thenRemoveAllEntries() {
+        MyObject o1 = new MyObject();
+        MyObject o2 = new MyObject();
+
+        set.add(o1);
+        set.add(o2);
+        set.clear();
+
+        assertThat(set, is(empty()));
+    }
+
+    @Test
+    public void clear_whenClosed_thenRemoveAllEntries() {
+        MyObject o1 = new MyObject();
+        MyObject o2 = new MyObject();
+
+        set.add(o1);
+        set.add(o2);
+        set.close();
+        set.clear();
+
+        assertThat(set, is(empty()));
+    }
+
+    @Test
+    public void clear_whenInClosedModeAndAfterInsertion_thenRemoveAllEntries() {
+        MyObject o1 = new MyObject();
+        MyObject o2 = new MyObject();
+
+        set.add(o1);
+        set.close();
+        set.add(o2);
+        set.clear();
+
+        assertThat(set, is(empty()));
+    }
+
+    @Test
+    public void clear_whenInClosedModeAndAfterLookUp_thenRemoveAllEntries() {
+        MyObject o1 = new MyObject();
+        MyObject o2 = new MyObject();
+
+        set.add(o1);
+        set.add(o2);
+        set.close();
+        set.contains(o1);
+        set.clear();
+
+        assertThat(set, is(empty()));
+    }
+
+
+    @Test(expected = IllegalStateException.class)
+    public void close_whenNotInInitialLoad_thenThrowIllegalStateException() {
+        set.close();
+        set.close();
+    }
+
+    @Test
+    public void remove_whenInInitialLoad_thenRemoveObject() {
+        MyObject o = new MyObject();
+        set.add(o);
+        set.remove(o);
+
+        assertThat(set, is(empty()));
+    }
+
+    @Test
+    public void remove_whenClosed_thenRemoveObject() {
+        MyObject o = new MyObject();
+        set.add(o);
+        set.close();
+        set.remove(o);
+
+        assertThat(set, is(empty()));
+    }
+
+    @Test
+    public void remove_whenClosedAndAfterLookup_thenRemoveObject() {
+        MyObject o = new MyObject();
+        set.add(o);
+        set.close();
+        set.contains(o);
+        set.remove(o);
+
+        assertThat(set, is(empty()));
+    }
+
+    @Test
+    public void remove_whenClosedAndAfterInsertion_thenRemoveObject() {
+        set.close();
+        MyObject o = new MyObject();
+        set.add(o);
+        set.remove(o);
+
+        assertThat(set, is(empty()));
+    }
+
+    @Test
+    public void size_whenInInitalState_thenReturnSize() {
+        MyObject o = new MyObject();
+        set.add(o);
+
+        assertThat(set, hasSize(1));
+    }
+
+    @Test
+    public void size_whenClosedAndAfterInsertion_thenReturnSize() {
+        set.close();
+        MyObject o = new MyObject();
+        set.add(o);
+
+        assertThat(set, hasSize(1));
+    }
+
+    @Test
+    public void contains_whenInInitialLoadAndObjectInserted_thenReturnTrue() {
+        MyObject o = new MyObject();
+        set.add(o);
+
+        assertThat(set.contains(o), is(true));
+    }
+
+
+    @Test(expected = ConcurrentModificationException.class)
+    public void iterator_next_whenModifiedInClosedState_thenFailFast() {
+        MyObject o1 = new MyObject();
+        set.add(o1);
+        set.close();
+
+        Iterator<Object> iterator = set.iterator();
+        MyObject o2 = new MyObject();
+        set.add(o2);
+
+        iterator.next();
+    }
+
+    @Test
+    public void iterator_remove_whenClosedAndLookedUp_thenRemoveFromCollection() {
+        MyObject o1 = new MyObject();
+        set.add(o1);
+        set.close();
+
+        Iterator<Object> iterator = set.iterator();
+        set.contains(o1);
+        iterator.next();
+        iterator.remove();
+
+        assertThat(set, is(empty()));
+    }
+
+
+    private static class MyObject {
+        int equalsCount;
+        int hashCodeCount;
+
+        @Override
+        public boolean equals(Object obj) {
+            equalsCount++;
+            return super.equals(obj);
+        }
+
+        @Override
+        public int hashCode() {
+            hashCodeCount++;
+            return super.hashCode();
+        }
+    }
+}


### PR DESCRIPTION
This PR avoid potentially slow HashSet creation. 

Our tests have shown adding data into HashSet might be a bottleneck - specially when equals/hashdode methods are somewhat slow. This PR introduces `InflatableSet` - we are playing a bet most Sets obtained via querying a map are simple iterated over and they are rarely modified. I have a test (obtained from a real customer) which shows 3-5x improvement in throughput with this PR.

See commit messages for details. This is the test: https://github.com/hazelcast/hazelcast-simulator/pull/728

This modifies the old Java client only. I have yet to check how to ports these changes into the new client. 