### PR TITLE
Changes after reviewing protocol AtomicLong AtomicReference and JCache

### DIFF
--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/cache/impl/AbstractClientCacheProxy.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/cache/impl/AbstractClientCacheProxy.java
@@ -229,7 +229,7 @@ abstract class AbstractClientCacheProxy<K, V>
         if (keys.isEmpty()) {
             return Collections.EMPTY_MAP;
         }
-        final Set<Data> keySet = new HashSet(keys.size());
+        final Set<Data> keySet = new HashSet<Data>(keys.size());
         for (K key : keys) {
             final Data k = toData(key);
             keySet.add(k);

--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/cache/impl/AbstractClientInternalCacheProxy.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/cache/impl/AbstractClientInternalCacheProxy.java
@@ -46,9 +46,9 @@ import com.hazelcast.client.spi.ClientContext;
 import com.hazelcast.client.spi.ClientExecutionService;
 import com.hazelcast.client.spi.ClientListenerService;
 import com.hazelcast.client.spi.EventHandler;
-import com.hazelcast.client.spi.impl.ClientListenerInvocation;
 import com.hazelcast.client.spi.impl.ClientInvocation;
 import com.hazelcast.client.spi.impl.ClientInvocationFuture;
+import com.hazelcast.client.spi.impl.ClientListenerInvocation;
 import com.hazelcast.client.spi.impl.ListenerRemoveCodec;
 import com.hazelcast.client.util.ClientDelegatingFuture;
 import com.hazelcast.config.CacheConfig;
@@ -415,13 +415,9 @@ abstract class AbstractClientInternalCacheProxy<K, V>
 
     protected void removeAllKeysInternal(Set<? extends K> keys) {
         final Set<Data> keysData;
-        if (keys != null) {
-            keysData = new HashSet<Data>();
-            for (K key : keys) {
-                keysData.add(toData(key));
-            }
-        } else {
-            keysData = null;
+        keysData = new HashSet<Data>();
+        for (K key : keys) {
+            keysData.add(toData(key));
         }
         final int partitionCount = clientContext.getPartitionService().getPartitionCount();
         final int completionId = nextCompletionId();

--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/cache/impl/ClientClusterWideIterator.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/cache/impl/ClientClusterWideIterator.java
@@ -61,7 +61,8 @@ public class ClientClusterWideIterator<K, V>
         try {
             ClientInvocation clientInvocation = new ClientInvocation(client, request, partitionIndex);
             ClientInvocationFuture f = clientInvocation.invoke();
-            return toObject(CacheIterateCodec.decodeResponse(f.get()).response);
+            CacheIterateCodec.ResponseParameters responseParameters = CacheIterateCodec.decodeResponse(f.get());
+            return new CacheKeyIteratorResult(responseParameters.keys, responseParameters.tableIndex);
         } catch (Exception e) {
             throw ExceptionUtil.rethrow(e);
         }

--- a/hazelcast-client-new/src/test/java/com/hazelcast/client/cache/ClientCacheIteratorTest.java
+++ b/hazelcast-client-new/src/test/java/com/hazelcast/client/cache/ClientCacheIteratorTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.cache;
+
+import com.hazelcast.cache.AbstractCacheIteratorTest;
+import com.hazelcast.client.cache.impl.HazelcastClientCachingProvider;
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import javax.cache.spi.CachingProvider;
+
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ClientCacheIteratorTest extends AbstractCacheIteratorTest {
+
+    private TestHazelcastFactory factory = new TestHazelcastFactory();
+
+    @Override
+    protected CachingProvider createCachingProvider() {
+        factory.newHazelcastInstance();
+        HazelcastInstance hazelcastInstance = factory.newHazelcastClient();
+        return HazelcastClientCachingProvider.createCachingProvider(hazelcastInstance);
+    }
+
+
+    @After
+    public void tear() {
+        factory.shutdownAll();
+    }
+
+}
+

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/ClientCacheIteratorTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/ClientCacheIteratorTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.cache;
+
+import com.hazelcast.cache.AbstractCacheIteratorTest;
+import com.hazelcast.client.cache.impl.HazelcastClientCachingProvider;
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import javax.cache.spi.CachingProvider;
+
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ClientCacheIteratorTest extends AbstractCacheIteratorTest {
+
+    private TestHazelcastFactory factory = new TestHazelcastFactory();
+
+    @Override
+    protected CachingProvider createCachingProvider() {
+        factory.newHazelcastInstance();
+        HazelcastInstance hazelcastInstance = factory.newHazelcastClient();
+        return HazelcastClientCachingProvider.createCachingProvider(hazelcastInstance);
+    }
+
+
+    @After
+    public void tear() {
+        factory.shutdownAll();
+    }
+
+}
+

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/ResponseMessageConst.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/ResponseMessageConst.java
@@ -43,4 +43,5 @@ public final class ResponseMessageConst {
     public static final int SET_DATA = 113;
     public static final int SET_ENTRY = 114;
     public static final int READ_RESULT_SET = 115;
+    public static final int CACHE_KEY_ITERATOR_RESULT = 116;
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/atomiclong/AtomicLongAlterMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/atomiclong/AtomicLongAlterMessageTask.java
@@ -50,7 +50,7 @@ public class AtomicLongAlterMessageTask
 
     @Override
     protected ClientMessage encodeResponse(Object response) {
-        return AtomicLongAlterCodec.encodeResponse((Long) response);
+        return AtomicLongAlterCodec.encodeResponse();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheIterateMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheIterateMessageTask.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.client.impl.protocol.task.cache;
 
+import com.hazelcast.cache.impl.CacheKeyIteratorResult;
 import com.hazelcast.cache.impl.CacheOperationProvider;
 import com.hazelcast.cache.impl.operation.CacheKeyIteratorOperation;
 import com.hazelcast.client.impl.protocol.ClientMessage;
@@ -49,7 +50,8 @@ public class CacheIterateMessageTask
 
     @Override
     protected ClientMessage encodeResponse(Object response) {
-        return CacheIterateCodec.encodeResponse(serializationService.toData(response));
+        CacheKeyIteratorResult cacheKeyIteratorResult = (CacheKeyIteratorResult) response;
+        return CacheIterateCodec.encodeResponse(cacheKeyIteratorResult.getTableIndex(), cacheKeyIteratorResult.getKeys());
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheManagementConfigMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheManagementConfigMessageTask.java
@@ -53,7 +53,7 @@ public class CacheManagementConfigMessageTask
 
     @Override
     protected ClientMessage encodeResponse(Object response) {
-        return CacheManagementConfigCodec.encodeResponse(serializationService.toData(response));
+        return CacheManagementConfigCodec.encodeResponse();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheRemoveAllKeysMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheRemoveAllKeysMessageTask.java
@@ -23,12 +23,10 @@ import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.CacheRemoveAllKeysCodec;
 import com.hazelcast.instance.Node;
 import com.hazelcast.nio.Connection;
-import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.OperationFactory;
 
 import javax.cache.CacheException;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * This client request  specifically calls {@link CacheRemoveAllOperationFactory} on the server side.
@@ -55,7 +53,7 @@ public class CacheRemoveAllKeysMessageTask
     @Override
     protected OperationFactory createOperationFactory() {
         CacheOperationProvider operationProvider = getOperationProvider(parameters.name);
-        return operationProvider.createRemoveAllOperationFactory((Set<Data>) parameters.keys, parameters.completionId);
+        return operationProvider.createRemoveAllOperationFactory(parameters.keys, parameters.completionId);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/AtomicLongCodecTemplate.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/AtomicLongCodecTemplate.java
@@ -23,8 +23,7 @@ import com.hazelcast.nio.serialization.Data;
 
 @GenerateCodec(id = TemplateConstants.ATOMIC_LONG_TEMPLATE_ID,
         name = "AtomicLong", ns = "Hazelcast.Client.Protocol.AtomicLong")
-public interface
-        AtomicLongCodecTemplate {
+public interface AtomicLongCodecTemplate {
 
     /**
      *
@@ -39,10 +38,9 @@ public interface
      *
      * @param name The name of this IAtomicLong instance.
      * @param function The function applied to the currently stored value.
-     * @return The result of the function application.
      */
-    @Request(id = 2, retryable = false, response = ResponseMessageConst.LONG)
-    Object alter(String name, Data function);
+    @Request(id = 2, retryable = false, response = ResponseMessageConst.VOID)
+    void alter(String name, Data function);
 
     /**
      *

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/CacheCodecTemplate.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/CacheCodecTemplate.java
@@ -181,7 +181,7 @@ public interface CacheCodecTemplate {
      * @param batch The number of items to be batched
      * @return Serialised com.hazelcast.cache.impl.CacheKeyIteratorResult object.
      */
-    @Request(id = 15, retryable = false, response = ResponseMessageConst.DATA)
+    @Request(id = 15, retryable = false, response = ResponseMessageConst.CACHE_KEY_ITERATOR_RESULT)
     Object iterate(String name, int partitionId, int tableIndex, int batch);
 
     /**
@@ -212,7 +212,7 @@ public interface CacheCodecTemplate {
      * @param enabled true if enabled, false to disable.
      * @param address the address of the host to enable.
      */
-    @Request(id = 18, retryable = true, response = ResponseMessageConst.DATA)
+    @Request(id = 18, retryable = true, response = ResponseMessageConst.VOID)
     void managementConfig(String name, boolean isStat, boolean enabled, Address address);
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/ResponseTemplate.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/ResponseTemplate.java
@@ -139,6 +139,13 @@ public interface ResponseTemplate {
     @Response(ResponseMessageConst.JOB_PROCESS_INFO)
     Object JobProcessInfo(List<JobPartitionState> jobPartitionStates, int processRecords);
 
+    /***
+     * @param tableIndex the last tableIndex processed
+     * @param keys       list of keys
+     */
+    @Response(ResponseMessageConst.CACHE_KEY_ITERATOR_RESULT)
+    void CacheKeyIteratorResult(int tableIndex, List<Data> keys);
+
     /**
      * @param errorCode      error code of this exception
      * @param className      java class name of exception
@@ -156,7 +163,6 @@ public interface ResponseTemplate {
      * @param readCount Number of items in the response.
      * @param items The array of serialised items.
      */
-    //FIXME review this one
     @Response(ResponseMessageConst.READ_RESULT_SET)
     void ReadResultSet(int readCount, List<Data> items);
 

--- a/hazelcast/src/test/java/com/hazelcast/cache/AbstractCacheIteratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/AbstractCacheIteratorTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.cache;
+
+import com.hazelcast.config.CacheConfig;
+import com.hazelcast.test.HazelcastTestSupport;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.cache.Cache;
+import javax.cache.CacheManager;
+import javax.cache.spi.CachingProvider;
+import java.util.Arrays;
+import java.util.Iterator;
+
+import static org.junit.Assert.assertEquals;
+
+public abstract class AbstractCacheIteratorTest extends HazelcastTestSupport {
+
+    private CachingProvider cachingProvider;
+
+    @Before
+    public void init() {
+        cachingProvider = createCachingProvider();
+    }
+
+    protected abstract CachingProvider createCachingProvider();
+
+    @After
+    public void tear() {
+        cachingProvider.close();
+    }
+
+    private Cache<Integer, Integer> getCache() {
+        String cacheName = randomString();
+        CacheManager cacheManager = cachingProvider.getCacheManager();
+        CacheConfig<Integer, Integer> config = new CacheConfig<Integer, Integer>();
+        return cacheManager.createCache(cacheName, config);
+
+    }
+
+    @Test
+    public void testIterator() {
+        ICache<Integer, Integer> cache = (ICache<Integer, Integer>) getCache();
+        int size = 1111;
+        int multiplier = 11;
+        for (int i = 0; i < size; i++) {
+            cache.put(i, i * multiplier);
+        }
+
+        int[] keys = new int[size];
+        int k = 0;
+        Iterator<Cache.Entry<Integer, Integer>> iter = cache.iterator();
+        while (iter.hasNext()) {
+            Cache.Entry<Integer, Integer> e = iter.next();
+            int key = e.getKey();
+            int value = e.getValue();
+            assertEquals(key * multiplier, value);
+            keys[k++] = key;
+        }
+        assertEquals(size, k);
+
+        Arrays.sort(keys);
+        for (int i = 0; i < size; i++) {
+            assertEquals(i, keys[i]);
+        }
+    }
+
+    @Test
+    public void testIteratorRemove() {
+        ICache<Integer, Integer> cache = (ICache<Integer, Integer>) getCache();
+        int size = 1111;
+        for (int i = 0; i < size; i++) {
+            cache.put(i, i);
+        }
+
+        Iterator<Cache.Entry<Integer, Integer>> iter = cache.iterator();
+        while (iter.hasNext()) {
+            iter.next();
+            iter.remove();
+        }
+        assertEquals(0, cache.size());
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testIteratorIllegalRemove() {
+        ICache<Integer, Integer> cache = (ICache<Integer, Integer>) getCache();
+        int size = 10;
+        for (int i = 0; i < size; i++) {
+            cache.put(i, i);
+        }
+
+        Iterator<Cache.Entry<Integer, Integer>> iter = cache.iterator();
+        if (iter.hasNext()) {
+            iter.remove();
+        }
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/cache/CacheIteratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CacheIteratorTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.cache;
+
+import com.hazelcast.cache.impl.HazelcastServerCachingProvider;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import javax.cache.spi.CachingProvider;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class CacheIteratorTest extends AbstractCacheIteratorTest {
+
+    @Override
+    protected CachingProvider createCachingProvider() {
+        HazelcastInstance hazelcastInstance = createHazelcastInstance();
+        return HazelcastServerCachingProvider.createCachingProvider(hazelcastInstance);
+    }
+}


### PR DESCRIPTION
1) AtomicLong.alter response converted to void from Long.
2) JCache.managementConfig response converted to void from Data.
3) New response type CACHE_KEY_ITEREATOR_RESULT is introduced.
4) JCache.iterate response converted to CACHE_KEY_ITEREATOR_RESULT from Data.
5) Basic iterator test is implemented.
6) A couple null checks removed in cache proxy where it is already null checked or impossible
to be null.