### PR TITLE
Added new CheckStyle rule to prevent UUID.randomUUID() calls

### DIFF
--- a/checkstyle/checkstyle.xml
+++ b/checkstyle/checkstyle.xml
@@ -281,6 +281,13 @@
         <module name="ArrayTypeStyle"/>
         <module name="UpperEll"/>
 
+        <!-- Check for usage of UuidUtil instead of UUID -->
+        <module name="RegexpSinglelineJava">
+            <property name="format" value="(import static java\.util\.UUID\.randomUUID|UUID\.randomUUID\(\))"/>
+            <property name="ignoreComments" value="true"/>
+            <property name="message" value="Please use UuidUtil.buildRandomUUID() instead of UUID.randomUUID()!"/>
+        </module>
+
     </module>
 
 </module>

--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/impl/LifecycleServiceImpl.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/impl/LifecycleServiceImpl.java
@@ -68,7 +68,7 @@ public final class LifecycleServiceImpl implements LifecycleService {
 
     @Override
     public String addLifecycleListener(LifecycleListener lifecycleListener) {
-        final String id = UuidUtil.buildRandomUuidString();
+        final String id = UuidUtil.newUnsecureUuidString();
         lifecycleListeners.put(id, lifecycleListener);
         return id;
     }

--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/proxy/ClientExecutorServiceProxy.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/proxy/ClientExecutorServiceProxy.java
@@ -630,7 +630,7 @@ public class ClientExecutorServiceProxy extends ClientProxy implements IExecutor
     }
 
     private String getUUID() {
-        return UuidUtil.buildRandomUuidString();
+        return UuidUtil.newUnsecureUuidString();
     }
 
     private Address getMemberAddress(Member member) {

--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/proxy/ClientMapReduceProxy.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/proxy/ClientMapReduceProxy.java
@@ -126,7 +126,7 @@ public class ClientMapReduceProxy
         @Override
         protected <T> JobCompletableFuture<T> invoke(final Collator collator) {
             try {
-                final String jobId = UuidUtil.buildRandomUuidString();
+                final String jobId = UuidUtil.newUnsecureUuidString();
 
                 ClientMessage request = getRequest(name, jobId, keys, predicate, mapper, combinerFactory, reducerFactory,
                         keyValueSource, chunkSize, topologyChangedStrategy);

--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/proxy/ClientReliableTopicProxy.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/proxy/ClientReliableTopicProxy.java
@@ -27,11 +27,11 @@ import com.hazelcast.core.ITopic;
 import com.hazelcast.core.Member;
 import com.hazelcast.core.Message;
 import com.hazelcast.core.MessageListener;
+import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.monitor.LocalTopicStats;
 import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.ringbuffer.OverflowPolicy;
 import com.hazelcast.ringbuffer.ReadResultSet;
 import com.hazelcast.ringbuffer.Ringbuffer;
@@ -42,8 +42,8 @@ import com.hazelcast.topic.TopicOverloadException;
 import com.hazelcast.topic.TopicOverloadPolicy;
 import com.hazelcast.topic.impl.reliable.ReliableMessageListenerAdapter;
 import com.hazelcast.topic.impl.reliable.ReliableTopicMessage;
+import com.hazelcast.util.UuidUtil;
 
-import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Executor;
@@ -147,7 +147,7 @@ public class ClientReliableTopicProxy<E> extends ClientProxy implements ITopic<E
     public String addMessageListener(MessageListener<E> listener) {
         checkNotNull(listener, "listener can't be null");
 
-        String id = UUID.randomUUID().toString();
+        String id = UuidUtil.newUnsecureUuidString();
         ReliableMessageListener<E> reliableMessageListener = toReliableMessageListener(listener);
 
         MessageRunner runner = new MessageRunner(id, reliableMessageListener);

--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/spi/impl/ClientClusterServiceImpl.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/spi/impl/ClientClusterServiceImpl.java
@@ -33,11 +33,11 @@ import com.hazelcast.core.Member;
 import com.hazelcast.core.MemberAttributeEvent;
 import com.hazelcast.core.MembershipEvent;
 import com.hazelcast.core.MembershipListener;
+import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ClassLoaderUtil;
-import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.util.Clock;
 import com.hazelcast.util.UuidUtil;
 
@@ -47,7 +47,6 @@ import java.util.Collections;
 import java.util.EventListener;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicReference;
@@ -140,7 +139,7 @@ public class ClientClusterServiceImpl extends ClusterListenerSupport {
             throw new NullPointerException("listener can't be null");
         }
 
-        final String id = UuidUtil.buildRandomUuidString();
+        String id = UuidUtil.newUnsecureUuidString();
         listeners.put(id, listener);
         if (listener instanceof InitialMembershipListener) {
             // TODO: needs sync with membership events...
@@ -151,7 +150,7 @@ public class ClientClusterServiceImpl extends ClusterListenerSupport {
     }
 
     private String addMembershipListenerWithoutInit(MembershipListener listener) {
-        final String id = UUID.randomUUID().toString();
+        String id = UuidUtil.newUnsecureUuidString();
         listeners.put(id, listener);
         return id;
     }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/LifecycleServiceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/LifecycleServiceImpl.java
@@ -68,7 +68,7 @@ public final class LifecycleServiceImpl implements LifecycleService {
 
     @Override
     public String addLifecycleListener(LifecycleListener lifecycleListener) {
-        final String id = UuidUtil.buildRandomUuidString();
+        final String id = UuidUtil.newUnsecureUuidString();
         lifecycleListeners.put(id, lifecycleListener);
         return id;
     }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientExecutorServiceProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientExecutorServiceProxy.java
@@ -575,7 +575,7 @@ public class ClientExecutorServiceProxy extends ClientProxy implements IExecutor
     }
 
     private String getUUID() {
-        return UuidUtil.buildRandomUuidString();
+        return UuidUtil.newUnsecureUuidString();
     }
 
     private Address getMemberAddress(Member member) {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapReduceProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapReduceProxy.java
@@ -110,7 +110,7 @@ public class ClientMapReduceProxy
         @Override
         protected <T> JobCompletableFuture<T> invoke(final Collator collator) {
             try {
-                final String jobId = UuidUtil.buildRandomUuidString();
+                final String jobId = UuidUtil.newUnsecureUuidString();
 
                 ClientMapReduceRequest request = new ClientMapReduceRequest(name, jobId, keys,
                         predicate, mapper, combinerFactory, reducerFactory, keyValueSource,

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientReliableTopicProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientReliableTopicProxy.java
@@ -27,11 +27,11 @@ import com.hazelcast.core.ITopic;
 import com.hazelcast.core.Member;
 import com.hazelcast.core.Message;
 import com.hazelcast.core.MessageListener;
+import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.monitor.LocalTopicStats;
 import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.ringbuffer.OverflowPolicy;
 import com.hazelcast.ringbuffer.ReadResultSet;
 import com.hazelcast.ringbuffer.Ringbuffer;
@@ -42,8 +42,8 @@ import com.hazelcast.topic.TopicOverloadException;
 import com.hazelcast.topic.TopicOverloadPolicy;
 import com.hazelcast.topic.impl.reliable.ReliableMessageListenerAdapter;
 import com.hazelcast.topic.impl.reliable.ReliableTopicMessage;
+import com.hazelcast.util.UuidUtil;
 
-import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Executor;
@@ -147,7 +147,7 @@ public class ClientReliableTopicProxy<E> extends ClientProxy implements ITopic<E
     public String addMessageListener(MessageListener<E> listener) {
         checkNotNull(listener, "listener can't be null");
 
-        String id = UUID.randomUUID().toString();
+        String id = UuidUtil.newUnsecureUuidString();
         ReliableMessageListener<E> reliableMessageListener = toReliableMessageListener(listener);
 
         MessageRunner runner = new MessageRunner(id, reliableMessageListener);

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientClusterServiceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientClusterServiceImpl.java
@@ -33,11 +33,11 @@ import com.hazelcast.core.Member;
 import com.hazelcast.core.MemberAttributeEvent;
 import com.hazelcast.core.MembershipEvent;
 import com.hazelcast.core.MembershipListener;
+import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ClassLoaderUtil;
-import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.util.Clock;
 import com.hazelcast.util.UuidUtil;
 
@@ -47,7 +47,6 @@ import java.util.Collections;
 import java.util.EventListener;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicReference;
@@ -141,7 +140,7 @@ public class ClientClusterServiceImpl extends ClusterListenerSupport {
             throw new NullPointerException("listener can't be null");
         }
 
-        final String id = UuidUtil.buildRandomUuidString();
+        String id = UuidUtil.newUnsecureUuidString();
         listeners.put(id, listener);
         if (listener instanceof InitialMembershipListener) {
             // TODO: needs sync with membership events...
@@ -152,7 +151,7 @@ public class ClientClusterServiceImpl extends ClusterListenerSupport {
     }
 
     private String addMembershipListenerWithoutInit(MembershipListener listener) {
-        final String id = UUID.randomUUID().toString();
+        String id = UuidUtil.newUnsecureUuidString();
         listeners.put(id, listener);
         return id;
     }

--- a/hazelcast-wm/src/main/java/com/hazelcast/web/ClusteredSessionService.java
+++ b/hazelcast-wm/src/main/java/com/hazelcast/web/ClusteredSessionService.java
@@ -21,15 +21,15 @@ import com.hazelcast.config.MapConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.instance.OutOfMemoryErrorDispatcher;
+import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
-
 import com.hazelcast.map.EntryProcessor;
 import com.hazelcast.map.impl.MapEntrySimple;
 import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.spi.impl.SerializationServiceSupport;
 import com.hazelcast.util.EmptyStatement;
+import com.hazelcast.util.UuidUtil;
 import com.hazelcast.web.entryprocessor.DeleteSessionEntryProcessor;
 import com.hazelcast.web.entryprocessor.GetAttributeEntryProcessor;
 import com.hazelcast.web.entryprocessor.GetAttributeNamesEntryProcessor;
@@ -44,7 +44,6 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Queue;
 import java.util.Set;
-import java.util.UUID;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ScheduledExecutorService;
@@ -69,7 +68,7 @@ public class ClusteredSessionService {
     private static final long CLUSTER_CHECK_INTERVAL = 5L;
     private static final long RETRY_MILLIS = 7000;
 
-    private final String jvmId = UUID.randomUUID().toString();
+    private final String jvmId = UuidUtil.newSecureUuidString();
     private volatile IMap clusterMap;
     private volatile SerializationServiceSupport sss;
     private volatile HazelcastInstance hazelcastInstance;
@@ -90,10 +89,10 @@ public class ClusteredSessionService {
     /**
      * Instantiates a new Clustered session service.
      *
-     * @param filterConfig the filter config
-     * @param properties the properties
+     * @param filterConfig   the filter config
+     * @param properties     the properties
      * @param clusterMapName the cluster map name
-     * @param sessionTTL the session tTL
+     * @param sessionTTL     the session tTL
      */
     public ClusteredSessionService(FilterConfig filterConfig, Properties properties, String clusterMapName, String sessionTTL) {
         this.filterConfig = filterConfig;
@@ -214,7 +213,7 @@ public class ClusteredSessionService {
     /**
      * Gets attribute.
      *
-     * @param sessionId the session id
+     * @param sessionId     the session id
      * @param attributeName the attribute name
      * @return the attribute
      * @throws Exception the exception
@@ -228,7 +227,7 @@ public class ClusteredSessionService {
     /**
      * Delete attribute.
      *
-     * @param sessionId the session id
+     * @param sessionId     the session id
      * @param attributeName the attribute name
      * @throws Exception the exception
      */
@@ -239,9 +238,9 @@ public class ClusteredSessionService {
     /**
      * Sets attribute.
      *
-     * @param sessionId the session id
+     * @param sessionId     the session id
      * @param attributeName the attribute name
-     * @param value the value
+     * @param value         the value
      * @throws Exception the exception
      */
     void setAttribute(String sessionId, String attributeName, Object value) throws Exception {
@@ -254,7 +253,7 @@ public class ClusteredSessionService {
     /**
      * Delete session.
      *
-     * @param sessionId sessionId
+     * @param sessionId  sessionId
      * @param invalidate if true remove the distributed session, otherwise just
      *                   remove the jvm reference
      * @return the boolean
@@ -289,7 +288,7 @@ public class ClusteredSessionService {
     /**
      * Update attributes.
      *
-     * @param id the id
+     * @param id      the id
      * @param updates the updates
      * @throws Exception the exception
      */

--- a/hazelcast-wm/src/main/java/com/hazelcast/web/WebFilter.java
+++ b/hazelcast-wm/src/main/java/com/hazelcast/web/WebFilter.java
@@ -21,6 +21,7 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
+import com.hazelcast.util.UuidUtil;
 
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
@@ -38,7 +39,6 @@ import javax.servlet.http.HttpServletResponseWrapper;
 import javax.servlet.http.HttpSession;
 import java.io.IOException;
 import java.util.Properties;
-import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.logging.Level;
@@ -136,9 +136,9 @@ public class WebFilter implements Filter {
     }
 
     private static String generateSessionId() {
-        final String id = UUID.randomUUID().toString();
-        final StringBuilder sb = new StringBuilder("HZ");
-        final char[] chars = id.toCharArray();
+        String id = UuidUtil.newSecureUuidString();
+        StringBuilder sb = new StringBuilder("HZ");
+        char[] chars = id.toCharArray();
         for (final char c : chars) {
             if (c != '-') {
                 if (Character.isLetter(c)) {

--- a/hazelcast/src/main/java/com/hazelcast/executor/impl/ExecutorServiceProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/executor/impl/ExecutorServiceProxy.java
@@ -62,7 +62,7 @@ import static com.hazelcast.util.FutureUtil.ExceptionHandler;
 import static com.hazelcast.util.FutureUtil.logAllExceptions;
 import static com.hazelcast.util.FutureUtil.waitWithDeadline;
 import static com.hazelcast.util.Preconditions.checkNotNull;
-import static com.hazelcast.util.UuidUtil.buildRandomUuidString;
+import static com.hazelcast.util.UuidUtil.newUnsecureUuidString;
 
 public class ExecutorServiceProxy
         extends AbstractDistributedObject<DistributedExecutorService>
@@ -197,7 +197,7 @@ public class ExecutorServiceProxy
         NodeEngine nodeEngine = getNodeEngine();
         Callable<T> callable = createRunnableAdapter(task);
         Data callableData = nodeEngine.toData(callable);
-        String uuid = buildRandomUuidString();
+        String uuid = newUnsecureUuidString();
         int partitionId = getTaskPartitionId(callable);
 
         CallableTaskOperation op = new CallableTaskOperation(name, uuid, callableData);
@@ -238,7 +238,7 @@ public class ExecutorServiceProxy
 
         NodeEngine nodeEngine = getNodeEngine();
         Data taskData = nodeEngine.toData(task);
-        String uuid = buildRandomUuidString();
+        String uuid = newUnsecureUuidString();
 
         boolean sync = !preventSync && checkSync();
         CallableTaskOperation op = new CallableTaskOperation(name, uuid, taskData);
@@ -295,7 +295,7 @@ public class ExecutorServiceProxy
 
         NodeEngine nodeEngine = getNodeEngine();
         Data taskData = nodeEngine.toData(task);
-        String uuid = buildRandomUuidString();
+        String uuid = newUnsecureUuidString();
         Address target = ((MemberImpl) member).getAddress();
 
         boolean sync = checkSync();

--- a/hazelcast/src/main/java/com/hazelcast/instance/LifecycleServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/LifecycleServiceImpl.java
@@ -50,7 +50,7 @@ public class LifecycleServiceImpl implements LifecycleService {
 
     @Override
     public String addLifecycleListener(LifecycleListener lifecycleListener) {
-        final String id = UuidUtil.buildRandomUuidString();
+        final String id = UuidUtil.newUnsecureUuidString();
         lifecycleListeners.put(id, lifecycleListener);
         return id;
     }

--- a/hazelcast/src/main/java/com/hazelcast/instance/Node.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/Node.java
@@ -150,8 +150,7 @@ public class Node {
             localMember = new MemberImpl(address, true, createMemberUuid(address), hazelcastInstance, memberAttributes);
             loggingService.setThisMember(localMember);
             logger = loggingService.getLogger(Node.class.getName());
-            hazelcastThreadGroup = new HazelcastThreadGroup(
-                    hazelcastInstance.getName(), logger, configClassLoader);
+            hazelcastThreadGroup = new HazelcastThreadGroup(hazelcastInstance.getName(), logger, configClassLoader);
             nodeExtension = NodeExtensionFactory.create(configClassLoader);
             nodeExtension.beforeStart(this);
 
@@ -529,16 +528,12 @@ public class Node {
         return null;
     }
 
-
     public void setAsMaster() {
         logger.finest("This node is being set as the master");
         masterAddress = address;
         setJoined();
-        this.getClusterService().getClusterClock().
-                setClusterStartTime(Clock.currentTimeMillis());
-        this.getClusterService().setClusterId(
-                UuidUtil.createClusterUuid()
-        );
+        this.getClusterService().getClusterClock().setClusterStartTime(Clock.currentTimeMillis());
+        this.getClusterService().setClusterId(UuidUtil.createClusterUuid());
     }
 
     public Config getConfig() {

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/KeyValueJob.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/KeyValueJob.java
@@ -57,7 +57,7 @@ public class KeyValueJob<KeyIn, ValueIn>
 
     @Override
     protected <T> JobCompletableFuture<T> invoke(Collator collator) {
-        String jobId = UuidUtil.buildRandomUuidString();
+        String jobId = UuidUtil.newUnsecureUuidString();
 
         AbstractJobTracker jobTracker = (AbstractJobTracker) this.jobTracker;
         TrackableJobFuture<T> jobFuture = new TrackableJobFuture<T>(name, jobId, jobTracker, nodeEngine, collator);

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/EventServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/EventServiceImpl.java
@@ -22,12 +22,12 @@ import com.hazelcast.instance.HazelcastThreadGroup;
 import com.hazelcast.instance.MemberImpl;
 import com.hazelcast.instance.Node;
 import com.hazelcast.internal.metrics.Probe;
+import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.Packet;
 import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.spi.EventFilter;
 import com.hazelcast.spi.EventRegistration;
 import com.hazelcast.spi.EventService;
@@ -39,6 +39,7 @@ import com.hazelcast.spi.impl.eventservice.impl.operations.PostJoinRegistrationO
 import com.hazelcast.spi.impl.eventservice.impl.operations.RegistrationOperation;
 import com.hazelcast.spi.impl.eventservice.impl.operations.SendEventOperation;
 import com.hazelcast.util.EmptyStatement;
+import com.hazelcast.util.UuidUtil;
 import com.hazelcast.util.counters.MwCounter;
 import com.hazelcast.util.executor.StripedExecutor;
 
@@ -48,7 +49,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedList;
-import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Future;
@@ -168,8 +168,8 @@ public class EventServiceImpl implements InternalEventService {
         return registerListenerInternal(serviceName, topic, filter, listener, false);
     }
 
-    private EventRegistration registerListenerInternal(String serviceName, String topic, EventFilter filter,
-                                                       Object listener, boolean localOnly) {
+    private EventRegistration registerListenerInternal(String serviceName, String topic, EventFilter filter, Object listener,
+                                                       boolean localOnly) {
         if (listener == null) {
             throw new IllegalArgumentException("Listener required!");
         }
@@ -177,8 +177,8 @@ public class EventServiceImpl implements InternalEventService {
             throw new IllegalArgumentException("EventFilter required!");
         }
         EventServiceSegment segment = getSegment(serviceName, true);
-        Registration reg = new Registration(UUID.randomUUID().toString(), serviceName, topic, filter,
-                nodeEngine.getThisAddress(), listener, localOnly);
+        String id = UuidUtil.newUnsecureUuidString();
+        Registration reg = new Registration(id, serviceName, topic, filter, nodeEngine.getThisAddress(), listener, localOnly);
         if (!segment.addRegistration(topic, reg)) {
             return null;
         }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/ProxyServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/ProxyServiceImpl.java
@@ -205,7 +205,7 @@ public class ProxyServiceImpl
 
     @Override
     public String addProxyListener(DistributedObjectListener distributedObjectListener) {
-        String id = UuidUtil.buildRandomUuidString();
+        String id = UuidUtil.newUnsecureUuidString();
         listeners.put(id, distributedObjectListener);
         return id;
     }

--- a/hazelcast/src/main/java/com/hazelcast/topic/impl/reliable/ReliableTopicProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/impl/reliable/ReliableTopicProxy.java
@@ -35,8 +35,8 @@ import com.hazelcast.topic.ReliableMessageListener;
 import com.hazelcast.topic.TopicOverloadException;
 import com.hazelcast.topic.TopicOverloadPolicy;
 import com.hazelcast.util.ExceptionUtil;
+import com.hazelcast.util.UuidUtil;
 
-import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Executor;
@@ -204,7 +204,7 @@ public class ReliableTopicProxy<E> extends AbstractDistributedObject<ReliableTop
     public String addMessageListener(MessageListener<E> listener) {
         checkNotNull(listener, "listener can't be null");
 
-        String id = UUID.randomUUID().toString();
+        String id = UuidUtil.newUnsecureUuidString();
         ReliableMessageListener<E> reliableMessageListener;
         if (listener instanceof ReliableMessageListener) {
             reliableMessageListener = (ReliableMessageListener) listener;

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionImpl.java
@@ -86,7 +86,7 @@ public class TransactionImpl implements Transaction {
         this.transactionLog = new TransactionLog();
         this.transactionManagerService = transactionManagerService;
         this.nodeEngine = nodeEngine;
-        this.txnId = UuidUtil.buildRandomUuidString();
+        this.txnId = UuidUtil.newUnsecureUuidString();
         this.timeoutMillis = options.getTimeoutMillis();
         this.durability = options.getDurability();
         this.transactionType = options.getTransactionType();

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/XATransaction.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/XATransaction.java
@@ -85,7 +85,7 @@ public final class XATransaction implements Transaction {
         this.transactionLog = new TransactionLog();
         this.nodeEngine = nodeEngine;
         this.timeoutMillis = SECONDS.toMillis(timeout);
-        this.txnId = UuidUtil.buildRandomUuidString();
+        this.txnId = UuidUtil.newUnsecureUuidString();
         this.xid = new SerializableXID(xid.getFormatId(), xid.getGlobalTransactionId(), xid.getBranchQualifier());
         this.txOwnerUuid = txOwnerUuid == null ? nodeEngine.getLocalMember().getUuid() : txOwnerUuid;
 

--- a/hazelcast/src/test/java/com/hazelcast/map/query/QueryBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/query/QueryBasicTest.java
@@ -465,10 +465,10 @@ public class QueryBasicTest extends HazelcastTestSupport {
         IMap map = instance.getMap("testPredicateCustomAttribute");
 
         CustomAttribute attribute = new CustomAttribute(78, 145);
-        CustomObject object = new CustomObject("name1", UuidUtil.buildRandomUUID(), attribute);
+        CustomObject object = new CustomObject("name1", UuidUtil.newUnsecureUUID(), attribute);
         map.put(1, object);
 
-        CustomObject object2 = new CustomObject("name2", UuidUtil.buildRandomUUID(), attribute);
+        CustomObject object2 = new CustomObject("name2", UuidUtil.newUnsecureUUID(), attribute);
         map.put(2, object2);
 
         assertEquals(object, map.values(new PredicateBuilder().getEntryObject().get("uuid").equal(object.getUuid())).iterator().next());

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/SerializationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/SerializationTest.java
@@ -105,8 +105,8 @@ public class SerializationTest
     @Test
     public void test_callid_on_correct_stream_position() throws Exception {
         SerializationService serializationService = new DefaultSerializationServiceBuilder().build();
-        CancellationOperation operation = new CancellationOperation(UuidUtil.buildRandomUuidString(), true);
-        operation.setCallerUuid(UuidUtil.buildRandomUuidString());
+        CancellationOperation operation = new CancellationOperation(UuidUtil.newUnsecureUuidString(), true);
+        operation.setCallerUuid(UuidUtil.newUnsecureUuidString());
         OperationAccessor.setCallId(operation, 12345);
 
         Data data = serializationService.toData(operation);
@@ -337,7 +337,7 @@ public class SerializationTest
     
     @Test
     public void testMemberLeftException_usingMemberImpl() throws IOException, ClassNotFoundException {
-        String uuid = UuidUtil.buildRandomUuidString();
+        String uuid = UuidUtil.newUnsecureUuidString();
         String host = "127.0.0.1";
         int port = 5000;
 
@@ -348,7 +348,7 @@ public class SerializationTest
 
     @Test
     public void testMemberLeftException_usingSimpleMember() throws IOException, ClassNotFoundException {
-        String uuid = UuidUtil.buildRandomUuidString();
+        String uuid = UuidUtil.newUnsecureUuidString();
         String host = "127.0.0.1";
         int port = 5000;
 

--- a/hazelcast/src/test/java/com/hazelcast/topic/TopicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/topic/TopicTest.java
@@ -184,7 +184,7 @@ public class TopicTest extends HazelcastTestSupport {
 
                     Member localMember = hz.getCluster().getLocalMember();
                     for (int j = 0; j < count; j++) {
-                        topic.publish(new TestMessage(localMember, UuidUtil.buildRandomUuidString()));
+                        topic.publish(new TestMessage(localMember, UuidUtil.newUnsecureUuidString()));
                         publishLatch.countDown();
                     }
                 }


### PR DESCRIPTION
Added a new CheckStyle rule to prevent `UUID.randomUUID()` calls (static import and direct method call). We should use `UuidUtil.buildRandomUUID()` instead. Fixed all classes which used `UUID` so far.