### PR TITLE
added unlock without ownerUuid

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockResourceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockResourceImpl.java
@@ -139,8 +139,40 @@ final class LockResourceImpl implements DataSerializable, LockResource {
         return true;
     }
 
+    /**
+     * introduced as a workaround, will be dropped at 3.6
+     * @param threadId
+     * @return
+     * @since 3.5.3
+     */
+    boolean unlockWithoutCheckingOwnership(long threadId) {
+        if (lockCount == 0) {
+            return false;
+        }
+
+        if (this.threadId != threadId) {
+            return false;
+        }
+
+        lockCount--;
+        if (lockCount == 0) {
+            clear();
+        }
+        return true;
+    }
+
     boolean canAcquireLock(String caller, long threadId) {
         return lockCount == 0 || getThreadId() == threadId && getOwner().equals(caller);
+    }
+
+    /**
+     * introduced as a workaround, will be dropped at 3.6
+     * @param threadId
+     * @return
+     * @since 3.5.3
+     */
+    boolean canAcquireLockWithoutCheckingOwnership(long threadId) {
+        return lockCount == 0 || getThreadId() == threadId;
     }
 
     boolean addAwait(String conditionId, String caller, long threadId) {

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockStore.java
@@ -30,6 +30,16 @@ public interface LockStore {
 
     boolean unlock(Data key, String caller, long threadId);
 
+    /**
+     * unlocks ignoring owner information
+     * introduced as a workaround, will be dropped at 3.6
+     * @param key
+     * @param threadId
+     * @return
+     * @since 3.5.3
+     */
+    boolean unlockWithoutCheckingOwnership(Data key, long threadId);
+
     boolean isLocked(Data key);
 
     boolean isLockedBy(Data key, String caller, long threadId);

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockStoreImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockStoreImpl.java
@@ -160,6 +160,25 @@ public final class LockStoreImpl implements DataSerializable, LockStore {
     }
 
     @Override
+    public boolean unlockWithoutCheckingOwnership(Data key, long threadId) {
+        LockResourceImpl lock = locks.get(key);
+        if (lock == null) {
+            return false;
+        }
+
+        boolean result = false;
+        if (lock.canAcquireLockWithoutCheckingOwnership(threadId)) {
+            if (lock.unlockWithoutCheckingOwnership(threadId)) {
+                result = true;
+            }
+        }
+        if (lock.isRemovable()) {
+            locks.remove(key);
+        }
+        return result;
+    }
+
+    @Override
     public boolean forceUnlock(Data key) {
         LockResourceImpl lock = locks.get(key);
         if (lock == null) {

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockStoreProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockStoreProxy.java
@@ -57,6 +57,12 @@ public final class LockStoreProxy implements LockStore {
     }
 
     @Override
+    public boolean unlockWithoutCheckingOwnership(Data key, long threadId) {
+        LockStore lockStore = getLockStoreOrNull();
+        return lockStore != null && lockStore.unlockWithoutCheckingOwnership(key, threadId);
+    }
+
+    @Override
     public boolean isLocked(Data key) {
         LockStore lockStore = getLockStoreOrNull();
         return lockStore != null && lockStore.isLocked(key);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/DefaultRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/DefaultRecordStore.java
@@ -301,6 +301,12 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore implements 
     }
 
     @Override
+    public boolean unlockWithoutCheckingOwnership(Data key, long threadId) {
+        checkIfLoaded();
+        return lockStore != null && lockStore.unlockWithoutCheckingOwnership(key, threadId);
+    }
+
+    @Override
     public boolean forceUnlock(Data dataKey) {
         return lockStore != null && lockStore.forceUnlock(dataKey);
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/RecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/RecordStore.java
@@ -196,6 +196,16 @@ public interface RecordStore {
 
     boolean unlock(Data key, String caller, long threadId);
 
+    /**
+     * unlocks ignoring owner information
+     * introduced as a workaround, will be dropped at 3.6
+     * @param key
+     * @param threadId
+     * @return
+     * @since 3.5.3
+     */
+    boolean unlockWithoutCheckingOwnership(Data key, long threadId);
+
     boolean isLocked(Data key);
 
     boolean isTransactionallyLocked(Data key);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnUnlockBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnUnlockBackupOperation.java
@@ -35,7 +35,9 @@ public class TxnUnlockBackupOperation extends KeyBasedMapOperation implements Ba
 
     @Override
     public void run() {
-        recordStore.unlock(dataKey, getCallerUuid(), getThreadId());
+        // we unlock without caller uuid because it is not the correct owner uuid of the lock
+        // please see https://github.com/hazelcast/hazelcast/issues/6039
+        recordStore.unlockWithoutCheckingOwnership(dataKey, getThreadId());
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/map/MapTransactionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapTransactionTest.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.map;
 
+import com.hazelcast.concurrent.lock.LockResource;
+import com.hazelcast.concurrent.lock.LockService;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.MapStoreConfig;
 import com.hazelcast.core.EntryAdapter;
@@ -27,6 +29,9 @@ import com.hazelcast.core.IMap;
 import com.hazelcast.core.MapStoreAdapter;
 import com.hazelcast.core.TransactionalMap;
 import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.instance.Node;
+import com.hazelcast.instance.TestUtil;
+import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.Portable;
 import com.hazelcast.nio.serialization.PortableFactory;
 import com.hazelcast.query.EntryObject;
@@ -47,6 +52,10 @@ import com.hazelcast.transaction.TransactionNotActiveException;
 import com.hazelcast.transaction.TransactionOptions;
 import com.hazelcast.transaction.TransactionalTask;
 import com.hazelcast.transaction.TransactionalTaskContext;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.Random;
@@ -54,9 +63,6 @@ import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -126,6 +132,34 @@ public class MapTransactionTest extends HazelcastTestSupport {
         });
         assertEquals("value6", h4.getMap("default").get("1"));
     }
+
+    @Test
+    public void testGetForUpdate_releasesBackupLock() {
+        Config config = new Config();
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(2);
+        HazelcastInstance instance1 = factory.newHazelcastInstance(config);
+        HazelcastInstance instance2 = factory.newHazelcastInstance(config);
+        final String keyOwnedByInstance2 = generateKeyOwnedBy(instance2);
+
+        instance1.executeTransaction(new TransactionalTask<Object>() {
+            @Override
+            public Object execute(TransactionalTaskContext context) throws TransactionException {
+                TransactionalMap<Object, Object> map = context.getMap(randomString());
+                map.getForUpdate(keyOwnedByInstance2);
+                return null;
+            }
+        });
+
+        Node node = TestUtil.getNode(instance1);
+        Data keyData = node.nodeEngine.toData(keyOwnedByInstance2);
+        LockService lockService = node.nodeEngine.getService(LockService.SERVICE_NAME);
+        for (LockResource lockResource : lockService.getAllLocks()) {
+            if (keyData.equals(lockResource.getKey())) {
+                assertEquals(0, lockResource.getLockCount());
+            }
+        }
+    }
+
 
     @Test
     public void testTxnCommit() throws TransactionException {
@@ -1256,6 +1290,7 @@ public class MapTransactionTest extends HazelcastTestSupport {
         });
         node.shutdown();
     }
+
     @Test
     public void testValues_shouldNotDeduplicateEntriesWhenGettingByPredicate() throws TransactionException {
         final int nodeCount = 1;


### PR DESCRIPTION
TxnUnlockBackupOperation now uses it as a workaround
see https://github.com/hazelcast/hazelcast/issues/6039

I don't know the side-effects of this change, it is here to collect comments/ideas