### PR TITLE
Removed unnecessary CheckStyle suppressions for DataAwareMessage and TopicEvent

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -318,8 +318,6 @@
 
     <!-- Topic -->
     <suppress checks="VisibilityModifier" files="com/hazelcast/topic/impl/TopicEvent"/>
-    <suppress checks="" files="com/hazelcast/topic/DataAwareMessage"/>
-    <suppress checks="Todo" files="com/hazelcast/topic/impl/TopicEvent"/>
 
     <!-- Ascii -->
     <suppress checks="JavadocMethod" files="com/hazelcast/internal/ascii/"/>

--- a/hazelcast/src/main/java/com/hazelcast/topic/impl/DataAwareMessage.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/impl/DataAwareMessage.java
@@ -25,15 +25,15 @@ import java.io.IOException;
 import java.io.NotSerializableException;
 import java.io.ObjectOutputStream;
 
-public class DataAwareMessage extends Message {
+public class DataAwareMessage extends Message<Object> {
 
     private static final long serialVersionUID = 1;
 
     private final transient Data messageData;
     private final transient SerializationService serializationService;
 
-    public DataAwareMessage(String topicName, Data messageData, long publishTime,
-            Member publishingMember, SerializationService serializationService) {
+    public DataAwareMessage(String topicName, Data messageData, long publishTime, Member publishingMember,
+                            SerializationService serializationService) {
         super(topicName, null, publishTime, publishingMember);
         this.serializationService = serializationService;
         this.messageData = messageData;

--- a/hazelcast/src/main/java/com/hazelcast/topic/impl/TopicEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/impl/TopicEvent.java
@@ -36,9 +36,9 @@ public class TopicEvent implements IdentifiedDataSerializable {
     }
 
     public TopicEvent(String name, Data data, Address publisherAddress) {
-        publishTime = Clock.currentTimeMillis();
-        this.publisherAddress = publisherAddress;
         this.name = name;
+        this.publishTime = Clock.currentTimeMillis();
+        this.publisherAddress = publisherAddress;
         this.data = data;
     }
 


### PR DESCRIPTION
* Removed unnecessary CheckStyle suppressions of `DataAwareMessage` and `TopicEvent`.
* Removed simple warning in `DataAwareMessage`.
* Aligned assignment order in `TopicEvent` to field order (and remaning methods).