### PR TITLE
ClientMapProxy.putAll should go direct to key owners

### DIFF
--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
@@ -79,6 +79,7 @@ import com.hazelcast.client.impl.protocol.codec.MapValuesWithPredicateCodec;
 import com.hazelcast.client.nearcache.ClientHeapNearCache;
 import com.hazelcast.client.nearcache.ClientNearCache;
 import com.hazelcast.client.spi.ClientListenerService;
+import com.hazelcast.client.spi.ClientPartitionService;
 import com.hazelcast.client.spi.ClientProxy;
 import com.hazelcast.client.spi.EventHandler;
 import com.hazelcast.client.spi.impl.ClientInvocation;
@@ -1233,15 +1234,46 @@ public class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V> {
 
     @Override
     public void putAll(Map<? extends K, ? extends V> m) {
-        Map<Data, Data> map = new HashMap<Data, Data>();
+        ClientPartitionService partitionService = getContext().getPartitionService();
+        Map<Integer, Map<Data, Data>> entryMap = new HashMap<Integer, Map<Data, Data>>(partitionService.getPartitionCount());
+        
         for (Entry<? extends K, ? extends V> entry : m.entrySet()) {
+            checkNotNull(entry.getKey(), NULL_KEY_IS_NOT_ALLOWED);
+            checkNotNull(entry.getValue(), NULL_VALUE_IS_NOT_ALLOWED);
+            
             final Data keyData = toData(entry.getKey());
             invalidateNearCache(keyData);
-            map.put(keyData, toData(entry.getValue()));
+            
+            int partitionId = partitionService.getPartitionId(entry.getKey());
+            if (!entryMap.containsKey(partitionId)) {
+                entryMap.put(partitionId, new HashMap<Data, Data>());
+            }
+            
+            entryMap.get(partitionId).put(keyData, toData(entry.getValue()));
+        }
+        
+        List<Future<?>> futures = new ArrayList<Future<?>>(entryMap.size());
+        for (final Map.Entry<Integer, Map<Data, Data>> entry : entryMap.entrySet()) {
+            final Integer partitionId = entry.getKey();
+            //If there is only one entry, consider how we can use MapPutRequest without
+            //having to get back the return value.
+            ClientMessage request = MapPutAllCodec.encodeRequest(name, entry.getValue());
+            
+            //invoke by partition owner address rather than id, as
+            //the latter will embed the partitionId into the Packet payload,
+            //routing the invocation to the operation service, which does 
+            //not handle MapPutAllRequest and other similar requests
+            futures.add(new ClientInvocation(getClient(), request, partitionService.getPartitionOwner(partitionId)).invoke());
         }
 
-        ClientMessage request = MapPutAllCodec.encodeRequest(name, map);
-        invoke(request);
+        try {
+            for (Future<?> future : futures) {
+                future.get();
+            }
+        } catch (Exception e) {
+            ExceptionUtil.rethrow(e);
+        }
+        
     }
 
     @Override

--- a/hazelcast-client-new/src/test/java/com/hazelcast/client/map/ClientMapTest.java
+++ b/hazelcast-client-new/src/test/java/com/hazelcast/client/map/ClientMapTest.java
@@ -226,6 +226,20 @@ public class ClientMapTest {
     }
 
     @Test
+    public void testPutAllWithTooManyEntries() {
+        final IMap map = createMap();
+        Map mm = new HashMap();
+        for (int i = 0; i < 1000; i++) {
+            mm.put(i, i);
+        }
+        map.putAll(mm);
+        assertEquals(map.size(), 1000);
+        for (int i = 0; i < 1000; i++) {
+            assertEquals(map.get(i), i);
+        }
+    }
+    
+    @Test
     public void testAsyncGet() throws Exception {
         final IMap map = createMap();
         fillMap(map);

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapTest.java
@@ -226,6 +226,20 @@ public class ClientMapTest {
     }
 
     @Test
+    public void testPutAllWithTooManyEntries() {
+        final IMap map = createMap();
+        Map mm = new HashMap();
+        for (int i = 0; i < 1000; i++) {
+            mm.put(i, i);
+        }
+        map.putAll(mm);
+        assertEquals(map.size(), 1000);
+        for (int i = 0; i < 1000; i++) {
+            assertEquals(map.get(i), i);
+        }
+    }
+    
+    @Test
     public void testAsyncGet() throws Exception {
         final IMap map = createMap();
         fillMap(map);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/client/MapPutAllRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/client/MapPutAllRequest.java
@@ -16,12 +16,12 @@
 
 package com.hazelcast.map.impl.client;
 
-import com.hazelcast.client.impl.client.AllPartitionsClientRequest;
+import com.hazelcast.client.impl.client.PartitionClientRequest;
 import com.hazelcast.client.impl.client.SecureRequest;
 import com.hazelcast.map.impl.MapEntrySet;
 import com.hazelcast.map.impl.MapPortableHook;
 import com.hazelcast.map.impl.MapService;
-import com.hazelcast.map.impl.operation.MapPutAllOperationFactory;
+import com.hazelcast.map.impl.operation.PutAllOperation;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -30,24 +30,25 @@ import com.hazelcast.nio.serialization.PortableReader;
 import com.hazelcast.nio.serialization.PortableWriter;
 import com.hazelcast.security.permission.ActionConstants;
 import com.hazelcast.security.permission.MapPermission;
-import com.hazelcast.spi.OperationFactory;
-import com.hazelcast.util.ExceptionUtil;
+import com.hazelcast.spi.Operation;
 import java.io.IOException;
 import java.security.Permission;
 import java.util.HashMap;
 import java.util.Map;
 
-public class MapPutAllRequest extends AllPartitionsClientRequest implements Portable, SecureRequest {
+public class MapPutAllRequest extends PartitionClientRequest implements Portable, SecureRequest {
 
     protected String name;
     private MapEntrySet entrySet;
+    private int partitionId;
 
     public MapPutAllRequest() {
     }
 
-    public MapPutAllRequest(String name, MapEntrySet entrySet) {
+    public MapPutAllRequest(String name, MapEntrySet entrySet, int partitionId) {
         this.name = name;
         this.entrySet = entrySet;
+        this.partitionId = partitionId;
     }
 
     public int getFactoryId() {
@@ -59,20 +60,15 @@ public class MapPutAllRequest extends AllPartitionsClientRequest implements Port
     }
 
     @Override
-    protected OperationFactory createOperationFactory() {
-        return new MapPutAllOperationFactory(name, entrySet);
+    protected Operation prepareOperation() {
+        PutAllOperation operation = new PutAllOperation(name, entrySet);
+        operation.setPartitionId(partitionId);
+        return operation;
     }
 
     @Override
-    protected Object reduce(Map<Integer, Object> map) {
-        MapService mapService = getService();
-        for (Map.Entry<Integer, Object> entry : map.entrySet()) {
-            Object result = mapService.getMapServiceContext().toObject(entry.getValue());
-            if (result instanceof Throwable) {
-                throw ExceptionUtil.rethrow((Throwable) result);
-            }
-        }
-        return null;
+    protected int getPartition() {
+        return partitionId;
     }
 
     public String getServiceName() {
@@ -81,12 +77,14 @@ public class MapPutAllRequest extends AllPartitionsClientRequest implements Port
 
     public void write(PortableWriter writer) throws IOException {
         writer.writeUTF("n", name);
+        writer.writeInt("p", partitionId);
         ObjectDataOutput output = writer.getRawDataOutput();
         entrySet.writeData(output);
     }
 
     public void read(PortableReader reader) throws IOException {
         name = reader.readUTF("n");
+        partitionId = reader.readInt("p");
         ObjectDataInput input = reader.getRawDataInput();
         entrySet = new MapEntrySet();
         entrySet.readData(input);


### PR DESCRIPTION
Port code from MapProxySupport so that MapPutAllRequests are sent directly to key owners rather than mediated by a randomly chosen member of the cluster

Implements part of #6083