### PR TITLE
Skip transactionlog replication if singleton transaction

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionImpl.java
@@ -241,6 +241,13 @@ public class TransactionImpl implements Transaction {
 
     // todo: should be moved to TransactionLog?
     private void replicateTxnLog() throws InterruptedException, ExecutionException, java.util.concurrent.TimeoutException {
+        // If there is a single item in the transaction-log, the transactionLog doesn't need to be replicated since the system
+        // can't end up in a partially committed state (where some records have been written and some have not).
+        // This should speed up the performance of transactions toughing a single item.
+        if (transactionLog.size() <= 1) {
+            return;
+        }
+
         List<Future> futures = new ArrayList<Future>(transactionLog.size());
         OperationService operationService = nodeEngine.getOperationService();
         for (Address backupAddress : backupAddresses) {


### PR DESCRIPTION
If the transactionlog contains a single transactionlog record, there is no added value
to copying the transactionlog. The goal of copying the transactionlog is that the system
can't be left in an inconsistent state if the transaction initiator fails after the
prepare and has written some log records, but fails to write the rest.

If there is a single item in the transactionlog, it can't happen that some log records are written
and others are not since there is only a single item.

So this optimization check the number of items in the transactionlog after the prepare
and if there is one or less, it skips the replication of the transactionlog.