### PR TITLE
cleanup client proxies in new client

### DIFF
--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/proxy/ClientExecutorServiceProxy.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/proxy/ClientExecutorServiceProxy.java
@@ -85,14 +85,12 @@ public class ClientExecutorServiceProxy extends ClientProxy implements IExecutor
         }
     };
 
-    private final String name;
     private final Random random = new Random(-System.currentTimeMillis());
     private final AtomicInteger consecutiveSubmits = new AtomicInteger();
     private volatile long lastSubmitTime;
 
     public ClientExecutorServiceProxy(String serviceName, String objectId) {
         super(serviceName, objectId);
-        name = objectId;
     }
 
     // execute on members
@@ -481,7 +479,7 @@ public class ClientExecutorServiceProxy extends ClientProxy implements IExecutor
 
     @Override
     public String toString() {
-        return "IExecutorService{" + "name='" + getName() + '\'' + '}';
+        return "IExecutorService{" + "name='" + name + '\'' + '}';
     }
 
     private <T> Future<T> checkSync(ClientInvocationFuture f, String uuid, Address address,

--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/proxy/ClientIdGeneratorProxy.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/proxy/ClientIdGeneratorProxy.java
@@ -25,21 +25,15 @@ import java.util.concurrent.atomic.AtomicLong;
 
 public class ClientIdGeneratorProxy extends ClientProxy implements IdGenerator {
 
-
     private static final int BLOCK_SIZE = 10000;
 
-    final String name;
-
-    final IAtomicLong atomicLong;
-
-    AtomicInteger residue;
-
-    AtomicLong local;
+    private final IAtomicLong atomicLong;
+    private final AtomicInteger residue;
+    private final AtomicLong local;
 
     public ClientIdGeneratorProxy(String serviceName, String objectId, IAtomicLong atomicLong) {
         super(serviceName, objectId);
         this.atomicLong = atomicLong;
-        this.name = objectId;
         residue = new AtomicInteger(BLOCK_SIZE);
         local = new AtomicLong(-1);
     }
@@ -78,12 +72,10 @@ public class ClientIdGeneratorProxy extends ClientProxy implements IdGenerator {
 
     protected void onDestroy() {
         atomicLong.destroy();
-        residue = null;
-        local = null;
     }
 
     @Override
     public String toString() {
-        return "IdGenerator{" + "name='" + getName() + '\'' + '}';
+        return "IdGenerator{" + "name='" + name + '\'' + '}';
     }
 }

--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/proxy/ClientListProxy.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/proxy/ClientListProxy.java
@@ -42,7 +42,6 @@ import com.hazelcast.client.impl.protocol.codec.ListSetCodec;
 import com.hazelcast.client.impl.protocol.codec.ListSizeCodec;
 import com.hazelcast.client.impl.protocol.codec.ListSubCodec;
 import com.hazelcast.client.spi.ClientClusterService;
-import com.hazelcast.client.spi.ClientProxy;
 import com.hazelcast.client.spi.EventHandler;
 import com.hazelcast.client.spi.impl.ListenerRemoveCodec;
 import com.hazelcast.core.IList;
@@ -50,8 +49,8 @@ import com.hazelcast.core.ItemEvent;
 import com.hazelcast.core.ItemEventType;
 import com.hazelcast.core.ItemListener;
 import com.hazelcast.core.Member;
-import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.internal.serialization.SerializationService;
+import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.impl.UnmodifiableLazyList;
 
 import java.util.ArrayList;
@@ -62,16 +61,10 @@ import java.util.List;
 import java.util.ListIterator;
 import java.util.Set;
 
-/**
- * @author ali 5/20/13
- */
-public class ClientListProxy<E> extends ClientProxy implements IList<E> {
-
-    private final String name;
+public class ClientListProxy<E> extends PartitionSpecificClientProxy implements IList<E> {
 
     public ClientListProxy(String serviceName, String name) {
         super(serviceName, name);
-        this.name = name;
     }
 
     public boolean addAll(int index, Collection<? extends E> c) {
@@ -82,14 +75,14 @@ public class ClientListProxy<E> extends ClientProxy implements IList<E> {
             valueList.add(toData(e));
         }
         ClientMessage request = ListAddAllWithIndexCodec.encodeRequest(name, index, valueList);
-        ClientMessage response = invoke(request);
+        ClientMessage response = invokeOnPartition(request);
         ListAddAllWithIndexCodec.ResponseParameters resultParameters = ListAddAllWithIndexCodec.decodeResponse(response);
         return resultParameters.response;
     }
 
     public E get(int index) {
         ClientMessage request = ListGetCodec.encodeRequest(name, index);
-        ClientMessage response = invoke(request);
+        ClientMessage response = invokeOnPartition(request);
         ListGetCodec.ResponseParameters resultParameters = ListGetCodec.decodeResponse(response);
         return toObject(resultParameters.response);
     }
@@ -98,7 +91,7 @@ public class ClientListProxy<E> extends ClientProxy implements IList<E> {
         throwExceptionIfNull(element);
         final Data value = toData(element);
         ClientMessage request = ListSetCodec.encodeRequest(name, index, value);
-        ClientMessage response = invoke(request);
+        ClientMessage response = invokeOnPartition(request);
         ListSetCodec.ResponseParameters resultParameters = ListSetCodec.decodeResponse(response);
         return toObject(resultParameters.response);
     }
@@ -107,26 +100,26 @@ public class ClientListProxy<E> extends ClientProxy implements IList<E> {
         throwExceptionIfNull(element);
         final Data value = toData(element);
         ClientMessage request = ListAddWithIndexCodec.encodeRequest(name, index, value);
-        invoke(request);
+        invokeOnPartition(request);
     }
 
     public E remove(int index) {
         ClientMessage request = ListRemoveWithIndexCodec.encodeRequest(name, index);
-        ClientMessage response = invoke(request);
+        ClientMessage response = invokeOnPartition(request);
         ListRemoveWithIndexCodec.ResponseParameters resultParameters = ListRemoveWithIndexCodec.decodeResponse(response);
         return toObject(resultParameters.response);
     }
 
     public int size() {
         ClientMessage request = ListSizeCodec.encodeRequest(name);
-        ClientMessage response = invoke(request);
+        ClientMessage response = invokeOnPartition(request);
         ListSizeCodec.ResponseParameters resultParameters = ListSizeCodec.decodeResponse(response);
         return resultParameters.response;
     }
 
     public boolean isEmpty() {
         ClientMessage request = ListIsEmptyCodec.encodeRequest(name);
-        ClientMessage response = invoke(request);
+        ClientMessage response = invokeOnPartition(request);
         ListIsEmptyCodec.ResponseParameters resultParameters = ListIsEmptyCodec.decodeResponse(response);
         return resultParameters.response;
     }
@@ -135,14 +128,14 @@ public class ClientListProxy<E> extends ClientProxy implements IList<E> {
         throwExceptionIfNull(o);
         final Data value = toData(o);
         ClientMessage request = ListContainsCodec.encodeRequest(name, value);
-        ClientMessage response = invoke(request);
+        ClientMessage response = invokeOnPartition(request);
         ListContainsCodec.ResponseParameters resultParameters = ListContainsCodec.decodeResponse(response);
         return resultParameters.response;
     }
 
     public Iterator<E> iterator() {
         ClientMessage request = ListIteratorCodec.encodeRequest(name);
-        ClientMessage response = invoke(request);
+        ClientMessage response = invokeOnPartition(request);
         ListIteratorCodec.ResponseParameters resultParameters = ListIteratorCodec.decodeResponse(response);
         List<Data> resultCollection = (List<Data>) resultParameters.list;
         SerializationService serializationService = getContext().getSerializationService();
@@ -161,7 +154,7 @@ public class ClientListProxy<E> extends ClientProxy implements IList<E> {
         throwExceptionIfNull(e);
         final Data element = toData(e);
         ClientMessage request = ListAddCodec.encodeRequest(name, element);
-        ClientMessage response = invoke(request);
+        ClientMessage response = invokeOnPartition(request);
         ListAddCodec.ResponseParameters resultParameters = ListAddCodec.decodeResponse(response);
         return resultParameters.response;
     }
@@ -170,7 +163,7 @@ public class ClientListProxy<E> extends ClientProxy implements IList<E> {
         throwExceptionIfNull(o);
         final Data value = toData(o);
         ClientMessage request = ListRemoveCodec.encodeRequest(name, value);
-        ClientMessage response = invoke(request);
+        ClientMessage response = invokeOnPartition(request);
         ListRemoveCodec.ResponseParameters resultParameters = ListRemoveCodec.decodeResponse(response);
         return resultParameters.response;
     }
@@ -183,7 +176,7 @@ public class ClientListProxy<E> extends ClientProxy implements IList<E> {
             valueSet.add(toData(o));
         }
         ClientMessage request = ListContainsAllCodec.encodeRequest(name, valueSet);
-        ClientMessage response = invoke(request);
+        ClientMessage response = invokeOnPartition(request);
         ListContainsAllCodec.ResponseParameters resultParameters = ListContainsAllCodec.decodeResponse(response);
         return resultParameters.response;
     }
@@ -196,7 +189,7 @@ public class ClientListProxy<E> extends ClientProxy implements IList<E> {
             valueList.add(toData(e));
         }
         ClientMessage request = ListAddAllCodec.encodeRequest(name, valueList);
-        ClientMessage response = invoke(request);
+        ClientMessage response = invokeOnPartition(request);
         ListAddAllCodec.ResponseParameters resultParameters = ListAddAllCodec.decodeResponse(response);
         return resultParameters.response;
     }
@@ -209,7 +202,7 @@ public class ClientListProxy<E> extends ClientProxy implements IList<E> {
             valueSet.add(toData(o));
         }
         ClientMessage request = ListCompareAndRemoveAllCodec.encodeRequest(name, valueSet);
-        ClientMessage response = invoke(request);
+        ClientMessage response = invokeOnPartition(request);
         ListCompareAndRemoveAllCodec.ResponseParameters resultParameters = ListCompareAndRemoveAllCodec.decodeResponse(response);
         return resultParameters.response;
     }
@@ -222,14 +215,14 @@ public class ClientListProxy<E> extends ClientProxy implements IList<E> {
             valueSet.add(toData(o));
         }
         ClientMessage request = ListCompareAndRetainAllCodec.encodeRequest(name, valueSet);
-        ClientMessage response = invoke(request);
+        ClientMessage response = invokeOnPartition(request);
         ListCompareAndRetainAllCodec.ResponseParameters resultParameters = ListCompareAndRetainAllCodec.decodeResponse(response);
         return resultParameters.response;
     }
 
     public void clear() {
         ClientMessage request = ListClearCodec.encodeRequest(name);
-        invoke(request);
+        invokeOnPartition(request);
     }
 
     @Override
@@ -260,13 +253,9 @@ public class ClientListProxy<E> extends ClientProxy implements IList<E> {
         });
     }
 
-    protected <T> T invoke(ClientMessage req) {
-        return super.invoke(req, getPartitionKey());
-    }
-
     private Collection<E> getAll() {
         ClientMessage request = ListGetAllCodec.encodeRequest(name);
-        ClientMessage response = invoke(request);
+        ClientMessage response = invokeOnPartition(request);
         ListGetAllCodec.ResponseParameters resultParameters = ListGetAllCodec.decodeResponse(response);
         Collection<Data> resultCollection = resultParameters.list;
         final ArrayList<E> list = new ArrayList<E>(resultCollection.size());
@@ -280,7 +269,7 @@ public class ClientListProxy<E> extends ClientProxy implements IList<E> {
         throwExceptionIfNull(o);
         final Data value = toData(o);
         ClientMessage request = ListLastIndexOfCodec.encodeRequest(name, value);
-        ClientMessage response = invoke(request);
+        ClientMessage response = invokeOnPartition(request);
         ListLastIndexOfCodec.ResponseParameters resultParameters = ListLastIndexOfCodec.decodeResponse(response);
         return resultParameters.response;
     }
@@ -289,7 +278,7 @@ public class ClientListProxy<E> extends ClientProxy implements IList<E> {
         throwExceptionIfNull(o);
         final Data value = toData(o);
         ClientMessage request = ListIndexOfCodec.encodeRequest(name, value);
-        ClientMessage response = invoke(request);
+        ClientMessage response = invokeOnPartition(request);
         ListIndexOfCodec.ResponseParameters resultParameters = ListIndexOfCodec.decodeResponse(response);
         return resultParameters.response;
     }
@@ -300,25 +289,25 @@ public class ClientListProxy<E> extends ClientProxy implements IList<E> {
 
     public ListIterator<E> listIterator(int index) {
         ClientMessage request = ListListIteratorCodec.encodeRequest(name, index);
-        ClientMessage response = invoke(request);
+        ClientMessage response = invokeOnPartition(request);
         ListListIteratorCodec.ResponseParameters resultParameters = ListListIteratorCodec.decodeResponse(response);
-        List<Data> resultCollection = (List<Data>) resultParameters.list;
+        List<Data> resultCollection = resultParameters.list;
         SerializationService serializationService = getContext().getSerializationService();
         return new UnmodifiableLazyList<E>(resultCollection, serializationService).listIterator();
     }
 
     public List<E> subList(int fromIndex, int toIndex) {
         ClientMessage request = ListSubCodec.encodeRequest(name, fromIndex, toIndex);
-        ClientMessage response = invoke(request);
+        ClientMessage response = invokeOnPartition(request);
         ListSubCodec.ResponseParameters resultParameters = ListSubCodec.decodeResponse(response);
-        List<Data> resultCollection = (List<Data>) resultParameters.list;
+        List<Data> resultCollection = resultParameters.list;
         SerializationService serializationService = getContext().getSerializationService();
         return new UnmodifiableLazyList<E>(resultCollection, serializationService);
     }
 
     @Override
     public String toString() {
-        return "IList{" + "name='" + getName() + '\'' + '}';
+        return "IList{" + "name='" + name + '\'' + '}';
     }
 
     private class ItemEventHandler extends ListAddListenerCodec.AbstractEventHandler

--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
@@ -98,6 +98,7 @@ import com.hazelcast.core.IMap;
 import com.hazelcast.core.IMapEvent;
 import com.hazelcast.core.MapEvent;
 import com.hazelcast.core.Member;
+import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.map.EntryProcessor;
 import com.hazelcast.map.MapInterceptor;
@@ -120,7 +121,6 @@ import com.hazelcast.mapreduce.aggregation.Supplier;
 import com.hazelcast.monitor.LocalMapStats;
 import com.hazelcast.monitor.impl.LocalMapStatsImpl;
 import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.query.PagingPredicate;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.util.ExceptionUtil;
@@ -152,7 +152,6 @@ public class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V> {
     protected static final String NULL_KEY_IS_NOT_ALLOWED = "Null key is not allowed!";
     protected static final String NULL_VALUE_IS_NOT_ALLOWED = "Null value is not allowed!";
 
-    private final String name;
     private final AtomicBoolean nearCacheInitialized = new AtomicBoolean();
     private volatile ClientHeapNearCache<Data> nearCache;
 
@@ -176,7 +175,7 @@ public class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V> {
             return (T) MapRemoveAsyncCodec.decodeResponse(clientMessage).response;
         }
     };
-    
+
     private static final ClientMessageDecoder submitToKeyResponseDecoder = new ClientMessageDecoder() {
         @Override
         public <T> T decodeClientMessage(ClientMessage clientMessage) {
@@ -186,7 +185,6 @@ public class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V> {
 
     public ClientMapProxy(String serviceName, String name) {
         super(serviceName, name);
-        this.name = name;
     }
 
     @Override
@@ -1157,7 +1155,7 @@ public class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V> {
                                                     Aggregation<K, SuppliedValue, Result> aggregation) {
 
         HazelcastInstance hazelcastInstance = getContext().getHazelcastInstance();
-        JobTracker jobTracker = hazelcastInstance.getJobTracker("hz::aggregation-map-" + getName());
+        JobTracker jobTracker = hazelcastInstance.getJobTracker("hz::aggregation-map-" + name);
         return aggregate(supplier, aggregation, jobTracker);
     }
 
@@ -1354,7 +1352,7 @@ public class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V> {
 
     @Override
     public String toString() {
-        return "IMap{" + "name='" + getName() + '\'' + '}';
+        return "IMap{" + "name='" + name + '\'' + '}';
     }
 
     private class ClientMapEventHandler extends MapAddEntryListenerCodec.AbstractEventHandler

--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/proxy/ClientMapReduceProxy.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/proxy/ClientMapReduceProxy.java
@@ -91,7 +91,7 @@ public class ClientMapReduceProxy
 
     @Override
     public <K, V> Job<K, V> newJob(KeyValueSource<K, V> source) {
-        return new ClientJob<K, V>(getName(), source);
+        return new ClientJob<K, V>(name, source);
     }
 
     @Override
@@ -101,7 +101,7 @@ public class ClientMapReduceProxy
 
     @Override
     public String toString() {
-        return "JobTracker{" + "name='" + getName() + '\'' + '}';
+        return "JobTracker{" + "name='" + name + '\'' + '}';
     }
 
     private ClientMessage invoke(ClientMessage request, String jobId)
@@ -259,7 +259,7 @@ public class ClientMapReduceProxy
         @Override
         public boolean cancel(boolean mayInterruptIfRunning) {
             try {
-                ClientMessage request = MapReduceCancelCodec.encodeRequest(getName(), jobId);
+                ClientMessage request = MapReduceCancelCodec.encodeRequest(name, jobId);
                 ClientMessage response = invoke(request, jobId);
                 cancelled = MapReduceCancelCodec.decodeResponse(response).response;
             } catch (Exception ignore) {
@@ -310,7 +310,7 @@ public class ClientMapReduceProxy
 
         @Override
         public String getName() {
-            return ClientMapReduceProxy.this.getName();
+            return ClientMapReduceProxy.this.name;
         }
 
         @Override
@@ -326,7 +326,7 @@ public class ClientMapReduceProxy
         @Override
         public JobProcessInformation getJobProcessInformation() {
             try {
-                ClientMessage request = MapReduceJobProcessInformationCodec.encodeRequest(getName(), jobId);
+                ClientMessage request = MapReduceJobProcessInformationCodec.encodeRequest(name, jobId);
 
                 MapReduceJobProcessInformationCodec.ResponseParameters responseParameters = MapReduceJobProcessInformationCodec
                         .decodeResponse(invoke(request, jobId));

--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/proxy/ClientMultiMapProxy.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/proxy/ClientMultiMapProxy.java
@@ -91,11 +91,8 @@ public class ClientMultiMapProxy<K, V> extends ClientProxy implements MultiMap<K
     protected static final String NULL_KEY_IS_NOT_ALLOWED = "Null key is not allowed!";
     protected static final String NULL_VALUE_IS_NOT_ALLOWED = "Null value is not allowed!";
 
-    private final String name;
-
     public ClientMultiMapProxy(String serviceName, String name) {
         super(serviceName, name);
-        this.name = name;
     }
 
     public boolean put(K key, V value) {
@@ -380,7 +377,7 @@ public class ClientMultiMapProxy<K, V> extends ClientProxy implements MultiMap<K
                                                     Aggregation<K, SuppliedValue, Result> aggregation) {
 
         HazelcastInstance hazelcastInstance = getContext().getHazelcastInstance();
-        JobTracker jobTracker = hazelcastInstance.getJobTracker("hz::aggregation-multimap-" + getName());
+        JobTracker jobTracker = hazelcastInstance.getJobTracker("hz::aggregation-multimap-" + name);
         return aggregate(supplier, aggregation, jobTracker);
     }
 
@@ -427,7 +424,7 @@ public class ClientMultiMapProxy<K, V> extends ClientProxy implements MultiMap<K
 
     @Override
     public String toString() {
-        return "MultiMap{" + "name='" + getName() + '\'' + '}';
+        return "MultiMap{" + "name='" + name + '\'' + '}';
     }
 
     private class ClientMultiMapEventHandler extends MultiMapAddEntryListenerCodec.AbstractEventHandler

--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/proxy/ClientReplicatedMapProxy.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/proxy/ClientReplicatedMapProxy.java
@@ -101,7 +101,7 @@ public class ClientReplicatedMapProxy<K, V>
 
         Data valueData = toData(value);
         Data keyData = toData(key);
-        ClientMessage request = ReplicatedMapPutCodec.encodeRequest(getName(), keyData, valueData, timeUnit.toMillis(ttl));
+        ClientMessage request = ReplicatedMapPutCodec.encodeRequest(name, keyData, valueData, timeUnit.toMillis(ttl));
         ClientMessage response = invoke(request);
         ReplicatedMapPutCodec.ResponseParameters result = ReplicatedMapPutCodec.decodeResponse(response);
         return toObject(result.response);
@@ -110,7 +110,7 @@ public class ClientReplicatedMapProxy<K, V>
 
     @Override
     public int size() {
-        ClientMessage request = ReplicatedMapSizeCodec.encodeRequest(getName());
+        ClientMessage request = ReplicatedMapSizeCodec.encodeRequest(name);
         ClientMessage response = invoke(request);
         ReplicatedMapSizeCodec.ResponseParameters result = ReplicatedMapSizeCodec.decodeResponse(response);
         return result.response;
@@ -118,7 +118,7 @@ public class ClientReplicatedMapProxy<K, V>
 
     @Override
     public boolean isEmpty() {
-        ClientMessage request = ReplicatedMapIsEmptyCodec.encodeRequest(getName());
+        ClientMessage request = ReplicatedMapIsEmptyCodec.encodeRequest(name);
         ClientMessage response = invoke(request);
         ReplicatedMapIsEmptyCodec.ResponseParameters result = ReplicatedMapIsEmptyCodec.decodeResponse(response);
         return result.response;
@@ -128,7 +128,7 @@ public class ClientReplicatedMapProxy<K, V>
     public boolean containsKey(Object key) {
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
         Data keyData = toData(key);
-        ClientMessage request = ReplicatedMapContainsKeyCodec.encodeRequest(getName(), keyData);
+        ClientMessage request = ReplicatedMapContainsKeyCodec.encodeRequest(name, keyData);
         ClientMessage response = invoke(request);
         ReplicatedMapContainsKeyCodec.ResponseParameters result = ReplicatedMapContainsKeyCodec.decodeResponse(response);
         return result.response;
@@ -138,7 +138,7 @@ public class ClientReplicatedMapProxy<K, V>
     public boolean containsValue(Object value) {
         checkNotNull(value, NULL_KEY_IS_NOT_ALLOWED);
         Data valueData = toData(value);
-        ClientMessage request = ReplicatedMapContainsValueCodec.encodeRequest(getName(), valueData);
+        ClientMessage request = ReplicatedMapContainsValueCodec.encodeRequest(name, valueData);
         ClientMessage response = invoke(request);
         ReplicatedMapContainsValueCodec.ResponseParameters result = ReplicatedMapContainsValueCodec.decodeResponse(response);
         return result.response;
@@ -159,7 +159,7 @@ public class ClientReplicatedMapProxy<K, V>
         }
 
         Data keyData = toData(key);
-        ClientMessage request = ReplicatedMapGetCodec.encodeRequest(getName(), keyData);
+        ClientMessage request = ReplicatedMapGetCodec.encodeRequest(name, keyData);
         ClientMessage response = invoke(request);
 
         ReplicatedMapGetCodec.ResponseParameters result = ReplicatedMapGetCodec.decodeResponse(response);
@@ -180,7 +180,7 @@ public class ClientReplicatedMapProxy<K, V>
     public V remove(Object key) {
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
         Data keyData = toData(key);
-        ClientMessage request = ReplicatedMapRemoveCodec.encodeRequest(getName(), keyData);
+        ClientMessage request = ReplicatedMapRemoveCodec.encodeRequest(name, keyData);
         ClientMessage response = invoke(request);
         ReplicatedMapRemoveCodec.ResponseParameters result = ReplicatedMapRemoveCodec.decodeResponse(response);
         return toObject(result.response);
@@ -194,19 +194,18 @@ public class ClientReplicatedMapProxy<K, V>
             map.put(keyData, toData(entry.getValue()));
         }
 
-        ClientMessage request = ReplicatedMapPutAllCodec.encodeRequest(getName(), map);
+        ClientMessage request = ReplicatedMapPutAllCodec.encodeRequest(name, map);
         invoke(request);
     }
 
     @Override
     public void clear() {
-        ClientMessage request = ReplicatedMapClearCodec.encodeRequest(getName());
+        ClientMessage request = ReplicatedMapClearCodec.encodeRequest(name);
         invoke(request);
     }
 
     @Override
     public boolean removeEntryListener(String registrationId) {
-        final String name = getName();
         return stopListening(registrationId, new ListenerRemoveCodec() {
             @Override
             public ClientMessage encodeRequest(String realRegistrationId) {
@@ -222,7 +221,7 @@ public class ClientReplicatedMapProxy<K, V>
 
     @Override
     public String addEntryListener(EntryListener<K, V> listener) {
-        ClientMessage request = ReplicatedMapAddEntryListenerCodec.encodeRequest(getName());
+        ClientMessage request = ReplicatedMapAddEntryListenerCodec.encodeRequest(name);
         EventHandler<ClientMessage> handler = createHandler(listener);
         ClientMessageDecoder responseDecoder = new ClientMessageDecoder() {
             @Override
@@ -237,7 +236,7 @@ public class ClientReplicatedMapProxy<K, V>
     public String addEntryListener(EntryListener<K, V> listener, K key) {
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
         Data keyData = toData(key);
-        ClientMessage request = ReplicatedMapAddEntryListenerToKeyCodec.encodeRequest(getName(), keyData);
+        ClientMessage request = ReplicatedMapAddEntryListenerToKeyCodec.encodeRequest(name, keyData);
         EventHandler<ClientMessage> handler = createHandler(listener);
         ClientMessageDecoder responseDecoder = new ClientMessageDecoder() {
             @Override
@@ -251,7 +250,7 @@ public class ClientReplicatedMapProxy<K, V>
     @Override
     public String addEntryListener(EntryListener<K, V> listener, Predicate<K, V> predicate) {
         Data predicateData = toData(predicate);
-        ClientMessage request = ReplicatedMapAddEntryListenerWithPredicateCodec.encodeRequest(getName(), predicateData);
+        ClientMessage request = ReplicatedMapAddEntryListenerWithPredicateCodec.encodeRequest(name, predicateData);
         EventHandler<ClientMessage> handler = createHandler(listener);
         ClientMessageDecoder responseDecoder = new ClientMessageDecoder() {
             @Override
@@ -268,7 +267,7 @@ public class ClientReplicatedMapProxy<K, V>
         Data keyData = toData(key);
         Data predicateData = toData(predicate);
         ClientMessage request =
-                ReplicatedMapAddEntryListenerToKeyWithPredicateCodec.encodeRequest(getName(), keyData, predicateData);
+                ReplicatedMapAddEntryListenerToKeyWithPredicateCodec.encodeRequest(name, keyData, predicateData);
         EventHandler<ClientMessage> handler = createHandler(listener);
         ClientMessageDecoder responseDecoder = new ClientMessageDecoder() {
             @Override
@@ -281,7 +280,7 @@ public class ClientReplicatedMapProxy<K, V>
 
     @Override
     public Set<K> keySet() {
-        ClientMessage request = ReplicatedMapKeySetCodec.encodeRequest(getName());
+        ClientMessage request = ReplicatedMapKeySetCodec.encodeRequest(name);
         ClientMessage response = invoke(request);
         ReplicatedMapKeySetCodec.ResponseParameters result = ReplicatedMapKeySetCodec.decodeResponse(response);
         Set<K> resultSet = new HashSet<K>(result.set.size());
@@ -293,7 +292,7 @@ public class ClientReplicatedMapProxy<K, V>
 
     @Override
     public Collection<V> values() {
-        ClientMessage request = ReplicatedMapValuesCodec.encodeRequest(getName());
+        ClientMessage request = ReplicatedMapValuesCodec.encodeRequest(name);
         ClientMessage response = invoke(request);
         ReplicatedMapValuesCodec.ResponseParameters result = ReplicatedMapValuesCodec.decodeResponse(response);
         Collection<V> resultCollection = new ArrayList<V>(result.list.size());
@@ -312,7 +311,7 @@ public class ClientReplicatedMapProxy<K, V>
 
     @Override
     public Set<Entry<K, V>> entrySet() {
-        ClientMessage request = ReplicatedMapEntrySetCodec.encodeRequest(getName());
+        ClientMessage request = ReplicatedMapEntrySetCodec.encodeRequest(name);
         ClientMessage response = invoke(request);
         ReplicatedMapEntrySetCodec.ResponseParameters result = ReplicatedMapEntrySetCodec.decodeResponse(response);
         Set<Entry<K, V>> resultCollection = new HashSet<Entry<K, V>>(result.entrySet.size());
@@ -330,11 +329,11 @@ public class ClientReplicatedMapProxy<K, V>
 
     private void initNearCache() {
         if (nearCacheInitialized.compareAndSet(false, true)) {
-            final NearCacheConfig nearCacheConfig = getContext().getClientConfig().getNearCacheConfig(getName());
+            final NearCacheConfig nearCacheConfig = getContext().getClientConfig().getNearCacheConfig(name);
             if (nearCacheConfig == null) {
                 return;
             }
-            ClientHeapNearCache<Object> nearCache = new ClientHeapNearCache<Object>(getName(),
+            ClientHeapNearCache<Object> nearCache = new ClientHeapNearCache<Object>(name,
                     getContext(), nearCacheConfig);
             this.nearCache = nearCache;
             if (nearCache.isInvalidateOnChange()) {
@@ -345,7 +344,7 @@ public class ClientReplicatedMapProxy<K, V>
 
     private void addNearCacheInvalidateListener() {
         try {
-            ClientMessage request = ReplicatedMapAddNearCacheEntryListenerCodec.encodeRequest(getName(), false);
+            ClientMessage request = ReplicatedMapAddNearCacheEntryListenerCodec.encodeRequest(name, false);
             EventHandler handler = new ReplicatedMapAddNearCacheEventHandler();
             String registrationId = getContext().getListenerService().startListening(request, null, handler,
                     new ClientMessageDecoder() {
@@ -364,7 +363,6 @@ public class ClientReplicatedMapProxy<K, V>
     private void removeNearCacheInvalidationListener() {
         if (nearCache != null && nearCache.getId() != null) {
             String registrationId = nearCache.getId();
-            final String name = getName();
             getContext().getListenerService().stopListening(registrationId, new ListenerRemoveCodec() {
                 @Override
                 public ClientMessage encodeRequest(String realRegistrationId) {
@@ -381,7 +379,7 @@ public class ClientReplicatedMapProxy<K, V>
 
     @Override
     public String toString() {
-        return "ReplicatedMap{" + "name='" + getName() + '\'' + '}';
+        return "ReplicatedMap{" + "name='" + name + '\'' + '}';
     }
 
     private class ReplicatedMapEventHandler extends ReplicatedMapAddEntryListenerCodec.AbstractEventHandler
@@ -400,7 +398,7 @@ public class ClientReplicatedMapProxy<K, V>
             K key = toObject(keyData);
             Member member = getContext().getClusterService().getMember(uuid);
             EntryEventType eventType = EntryEventType.getByType(eventTypeId);
-            EntryEvent<K, V> entryEvent = new EntryEvent<K, V>(getName(), member, eventTypeId, key,
+            EntryEvent<K, V> entryEvent = new EntryEvent<K, V>(name, member, eventTypeId, key,
                     oldValue, value);
             switch (eventType) {
                 case ADDED:

--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/proxy/ClientRingbufferProxy.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/proxy/ClientRingbufferProxy.java
@@ -79,7 +79,7 @@ public class ClientRingbufferProxy<E> extends ClientProxy implements Ringbuffer<
 
     @Override
     protected void onInitialize() {
-        partitionId = getContext().getPartitionService().getPartitionId(getName());
+        partitionId = getContext().getPartitionService().getPartitionId(name);
         final SerializationService serializationService = getContext().getSerializationService();
 
         readManyAsyncResponseDecoder = new ClientMessageDecoder() {
@@ -98,7 +98,7 @@ public class ClientRingbufferProxy<E> extends ClientProxy implements Ringbuffer<
     @Override
     public long capacity() {
         if (capacity == -1) {
-            ClientMessage request = RingbufferCapacityCodec.encodeRequest(getName());
+            ClientMessage request = RingbufferCapacityCodec.encodeRequest(name);
             ClientMessage response = invoke(request, partitionId);
             RingbufferCapacityCodec.ResponseParameters resultParameters = RingbufferCapacityCodec.decodeResponse(response);
             capacity = resultParameters.response;
@@ -109,7 +109,7 @@ public class ClientRingbufferProxy<E> extends ClientProxy implements Ringbuffer<
 
     @Override
     public long size() {
-        ClientMessage request = RingbufferSizeCodec.encodeRequest(getName());
+        ClientMessage request = RingbufferSizeCodec.encodeRequest(name);
         ClientMessage response = invoke(request, partitionId);
         RingbufferSizeCodec.ResponseParameters resultParameters = RingbufferSizeCodec.decodeResponse(response);
         return resultParameters.response;
@@ -117,7 +117,7 @@ public class ClientRingbufferProxy<E> extends ClientProxy implements Ringbuffer<
 
     @Override
     public long tailSequence() {
-        ClientMessage request = RingbufferTailSequenceCodec.encodeRequest(getName());
+        ClientMessage request = RingbufferTailSequenceCodec.encodeRequest(name);
         ClientMessage response = invoke(request, partitionId);
         RingbufferTailSequenceCodec.ResponseParameters resultParameters = RingbufferTailSequenceCodec.decodeResponse(response);
         return resultParameters.response;
@@ -125,7 +125,7 @@ public class ClientRingbufferProxy<E> extends ClientProxy implements Ringbuffer<
 
     @Override
     public long headSequence() {
-        ClientMessage request = RingbufferHeadSequenceCodec.encodeRequest(getName());
+        ClientMessage request = RingbufferHeadSequenceCodec.encodeRequest(name);
         ClientMessage response = invoke(request, partitionId);
         RingbufferHeadSequenceCodec.ResponseParameters resultParameters = RingbufferHeadSequenceCodec.decodeResponse(response);
         return resultParameters.response;
@@ -133,7 +133,7 @@ public class ClientRingbufferProxy<E> extends ClientProxy implements Ringbuffer<
 
     @Override
     public long remainingCapacity() {
-        ClientMessage request = RingbufferRemainingCapacityCodec.encodeRequest(getName());
+        ClientMessage request = RingbufferRemainingCapacityCodec.encodeRequest(name);
         ClientMessage response = invoke(request, partitionId);
         RingbufferRemainingCapacityCodec.ResponseParameters resultParameters
                 = RingbufferRemainingCapacityCodec.decodeResponse(response);
@@ -145,7 +145,7 @@ public class ClientRingbufferProxy<E> extends ClientProxy implements Ringbuffer<
         checkNotNull(item, "item can't be null");
 
         Data element = toData(item);
-        ClientMessage request = RingbufferAddCodec.encodeRequest(getName(), OverflowPolicy.OVERWRITE.getId(), element);
+        ClientMessage request = RingbufferAddCodec.encodeRequest(name, OverflowPolicy.OVERWRITE.getId(), element);
         ClientMessage response = invoke(request, partitionId);
         RingbufferAddCodec.ResponseParameters resultParameters = RingbufferAddCodec.decodeResponse(response);
         return resultParameters.response;
@@ -157,7 +157,7 @@ public class ClientRingbufferProxy<E> extends ClientProxy implements Ringbuffer<
         checkNotNull(overflowPolicy, "overflowPolicy can't be null");
 
         Data element = toData(item);
-        ClientMessage request = RingbufferAddCodec.encodeRequest(getName(), overflowPolicy.getId(), element);
+        ClientMessage request = RingbufferAddCodec.encodeRequest(name, overflowPolicy.getId(), element);
         request.setPartitionId(partitionId);
 
         try {
@@ -175,7 +175,7 @@ public class ClientRingbufferProxy<E> extends ClientProxy implements Ringbuffer<
     public E readOne(long sequence) throws InterruptedException {
         checkSequence(sequence);
 
-        ClientMessage request = RingbufferReadOneCodec.encodeRequest(getName(), sequence);
+        ClientMessage request = RingbufferReadOneCodec.encodeRequest(name, sequence);
         ClientMessage response = invoke(request, partitionId);
         RingbufferReadOneCodec.ResponseParameters resultParameters = RingbufferReadOneCodec.decodeResponse(response);
         return toObject(resultParameters.response);
@@ -194,7 +194,7 @@ public class ClientRingbufferProxy<E> extends ClientProxy implements Ringbuffer<
             valueList.add(toData(e));
         }
 
-        ClientMessage request = RingbufferAddAllAsyncCodec.encodeRequest(getName(), valueList, overflowPolicy.getId());
+        ClientMessage request = RingbufferAddAllAsyncCodec.encodeRequest(name, valueList, overflowPolicy.getId());
         request.setPartitionId(partitionId);
 
         try {
@@ -219,7 +219,7 @@ public class ClientRingbufferProxy<E> extends ClientProxy implements Ringbuffer<
         checkTrue(maxCount <= MAX_BATCH_SIZE, "maxCount can't be larger than " + MAX_BATCH_SIZE);
 
         ClientMessage request = RingbufferReadManyAsyncCodec.encodeRequest(
-                getName(),
+                name,
                 startSequence,
                 minCount,
                 maxCount,

--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/proxy/PartitionSpecificClientProxy.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/proxy/PartitionSpecificClientProxy.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.proxy;
+
+import com.hazelcast.client.impl.protocol.ClientMessage;
+import com.hazelcast.client.spi.ClientProxy;
+
+/**
+ * Base class for proxies of distributed objects that lives in on partition.
+ */
+abstract class PartitionSpecificClientProxy extends ClientProxy {
+
+    private int partitionId;
+
+    protected PartitionSpecificClientProxy(String serviceName, String objectName) {
+        super(serviceName, objectName);
+    }
+
+    @Override
+    protected void onInitialize() {
+        partitionId = getContext().getPartitionService().getPartitionId(name);
+    }
+
+    protected ClientMessage invokeOnPartition(ClientMessage req) {
+        return invokeOnPartition(req, partitionId);
+    }
+
+    protected <T> T invokeOnPartitionInterruptibly(ClientMessage clientMessage) throws InterruptedException {
+        return invokeOnPartitionInterruptibly(clientMessage, partitionId);
+    }
+}

--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/proxy/txn/ClientTxnListProxy.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/proxy/txn/ClientTxnListProxy.java
@@ -39,7 +39,7 @@ public class ClientTxnListProxy<E> extends AbstractClientTxnCollectionProxy<E> i
     public boolean add(E e) {
         throwExceptionIfNull(e);
         final Data value = toData(e);
-        ClientMessage request = TransactionalListAddCodec.encodeRequest(getName(), getTransactionId()
+        ClientMessage request = TransactionalListAddCodec.encodeRequest(name, getTransactionId()
                 , ThreadUtil.getThreadId(), value);
         ClientMessage response = invoke(request);
         return TransactionalListAddCodec.decodeResponse(response).response;
@@ -48,14 +48,14 @@ public class ClientTxnListProxy<E> extends AbstractClientTxnCollectionProxy<E> i
     public boolean remove(E e) {
         throwExceptionIfNull(e);
         final Data value = toData(e);
-        ClientMessage request = TransactionalListRemoveCodec.encodeRequest(getName(), getTransactionId()
+        ClientMessage request = TransactionalListRemoveCodec.encodeRequest(name, getTransactionId()
                 , ThreadUtil.getThreadId(), value);
         ClientMessage response = invoke(request);
         return TransactionalListRemoveCodec.decodeResponse(response).response;
     }
 
     public int size() {
-        ClientMessage request = TransactionalListSizeCodec.encodeRequest(getName(), getTransactionId()
+        ClientMessage request = TransactionalListSizeCodec.encodeRequest(name, getTransactionId()
                 , ThreadUtil.getThreadId());
         ClientMessage response = invoke(request);
         return TransactionalListSizeCodec.decodeResponse(response).response;

--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/proxy/txn/ClientTxnMapProxy.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/proxy/txn/ClientTxnMapProxy.java
@@ -58,7 +58,7 @@ public class ClientTxnMapProxy<K, V> extends ClientTxnProxy implements Transacti
 
     @Override
     public boolean containsKey(Object key) {
-        ClientMessage request = TransactionalMapContainsKeyCodec.encodeRequest(getName(), getTransactionId(),
+        ClientMessage request = TransactionalMapContainsKeyCodec.encodeRequest(name, getTransactionId(),
                 ThreadUtil.getThreadId(), toData(key));
         ClientMessage response = invoke(request);
         return TransactionalMapContainsKeyCodec.decodeResponse(response).response;
@@ -66,7 +66,7 @@ public class ClientTxnMapProxy<K, V> extends ClientTxnProxy implements Transacti
 
     @Override
     public V get(Object key) {
-        ClientMessage request = TransactionalMapGetCodec.encodeRequest(getName(), getTransactionId(),
+        ClientMessage request = TransactionalMapGetCodec.encodeRequest(name, getTransactionId(),
                 ThreadUtil.getThreadId(), toData(key));
         ClientMessage response = invoke(request);
         return (V) toObject(TransactionalMapGetCodec.decodeResponse(response).response);
@@ -74,7 +74,7 @@ public class ClientTxnMapProxy<K, V> extends ClientTxnProxy implements Transacti
 
     @Override
     public V getForUpdate(Object key) {
-        ClientMessage request = TransactionalMapGetForUpdateCodec.encodeRequest(getName(), getTransactionId(),
+        ClientMessage request = TransactionalMapGetForUpdateCodec.encodeRequest(name, getTransactionId(),
                 ThreadUtil.getThreadId(), toData(key));
         ClientMessage response = invoke(request);
         return (V) toObject(TransactionalMapGetForUpdateCodec.decodeResponse(response).response);
@@ -82,7 +82,7 @@ public class ClientTxnMapProxy<K, V> extends ClientTxnProxy implements Transacti
 
     @Override
     public int size() {
-        ClientMessage request = TransactionalMapSizeCodec.encodeRequest(getName(), getTransactionId(),
+        ClientMessage request = TransactionalMapSizeCodec.encodeRequest(name, getTransactionId(),
                 ThreadUtil.getThreadId());
         ClientMessage response = invoke(request);
         return TransactionalMapSizeCodec.decodeResponse(response).response;
@@ -100,7 +100,7 @@ public class ClientTxnMapProxy<K, V> extends ClientTxnProxy implements Transacti
 
     @Override
     public V put(K key, V value, long ttl, TimeUnit timeunit) {
-        ClientMessage request = TransactionalMapPutCodec.encodeRequest(getName(), getTransactionId(),
+        ClientMessage request = TransactionalMapPutCodec.encodeRequest(name, getTransactionId(),
                 ThreadUtil.getThreadId(), toData(key), toData(value), timeunit.toMillis(ttl));
         ClientMessage response = invoke(request);
         return (V) toObject(TransactionalMapPutCodec.decodeResponse(response).response);
@@ -108,14 +108,14 @@ public class ClientTxnMapProxy<K, V> extends ClientTxnProxy implements Transacti
 
     @Override
     public void set(K key, V value) {
-        ClientMessage request = TransactionalMapSetCodec.encodeRequest(getName(), getTransactionId(),
+        ClientMessage request = TransactionalMapSetCodec.encodeRequest(name, getTransactionId(),
                 ThreadUtil.getThreadId(), toData(key), toData(value));
         invoke(request);
     }
 
     @Override
     public V putIfAbsent(K key, V value) {
-        ClientMessage request = TransactionalMapPutIfAbsentCodec.encodeRequest(getName(), getTransactionId(),
+        ClientMessage request = TransactionalMapPutIfAbsentCodec.encodeRequest(name, getTransactionId(),
                 ThreadUtil.getThreadId(), toData(key), toData(value));
         ClientMessage response = invoke(request);
         return (V) toObject(TransactionalMapPutIfAbsentCodec.decodeResponse(response).response);
@@ -123,7 +123,7 @@ public class ClientTxnMapProxy<K, V> extends ClientTxnProxy implements Transacti
 
     @Override
     public V replace(K key, V value) {
-        ClientMessage request = TransactionalMapReplaceCodec.encodeRequest(getName(), getTransactionId(),
+        ClientMessage request = TransactionalMapReplaceCodec.encodeRequest(name, getTransactionId(),
                 ThreadUtil.getThreadId(), toData(key), toData(value));
         ClientMessage response = invoke(request);
         return (V) toObject(TransactionalMapReplaceCodec.decodeResponse(response).response);
@@ -131,7 +131,7 @@ public class ClientTxnMapProxy<K, V> extends ClientTxnProxy implements Transacti
 
     @Override
     public boolean replace(K key, V oldValue, V newValue) {
-        ClientMessage request = TransactionalMapReplaceIfSameCodec.encodeRequest(getName(), getTransactionId(),
+        ClientMessage request = TransactionalMapReplaceIfSameCodec.encodeRequest(name, getTransactionId(),
                 ThreadUtil.getThreadId(), toData(key), toData(oldValue), toData(newValue));
         ClientMessage response = invoke(request);
         return TransactionalMapReplaceIfSameCodec.decodeResponse(response).response;
@@ -139,7 +139,7 @@ public class ClientTxnMapProxy<K, V> extends ClientTxnProxy implements Transacti
 
     @Override
     public V remove(Object key) {
-        ClientMessage request = TransactionalMapRemoveCodec.encodeRequest(getName(), getTransactionId(),
+        ClientMessage request = TransactionalMapRemoveCodec.encodeRequest(name, getTransactionId(),
                 ThreadUtil.getThreadId(), toData(key));
         ClientMessage response = invoke(request);
         return (V) toObject(TransactionalMapRemoveCodec.decodeResponse(response).response);
@@ -147,14 +147,14 @@ public class ClientTxnMapProxy<K, V> extends ClientTxnProxy implements Transacti
 
     @Override
     public void delete(Object key) {
-        ClientMessage request = TransactionalMapDeleteCodec.encodeRequest(getName(), getTransactionId(),
+        ClientMessage request = TransactionalMapDeleteCodec.encodeRequest(name, getTransactionId(),
                 ThreadUtil.getThreadId(), toData(key));
         invoke(request);
     }
 
     @Override
     public boolean remove(Object key, Object value) {
-        ClientMessage request = TransactionalMapRemoveIfSameCodec.encodeRequest(getName(), getTransactionId(),
+        ClientMessage request = TransactionalMapRemoveIfSameCodec.encodeRequest(name, getTransactionId(),
                 ThreadUtil.getThreadId(), toData(key), toData(value));
         ClientMessage response = invoke(request);
         return TransactionalMapRemoveIfSameCodec.decodeResponse(response).response;
@@ -163,7 +163,7 @@ public class ClientTxnMapProxy<K, V> extends ClientTxnProxy implements Transacti
     @Override
     @SuppressWarnings("unchecked")
     public Set<K> keySet() {
-        ClientMessage request = TransactionalMapKeySetCodec.encodeRequest(getName(), getTransactionId(),
+        ClientMessage request = TransactionalMapKeySetCodec.encodeRequest(name, getTransactionId(),
                 ThreadUtil.getThreadId());
         ClientMessage response = invoke(request);
         Collection<Data> dataKeySet = TransactionalMapKeySetCodec.decodeResponse(response).set;
@@ -180,7 +180,7 @@ public class ClientTxnMapProxy<K, V> extends ClientTxnProxy implements Transacti
         if (predicate == null) {
             throw new NullPointerException("Predicate should not be null!");
         }
-        ClientMessage request = TransactionalMapKeySetWithPredicateCodec.encodeRequest(getName(), getTransactionId(),
+        ClientMessage request = TransactionalMapKeySetWithPredicateCodec.encodeRequest(name, getTransactionId(),
                 ThreadUtil.getThreadId(), toData(predicate));
         ClientMessage response = invoke(request);
         Collection<Data> dataKeySet = TransactionalMapKeySetWithPredicateCodec.decodeResponse(response).set;
@@ -195,7 +195,7 @@ public class ClientTxnMapProxy<K, V> extends ClientTxnProxy implements Transacti
     @Override
     @SuppressWarnings("unchecked")
     public Collection<V> values() {
-        ClientMessage request = TransactionalMapValuesCodec.encodeRequest(getName(), getTransactionId(),
+        ClientMessage request = TransactionalMapValuesCodec.encodeRequest(name, getTransactionId(),
                 ThreadUtil.getThreadId());
         ClientMessage response = invoke(request);
         Collection<Data> dataValues = TransactionalMapValuesCodec.decodeResponse(response).list;
@@ -212,7 +212,7 @@ public class ClientTxnMapProxy<K, V> extends ClientTxnProxy implements Transacti
         if (predicate == null) {
             throw new NullPointerException("Predicate should not be null!");
         }
-        ClientMessage request = TransactionalMapValuesWithPredicateCodec.encodeRequest(getName(), getTransactionId(),
+        ClientMessage request = TransactionalMapValuesWithPredicateCodec.encodeRequest(name, getTransactionId(),
                 ThreadUtil.getThreadId(), toData(predicate));
         ClientMessage response = invoke(request);
         Collection<Data> dataValues = TransactionalMapValuesWithPredicateCodec.decodeResponse(response).list;

--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/proxy/txn/ClientTxnMultiMapProxy.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/proxy/txn/ClientTxnMultiMapProxy.java
@@ -45,14 +45,14 @@ public class ClientTxnMultiMapProxy<K, V>
             throws TransactionException {
 
         ClientMessage request = TransactionalMultiMapPutCodec
-                .encodeRequest(getName(), getTransactionId(), ThreadUtil.getThreadId(), toData(key), toData(value));
+                .encodeRequest(name, getTransactionId(), ThreadUtil.getThreadId(), toData(key), toData(value));
         ClientMessage response = invoke(request);
         return TransactionalMultiMapPutCodec.decodeResponse(response).response;
     }
 
     public Collection<V> get(K key) {
         ClientMessage request = TransactionalMultiMapGetCodec
-                .encodeRequest(getName(), getTransactionId(), ThreadUtil.getThreadId(), toData(key));
+                .encodeRequest(name, getTransactionId(), ThreadUtil.getThreadId(), toData(key));
 
         ClientMessage response = invoke(request);
         Collection<Data> collection = TransactionalMultiMapGetCodec.decodeResponse(response).list;
@@ -65,14 +65,14 @@ public class ClientTxnMultiMapProxy<K, V>
 
     public boolean remove(Object key, Object value) {
         ClientMessage request = TransactionalMultiMapRemoveEntryCodec
-                .encodeRequest(getName(), getTransactionId(), ThreadUtil.getThreadId(), toData(key), toData(value));
+                .encodeRequest(name, getTransactionId(), ThreadUtil.getThreadId(), toData(key), toData(value));
         ClientMessage response = invoke(request);
         return TransactionalMultiMapRemoveEntryCodec.decodeResponse(response).response;
     }
 
     public Collection<V> remove(Object key) {
         ClientMessage request = TransactionalMultiMapRemoveCodec
-                .encodeRequest(getName(), getTransactionId(), ThreadUtil.getThreadId(), toData(key));
+                .encodeRequest(name, getTransactionId(), ThreadUtil.getThreadId(), toData(key));
         ClientMessage response = invoke(request);
         Collection<Data> collection = TransactionalMultiMapRemoveCodec.decodeResponse(response).list;
         Collection<V> coll = new ArrayList<V>(collection.size());
@@ -84,14 +84,14 @@ public class ClientTxnMultiMapProxy<K, V>
 
     public int valueCount(K key) {
         ClientMessage request = TransactionalMultiMapValueCountCodec
-                .encodeRequest(getName(), getTransactionId(), ThreadUtil.getThreadId(), toData(key));
+                .encodeRequest(name, getTransactionId(), ThreadUtil.getThreadId(), toData(key));
         ClientMessage response = invoke(request);
         return TransactionalMultiMapValueCountCodec.decodeResponse(response).response;
     }
 
     public int size() {
         ClientMessage request = TransactionalMultiMapSizeCodec
-                .encodeRequest(getName(), getTransactionId(), ThreadUtil.getThreadId());
+                .encodeRequest(name, getTransactionId(), ThreadUtil.getThreadId());
         ClientMessage response = invoke(request);
         return TransactionalMultiMapSizeCodec.decodeResponse(response).response;
     }

--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/proxy/txn/ClientTxnProxy.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/proxy/txn/ClientTxnProxy.java
@@ -31,11 +31,11 @@ import java.util.concurrent.Future;
 
 abstract class ClientTxnProxy implements TransactionalObject {
 
-    final String objectName;
+    final String name;
     final ClientTransactionContext transactionContext;
 
-    ClientTxnProxy(String objectName, ClientTransactionContext transactionContext) {
-        this.objectName = objectName;
+    ClientTxnProxy(String name, ClientTransactionContext transactionContext) {
+        this.name = name;
         this.transactionContext = transactionContext;
     }
 
@@ -60,18 +60,18 @@ abstract class ClientTxnProxy implements TransactionalObject {
     @Override
     public final void destroy() {
         onDestroy();
-        ClientMessage request = ClientDestroyProxyCodec.encodeRequest(objectName, getServiceName());
+        ClientMessage request = ClientDestroyProxyCodec.encodeRequest(name, getServiceName());
         invoke(request);
     }
 
     @Override
     public String getName() {
-        return objectName;
+        return name;
     }
 
     @Override
     public String getPartitionKey() {
-        return StringPartitioningStrategy.getPartitionKey(getName());
+        return StringPartitioningStrategy.getPartitionKey(name);
     }
 
     Data toData(Object obj) {

--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/proxy/txn/ClientTxnQueueProxy.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/proxy/txn/ClientTxnQueueProxy.java
@@ -46,7 +46,7 @@ public class ClientTxnQueueProxy<E> extends ClientTxnProxy implements Transactio
 
     public boolean offer(E e, long timeout, TimeUnit unit) throws InterruptedException {
         final Data data = toData(e);
-        ClientMessage request = TransactionalQueueOfferCodec.encodeRequest(getName(), getTransactionId(),
+        ClientMessage request = TransactionalQueueOfferCodec.encodeRequest(name, getTransactionId(),
                 ThreadUtil.getThreadId(), data, unit.toMillis(timeout));
         ClientMessage response = invoke(request);
         return TransactionalQueueOfferCodec.decodeResponse(response).response;
@@ -54,7 +54,7 @@ public class ClientTxnQueueProxy<E> extends ClientTxnProxy implements Transactio
 
     @Override
     public E take() throws InterruptedException {
-        ClientMessage request = TransactionalQueueTakeCodec.encodeRequest(getName(), getTransactionId(),
+        ClientMessage request = TransactionalQueueTakeCodec.encodeRequest(name, getTransactionId(),
                 ThreadUtil.getThreadId());
         ClientMessage response = invoke(request);
         return (E) toObject(TransactionalQueueTakeCodec.decodeResponse(response).response);
@@ -69,7 +69,7 @@ public class ClientTxnQueueProxy<E> extends ClientTxnProxy implements Transactio
     }
 
     public E poll(long timeout, TimeUnit unit) throws InterruptedException {
-        ClientMessage request = TransactionalQueuePollCodec.encodeRequest(getName(), getTransactionId(),
+        ClientMessage request = TransactionalQueuePollCodec.encodeRequest(name, getTransactionId(),
                 ThreadUtil.getThreadId(), unit.toMillis(timeout));
         ClientMessage response = invoke(request);
         return (E) toObject(TransactionalQueuePollCodec.decodeResponse(response).response);
@@ -86,14 +86,14 @@ public class ClientTxnQueueProxy<E> extends ClientTxnProxy implements Transactio
 
     @Override
     public E peek(long timeout, TimeUnit unit) throws InterruptedException {
-        ClientMessage request = TransactionalQueuePeekCodec.encodeRequest(getName(), getTransactionId(),
+        ClientMessage request = TransactionalQueuePeekCodec.encodeRequest(name, getTransactionId(),
                 ThreadUtil.getThreadId(), unit.toMillis(timeout));
         ClientMessage response = invoke(request);
         return (E) toObject(TransactionalQueuePeekCodec.decodeResponse(response).response);
     }
 
     public int size() {
-        ClientMessage request = TransactionalQueueSizeCodec.encodeRequest(getName(), getTransactionId(),
+        ClientMessage request = TransactionalQueueSizeCodec.encodeRequest(name, getTransactionId(),
                 ThreadUtil.getThreadId());
         ClientMessage response = invoke(request);
         return TransactionalQueueSizeCodec.decodeResponse(response).response;

--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/proxy/txn/ClientTxnSetProxy.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/proxy/txn/ClientTxnSetProxy.java
@@ -35,7 +35,7 @@ public class ClientTxnSetProxy<E> extends AbstractClientTxnCollectionProxy<E> im
     public boolean add(E e) {
         throwExceptionIfNull(e);
         Data value = toData(e);
-        ClientMessage request = TransactionalSetAddCodec.encodeRequest(getName(), getTransactionId()
+        ClientMessage request = TransactionalSetAddCodec.encodeRequest(name, getTransactionId()
                 , ThreadUtil.getThreadId(), value);
         ClientMessage response = invoke(request);
         return TransactionalSetAddCodec.decodeResponse(response).response;
@@ -44,14 +44,14 @@ public class ClientTxnSetProxy<E> extends AbstractClientTxnCollectionProxy<E> im
     public boolean remove(E e) {
         throwExceptionIfNull(e);
         Data value = toData(e);
-        ClientMessage request = TransactionalSetRemoveCodec.encodeRequest(getName(), getTransactionId()
+        ClientMessage request = TransactionalSetRemoveCodec.encodeRequest(name, getTransactionId()
                 , ThreadUtil.getThreadId(), value);
         ClientMessage response = invoke(request);
         return TransactionalSetRemoveCodec.decodeResponse(response).response;
     }
 
     public int size() {
-        ClientMessage request = TransactionalSetSizeCodec.encodeRequest(getName(), getTransactionId()
+        ClientMessage request = TransactionalSetSizeCodec.encodeRequest(name, getTransactionId()
                 , ThreadUtil.getThreadId());
         ClientMessage response = invoke(request);
         return TransactionalSetSizeCodec.decodeResponse(response).response;


### PR DESCRIPTION
Removed references that is already stored in base class.
Partition id calculation done only once for distributed objects that is stored in one partition.

fixes #5848