### PR TITLE
MapProxySupport.putAllInternal: use setInternal instead of putInternal

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
@@ -862,7 +862,7 @@ abstract class MapProxySupport extends AbstractDistributedObject<MapService> imp
                     checkNotNull(entry.getKey(), NULL_KEY_IS_NOT_ALLOWED);
                     checkNotNull(entry.getValue(), NULL_VALUE_IS_NOT_ALLOWED);
 
-                    putInternal(mapService.getMapServiceContext().toData(entry.getKey(), partitionStrategy),
+                    setInternal(mapService.getMapServiceContext().toData(entry.getKey(), partitionStrategy),
                             mapService.getMapServiceContext().toData(entry.getValue()),
                             -1,
                             TimeUnit.MILLISECONDS);


### PR DESCRIPTION
setInternal has a void return type, which fits the return type of
putAllInternal, and avoids retrieving the previous value mapped to the key that putInternal does

Partially implements #6083 