### PR TITLE
[DONT-MERGE] ClientMapProxy should go direct to key owners

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -10,6 +10,7 @@
     <suppress checks="StrictDuplicateCode" files="\.java" lines="1-15"/>
 
     <!-- Suppress checking of copyright notice -->
+    <suppress checks="Header" files="com/hazelcast/buildutils/ElementParser"/>
     <suppress checks="Header" files="com/hazelcast/logging/Log4j2Factory\.java"/>
     <suppress checks="Header" files="/hazelcast-code-generator/"/>
 
@@ -249,9 +250,6 @@
     <suppress checks="VariableName" files="com/hazelcast/instance/GroupProperties"/>
     <suppress checks="MethodLength" files="com/hazelcast/instance/GroupProperties"/>
     <suppress checks="ExecutableStatementCount" files="com/hazelcast/instance/GroupProperties"/>
-    <!-- TODO: work in progress -->
-    <suppress checks="MethodLength|NestedIfDepth|NPathComplexity" files="com/hazelcast/instance/DefaultAddressPicker"/>
-    <suppress checks="" files="com/hazelcast/instance/HazelcastInstanceFactory"/>
     <suppress checks="" files="com/hazelcast/instance/Node"/>
 
     <!-- SPI -->
@@ -318,8 +316,6 @@
 
     <!-- Topic -->
     <suppress checks="VisibilityModifier" files="com/hazelcast/topic/impl/TopicEvent"/>
-    <suppress checks="" files="com/hazelcast/topic/DataAwareMessage"/>
-    <suppress checks="Todo" files="com/hazelcast/topic/impl/TopicEvent"/>
 
     <!-- Ascii -->
     <suppress checks="JavadocMethod" files="com/hazelcast/internal/ascii/"/>
@@ -480,9 +476,6 @@
     as explained at http://creativecommons/org/licenses/publicdomain -->
     <suppress checks="MagicNumber|FileLength|DeclarationOrder|RedundantModifier|InnerAssignment|NPath|Cyclomatic"
               files="com/hazelcast/util/ConcurrentReferenceHashMap"/>
-
-    <!-- Build Utils (taken from JBOSS project) -->
-    <suppress checks="" files="com/hazelcast/buildutils/ElementParser"/>
 
     <!-- Exclude Clover instrumented sources -->
     <suppress checks="" files="/src-instrumented/"/>

--- a/hazelcast-build-utils/src/test/java/com/hazelcast/buildutils/ExportPackageViewer.java
+++ b/hazelcast-build-utils/src/test/java/com/hazelcast/buildutils/ExportPackageViewer.java
@@ -28,11 +28,9 @@ import java.util.Set;
 
 public class ExportPackageViewer {
 
-    public static void main(String[] args)
-            throws Exception {
-
-        String sourcefile = args[0];
-        File file = new File(sourcefile);
+    public static void main(String[] args) throws Exception {
+        String sourceFile = args[0];
+        File file = new File(sourceFile);
         FileReader fileReader = new FileReader(file);
 
         BufferedReader reader = new LineNumberReader(fileReader);
@@ -45,7 +43,6 @@ public class ExportPackageViewer {
             if (usesIndex != -1) {
                 entry = entry.substring(0, usesIndex);
             }
-
             packages.add(entry);
         }
 
@@ -56,5 +53,4 @@ public class ExportPackageViewer {
             System.out.println(p);
         }
     }
-
 }

--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
@@ -79,6 +79,7 @@ import com.hazelcast.client.impl.protocol.codec.MapValuesWithPredicateCodec;
 import com.hazelcast.client.nearcache.ClientHeapNearCache;
 import com.hazelcast.client.nearcache.ClientNearCache;
 import com.hazelcast.client.spi.ClientListenerService;
+import com.hazelcast.client.spi.ClientPartitionService;
 import com.hazelcast.client.spi.ClientProxy;
 import com.hazelcast.client.spi.EventHandler;
 import com.hazelcast.client.spi.impl.ClientInvocation;
@@ -136,9 +137,11 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.Map.Entry;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -1233,15 +1236,46 @@ public class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V> {
 
     @Override
     public void putAll(Map<? extends K, ? extends V> m) {
-        Map<Data, Data> map = new HashMap<Data, Data>();
+        ClientPartitionService partitionService = getContext().getPartitionService();
+        Map<Integer, Map<Data, Data>> entryMap = new HashMap<Integer, Map<Data, Data>>(partitionService.getPartitionCount());
+        
         for (Entry<? extends K, ? extends V> entry : m.entrySet()) {
+            checkNotNull(entry.getKey(), NULL_KEY_IS_NOT_ALLOWED);
+            checkNotNull(entry.getValue(), NULL_VALUE_IS_NOT_ALLOWED);
+            
             final Data keyData = toData(entry.getKey());
             invalidateNearCache(keyData);
-            map.put(keyData, toData(entry.getValue()));
+            
+            int partitionId = partitionService.getPartitionId(entry.getKey());
+            if (!entryMap.containsKey(partitionId)) {
+                entryMap.put(partitionId, new HashMap<Data, Data>());
+            }
+            
+            entryMap.get(partitionId).put(keyData, toData(entry.getValue()));
+        }
+        
+        List<Future<?>> futures = new ArrayList<Future<?>>(entryMap.size());
+        for (final Map.Entry<Integer, Map<Data, Data>> entry : entryMap.entrySet()) {
+            final Integer partitionId = entry.getKey();
+            //If there is only one entry, consider how we can use MapPutRequest without
+            //having to get back the return value.
+            ClientMessage request = MapPutAllCodec.encodeRequest(name, entry.getValue());
+            
+            //invoke by partition owner address rather than id, as
+            //the latter will embed the partitionId into the Packet payload,
+            //routing the invocation to the operation service, which does 
+            //not handle MapPutAllRequest and other similar requests
+            futures.add(new ClientInvocation(getClient(), request, partitionService.getPartitionOwner(partitionId)).invoke());
         }
 
-        ClientMessage request = MapPutAllCodec.encodeRequest(name, map);
-        invoke(request);
+        try {
+            for (Future<?> future : futures) {
+                future.get();
+            }
+        } catch (Exception e) {
+            ExceptionUtil.rethrow(e);
+        }
+        
     }
 
     @Override

--- a/hazelcast-client-new/src/test/java/com/hazelcast/client/map/ClientMapTest.java
+++ b/hazelcast-client-new/src/test/java/com/hazelcast/client/map/ClientMapTest.java
@@ -226,6 +226,20 @@ public class ClientMapTest {
     }
 
     @Test
+    public void testPutAllWithTooManyEntries() {
+        final IMap map = createMap();
+        Map mm = new HashMap();
+        for (int i = 0; i < 1000; i++) {
+            mm.put(i, i);
+        }
+        map.putAll(mm);
+        assertEquals(map.size(), 1000);
+        for (int i = 0; i < 1000; i++) {
+            assertEquals(map.get(i), i);
+        }
+    }
+    
+    @Test
     public void testAsyncGet() throws Exception {
         final IMap map = createMap();
         fillMap(map);

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
@@ -20,6 +20,7 @@ import com.hazelcast.client.impl.client.BaseClientRemoveListenerRequest;
 import com.hazelcast.client.impl.client.ClientRequest;
 import com.hazelcast.client.nearcache.ClientHeapNearCache;
 import com.hazelcast.client.nearcache.ClientNearCache;
+import com.hazelcast.client.spi.ClientPartitionService;
 import com.hazelcast.client.spi.ClientProxy;
 import com.hazelcast.client.spi.EventHandler;
 import com.hazelcast.client.spi.impl.ClientInvocation;
@@ -123,6 +124,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -1036,14 +1038,50 @@ public class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V> {
 
     @Override
     public void putAll(Map<? extends K, ? extends V> m) {
-        MapEntrySet entrySet = new MapEntrySet();
+        ClientPartitionService partitionService = getContext().getPartitionService();
+        int partitionCount = partitionService.getPartitionCount();
+        List<Future<?>> futures = new ArrayList<Future<?>>(partitionCount);
+        MapEntrySet[] entrySetPerPartition = new MapEntrySet[partitionCount];
+        
         for (Entry<? extends K, ? extends V> entry : m.entrySet()) {
+            checkNotNull(entry.getKey(), NULL_KEY_IS_NOT_ALLOWED);
+            checkNotNull(entry.getValue(), NULL_VALUE_IS_NOT_ALLOWED);
+            
             final Data keyData = toData(entry.getKey());
             invalidateNearCache(keyData);
+            
+            int partitionId = partitionService.getPartitionId(entry.getKey());
+            MapEntrySet entrySet = entrySetPerPartition[partitionId];
+            if (entrySet == null) {
+                entrySet = new MapEntrySet();
+                entrySetPerPartition[partitionId] = entrySet;
+            }
+            
             entrySet.add(new AbstractMap.SimpleImmutableEntry<Data, Data>(keyData, toData(entry.getValue())));
         }
-        MapPutAllRequest request = new MapPutAllRequest(name, entrySet);
-        invoke(request);
+        
+        for (int partitionId = 0; partitionId < entrySetPerPartition.length; partitionId++) {
+            MapEntrySet entrySet = entrySetPerPartition[partitionId];
+            if (entrySet != null) {
+                //If there is only one entry, consider how we can use MapPutRequest without
+                //having to get back the return value.
+                MapPutAllRequest request = new MapPutAllRequest(name, entrySet);
+                
+                //invoke by partition owner address rather than id, as
+                //the latter will embed the partitionId into the Packet payload,
+                //routing the invocation to the operation service, which does 
+                //not handle MapPutAllRequest and other similar requests
+                futures.add(new ClientInvocation(getClient(), request, partitionService.getPartitionOwner(partitionId)).invoke());
+            }
+        }
+
+        try {
+            for (Future<?> future : futures) {
+                future.get();
+            }
+        } catch (Exception e) {
+            ExceptionUtil.rethrow(e);
+        }
     }
 
     @Override

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapTest.java
@@ -226,6 +226,20 @@ public class ClientMapTest {
     }
 
     @Test
+    public void testPutAllWithTooManyEntries() {
+        final IMap map = createMap();
+        Map mm = new HashMap();
+        for (int i = 0; i < 1000; i++) {
+            mm.put(i, i);
+        }
+        map.putAll(mm);
+        assertEquals(map.size(), 1000);
+        for (int i = 0; i < 1000; i++) {
+            assertEquals(map.get(i), i);
+        }
+    }
+    
+    @Test
     public void testAsyncGet() throws Exception {
         final IMap map = createMap();
         fillMap(map);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/ClientMessage.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/ClientMessage.java
@@ -327,12 +327,12 @@ public class ClientMessage
     }
 
     @Override
-    public boolean writeTo(ByteBuffer destination) {
+    public boolean writeTo(ByteBuffer dst) {
         byte[] byteArray = buffer.byteArray();
         int size = getFrameLength();
 
         // the number of bytes that can be written to the bb.
-        int bytesWritable = destination.remaining();
+        int bytesWritable = dst.remaining();
 
         // the number of bytes that need to be written.
         int bytesNeeded = size - writeOffset;
@@ -349,7 +349,7 @@ public class ClientMessage
             done = false;
         }
 
-        destination.put(byteArray, writeOffset, bytesWrite);
+        dst.put(byteArray, writeOffset, bytesWrite);
         writeOffset += bytesWrite;
 
         if (done) {
@@ -359,12 +359,12 @@ public class ClientMessage
         return done;
     }
 
-    public boolean readFrom(ByteBuffer source) {
+    public boolean readFrom(ByteBuffer src) {
         if (index() == 0) {
-            initFrameSize(source);
+            initFrameSize(src);
         }
-        while (index() >= Bits.INT_SIZE_IN_BYTES && source.hasRemaining() && !isComplete()) {
-            accumulate(source, getFrameLength() - index());
+        while (index() >= Bits.INT_SIZE_IN_BYTES && src.hasRemaining() && !isComplete()) {
+            accumulate(src, getFrameLength() - index());
         }
         return isComplete();
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheIterateMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheIterateMessageTask.java
@@ -23,7 +23,10 @@ import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.CacheIterateCodec;
 import com.hazelcast.instance.Node;
 import com.hazelcast.nio.Connection;
+import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.Operation;
+
+import java.util.Collections;
 
 /**
  * This client request  specifically calls {@link CacheKeyIteratorOperation} on the server side.
@@ -50,8 +53,11 @@ public class CacheIterateMessageTask
 
     @Override
     protected ClientMessage encodeResponse(Object response) {
-        CacheKeyIteratorResult cacheKeyIteratorResult = (CacheKeyIteratorResult) response;
-        return CacheIterateCodec.encodeResponse(cacheKeyIteratorResult.getTableIndex(), cacheKeyIteratorResult.getKeys());
+        if (response == null) {
+            return CacheIterateCodec.encodeResponse(0, Collections.<Data>emptyList());
+        }
+        CacheKeyIteratorResult keyIteratorResult = (CacheKeyIteratorResult) response;
+        return CacheIterateCodec.encodeResponse(keyIteratorResult.getTableIndex(), keyIteratorResult.getKeys());
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/NoOpCommand.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/NoOpCommand.java
@@ -28,13 +28,13 @@ public class NoOpCommand extends AbstractTextCommand {
         this.response = ByteBuffer.wrap(response);
     }
 
-    public boolean readFrom(ByteBuffer cb) {
+    public boolean readFrom(ByteBuffer src) {
         return true;
     }
 
-    public boolean writeTo(ByteBuffer bb) {
-        while (bb.hasRemaining() && response.hasRemaining()) {
-            bb.put(response.get());
+    public boolean writeTo(ByteBuffer dst) {
+        while (dst.hasRemaining() && response.hasRemaining()) {
+            dst.put(response.get());
         }
         return !response.hasRemaining();
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/TextCommandServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/TextCommandServiceImpl.java
@@ -394,12 +394,12 @@ public class TextCommandServiceImpl implements TextCommandService {
                 try {
                     blockingQueue.offer(new AbstractTextCommand(TextCommandConstants.TextCommandType.STOP) {
                         @Override
-                        public boolean readFrom(ByteBuffer cb) {
+                        public boolean readFrom(ByteBuffer src) {
                             return true;
                         }
 
                         @Override
-                        public boolean writeTo(ByteBuffer bb) {
+                        public boolean writeTo(ByteBuffer dst) {
                             return true;
                         }
                     });

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/DeleteCommand.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/DeleteCommand.java
@@ -34,7 +34,7 @@ public class DeleteCommand extends AbstractTextCommand {
         this.noreply = noreply;
     }
 
-    public boolean readFrom(ByteBuffer cb) {
+    public boolean readFrom(ByteBuffer src) {
         return true;
     }
 
@@ -42,12 +42,12 @@ public class DeleteCommand extends AbstractTextCommand {
         this.response = ByteBuffer.wrap(value);
     }
 
-    public boolean writeTo(ByteBuffer bb) {
+    public boolean writeTo(ByteBuffer dst) {
         if (response == null) {
             response = ByteBuffer.wrap(TextCommandConstants.STORED);
         }
-        while (bb.hasRemaining() && response.hasRemaining()) {
-            bb.put(response.get());
+        while (dst.hasRemaining() && response.hasRemaining()) {
+            dst.put(response.get());
         }
         return !response.hasRemaining();
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/ErrorCommand.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/ErrorCommand.java
@@ -56,12 +56,12 @@ public class ErrorCommand extends AbstractTextCommand {
         response.flip();
     }
 
-    public boolean readFrom(ByteBuffer cb) {
+    public boolean readFrom(ByteBuffer src) {
         return true;
     }
 
-    public boolean writeTo(ByteBuffer bb) {
-        IOUtil.copyToHeapBuffer(response, bb);
+    public boolean writeTo(ByteBuffer dst) {
+        IOUtil.copyToHeapBuffer(response, dst);
         return !response.hasRemaining();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/GetCommand.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/GetCommand.java
@@ -40,7 +40,7 @@ public class GetCommand extends AbstractTextCommand {
         return key;
     }
 
-    public boolean readFrom(ByteBuffer cb) {
+    public boolean readFrom(ByteBuffer src) {
         return true;
     }
 
@@ -51,12 +51,12 @@ public class GetCommand extends AbstractTextCommand {
         lastOne = (singleGet) ? ByteBuffer.wrap(TextCommandConstants.END) : null;
     }
 
-    public boolean writeTo(ByteBuffer bb) {
+    public boolean writeTo(ByteBuffer dst) {
         if (value != null) {
-            IOUtil.copyToHeapBuffer(value, bb);
+            IOUtil.copyToHeapBuffer(value, dst);
         }
         if (lastOne != null) {
-            IOUtil.copyToHeapBuffer(lastOne, bb);
+            IOUtil.copyToHeapBuffer(lastOne, dst);
         }
         return !((value != null && value.hasRemaining())
                 || (lastOne != null && lastOne.hasRemaining()));

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/IncrementCommand.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/IncrementCommand.java
@@ -40,14 +40,14 @@ public class IncrementCommand extends AbstractTextCommand {
         this.noreply = noReply;
     }
 
-    public boolean writeTo(ByteBuffer destination) {
-        while (destination.hasRemaining() && response.hasRemaining()) {
-            destination.put(response.get());
+    public boolean writeTo(ByteBuffer dst) {
+        while (dst.hasRemaining() && response.hasRemaining()) {
+            dst.put(response.get());
         }
         return !response.hasRemaining();
     }
 
-    public boolean readFrom(ByteBuffer source) {
+    public boolean readFrom(ByteBuffer src) {
         return true;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/SetCommand.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/SetCommand.java
@@ -42,11 +42,11 @@ public class SetCommand extends AbstractTextCommand {
         bbValue = ByteBuffer.allocate(valueLen);
     }
 
-    public boolean readFrom(ByteBuffer cb) {
-        copy(cb);
+    public boolean readFrom(ByteBuffer src) {
+        copy(src);
         if (!bbValue.hasRemaining()) {
-            while (cb.hasRemaining()) {
-                char c = (char) cb.get();
+            while (src.hasRemaining()) {
+                char c = (char) src.get();
                 if (c == '\n') {
                     bbValue.flip();
                     return true;
@@ -72,12 +72,12 @@ public class SetCommand extends AbstractTextCommand {
         this.response = ByteBuffer.wrap(value);
     }
 
-    public boolean writeTo(ByteBuffer bb) {
+    public boolean writeTo(ByteBuffer dst) {
         if (response == null) {
             response = ByteBuffer.wrap(TextCommandConstants.STORED);
         }
-        while (bb.hasRemaining() && response.hasRemaining()) {
-            bb.put(response.get());
+        while (dst.hasRemaining() && response.hasRemaining()) {
+            dst.put(response.get());
         }
         return !response.hasRemaining();
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/SimpleCommand.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/SimpleCommand.java
@@ -28,7 +28,7 @@ public class SimpleCommand extends AbstractTextCommand {
         super(type);
     }
 
-    public boolean readFrom(ByteBuffer cb) {
+    public boolean readFrom(ByteBuffer src) {
         return true;
     }
 
@@ -36,9 +36,9 @@ public class SimpleCommand extends AbstractTextCommand {
         this.response = ByteBuffer.wrap(value);
     }
 
-    public boolean writeTo(ByteBuffer bb) {
-        while (bb.hasRemaining() && response.hasRemaining()) {
-            bb.put(response.get());
+    public boolean writeTo(ByteBuffer dst) {
+        while (dst.hasRemaining() && response.hasRemaining()) {
+            dst.put(response.get());
         }
         return !response.hasRemaining();
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/StatsCommand.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/StatsCommand.java
@@ -53,7 +53,7 @@ public class StatsCommand extends AbstractTextCommand {
         super(TextCommandConstants.TextCommandType.STATS);
     }
 
-    public boolean readFrom(ByteBuffer cb) {
+    public boolean readFrom(ByteBuffer src) {
         return true;
     }
 
@@ -94,11 +94,11 @@ public class StatsCommand extends AbstractTextCommand {
         response.put(TextCommandConstants.RETURN);
     }
 
-    public boolean writeTo(ByteBuffer bb) {
+    public boolean writeTo(ByteBuffer dst) {
         if (response == null) {
             response = ByteBuffer.allocate(0);
         }
-        IOUtil.copyToHeapBuffer(response, bb);
+        IOUtil.copyToHeapBuffer(response, dst);
         return !response.hasRemaining();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/TouchCommand.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/TouchCommand.java
@@ -40,17 +40,17 @@ public class TouchCommand extends AbstractTextCommand {
         this.noreply = noReply;
     }
 
-    public boolean writeTo(ByteBuffer destination) {
+    public boolean writeTo(ByteBuffer dst) {
         if (response == null) {
             response = ByteBuffer.wrap(TextCommandConstants.STORED);
         }
-        while (destination.hasRemaining() && response.hasRemaining()) {
-            destination.put(response.get());
+        while (dst.hasRemaining() && response.hasRemaining()) {
+            dst.put(response.get());
         }
         return !response.hasRemaining();
     }
 
-    public boolean readFrom(ByteBuffer source) {
+    public boolean readFrom(ByteBuffer src) {
         return true;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/VersionCommand.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/VersionCommand.java
@@ -31,12 +31,12 @@ public class VersionCommand extends AbstractTextCommand {
         super(type);
     }
 
-    public boolean writeTo(ByteBuffer destination) {
-        destination.put(VERSION);
+    public boolean writeTo(ByteBuffer dst) {
+        dst.put(VERSION);
         return true;
     }
 
-    public boolean readFrom(ByteBuffer source) {
+    public boolean readFrom(ByteBuffer src) {
         return true;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpCommand.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpCommand.java
@@ -118,8 +118,8 @@ public abstract class HttpCommand extends AbstractTextCommand {
         response.flip();
     }
 
-    public boolean writeTo(ByteBuffer bb) {
-        IOUtil.copyToHeapBuffer(response, bb);
+    public boolean writeTo(ByteBuffer dst) {
+        IOUtil.copyToHeapBuffer(response, dst);
         return !response.hasRemaining();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpDeleteCommand.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpDeleteCommand.java
@@ -27,9 +27,9 @@ public class HttpDeleteCommand extends HttpCommand {
         super(TextCommandConstants.TextCommandType.HTTP_DELETE, uri);
     }
 
-    public boolean readFrom(ByteBuffer cb) {
-        while (cb.hasRemaining()) {
-            char c = (char) cb.get();
+    public boolean readFrom(ByteBuffer src) {
+        while (src.hasRemaining()) {
+            char c = (char) src.get();
             if (c == '\n') {
                 if (nextLine) {
                     return true;

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpGetCommand.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpGetCommand.java
@@ -27,9 +27,9 @@ public class HttpGetCommand extends HttpCommand {
         super(TextCommandConstants.TextCommandType.HTTP_GET, uri);
     }
 
-    public boolean readFrom(ByteBuffer cb) {
-        while (cb.hasRemaining()) {
-            char c = (char) cb.get();
+    public boolean readFrom(ByteBuffer src) {
+        while (src.hasRemaining()) {
+            char c = (char) src.get();
             if (c == '\n') {
                 if (nextLine) {
                     return true;

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpPostCommand.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpPostCommand.java
@@ -54,13 +54,13 @@ public class HttpPostCommand extends HttpCommand {
      * byte[45]
      * <next_line>
      *
-     * @param cb
+     * @param src
      * @return
      */
-    public boolean readFrom(ByteBuffer cb) {
-        boolean complete = doActualRead(cb);
-        while (!complete && readyToReadData && chunked && cb.hasRemaining()) {
-            complete = doActualRead(cb);
+    public boolean readFrom(ByteBuffer src) {
+        boolean complete = doActualRead(src);
+        while (!complete && readyToReadData && chunked && src.hasRemaining()) {
+            complete = doActualRead(src);
         }
         if (complete) {
             if (data != null) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
@@ -483,6 +483,8 @@ abstract class MapProxySupport extends AbstractDistributedObject<MapService> imp
         return result;
     }
 
+    //warning: When UpdateEvent is fired it does *NOT* contain oldValue.
+    //see this: https://github.com/hazelcast/hazelcast/pull/6088#issuecomment-136025968
     protected void setInternal(final Data key, final Data value, final long ttl, final TimeUnit timeunit) {
         SetOperation operation = new SetOperation(name, key, value, timeunit.toMillis(ttl));
         invokeOperation(key, operation);

--- a/hazelcast/src/main/java/com/hazelcast/nio/IOUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/IOUtil.java
@@ -115,63 +115,63 @@ public final class IOUtil {
         };
     }
 
-    public static OutputStream newOutputStream(final ByteBuffer buf) {
+    public static OutputStream newOutputStream(final ByteBuffer dst) {
         return new OutputStream() {
             public void write(int b) throws IOException {
-                buf.put((byte) b);
+                dst.put((byte) b);
             }
 
             public void write(byte[] bytes, int off, int len) throws IOException {
-                buf.put(bytes, off, len);
+                dst.put(bytes, off, len);
             }
         };
     }
 
-    public static InputStream newInputStream(final ByteBuffer buf) {
+    public static InputStream newInputStream(final ByteBuffer src) {
         return new InputStream() {
             public int read() throws IOException {
-                if (!buf.hasRemaining()) {
+                if (!src.hasRemaining()) {
                     return -1;
                 }
-                return buf.get() & 0xff;
+                return src.get() & 0xff;
             }
 
             public int read(byte[] bytes, int off, int len) throws IOException {
-                if (!buf.hasRemaining()) {
+                if (!src.hasRemaining()) {
                     return -1;
                 }
-                len = Math.min(len, buf.remaining());
-                buf.get(bytes, off, len);
+                len = Math.min(len, src.remaining());
+                src.get(bytes, off, len);
                 return len;
             }
         };
     }
 
-    public static int copyToHeapBuffer(ByteBuffer src, ByteBuffer dest) {
+    public static int copyToHeapBuffer(ByteBuffer src, ByteBuffer dst) {
         if (src == null) {
             return 0;
         }
-        int n = Math.min(src.remaining(), dest.remaining());
+        int n = Math.min(src.remaining(), dst.remaining());
         if (n > 0) {
             if (n < 16) {
                 for (int i = 0; i < n; i++) {
-                    dest.put(src.get());
+                    dst.put(src.get());
                 }
             } else {
                 int srcPosition = src.position();
-                int destPosition = dest.position();
-                System.arraycopy(src.array(), srcPosition, dest.array(), destPosition, n);
+                int destPosition = dst.position();
+                System.arraycopy(src.array(), srcPosition, dst.array(), destPosition, n);
                 src.position(srcPosition + n);
-                dest.position(destPosition + n);
+                dst.position(destPosition + n);
             }
         }
         return n;
     }
 
-    public static int copyToDirectBuffer(ByteBuffer src, ByteBuffer dest) {
-        int n = Math.min(src.remaining(), dest.remaining());
+    public static int copyToDirectBuffer(ByteBuffer src, ByteBuffer dst) {
+        int n = Math.min(src.remaining(), dst.remaining());
         if (n > 0) {
-            dest.put(src.array(), src.position(), n);
+            dst.put(src.array(), src.position(), n);
             src.position(src.position() + n);
         }
         return n;

--- a/hazelcast/src/main/java/com/hazelcast/nio/SocketReadable.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/SocketReadable.java
@@ -19,9 +19,24 @@ package com.hazelcast.nio;
 import java.nio.ByteBuffer;
 
 /**
- * Represents something where data can be read from.
+ * Represents a data-structure that can reconstruct itself based on the content of a byte-buffer.
+ *
+ * @see SocketWritable
+ * @see Packet
  */
 public interface SocketReadable {
 
-    boolean readFrom(ByteBuffer source);
+    /**
+     * Reads from the src.
+     *
+     * As long as the readFrom returns false, this SocketReadable is not yet finished. E.g. it could be the SocketReadable
+     * requires 1 MB of data, but if 100KB ByteBuffer is passed, 10 calls readFrom calls are needed, where the first 9 return
+     * false and the 10th returns true.
+     *
+     * It is up to the SocketReadable to keep track of where it is in the reading process.
+     *
+     * @param src the ByteBuffer to read from.
+     * @return true if the object has been fully read and no more readFrom calls are needed.
+     */
+    boolean readFrom(ByteBuffer src);
 }

--- a/hazelcast/src/main/java/com/hazelcast/nio/SocketWritable.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/SocketWritable.java
@@ -21,19 +21,26 @@ import java.nio.ByteBuffer;
 /**
  * Represents something that can be written to a {@link com.hazelcast.nio.Connection}.
  *
- * todo:
- * Perhaps this class should be renamed to ConnectionWritable since it is written to a
- * {@link com.hazelcast.nio.Connection#write(SocketWritable)}. This aligns the names.
+ * @see SocketReadable
+ * @see com.hazelcast.nio.serialization.Data
+ * @see Connection#write(SocketWritable)
  */
 public interface SocketWritable {
 
     /**
      * Asks the SocketWritable to write its content to the destination ByteBuffer.
      *
-     * @param destination the ByteBuffer to write to.
-     * @return todo: unclear what return value means.
+     * As long as the writeTo returns false, this SocketWritable is not yet finished. E.g. it could be the SocketWritable
+     * contains 1 MB of data, but if 100KB ByteBuffer is passed, 10 calls writeTo calls are needed, where the first 9 return
+     * false and the 10th returns true.
+     *
+     * It is up to the SocketWritable to keep track of where it is in the writing process. For this reason a SocketWritable
+     * can't be shared by multiple threads.
+     *
+     * @param dst the ByteBuffer to write to.
+     * @return true if the object is fully written.
      */
-    boolean writeTo(ByteBuffer destination);
+    boolean writeTo(ByteBuffer dst);
 
     /**
      * Checks if this SocketWritable is urgent.

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/DefaultSocketChannelWrapper.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/DefaultSocketChannelWrapper.java
@@ -65,8 +65,8 @@ public class DefaultSocketChannelWrapper implements SocketChannelWrapper {
     }
 
     @Override
-    public SelectableChannel configureBlocking(boolean b) throws IOException {
-        return socketChannel.configureBlocking(b);
+    public SelectableChannel configureBlocking(boolean block) throws IOException {
+        return socketChannel.configureBlocking(block);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/SocketChannelWrapper.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/SocketChannelWrapper.java
@@ -19,38 +19,80 @@ package com.hazelcast.nio.tcp;
 import java.io.Closeable;
 import java.io.IOException;
 import java.net.Socket;
+
 import java.nio.ByteBuffer;
 import java.nio.channels.ClosedChannelException;
 import java.nio.channels.SelectableChannel;
 import java.nio.channels.SelectionKey;
 import java.nio.channels.Selector;
+import java.nio.channels.SocketChannel;
 
+/**
+ * Wraps a {@link java.nio.channels.SocketChannel}.
+ *
+ * The reason this class exists is because for enterprise encryption. Ideally the SocketChannel should have been decorated
+ * with this encryption functionality, but unfortunately that isn't possible with this class.
+ *
+ * That is why a new 'wrapper' interface is introduced which acts like a SocketChannel and the implementations wrap a
+ * SocketChannel.
+ */
 public interface SocketChannelWrapper extends Closeable {
 
+    /**
+     * @see java.nio.channels.SocketChannel#isOpen()
+     */
     boolean isBlocking();
 
+    /**
+     * @see java.nio.channels.SocketChannel#socket()
+     */
     Socket socket();
 
+    /**
+     * @see SocketChannel#isConnected() ()
+     */
     boolean isConnected();
 
+    /**
+     * @see java.nio.channels.SocketChannel#connect(java.net.SocketAddress)
+     */
     boolean connect(java.net.SocketAddress socketAddress) throws IOException;
 
+    /**
+     * @see java.nio.channels.SocketChannel#keyFor(Selector)
+     */
     SelectionKey keyFor(Selector selector);
 
+    /**
+     * @see java.nio.channels.SocketChannel#register(Selector, int, Object)
+     */
     SelectionKey register(Selector selector, int ops, Object attachment) throws ClosedChannelException;
 
+    /**
+     * @see java.nio.channels.SocketChannel#read(ByteBuffer)
+     */
     int read(ByteBuffer dst) throws IOException;
 
+    /**
+     * @see java.nio.channels.SocketChannel#write(ByteBuffer)
+     */
     int write(ByteBuffer src) throws IOException;
 
-    SelectableChannel configureBlocking(boolean b) throws IOException;
+    /**
+     * @see java.nio.channels.SocketChannel#configureBlocking(boolean)
+     */
+    SelectableChannel configureBlocking(boolean block) throws IOException;
 
+    /**
+     * @see java.nio.channels.SocketChannel#isOpen()
+     */
     boolean isOpen();
 
     /**
      * Closes inbound.
      *
      * <p>Not thread safe. Should be called in channel reader thread.</p>
+     *
      * @throws IOException
      */
     void closeInbound() throws IOException;
@@ -59,14 +101,13 @@ public interface SocketChannelWrapper extends Closeable {
      * Closes outbound.
      *
      * <p>Not thread safe. Should be called in channel writer thread.</p>
+     *
      * @throws IOException
      */
     void closeOutbound() throws IOException;
 
     /**
-     * Closes socket channel.
-     *
-     * @throws IOException
+     * @see java.nio.channels.SocketChannel#close()
      */
     void close() throws IOException;
 }

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/SocketChannelWrapperFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/SocketChannelWrapperFactory.java
@@ -18,6 +18,9 @@ package com.hazelcast.nio.tcp;
 
 import java.nio.channels.SocketChannel;
 
+/**
+ * A factory for creating {@link SocketChannelWrapper} instances.
+ */
 public interface SocketChannelWrapperFactory {
 
     SocketChannelWrapper wrapSocketChannel(SocketChannel socketChannel, boolean client) throws Exception;

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/NonBlockingWriteHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/NonBlockingWriteHandler.java
@@ -462,7 +462,7 @@ public final class NonBlockingWriteHandler extends AbstractSelectionHandler impl
         abstract void run();
 
         @Override
-        public boolean writeTo(ByteBuffer destination) {
+        public boolean writeTo(ByteBuffer dst) {
             throw new UnsupportedOperationException();
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/spinning/SpinningWriteHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/spinning/SpinningWriteHandler.java
@@ -315,7 +315,7 @@ public class SpinningWriteHandler extends AbstractHandler implements WriteHandle
         abstract void run();
 
         @Override
-        public boolean writeTo(ByteBuffer destination) {
+        public boolean writeTo(ByteBuffer dst) {
             throw new UnsupportedOperationException();
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/topic/impl/DataAwareMessage.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/impl/DataAwareMessage.java
@@ -25,15 +25,15 @@ import java.io.IOException;
 import java.io.NotSerializableException;
 import java.io.ObjectOutputStream;
 
-public class DataAwareMessage extends Message {
+public class DataAwareMessage extends Message<Object> {
 
     private static final long serialVersionUID = 1;
 
     private final transient Data messageData;
     private final transient SerializationService serializationService;
 
-    public DataAwareMessage(String topicName, Data messageData, long publishTime,
-            Member publishingMember, SerializationService serializationService) {
+    public DataAwareMessage(String topicName, Data messageData, long publishTime, Member publishingMember,
+                            SerializationService serializationService) {
         super(topicName, null, publishTime, publishingMember);
         this.serializationService = serializationService;
         this.messageData = messageData;

--- a/hazelcast/src/main/java/com/hazelcast/topic/impl/TopicEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/impl/TopicEvent.java
@@ -36,9 +36,9 @@ public class TopicEvent implements IdentifiedDataSerializable {
     }
 
     public TopicEvent(String name, Data data, Address publisherAddress) {
-        publishTime = Clock.currentTimeMillis();
-        this.publisherAddress = publisherAddress;
         this.name = name;
+        this.publishTime = Clock.currentTimeMillis();
+        this.publisherAddress = publisherAddress;
         this.data = data;
     }
 


### PR DESCRIPTION
Port code from MapProxySupport so that MapPutAllRequests are sent
directly to key owners rather than mediated by a randomly chosen member
of the cluster

Implements part of #6083 

DO NOT MERGE - This PR currently breaks behaviour in that events relating to putAll operations will no longer fire since set instead of put is being called. This will be replaced by something else pending the acceptance of #6093