### PR TITLE
OSGI Improvements

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -128,6 +128,9 @@
     <suppress checks="JavadocMethod" files="com/hazelcast/internal/storage/"/>
     <suppress checks="JavadocVariable" files="com/hazelcast/internal/storage/"/>
 
+    <!-- OSGI -->
+    <suppress checks="MethodCount" files="com/hazelcast/osgi/impl/HazelcastOSGiInstanceImpl"/>
+
     <!-- Client -->
     <!-- TODO: These JavaDoc issues need to be addressed -->
     <suppress checks="JavadocMethod" files="com/hazelcast/client/"/>

--- a/hazelcast/pom.xml
+++ b/hazelcast/pom.xml
@@ -136,7 +136,7 @@
                         </goals>
                         <configuration>
                             <instructions>
-                                <Bundle-Activator>com.hazelcast.internal.osgi.Activator</Bundle-Activator>
+                                <Bundle-Activator>com.hazelcast.osgi.impl.Activator</Bundle-Activator>
                                 <Export-Package>
                                     com.hazelcast.*
                                 </Export-Package>

--- a/hazelcast/src/main/java/com/hazelcast/osgi/HazelcastOSGiInstance.java
+++ b/hazelcast/src/main/java/com/hazelcast/osgi/HazelcastOSGiInstance.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.osgi;
+
+import com.hazelcast.core.HazelcastInstance;
+
+/**
+ * Contract point for {@link com.hazelcast.core.HazelcastInstance} implementations based on OSGi service.
+ */
+public interface HazelcastOSGiInstance
+        extends HazelcastInstance {
+
+    /**
+     * Gets the delegated (underlying) {@link com.hazelcast.core.HazelcastInstance}.
+     *
+     * @return the delegated (underlying) {@link com.hazelcast.core.HazelcastInstance
+     */
+    HazelcastInstance getDelegatedInstance();
+
+    /**
+     * Gets the owner {@link HazelcastOSGiService} of this instance.
+     *
+     * @return the owner {@link HazelcastOSGiService} of this instance
+     */
+    HazelcastOSGiService getOwnerService();
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/osgi/HazelcastOSGiService.java
+++ b/hazelcast/src/main/java/com/hazelcast/osgi/HazelcastOSGiService.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.osgi;
+
+import com.hazelcast.config.Config;
+import org.osgi.framework.Bundle;
+
+import java.util.Set;
+
+/**
+ * Contract point for Hazelcast services on top of OSGI.
+ */
+public interface HazelcastOSGiService {
+
+    /**
+     * System property for starting a default Hazelcast instance per Hazelcast OSGI bundle.
+     */
+    String HAZELCAST_OSGI_START = "hazelcast.osgi.start";
+
+    /**
+     * System property for disabling the behaviour that registers created Hazelcast instances as OSGI service.
+     */
+    String HAZELCAST_OSGI_REGISTER_DISABLED = "hazelcast.osgi.register.disabled";
+
+    /**
+     * System property for disabling the behaviour that gives different group name
+     * to each Hazelcast bundle.
+     */
+    String HAZELCAST_OSGI_GROUPING_DISABLED = "hazelcast.osgi.grouping.disabled";
+
+    /**
+     * Gets the id of service.
+     *
+     * @return the id of service
+     */
+    String getId();
+
+    /**
+     * Gets the owner {@link Bundle} of this instance.
+     *
+     * @return the owner {@link Bundle} of this instance
+     */
+    Bundle getOwnerBundle();
+
+    /**
+     * Gets the default {@link HazelcastOSGiInstance}.
+     *
+     * @return the default {@link HazelcastOSGiInstance}
+     */
+    HazelcastOSGiInstance getDefaultHazelcastInstance();
+
+    /**
+     * Creates a new {@link HazelcastOSGiInstance}
+     * on the owner bundle with specified configuration.
+     *
+     * @param config Configuration for the new {@link HazelcastOSGiInstance} (member)
+     * @return the new {@link HazelcastOSGiInstance}
+     */
+    HazelcastOSGiInstance newHazelcastInstance(Config config);
+
+    /**
+     * Creates a new {@link HazelcastOSGiInstance}
+     * on the owner bundle with default configuration.
+     *
+     * @return the new {@link HazelcastOSGiInstance}
+     */
+    HazelcastOSGiInstance newHazelcastInstance();
+
+    /**
+     * Gets an existing {@link HazelcastOSGiInstance} with its <code>instanceName</code>.
+     *
+     * @param instanceName Name of the {@link HazelcastOSGiInstance} (member)
+     * @return an existing {@link HazelcastOSGiInstance}
+     */
+    HazelcastOSGiInstance getHazelcastInstanceByName(String instanceName);
+
+    /**
+     * Gets all active/running {@link HazelcastOSGiInstance}s on the owner bundle.
+     *
+     * @return all active/running {@link HazelcastOSGiInstance}s on the owner bundle
+     */
+    Set<HazelcastOSGiInstance> getAllHazelcastInstances();
+
+    /**
+     * Shuts down the given {@link HazelcastOSGiInstance} on the owner bundle.
+     *
+     * @param instance the {@link HazelcastOSGiInstance} to shutdown
+     */
+    void shutdownHazelcastInstance(HazelcastOSGiInstance instance);
+
+    /**
+     * Shuts down all running {@link HazelcastOSGiInstance}s on the owner bundle.
+     */
+    void shutdownAll();
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/osgi/impl/HazelcastInternalOSGiService.java
+++ b/hazelcast/src/main/java/com/hazelcast/osgi/impl/HazelcastInternalOSGiService.java
@@ -14,7 +14,33 @@
  * limitations under the License.
  */
 
+package com.hazelcast.osgi.impl;
+
+import com.hazelcast.osgi.HazelcastOSGiService;
+
 /**
- * <p>This package contains the OSGI functionality for Hazelcast.<br/>
+ * Contract point for internal Hazelcast services on top of OSGI.
+ *
+ * @see com.hazelcast.osgi.HazelcastOSGiService
  */
-package com.hazelcast.internal.osgi;
+public interface HazelcastInternalOSGiService
+        extends HazelcastOSGiService {
+
+    /**
+     * Returns the state of the service about if it is active or not.
+     *
+     * @return <code>true</code> if the service is active, otherwise <code>false</code>
+     */
+    boolean isActive();
+
+    /**
+     * Activates the service.
+     */
+    void activate();
+
+    /**
+     * Deactivates the service.
+     */
+    void deactivate();
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/osgi/impl/HazelcastOSGiInstanceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/osgi/impl/HazelcastOSGiInstanceImpl.java
@@ -1,0 +1,313 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.osgi.impl;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.GroupConfig;
+import com.hazelcast.core.ClientService;
+import com.hazelcast.core.Cluster;
+import com.hazelcast.core.DistributedObject;
+import com.hazelcast.core.DistributedObjectListener;
+import com.hazelcast.core.Endpoint;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IAtomicLong;
+import com.hazelcast.core.IAtomicReference;
+import com.hazelcast.core.ICountDownLatch;
+import com.hazelcast.core.IExecutorService;
+import com.hazelcast.core.IList;
+import com.hazelcast.core.ILock;
+import com.hazelcast.core.IMap;
+import com.hazelcast.core.IQueue;
+import com.hazelcast.core.ISemaphore;
+import com.hazelcast.core.ISet;
+import com.hazelcast.core.ITopic;
+import com.hazelcast.core.IdGenerator;
+import com.hazelcast.core.LifecycleService;
+import com.hazelcast.core.MultiMap;
+import com.hazelcast.core.PartitionService;
+import com.hazelcast.core.ReplicatedMap;
+import com.hazelcast.osgi.HazelcastOSGiInstance;
+import com.hazelcast.osgi.HazelcastOSGiService;
+import com.hazelcast.logging.LoggingService;
+import com.hazelcast.mapreduce.JobTracker;
+import com.hazelcast.quorum.QuorumService;
+import com.hazelcast.ringbuffer.Ringbuffer;
+import com.hazelcast.transaction.HazelcastXAResource;
+import com.hazelcast.transaction.TransactionContext;
+import com.hazelcast.transaction.TransactionException;
+import com.hazelcast.transaction.TransactionOptions;
+import com.hazelcast.transaction.TransactionalTask;
+import com.hazelcast.util.StringUtil;
+
+import java.util.Collection;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * {@link com.hazelcast.osgi.HazelcastOSGiInstance} implementation
+ * as proxy of delegated {@link com.hazelcast.core.HazelcastInstance} for getting from OSGi service.
+ */
+class HazelcastOSGiInstanceImpl
+        implements HazelcastOSGiInstance {
+
+    private final HazelcastInstance delegatedInstance;
+    private final HazelcastOSGiService ownerService;
+
+    public HazelcastOSGiInstanceImpl(HazelcastInstance delegatedInstance,
+                                     HazelcastOSGiService ownerService) {
+        this.delegatedInstance = delegatedInstance;
+        this.ownerService = ownerService;
+    }
+
+    @Override
+    public String getName() {
+        return delegatedInstance.getName();
+    }
+
+    @Override
+    public <E> IQueue<E> getQueue(String name) {
+        return delegatedInstance.getQueue(name);
+    }
+
+    @Override
+    public <E> ITopic<E> getTopic(String name) {
+        return delegatedInstance.getTopic(name);
+    }
+
+    @Override
+    public <E> ISet<E> getSet(String name) {
+        return delegatedInstance.getSet(name);
+    }
+
+    @Override
+    public <E> IList<E> getList(String name) {
+        return delegatedInstance.getList(name);
+    }
+
+    @Override
+    public <K, V> IMap<K, V> getMap(String name) {
+        return delegatedInstance.getMap(name);
+    }
+
+    @Override
+    public <K, V> ReplicatedMap<K, V> getReplicatedMap(String name) {
+        return delegatedInstance.getReplicatedMap(name);
+    }
+
+    @Override
+    public JobTracker getJobTracker(String name) {
+        return delegatedInstance.getJobTracker(name);
+    }
+
+    @Override
+    public <K, V> MultiMap<K, V> getMultiMap(String name) {
+        return delegatedInstance.getMultiMap(name);
+    }
+
+    @Override
+    public ILock getLock(String key) {
+        return delegatedInstance.getLock(key);
+    }
+
+    @Override
+    public <E> Ringbuffer<E> getRingbuffer(String name) {
+        return delegatedInstance.getRingbuffer(name);
+    }
+
+    @Override
+    public <E> ITopic<E> getReliableTopic(String name) {
+        return delegatedInstance.getReliableTopic(name);
+    }
+
+    @Override
+    public Cluster getCluster() {
+        return delegatedInstance.getCluster();
+    }
+
+    @Override
+    public Endpoint getLocalEndpoint() {
+        return delegatedInstance.getLocalEndpoint();
+    }
+
+    @Override
+    public IExecutorService getExecutorService(String name) {
+        return delegatedInstance.getExecutorService(name);
+    }
+
+    @Override
+    public <T> T executeTransaction(TransactionalTask<T> task) throws TransactionException {
+        return delegatedInstance.executeTransaction(task);
+    }
+
+    @Override
+    public <T> T executeTransaction(TransactionOptions options, TransactionalTask<T> task) throws TransactionException {
+        return delegatedInstance.executeTransaction(options, task);
+    }
+
+    @Override
+    public TransactionContext newTransactionContext() {
+        return delegatedInstance.newTransactionContext();
+    }
+
+    @Override
+    public TransactionContext newTransactionContext(TransactionOptions options) {
+        return delegatedInstance.newTransactionContext(options);
+    }
+
+    @Override
+    public IdGenerator getIdGenerator(String name) {
+        return delegatedInstance.getIdGenerator(name);
+    }
+
+    @Override
+    public IAtomicLong getAtomicLong(String name) {
+        return delegatedInstance.getAtomicLong(name);
+    }
+
+    @Override
+    public <E> IAtomicReference<E> getAtomicReference(String name) {
+        return delegatedInstance.getAtomicReference(name);
+    }
+
+    @Override
+    public ICountDownLatch getCountDownLatch(String name) {
+        return delegatedInstance.getCountDownLatch(name);
+    }
+
+    @Override
+    public ISemaphore getSemaphore(String name) {
+        return delegatedInstance.getSemaphore(name);
+    }
+
+    @Override
+    public Collection<DistributedObject> getDistributedObjects() {
+        return delegatedInstance.getDistributedObjects();
+    }
+
+    @Override
+    public String addDistributedObjectListener(DistributedObjectListener distributedObjectListener) {
+        return delegatedInstance.addDistributedObjectListener(distributedObjectListener);
+    }
+
+    @Override
+    public boolean removeDistributedObjectListener(String registrationId) {
+        return delegatedInstance.removeDistributedObjectListener(registrationId);
+    }
+
+    @Override
+    public Config getConfig() {
+        return delegatedInstance.getConfig();
+    }
+
+    @Override
+    public PartitionService getPartitionService() {
+        return delegatedInstance.getPartitionService();
+    }
+
+    @Override
+    public QuorumService getQuorumService() {
+        return delegatedInstance.getQuorumService();
+    }
+
+    @Override
+    public ClientService getClientService() {
+        return delegatedInstance.getClientService();
+    }
+
+    @Override
+    public LoggingService getLoggingService() {
+        return delegatedInstance.getLoggingService();
+    }
+
+    @Override
+    public LifecycleService getLifecycleService() {
+        return delegatedInstance.getLifecycleService();
+    }
+
+    @Override
+    public <T extends DistributedObject> T getDistributedObject(String serviceName, String name) {
+        return delegatedInstance.getDistributedObject(serviceName, name);
+    }
+
+    @Override
+    public ConcurrentMap<String, Object> getUserContext() {
+        return delegatedInstance.getUserContext();
+    }
+
+    @Override
+    public HazelcastXAResource getXAResource() {
+        return delegatedInstance.getXAResource();
+    }
+
+    @Override
+    public void shutdown() {
+        delegatedInstance.shutdown();
+    }
+
+    @Override
+    public HazelcastInstance getDelegatedInstance() {
+        return delegatedInstance;
+    }
+
+    @Override
+    public HazelcastOSGiService getOwnerService() {
+        return ownerService;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        HazelcastOSGiInstanceImpl that = (HazelcastOSGiInstanceImpl) o;
+
+        if (!delegatedInstance.equals(that.delegatedInstance)) {
+            return false;
+        }
+        if (!ownerService.equals(that.ownerService)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = ownerService.hashCode();
+        result = 31 * result + delegatedInstance.hashCode();
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder();
+        sb.append("HazelcastOSGiInstanceImpl");
+        sb.append("{delegatedInstance='").append(delegatedInstance).append('\'');
+        Config config = getConfig();
+        GroupConfig groupConfig = config.getGroupConfig();
+        if (groupConfig != null && !StringUtil.isNullOrEmpty(groupConfig.getName())) {
+            sb.append(", groupName=").append(groupConfig.getName());
+        }
+        sb.append(", ownerServiceId=").append(ownerService.getId());
+        sb.append('}');
+        return sb.toString();
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/osgi/impl/HazelcastOSGiServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/osgi/impl/HazelcastOSGiServiceImpl.java
@@ -1,0 +1,377 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.osgi.impl;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.GroupConfig;
+import com.hazelcast.config.XmlConfigBuilder;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.instance.BuildInfoProvider;
+import com.hazelcast.osgi.HazelcastOSGiInstance;
+import com.hazelcast.osgi.HazelcastOSGiService;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
+import com.hazelcast.util.ExceptionUtil;
+import com.hazelcast.util.StringUtil;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceReference;
+import org.osgi.framework.ServiceRegistration;
+
+import java.util.Collections;
+import java.util.Dictionary;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * Implementation of {@link HazelcastInternalOSGiService}.
+ *
+ * @see HazelcastInternalOSGiService
+ * @see com.hazelcast.osgi.HazelcastOSGiService
+ */
+class HazelcastOSGiServiceImpl
+        implements HazelcastInternalOSGiService {
+
+    private static final ILogger LOGGER = Logger.getLogger(HazelcastOSGiService.class);
+
+    private static final String DEFAULT_ID =
+            BuildInfoProvider.getBuildInfo().getVersion()
+            + "#"
+            + (BuildInfoProvider.getBuildInfo().isEnterprise() ? "EE" : "OSS");
+
+    private static final ServiceRegistration EMPTY_SERVICE_REGISTRATION
+            = new ServiceRegistration() {
+                @Override
+                public ServiceReference getReference() {
+                    return null;
+                }
+
+                @Override
+                public void setProperties(Dictionary properties) {
+                }
+
+                @Override
+                public void unregister() {
+                }
+            };
+
+    private final Object serviceMutex = new Object();
+
+    private final Bundle ownerBundle;
+    private final BundleContext ownerBundleContext;
+    private final String id;
+    private final ConcurrentMap<HazelcastOSGiInstance, ServiceRegistration> instanceServiceRegistrationMap
+            = new ConcurrentHashMap<HazelcastOSGiInstance, ServiceRegistration>();
+    private final ConcurrentMap<String, HazelcastOSGiInstance> instanceMap
+            = new ConcurrentHashMap<String, HazelcastOSGiInstance>();
+
+    // No need to "volatile" since this field is guarded and happens-before is handled by
+    // `synchronized` blocks of `serviceMutex` instance.
+    private ServiceRegistration serviceRegistration;
+
+    // Defined as `volatile` because even though this field is written inside `synchronized` blocks,
+    // it can be read from any thread without `synchronized` blocks and without `volatile` they may seen invalid value.
+    private volatile HazelcastOSGiInstance hazelcastInstance;
+
+    public HazelcastOSGiServiceImpl(Bundle ownerBundle) {
+        this(ownerBundle, DEFAULT_ID);
+    }
+
+    public HazelcastOSGiServiceImpl(Bundle ownerBundle, String id) {
+        this.ownerBundle = ownerBundle;
+        this.ownerBundleContext = ownerBundle.getBundleContext();
+        this.id = id;
+    }
+
+    private void checkActive() {
+        if (!isActive()) {
+            throw new IllegalStateException("Hazelcast OSGI Service is not active!");
+        }
+    }
+
+    private boolean shouldSetGroupName(GroupConfig groupConfig) {
+        if (groupConfig == null
+                || StringUtil.isNullOrEmpty(groupConfig.getName())
+                || GroupConfig.DEFAULT_GROUP_NAME.equals(groupConfig.getName())) {
+            if (!Boolean.getBoolean(HAZELCAST_OSGI_GROUPING_DISABLED)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private Config getConfig(Config config) {
+        if (config == null) {
+            config = new XmlConfigBuilder().build();
+        }
+        GroupConfig groupConfig = config.getGroupConfig();
+        if (shouldSetGroupName(groupConfig)) {
+            String groupName = id;
+            if (groupConfig == null) {
+                config.setGroupConfig(new GroupConfig(groupName));
+            } else {
+                groupConfig.setName(groupName);
+            }
+        }
+        return config;
+    }
+
+    private HazelcastInstance createHazelcastInstance(Config config) {
+        return Hazelcast.newHazelcastInstance(getConfig(config));
+    }
+
+    private HazelcastOSGiInstance registerInstance(HazelcastInstance instance) {
+        HazelcastOSGiInstance hazelcastOSGiInstance;
+        if (instance instanceof HazelcastOSGiInstance) {
+            hazelcastOSGiInstance = (HazelcastOSGiInstance) instance;
+        } else {
+            hazelcastOSGiInstance = new HazelcastOSGiInstanceImpl(instance, this);
+        }
+        ServiceRegistration serviceRegistration;
+        if (!Boolean.getBoolean(HAZELCAST_OSGI_REGISTER_DISABLED)) {
+            serviceRegistration =
+                    ownerBundleContext.registerService(HazelcastInstance.class.getName(), hazelcastOSGiInstance, null);
+        } else {
+            serviceRegistration = EMPTY_SERVICE_REGISTRATION;
+        }
+        instanceServiceRegistrationMap.put(hazelcastOSGiInstance, serviceRegistration);
+        instanceMap.put(instance.getName(), hazelcastOSGiInstance);
+        return hazelcastOSGiInstance;
+    }
+
+    private void deregisterInstance(HazelcastOSGiInstance hazelcastOSGiInstance) {
+        instanceMap.remove(hazelcastOSGiInstance.getName());
+        ServiceRegistration serviceRegistration =
+                instanceServiceRegistrationMap.remove(hazelcastOSGiInstance);
+        if (serviceRegistration != null && serviceRegistration != EMPTY_SERVICE_REGISTRATION) {
+            ownerBundleContext.ungetService(serviceRegistration.getReference());
+        }
+    }
+
+    private void shutdownAllInternal() {
+        try {
+            for (HazelcastOSGiInstance instance : instanceServiceRegistrationMap.keySet()) {
+                try {
+                    deregisterInstance(instance);
+                } catch (Throwable t) {
+                    LOGGER.finest("Error occurred while deregistering " + instance, t);
+                }
+                try {
+                    instance.shutdown();
+                } catch (Throwable t) {
+                    LOGGER.finest("Error occurred while shutting down " + instance, t);
+                }
+            }
+        } finally {
+            if (hazelcastInstance != null) {
+                // Default instance may not be registered due to set "HAZELCAST_OSGI_REGISTER_DISABLED" flag,
+                // So be sure that is it shutdown.
+                try {
+                    hazelcastInstance.shutdown();
+                } catch (Throwable t) {
+                    LOGGER.finest("Error occurred while shutting down the default Hazelcast instance !", t);
+                } finally {
+                    hazelcastInstance = null;
+                }
+            }
+        }
+    }
+
+    @Override
+    public String getId() {
+        return id;
+    }
+
+    @Override
+    public Bundle getOwnerBundle() {
+        return ownerBundle;
+    }
+
+    @Override
+    public boolean isActive() {
+        return ownerBundle.getState() == Bundle.ACTIVE;
+    }
+
+    @Override
+    public void activate() {
+        // No need to complex lock-free approaches since this is not called frequently. Simple is good.
+        synchronized (serviceMutex) {
+            if (!isActive()) {
+                try {
+                    if (hazelcastInstance != null) {
+                        try {
+                            LOGGER.warning("Default Hazelcast instance should be null while activating service !");
+                            hazelcastInstance.shutdown();
+                        } catch (Throwable t) {
+                            LOGGER.finest("Error occurred while shutting down the default Hazelcast instance !", t);
+                        } finally {
+                            hazelcastInstance = null;
+                        }
+                    }
+                    try {
+                        if (Boolean.getBoolean(HAZELCAST_OSGI_START)) {
+                            hazelcastInstance =
+                                    new HazelcastOSGiInstanceImpl(createHazelcastInstance(null), this);
+                            LOGGER.info("Default Hazelcast instance has been created");
+                        }
+                        if (hazelcastInstance != null && !Boolean.getBoolean(HAZELCAST_OSGI_REGISTER_DISABLED)) {
+                            registerInstance(hazelcastInstance);
+                            LOGGER.info("Default Hazelcast instance has been registered as OSGI service");
+                        }
+                    } catch (Throwable t) {
+                        if (hazelcastInstance != null) {
+                            shutdownHazelcastInstance(hazelcastInstance);
+                            hazelcastInstance = null;
+                        }
+                        ExceptionUtil.rethrow(t);
+                    }
+                    serviceRegistration =
+                            ownerBundleContext.registerService(HazelcastOSGiService.class.getName(), this, null);
+                    LOGGER.info(this + " has been registered as OSGI service and activated now");
+                } catch (Throwable t1) {
+                    if (hazelcastInstance != null) {
+                        // If somehow default instance is activated, revert and deactivate it.
+                        try {
+                            hazelcastInstance.shutdown();
+                        }  catch (Throwable t2) {
+                            LOGGER.finest("Error occurred while shutting down the default Hazelcast instance !", t2);
+                        } finally {
+                            hazelcastInstance = null;
+                        }
+                    }
+                    ExceptionUtil.rethrow(t1);
+                }
+            }
+        }
+    }
+
+    @Override
+    public void deactivate() {
+        // No need to complex lock-free approaches since this is not called frequently. Simple is good.
+        synchronized (serviceMutex) {
+            if (isActive()) {
+                try {
+                    shutdownAllInternal();
+                    try {
+                        ownerBundleContext.ungetService(serviceRegistration.getReference());
+                    } catch (Throwable t) {
+                        LOGGER.finest("Error occurred while deregistering " + this, t);
+                    }
+                    LOGGER.info(this + " has been deregistered as OSGI service and deactivated");
+                } catch (Throwable t) {
+                    LOGGER.info(this + " will be forcefully deregistered as OSGI service "
+                            + "and will be forcefully deactivated");
+                    ExceptionUtil.rethrow(t);
+                } finally {
+                    serviceRegistration = null;
+                }
+            }
+        }
+    }
+
+    @Override
+    public HazelcastOSGiInstance getDefaultHazelcastInstance() {
+        checkActive();
+
+        // No need to synchronization since this is not a mutating operation on instances.
+        // If at this time service is deactivated, this method just returns terminated instance.
+
+        return hazelcastInstance;
+    }
+
+    @Override
+    public HazelcastOSGiInstance newHazelcastInstance(Config config) {
+        // No need to complex lock-free approaches since this is not called frequently. Simple is good.
+        synchronized (serviceMutex) {
+            checkActive();
+
+            return registerInstance(createHazelcastInstance(config));
+        }
+    }
+
+    @Override
+    public HazelcastOSGiInstance newHazelcastInstance() {
+        // No need to complex lock-free approaches since this is not called frequently. Simple is good.
+        synchronized (serviceMutex) {
+            checkActive();
+
+            return registerInstance(createHazelcastInstance(null));
+        }
+    }
+
+    @Override
+    public HazelcastOSGiInstance getHazelcastInstanceByName(String instanceName) {
+        checkActive();
+
+        // No need to synchronization since this is not a mutating operation on instances.
+        // If at this time service is deactivated, this method just returns terminated instance.
+
+        return instanceMap.get(instanceName);
+    }
+
+    @Override
+    public Set<HazelcastOSGiInstance> getAllHazelcastInstances() {
+        checkActive();
+
+        // No need to synchronization since this is not a mutating operation on instances.
+        // If at this time service is deactivated, this method just returns terminated instances.
+
+        return Collections.unmodifiableSet(instanceServiceRegistrationMap.keySet());
+    }
+
+    @Override
+    public void shutdownHazelcastInstance(HazelcastOSGiInstance instance) {
+        // No need to complex lock-free approaches since this is not called frequently. Simple is good.
+        synchronized (serviceMutex) {
+            checkActive();
+
+            try {
+                deregisterInstance(instance);
+            } catch (Throwable t) {
+                LOGGER.finest("Error occurred while deregistering " + instance, t);
+            }
+            try {
+                instance.shutdown();
+            } catch (Throwable t) {
+                LOGGER.finest("Error occurred while shutting down " + instance, t);
+            }
+        }
+    }
+
+    @Override
+    public void shutdownAll() {
+        // No need to complex lock-free approaches since this is not called frequently. Simple is good.
+        synchronized (serviceMutex) {
+            checkActive();
+
+            shutdownAllInternal();
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "HazelcastOSGiServiceImpl{"
+                    + "ownerBundle=" + ownerBundle
+                    + ", hazelcastInstance=" + hazelcastInstance
+                    + ", active=" + isActive()
+                    + ", id=" + id
+                + '}';
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/osgi/impl/OSGiScriptEngine.java
+++ b/hazelcast/src/main/java/com/hazelcast/osgi/impl/OSGiScriptEngine.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.hazelcast.internal.osgi;
+package com.hazelcast.osgi.impl;
 
 import javax.script.Bindings;
 import javax.script.ScriptContext;
@@ -31,7 +31,8 @@ http://svn.apache.org/repos/asf/felix/trunk/mishell/src/main/java/org/apache/fel
 /**
  * This adapter class is used to create / bind ScriptEngine implementations in OSGi contexts.
  */
-public class OSGiScriptEngine implements ScriptEngine {
+class OSGiScriptEngine implements ScriptEngine {
+
     private ScriptEngine engine;
     private OSGiScriptEngineFactory factory;
 
@@ -109,4 +110,5 @@ public class OSGiScriptEngine implements ScriptEngine {
     public void setContext(ScriptContext context) {
         engine.setContext(context);
     }
+
 }

--- a/hazelcast/src/main/java/com/hazelcast/osgi/impl/OSGiScriptEngineFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/osgi/impl/OSGiScriptEngineFactory.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.hazelcast.internal.osgi;
+package com.hazelcast.osgi.impl;
 
 import javax.script.ScriptEngine;
 import javax.script.ScriptEngineFactory;
@@ -31,6 +31,7 @@ http://svn.apache.org/repos/asf/felix/trunk/mishell/src/main/java/org/apache/fel
  * (i.e., their "native" classes)
  */
 public class OSGiScriptEngineFactory implements ScriptEngineFactory {
+
     private ScriptEngineFactory factory;
     private ClassLoader contextClassLoader;
 
@@ -108,4 +109,5 @@ public class OSGiScriptEngineFactory implements ScriptEngineFactory {
         }
         return engine;
     }
+
 }

--- a/hazelcast/src/main/java/com/hazelcast/osgi/impl/OSGiScriptEngineManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/osgi/impl/OSGiScriptEngineManager.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.hazelcast.internal.osgi;
+package com.hazelcast.osgi.impl;
 
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
@@ -76,6 +76,7 @@ http://svn.apache.org/repos/asf/felix/trunk/mishell/src/main/java/org/apache/fel
  * </li></ul>
  */
 public class OSGiScriptEngineManager extends ScriptEngineManager {
+
     private static final String RHINO_SCRIPT_ENGINE_FACTORY = "com.sun.script.javascript.RhinoScriptEngineFactory";
     private static final String NASHORN_SCRIPT_ENGINE_FACTORY = "jdk.nashorn.api.scripting.NashornScriptEngineFactory";
 
@@ -330,4 +331,5 @@ public class OSGiScriptEngineManager extends ScriptEngineManager {
             logger.warning("No built-in JavaScript ScriptEngineFactory found.");
         }
     }
+
 }

--- a/hazelcast/src/main/java/com/hazelcast/osgi/impl/ScriptEngineActivator.java
+++ b/hazelcast/src/main/java/com/hazelcast/osgi/impl/ScriptEngineActivator.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.hazelcast.internal.osgi;
+package com.hazelcast.osgi.impl;
 
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
@@ -52,4 +52,5 @@ final class ScriptEngineActivator {
             LOGGER.finest(msg.toString());
         }
     }
+
 }

--- a/hazelcast/src/main/java/com/hazelcast/osgi/impl/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/osgi/impl/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * <p>This package contains the OSGI functionality implementations for Hazelcast.<br/>
+ */
+package com.hazelcast.osgi.impl;

--- a/hazelcast/src/main/java/com/hazelcast/osgi/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/osgi/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * <p>This package contains the OSGI functionality contract points for Hazelcast.<br/>
+ */
+package com.hazelcast.osgi;


### PR DESCRIPTION
This PR contains:
- Hazelcast bundles provide OSGI services so users can manage (create, access, shutdown) Hazelcast instances through this service on OSGI environment.
- Created Hazelcast instances can be served as OSGI service to be accessed by other bundles.
- Each Hazelcast bundle provide a different OSGI service and their instances can be grouped (clustered) together for preventing possible compatibility issues between different Hazelcast versions/bundles.
- Hazelcast OSGI service's lifecycle (and so also the owned/created instances's lifecycles) are same with the owner Hazelcast bundles. When the bundle is stopped (deactivated), owned service and Hazelcast instances are also deactivated/shutdown and deregistered automatically. Then when the bundle is activated again, its service is registered again.