### PR TITLE
Added target-aware transaction support

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/TargetAwareTransactionLogRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/TargetAwareTransactionLogRecord.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.transaction.impl;
+
+import com.hazelcast.nio.Address;
+
+/**
+ * Represents a change made in a transaction on a specific target <tt>Address</tt>.
+ *
+ * @see Transaction
+ * @see TransactionLogRecord
+ */
+public interface TargetAwareTransactionLogRecord extends TransactionLogRecord {
+
+    /**
+     * Returns target of changes made by this transaction record.
+     *
+     * @return target of changes made by this transaction record
+     */
+    Address getTarget();
+}

--- a/hazelcast/src/test/java/com/hazelcast/map/MapTransactionStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapTransactionStressTest.java
@@ -323,16 +323,15 @@ public class MapTransactionStressTest extends HazelcastTestSupport {
 
         @Override
         public Operation newPrepareOperation() {
-            return new AbstractOperation() {
-                @Override
-                public void run() throws Exception {
-                }
-            };
+            return newEmptyOperation();
         }
 
         @Override
         public Operation newCommitOperation() {
             return new AbstractOperation() {
+                {
+                    setPartitionId(0);
+                }
                 @Override
                 public void run() throws Exception {
                     LockSupport.parkNanos(10000);
@@ -342,7 +341,14 @@ public class MapTransactionStressTest extends HazelcastTestSupport {
 
         @Override
         public Operation newRollbackOperation() {
+            return newEmptyOperation();
+        }
+
+        private AbstractOperation newEmptyOperation() {
             return new AbstractOperation() {
+                {
+                    setPartitionId(0);
+                }
                 @Override
                 public void run() throws Exception {
                 }


### PR DESCRIPTION
Before this change, a transaction record can be only mapped to a partition. Now it's possible to map a transaction record to a specific target member directly.

_This feature is required to provide transactional cluster state change for hot-restart module._