### PR TITLE
Fixes #6020. 

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/AbstractCompletableFutureTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/AbstractCompletableFutureTest.java
@@ -10,19 +10,20 @@ import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
-import com.hazelcast.util.ExceptionUtil;
+import com.hazelcast.test.annotation.Repeat;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 
-import java.util.concurrent.ExecutionException;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import static com.hazelcast.spi.impl.AbstractCompletableFuture.ExecutionCallbackNode;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
@@ -36,12 +37,18 @@ import static org.mockito.Mockito.verifyZeroInteractions;
 @Category({QuickTest.class, ParallelTest.class})
 public class AbstractCompletableFutureTest extends HazelcastTestSupport {
 
-    private final static Object FAKE_GET_RESPONSE = "foobar";
+    private final static Object RESULT = "foobar";
+
+    private final static String EXCEPTION_MESSAGE = "You screwed buddy!";
+    private final static Exception EXCEPTION = new RuntimeException(EXCEPTION_MESSAGE);
 
     private HazelcastInstance hz;
     private ILogger logger;
     private NodeEngineImpl nodeEngine;
     private Executor executor;
+
+    @Rule
+    public ExpectedException expected = ExpectedException.none();
 
     @Before
     public void setup() {
@@ -51,16 +58,268 @@ public class AbstractCompletableFutureTest extends HazelcastTestSupport {
         executor = Executors.newFixedThreadPool(1);
     }
 
-    // ==================== setResult ===========================================
-
     @Test
-    public void setResult_whenPendingCallback() {
-        setResult_whenPendingCallback(null);
-        setResult_whenPendingCallback("foo");
-        setResult_whenPendingCallback(new Exception());
+    public void future_notExecuted_notDoneNotCancelled() throws Exception {
+        FutureImpl future = new FutureImpl(nodeEngine, logger);
+
+        assertFalse("New future should not be done", future.isDone());
+        assertFalse("New future should not be cancelled", future.isCancelled());
     }
 
-    public void setResult_whenPendingCallback(final Object result) {
+    @Test
+    public void future_notExecuted_callbackRegistered_notDoneNotCancelled() throws Exception {
+        FutureImpl future = new FutureImpl(nodeEngine, logger);
+        future.andThen(mock(ExecutionCallback.class));
+
+        assertFalse("New future should not be done", future.isDone());
+        assertFalse("New future should not be cancelled", future.isCancelled());
+    }
+
+    @Test
+    public void future_ordinaryResultSet_doneNotCancelled() throws Exception {
+        future_resultSet_doneNotCancelled(RESULT);
+    }
+
+    @Test
+    public void future_nullResultSet_doneNotCancelled() throws Exception {
+        future_resultSet_doneNotCancelled(null);
+    }
+
+    @Test
+    public void future_exceptionResultSet_doneNotCancelled() throws Exception {
+        future_resultSet_doneNotCancelled(EXCEPTION);
+    }
+
+    private void future_resultSet_doneNotCancelled(Object result) {
+        FutureImpl future = new FutureImpl(nodeEngine, logger);
+        future.setResult(result);
+
+        assertTrue("Future with result should be done", future.isDone());
+        assertFalse("Done future should not be cancelled", future.isCancelled());
+    }
+
+    @Test
+    public void future_resultNotSet_cancelled() throws Exception {
+        FutureImpl future = new FutureImpl(nodeEngine, logger);
+        boolean cancelled = future.cancel(false);
+
+        assertTrue(cancelled);
+        assertTrue("Cancelled future should be done", future.isDone());
+        assertTrue("Cancelled future should be cancelled", future.isCancelled());
+    }
+
+    @Test
+    public void future_resultSetAndCancelled() throws Exception {
+        FutureImpl future = new FutureImpl(nodeEngine, logger);
+        future.setResult(RESULT);
+        boolean cancelled = future.cancel(false);
+
+        assertFalse(cancelled);
+        assertTrue("Done future should be done", future.isDone());
+        assertFalse("Done future should not be cancelled even if cancelled executed", future.isCancelled());
+    }
+
+    @Test
+    public void future_cancelledAndResultSet() throws Exception {
+        FutureImpl future = new FutureImpl(nodeEngine, logger);
+        boolean cancelled = future.cancel(false);
+        future.setResult(RESULT);
+
+        assertTrue(cancelled);
+        assertTrue("Cancelled future should be done", future.isDone());
+        assertTrue("Cancelled future should be cancelled", future.isCancelled());
+        assertNull("Internal result should be null", future.getResult());
+    }
+
+    @Test(expected = CancellationException.class)
+    public void get_cancelledFuture_exceptionThrown() throws Exception {
+        FutureImpl future = new FutureImpl(nodeEngine, logger);
+
+        future.cancel(false);
+
+        future.get();
+    }
+
+    @Test(expected = CancellationException.class)
+    public void getWithTimeout_cancelledFuture_exceptionThrown() throws Exception {
+        FutureImpl future = new FutureImpl(nodeEngine, logger);
+
+        future.cancel(false);
+
+        future.get(10, TimeUnit.MILLISECONDS);
+    }
+
+    @Test
+    public void get_ordinaryResultSet_returnsResult() throws Exception {
+        FutureImpl future = new FutureImpl(nodeEngine, logger);
+        future.setResult(RESULT);
+
+        Object result = future.get();
+
+        assertSame(RESULT, result);
+    }
+
+    @Test
+    public void getWithTimeout_ordinaryResultSet_returnsResult() throws Exception {
+        FutureImpl future = new FutureImpl(nodeEngine, logger);
+        future.setResult(RESULT);
+
+        Object result = future.get(10, TimeUnit.MILLISECONDS);
+
+        assertSame(RESULT, result);
+    }
+
+    @Test
+    public void get_exceptionResultSet_exceptionThrown() throws Exception {
+        FutureImpl future = new FutureImpl(nodeEngine, logger);
+        future.setResult(EXCEPTION);
+
+        expected.expect(EXCEPTION.getClass());
+        expected.expectMessage(EXCEPTION_MESSAGE);
+
+        future.get();
+    }
+
+    @Test
+    public void getWithTimeout_exceptionResultSet_exceptionThrown_noTimeout() throws Exception {
+        FutureImpl future = new FutureImpl(nodeEngine, logger);
+        future.setResult(EXCEPTION);
+
+        expected.expect(EXCEPTION.getClass());
+        expected.expectMessage(EXCEPTION_MESSAGE);
+
+        future.get(1, TimeUnit.NANOSECONDS);
+    }
+
+    @Test
+    public void get_nullResultSet_returnsResult() throws Exception {
+        FutureImpl future = new FutureImpl(nodeEngine, logger);
+        future.setResult(null);
+
+        Object result = future.get();
+
+        assertNull(result);
+    }
+
+    @Test
+    public void getWithTimeout_nullResultSet_returnsResult() throws Exception {
+        FutureImpl future = new FutureImpl(nodeEngine, logger);
+        future.setResult(null);
+
+        Object result = future.get(10, TimeUnit.MILLISECONDS);
+
+        assertNull(result);
+    }
+
+    @Test(expected = TimeoutException.class, timeout = 120000)
+    @Repeat(10)
+    public void getWithTimeout_resultNotSet_timesOut() throws Exception {
+        FutureImpl future = new FutureImpl(nodeEngine, logger);
+
+        future.get(10, TimeUnit.MILLISECONDS);
+    }
+
+    @Test(expected = TimeoutException.class, timeout = 60000)
+    public void getWithTimeout_zeroTimeout_resultNotSet_timesOut() throws Exception {
+        FutureImpl future = new FutureImpl(nodeEngine, logger);
+
+        future.get(0, TimeUnit.MILLISECONDS);
+    }
+
+    @Test(expected = TimeoutException.class, timeout = 60000)
+    public void getWithTimeout_negativeTimeout_resultNotSet_timesOut() throws Exception {
+        FutureImpl future = new FutureImpl(nodeEngine, logger);
+
+        future.get(-1, TimeUnit.MILLISECONDS);
+    }
+
+    @Test(expected = TimeoutException.class, timeout = 60000)
+    public void getWithTimeout_lowerThanOneMilliTimeout_resultNotSet_timesOut() throws Exception {
+        FutureImpl future = new FutureImpl(nodeEngine, logger);
+
+        future.get(1, TimeUnit.NANOSECONDS);
+    }
+
+    @Test
+    public void getWithTimeout_threadInterrupted_exceptionThrown() throws Exception {
+        FutureImpl future = new FutureImpl(nodeEngine, logger);
+
+        Thread.currentThread().interrupt();
+
+        expected.expect(InterruptedException.class);
+        future.get(100, TimeUnit.MILLISECONDS);
+    }
+
+    @Test(timeout = 60000)
+    public void getWithTimeout_waited_notifiedOnSet() throws Exception {
+        FutureImpl future = new FutureImpl(nodeEngine, logger);
+
+        submitSetResultAfterTimeInMillis(future, RESULT, 200);
+        Object result = future.get(30000, TimeUnit.MILLISECONDS);
+
+        assertEquals(RESULT, result);
+    }
+
+    @Test(timeout = 60000)
+    public void getWithTimeout_waited_waited_notifiedOnCancel() throws Exception {
+        FutureImpl future = new FutureImpl(nodeEngine, logger);
+
+        submitCancelAfterTimeInMillis(future, 200);
+
+        expected.expect(CancellationException.class);
+        future.get(30000, TimeUnit.MILLISECONDS);
+    }
+
+    @Test
+    public void setResult_ordinaryResultSet_futureDone() throws Exception {
+        setResult_resultSet_futureDone(RESULT);
+    }
+
+    @Test
+    public void setResult_exceptionResultSet_futureDone() throws Exception {
+        setResult_resultSet_futureDone(EXCEPTION);
+    }
+
+    @Test
+    public void setResult_nullResultSet_futureDone() throws Exception {
+        setResult_resultSet_futureDone(null);
+    }
+
+    private void setResult_resultSet_futureDone(Object result) {
+        FutureImpl future = new FutureImpl(nodeEngine, logger);
+
+        future.setResult(result);
+
+        assertTrue("Future should be done after result has been set", future.isDone());
+    }
+
+    @Test
+    public void setResult_whenResultAlreadySet_secondResultDiscarded() throws Exception {
+        FutureImpl future = new FutureImpl(nodeEngine, logger);
+        Object initialResult = "firstresult", secondResult = "secondresult";
+
+        future.setResult(initialResult);
+        future.setResult(secondResult);
+
+        assertSame(initialResult, future.get());
+    }
+
+    @Test
+    public void setResult_whenPendingCallback_nullResult() {
+        setResult_whenPendingCallback_callbacksExecutedCorrectly(null);
+    }
+
+    @Test
+    public void setResult_whenPendingCallback_ordinaryResult() {
+        setResult_whenPendingCallback_callbacksExecutedCorrectly("foo");
+    }
+
+    @Test
+    public void setResult_whenPendingCallback_exceptionResult() {
+        setResult_whenPendingCallback_callbacksExecutedCorrectly(new Exception());
+    }
+
+    public void setResult_whenPendingCallback_callbacksExecutedCorrectly(final Object result) {
         FutureImpl future = new FutureImpl(nodeEngine, logger);
         final ExecutionCallback callback1 = mock(ExecutionCallback.class);
         final ExecutionCallback callback2 = mock(ExecutionCallback.class);
@@ -69,7 +328,6 @@ public class AbstractCompletableFutureTest extends HazelcastTestSupport {
 
         future.setResult(result);
 
-        assertSame(result, future.state);
         assertTrueEventually(new AssertTask() {
             @Override
             public void run() throws Exception {
@@ -80,7 +338,6 @@ public class AbstractCompletableFutureTest extends HazelcastTestSupport {
                 }
             }
         });
-
         assertTrueEventually(new AssertTask() {
             @Override
             public void run() throws Exception {
@@ -94,120 +351,105 @@ public class AbstractCompletableFutureTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void setResult_whenNoPendingCallback() {
-        setResult_whenNoPendingCallback(null);
-        setResult_whenNoPendingCallback("foo");
-    }
-
-    public void setResult_whenNoPendingCallback(Object result) {
-        FutureImpl future = new FutureImpl(nodeEngine, logger);
-
-        future.setResult(result);
-
-        assertSame(result, future.state);
-    }
-
-
-    @Test
-    public void setResult_whenResultAlreadySet() {
-        FutureImpl future = new FutureImpl(nodeEngine, logger);
-        Object initialResult = "firstresult";
-
-        future.setResult(initialResult);
-
-        future.setResult("secondresult");
-        assertSame(initialResult, future.state);
-    }
-
-    // ==================== get ===========================================
-
-    @Test
-    public void get() throws ExecutionException, InterruptedException {
-        FutureImpl future = new FutureImpl(nodeEngine, logger);
-
-        Object result = future.get();
-
-        assertSame(FAKE_GET_RESPONSE, result);
-        assertEquals(Long.MAX_VALUE, future.timeout);
-        assertEquals(TimeUnit.MILLISECONDS, future.unit);
-    }
-
-    @Test
-    public void get_whenTimeout() throws ExecutionException, InterruptedException {
-        FutureImpl future = new FutureImpl(nodeEngine, logger);
-        future.getException = new TimeoutException();
-        Object result = future.get();
-
-        assertNull(result);
-    }
-
-    // ==================== getResult ===========================================
-
-    @Test
-    public void getResult_whenInitialState() {
+    public void getResult_whenInitialState() throws Exception {
         FutureImpl future = new FutureImpl(nodeEngine, logger);
 
         Object result = future.getResult();
 
-        assertNull(result);
+        assertNull("Internal result should be null initially", result);
     }
 
     @Test
-    public void getResult_whenPendingCallback() {
+    public void getResult_whenPendingCallback() throws Exception {
         FutureImpl future = new FutureImpl(nodeEngine, logger);
         future.andThen(mock(ExecutionCallback.class));
 
         Object result = future.getResult();
 
-        assertNull(result);
+        assertNull("Internal result should be null initially", result);
     }
 
     @Test
-    public void getResult_whenNullResult() {
+    public void getResult_whenNullResult() throws Exception {
         FutureImpl future = new FutureImpl(nodeEngine, logger);
         future.setResult(null);
 
         Object result = future.getResult();
 
-        assertNull(result);
+        assertNull("Internal result should be null when set to null", result);
     }
 
-    @Test
-    public void getResult_whenNoneNullResult() {
-        FutureImpl future = new FutureImpl(nodeEngine, logger);
-        Object expectedResult = "result";
-        future.setResult(expectedResult);
-
-        Object result = future.getResult();
-
-        assertSame(expectedResult, result);
-    }
-
-    // ==================== andThen ===========================================
 
     @Test(expected = IllegalArgumentException.class)
-    public void andThen_whenNullCallback() {
+    public void andThen_whenNullCallback_exceptionThrown() {
         FutureImpl future = new FutureImpl(nodeEngine, logger);
         future.andThen(null, executor);
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void andThen_whenNullExecutor() {
+    public void andThen_whenNullExecutor_exceptionThrown() {
         FutureImpl future = new FutureImpl(nodeEngine, logger);
         future.andThen(mock(ExecutionCallback.class), null);
     }
 
     @Test
-    public void andThen_whenResultAvailable() {
+    public void andThen_whenInitialState() {
         FutureImpl future = new FutureImpl(nodeEngine, logger);
-        final Object result = "result";
-        future.setResult(result);
+        ExecutionCallback callback = mock(ExecutionCallback.class);
 
-        final ExecutionCallback callback = mock(ExecutionCallback.class);
         future.andThen(callback, executor);
 
-        assertSame(result, future.state);
+        verifyZeroInteractions(callback);
+    }
 
+    @Test
+    public void andThen_whenCancelled() {
+        FutureImpl future = new FutureImpl(nodeEngine, logger);
+        ExecutionCallback callback = mock(ExecutionCallback.class);
+
+        future.cancel(false);
+        future.andThen(callback, executor);
+
+        verifyZeroInteractions(callback);
+    }
+
+    @Test
+    public void andThen_whenPendingCallback() {
+        FutureImpl future = new FutureImpl(nodeEngine, logger);
+        ExecutionCallback callback1 = mock(ExecutionCallback.class);
+        ExecutionCallback callback2 = mock(ExecutionCallback.class);
+
+        future.andThen(callback1, executor);
+        future.andThen(callback2, executor);
+
+        verifyZeroInteractions(callback1);
+        verifyZeroInteractions(callback2);
+    }
+
+    @Test
+    public void andThen_whenPendingCallback_andCancelled() {
+        FutureImpl future = new FutureImpl(nodeEngine, logger);
+        ExecutionCallback callback1 = mock(ExecutionCallback.class);
+        ExecutionCallback callback2 = mock(ExecutionCallback.class);
+
+        future.andThen(callback1, executor);
+        future.cancel(false);
+        future.andThen(callback2, executor);
+
+        verifyZeroInteractions(callback1);
+        verifyZeroInteractions(callback2);
+    }
+
+    @Test
+    public void andThen_whenResultAvailable() throws Exception {
+        FutureImpl future = new FutureImpl(nodeEngine, logger);
+        final Object result = "result";
+        final ExecutionCallback callback = mock(ExecutionCallback.class);
+
+        future.setResult(result);
+        future.andThen(callback, executor);
+
+        assertSame(result, future.get());
         assertTrueEventually(new AssertTask() {
             @Override
             public void run() throws Exception {
@@ -216,112 +458,39 @@ public class AbstractCompletableFutureTest extends HazelcastTestSupport {
         });
     }
 
-    @Test
-    public void andThen_whenInitialState() {
-        FutureImpl future = new FutureImpl(nodeEngine, logger);
-
-        ExecutionCallback callback = mock(ExecutionCallback.class);
-        future.andThen(callback, executor);
-
-        ExecutionCallbackNode node = assertInstanceOf(ExecutionCallbackNode.class, future.state);
-        assertSame(node.callback, callback);
-        assertSame(node.executor, executor);
-        assertSame(node.next, AbstractCompletableFuture.INITIAL_STATE);
-        verifyZeroInteractions(callback);
+    private void submitCancelAfterTimeInMillis(final FutureImpl future, final int timeInMillis) {
+        submit(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    sleepMillis(timeInMillis);
+                } finally {
+                    future.cancel(false);
+                }
+            }
+        });
     }
 
-    @Test
-    public void andThen_whenPendingCallback() {
-        FutureImpl future = new FutureImpl(nodeEngine, logger);
-
-        ExecutionCallback callback1 = mock(ExecutionCallback.class);
-        future.andThen(callback1, executor);
-
-        ExecutionCallback callback2 = mock(ExecutionCallback.class);
-        future.andThen(callback2, executor);
-
-        ExecutionCallbackNode secondNode = assertInstanceOf(ExecutionCallbackNode.class, future.state);
-        assertSame(secondNode.callback, callback2);
-        assertSame(secondNode.executor, executor);
-
-        ExecutionCallbackNode firstNode = secondNode.next;
-        assertSame(firstNode.callback, callback1);
-        assertSame(firstNode.executor, executor);
-        assertSame(firstNode.next, AbstractCompletableFuture.INITIAL_STATE);
-
-        verifyZeroInteractions(callback1);
-        verifyZeroInteractions(callback2);
+    private void submitSetResultAfterTimeInMillis(final FutureImpl future, final Object result, final int timeInMillis) {
+        submit(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    sleepMillis(timeInMillis);
+                } finally {
+                    future.setResult(result);
+                }
+            }
+        });
     }
 
-    // ==================== isDone ===========================================
-
-    @Test
-    public void isDone_whenInitialState() {
-        FutureImpl future = new FutureImpl(nodeEngine, logger);
-
-        boolean result = future.isDone();
-
-        assertFalse(result);
+    private void submit(Runnable runnable) {
+        new Thread(runnable).start();
     }
 
-    @Test
-    public void isDone_whenCallbackRegistered() {
-        FutureImpl future = new FutureImpl(nodeEngine, logger);
-        future.andThen(mock(ExecutionCallback.class));
-
-        boolean result = future.isDone();
-
-        assertFalse(result);
-    }
-
-    @Test
-    public void isDone_whenNullResultSet() {
-        FutureImpl future = new FutureImpl(nodeEngine, logger);
-        future.setResult(null);
-
-        boolean result = future.isDone();
-
-        assertTrue(result);
-    }
-
-    @Test
-    public void isDone_whenNoneNullResultSet() {
-        FutureImpl future = new FutureImpl(nodeEngine, logger);
-        future.setResult("foo");
-
-        boolean result = future.isDone();
-
-        assertTrue(result);
-    }
-
-    class FutureImpl extends AbstractCompletableFuture {
-
-        private long timeout;
-        private TimeUnit unit;
-        private Exception getException;
-
+    private class FutureImpl extends AbstractCompletableFuture<Object> {
         protected FutureImpl(NodeEngine nodeEngine, ILogger logger) {
             super(nodeEngine, logger);
-        }
-
-        @Override
-        public boolean cancel(boolean mayInterruptIfRunning) {
-            return false;
-        }
-
-        @Override
-        public boolean isCancelled() {
-            return false;
-        }
-
-        @Override
-        public Object get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
-            this.timeout = timeout;
-            this.unit = unit;
-            if(getException!=null){
-                ExceptionUtil.sneakyThrow(getException);
-            }
-            return FAKE_GET_RESPONSE;
         }
     }
 }


### PR DESCRIPTION
Fix for #6020 

* As suggested by Peter the AbstractCompletableFuture class has been extended so that it may be a base class for all CompletableFuture classes - in this way we omit duplication in the execution of callbacks, which was a root cause of #6020. Some classes executed the callbacks correctly - some, like the CompletableFutureTask did not - now it's unified.
* Currently, AbstractCompletableFuture class handles the cancellation and get(timeout). It enables us to remove the `extends FutureTask` in the ComputableFutureTask. As a result we create less litter and do not track the state of the task in two classes at once. Earlier it was done by the  ComputableFutureTask and the base FutureTask; what is more it was not fully in sync either.
* This change was supposed to be minimalistic so no other changes has been done in the logic of the AbstractCompletableFuture class - apart from the things mentioned above. It may be a topic for future improvements. 
* There's some more classes that encompass the logic of callbacks' execution in the codebase (listed below). They could be refactored now, so that they extend the AbstractCompletableFuture - in this way we would omit even more duplication.
   * InvocationFuture
   * ClientInvocationFuture
   * CompletedFuture


 