### PR TITLE
Cleanup of CheckStyle suppressions for HazelcastInstanceFactory.

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -251,7 +251,6 @@
     <suppress checks="ExecutableStatementCount" files="com/hazelcast/instance/GroupProperties"/>
     <!-- TODO: work in progress -->
     <suppress checks="MethodLength|NestedIfDepth|NPathComplexity" files="com/hazelcast/instance/DefaultAddressPicker"/>
-    <suppress checks="" files="com/hazelcast/instance/HazelcastInstanceFactory"/>
     <suppress checks="" files="com/hazelcast/instance/Node"/>
 
     <!-- SPI -->


### PR DESCRIPTION
Not much to say, there were just some "needs at least one statemen" and a magic number. Very little cleanup needed for a full CheckStyle suppression.