### PR TITLE
Fix for #6080

### DIFF
--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/proxy/ClientMapReduceProxy.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/proxy/ClientMapReduceProxy.java
@@ -29,6 +29,7 @@ import com.hazelcast.client.spi.impl.ClientInvocation;
 import com.hazelcast.client.spi.impl.ClientInvocationFuture;
 import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.core.ICompletableFuture;
+import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.mapreduce.Collator;
 import com.hazelcast.mapreduce.CombinerFactory;
@@ -51,7 +52,6 @@ import com.hazelcast.mapreduce.impl.SetKeyValueSource;
 import com.hazelcast.mapreduce.impl.task.TransferableJobProcessInformation;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.spi.impl.AbstractCompletableFuture;
 import com.hazelcast.util.EmptyStatement;
 import com.hazelcast.util.UuidUtil;
@@ -65,12 +65,7 @@ import java.util.Set;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-
-import static com.hazelcast.util.Preconditions.isNotNull;
 
 public class ClientMapReduceProxy
         extends ClientProxy
@@ -241,14 +236,10 @@ public class ClientMapReduceProxy
             implements JobCompletableFuture<V> {
 
         private final String jobId;
-        private final CountDownLatch latch;
-
-        private volatile boolean cancelled;
 
         protected ClientCompletableFuture(String jobId) {
             super(getContext().getExecutionService().getAsyncExecutor(), Logger.getLogger(ClientCompletableFuture.class));
             this.jobId = jobId;
-            this.latch = new CountDownLatch(1);
         }
 
         @Override
@@ -257,7 +248,8 @@ public class ClientMapReduceProxy
         }
 
         @Override
-        public boolean cancel(boolean mayInterruptIfRunning) {
+        protected boolean shouldCancel(boolean mayInterruptIfRunning) {
+            boolean cancelled = false;
             try {
                 ClientMessage request = MapReduceCancelCodec.encodeRequest(getName(), jobId);
                 ClientMessage response = invoke(request, jobId);
@@ -269,25 +261,10 @@ public class ClientMapReduceProxy
         }
 
         @Override
-        public boolean isCancelled() {
-            return cancelled;
-        }
-
-        @Override
-        public void setResult(Object result) {
+        protected void setResult(Object result) {
             super.setResult(result);
-            latch.countDown();
         }
 
-        @Override
-        public V get(long timeout, TimeUnit unit)
-                throws InterruptedException, ExecutionException, TimeoutException {
-            isNotNull(unit, "unit");
-            if (!latch.await(timeout, unit) || !isDone()) {
-                throw new TimeoutException("timeout reached");
-            }
-            return getResult();
-        }
     }
 
     private final class ClientTrackableJob<V>

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapKeyLoader.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapKeyLoader.java
@@ -369,13 +369,13 @@ public class MapKeyLoader {
         }
 
         @Override
-        public boolean isCancelled() {
+        protected boolean shouldCancel(boolean mayInterruptIfRunning) {
             return false;
         }
 
         @Override
-        public boolean cancel(boolean mayInterruptIfRunning) {
-            return false;
+        protected void setResult(Object result) {
+            super.setResult(result);
         }
 
         @Override

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/TrackableJobFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/TrackableJobFuture.java
@@ -52,8 +52,6 @@ public class TrackableJobFuture<V>
     private final Collator collator;
     private final MapReduceService mapReduceService;
 
-    private volatile boolean cancelled;
-
     public TrackableJobFuture(String name, String jobId, JobTracker jobTracker, NodeEngine nodeEngine, Collator collator) {
         super(nodeEngine, nodeEngine.getLogger(TrackableJobFuture.class));
         this.name = name;
@@ -86,7 +84,7 @@ public class TrackableJobFuture<V>
     }
 
     @Override
-    public boolean cancel(boolean mayInterruptIfRunning) {
+    protected boolean shouldCancel(boolean mayInterruptIfRunning) {
         Address jobOwner = mapReduceService.getLocalAddress();
         if (!mapReduceService.registerJobSupervisorCancellation(name, jobId, jobOwner)) {
             return false;
@@ -96,8 +94,7 @@ public class TrackableJobFuture<V>
             return false;
         }
         Exception exception = new CancellationException("Operation was cancelled by the user");
-        cancelled = supervisor.cancelAndNotify(exception) && super.cancel(mayInterruptIfRunning);
-        return cancelled;
+        return supervisor.cancelAndNotify(exception);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/executionservice/impl/CompletableFutureEntry.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/executionservice/impl/CompletableFutureEntry.java
@@ -29,16 +29,6 @@ final class CompletableFutureEntry<V> {
     }
 
     boolean processState() {
-        if (completableFuture.isDone()) {
-            Object result;
-            try {
-                result = completableFuture.future.get();
-            } catch (Throwable t) {
-                result = t;
-            }
-            completableFuture.setResult(result);
-            return true;
-        }
-        return false;
+        return completableFuture.isDone();
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/AbstractCompletableFutureTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/AbstractCompletableFutureTest.java
@@ -59,7 +59,7 @@ public class AbstractCompletableFutureTest extends HazelcastTestSupport {
 
     @Test
     public void future_notExecuted_notDoneNotCancelled() throws Exception {
-        FutureImpl future = new FutureImpl(nodeEngine, logger);
+        TestFutureImpl future = new TestFutureImpl(nodeEngine, logger);
 
         assertFalse("New future should not be done", future.isDone());
         assertFalse("New future should not be cancelled", future.isCancelled());
@@ -67,7 +67,7 @@ public class AbstractCompletableFutureTest extends HazelcastTestSupport {
 
     @Test
     public void future_notExecuted_callbackRegistered_notDoneNotCancelled() throws Exception {
-        FutureImpl future = new FutureImpl(nodeEngine, logger);
+        TestFutureImpl future = new TestFutureImpl(nodeEngine, logger);
         future.andThen(mock(ExecutionCallback.class));
 
         assertFalse("New future should not be done", future.isDone());
@@ -90,7 +90,7 @@ public class AbstractCompletableFutureTest extends HazelcastTestSupport {
     }
 
     private void future_resultSet_doneNotCancelled(Object result) {
-        FutureImpl future = new FutureImpl(nodeEngine, logger);
+        TestFutureImpl future = new TestFutureImpl(nodeEngine, logger);
         future.setResult(result);
 
         assertTrue("Future with result should be done", future.isDone());
@@ -99,7 +99,7 @@ public class AbstractCompletableFutureTest extends HazelcastTestSupport {
 
     @Test
     public void future_resultNotSet_cancelled() throws Exception {
-        FutureImpl future = new FutureImpl(nodeEngine, logger);
+        TestFutureImpl future = new TestFutureImpl(nodeEngine, logger);
         boolean cancelled = future.cancel(false);
 
         assertTrue(cancelled);
@@ -109,7 +109,7 @@ public class AbstractCompletableFutureTest extends HazelcastTestSupport {
 
     @Test
     public void future_resultSetAndCancelled() throws Exception {
-        FutureImpl future = new FutureImpl(nodeEngine, logger);
+        TestFutureImpl future = new TestFutureImpl(nodeEngine, logger);
         future.setResult(RESULT);
         boolean cancelled = future.cancel(false);
 
@@ -120,7 +120,7 @@ public class AbstractCompletableFutureTest extends HazelcastTestSupport {
 
     @Test
     public void future_cancelledAndResultSet() throws Exception {
-        FutureImpl future = new FutureImpl(nodeEngine, logger);
+        TestFutureImpl future = new TestFutureImpl(nodeEngine, logger);
         boolean cancelled = future.cancel(false);
         future.setResult(RESULT);
 
@@ -132,7 +132,7 @@ public class AbstractCompletableFutureTest extends HazelcastTestSupport {
 
     @Test(expected = CancellationException.class)
     public void get_cancelledFuture_exceptionThrown() throws Exception {
-        FutureImpl future = new FutureImpl(nodeEngine, logger);
+        TestFutureImpl future = new TestFutureImpl(nodeEngine, logger);
 
         future.cancel(false);
 
@@ -141,7 +141,7 @@ public class AbstractCompletableFutureTest extends HazelcastTestSupport {
 
     @Test(expected = CancellationException.class)
     public void getWithTimeout_cancelledFuture_exceptionThrown() throws Exception {
-        FutureImpl future = new FutureImpl(nodeEngine, logger);
+        TestFutureImpl future = new TestFutureImpl(nodeEngine, logger);
 
         future.cancel(false);
 
@@ -150,7 +150,7 @@ public class AbstractCompletableFutureTest extends HazelcastTestSupport {
 
     @Test
     public void get_ordinaryResultSet_returnsResult() throws Exception {
-        FutureImpl future = new FutureImpl(nodeEngine, logger);
+        TestFutureImpl future = new TestFutureImpl(nodeEngine, logger);
         future.setResult(RESULT);
 
         Object result = future.get();
@@ -160,7 +160,7 @@ public class AbstractCompletableFutureTest extends HazelcastTestSupport {
 
     @Test
     public void getWithTimeout_ordinaryResultSet_returnsResult() throws Exception {
-        FutureImpl future = new FutureImpl(nodeEngine, logger);
+        TestFutureImpl future = new TestFutureImpl(nodeEngine, logger);
         future.setResult(RESULT);
 
         Object result = future.get(10, TimeUnit.MILLISECONDS);
@@ -170,7 +170,7 @@ public class AbstractCompletableFutureTest extends HazelcastTestSupport {
 
     @Test
     public void get_exceptionResultSet_exceptionThrown() throws Exception {
-        FutureImpl future = new FutureImpl(nodeEngine, logger);
+        TestFutureImpl future = new TestFutureImpl(nodeEngine, logger);
         future.setResult(EXCEPTION);
 
         expected.expect(EXCEPTION.getClass());
@@ -181,7 +181,7 @@ public class AbstractCompletableFutureTest extends HazelcastTestSupport {
 
     @Test
     public void getWithTimeout_exceptionResultSet_exceptionThrown_noTimeout() throws Exception {
-        FutureImpl future = new FutureImpl(nodeEngine, logger);
+        TestFutureImpl future = new TestFutureImpl(nodeEngine, logger);
         future.setResult(EXCEPTION);
 
         expected.expect(EXCEPTION.getClass());
@@ -192,7 +192,7 @@ public class AbstractCompletableFutureTest extends HazelcastTestSupport {
 
     @Test
     public void get_nullResultSet_returnsResult() throws Exception {
-        FutureImpl future = new FutureImpl(nodeEngine, logger);
+        TestFutureImpl future = new TestFutureImpl(nodeEngine, logger);
         future.setResult(null);
 
         Object result = future.get();
@@ -202,7 +202,7 @@ public class AbstractCompletableFutureTest extends HazelcastTestSupport {
 
     @Test
     public void getWithTimeout_nullResultSet_returnsResult() throws Exception {
-        FutureImpl future = new FutureImpl(nodeEngine, logger);
+        TestFutureImpl future = new TestFutureImpl(nodeEngine, logger);
         future.setResult(null);
 
         Object result = future.get(10, TimeUnit.MILLISECONDS);
@@ -212,35 +212,35 @@ public class AbstractCompletableFutureTest extends HazelcastTestSupport {
 
     @Test(expected = TimeoutException.class, timeout = 120000)
     public void getWithTimeout_resultNotSet_timesOut() throws Exception {
-        FutureImpl future = new FutureImpl(nodeEngine, logger);
+        TestFutureImpl future = new TestFutureImpl(nodeEngine, logger);
 
         future.get(10, TimeUnit.MILLISECONDS);
     }
 
     @Test(expected = TimeoutException.class, timeout = 60000)
     public void getWithTimeout_zeroTimeout_resultNotSet_timesOut() throws Exception {
-        FutureImpl future = new FutureImpl(nodeEngine, logger);
+        TestFutureImpl future = new TestFutureImpl(nodeEngine, logger);
 
         future.get(0, TimeUnit.MILLISECONDS);
     }
 
     @Test(expected = TimeoutException.class, timeout = 60000)
     public void getWithTimeout_negativeTimeout_resultNotSet_timesOut() throws Exception {
-        FutureImpl future = new FutureImpl(nodeEngine, logger);
+        TestFutureImpl future = new TestFutureImpl(nodeEngine, logger);
 
         future.get(-1, TimeUnit.MILLISECONDS);
     }
 
     @Test(expected = TimeoutException.class, timeout = 60000)
     public void getWithTimeout_lowerThanOneMilliTimeout_resultNotSet_timesOut() throws Exception {
-        FutureImpl future = new FutureImpl(nodeEngine, logger);
+        TestFutureImpl future = new TestFutureImpl(nodeEngine, logger);
 
         future.get(1, TimeUnit.NANOSECONDS);
     }
 
     @Test
     public void getWithTimeout_threadInterrupted_exceptionThrown() throws Exception {
-        FutureImpl future = new FutureImpl(nodeEngine, logger);
+        TestFutureImpl future = new TestFutureImpl(nodeEngine, logger);
 
         Thread.currentThread().interrupt();
 
@@ -250,7 +250,7 @@ public class AbstractCompletableFutureTest extends HazelcastTestSupport {
 
     @Test(timeout = 60000)
     public void getWithTimeout_waited_notifiedOnSet() throws Exception {
-        FutureImpl future = new FutureImpl(nodeEngine, logger);
+        TestFutureImpl future = new TestFutureImpl(nodeEngine, logger);
 
         submitSetResultAfterTimeInMillis(future, RESULT, 200);
         Object result = future.get(30000, TimeUnit.MILLISECONDS);
@@ -260,7 +260,7 @@ public class AbstractCompletableFutureTest extends HazelcastTestSupport {
 
     @Test(timeout = 60000)
     public void getWithTimeout_waited_waited_notifiedOnCancel() throws Exception {
-        FutureImpl future = new FutureImpl(nodeEngine, logger);
+        TestFutureImpl future = new TestFutureImpl(nodeEngine, logger);
 
         submitCancelAfterTimeInMillis(future, 200);
 
@@ -284,7 +284,7 @@ public class AbstractCompletableFutureTest extends HazelcastTestSupport {
     }
 
     private void setResult_resultSet_futureDone(Object result) {
-        FutureImpl future = new FutureImpl(nodeEngine, logger);
+        TestFutureImpl future = new TestFutureImpl(nodeEngine, logger);
 
         future.setResult(result);
 
@@ -293,7 +293,7 @@ public class AbstractCompletableFutureTest extends HazelcastTestSupport {
 
     @Test
     public void setResult_whenResultAlreadySet_secondResultDiscarded() throws Exception {
-        FutureImpl future = new FutureImpl(nodeEngine, logger);
+        TestFutureImpl future = new TestFutureImpl(nodeEngine, logger);
         Object initialResult = "firstresult", secondResult = "secondresult";
 
         future.setResult(initialResult);
@@ -318,7 +318,7 @@ public class AbstractCompletableFutureTest extends HazelcastTestSupport {
     }
 
     public void setResult_whenPendingCallback_callbacksExecutedCorrectly(final Object result) {
-        FutureImpl future = new FutureImpl(nodeEngine, logger);
+        TestFutureImpl future = new TestFutureImpl(nodeEngine, logger);
         final ExecutionCallback callback1 = mock(ExecutionCallback.class);
         final ExecutionCallback callback2 = mock(ExecutionCallback.class);
         future.andThen(callback1);
@@ -350,7 +350,7 @@ public class AbstractCompletableFutureTest extends HazelcastTestSupport {
 
     @Test
     public void getResult_whenInitialState() throws Exception {
-        FutureImpl future = new FutureImpl(nodeEngine, logger);
+        TestFutureImpl future = new TestFutureImpl(nodeEngine, logger);
 
         Object result = future.getResult();
 
@@ -359,7 +359,7 @@ public class AbstractCompletableFutureTest extends HazelcastTestSupport {
 
     @Test
     public void getResult_whenPendingCallback() throws Exception {
-        FutureImpl future = new FutureImpl(nodeEngine, logger);
+        TestFutureImpl future = new TestFutureImpl(nodeEngine, logger);
         future.andThen(mock(ExecutionCallback.class));
 
         Object result = future.getResult();
@@ -369,7 +369,7 @@ public class AbstractCompletableFutureTest extends HazelcastTestSupport {
 
     @Test
     public void getResult_whenNullResult() throws Exception {
-        FutureImpl future = new FutureImpl(nodeEngine, logger);
+        TestFutureImpl future = new TestFutureImpl(nodeEngine, logger);
         future.setResult(null);
 
         Object result = future.getResult();
@@ -380,19 +380,19 @@ public class AbstractCompletableFutureTest extends HazelcastTestSupport {
 
     @Test(expected = IllegalArgumentException.class)
     public void andThen_whenNullCallback_exceptionThrown() {
-        FutureImpl future = new FutureImpl(nodeEngine, logger);
+        TestFutureImpl future = new TestFutureImpl(nodeEngine, logger);
         future.andThen(null, executor);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void andThen_whenNullExecutor_exceptionThrown() {
-        FutureImpl future = new FutureImpl(nodeEngine, logger);
+        TestFutureImpl future = new TestFutureImpl(nodeEngine, logger);
         future.andThen(mock(ExecutionCallback.class), null);
     }
 
     @Test
     public void andThen_whenInitialState() {
-        FutureImpl future = new FutureImpl(nodeEngine, logger);
+        TestFutureImpl future = new TestFutureImpl(nodeEngine, logger);
         ExecutionCallback callback = mock(ExecutionCallback.class);
 
         future.andThen(callback, executor);
@@ -402,7 +402,7 @@ public class AbstractCompletableFutureTest extends HazelcastTestSupport {
 
     @Test
     public void andThen_whenCancelled() {
-        FutureImpl future = new FutureImpl(nodeEngine, logger);
+        TestFutureImpl future = new TestFutureImpl(nodeEngine, logger);
         ExecutionCallback callback = mock(ExecutionCallback.class);
 
         future.cancel(false);
@@ -413,7 +413,7 @@ public class AbstractCompletableFutureTest extends HazelcastTestSupport {
 
     @Test
     public void andThen_whenPendingCallback() {
-        FutureImpl future = new FutureImpl(nodeEngine, logger);
+        TestFutureImpl future = new TestFutureImpl(nodeEngine, logger);
         ExecutionCallback callback1 = mock(ExecutionCallback.class);
         ExecutionCallback callback2 = mock(ExecutionCallback.class);
 
@@ -426,7 +426,7 @@ public class AbstractCompletableFutureTest extends HazelcastTestSupport {
 
     @Test
     public void andThen_whenPendingCallback_andCancelled() {
-        FutureImpl future = new FutureImpl(nodeEngine, logger);
+        TestFutureImpl future = new TestFutureImpl(nodeEngine, logger);
         ExecutionCallback callback1 = mock(ExecutionCallback.class);
         ExecutionCallback callback2 = mock(ExecutionCallback.class);
 
@@ -440,7 +440,7 @@ public class AbstractCompletableFutureTest extends HazelcastTestSupport {
 
     @Test
     public void andThen_whenResultAvailable() throws Exception {
-        FutureImpl future = new FutureImpl(nodeEngine, logger);
+        TestFutureImpl future = new TestFutureImpl(nodeEngine, logger);
         final Object result = "result";
         final ExecutionCallback callback = mock(ExecutionCallback.class);
 
@@ -456,7 +456,7 @@ public class AbstractCompletableFutureTest extends HazelcastTestSupport {
         });
     }
 
-    private void submitCancelAfterTimeInMillis(final FutureImpl future, final int timeInMillis) {
+    private void submitCancelAfterTimeInMillis(final TestFutureImpl future, final int timeInMillis) {
         submit(new Runnable() {
             @Override
             public void run() {
@@ -469,7 +469,7 @@ public class AbstractCompletableFutureTest extends HazelcastTestSupport {
         });
     }
 
-    private void submitSetResultAfterTimeInMillis(final FutureImpl future, final Object result, final int timeInMillis) {
+    private void submitSetResultAfterTimeInMillis(final TestFutureImpl future, final Object result, final int timeInMillis) {
         submit(new Runnable() {
             @Override
             public void run() {
@@ -486,8 +486,8 @@ public class AbstractCompletableFutureTest extends HazelcastTestSupport {
         new Thread(runnable).start();
     }
 
-    private class FutureImpl extends AbstractCompletableFuture<Object> {
-        protected FutureImpl(NodeEngine nodeEngine, ILogger logger) {
+    private class TestFutureImpl extends AbstractCompletableFuture<Object> {
+        protected TestFutureImpl(NodeEngine nodeEngine, ILogger logger) {
             super(nodeEngine, logger);
         }
     }

--- a/hazelcast/src/test/java/com/hazelcast/util/FutureUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/FutureUtilTest.java
@@ -315,7 +315,7 @@ public class FutureUtilTest extends HazelcastTestSupport {
         }
 
         @Override
-        public boolean cancel(boolean mayInterruptIfRunning) {
+        protected boolean shouldCancel(boolean mayInterruptIfRunning) {
             return false;
         }
 
@@ -323,11 +323,6 @@ public class FutureUtilTest extends HazelcastTestSupport {
         public V get(long timeout, TimeUnit unit) throws InterruptedException,
                 ExecutionException, TimeoutException {
             return null;
-        }
-
-        @Override
-        public boolean isCancelled() {
-            return false;
         }
 
     }


### PR DESCRIPTION
Follow up on #6020 #6062 and #6081; Fixes #6080

Key points:
* All the Futures extending AbstractCompletableFuture have been refactored in order to take advantage of the features added to AbstractCompletableFuture. Thus, all the latches and synchronisation mechanisms could have been removed making the code of a couple of Future's much simpler. 
* BasicCompletableFuture has been fixed, documented, unit-tested and made more "digestible".
* After all classes that extend AbstractCompletableFuture had been refactored the class itself was also modified to make some methods final / protected and basically to keeps its state "more" secure. There have also been some minor fixes in the get() or getResult() methods