### PR TITLE
Fixes memory leak in client listeners

### DIFF
--- a/hazelcast-client-new/src/test/java/com/hazelcast/client/listeners/ListenerLeakTest.java
+++ b/hazelcast-client-new/src/test/java/com/hazelcast/client/listeners/ListenerLeakTest.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.listeners;
+
+import com.hazelcast.client.ClientEndpoint;
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.core.DistributedObjectListener;
+import com.hazelcast.core.EntryListener;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IFunction;
+import com.hazelcast.core.IList;
+import com.hazelcast.core.IMap;
+import com.hazelcast.core.IQueue;
+import com.hazelcast.core.ISet;
+import com.hazelcast.core.ITopic;
+import com.hazelcast.core.ItemListener;
+import com.hazelcast.core.MessageListener;
+import com.hazelcast.core.MultiMap;
+import com.hazelcast.core.ReplicatedMap;
+import com.hazelcast.instance.Node;
+import com.hazelcast.map.listener.MapListener;
+import com.hazelcast.map.listener.MapPartitionLostListener;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Collection;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ListenerLeakTest extends HazelcastTestSupport {
+
+    private final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
+
+    @After
+    public void cleanup() {
+        hazelcastFactory.terminateAll();
+    }
+
+    private void testListenerLeak(IFunction listenerAddRemoveFunc) {
+        HazelcastInstance hazelcast = hazelcastFactory.newHazelcastInstance();
+        Node node = getNode(hazelcast);
+
+        HazelcastInstance client = hazelcastFactory.newHazelcastClient();
+        String id = (String) listenerAddRemoveFunc.apply(client);
+
+        Collection<ClientEndpoint> endpoints = node.clientEngine.getEndpointManager().getEndpoints();
+        for (ClientEndpoint endpoint : endpoints) {
+            assertFalse(endpoint.removeDestroyAction(id));
+        }
+    }
+
+    @Test
+    public void testMapEntryListeners() {
+        testListenerLeak(new IFunction() {
+            @Override
+            public Object apply(Object input) {
+                HazelcastInstance client = (HazelcastInstance) input;
+                IMap map = client.getMap(randomString());
+                String id = map.addEntryListener(mock(MapListener.class), false);
+                assertTrue(map.removeEntryListener(id));
+                return id;
+            }
+        });
+    }
+
+    @Test
+    public void testMapPartitionLostListeners() {
+        testListenerLeak(new IFunction() {
+            @Override
+            public Object apply(Object input) {
+                HazelcastInstance client = (HazelcastInstance) input;
+                IMap map = client.getMap(randomString());
+                String id = map.addPartitionLostListener(mock(MapPartitionLostListener.class));
+                assertTrue(map.removePartitionLostListener(id));
+                return id;
+            }
+        });
+    }
+
+    @Test
+    public void testMultiMapEntryListeners() {
+        testListenerLeak(new IFunction() {
+            @Override
+            public Object apply(Object input) {
+                HazelcastInstance client = (HazelcastInstance) input;
+                MultiMap multiMap = client.getMultiMap(randomString());
+                String id = multiMap.addEntryListener(mock(EntryListener.class), false);
+                assertTrue(multiMap.removeEntryListener(id));
+                return id;
+            }
+        });
+    }
+
+    @Test
+    public void testListListeners() {
+        testListenerLeak(new IFunction() {
+            @Override
+            public Object apply(Object input) {
+                HazelcastInstance client = (HazelcastInstance) input;
+                IList<Object> list = client.getList(randomString());
+                String id = list.addItemListener(mock(ItemListener.class), false);
+                assertTrue(list.removeItemListener(id));
+                return id;
+            }
+        });
+    }
+
+    @Test
+    public void testSetListeners() {
+        testListenerLeak(new IFunction() {
+            @Override
+            public Object apply(Object input) {
+                HazelcastInstance client = (HazelcastInstance) input;
+                ISet<Object> set = client.getSet(randomString());
+                String id = set.addItemListener(mock(ItemListener.class), false);
+                assertTrue(set.removeItemListener(id));
+                return id;
+            }
+        });
+    }
+
+    @Test
+    public void testQueueListeners() {
+        testListenerLeak(new IFunction() {
+            @Override
+            public Object apply(Object input) {
+                HazelcastInstance client = (HazelcastInstance) input;
+                IQueue<Object> queue = client.getQueue(randomString());
+                String id = queue.addItemListener(mock(ItemListener.class), false);
+                assertTrue(queue.removeItemListener(id));
+                return id;
+            }
+        });
+    }
+
+    @Test
+    public void testReplicatedMapListeners() {
+        testListenerLeak(new IFunction() {
+            @Override
+            public Object apply(Object input) {
+                HazelcastInstance client = (HazelcastInstance) input;
+                ReplicatedMap<Object, Object> replicatedMap = client.getReplicatedMap(randomString());
+                String id = replicatedMap.addEntryListener(mock(EntryListener.class));
+                assertTrue(replicatedMap.removeEntryListener(id));
+                return id;
+            }
+        });
+    }
+
+    @Test
+    public void testDistributedObjectListeners() {
+        testListenerLeak(new IFunction() {
+            @Override
+            public Object apply(Object input) {
+                HazelcastInstance client = (HazelcastInstance) input;
+                String id = client.addDistributedObjectListener(mock(DistributedObjectListener.class));
+                assertTrue(client.removeDistributedObjectListener(id));
+                return id;
+            }
+        });
+    }
+
+
+    @Test
+    public void testTopicMessageListener() {
+        testListenerLeak(new IFunction() {
+            @Override
+            public Object apply(Object input) {
+                HazelcastInstance client = (HazelcastInstance) input;
+                ITopic<Object> topic = client.getTopic(randomString());
+                String id = topic.addMessageListener(mock(MessageListener.class));
+                assertTrue(topic.removeMessageListener(id));
+                return id;
+            }
+        });
+    }
+}

--- a/hazelcast-client/src/test/java/com/hazelcast/client/listeners/ListenerLeakTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/listeners/ListenerLeakTest.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.listeners;
+
+import com.hazelcast.client.ClientEndpoint;
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.core.DistributedObjectListener;
+import com.hazelcast.core.EntryListener;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IFunction;
+import com.hazelcast.core.IList;
+import com.hazelcast.core.IMap;
+import com.hazelcast.core.IQueue;
+import com.hazelcast.core.ISet;
+import com.hazelcast.core.ITopic;
+import com.hazelcast.core.ItemListener;
+import com.hazelcast.core.MessageListener;
+import com.hazelcast.core.MultiMap;
+import com.hazelcast.core.ReplicatedMap;
+import com.hazelcast.instance.Node;
+import com.hazelcast.map.listener.MapListener;
+import com.hazelcast.map.listener.MapPartitionLostListener;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Collection;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ListenerLeakTest extends HazelcastTestSupport {
+
+    private final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
+
+    @After
+    public void cleanup() {
+        hazelcastFactory.terminateAll();
+    }
+
+    private void testListenerLeak(IFunction listenerAddRemoveFunc) {
+        HazelcastInstance hazelcast = hazelcastFactory.newHazelcastInstance();
+        Node node = getNode(hazelcast);
+
+        HazelcastInstance client = hazelcastFactory.newHazelcastClient();
+        String id = (String) listenerAddRemoveFunc.apply(client);
+
+        Collection<ClientEndpoint> endpoints = node.clientEngine.getEndpointManager().getEndpoints();
+        for (ClientEndpoint endpoint : endpoints) {
+            assertFalse(endpoint.removeDestroyAction(id));
+        }
+    }
+
+    @Test
+    public void testMapEntryListeners() {
+        testListenerLeak(new IFunction() {
+            @Override
+            public Object apply(Object input) {
+                HazelcastInstance client = (HazelcastInstance) input;
+                IMap map = client.getMap(randomString());
+                String id = map.addEntryListener(mock(MapListener.class), false);
+                assertTrue(map.removeEntryListener(id));
+                return id;
+            }
+        });
+    }
+
+    @Test
+    public void testMapPartitionLostListeners() {
+        testListenerLeak(new IFunction() {
+            @Override
+            public Object apply(Object input) {
+                HazelcastInstance client = (HazelcastInstance) input;
+                IMap map = client.getMap(randomString());
+                String id = map.addPartitionLostListener(mock(MapPartitionLostListener.class));
+                assertTrue(map.removePartitionLostListener(id));
+                return id;
+            }
+        });
+    }
+
+    @Test
+    public void testMultiMapEntryListeners() {
+        testListenerLeak(new IFunction() {
+            @Override
+            public Object apply(Object input) {
+                HazelcastInstance client = (HazelcastInstance) input;
+                MultiMap multiMap = client.getMultiMap(randomString());
+                String id = multiMap.addEntryListener(mock(EntryListener.class), false);
+                assertTrue(multiMap.removeEntryListener(id));
+                return id;
+            }
+        });
+    }
+
+    @Test
+    public void testListListeners() {
+        testListenerLeak(new IFunction() {
+            @Override
+            public Object apply(Object input) {
+                HazelcastInstance client = (HazelcastInstance) input;
+                IList<Object> list = client.getList(randomString());
+                String id = list.addItemListener(mock(ItemListener.class), false);
+                assertTrue(list.removeItemListener(id));
+                return id;
+            }
+        });
+    }
+
+    @Test
+    public void testSetListeners() {
+        testListenerLeak(new IFunction() {
+            @Override
+            public Object apply(Object input) {
+                HazelcastInstance client = (HazelcastInstance) input;
+                ISet<Object> set = client.getSet(randomString());
+                String id = set.addItemListener(mock(ItemListener.class), false);
+                assertTrue(set.removeItemListener(id));
+                return id;
+            }
+        });
+    }
+
+    @Test
+    public void testQueueListeners() {
+        testListenerLeak(new IFunction() {
+            @Override
+            public Object apply(Object input) {
+                HazelcastInstance client = (HazelcastInstance) input;
+                IQueue<Object> queue = client.getQueue(randomString());
+                String id = queue.addItemListener(mock(ItemListener.class), false);
+                assertTrue(queue.removeItemListener(id));
+                return id;
+            }
+        });
+    }
+
+    @Test
+    public void testReplicatedMapListeners() {
+        testListenerLeak(new IFunction() {
+            @Override
+            public Object apply(Object input) {
+                HazelcastInstance client = (HazelcastInstance) input;
+                ReplicatedMap<Object, Object> replicatedMap = client.getReplicatedMap(randomString());
+                String id = replicatedMap.addEntryListener(mock(EntryListener.class));
+                assertTrue(replicatedMap.removeEntryListener(id));
+                return id;
+            }
+        });
+    }
+
+    @Test
+    public void testDistributedObjectListeners() {
+        testListenerLeak(new IFunction() {
+            @Override
+            public Object apply(Object input) {
+                HazelcastInstance client = (HazelcastInstance) input;
+                String id = client.addDistributedObjectListener(mock(DistributedObjectListener.class));
+                assertTrue(client.removeDistributedObjectListener(id));
+                return id;
+            }
+        });
+    }
+
+
+    @Test
+    public void testTopicMessageListener() {
+        testListenerLeak(new IFunction() {
+            @Override
+            public Object apply(Object input) {
+                HazelcastInstance client = (HazelcastInstance) input;
+                ITopic<Object> topic = client.getTopic(randomString());
+                String id = topic.addMessageListener(mock(MessageListener.class));
+                assertTrue(topic.removeMessageListener(id));
+                return id;
+            }
+        });
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/client/CacheAddEntryListenerRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/client/CacheAddEntryListenerRequest.java
@@ -23,10 +23,11 @@ import com.hazelcast.cache.impl.CacheEventSet;
 import com.hazelcast.cache.impl.CachePortableHook;
 import com.hazelcast.cache.impl.CacheService;
 import com.hazelcast.client.ClientEndpoint;
+import com.hazelcast.client.impl.ClientEndpointImpl;
 import com.hazelcast.client.impl.client.CallableClientRequest;
 import com.hazelcast.client.impl.client.RetryableRequest;
-import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.internal.serialization.impl.HeapData;
+import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.PortableReader;
 import com.hazelcast.nio.serialization.PortableWriter;
 import com.hazelcast.spi.EventRegistration;
@@ -38,6 +39,7 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.security.Permission;
 import java.util.Set;
+import java.util.concurrent.Callable;
 
 /**
  * Client request which registers an event listener on behalf of the client and delegates the received events
@@ -60,10 +62,17 @@ public class CacheAddEntryListenerRequest
 
     @Override
     public Object call() {
-        final ClientEndpoint endpoint = getEndpoint();
+        final ClientEndpointImpl endpoint = (ClientEndpointImpl) getEndpoint();
         final CacheService service = getService();
         CacheEntryListener cacheEntryListener = new CacheEntryListener(getCallId(), endpoint);
-        return service.registerListener(name, cacheEntryListener, cacheEntryListener);
+        final String registrationId = service.registerListener(name, cacheEntryListener, cacheEntryListener);
+        endpoint.addDestroyAction(registrationId, new Callable<Boolean>() {
+            @Override
+            public Boolean call() throws Exception {
+                return service.deregisterListener(name, registrationId);
+            }
+        });
+        return registrationId;
     }
 
     @SuppressFBWarnings(value = "SE_NO_SERIALVERSIONID",

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/client/CacheAddInvalidationListenerRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/client/CacheAddInvalidationListenerRequest.java
@@ -49,7 +49,7 @@ public class CacheAddInvalidationListenerRequest
         CacheContext cacheContext = cacheService.getOrCreateCacheContext(name);
         CacheInvalidationListener listener = new CacheInvalidationListener(endpoint, getCallId(), cacheContext);
         String registrationId = cacheService.addInvalidationListener(name, listener);
-        endpoint.setListenerRegistration(CacheService.SERVICE_NAME, name, registrationId);
+        endpoint.addListenerDestroyAction(CacheService.SERVICE_NAME, name, registrationId);
         return registrationId;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/client/CacheAddPartitionLostListenerRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/client/CacheAddPartitionLostListenerRequest.java
@@ -72,7 +72,7 @@ public class CacheAddPartitionLostListenerRequest extends CallableClientRequest
                 getEventService().registerListener(AbstractCacheService.SERVICE_NAME,
                 name, filter, listenerAdapter);
         final String registrationId = registration.getId();
-        endpoint.setListenerRegistration(CacheService.SERVICE_NAME, name, registrationId);
+        endpoint.addListenerDestroyAction(CacheService.SERVICE_NAME, name, registrationId);
 
         return registrationId;
     }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/client/CacheRemoveEntryListenerRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/client/CacheRemoveEntryListenerRequest.java
@@ -38,8 +38,7 @@ public class CacheRemoveEntryListenerRequest
     }
 
     @Override
-    public Object call()
-            throws Exception {
+    protected boolean deRegisterListener() {
         final CacheService service = getService();
         return service.deregisterListener(name, registrationId);
     }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/client/CacheRemoveInvalidationListenerRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/client/CacheRemoveInvalidationListenerRequest.java
@@ -25,7 +25,6 @@ import java.security.Permission;
 /**
  * Client request which unregisters the invalidation listener on behalf of the client.
  *
- * @see com.hazelcast.cache.impl.CacheService#deregisterListener(String, String)
  */
 public class CacheRemoveInvalidationListenerRequest
         extends BaseClientRemoveListenerRequest {
@@ -38,8 +37,7 @@ public class CacheRemoveInvalidationListenerRequest
     }
 
     @Override
-    public Object call()
-            throws Exception {
+    protected boolean deRegisterListener() {
         final CacheService service = getService();
         return service.deregisterListener(name, registrationId);
     }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/client/CacheRemovePartitionLostListenerRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/client/CacheRemovePartitionLostListenerRequest.java
@@ -24,7 +24,7 @@ import com.hazelcast.client.impl.client.BaseClientRemoveListenerRequest;
 
 import java.security.Permission;
 
-public class CacheRemovePartitionLostListenerRequest  extends BaseClientRemoveListenerRequest {
+public class CacheRemovePartitionLostListenerRequest extends BaseClientRemoveListenerRequest {
 
 
     public CacheRemovePartitionLostListenerRequest() {
@@ -34,7 +34,7 @@ public class CacheRemovePartitionLostListenerRequest  extends BaseClientRemoveLi
         super(name, registrationId);
     }
 
-    public Object call() throws Exception {
+    protected boolean deRegisterListener() {
         final ICacheService service = getService();
         return service.getNodeEngine().getEventService().
                 deregisterListener(AbstractCacheService.SERVICE_NAME,

--- a/hazelcast/src/main/java/com/hazelcast/client/ClientEndpoint.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/ClientEndpoint.java
@@ -23,6 +23,7 @@ import com.hazelcast.transaction.TransactionContext;
 
 import javax.security.auth.Subject;
 import javax.security.auth.login.LoginContext;
+import java.util.concurrent.Callable;
 
 /**
  * Represents an endpoint to a client. So for each client connected to a member, a ClientEndpoint object is available.
@@ -42,7 +43,33 @@ public interface ClientEndpoint {
     //TODO remove after requests removed
     void sendEvent(Object key, Object event, int callId);
 
-    void setListenerRegistration(String service, String topic, String id);
+
+    /**
+     * Adds a remove callable to be called when endpoint is destroyed to clean related listener
+     * Following line will be called when endpoint destroyed :
+     * eventService.deregisterListener(service, topic, id);
+     * Note: removeDestroyAction should be called when there is no need to destroy action anymore.
+     *
+     * @param service name of the related service of listener
+     * @param topic   topic name of listener(mostly distributed object name)
+     * @param id      registration id of remove action
+     */
+    void addListenerDestroyAction(String service, String topic, String id);
+
+    /**
+     * Adds a remove callable to be called when endpoint is destroyed
+     * Note: removeDestroyAction should be called when there is no need to destroy action anymore.
+     *
+     * @param registrationId registration id of destroy action
+     * @param removeAction   callable that will be called when endpoint is destroyed
+     */
+    void addDestroyAction(String registrationId, Callable<Boolean> removeAction);
+
+    /**
+     * @param id registration id of destroy action
+     * @return true if remove is successful
+     */
+    boolean removeDestroyAction(String id);
 
     String getUuid();
 
@@ -67,8 +94,6 @@ public interface ClientEndpoint {
     void authenticated(ClientPrincipal principal, Credentials credentials, boolean firstConnection);
 
     void authenticated(ClientPrincipal principal);
-
-    void setDistributedObjectListener(String registrationId);
 
     ClientPrincipal getPrincipal();
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEndpointImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEndpointImpl.java
@@ -24,9 +24,9 @@ import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.core.Client;
 import com.hazelcast.core.ClientType;
 import com.hazelcast.core.HazelcastInstanceNotActiveException;
+import com.hazelcast.internal.serialization.impl.HeapData;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Connection;
-import com.hazelcast.internal.serialization.impl.HeapData;
 import com.hazelcast.nio.tcp.TcpIpConnection;
 import com.hazelcast.security.Credentials;
 import com.hazelcast.spi.EventService;
@@ -39,9 +39,7 @@ import javax.security.auth.login.LoginContext;
 import javax.security.auth.login.LoginException;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
-import java.util.Collections;
-import java.util.LinkedList;
-import java.util.List;
+import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
@@ -54,7 +52,7 @@ public final class ClientEndpointImpl implements Client, ClientEndpoint {
     private final Connection conn;
     private final ConcurrentMap<String, TransactionContext> transactionContextMap
             = new ConcurrentHashMap<String, TransactionContext>();
-    private final List<Runnable> removeListenerActions = Collections.synchronizedList(new LinkedList<Runnable>());
+    private final ConcurrentHashMap<String, Callable> removeListenerActions = new ConcurrentHashMap<String, Callable>();
     private final SocketAddress socketAddress;
 
     private LoginContext loginContext;
@@ -184,34 +182,31 @@ public final class ClientEndpointImpl implements Client, ClientEndpoint {
     }
 
     @Override
-    public void setListenerRegistration(final String service, final String topic, final String id) {
-        removeListenerActions.add(new Runnable() {
+    public void addListenerDestroyAction(final String service, final String topic, final String id) {
+        final EventService eventService = clientEngine.getEventService();
+        addDestroyAction(id, new Callable<Boolean>() {
             @Override
-            public void run() {
-                EventService eventService = clientEngine.getEventService();
-                eventService.deregisterListener(service, topic, id);
+            public Boolean call() {
+                return eventService.deregisterListener(service, topic, id);
             }
         });
     }
 
     @Override
-    public void setDistributedObjectListener(final String id) {
-        removeListenerActions.add(new Runnable() {
-            @Override
-            public void run() {
-                clientEngine.getProxyService().removeProxyListener(id);
-            }
-        });
+    public void addDestroyAction(String registrationId, Callable<Boolean> removeAction) {
+        removeListenerActions.put(registrationId, removeAction);
+    }
+
+    @Override
+    public boolean removeDestroyAction(String id) {
+        return removeListenerActions.remove(id) != null;
     }
 
     @Override
     public void clearAllListeners() {
-        //Changed from normal iteration to copying with toArray because of ConcurrentModificationException.
-        // toArray is called under internal mutex of synchronized list.
-        Object[] actions = removeListenerActions.toArray();
-        for (Object removeAction : actions) {
+        for (Callable removeAction : removeListenerActions.values()) {
             try {
-                ((Runnable) removeAction).run();
+                removeAction.call();
             } catch (Exception e) {
                 getLogger().warning("Exception during remove listener action", e);
             }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/client/BaseClientRemoveListenerRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/client/BaseClientRemoveListenerRequest.java
@@ -34,6 +34,13 @@ public abstract class BaseClientRemoveListenerRequest extends CallableClientRequ
         this.registrationId = registrationId;
     }
 
+    public final Object call() {
+        endpoint.removeDestroyAction(registrationId);
+        return deRegisterListener();
+    }
+
+    protected abstract boolean deRegisterListener();
+
     public String getRegistrationId() {
         return registrationId;
     }
@@ -68,7 +75,7 @@ public abstract class BaseClientRemoveListenerRequest extends CallableClientRequ
     }
 
     @Override
-    public Object[] getParameters() {
+    public final Object[] getParameters() {
         return new Object[]{registrationId};
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/client/DistributedObjectListenerRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/client/DistributedObjectListenerRequest.java
@@ -23,17 +23,24 @@ import com.hazelcast.spi.impl.PortableDistributedObjectEvent;
 import com.hazelcast.spi.impl.proxyservice.impl.ProxyServiceImpl;
 
 import java.security.Permission;
+import java.util.concurrent.Callable;
 
-public class DistributedObjectListenerRequest extends CallableClientRequest implements RetryableRequest {
+public class DistributedObjectListenerRequest extends CallableClientRequest implements RetryableRequest
+        , DistributedObjectListener {
 
     public DistributedObjectListenerRequest() {
     }
 
     @Override
     public Object call() throws Exception {
-        ProxyService proxyService = getService();
-        String registrationId = proxyService.addProxyListener(new MyDistributedObjectListener());
-        endpoint.setDistributedObjectListener(registrationId);
+        final ProxyService proxyService = clientEngine.getProxyService();
+        final String registrationId = proxyService.addProxyListener(this);
+        endpoint.addDestroyAction(registrationId, new Callable() {
+            @Override
+            public Boolean call() {
+                return proxyService.removeProxyListener(registrationId);
+            }
+        });
         return registrationId;
     }
 
@@ -52,23 +59,21 @@ public class DistributedObjectListenerRequest extends CallableClientRequest impl
         return ClientPortableHook.LISTENER;
     }
 
-    private class MyDistributedObjectListener implements DistributedObjectListener {
-        @Override
-        public void distributedObjectCreated(DistributedObjectEvent event) {
-            send(event);
-        }
+    @Override
+    public void distributedObjectCreated(DistributedObjectEvent event) {
+        send(event);
+    }
 
-        @Override
-        public void distributedObjectDestroyed(DistributedObjectEvent event) {
-            send(event);
-        }
+    @Override
+    public void distributedObjectDestroyed(DistributedObjectEvent event) {
+        send(event);
+    }
 
-        private void send(DistributedObjectEvent event) {
-            if (endpoint.isAlive()) {
-                PortableDistributedObjectEvent portableEvent = new PortableDistributedObjectEvent(
-                        event.getEventType(), event.getDistributedObject().getName(), event.getServiceName());
-                endpoint.sendEvent(null, portableEvent, getCallId());
-            }
+    private void send(DistributedObjectEvent event) {
+        if (endpoint.isAlive()) {
+            PortableDistributedObjectEvent portableEvent = new PortableDistributedObjectEvent(
+                    event.getEventType(), event.getDistributedObject().getName(), event.getServiceName());
+            endpoint.sendEvent(null, portableEvent, getCallId());
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/client/RemoveDistributedObjectListenerRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/client/RemoveDistributedObjectListenerRequest.java
@@ -22,7 +22,7 @@ import com.hazelcast.spi.impl.proxyservice.impl.ProxyServiceImpl;
 import java.security.Permission;
 
 /**
- * Client request to add a distributed object listener to a remote node.
+ * Client request to remove a distributed object listener from a remote node.
  */
 public class RemoveDistributedObjectListenerRequest extends BaseClientRemoveListenerRequest {
 
@@ -34,7 +34,7 @@ public class RemoveDistributedObjectListenerRequest extends BaseClientRemoveList
     }
 
     @Override
-    public Object call() throws Exception {
+    protected boolean deRegisterListener() {
         ProxyService proxyService = getService();
         return proxyService.removeProxyListener(registrationId);
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractRemoveListenerMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractRemoveListenerMessageTask.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.impl.protocol.task;
+
+import com.hazelcast.client.impl.protocol.ClientMessage;
+import com.hazelcast.instance.Node;
+import com.hazelcast.nio.Connection;
+
+/**
+ * Base class for remove listener message tasks that removes a client listener registration
+ * from a node
+ *
+ * @param <P> listener registration request parameters type
+ */
+public abstract class AbstractRemoveListenerMessageTask<P> extends AbstractCallableMessageTask<P> {
+
+    protected AbstractRemoveListenerMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
+        super(clientMessage, node, connection);
+    }
+
+    public final Object call() {
+        endpoint.removeDestroyAction(getRegistrationId());
+        return deRegisterListener();
+    }
+
+    protected abstract boolean deRegisterListener();
+
+    protected abstract String getRegistrationId();
+
+    @Override
+    public final Object[] getParameters() {
+        return new Object[]{getRegistrationId()};
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AddPartitionLostListenerMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AddPartitionLostListenerMessageTask.java
@@ -52,7 +52,7 @@ public class AddPartitionLostListenerMessageTask
         };
 
         final String registrationId = partitionService.addPartitionLostListener(listener);
-        endpoint.setListenerRegistration(getServiceName(), PARTITION_LOST_EVENT_TOPIC, registrationId);
+        endpoint.addListenerDestroyAction(getServiceName(), PARTITION_LOST_EVENT_TOPIC, registrationId);
         return registrationId;
 
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/RegisterMembershipListenerMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/RegisterMembershipListenerMessageTask.java
@@ -46,7 +46,7 @@ public class RegisterMembershipListenerMessageTask
         ClusterServiceImpl service = getService(serviceName);
         ClientEndpoint endpoint = getEndpoint();
         String registrationId = service.addMembershipListener(new MembershipListenerImpl(endpoint));
-        endpoint.setListenerRegistration(serviceName, serviceName, registrationId);
+        endpoint.addListenerDestroyAction(serviceName, serviceName, registrationId);
         return registrationId;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/RemoveDistributedObjectListenerMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/RemoveDistributedObjectListenerMessageTask.java
@@ -25,16 +25,21 @@ import com.hazelcast.spi.impl.proxyservice.impl.ProxyServiceImpl;
 import java.security.Permission;
 
 public class RemoveDistributedObjectListenerMessageTask
-        extends AbstractCallableMessageTask<ClientRemoveDistributedObjectListenerCodec.RequestParameters> {
+        extends AbstractRemoveListenerMessageTask<ClientRemoveDistributedObjectListenerCodec.RequestParameters> {
 
     public RemoveDistributedObjectListenerMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);
     }
 
     @Override
-    protected Object call() throws Exception {
+    protected boolean deRegisterListener() {
         boolean success = clientEngine.getProxyService().removeProxyListener(parameters.registrationId);
         return success;
+    }
+
+    @Override
+    protected String getRegistrationId() {
+        return parameters.registrationId;
     }
 
     @Override
@@ -67,8 +72,4 @@ public class RemoveDistributedObjectListenerMessageTask
         return "removeDistributedObjectListener";
     }
 
-    @Override
-    public Object[] getParameters() {
-        return new Object[]{parameters.registrationId};
-    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/RemovePartitionLostListenerMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/RemovePartitionLostListenerMessageTask.java
@@ -25,17 +25,21 @@ import com.hazelcast.partition.InternalPartitionService;
 import java.security.Permission;
 
 public class RemovePartitionLostListenerMessageTask
-        extends AbstractCallableMessageTask<ClientRemovePartitionLostListenerCodec.RequestParameters> {
+        extends AbstractRemoveListenerMessageTask<ClientRemovePartitionLostListenerCodec.RequestParameters> {
 
     public RemovePartitionLostListenerMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);
     }
 
     @Override
-    protected Object call() throws Exception {
+    protected boolean deRegisterListener() {
         final InternalPartitionService service = getService(InternalPartitionService.SERVICE_NAME);
-        boolean success = service.removePartitionLostListener(parameters.registrationId);
-        return success;
+        return service.removePartitionLostListener(parameters.registrationId);
+    }
+
+    @Override
+    protected String getRegistrationId() {
+        return parameters.registrationId;
     }
 
     @Override
@@ -68,8 +72,4 @@ public class RemovePartitionLostListenerMessageTask
         return "removePartitionLostListener";
     }
 
-    @Override
-    public Object[] getParameters() {
-        return new Object[]{parameters.registrationId};
-    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheAddInvalidationListenerTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheAddInvalidationListenerTask.java
@@ -51,7 +51,7 @@ public class CacheAddInvalidationListenerTask
         String registrationId =
                 cacheService.addInvalidationListener(parameters.name,
                                                      new CacheInvalidationEventListener(endpoint, cacheContext));
-        endpoint.setListenerRegistration(CacheService.SERVICE_NAME, parameters.name, registrationId);
+        endpoint.addListenerDestroyAction(CacheService.SERVICE_NAME, parameters.name, registrationId);
         return registrationId;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheAddPartitionLostListenerMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheAddPartitionLostListenerMessageTask.java
@@ -65,7 +65,7 @@ public class CacheAddPartitionLostListenerMessageTask
                 getEventService().registerListener(AbstractCacheService.SERVICE_NAME,
                 parameters.name, filter, listenerAdapter);
         final String registrationId = registration.getId();
-        endpoint.setListenerRegistration(CacheService.SERVICE_NAME, parameters.name, registrationId);
+        endpoint.addListenerDestroyAction(CacheService.SERVICE_NAME, parameters.name, registrationId);
         return registrationId;
 
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheRemoveEntryListenerMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheRemoveEntryListenerMessageTask.java
@@ -19,7 +19,7 @@ package com.hazelcast.client.impl.protocol.task.cache;
 import com.hazelcast.cache.impl.CacheService;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.CacheRemoveEntryListenerCodec;
-import com.hazelcast.client.impl.protocol.task.AbstractCallableMessageTask;
+import com.hazelcast.client.impl.protocol.task.AbstractRemoveListenerMessageTask;
 import com.hazelcast.instance.Node;
 import com.hazelcast.nio.Connection;
 
@@ -31,14 +31,19 @@ import java.security.Permission;
  * @see com.hazelcast.cache.impl.CacheService#deregisterListener(String, String)
  */
 public class CacheRemoveEntryListenerMessageTask
-        extends AbstractCallableMessageTask<CacheRemoveEntryListenerCodec.RequestParameters> {
+        extends AbstractRemoveListenerMessageTask<CacheRemoveEntryListenerCodec.RequestParameters> {
 
     public CacheRemoveEntryListenerMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);
     }
 
     @Override
-    protected Object call() {
+    protected String getRegistrationId() {
+        return parameters.registrationId;
+    }
+
+    @Override
+    protected boolean deRegisterListener() {
         CacheService service = getService(CacheService.SERVICE_NAME);
         return service.deregisterListener(parameters.name, parameters.registrationId);
     }
@@ -73,8 +78,4 @@ public class CacheRemoveEntryListenerMessageTask
         return null;
     }
 
-    @Override
-    public Object[] getParameters() {
-        return null;
-    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheRemoveInvalidationListenerMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheRemoveInvalidationListenerMessageTask.java
@@ -19,7 +19,7 @@ package com.hazelcast.client.impl.protocol.task.cache;
 import com.hazelcast.cache.impl.CacheService;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.CacheRemoveInvalidationListenerCodec;
-import com.hazelcast.client.impl.protocol.task.AbstractCallableMessageTask;
+import com.hazelcast.client.impl.protocol.task.AbstractRemoveListenerMessageTask;
 import com.hazelcast.instance.Node;
 import com.hazelcast.nio.Connection;
 
@@ -31,16 +31,21 @@ import java.security.Permission;
  * @see com.hazelcast.cache.impl.CacheService#deregisterListener(String, String)
  */
 public class CacheRemoveInvalidationListenerMessageTask
-        extends AbstractCallableMessageTask<CacheRemoveInvalidationListenerCodec.RequestParameters> {
+        extends AbstractRemoveListenerMessageTask<CacheRemoveInvalidationListenerCodec.RequestParameters> {
 
     public CacheRemoveInvalidationListenerMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);
     }
 
     @Override
-    protected Object call() {
+    protected boolean deRegisterListener() {
         CacheService service = getService(CacheService.SERVICE_NAME);
         return service.deregisterListener(parameters.name, parameters.registrationId);
+    }
+
+    @Override
+    protected String getRegistrationId() {
+        return parameters.registrationId;
     }
 
     @Override
@@ -73,8 +78,4 @@ public class CacheRemoveInvalidationListenerMessageTask
         return null;
     }
 
-    @Override
-    public Object[] getParameters() {
-        return null;
-    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheRemovePartitionLostListenerMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheRemovePartitionLostListenerMessageTask.java
@@ -21,14 +21,14 @@ import com.hazelcast.cache.impl.CacheService;
 import com.hazelcast.cache.impl.ICacheService;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.CacheRemovePartitionLostListenerCodec;
-import com.hazelcast.client.impl.protocol.task.AbstractCallableMessageTask;
+import com.hazelcast.client.impl.protocol.task.AbstractRemoveListenerMessageTask;
 import com.hazelcast.instance.Node;
 import com.hazelcast.nio.Connection;
 
 import java.security.Permission;
 
 public class CacheRemovePartitionLostListenerMessageTask
-        extends AbstractCallableMessageTask<CacheRemovePartitionLostListenerCodec.RequestParameters> {
+        extends AbstractRemoveListenerMessageTask<CacheRemovePartitionLostListenerCodec.RequestParameters> {
 
 
     public CacheRemovePartitionLostListenerMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
@@ -36,10 +36,15 @@ public class CacheRemovePartitionLostListenerMessageTask
     }
 
     @Override
-    protected Object call() {
+    protected boolean deRegisterListener() {
         ICacheService service = getService(CacheService.SERVICE_NAME);
         return service.getNodeEngine().getEventService().deregisterListener(AbstractCacheService.SERVICE_NAME,
                 parameters.name, parameters.registrationId);
+    }
+
+    @Override
+    protected String getRegistrationId() {
+        return parameters.registrationId;
     }
 
     @Override
@@ -72,8 +77,4 @@ public class CacheRemovePartitionLostListenerMessageTask
         return "removeCachePartitionLostListener";
     }
 
-    @Override
-    public Object[] getParameters() {
-        return new Object[]{parameters.registrationId};
-    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/ListAddListenerMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/ListAddListenerMessageTask.java
@@ -51,7 +51,7 @@ public class ListAddListenerMessageTask
         final CollectionEventFilter filter = new CollectionEventFilter(parameters.includeValue);
         final EventRegistration registration = eventService.registerListener(getServiceName(), parameters.name, filter, listener);
         final String registrationId = registration.getId();
-        endpoint.setListenerRegistration(getServiceName(), parameters.name, registrationId);
+        endpoint.addListenerDestroyAction(getServiceName(), parameters.name, registrationId);
         return registrationId;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/ListRemoveListenerMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/ListRemoveListenerMessageTask.java
@@ -18,7 +18,7 @@ package com.hazelcast.client.impl.protocol.task.list;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.ListRemoveListenerCodec;
-import com.hazelcast.client.impl.protocol.task.AbstractCallableMessageTask;
+import com.hazelcast.client.impl.protocol.task.AbstractRemoveListenerMessageTask;
 import com.hazelcast.collection.impl.list.ListService;
 import com.hazelcast.instance.Node;
 import com.hazelcast.nio.Connection;
@@ -33,16 +33,21 @@ import java.security.Permission;
  * {@link com.hazelcast.client.impl.protocol.codec.ListMessageType#LIST_REMOVELISTENER}
  */
 public class ListRemoveListenerMessageTask
-        extends AbstractCallableMessageTask<ListRemoveListenerCodec.RequestParameters> {
+        extends AbstractRemoveListenerMessageTask<ListRemoveListenerCodec.RequestParameters> {
 
     public ListRemoveListenerMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);
     }
 
     @Override
-    protected Object call() {
+    protected boolean deRegisterListener() {
         final EventService eventService = clientEngine.getEventService();
         return eventService.deregisterListener(getServiceName(), parameters.name, parameters.registrationId);
+    }
+
+    @Override
+    protected String getRegistrationId() {
+        return parameters.registrationId;
     }
 
     @Override
@@ -58,11 +63,6 @@ public class ListRemoveListenerMessageTask
     @Override
     public String getServiceName() {
         return ListService.SERVICE_NAME;
-    }
-
-    @Override
-    public Object[] getParameters() {
-        return new Object[]{parameters.registrationId};
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/AbstractMapAddEntryListenerMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/AbstractMapAddEntryListenerMessageTask.java
@@ -51,7 +51,7 @@ public abstract class AbstractMapAddEntryListenerMessageTask<Parameter>
         MapServiceContext mapServiceContext = mapService.getMapServiceContext();
         final String name = getDistributedObjectName();
         final String registrationId = mapServiceContext.addEventListener(listener, getEventFilter(), name);
-        endpoint.setListenerRegistration(MapService.SERVICE_NAME, name, registrationId);
+        endpoint.addListenerDestroyAction(MapService.SERVICE_NAME, name, registrationId);
         return registrationId;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapAddPartitionLostListenerMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapAddPartitionLostListenerMessageTask.java
@@ -56,7 +56,7 @@ public class MapAddPartitionLostListenerMessageTask
         };
 
         String registrationId = mapService.getMapServiceContext().addPartitionLostListener(listener, parameters.name);
-        endpoint.setListenerRegistration(MapService.SERVICE_NAME, parameters.name, registrationId);
+        endpoint.addListenerDestroyAction(MapService.SERVICE_NAME, parameters.name, registrationId);
         return registrationId;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapRemoveEntryListenerMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapRemoveEntryListenerMessageTask.java
@@ -18,7 +18,7 @@ package com.hazelcast.client.impl.protocol.task.map;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.MapRemoveEntryListenerCodec;
-import com.hazelcast.client.impl.protocol.task.AbstractCallableMessageTask;
+import com.hazelcast.client.impl.protocol.task.AbstractRemoveListenerMessageTask;
 import com.hazelcast.instance.Node;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.nio.Connection;
@@ -28,16 +28,21 @@ import com.hazelcast.security.permission.MapPermission;
 import java.security.Permission;
 
 public class MapRemoveEntryListenerMessageTask
-        extends AbstractCallableMessageTask<MapRemoveEntryListenerCodec.RequestParameters> {
+        extends AbstractRemoveListenerMessageTask<MapRemoveEntryListenerCodec.RequestParameters> {
 
     public MapRemoveEntryListenerMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);
     }
 
     @Override
-    protected Object call() {
+    protected boolean deRegisterListener() {
         MapService service = getService(MapService.SERVICE_NAME);
         return service.getMapServiceContext().removeEventListener(parameters.name, parameters.registrationId);
+    }
+
+    @Override
+    protected String getRegistrationId() {
+        return parameters.registrationId;
     }
 
     @Override
@@ -70,8 +75,4 @@ public class MapRemoveEntryListenerMessageTask
         return "removeEntryListener";
     }
 
-    @Override
-    public Object[] getParameters() {
-        return new Object[]{parameters.registrationId};
-    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapRemovePartitionLostListenerMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapRemovePartitionLostListenerMessageTask.java
@@ -18,7 +18,7 @@ package com.hazelcast.client.impl.protocol.task.map;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.MapRemovePartitionLostListenerCodec;
-import com.hazelcast.client.impl.protocol.task.AbstractCallableMessageTask;
+import com.hazelcast.client.impl.protocol.task.AbstractRemoveListenerMessageTask;
 import com.hazelcast.instance.Node;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.nio.Connection;
@@ -26,7 +26,7 @@ import com.hazelcast.nio.Connection;
 import java.security.Permission;
 
 public class MapRemovePartitionLostListenerMessageTask
-        extends AbstractCallableMessageTask<MapRemovePartitionLostListenerCodec.RequestParameters> {
+        extends AbstractRemoveListenerMessageTask<MapRemovePartitionLostListenerCodec.RequestParameters> {
 
 
     public MapRemovePartitionLostListenerMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
@@ -34,9 +34,14 @@ public class MapRemovePartitionLostListenerMessageTask
     }
 
     @Override
-    protected Object call() {
+    protected boolean deRegisterListener() {
         MapService mapService = getService(MapService.SERVICE_NAME);
         return mapService.getMapServiceContext().removePartitionLostListener(parameters.name, parameters.registrationId);
+    }
+
+    @Override
+    protected String getRegistrationId() {
+        return parameters.registrationId;
     }
 
     @Override
@@ -69,8 +74,4 @@ public class MapRemovePartitionLostListenerMessageTask
         return "removePartitionLostListener";
     }
 
-    @Override
-    public Object[] getParameters() {
-        return new Object[]{parameters.registrationId};
-    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/AbstractMultiMapAddEntryListenerMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/AbstractMultiMapAddEntryListenerMessageTask.java
@@ -49,7 +49,7 @@ public abstract class AbstractMultiMapAddEntryListenerMessageTask<P> extends Abs
         Data key = getKey();
         boolean includeValue = shouldIncludeValue();
         String registrationId = service.addListener(name, listener, key, includeValue, false);
-        endpoint.setListenerRegistration(MultiMapService.SERVICE_NAME, name, registrationId);
+        endpoint.addListenerDestroyAction(MultiMapService.SERVICE_NAME, name, registrationId);
         return registrationId;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapRemoveEntryListenerMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapRemoveEntryListenerMessageTask.java
@@ -18,7 +18,7 @@ package com.hazelcast.client.impl.protocol.task.multimap;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.MultiMapRemoveEntryListenerCodec;
-import com.hazelcast.client.impl.protocol.task.AbstractCallableMessageTask;
+import com.hazelcast.client.impl.protocol.task.AbstractRemoveListenerMessageTask;
 import com.hazelcast.instance.Node;
 import com.hazelcast.multimap.impl.MultiMapService;
 import com.hazelcast.nio.Connection;
@@ -32,16 +32,21 @@ import java.security.Permission;
  * {@link com.hazelcast.client.impl.protocol.codec.MultiMapMessageType#MULTIMAP_REMOVEENTRYLISTENER}
  */
 public class MultiMapRemoveEntryListenerMessageTask
-        extends AbstractCallableMessageTask<MultiMapRemoveEntryListenerCodec.RequestParameters> {
+        extends AbstractRemoveListenerMessageTask<MultiMapRemoveEntryListenerCodec.RequestParameters> {
 
     public MultiMapRemoveEntryListenerMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);
     }
 
     @Override
-    protected Object call() throws Exception {
+    protected boolean deRegisterListener() {
         final MultiMapService service = getService(MultiMapService.SERVICE_NAME);
         return service.removeListener(parameters.name, parameters.registrationId);
+    }
+
+    @Override
+    protected String getRegistrationId() {
+        return parameters.registrationId;
     }
 
     @Override
@@ -74,8 +79,4 @@ public class MultiMapRemoveEntryListenerMessageTask
         return "removeEntryListener";
     }
 
-    @Override
-    public Object[] getParameters() {
-        return new Object[]{parameters.registrationId};
-    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/queue/QueueAddListenerMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/queue/QueueAddListenerMessageTask.java
@@ -76,7 +76,7 @@ public class QueueAddListenerMessageTask
             }
         };
         String registrationId = service.addItemListener(parameters.name, listener, parameters.includeValue);
-        endpoint.setListenerRegistration(QueueService.SERVICE_NAME, parameters.name, registrationId);
+        endpoint.addListenerDestroyAction(QueueService.SERVICE_NAME, parameters.name, registrationId);
         return registrationId;
 
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/queue/QueueRemoveListenerMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/queue/QueueRemoveListenerMessageTask.java
@@ -18,7 +18,7 @@ package com.hazelcast.client.impl.protocol.task.queue;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.QueueRemoveListenerCodec;
-import com.hazelcast.client.impl.protocol.task.AbstractCallableMessageTask;
+import com.hazelcast.client.impl.protocol.task.AbstractRemoveListenerMessageTask;
 import com.hazelcast.collection.impl.queue.QueueService;
 import com.hazelcast.instance.Node;
 import com.hazelcast.nio.Connection;
@@ -32,16 +32,21 @@ import java.security.Permission;
  * {@link com.hazelcast.client.impl.protocol.codec.QueueMessageType#QUEUE_REMOVELISTENER}
  */
 public class QueueRemoveListenerMessageTask
-        extends AbstractCallableMessageTask<QueueRemoveListenerCodec.RequestParameters> {
+        extends AbstractRemoveListenerMessageTask<QueueRemoveListenerCodec.RequestParameters> {
 
     public QueueRemoveListenerMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);
     }
 
     @Override
-    protected Object call() {
+    protected boolean deRegisterListener() {
         final QueueService service = getService(getServiceName());
         return service.removeItemListener(parameters.name, parameters.registrationId);
+    }
+
+    @Override
+    protected String getRegistrationId() {
+        return parameters.registrationId;
     }
 
     @Override
@@ -52,11 +57,6 @@ public class QueueRemoveListenerMessageTask
     @Override
     protected ClientMessage encodeResponse(Object response) {
         return QueueRemoveListenerCodec.encodeResponse((Boolean) response);
-    }
-
-    @Override
-    public Object[] getParameters() {
-        return new Object[]{parameters.registrationId};
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/replicatedmap/AbstractReplicatedMapAddEntryListenerMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/replicatedmap/AbstractReplicatedMapAddEntryListenerMessageTask.java
@@ -53,7 +53,7 @@ public abstract class AbstractReplicatedMapAddEntryListenerMessageTask<Parameter
         } else {
             registrationId = recordStore.addEntryListener(this, predicate, getKey());
         }
-        endpoint.setListenerRegistration(ReplicatedMapService.SERVICE_NAME, getDistributedObjectName(), registrationId);
+        endpoint.addListenerDestroyAction(ReplicatedMapService.SERVICE_NAME, getDistributedObjectName(), registrationId);
         return registrationId;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/replicatedmap/ReplicatedMapRemoveEntryListenerMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/replicatedmap/ReplicatedMapRemoveEntryListenerMessageTask.java
@@ -18,7 +18,7 @@ package com.hazelcast.client.impl.protocol.task.replicatedmap;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.ReplicatedMapRemoveEntryListenerCodec;
-import com.hazelcast.client.impl.protocol.task.AbstractCallableMessageTask;
+import com.hazelcast.client.impl.protocol.task.AbstractRemoveListenerMessageTask;
 import com.hazelcast.instance.Node;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.replicatedmap.impl.ReplicatedMapService;
@@ -29,17 +29,22 @@ import com.hazelcast.security.permission.ReplicatedMapPermission;
 import java.security.Permission;
 
 public class ReplicatedMapRemoveEntryListenerMessageTask
-        extends AbstractCallableMessageTask<ReplicatedMapRemoveEntryListenerCodec.RequestParameters> {
+        extends AbstractRemoveListenerMessageTask<ReplicatedMapRemoveEntryListenerCodec.RequestParameters> {
 
     public ReplicatedMapRemoveEntryListenerMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);
     }
 
     @Override
-    protected Object call() throws Exception {
+    protected boolean deRegisterListener() {
         ReplicatedMapService replicatedMapService = getService(ReplicatedMapService.SERVICE_NAME);
         ReplicatedRecordStore recordStore = replicatedMapService.getReplicatedRecordStore(parameters.name, true);
         return recordStore.removeEntryListenerInternal(parameters.registrationId);
+    }
+
+    @Override
+    protected String getRegistrationId() {
+        return parameters.registrationId;
     }
 
     @Override
@@ -72,8 +77,4 @@ public class ReplicatedMapRemoveEntryListenerMessageTask
         return new ReplicatedMapPermission(parameters.name, ActionConstants.ACTION_LISTEN);
     }
 
-    @Override
-    public Object[] getParameters() {
-        return new Object[]{parameters.registrationId};
-    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/set/SetAddListenerMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/set/SetAddListenerMessageTask.java
@@ -55,7 +55,7 @@ public class SetAddListenerMessageTask
         final EventRegistration registration = eventService.registerListener(getServiceName(), parameters.name
                 , filter, listener);
         final String registrationId = registration.getId();
-        endpoint.setListenerRegistration(getServiceName(), parameters.name, registrationId);
+        endpoint.addListenerDestroyAction(getServiceName(), parameters.name, registrationId);
         return registrationId;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/set/SetRemoveListenerMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/set/SetRemoveListenerMessageTask.java
@@ -18,7 +18,7 @@ package com.hazelcast.client.impl.protocol.task.set;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.SetRemoveListenerCodec;
-import com.hazelcast.client.impl.protocol.task.AbstractCallableMessageTask;
+import com.hazelcast.client.impl.protocol.task.AbstractRemoveListenerMessageTask;
 import com.hazelcast.collection.impl.set.SetService;
 import com.hazelcast.instance.Node;
 import com.hazelcast.nio.Connection;
@@ -32,16 +32,21 @@ import java.security.Permission;
  * SetRemoveListenerMessageTask
  */
 public class SetRemoveListenerMessageTask
-        extends AbstractCallableMessageTask<SetRemoveListenerCodec.RequestParameters> {
+        extends AbstractRemoveListenerMessageTask<SetRemoveListenerCodec.RequestParameters> {
 
     public SetRemoveListenerMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);
     }
 
     @Override
-    protected Object call() {
+    protected boolean deRegisterListener() {
         final EventService eventService = clientEngine.getEventService();
         return eventService.deregisterListener(getServiceName(), parameters.name, parameters.registrationId);
+    }
+
+    @Override
+    protected String getRegistrationId() {
+        return parameters.registrationId;
     }
 
     @Override
@@ -57,11 +62,6 @@ public class SetRemoveListenerMessageTask
     @Override
     public String getServiceName() {
         return SetService.SERVICE_NAME;
-    }
-
-    @Override
-    public Object[] getParameters() {
-        return new Object[]{parameters.registrationId};
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/topic/TopicAddMessageListenerMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/topic/TopicAddMessageListenerMessageTask.java
@@ -48,7 +48,7 @@ public class TopicAddMessageListenerMessageTask
         TopicService service = getService(TopicService.SERVICE_NAME);
         ClientEndpoint endpoint = getEndpoint();
         String registrationId = service.addMessageListener(parameters.name, this);
-        endpoint.setListenerRegistration(TopicService.SERVICE_NAME, parameters.name, registrationId);
+        endpoint.addListenerDestroyAction(TopicService.SERVICE_NAME, parameters.name, registrationId);
         return registrationId;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/topic/TopicRemoveMessageListenerMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/topic/TopicRemoveMessageListenerMessageTask.java
@@ -18,7 +18,7 @@ package com.hazelcast.client.impl.protocol.task.topic;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.TopicRemoveMessageListenerCodec;
-import com.hazelcast.client.impl.protocol.task.AbstractCallableMessageTask;
+import com.hazelcast.client.impl.protocol.task.AbstractRemoveListenerMessageTask;
 import com.hazelcast.instance.Node;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.security.permission.ActionConstants;
@@ -28,17 +28,21 @@ import com.hazelcast.topic.impl.TopicService;
 import java.security.Permission;
 
 public class TopicRemoveMessageListenerMessageTask
-        extends AbstractCallableMessageTask<TopicRemoveMessageListenerCodec.RequestParameters> {
+        extends AbstractRemoveListenerMessageTask<TopicRemoveMessageListenerCodec.RequestParameters> {
 
     public TopicRemoveMessageListenerMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);
     }
 
     @Override
-    protected Object call() throws Exception {
+    protected boolean deRegisterListener() {
         TopicService service = getService(TopicService.SERVICE_NAME);
-        final boolean success = service.removeMessageListener(parameters.name, parameters.registrationId);
-        return success;
+        return service.removeMessageListener(parameters.name, parameters.registrationId);
+    }
+
+    @Override
+    protected String getRegistrationId() {
+        return parameters.registrationId;
     }
 
     @Override
@@ -71,11 +75,5 @@ public class TopicRemoveMessageListenerMessageTask
     public String getMethodName() {
         return "removeMessageListener";
     }
-
-    @Override
-    public Object[] getParameters() {
-        return new Object[]{parameters.registrationId};
-    }
-
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/cluster/client/AddMembershipListenerRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/client/AddMembershipListenerRequest.java
@@ -45,7 +45,7 @@ public final class AddMembershipListenerRequest extends CallableClientRequest im
         ClientEndpoint endpoint = getEndpoint();
         String registrationId = service.addMembershipListener(new MembershipListenerImpl(endpoint));
         String name = ClusterServiceImpl.SERVICE_NAME;
-        endpoint.setListenerRegistration(name, name, registrationId);
+        endpoint.addListenerDestroyAction(name, name, registrationId);
 
         Collection<MemberImpl> members = service.getMemberImpls();
         List<Data> response = new ArrayList<Data>(members.size());

--- a/hazelcast/src/main/java/com/hazelcast/cluster/client/RegisterMembershipListenerRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/client/RegisterMembershipListenerRequest.java
@@ -42,7 +42,7 @@ public final class RegisterMembershipListenerRequest extends CallableClientReque
         ClientEndpoint endpoint = getEndpoint();
         String registrationId = service.addMembershipListener(new MembershipListenerImpl(endpoint));
         String name = ClusterServiceImpl.SERVICE_NAME;
-        endpoint.setListenerRegistration(name, name, registrationId);
+        endpoint.addListenerDestroyAction(name, name, registrationId);
         return registrationId;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/client/CollectionAddListenerRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/client/CollectionAddListenerRequest.java
@@ -69,7 +69,7 @@ public class CollectionAddListenerRequest extends CallableClientRequest implemen
         final CollectionEventFilter filter = new CollectionEventFilter(includeValue);
         final EventRegistration registration = eventService.registerListener(getServiceName(), name, filter, listener);
         final String registrationId = registration.getId();
-        endpoint.setListenerRegistration(getServiceName(), name, registrationId);
+        endpoint.addListenerDestroyAction(getServiceName(), name, registrationId);
         return registrationId;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/client/CollectionRemoveListenerRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/client/CollectionRemoveListenerRequest.java
@@ -40,7 +40,7 @@ public class CollectionRemoveListenerRequest extends BaseClientRemoveListenerReq
     }
 
     @Override
-    public Object call() throws Exception {
+    protected boolean deRegisterListener() {
         final ClientEngine clientEngine = getClientEngine();
         final EventService eventService = clientEngine.getEventService();
         return eventService.deregisterListener(serviceName, name, registrationId);

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/client/AddListenerRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/client/AddListenerRequest.java
@@ -111,7 +111,7 @@ public class AddListenerRequest extends CallableClientRequest implements SecureR
             }
         };
         String registrationId = service.addItemListener(name, listener, includeValue);
-        endpoint.setListenerRegistration(QueueService.SERVICE_NAME, name, registrationId);
+        endpoint.addListenerDestroyAction(QueueService.SERVICE_NAME, name, registrationId);
         return registrationId;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/client/RemoveListenerRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/client/RemoveListenerRequest.java
@@ -37,7 +37,7 @@ public class RemoveListenerRequest extends BaseClientRemoveListenerRequest {
     }
 
     @Override
-    public Object call() throws Exception {
+    protected boolean deRegisterListener() {
         final QueueService service = getService();
         return service.removeItemListener(name, registrationId);
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/client/AbstractMapAddEntryListenerRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/client/AbstractMapAddEntryListenerRequest.java
@@ -98,7 +98,7 @@ public abstract class AbstractMapAddEntryListenerRequest extends CallableClientR
 
         final EventFilter eventFilter = getEventFilter();
         final String registrationId = mapService.getMapServiceContext().addEventListener(listener, eventFilter, name);
-        endpoint.setListenerRegistration(MapService.SERVICE_NAME, name, registrationId);
+        endpoint.addListenerDestroyAction(MapService.SERVICE_NAME, name, registrationId);
         return registrationId;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/client/MapAddPartitionLostListenerRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/client/MapAddPartitionLostListenerRequest.java
@@ -62,7 +62,7 @@ public class MapAddPartitionLostListenerRequest extends CallableClientRequest
         };
 
         final String registrationId = mapService.getMapServiceContext().addPartitionLostListener(listener, name);
-        endpoint.setListenerRegistration(MapService.SERVICE_NAME, name, registrationId);
+        endpoint.addListenerDestroyAction(MapService.SERVICE_NAME, name, registrationId);
         return registrationId;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/client/MapRemoveEntryListenerRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/client/MapRemoveEntryListenerRequest.java
@@ -33,7 +33,7 @@ public class MapRemoveEntryListenerRequest extends BaseClientRemoveListenerReque
         super(name, registrationId);
     }
 
-    public Object call() throws Exception {
+    protected boolean deRegisterListener() {
         final MapService service = getService();
         return service.getMapServiceContext().removeEventListener(name, registrationId);
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/client/MapRemovePartitionLostListenerRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/client/MapRemovePartitionLostListenerRequest.java
@@ -34,7 +34,7 @@ public class MapRemovePartitionLostListenerRequest extends BaseClientRemoveListe
         super(name, registrationId);
     }
 
-    public Object call() throws Exception {
+    protected boolean deRegisterListener() {
         final MapService service = getService();
         return service.getMapServiceContext().removePartitionLostListener(name, registrationId);
     }
@@ -59,11 +59,6 @@ public class MapRemovePartitionLostListenerRequest extends BaseClientRemoveListe
     @Override
     public String getMethodName() {
         return "removePartitionLostListener";
-    }
-
-    @Override
-    public Object[] getParameters() {
-        return new Object[]{registrationId};
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/client/AddEntryListenerRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/client/AddEntryListenerRequest.java
@@ -86,7 +86,7 @@ public class AddEntryListenerRequest extends CallableClientRequest implements Re
             }
         };
         String registrationId = service.addListener(name, listener, key, includeValue, false);
-        endpoint.setListenerRegistration(MultiMapService.SERVICE_NAME, name, registrationId);
+        endpoint.addListenerDestroyAction(MultiMapService.SERVICE_NAME, name, registrationId);
         return registrationId;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/client/RemoveEntryListenerRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/client/RemoveEntryListenerRequest.java
@@ -34,7 +34,7 @@ public class RemoveEntryListenerRequest extends BaseClientRemoveListenerRequest 
     }
 
     @Override
-    public Object call() throws Exception {
+    protected boolean deRegisterListener() {
         final MultiMapService service = getService();
         return service.removeListener(name, registrationId);
     }

--- a/hazelcast/src/main/java/com/hazelcast/partition/client/AddPartitionLostListenerRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/client/AddPartitionLostListenerRequest.java
@@ -54,7 +54,7 @@ public class AddPartitionLostListenerRequest
         };
 
         final String registrationId = partitionService.addPartitionLostListener(listener);
-        endpoint.setListenerRegistration(SERVICE_NAME, PARTITION_LOST_EVENT_TOPIC, registrationId);
+        endpoint.addListenerDestroyAction(SERVICE_NAME, PARTITION_LOST_EVENT_TOPIC, registrationId);
         return registrationId;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/partition/client/RemovePartitionLostListenerRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/client/RemovePartitionLostListenerRequest.java
@@ -33,8 +33,7 @@ public class RemovePartitionLostListenerRequest
     }
 
     @Override
-    public Object call()
-            throws Exception {
+    protected boolean deRegisterListener() {
         final InternalPartitionService service = getService();
         return service.removePartitionLostListener(registrationId);
     }
@@ -53,6 +52,7 @@ public class RemovePartitionLostListenerRequest
     public int getClassId() {
         return ClientPortableHook.REMOVE_PARTITION_LOST_LISTENER;
     }
+
     @Override
     public Permission getRequiredPermission() {
         return null;

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/client/ClientReplicatedMapAddEntryListenerRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/client/ClientReplicatedMapAddEntryListenerRequest.java
@@ -68,7 +68,7 @@ public class ClientReplicatedMapAddEntryListenerRequest
         } else {
             registrationId = replicatedRecordStore.addEntryListener(listener, predicate, key);
         }
-        endpoint.setListenerRegistration(ReplicatedMapService.SERVICE_NAME, getMapName(), registrationId);
+        endpoint.addListenerDestroyAction(ReplicatedMapService.SERVICE_NAME, getMapName(), registrationId);
         return registrationId;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/client/ClientReplicatedMapRemoveEntryListenerRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/client/ClientReplicatedMapRemoveEntryListenerRequest.java
@@ -37,8 +37,7 @@ public class ClientReplicatedMapRemoveEntryListenerRequest
         super(mapName, registrationId);
     }
 
-    public Object call()
-            throws Exception {
+    protected boolean deRegisterListener() {
         final ReplicatedRecordStore replicatedRecordStore = getReplicatedRecordStore();
         return replicatedRecordStore.removeEntryListenerInternal(registrationId);
     }
@@ -72,8 +71,4 @@ public class ClientReplicatedMapRemoveEntryListenerRequest
         return "removeEntryListener";
     }
 
-    @Override
-    public Object[] getParameters() {
-        return new Object[]{registrationId};
-    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/topic/impl/client/AddMessageListenerRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/impl/client/AddMessageListenerRequest.java
@@ -51,7 +51,7 @@ public class AddMessageListenerRequest extends CallableClientRequest implements 
         Data partitionKey = serializationService.toData(name);
         MessageListener listener = new MessageListenerImpl(endpoint, partitionKey, getCallId());
         String registrationId = service.addMessageListener(name, listener);
-        endpoint.setListenerRegistration(TopicService.SERVICE_NAME, name, registrationId);
+        endpoint.addListenerDestroyAction(TopicService.SERVICE_NAME, name, registrationId);
         return registrationId;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/topic/impl/client/RemoveMessageListenerRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/impl/client/RemoveMessageListenerRequest.java
@@ -34,7 +34,7 @@ public class RemoveMessageListenerRequest extends BaseClientRemoveListenerReques
     }
 
     @Override
-    public Boolean call() throws Exception {
+    protected boolean deRegisterListener() {
         TopicService service = getService();
         return service.removeMessageListener(name, registrationId);
     }


### PR DESCRIPTION
Memory leak occurs when a listener added and removed from client.
A remove runnable in the collection that is stored in ClientEndpointImpl
is the leftover. This remove runnable collection was used to cleanup the
listeners when client is disconnected. With this change, listener removal
is always done via this remove runnables and runnable itself removed.

fixes #5893