### PR TITLE
SelectionKey exception handling

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/NonBlockingIOThread.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/NonBlockingIOThread.java
@@ -261,6 +261,7 @@ public class NonBlockingIOThread extends Thread implements OperationHostileThrea
         SelectionHandler handler = (SelectionHandler) sk.attachment();
         try {
             if (!sk.isValid()) {
+                // if the selectionKey isn't valid, we throw this exception to feedback the situation into the handler.onFailure
                 throw new CancelledKeyException();
             }
 
@@ -270,13 +271,6 @@ public class NonBlockingIOThread extends Thread implements OperationHostileThrea
             handler.handle();
         } catch (Throwable t) {
             handler.onFailure(t);
-        }
-    }
-
-    public void handleSelectionKeyFailure(Throwable e) {
-        logger.warning("Selector exception at  " + getName() + ", cause= " + e.toString(), e);
-        if (e instanceof OutOfMemoryError) {
-            oomeHandler.handle((OutOfMemoryError) e);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/NonBlockingSocketReader.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/NonBlockingSocketReader.java
@@ -120,7 +120,11 @@ public final class NonBlockingSocketReader extends AbstractHandler implements So
         ioThread.addTaskAndWakeup(new Runnable() {
             @Override
             public void run() {
-                getSelectionKey();
+                try {
+                    getSelectionKey();
+                } catch (Throwable t) {
+                    onFailure(t);
+                }
             }
         });
     }
@@ -271,7 +275,11 @@ public final class NonBlockingSocketReader extends AbstractHandler implements So
                 return;
             }
 
-            startMigration(newOwner);
+            try {
+                startMigration(newOwner);
+            } catch (Throwable t) {
+                onFailure(t);
+            }
         }
     }
 }


### PR DESCRIPTION
In the old approach the exceptions around the selection key were caught and the connection was closed; but the flow was not aborted (so the methods keep running).
    
That has been resolved in this pr; so a selection key exception is propagated and caught just as any other  exception thrown from a handler (handler allows for checked exceptions to be thrown)
