### PR TITLE
Reader/Handler rename in IO

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -369,7 +369,7 @@
     <suppress checks="MethodCount" files="com/hazelcast/nio/Bits"/>
     <suppress checks="ExecutableStatementCount|ClassDataAbstractionCoupling|ClassFanOutComplexity"
               files="com/hazelcast/nio/tcp/TcpIpConnectionManager"/>
-    <suppress checks="NPathComplexity" files="com/hazelcast/nio/tcp/spinning/SpinningReadHandler"/>
+    <suppress checks="NPathComplexity" files="com/hazelcast/nio/tcp/spinning/SpinningSocketReader"/>
     <suppress checks="MethodCount|MagicNumber" files="com/hazelcast/internal/serialization/impl/ByteArrayObjectDataInput"/>
     <suppress checks="MethodCount|MagicNumber" files="com/hazelcast/internal/serialization/impl/ByteArrayObjectDataOutput"/>
     <suppress checks="MethodCount|MagicNumber" files="com/hazelcast/internal/serialization/impl/ByteBufferObjectDataInput"/>
@@ -385,7 +385,7 @@
     <suppress checks="ReturnCount" files="com/hazelcast/internal/serialization/impl/MorphingPortableReader"/>
     <suppress checks="MethodCount" files="com/hazelcast/nio/NodeIOService"/>
     <suppress checks="MagicNumber|ReturnCount|MethodCount|NPathComplexity" files="com/hazelcast/nio/Packet"/>
-    <suppress checks="NPathComplexity" files="com/hazelcast/nio/tcp/nonblocking/NonBlockingReadHandler"/>
+    <suppress checks="NPathComplexity" files="com/hazelcast/nio/tcp/nonblocking/NonBlockingSocketReader"/>
     <suppress checks="MagicNumber|EmptyBlock|MethodCount" files="com/hazelcast/nio/tcp/nonblocking/NonBlockingWriteHandler"/>
     <suppress checks="ClassFanOutComplexity|ClassDataAbstractionCoupling|MethodCount|ParameterNumber"
               files="com/hazelcast/internal/serialization/impl/SerializationServiceImpl"/>

--- a/hazelcast-client/src/test/java/com/hazelcast/client/io/IndependentBufferSizingTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/io/IndependentBufferSizingTest.java
@@ -22,10 +22,10 @@ import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.instance.GroupProperties;
 import com.hazelcast.instance.Node;
-import com.hazelcast.nio.tcp.nonblocking.NonBlockingReadHandler;
+import com.hazelcast.nio.tcp.nonblocking.NonBlockingSocketReader;
 import com.hazelcast.nio.tcp.TcpIpConnection;
 import com.hazelcast.nio.tcp.TcpIpConnectionManager;
-import com.hazelcast.nio.tcp.nonblocking.NonBlockingWriteHandler;
+import com.hazelcast.nio.tcp.nonblocking.NonBlockingSocketWriter;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.QuickTest;
@@ -57,14 +57,14 @@ public class IndependentBufferSizingTest extends HazelcastTestSupport {
         HazelcastInstance client = HazelcastClient.newHazelcastClient();
 
         TcpIpConnection clientConnection = getClientConnection(server);
-        NonBlockingReadHandler readHandler = (NonBlockingReadHandler) clientConnection.getReadHandler();
-        NonBlockingWriteHandler writeHandler = (NonBlockingWriteHandler) clientConnection.getWriteHandler();
+        NonBlockingSocketReader reader = (NonBlockingSocketReader) clientConnection.getSocketReader();
+        NonBlockingSocketWriter writer = (NonBlockingSocketWriter) clientConnection.getSocketWriter();
 
         int defaultReceiveBuffer = getDefaultReceiverBufferSize(server);
         int defaultSendBuffer = getDefaultSendBufferSize(server);
 
-        assertHasByteBufferWithSize(readHandler, "inputBuffer", defaultReceiveBuffer);
-        assertHasByteBufferWithSize(writeHandler, "outputBuffer", defaultSendBuffer);
+        assertHasByteBufferWithSize(reader, "inputBuffer", defaultReceiveBuffer);
+        assertHasByteBufferWithSize(writer, "outputBuffer", defaultSendBuffer);
     }
 
     @Test
@@ -80,11 +80,11 @@ public class IndependentBufferSizingTest extends HazelcastTestSupport {
         HazelcastInstance client = HazelcastClient.newHazelcastClient();
 
         TcpIpConnection clientConnection = getClientConnection(server);
-        NonBlockingReadHandler readHandler = (NonBlockingReadHandler) clientConnection.getReadHandler();
-        NonBlockingWriteHandler writeHandler = (NonBlockingWriteHandler) clientConnection.getWriteHandler();
+        NonBlockingSocketReader reader = (NonBlockingSocketReader) clientConnection.getSocketReader();
+        NonBlockingSocketWriter writer = (NonBlockingSocketWriter) clientConnection.getSocketWriter();
 
-        assertHasByteBufferWithSize(readHandler, "inputBuffer", receiveBufferSizeKB * 1024);
-        assertHasByteBufferWithSize(writeHandler, "outputBuffer", sendBufferSizeKB * 1024);
+        assertHasByteBufferWithSize(reader, "inputBuffer", receiveBufferSizeKB * 1024);
+        assertHasByteBufferWithSize(writer, "outputBuffer", sendBufferSizeKB * 1024);
     }
 
     private int getDefaultSendBufferSize(HazelcastInstance instance) {

--- a/hazelcast/src/main/java/com/hazelcast/instance/DefaultNodeExtension.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/DefaultNodeExtension.java
@@ -36,11 +36,11 @@ import com.hazelcast.nio.MemberSocketInterceptor;
 import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.internal.serialization.SerializationServiceBuilder;
 import com.hazelcast.nio.tcp.DefaultSocketChannelWrapperFactory;
-import com.hazelcast.nio.tcp.MemberSocketWriter;
-import com.hazelcast.nio.tcp.MemberSocketReader;
+import com.hazelcast.nio.tcp.MemberWriteHandler;
+import com.hazelcast.nio.tcp.MemberReadHandler;
 import com.hazelcast.nio.tcp.SocketChannelWrapperFactory;
-import com.hazelcast.nio.tcp.SocketReader;
-import com.hazelcast.nio.tcp.SocketWriter;
+import com.hazelcast.nio.tcp.ReadHandler;
+import com.hazelcast.nio.tcp.WriteHandler;
 import com.hazelcast.nio.tcp.TcpIpConnection;
 import com.hazelcast.partition.strategy.DefaultPartitioningStrategy;
 import com.hazelcast.security.SecurityContext;
@@ -161,14 +161,14 @@ public class DefaultNodeExtension implements NodeExtension {
     }
 
     @Override
-    public SocketReader createSocketReader(TcpIpConnection connection, IOService ioService) {
+    public ReadHandler createReadHandler(TcpIpConnection connection, IOService ioService) {
         NodeEngineImpl nodeEngine = node.nodeEngine;
-        return new MemberSocketReader(connection, nodeEngine.getPacketDispatcher());
+        return new MemberReadHandler(connection, nodeEngine.getPacketDispatcher());
     }
 
     @Override
-    public SocketWriter createSocketWriter(TcpIpConnection connection, IOService ioService) {
-        return new MemberSocketWriter();
+    public WriteHandler createWriteHandler(TcpIpConnection connection, IOService ioService) {
+        return new MemberWriteHandler();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/instance/NodeExtension.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/NodeExtension.java
@@ -24,8 +24,8 @@ import com.hazelcast.memory.MemoryStats;
 import com.hazelcast.nio.IOService;
 import com.hazelcast.nio.MemberSocketInterceptor;
 import com.hazelcast.nio.tcp.SocketChannelWrapperFactory;
-import com.hazelcast.nio.tcp.SocketReader;
-import com.hazelcast.nio.tcp.SocketWriter;
+import com.hazelcast.nio.tcp.ReadHandler;
+import com.hazelcast.nio.tcp.WriteHandler;
 import com.hazelcast.nio.tcp.TcpIpConnection;
 import com.hazelcast.security.SecurityContext;
 
@@ -95,22 +95,22 @@ public interface NodeExtension {
     SocketChannelWrapperFactory getSocketChannelWrapperFactory();
 
     /**
-     * Creates a <tt>PacketReader</tt> for given <tt>Connection</tt> instance.
+     * Creates a <tt>ReadHandler</tt> for given <tt>Connection</tt> instance.
      *
      * @param connection tcp-ip connection
      * @param ioService  IOService
-     * @return packet reader
+     * @return the created ReadHandler.
      */
-    SocketReader createSocketReader(TcpIpConnection connection, IOService ioService);
+    ReadHandler createReadHandler(TcpIpConnection connection, IOService ioService);
 
     /**
-     * Creates a <tt>PacketWriter</tt> for given <tt>Connection</tt> instance.
+     * Creates a <tt>WriteHandler</tt> for given <tt>Connection</tt> instance.
      *
      * @param connection tcp-ip connection
      * @param ioService  IOService
-     * @return packet writer
+     * @return the created WriteHandler
      */
-    SocketWriter createSocketWriter(TcpIpConnection connection, IOService ioService);
+    WriteHandler createWriteHandler(TcpIpConnection connection, IOService ioService);
 
     /**
      * Creates factory method that creates server side client message handlers

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/AbstractTextCommand.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/AbstractTextCommand.java
@@ -16,15 +16,14 @@
 
 package com.hazelcast.internal.ascii;
 
-import com.hazelcast.nio.ascii.SocketTextReader;
-import com.hazelcast.nio.ascii.SocketTextWriter;
+import com.hazelcast.nio.ascii.TextReadHandler;
+import com.hazelcast.nio.ascii.TextWriteHandler;
 
 public abstract class AbstractTextCommand implements TextCommand {
     protected final TextCommandConstants.TextCommandType type;
-    private SocketTextReader socketTextReader;
-    private SocketTextWriter socketTextWriter;
+    private TextReadHandler readHandler;
+    private TextWriteHandler writeHandler;
     private long requestId = -1;
-
 
     protected AbstractTextCommand(TextCommandConstants.TextCommandType type) {
         this.type = type;
@@ -36,13 +35,13 @@ public abstract class AbstractTextCommand implements TextCommand {
     }
 
     @Override
-    public SocketTextReader getSocketTextReader() {
-        return socketTextReader;
+    public TextReadHandler getReadHandler() {
+        return readHandler;
     }
 
     @Override
-    public SocketTextWriter getSocketTextWriter() {
-        return socketTextWriter;
+    public TextWriteHandler getWriteHandler() {
+        return writeHandler;
     }
 
     @Override
@@ -51,10 +50,10 @@ public abstract class AbstractTextCommand implements TextCommand {
     }
 
     @Override
-    public void init(SocketTextReader socketTextReader, long requestId) {
-        this.socketTextReader = socketTextReader;
+    public void init(TextReadHandler textReadHandler, long requestId) {
+        this.readHandler = textReadHandler;
         this.requestId = requestId;
-        this.socketTextWriter = socketTextReader.getSocketTextWriter();
+        this.writeHandler = textReadHandler.getTextWriteHandler();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/CommandParser.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/CommandParser.java
@@ -16,8 +16,8 @@
 
 package com.hazelcast.internal.ascii;
 
-import com.hazelcast.nio.ascii.SocketTextReader;
+import com.hazelcast.nio.ascii.TextReadHandler;
 
 public interface CommandParser  {
-    TextCommand parser(SocketTextReader socketTextReader, String cmd, int space);
+    TextCommand parser(TextReadHandler readHandler, String cmd, int space);
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/TextCommand.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/TextCommand.java
@@ -18,18 +18,18 @@ package com.hazelcast.internal.ascii;
 
 import com.hazelcast.nio.SocketReadable;
 import com.hazelcast.nio.SocketWritable;
-import com.hazelcast.nio.ascii.SocketTextReader;
-import com.hazelcast.nio.ascii.SocketTextWriter;
+import com.hazelcast.nio.ascii.TextReadHandler;
+import com.hazelcast.nio.ascii.TextWriteHandler;
 
 public interface TextCommand extends SocketWritable, SocketReadable {
 
     TextCommandConstants.TextCommandType getType();
 
-    void init(SocketTextReader socketTextReader, long requestId);
+    void init(TextReadHandler textReadHandler, long requestId);
 
-    SocketTextReader getSocketTextReader();
+    TextReadHandler getReadHandler();
 
-    SocketTextWriter getSocketTextWriter();
+    TextWriteHandler getWriteHandler();
 
     long getRequestId();
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/TextCommandServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/TextCommandServiceImpl.java
@@ -36,7 +36,7 @@ import com.hazelcast.instance.HazelcastThreadGroup;
 import com.hazelcast.instance.Node;
 import com.hazelcast.instance.OutOfMemoryErrorDispatcher;
 import com.hazelcast.logging.ILogger;
-import com.hazelcast.nio.ascii.SocketTextWriter;
+import com.hazelcast.nio.ascii.TextWriteHandler;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.util.Clock;
 import com.hazelcast.util.EmptyStatement;
@@ -375,8 +375,8 @@ public class TextCommandServiceImpl implements TextCommandService {
                             stopObject.notify();
                         }
                     } else {
-                        SocketTextWriter socketTextWriter = textCommand.getSocketTextWriter();
-                        socketTextWriter.enqueue(textCommand);
+                        TextWriteHandler textWriteHandler = textCommand.getWriteHandler();
+                        textWriteHandler.enqueue(textCommand);
                     }
                 } catch (InterruptedException e) {
                     return;

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/DeleteCommandParser.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/DeleteCommandParser.java
@@ -18,12 +18,12 @@ package com.hazelcast.internal.ascii.memcache;
 
 import com.hazelcast.internal.ascii.CommandParser;
 import com.hazelcast.internal.ascii.TextCommand;
-import com.hazelcast.nio.ascii.SocketTextReader;
+import com.hazelcast.nio.ascii.TextReadHandler;
 
 import java.util.StringTokenizer;
 
 public class DeleteCommandParser implements CommandParser {
-    public TextCommand parser(SocketTextReader socketTextReader, String cmd, int space) {
+    public TextCommand parser(TextReadHandler readHandler, String cmd, int space) {
         StringTokenizer st = new StringTokenizer(cmd);
         st.nextToken();
         String key = null;

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/GetCommandParser.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/GetCommandParser.java
@@ -18,24 +18,24 @@ package com.hazelcast.internal.ascii.memcache;
 
 import com.hazelcast.internal.ascii.CommandParser;
 import com.hazelcast.internal.ascii.TextCommand;
-import com.hazelcast.nio.ascii.SocketTextReader;
+import com.hazelcast.nio.ascii.TextReadHandler;
 
 import java.util.StringTokenizer;
 
 public class GetCommandParser implements CommandParser {
 
-    public TextCommand parser(SocketTextReader socketTextReader, String cmd, int space) {
+    public TextCommand parser(TextReadHandler readHandler, String cmd, int space) {
         String key = cmd.substring(space + 1);
         if (key.indexOf(' ') == -1) {
             GetCommand r = new GetCommand(key);
-            socketTextReader.publishRequest(r);
+            readHandler.publishRequest(r);
         } else {
             StringTokenizer st = new StringTokenizer(key);
             while (st.hasMoreTokens()) {
                 PartialGetCommand r = new PartialGetCommand(st.nextToken());
-                socketTextReader.publishRequest(r);
+                readHandler.publishRequest(r);
             }
-            socketTextReader.publishRequest(new EndCommand());
+            readHandler.publishRequest(new EndCommand());
         }
         return null;
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/IncrementCommandParser.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/IncrementCommandParser.java
@@ -20,7 +20,7 @@ package com.hazelcast.internal.ascii.memcache;
 import com.hazelcast.internal.ascii.TextCommand;
 import com.hazelcast.internal.ascii.TextCommandConstants;
 import com.hazelcast.internal.ascii.TypeAwareCommandParser;
-import com.hazelcast.nio.ascii.SocketTextReader;
+import com.hazelcast.nio.ascii.TextReadHandler;
 
 import java.util.StringTokenizer;
 
@@ -36,7 +36,7 @@ public class IncrementCommandParser extends TypeAwareCommandParser {
         super(type);
     }
 
-    public TextCommand parser(SocketTextReader socketTextReader, String cmd, int space) {
+    public TextCommand parser(TextReadHandler readHandler, String cmd, int space) {
         StringTokenizer st = new StringTokenizer(cmd);
         st.nextToken();
         String key = null;

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/SetCommandParser.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/SetCommandParser.java
@@ -19,7 +19,7 @@ package com.hazelcast.internal.ascii.memcache;
 import com.hazelcast.internal.ascii.TextCommand;
 import com.hazelcast.internal.ascii.TextCommandConstants;
 import com.hazelcast.internal.ascii.TypeAwareCommandParser;
-import com.hazelcast.nio.ascii.SocketTextReader;
+import com.hazelcast.nio.ascii.TextReadHandler;
 
 import java.util.StringTokenizer;
 
@@ -30,7 +30,7 @@ public class SetCommandParser extends TypeAwareCommandParser {
         super(type);
     }
 
-    public TextCommand parser(SocketTextReader socketTextReader, String cmd, int space) {
+    public TextCommand parser(TextReadHandler readHandler, String cmd, int space) {
         StringTokenizer st = new StringTokenizer(cmd);
         st.nextToken();
         String key = null;

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/SimpleCommandParser.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/SimpleCommandParser.java
@@ -19,7 +19,7 @@ package com.hazelcast.internal.ascii.memcache;
 import com.hazelcast.internal.ascii.TextCommand;
 import com.hazelcast.internal.ascii.TextCommandConstants;
 import com.hazelcast.internal.ascii.TypeAwareCommandParser;
-import com.hazelcast.nio.ascii.SocketTextReader;
+import com.hazelcast.nio.ascii.TextReadHandler;
 
 import static com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType.QUIT;
 import static com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType.STATS;
@@ -31,7 +31,7 @@ public class SimpleCommandParser extends TypeAwareCommandParser {
         super(type);
     }
 
-    public TextCommand parser(SocketTextReader socketTextReader, String cmd, int space) {
+    public TextCommand parser(TextReadHandler readHandler, String cmd, int space) {
         if (type == QUIT) {
             return new SimpleCommand(type);
         } else if (type == STATS) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/SimpleCommandProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/SimpleCommandProcessor.java
@@ -37,7 +37,7 @@ public class SimpleCommandProcessor extends MemcacheCommandProcessor<SimpleComma
     public void handle(SimpleCommand command) {
         if (command.getType() == QUIT) {
             try {
-                command.getSocketTextReader().closeConnection();
+                command.getReadHandler().closeConnection();
             } catch (Exception e) {
                 logger.warning(e);
             }

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/TouchCommandParser.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/TouchCommandParser.java
@@ -19,7 +19,7 @@ package com.hazelcast.internal.ascii.memcache;
 import com.hazelcast.internal.ascii.TextCommand;
 import com.hazelcast.internal.ascii.TextCommandConstants;
 import com.hazelcast.internal.ascii.TypeAwareCommandParser;
-import com.hazelcast.nio.ascii.SocketTextReader;
+import com.hazelcast.nio.ascii.TextReadHandler;
 
 import java.util.StringTokenizer;
 
@@ -36,7 +36,7 @@ public class TouchCommandParser extends TypeAwareCommandParser {
         super(type);
     }
 
-    public TextCommand parser(SocketTextReader socketTextReader, String cmd, int space) {
+    public TextCommand parser(TextReadHandler readHandler, String cmd, int space) {
         StringTokenizer st = new StringTokenizer(cmd);
         st.nextToken();
         String key = null;

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpDeleteCommandParser.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpDeleteCommandParser.java
@@ -19,7 +19,7 @@ package com.hazelcast.internal.ascii.rest;
 import com.hazelcast.internal.ascii.CommandParser;
 import com.hazelcast.internal.ascii.TextCommand;
 import com.hazelcast.internal.ascii.memcache.ErrorCommand;
-import com.hazelcast.nio.ascii.SocketTextReader;
+import com.hazelcast.nio.ascii.TextReadHandler;
 
 import java.util.StringTokenizer;
 
@@ -27,7 +27,7 @@ import static com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType.
 
 public class HttpDeleteCommandParser implements CommandParser {
 
-    public TextCommand parser(SocketTextReader socketTextReader, String cmd, int space) {
+    public TextCommand parser(TextReadHandler readHandler, String cmd, int space) {
         StringTokenizer st = new StringTokenizer(cmd);
         st.nextToken();
         String uri = null;

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpGetCommandParser.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpGetCommandParser.java
@@ -19,7 +19,7 @@ package com.hazelcast.internal.ascii.rest;
 import com.hazelcast.internal.ascii.CommandParser;
 import com.hazelcast.internal.ascii.TextCommand;
 import com.hazelcast.internal.ascii.memcache.ErrorCommand;
-import com.hazelcast.nio.ascii.SocketTextReader;
+import com.hazelcast.nio.ascii.TextReadHandler;
 
 import java.util.StringTokenizer;
 
@@ -27,7 +27,7 @@ import static com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType.
 
 public class HttpGetCommandParser implements CommandParser {
 
-    public TextCommand parser(SocketTextReader socketTextReader, String cmd, int space) {
+    public TextCommand parser(TextReadHandler readHandler, String cmd, int space) {
         StringTokenizer st = new StringTokenizer(cmd);
         st.nextToken();
         String uri = null;

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpPostCommand.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpPostCommand.java
@@ -19,7 +19,7 @@ package com.hazelcast.internal.ascii.rest;
 import com.hazelcast.internal.ascii.NoOpCommand;
 import com.hazelcast.internal.ascii.TextCommandConstants;
 import com.hazelcast.nio.IOUtil;
-import com.hazelcast.nio.ascii.SocketTextReader;
+import com.hazelcast.nio.ascii.TextReadHandler;
 import com.hazelcast.util.StringUtil;
 
 import java.nio.ByteBuffer;
@@ -36,12 +36,12 @@ public class HttpPostCommand extends HttpCommand {
     private ByteBuffer data;
     private ByteBuffer line = ByteBuffer.allocate(CAPACITY);
     private String contentType;
-    private final SocketTextReader socketTextRequestReader;
+    private final TextReadHandler readHandler;
     private boolean chunked;
 
-    public HttpPostCommand(SocketTextReader socketTextRequestReader, String uri) {
+    public HttpPostCommand(TextReadHandler readHandler, String uri) {
         super(TextCommandConstants.TextCommandType.HTTP_POST, uri);
-        this.socketTextRequestReader = socketTextRequestReader;
+        this.readHandler = readHandler;
     }
 
     /**
@@ -175,7 +175,7 @@ public class HttpPostCommand extends HttpCommand {
         } else if (!chunked && currentLine.startsWith(HEADER_CHUNKED)) {
             chunked = true;
         } else if (currentLine.startsWith(HEADER_EXPECT_100)) {
-            socketTextRequestReader.sendResponse(new NoOpCommand(RES_100));
+            readHandler.sendResponse(new NoOpCommand(RES_100));
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpPostCommandParser.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpPostCommandParser.java
@@ -19,7 +19,7 @@ package com.hazelcast.internal.ascii.rest;
 import com.hazelcast.internal.ascii.CommandParser;
 import com.hazelcast.internal.ascii.TextCommand;
 import com.hazelcast.internal.ascii.memcache.ErrorCommand;
-import com.hazelcast.nio.ascii.SocketTextReader;
+import com.hazelcast.nio.ascii.TextReadHandler;
 
 import java.util.StringTokenizer;
 
@@ -27,7 +27,7 @@ import static com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType.
 
 public class HttpPostCommandParser implements CommandParser {
 
-    public TextCommand parser(SocketTextReader socketTextReader, String cmd, int space) {
+    public TextCommand parser(TextReadHandler readHandler, String cmd, int space) {
         StringTokenizer st = new StringTokenizer(cmd);
         st.nextToken();
         String uri = null;
@@ -36,6 +36,6 @@ public class HttpPostCommandParser implements CommandParser {
         } else {
             return new ErrorCommand(ERROR_CLIENT);
         }
-        return new HttpPostCommand(socketTextReader, uri);
+        return new HttpPostCommand(readHandler, uri);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/nio/IOService.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/IOService.java
@@ -25,8 +25,8 @@ import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.nio.tcp.SocketChannelWrapperFactory;
-import com.hazelcast.nio.tcp.SocketReader;
-import com.hazelcast.nio.tcp.SocketWriter;
+import com.hazelcast.nio.tcp.ReadHandler;
+import com.hazelcast.nio.tcp.WriteHandler;
 import com.hazelcast.nio.tcp.TcpIpConnection;
 import com.hazelcast.spi.EventService;
 
@@ -137,7 +137,7 @@ public interface IOService {
 
     MemberSocketInterceptor getMemberSocketInterceptor();
 
-    SocketReader createSocketReader(TcpIpConnection connection);
+    ReadHandler createReadHandler(TcpIpConnection connection);
 
-    SocketWriter createSocketWriter(TcpIpConnection connection);
+    WriteHandler createWriteHandler(TcpIpConnection connection);
 }

--- a/hazelcast/src/main/java/com/hazelcast/nio/NodeIOService.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/NodeIOService.java
@@ -29,8 +29,8 @@ import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.nio.tcp.SocketChannelWrapperFactory;
-import com.hazelcast.nio.tcp.SocketReader;
-import com.hazelcast.nio.tcp.SocketWriter;
+import com.hazelcast.nio.tcp.ReadHandler;
+import com.hazelcast.nio.tcp.WriteHandler;
 import com.hazelcast.nio.tcp.TcpIpConnection;
 import com.hazelcast.spi.EventService;
 import com.hazelcast.spi.ExecutionService;
@@ -289,13 +289,13 @@ public class NodeIOService implements IOService {
     }
 
     @Override
-    public SocketReader createSocketReader(TcpIpConnection connection) {
-        return node.getNodeExtension().createSocketReader(connection, this);
+    public ReadHandler createReadHandler(TcpIpConnection connection) {
+        return node.getNodeExtension().createReadHandler(connection, this);
     }
 
     @Override
-    public SocketWriter createSocketWriter(TcpIpConnection connection) {
-        return node.getNodeExtension().createSocketWriter(connection, this);
+    public WriteHandler createWriteHandler(TcpIpConnection connection) {
+        return node.getNodeExtension().createWriteHandler(connection, this);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/nio/ascii/TextWriteHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/ascii/TextWriteHandler.java
@@ -17,19 +17,19 @@
 package com.hazelcast.nio.ascii;
 
 import com.hazelcast.internal.ascii.TextCommand;
-import com.hazelcast.nio.tcp.SocketWriter;
+import com.hazelcast.nio.tcp.WriteHandler;
 import com.hazelcast.nio.tcp.TcpIpConnection;
 
 import java.nio.ByteBuffer;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-public class SocketTextWriter implements SocketWriter<TextCommand> {
+public class TextWriteHandler implements WriteHandler<TextCommand> {
     private final TcpIpConnection connection;
     private final Map<Long, TextCommand> responses = new ConcurrentHashMap<Long, TextCommand>(100);
     private long currentRequestId;
 
-    public SocketTextWriter(TcpIpConnection connection) {
+    public TextWriteHandler(TcpIpConnection connection) {
         this.connection = connection;
     }
 
@@ -58,7 +58,7 @@ public class SocketTextWriter implements SocketWriter<TextCommand> {
     }
 
     @Override
-    public boolean write(TextCommand socketWritable, ByteBuffer dst) throws Exception {
-        return socketWritable.writeTo(dst);
+    public boolean onWrite(TextCommand textCommand, ByteBuffer dst) throws Exception {
+        return textCommand.writeTo(dst);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/InitConnectionTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/InitConnectionTask.java
@@ -147,7 +147,7 @@ public class InitConnectionTask implements Runnable {
 
             socketChannelWrapper.configureBlocking(false);
             TcpIpConnection connection = connectionManager.newConnection(socketChannelWrapper, address);
-            connection.getWriteHandler().setProtocol(Protocols.CLUSTER);
+            connection.getSocketWriter().setProtocol(Protocols.CLUSTER);
             connectionManager.sendBindRequest(connection, address, true);
         } catch (Exception e) {
             closeSocket(socketChannel);

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/MemberReadHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/MemberReadHandler.java
@@ -22,7 +22,15 @@ import com.hazelcast.util.counters.Counter;
 
 import java.nio.ByteBuffer;
 
-public class MemberSocketReader implements SocketReader {
+/**
+ * The {@link ReadHandler} for member to member communication.
+ *
+ * It reads as many packets from the src ByteBuffer as possible, and each of the Packets is send to the {@link PacketDispatcher}.
+ *
+ * @see PacketDispatcher
+ * @see MemberWriteHandler
+ */
+public class MemberReadHandler implements ReadHandler {
 
     protected final TcpIpConnection connection;
     protected Packet packet;
@@ -31,16 +39,16 @@ public class MemberSocketReader implements SocketReader {
     private final Counter normalPacketsRead;
     private final Counter priorityPacketsRead;
 
-    public MemberSocketReader(TcpIpConnection connection, PacketDispatcher packetDispatcher) {
+    public MemberReadHandler(TcpIpConnection connection, PacketDispatcher packetDispatcher) {
         this.connection = connection;
         this.packetDispatcher = packetDispatcher;
-        final ReadHandler readHandler = connection.getReadHandler();
-        this.normalPacketsRead = readHandler.getNormalPacketsReadCounter();
-        this.priorityPacketsRead = readHandler.getPriorityPacketsReadCounter();
+        SocketReader socketReader = connection.getSocketReader();
+        this.normalPacketsRead = socketReader.getNormalPacketsReadCounter();
+        this.priorityPacketsRead = socketReader.getPriorityPacketsReadCounter();
     }
 
     @Override
-    public void read(ByteBuffer src) throws Exception {
+    public void onRead(ByteBuffer src) throws Exception {
         while (src.hasRemaining()) {
             if (packet == null) {
                 packet = new Packet();

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/MemberWriteHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/MemberWriteHandler.java
@@ -20,10 +20,17 @@ import com.hazelcast.nio.Packet;
 
 import java.nio.ByteBuffer;
 
-public class MemberSocketWriter implements SocketWriter<Packet> {
+/**
+ * A {@link WriteHandler} that for member to member communication.
+ *
+ * It writes {@link Packet} instances to the {@link ByteBuffer}.
+ *
+ * @see MemberReadHandler
+ */
+public class MemberWriteHandler implements WriteHandler<Packet> {
 
     @Override
-    public boolean write(Packet packet, ByteBuffer dst) {
+    public boolean onWrite(Packet packet, ByteBuffer dst) {
         return packet.writeTo(dst);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/NewClientReadHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/NewClientReadHandler.java
@@ -25,22 +25,30 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 
 /**
- * A {@link SocketReader} that reads ClientMessage for the new-client.
+ * A {@link ReadHandler} for the new-client. It passes the ByteBuffer to the ClientMessageBuilder. For each
+ * constructed ClientMessage, the {@link #handleMessage(ClientMessage)} is called; which passes the message
+ * to the {@link IOService#handleClientMessage(ClientMessage, Connection)}.
+ *
+ * Probably the design can be simplified if the IOService would expose a method getMessageHandler; so we
+ * don't need to let the NewClientReadHandler act like the MessageHandler, but directly send to the right
+ * data-structure.
+ *
+ * @see NewClientWriteHandler
  */
-public class ClientMessageSocketReader implements SocketReader, ClientMessageBuilder.MessageHandler {
+public class NewClientReadHandler implements ReadHandler, ClientMessageBuilder.MessageHandler {
 
     private final ClientMessageBuilder builder;
     private final Connection connection;
     private final IOService ioService;
 
-    public ClientMessageSocketReader(Connection connection, IOService ioService) throws IOException {
+    public NewClientReadHandler(Connection connection, IOService ioService) throws IOException {
         this.connection = connection;
         this.ioService = ioService;
         this.builder = new ClientMessageBuilder(this);
     }
 
     @Override
-    public void read(ByteBuffer src) throws Exception {
+    public void onRead(ByteBuffer src) throws Exception {
         builder.onData(src);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/NewClientWriteHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/NewClientWriteHandler.java
@@ -21,12 +21,14 @@ import com.hazelcast.client.impl.protocol.ClientMessage;
 import java.nio.ByteBuffer;
 
 /**
- * A {@link SocketWriter} that write ClientMessage for the new-client.
+ * A {@link WriteHandler} for the new-client. It writes ClientMessages to the ByteBuffer.
+ *
+ * @see NewClientReadHandler
  */
-public class ClientMessageSocketWriter implements SocketWriter<ClientMessage> {
+public class NewClientWriteHandler implements WriteHandler<ClientMessage> {
 
     @Override
-    public boolean write(ClientMessage message, ByteBuffer dst) throws Exception {
+    public boolean onWrite(ClientMessage message, ByteBuffer dst) throws Exception {
         return message.writeTo(dst);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/OldClientReadHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/OldClientReadHandler.java
@@ -33,24 +33,26 @@ import static com.hazelcast.nio.ConnectionType.RUBY_CLIENT;
 import static com.hazelcast.util.StringUtil.bytesToString;
 
 /**
- * A {@link SocketReader} that reads Packets for the old-client.
+ * A {@link ReadHandler} for the old client. It reads Packets and sends them to {@link IOService#handleClientPacket(Packet)}.
  *
  * Once the old client is deleted, this code can be deleted.
+ *
+ * @see OldClientWriteHandler
  */
-public class ClientPacketSocketReader implements SocketReader {
+public class OldClientReadHandler implements ReadHandler {
 
     private final Connection connection;
     private final IOService ioService;
     private Packet packet;
     private boolean connectionTypeSet;
 
-    public ClientPacketSocketReader(Connection connection, IOService ioService) {
+    public OldClientReadHandler(Connection connection, IOService ioService) {
         this.connection = connection;
         this.ioService = ioService;
     }
 
     @Override
-    public void read(ByteBuffer src) throws Exception {
+    public void onRead(ByteBuffer src) throws Exception {
         while (src.hasRemaining()) {
             if (!connectionTypeSet) {
                 if (!setConnectionType(src)) {

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/OldClientWriteHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/OldClientWriteHandler.java
@@ -21,14 +21,16 @@ import com.hazelcast.nio.Packet;
 import java.nio.ByteBuffer;
 
 /**
- * A {@link SocketWriter} that write Packets for the old-client.
+ * A {@link WriteHandler} for the old client. It writes Packet into the ByteBuffer.
  *
  * Once the old client is deleted, this code can be deleted.
+ *
+ * @see OldClientReadHandler
  */
-public class ClientPacketSocketWriter implements SocketWriter<Packet> {
+public class OldClientWriteHandler implements WriteHandler<Packet> {
 
     @Override
-    public boolean write(Packet packet, ByteBuffer dst) throws Exception {
+    public boolean onWrite(Packet packet, ByteBuffer dst) throws Exception {
         return packet.writeTo(dst);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/ReadHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/ReadHandler.java
@@ -16,42 +16,64 @@
 
 package com.hazelcast.nio.tcp;
 
-import com.hazelcast.util.counters.Counter;
+import java.nio.ByteBuffer;
 
 /**
- * Each {@link TcpIpConnection} has a ReadHandler and it is responsible to read data from the socket on behalf of that
- * connection.
+ * Reads content from a {@link ByteBuffer} and processes it. The ReadHandler is invoked by the {@link SocketReader} after
+ * it has read data from the socket.
+ *
+ * A typical example is that Packet instances are created from the buffered data and handing them over the the
+ * {@link com.hazelcast.spi.impl.packetdispatcher.PacketDispatcher}. See {@link MemberReadHandler} for more information.
+ *
+ * Each {@link SocketReader} will have its own {@link ReadHandler} instance. Therefor it doesn't need to be thread-safe.
+ *
+ * <h1>Pipelining & Encryption</h1>
+ * The ReadHandler/WriteHandler can also form a pipeline. For example for SSL there could be a initial ReadHandler that decryption
+ * the ByteBuffer and passes the decrypted ByteBuffer to the next ReadHandler; which could be a {@link MemberReadHandler}
+ * that reads out any Packet from the decrypted ByteBuffer. Using this approach encryption can easily be added to any type of
+ * communication, not only member 2 member communication.
+ *
+ * Currently security is added by using a {@link SocketChannelWrapper}, but this is not needed if the handlers form a pipeline.
+ * Netty follows a similar approach with pipelining and adding encryption.
+ *
+ * There is no explicit support for setting up a 'pipeline' of ReadHandler/WriterHandlers but t can easily be realized by setting
+ * up the chain and let a handler explicitly forward to the next. Since it isn't a common practice for the handler so far, isn't
+ * needed to add additional complexity to the system; just set up a chain manually.
+ *
+ * pseudo code:
+ * <pre>
+ *     public class DecryptingReadHandler implements ReadHandler {
+ *         private final ReadHandler next;
+ *
+ *         public DecryptingReadHandler(ReadHandler next) {
+ *             this.next = next;
+ *         }
+ *
+ *         public void read(ByteBuffer src) {
+ *             decrypt(src, decryptedSrc);
+ *             next.read(decryptedSrc)
+ *         }
+ *     }
+ * </pre>
+ * The <code>next</code> ReadHandler is the next item in the pipeline.
+ *
+ * For encryption is similar approach can be followed where the DecryptingWriteHandler is the last WriteHandler in the pipeline.
+ *
+ * @see WriteHandler
+ * @see SocketReader
+ * @see TcpIpConnection
+ * @see IOThreadingModel
  */
 public interface ReadHandler {
 
     /**
-     * Returns the last {@link com.hazelcast.util.Clock#currentTimeMillis()} a read of network was done.
+     * A callback to indicate that data is available in the ByteBuffer to be processed.
      *
-     * @return the last time a read from the network was done.
+     * @param src the ByteBuffer containing the data to read. The ByteBuffer is already in reading mode and when completed,
+     *            should not be converted to write-mode using clear/compact. That is a task of the {@link SocketReader}.
+     * @throws Exception if something fails while reading data from the ByteBuffer or processing the data
+     *                   (e.g. when a Packet fails to get processed). When an exception is thrown, the TcpIpConnection
+     *                   is closed. There is no point continuing with a potentially corrupted stream.
      */
-    long getLastReadTimeMillis();
-
-    /**
-     * Gets the Counter that counts the number of normal packets that have been read.
-     *
-     * @return the normal packets counter.
-     */
-    Counter getNormalPacketsReadCounter();
-
-    /**
-     * Gets the Counter that counts the number of priority packets that have been read.
-     *
-     * @return the priority packets counter.
-     */
-    Counter getPriorityPacketsReadCounter();
-
-    /**
-     * Starts this ReadHandler.
-     */
-    void start();
-
-    /**
-     * Shutdown this ReadHandler.
-     */
-    void shutdown();
+    void onRead(ByteBuffer src) throws Exception;
 }

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/SocketChannelWrapper.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/SocketChannelWrapper.java
@@ -35,6 +35,9 @@ import java.nio.channels.SocketChannel;
  *
  * That is why a new 'wrapper' interface is introduced which acts like a SocketChannel and the implementations wrap a
  * SocketChannel.
+ *
+ * In the future we should get rid of this class and rely on {@link ReadHandler}/{@link WriteHandler} chaining to add encryption.
+ * This will remove more artifacts from the architecture that can't carry their weight.
  */
 public interface SocketChannelWrapper extends Closeable {
 

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/SocketWriter.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/SocketWriter.java
@@ -18,14 +18,79 @@ package com.hazelcast.nio.tcp;
 
 import com.hazelcast.nio.SocketWritable;
 
-import java.nio.ByteBuffer;
-
 /**
- * Writes a {@link SocketWriter} to a {@link ByteBuffer}.
+ * Each {@link TcpIpConnection} has a {@link SocketWriter} and it writes {@link SocketWritable} instances to the socket. Copying
+ * the SocketWritable instances to the byte-buffer is done using the {@link WriteHandler}.
  *
- * @param <T>
+ * Before Hazelcast 3.6 the name of this interface was WriteHandler.
+ *
+ * @see SocketReader
+ * @see ReadHandler
+ * @see IOThreadingModel
  */
-public interface SocketWriter<T extends SocketWritable> {
+public interface SocketWriter {
 
-    boolean write(T socketWritable, ByteBuffer dst) throws Exception;
+    /**
+     * Returns the total number of packets (urgent and non normal priority) pending to be written to the socket.
+     *
+     * @return total number of pending packets.
+     */
+    int totalPacketsPending();
+
+    /**
+     * Returns the last {@link com.hazelcast.util.Clock#currentTimeMillis()} that a write to the socket completed.
+     *
+     * Writing to the socket doesn't mean that data has been send or received; it means that data was written to the
+     * SocketChannel. It could very well be that this data is stuck somewhere in an io-buffer.
+     *
+     * @return the last time something was written to the socket.
+     */
+    long getLastWriteTimeMillis();
+
+    /**
+     * Offers a SocketWritable to be written to the socket.
+     *
+     * No guarantees are made that the packet is going to be written or received by the other side.
+     *
+     * @param packet the SocketWritable
+     */
+    void offer(SocketWritable packet);
+
+    /**
+     * Gets the {@link WriteHandler} that belongs to this SocketWriter.
+     *
+     * This method exists for the {@link com.hazelcast.nio.ascii.TextReadHandler}, but probably should be deleted.
+     *
+     * @return the WriteHandler
+     */
+    WriteHandler getWriteHandler();
+
+    /**
+     * Sets the protocol this SocketWriter should use.
+     *
+     * This should be called only once at the beginning of the connection.
+     *
+     * See {@link com.hazelcast.nio.Protocols}
+     *
+     * @param protocol the protocol
+     */
+    void setProtocol(String protocol);
+
+    /**
+     * Starts this SocketWriter.
+     *
+     * This method can be called from an arbitrary thread.
+     *
+     * @see #shutdown()
+     */
+    void start();
+
+    /**
+     * Shuts down this SocketWriter.
+     *
+     * This method can be called from an arbitrary thread.
+     *
+     * @see #start()
+     */
+    void shutdown();
 }

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnection.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnection.java
@@ -32,19 +32,21 @@ import java.util.concurrent.atomic.AtomicBoolean;
 /**
  * The Tcp/Ip implementation of the {@link com.hazelcast.nio.Connection}.
  *
- * A {@link TcpIpConnection} has 2 sides:
+ * A {@link TcpIpConnection} is not responsible for reading or writing data to a socket, this is done through:
  * <ol>
- * <li>{@link ReadHandler}: the side  that takes care of reading from the other side</li>
- * <li>{@link WriteHandler}: the side that takes care of writing data to the other side</li>
+ * <li>{@link SocketReader}: which care of reading from the socket and feeding it into the system/li>
+ * <li>{@link SocketWriter}: which care of writing data to the socket.</li>
  * </ol>
+ *
+ * @see IOThreadingModel
  */
 public final class TcpIpConnection implements Connection {
 
     private final SocketChannelWrapper socketChannel;
 
-    private final ReadHandler readHandler;
+    private final SocketReader socketReader;
 
-    private final WriteHandler writeHandler;
+    private final SocketWriter socketWriter;
 
     private final TcpIpConnectionManager connectionManager;
 
@@ -68,16 +70,16 @@ public final class TcpIpConnection implements Connection {
         this.logger = connectionManager.getIoService().getLogger(TcpIpConnection.class.getName());
         this.connectionManager = connectionManager;
         this.socketChannel = socketChannel;
-        this.writeHandler = ioThreadingModel.newWriteHandler(this);
-        this.readHandler = ioThreadingModel.newReadHandler(this);
+        this.socketWriter = ioThreadingModel.newSocketWriter(this);
+        this.socketReader = ioThreadingModel.newSocketReader(this);
     }
 
-    public ReadHandler getReadHandler() {
-        return readHandler;
+    public SocketReader getSocketReader() {
+        return socketReader;
     }
 
-    public WriteHandler getWriteHandler() {
-        return writeHandler;
+    public SocketWriter getSocketWriter() {
+        return socketWriter;
     }
 
     @Override
@@ -122,12 +124,12 @@ public final class TcpIpConnection implements Connection {
 
     @Override
     public long lastWriteTimeMillis() {
-        return writeHandler.getLastWriteTimeMillis();
+        return socketWriter.getLastWriteTimeMillis();
     }
 
     @Override
     public long lastReadTimeMillis() {
-        return readHandler.getLastReadTimeMillis();
+        return socketReader.getLastReadTimeMillis();
     }
 
     @Override
@@ -182,8 +184,8 @@ public final class TcpIpConnection implements Connection {
      * Starting means that the connection is going to register itself to listen to incoming traffic.
      */
     public void start() {
-        writeHandler.start();
-        readHandler.start();
+        socketWriter.start();
+        socketReader.init();
     }
 
     @Override
@@ -194,7 +196,7 @@ public final class TcpIpConnection implements Connection {
             }
             return false;
         }
-        writeHandler.offer(packet);
+        socketWriter.offer(packet);
         return true;
     }
 
@@ -228,8 +230,8 @@ public final class TcpIpConnection implements Connection {
 
         try {
             if (socketChannel != null && socketChannel.isOpen()) {
-                readHandler.shutdown();
-                writeHandler.shutdown();
+                socketReader.destroy();
+                socketWriter.shutdown();
                 socketChannel.close();
             }
         } catch (Exception e) {

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/AbstractHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/AbstractHandler.java
@@ -29,7 +29,7 @@ import java.nio.channels.SelectionKey;
 import java.nio.channels.Selector;
 import java.util.logging.Level;
 
-public abstract class AbstractSelectionHandler implements MigratableHandler {
+public abstract class AbstractHandler implements MigratableHandler {
 
     protected final ILogger logger;
     protected final SocketChannelWrapper socketChannel;
@@ -41,7 +41,7 @@ public abstract class AbstractSelectionHandler implements MigratableHandler {
     protected SelectionKey selectionKey;
     private final int initialOps;
 
-    public AbstractSelectionHandler(TcpIpConnection connection, NonBlockingIOThread ioThread, int initialOps) {
+    public AbstractHandler(TcpIpConnection connection, NonBlockingIOThread ioThread, int initialOps) {
         this.connection = connection;
         this.ioThread = ioThread;
         this.selector = ioThread.getSelector();

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/NonBlockingIOThreadingModel.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/NonBlockingIOThreadingModel.java
@@ -22,9 +22,9 @@ import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.LoggingService;
 import com.hazelcast.nio.IOService;
 import com.hazelcast.nio.tcp.IOThreadingModel;
-import com.hazelcast.nio.tcp.ReadHandler;
+import com.hazelcast.nio.tcp.SocketReader;
 import com.hazelcast.nio.tcp.TcpIpConnection;
-import com.hazelcast.nio.tcp.WriteHandler;
+import com.hazelcast.nio.tcp.SocketWriter;
 import com.hazelcast.nio.tcp.nonblocking.iobalancer.IOBalancer;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
@@ -183,14 +183,14 @@ public class NonBlockingIOThreadingModel implements IOThreadingModel {
     }
 
     @Override
-    public WriteHandler newWriteHandler(TcpIpConnection connection) {
+    public SocketWriter newSocketWriter(TcpIpConnection connection) {
         int index = hashToIndex(nextOutputThreadIndex.getAndIncrement(), outputThreads.length);
-        return new NonBlockingWriteHandler(connection, outputThreads[index], metricsRegistry);
+        return new NonBlockingSocketWriter(connection, outputThreads[index], metricsRegistry);
     }
 
     @Override
-    public ReadHandler newReadHandler(TcpIpConnection connection) {
+    public SocketReader newSocketReader(TcpIpConnection connection) {
         int index = hashToIndex(nextInputThreadIndex.getAndIncrement(), inputThreads.length);
-        return new NonBlockingReadHandler(connection, inputThreads[index], metricsRegistry);
+        return new NonBlockingSocketReader(connection, inputThreads[index], metricsRegistry);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/spinning/SpinningIOThreadingModel.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/spinning/SpinningIOThreadingModel.java
@@ -22,9 +22,9 @@ import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.LoggingService;
 import com.hazelcast.nio.IOService;
 import com.hazelcast.nio.tcp.IOThreadingModel;
-import com.hazelcast.nio.tcp.ReadHandler;
+import com.hazelcast.nio.tcp.SocketReader;
 import com.hazelcast.nio.tcp.TcpIpConnection;
-import com.hazelcast.nio.tcp.WriteHandler;
+import com.hazelcast.nio.tcp.SocketWriter;
 
 /**
  * A {@link IOThreadingModel} that uses (busy) spinning on the SocketChannels to see if there is something
@@ -67,15 +67,15 @@ public class SpinningIOThreadingModel implements IOThreadingModel {
     }
 
     @Override
-    public WriteHandler newWriteHandler(TcpIpConnection connection) {
-        ILogger logger = loggingService.getLogger(SpinningWriteHandler.class);
-        return new SpinningWriteHandler(connection, metricsRegistry, logger);
+    public SocketWriter newSocketWriter(TcpIpConnection connection) {
+        ILogger logger = loggingService.getLogger(SpinningSocketWriter.class);
+        return new SpinningSocketWriter(connection, metricsRegistry, logger);
     }
 
     @Override
-    public ReadHandler newReadHandler(TcpIpConnection connection) {
-        ILogger logger = loggingService.getLogger(SpinningReadHandler.class);
-        return new SpinningReadHandler(connection, metricsRegistry, logger);
+    public SocketReader newSocketReader(TcpIpConnection connection) {
+        ILogger logger = loggingService.getLogger(SpinningSocketReader.class);
+        return new SpinningSocketReader(connection, metricsRegistry, logger);
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/MemberWriteHandlerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/MemberWriteHandlerTest.java
@@ -19,22 +19,22 @@ import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class MemberSocketWriterTest extends HazelcastTestSupport {
+public class MemberWriteHandlerTest extends HazelcastTestSupport {
 
     private SerializationService serializationService;
-    private MemberSocketWriter writer;
+    private MemberWriteHandler writeHandler;
 
     @Before
     public void setup() {
         serializationService = new DefaultSerializationServiceBuilder().build();
-        writer = new MemberSocketWriter();
+        writeHandler = new MemberWriteHandler();
     }
 
     @Test
     public void test() throws Exception {
         Packet packet = new Packet(serializationService.toBytes("foobar"));
         ByteBuffer bb = ByteBuffer.allocate(1000);
-        boolean result = writer.write(packet, bb);
+        boolean result = writeHandler.onWrite(packet, bb);
 
         assertTrue(result);
 

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/MockIOService.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/MockIOService.java
@@ -374,8 +374,8 @@ public class MockIOService implements IOService {
     }
 
     @Override
-    public SocketReader createSocketReader(final TcpIpConnection connection) {
-        return new MemberSocketReader(connection, new PacketDispatcher() {
+    public ReadHandler createReadHandler(final TcpIpConnection connection) {
+        return new MemberReadHandler(connection, new PacketDispatcher() {
             private ILogger logger = getLogger("MockIOService");
 
             @Override
@@ -397,8 +397,8 @@ public class MockIOService implements IOService {
     }
 
     @Override
-    public SocketWriter createSocketWriter(TcpIpConnection connection) {
-        return new MemberSocketWriter();
+    public WriteHandler createWriteHandler(TcpIpConnection connection) {
+        return new MemberWriteHandler();
     }
 
 }

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/NewClientReadHandlerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/NewClientReadHandlerTest.java
@@ -21,9 +21,9 @@ import static org.mockito.Mockito.verify;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class ClientMessageSocketReaderTest {
+public class NewClientReadHandlerTest {
 
-    private ClientMessageSocketReader reader;
+    private NewClientReadHandler readHandler;
     private IOService ioService;
     private Connection connection;
 
@@ -31,7 +31,7 @@ public class ClientMessageSocketReaderTest {
     public void setup() throws IOException {
         ioService = mock(IOService.class);
         connection = mock(Connection.class);
-        reader = new ClientMessageSocketReader(connection, ioService);
+        readHandler = new NewClientReadHandler(connection, ioService);
     }
 
     @Test
@@ -46,7 +46,7 @@ public class ClientMessageSocketReaderTest {
         message.writeTo(bb);
         bb.flip();
 
-        reader.read(bb);
+        readHandler.onRead(bb);
 
         verify(ioService).handleClientMessage(any(ClientMessage.class), eq(connection));
     }

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/NewClientWriteHandlerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/NewClientWriteHandlerTest.java
@@ -18,13 +18,13 @@ import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class ClientMessageSocketWriterTest extends HazelcastTestSupport {
+public class NewClientWriteHandlerTest extends HazelcastTestSupport {
 
-    private ClientMessageSocketWriter writer;
+    private NewClientWriteHandler writeHandler;
 
     @Before
     public void setup() {
-        writer = new ClientMessageSocketWriter();
+        writeHandler = new NewClientWriteHandler();
     }
 
     @Test
@@ -34,7 +34,7 @@ public class ClientMessageSocketWriterTest extends HazelcastTestSupport {
                 .setMessageType(1);
 
         ByteBuffer bb = ByteBuffer.allocate(1000);
-        boolean result = writer.write(message, bb);
+        boolean result = writeHandler.onWrite(message, bb);
 
         assertTrue(result);
         bb.flip();

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/OldClientReadHandlerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/OldClientReadHandlerTest.java
@@ -31,9 +31,9 @@ import static org.mockito.Mockito.when;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class ClientPacketSocketReaderTest extends HazelcastTestSupport {
+public class OldClientReadHandlerTest extends HazelcastTestSupport {
 
-    private ClientPacketSocketReader reader;
+    private OldClientReadHandler readHandler;
     private Connection connection;
     private IOService ioService;
     private SerializationService serializationService;
@@ -45,7 +45,7 @@ public class ClientPacketSocketReaderTest extends HazelcastTestSupport {
         when(ioService.getLogger(anyString())).thenReturn(logger);
         serializationService = new DefaultSerializationServiceBuilder().build();
         connection = mock(Connection.class);
-        reader = new ClientPacketSocketReader(connection, ioService);
+        readHandler = new OldClientReadHandler(connection, ioService);
     }
 
     @Test
@@ -86,7 +86,7 @@ public class ClientPacketSocketReaderTest extends HazelcastTestSupport {
         packet.writeTo(buffer);
 
         buffer.flip();
-        reader.read(buffer);
+        readHandler.onRead(buffer);
 
         Mockito.verify(connection).setType(expected);
         verify(ioService).handleClientPacket(eq(packet));
@@ -98,7 +98,7 @@ public class ClientPacketSocketReaderTest extends HazelcastTestSupport {
         buffer.put("J".getBytes());
 
         buffer.flip();
-        reader.read(buffer);
+        readHandler.onRead(buffer);
 
         verifyZeroInteractions(connection);
     }
@@ -116,7 +116,7 @@ public class ClientPacketSocketReaderTest extends HazelcastTestSupport {
         packet3.writeTo(buffer);
 
         buffer.flip();
-        reader.read(buffer);
+        readHandler.onRead(buffer);
 
         verify(ioService).handleClientPacket(eq(packet1));
         verify(ioService).handleClientPacket(eq(packet2));

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/OldClientWriteHandlerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/OldClientWriteHandlerTest.java
@@ -18,22 +18,22 @@ import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class ClientPacketSocketWriterTest {
+public class OldClientWriteHandlerTest {
 
     private SerializationService serializationService;
-    private ClientPacketSocketWriter writer;
+    private OldClientWriteHandler writeHandler;
 
     @Before
     public void setup() {
         serializationService = new DefaultSerializationServiceBuilder().build();
-        writer = new ClientPacketSocketWriter();
+        writeHandler = new OldClientWriteHandler();
     }
 
     @Test
     public void test() throws Exception {
         Packet packet = new Packet(serializationService.toBytes("foobar"));
         ByteBuffer bb = ByteBuffer.allocate(1000);
-        boolean result = writer.write(packet, bb);
+        boolean result = writeHandler.onWrite(packet, bb);
 
         assertTrue(result);
 

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/TcpIpConnection_TransferStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/TcpIpConnection_TransferStressTest.java
@@ -91,12 +91,12 @@ public abstract class TcpIpConnection_TransferStressTest extends TcpIpConnection
         logger.info("expected normal packets: " + expectedNormalPackets);
         logger.info("expected priority packets: " + expectedUrgentPackets);
 
-        final ReadHandler readHandler = ((TcpIpConnection) connManagerB.getConnection(addressA)).getReadHandler();
+        final SocketReader XReadHandler = ((TcpIpConnection) connManagerB.getConnection(addressA)).getSocketReader();
         assertTrueEventually(new AssertTask() {
             @Override
             public void run() throws Exception {
-                assertEquals(expectedNormalPackets, readHandler.getNormalPacketsReadCounter().get());
-                assertEquals(expectedUrgentPackets, readHandler.getPriorityPacketsReadCounter().get());
+                assertEquals(expectedNormalPackets, XReadHandler.getNormalPacketsReadCounter().get());
+                assertEquals(expectedUrgentPackets, XReadHandler.getPriorityPacketsReadCounter().get());
             }
         });
 
@@ -142,13 +142,13 @@ public abstract class TcpIpConnection_TransferStressTest extends TcpIpConnection
 
     public class WriteThread extends TestThread {
         private final Random random = new Random();
-        private final WriteHandler writeHandler;
+        private final SocketWriter writeHandler;
         private long normalPackets;
         private long urgentPackets;
 
         public WriteThread(int id, TcpIpConnection c) {
             super("WriteThread-" + id);
-            this.writeHandler = c.getWriteHandler();
+            this.writeHandler = c.getSocketWriter();
         }
 
         @Override

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/nonblocking/iobalancer/IOBalancerStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/nonblocking/iobalancer/IOBalancerStressTest.java
@@ -25,10 +25,10 @@ import com.hazelcast.instance.HazelcastInstanceFactory;
 import com.hazelcast.nio.tcp.nonblocking.NonBlockingIOThread;
 import com.hazelcast.nio.tcp.nonblocking.MigratableHandler;
 import com.hazelcast.nio.tcp.nonblocking.NonBlockingIOThreadingModel;
-import com.hazelcast.nio.tcp.nonblocking.NonBlockingReadHandler;
+import com.hazelcast.nio.tcp.nonblocking.NonBlockingSocketReader;
 import com.hazelcast.nio.tcp.TcpIpConnection;
 import com.hazelcast.nio.tcp.TcpIpConnectionManager;
-import com.hazelcast.nio.tcp.nonblocking.NonBlockingWriteHandler;
+import com.hazelcast.nio.tcp.nonblocking.NonBlockingSocketWriter;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.NightlyTest;
@@ -112,9 +112,9 @@ public class IOBalancerStressTest extends HazelcastTestSupport {
             sb.append(in + " :" + in.getEventCount() + "\n");
 
             for (TcpIpConnection connection : connectionManager.getActiveConnections()) {
-                NonBlockingReadHandler readHandler = (NonBlockingReadHandler) connection.getReadHandler();
-                if (readHandler.getOwner() == in) {
-                    sb.append("\t" + readHandler + " eventCount:" + readHandler.getEventCount() + "\n");
+                NonBlockingSocketReader socketReader = (NonBlockingSocketReader) connection.getSocketReader();
+                if (socketReader.getOwner() == in) {
+                    sb.append("\t" + socketReader + " eventCount:" + socketReader.getEventCount() + "\n");
                 }
             }
         }
@@ -123,9 +123,9 @@ public class IOBalancerStressTest extends HazelcastTestSupport {
             sb.append(in + " :" + in.getEventCount() + "\n");
 
             for (TcpIpConnection connection : connectionManager.getActiveConnections()) {
-                NonBlockingWriteHandler writeHandler = (NonBlockingWriteHandler) connection.getWriteHandler();
-                if (writeHandler.getOwner() == in) {
-                    sb.append("\t" + writeHandler + " eventCount:" + writeHandler.getEventCount() + "\n");
+                NonBlockingSocketWriter socketWriter = (NonBlockingSocketWriter) connection.getSocketWriter();
+                if (socketWriter.getOwner() == in) {
+                    sb.append("\t" + socketWriter + " eventCount:" + socketWriter.getEventCount() + "\n");
                 }
             }
         }
@@ -137,8 +137,8 @@ public class IOBalancerStressTest extends HazelcastTestSupport {
     private Map<NonBlockingIOThread, Set<MigratableHandler>> getHandlersPerSelector(TcpIpConnectionManager connectionManager) {
         Map<NonBlockingIOThread, Set<MigratableHandler>> handlersPerSelector = new HashMap<NonBlockingIOThread, Set<MigratableHandler>>();
         for (TcpIpConnection connection : connectionManager.getActiveConnections()) {
-            add(handlersPerSelector, (MigratableHandler) connection.getReadHandler());
-            add(handlersPerSelector, (MigratableHandler) connection.getWriteHandler());
+            add(handlersPerSelector, (MigratableHandler) connection.getSocketReader());
+            add(handlersPerSelector, (MigratableHandler) connection.getSocketWriter());
         }
         return handlersPerSelector;
     }


### PR DESCRIPTION
The names of Read/WriteHandler are not obvious (it is a violation of the principle of least surprise; see architectural principles on the wiki).

The SocketReader for example doesn't read from a socket at all; it process the data in from the bytebuffer that has been read by the ReadHandler. The same goes for the WriteHandler.

ReadHandler -> SocketReader
WriteHandler -> SocketWriter
SocketReader -> ReadHandler
SocketWriter -> WriteHandler

Also ReadHandler like ClientMessageReadHandler or and ClientPacketReadHandler have been renamed to NewClientReadHandler and OldClientReadHandler. It isn't relevant they that deal with messages or packets; that is an implementation detail. 

This is a controversial change so I want a few people to have a look at it. In the end I believe it is better since the new code is not surprising anymore. Also a lot of documentation has been added to explain to everyone how the objects fit together. 

Depends on this PR:
https://github.com/hazelcast/hazelcast/pull/6089

This is the enterprise PR:
https://github.com/hazelcast/hazelcast-enterprise/pull/353