### PR TITLE
Speeds up single item transactions

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionDataSerializerHook.java
@@ -20,11 +20,11 @@ import com.hazelcast.nio.serialization.DataSerializableFactory;
 import com.hazelcast.internal.serialization.DataSerializerHook;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.internal.serialization.impl.FactoryIdHelper;
-import com.hazelcast.transaction.impl.operations.BeginTxBackupOperation;
+import com.hazelcast.transaction.impl.operations.CreateTxBackupLogOperation;
 import com.hazelcast.transaction.impl.operations.BroadcastTxRollbackOperation;
-import com.hazelcast.transaction.impl.operations.PurgeTxBackupOperation;
-import com.hazelcast.transaction.impl.operations.ReplicateTxOperation;
-import com.hazelcast.transaction.impl.operations.RollbackTxBackupOperation;
+import com.hazelcast.transaction.impl.operations.PurgeTxBackupLogOperation;
+import com.hazelcast.transaction.impl.operations.ReplicateTxBackupLogOperation;
+import com.hazelcast.transaction.impl.operations.RollbackTxBackupLogOperation;
 
 import static com.hazelcast.internal.serialization.impl.FactoryIdHelper.TRANSACTION_DS_FACTORY;
 import static com.hazelcast.internal.serialization.impl.FactoryIdHelper.TRANSACTION_DS_FACTORY_ID;
@@ -33,11 +33,11 @@ public final class TransactionDataSerializerHook implements DataSerializerHook {
 
     public static final int F_ID = FactoryIdHelper.getFactoryId(TRANSACTION_DS_FACTORY, TRANSACTION_DS_FACTORY_ID);
 
-    public static final int BEGIN_TX_BACKUP = 0;
+    public static final int CREATE_TX_BACKUP_LOG = 0;
     public static final int BROADCAST_TX_ROLLBACK = 1;
-    public static final int PURGE_TX_BACKUP = 2;
-    public static final int REPLICATE_TX = 3;
-    public static final int ROLLBACK_TX_BACKUP = 4;
+    public static final int PURGE_TX_BACKUP_LOG = 2;
+    public static final int REPLICATE_TX_BACKUP_LOG = 3;
+    public static final int ROLLBACK_TX_BACKUP_LOG = 4;
 
     @Override
     public int getFactoryId() {
@@ -50,16 +50,16 @@ public final class TransactionDataSerializerHook implements DataSerializerHook {
             @Override
             public IdentifiedDataSerializable create(int typeId) {
                 switch (typeId) {
-                    case BEGIN_TX_BACKUP:
-                        return new BeginTxBackupOperation();
+                    case CREATE_TX_BACKUP_LOG:
+                        return new CreateTxBackupLogOperation();
                     case BROADCAST_TX_ROLLBACK:
                         return new BroadcastTxRollbackOperation();
-                    case PURGE_TX_BACKUP:
-                        return new PurgeTxBackupOperation();
-                    case REPLICATE_TX:
-                        return new ReplicateTxOperation();
-                    case ROLLBACK_TX_BACKUP:
-                        return new RollbackTxBackupOperation();
+                    case PURGE_TX_BACKUP_LOG:
+                        return new PurgeTxBackupLogOperation();
+                    case REPLICATE_TX_BACKUP_LOG:
+                        return new ReplicateTxBackupLogOperation();
+                    case ROLLBACK_TX_BACKUP_LOG:
+                        return new RollbackTxBackupLogOperation();
                     default:
                         return null;
                 }

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/operations/PurgeTxBackupLogOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/operations/PurgeTxBackupLogOperation.java
@@ -26,23 +26,23 @@ import com.hazelcast.transaction.impl.TransactionManagerServiceImpl;
 import java.io.IOException;
 
 import static com.hazelcast.spi.ExceptionAction.THROW_EXCEPTION;
-import static com.hazelcast.transaction.impl.TransactionDataSerializerHook.PURGE_TX_BACKUP;
+import static com.hazelcast.transaction.impl.TransactionDataSerializerHook.PURGE_TX_BACKUP_LOG;
 
-public final class PurgeTxBackupOperation extends TxBaseOperation {
+public final class PurgeTxBackupLogOperation extends TxBaseOperation {
 
     private String txnId;
 
-    public PurgeTxBackupOperation() {
+    public PurgeTxBackupLogOperation() {
     }
 
-    public PurgeTxBackupOperation(String txnId) {
+    public PurgeTxBackupLogOperation(String txnId) {
         this.txnId = txnId;
     }
 
     @Override
     public void run() throws Exception {
         TransactionManagerServiceImpl txManagerService = getService();
-        txManagerService.purgeTxBackupLog(txnId);
+        txManagerService.purgeBackupLog(txnId);
     }
 
     @Override
@@ -55,7 +55,7 @@ public final class PurgeTxBackupOperation extends TxBaseOperation {
 
     @Override
     public int getId() {
-        return PURGE_TX_BACKUP;
+        return PURGE_TX_BACKUP_LOG;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/operations/RollbackTxBackupLogOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/operations/RollbackTxBackupLogOperation.java
@@ -26,23 +26,23 @@ import com.hazelcast.transaction.impl.TransactionManagerServiceImpl;
 import java.io.IOException;
 
 import static com.hazelcast.spi.ExceptionAction.THROW_EXCEPTION;
-import static com.hazelcast.transaction.impl.TransactionDataSerializerHook.ROLLBACK_TX_BACKUP;
+import static com.hazelcast.transaction.impl.TransactionDataSerializerHook.ROLLBACK_TX_BACKUP_LOG;
 
-public final class RollbackTxBackupOperation extends TxBaseOperation {
+public final class RollbackTxBackupLogOperation extends TxBaseOperation {
 
     private String txnId;
 
-    public RollbackTxBackupOperation() {
+    public RollbackTxBackupLogOperation() {
     }
 
-    public RollbackTxBackupOperation(String txnId) {
+    public RollbackTxBackupLogOperation(String txnId) {
         this.txnId = txnId;
     }
 
     @Override
     public void run() throws Exception {
         TransactionManagerServiceImpl txManagerService = getService();
-        txManagerService.rollbackTxBackupLog(txnId);
+        txManagerService.rollbackBackupLog(txnId);
     }
 
     @Override
@@ -60,7 +60,7 @@ public final class RollbackTxBackupOperation extends TxBaseOperation {
 
     @Override
     public int getId() {
-        return ROLLBACK_TX_BACKUP;
+        return ROLLBACK_TX_BACKUP_LOG;
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/transaction/impl/MockTransactionLogRecord.java
+++ b/hazelcast/src/test/java/com/hazelcast/transaction/impl/MockTransactionLogRecord.java
@@ -1,0 +1,143 @@
+package com.hazelcast.transaction.impl;
+
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.spi.AbstractOperation;
+import com.hazelcast.spi.Operation;
+import com.hazelcast.transaction.TransactionException;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class MockTransactionLogRecord implements TransactionLogRecord {
+
+    //public final static ConcurrentMap<String, AtomicInteger> prepare
+
+    private boolean failPrepare;
+    private boolean failCommit;
+    private boolean failRollback;
+
+    private boolean prepareCalled;
+    private boolean commitCalled;
+    private boolean rollbackCalled;
+
+    public MockTransactionLogRecord() {
+    }
+
+    public MockTransactionLogRecord failPrepare() {
+        this.failPrepare = true;
+        return this;
+    }
+
+    public MockTransactionLogRecord failCommit() {
+        this.failCommit = true;
+        return this;
+    }
+
+    public MockTransactionLogRecord failRollback() {
+        this.failRollback = true;
+        return this;
+    }
+
+    @Override
+    public Object getKey() {
+        return null;
+    }
+
+    @Override
+    public Operation newPrepareOperation() {
+        prepareCalled = true;
+        return createOperation(failPrepare);
+    }
+
+    @Override
+    public Operation newCommitOperation() {
+        commitCalled = true;
+        return createOperation(failCommit);
+    }
+
+    @Override
+    public Operation newRollbackOperation() {
+        rollbackCalled = true;
+        return createOperation(failRollback);
+    }
+
+    public Operation createOperation(boolean fail) {
+        return new MockOperation(fail);
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
+        out.writeBoolean(failPrepare);
+        out.writeBoolean(failCommit);
+        out.writeBoolean(failRollback);
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) throws IOException {
+        failPrepare = in.readBoolean();
+        failCommit = in.readBoolean();
+        failRollback = in.readBoolean();
+    }
+
+    public MockTransactionLogRecord assertCommitCalled() {
+        assertTrue("commit should have been called", commitCalled);
+        return this;
+    }
+
+    public MockTransactionLogRecord assertPrepareCalled() {
+        assertTrue("prepare should have been called", prepareCalled);
+        return this;
+    }
+
+    public MockTransactionLogRecord assertPrepareNotCalled() {
+        assertFalse("prepare should have not been called", prepareCalled);
+        return this;
+    }
+
+    public MockTransactionLogRecord assertCommitNotCalled() {
+        assertFalse("commit should not have been called", commitCalled);
+        return this;
+    }
+
+    public MockTransactionLogRecord assertRollbackNotCalled() {
+        assertFalse("rollback should not have been called", rollbackCalled);
+        return this;
+    }
+
+    public MockTransactionLogRecord assertRollbackCalled() {
+        assertTrue("rollback should have been called", rollbackCalled);
+        return this;
+    }
+
+    static class MockOperation extends AbstractOperation {
+        private boolean fail;
+
+        public MockOperation() {
+        }
+
+        public MockOperation(boolean fail) {
+            setPartitionId(0);
+            this.fail = fail;
+        }
+
+        @Override
+        public void run() throws Exception {
+            if (fail) {
+                throw new TransactionException();
+            }
+        }
+
+        @Override
+        protected void writeInternal(ObjectDataOutput out) throws IOException {
+            out.writeBoolean(fail);
+        }
+
+        @Override
+        protected void readInternal(ObjectDataInput in) throws IOException {
+            fail = in.readBoolean();
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/transaction/impl/TransactionContextImpl_backupLogsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/transaction/impl/TransactionContextImpl_backupLogsTest.java
@@ -1,0 +1,101 @@
+package com.hazelcast.transaction.impl;
+
+import com.hazelcast.collection.impl.list.ListService;
+import com.hazelcast.collection.impl.queue.QueueService;
+import com.hazelcast.collection.impl.set.SetService;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.map.impl.MapService;
+import com.hazelcast.multimap.impl.MultiMapService;
+import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.transaction.TransactionOptions;
+import com.hazelcast.transaction.TransactionalObject;
+import com.hazelcast.util.UuidUtil;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+/**
+ * A test that makes sure that the backup logs are triggered to be created. Some data-structures like
+ * the list/set/queue require it, but others do not.
+ */
+@RunWith(HazelcastParallelClassRunner.class)
+@Category(QuickTest.class)
+public class TransactionContextImpl_backupLogsTest extends HazelcastTestSupport {
+
+    private TransactionManagerServiceImpl localTxManager;
+    private TransactionManagerServiceImpl remoteTxManager;
+    private String ownerUuid;
+    private HazelcastInstance localHz;
+    private NodeEngineImpl localNodeEngine;
+
+    @Before
+    public void setup() {
+        HazelcastInstance[] cluster = createHazelcastInstanceFactory(2).newInstances();
+        localHz = cluster[0];
+        localNodeEngine = getNodeEngineImpl(localHz);
+        localTxManager = getTransactionManagerService(cluster[0]);
+        remoteTxManager = getTransactionManagerService(cluster[1]);
+        ownerUuid = UuidUtil.newUnsecureUuidString();
+    }
+
+    private TransactionManagerServiceImpl getTransactionManagerService(HazelcastInstance hz) {
+        NodeEngineImpl nodeEngine = getNodeEngineImpl(hz);
+        return (TransactionManagerServiceImpl) nodeEngine.getTransactionManagerService();
+    }
+
+    @Test
+    public void list_backupLogCreationForced() {
+        assertBackupLogCreationForced(ListService.SERVICE_NAME);
+    }
+
+    @Test
+    public void set_backupLogCreationForced() {
+        assertBackupLogCreationForced(SetService.SERVICE_NAME);
+    }
+
+    @Test
+    public void queue_backupLogCreationForced() {
+        assertBackupLogCreationForced(QueueService.SERVICE_NAME);
+    }
+
+    public void assertBackupLogCreationForced(String serviceName) {
+        TransactionOptions options = new TransactionOptions();
+
+        TransactionContextImpl txContext = new TransactionContextImpl(localTxManager, localNodeEngine, options, ownerUuid);
+        txContext.beginTransaction();
+
+        TransactionalObject result = txContext.getTransactionalObject(serviceName, "foo");
+
+        assertNotNull(result);
+        assertNotNull(remoteTxManager.txBackupLogs.get(txContext.getTxnId()));
+    }
+
+    @Test
+    public void map_thenNotForcesBackupLogCreation() {
+        assertBackupLogCreationNotForced(MapService.SERVICE_NAME);
+    }
+
+    @Test
+    public void multimap_thenNotForceBackupLogCreation() {
+        assertBackupLogCreationNotForced(MultiMapService.SERVICE_NAME);
+    }
+
+    public void assertBackupLogCreationNotForced(String serviceName) {
+        TransactionOptions options = new TransactionOptions();
+
+        TransactionContextImpl txContext = new TransactionContextImpl(localTxManager, localNodeEngine, options, ownerUuid);
+        txContext.beginTransaction();
+
+        TransactionalObject result = txContext.getTransactionalObject(serviceName, "foo");
+
+        assertNotNull(result);
+        assertNull(remoteTxManager.txBackupLogs.get(txContext.getTxnId()));
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/transaction/impl/TransactionImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/transaction/impl/TransactionImplTest.java
@@ -1,227 +1,71 @@
-/*
- * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package com.hazelcast.transaction.impl;
 
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.instance.MemberImpl;
-import com.hazelcast.logging.AbstractLogger;
-import com.hazelcast.logging.LogEvent;
-import com.hazelcast.nio.ObjectDataInput;
-import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.spi.AbstractOperation;
+import com.hazelcast.logging.ILogger;
 import com.hazelcast.spi.NodeEngine;
-import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.impl.operationservice.InternalOperationService;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.QuickTest;
-import com.hazelcast.transaction.TransactionException;
 import com.hazelcast.transaction.TransactionOptions;
-import com.hazelcast.transaction.TransactionOptions.TransactionType;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import java.io.IOException;
-import java.util.logging.Level;
-
+import static com.hazelcast.transaction.TransactionOptions.TransactionType.LOCAL;
+import static java.lang.String.format;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
-import static org.mockito.Matchers.anyInt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+/**
+ * Tests some basic behavior that doesn't rely too much on the type of transaction
+ */
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
 public class TransactionImplTest extends HazelcastTestSupport {
 
     private InternalOperationService operationService;
+    private ILogger logger;
+    private TransactionManagerServiceImpl txManagerService;
+    private NodeEngine nodeEngine;
+    private TransactionOptions options;
 
     @Before
     public void setup() {
         HazelcastInstance hz = createHazelcastInstance();
         operationService = getOperationService(hz);
+        logger = mock(ILogger.class);
+
+        txManagerService = mock(TransactionManagerServiceImpl.class);
+
+        nodeEngine = mock(NodeEngine.class);
+        when(nodeEngine.getOperationService()).thenReturn(operationService);
+        when(nodeEngine.getLocalMember()).thenReturn(new MemberImpl());
+        when(nodeEngine.getLogger(TransactionImpl.class)).thenReturn(logger);
+        options = new TransactionOptions().setTransactionType(LOCAL);
     }
 
     @Test
-    public void testTransactionBegin_whenBeginThrowsException() throws Exception {
-        TransactionImpl transaction;
-        TransactionManagerServiceImpl transactionManagerService = mock(TransactionManagerServiceImpl.class);
-        RuntimeException expectedException = new RuntimeException("example exception");
-        when(transactionManagerService.pickBackupAddresses(anyInt()))
-                .thenThrow(expectedException);
-
-        NodeEngine nodeEngine = mock(NodeEngine.class);
-        when(nodeEngine.getOperationService()).thenReturn(operationService);
-        when(nodeEngine.getLocalMember()).thenReturn(new MemberImpl());
-        when(nodeEngine.getLogger(TransactionImpl.class)).thenReturn(new DummyLogger());
-
-        TransactionOptions options = TransactionOptions.getDefault();
-        transaction = new TransactionImpl(transactionManagerService, nodeEngine, options, null);
-        try {
-            transaction.begin();
-            fail("Transaction expected to fail");
-        } catch (Exception e) {
-            assertEquals(expectedException, e);
-        }
-
-        // other independent transaction in same thread
-        // should behave identically
-        transaction = new TransactionImpl(transactionManagerService, nodeEngine, options, "123");
-        try {
-            transaction.begin();
-            fail("Transaction expected to fail");
-        } catch (Exception e) {
-            assertEquals(expectedException, e);
-        }
-    }
-
-    @Test(expected = TransactionException.class)
-    public void testLocalTransaction_ThrowsExceptionDuringCommit() throws Exception {
-        TransactionImpl transaction;
-        TransactionManagerServiceImpl transactionManagerService = mock(TransactionManagerServiceImpl.class);
-
-        NodeEngine nodeEngine = mock(NodeEngine.class);
-        when(nodeEngine.getOperationService()).thenReturn(operationService);
-        when(nodeEngine.getLocalMember()).thenReturn(new MemberImpl());
-        when(nodeEngine.getLogger(TransactionImpl.class)).thenReturn(new DummyLogger());
-
-        TransactionOptions options = new TransactionOptions().setTransactionType(TransactionType.LOCAL);
-        transaction = new TransactionImpl(transactionManagerService, nodeEngine, options, "dummy-uuid");
-        transaction.begin();
-        transaction.add(new FailingTransactionLogRecord(false, true, false));
-        transaction.commit();
-    }
-
-    @Test(expected = TransactionException.class)
-    public void test2PhaseTransaction_ThrowsExceptionDuringPrepare() throws Exception {
-        TransactionImpl transaction;
-        TransactionManagerServiceImpl transactionManagerService = mock(TransactionManagerServiceImpl.class);
-
-        NodeEngine nodeEngine = mock(NodeEngine.class);
-        when(nodeEngine.getOperationService()).thenReturn(operationService);
-        when(nodeEngine.getLocalMember()).thenReturn(new MemberImpl());
-        when(nodeEngine.getLogger(TransactionImpl.class)).thenReturn(new DummyLogger());
-
-        TransactionOptions options = new TransactionOptions()
-                .setTransactionType(TransactionType.TWO_PHASE).setDurability(0);
-        transaction = new TransactionImpl(transactionManagerService, nodeEngine, options, "dummy-uuid");
-
-        transaction.begin();
-        transaction.add(new FailingTransactionLogRecord(true, true, false));
-        transaction.prepare();
+    public void getTimeoutMillis() throws Exception {
+        TransactionImpl tx = new TransactionImpl(txManagerService, nodeEngine, options, "dummy-uuid");
+        assertEquals(options.getTimeoutMillis(), tx.getTimeoutMillis());
     }
 
     @Test
-    public void test2PhaseTransaction_ThrowsExceptionDuringCommit() throws Exception {
-        TransactionImpl transaction;
-        TransactionManagerServiceImpl transactionManagerService = mock(TransactionManagerServiceImpl.class);
-
-        NodeEngine nodeEngine = mock(NodeEngine.class);
-        when(nodeEngine.getOperationService()).thenReturn(operationService);
-        when(nodeEngine.getLocalMember()).thenReturn(new MemberImpl());
-        when(nodeEngine.getLogger(TransactionImpl.class)).thenReturn(new DummyLogger());
-
-        TransactionOptions options = new TransactionOptions()
-                .setTransactionType(TransactionType.TWO_PHASE).setDurability(0);
-        transaction = new TransactionImpl(transactionManagerService, nodeEngine, options, "dummy-uuid");
-        transaction.begin();
-        transaction.add(new FailingTransactionLogRecord(false, true, false));
-        transaction.prepare();
-        transaction.commit();
+    public void testToString() throws Exception {
+        TransactionImpl tx = new TransactionImpl(txManagerService, nodeEngine, options, "dummy-uuid");
+        assertEquals(format("Transaction{txnId='%s', state=%s, txType=%s, timeoutMillis=%s}",
+                tx.getTxnId(), tx.getState(), options.getTransactionType(), options.getTimeoutMillis()), tx.toString());
     }
 
-    private static class FailingTransactionLogRecord implements TransactionLogRecord {
-        final boolean failPrepare;
-        final boolean failCommit;
-        final boolean failRollback;
-
-        public FailingTransactionLogRecord(boolean failPrepare, boolean failCommit, boolean failRollback) {
-            this.failPrepare = failPrepare;
-            this.failCommit = failCommit;
-            this.failRollback = failRollback;
-        }
-
-        @Override
-        public Object getKey() {
-            return null;
-        }
-
-        @Override
-        public Operation newPrepareOperation() {
-            return createOperation(failPrepare);
-        }
-
-        @Override
-        public Operation newCommitOperation() {
-            return createOperation(failCommit);
-        }
-
-        @Override
-        public Operation newRollbackOperation() {
-            return createOperation(failRollback);
-        }
-
-        public Operation createOperation(final boolean fail) {
-            return new AbstractOperation() {
-                {
-                    setPartitionId(0);
-                }
-
-                @Override
-                public void run() throws Exception {
-                    if (fail) {
-                        throw new TransactionException();
-                    }
-                }
-            };
-        }
-
-        @Override
-        public void writeData(ObjectDataOutput out) throws IOException {
-        }
-
-        @Override
-        public void readData(ObjectDataInput in) throws IOException {
-        }
+    @Test
+    public void getOwnerUUID() throws Exception {
+        String ownerUUID = "dummy-uuid";
+        TransactionImpl tx = new TransactionImpl(txManagerService, nodeEngine, options, ownerUUID);
+        assertEquals(ownerUUID, tx.getOwnerUuid());
     }
 
-    private class DummyLogger extends AbstractLogger {
-        @Override
-        public void log(Level level, String message) {
-        }
-
-        @Override
-        public void log(Level level, String message, Throwable thrown) {
-        }
-
-        @Override
-        public void log(LogEvent logEvent) {
-        }
-
-        @Override
-        public Level getLevel() {
-            return Level.INFO;
-        }
-
-        @Override
-        public boolean isLoggable(Level level) {
-            return false;
-        }
-    }
 }

--- a/hazelcast/src/test/java/com/hazelcast/transaction/impl/TransactionImpl_LocalTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/transaction/impl/TransactionImpl_LocalTest.java
@@ -1,0 +1,128 @@
+package com.hazelcast.transaction.impl;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.instance.MemberImpl;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.spi.NodeEngine;
+import com.hazelcast.spi.impl.operationservice.InternalOperationService;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.transaction.TransactionException;
+import com.hazelcast.transaction.TransactionNotActiveException;
+import com.hazelcast.transaction.TransactionOptions;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static com.hazelcast.transaction.TransactionOptions.TransactionType.LOCAL;
+import static com.hazelcast.transaction.TransactionOptions.TransactionType.TWO_PHASE;
+import static com.hazelcast.transaction.impl.Transaction.State.ROLLED_BACK;
+import static java.lang.String.format;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class TransactionImpl_LocalTest extends HazelcastTestSupport {
+
+    private InternalOperationService operationService;
+    private ILogger logger;
+    private TransactionManagerServiceImpl txManagerService;
+    private NodeEngine nodeEngine;
+    private TransactionOptions options;
+
+    @Before
+    public void setup() {
+        HazelcastInstance hz = createHazelcastInstance();
+        operationService = getOperationService(hz);
+        logger = mock(ILogger.class);
+
+        txManagerService = mock(TransactionManagerServiceImpl.class);
+
+        nodeEngine = mock(NodeEngine.class);
+        when(nodeEngine.getOperationService()).thenReturn(operationService);
+        when(nodeEngine.getLocalMember()).thenReturn(new MemberImpl());
+        when(nodeEngine.getLogger(TransactionImpl.class)).thenReturn(logger);
+        options = new TransactionOptions().setTransactionType(LOCAL);
+    }
+
+    // ====================== requiresPrepare ===============================
+
+    @Test
+    public void requiresPrepare() throws Exception {
+        TransactionImpl tx = new TransactionImpl(txManagerService, nodeEngine, options, "dummy-uuid");
+        tx.begin();
+
+        assertFalse(tx.requiresPrepare());
+    }
+
+    // ====================== prepare ===============================
+
+    @Test(expected = TransactionNotActiveException.class)
+    public void prepare_whenNotActive() throws Exception {
+        TransactionImpl tx = new TransactionImpl(txManagerService, nodeEngine, options, "dummy-uuid");
+        tx.begin();
+        tx.rollback();
+
+        tx.prepare();
+    }
+
+    // ====================== commit ===============================
+
+    @Test(expected = IllegalStateException.class)
+    public void commit_whenNotActive() {
+        TransactionImpl tx = new TransactionImpl(txManagerService, nodeEngine, options, "dummy-uuid");
+        tx.begin();
+        tx.rollback();
+
+        tx.commit();
+    }
+
+    @Test(expected = TransactionException.class)
+    public void commit_ThrowsExceptionDuringCommit() throws Exception {
+        TransactionImpl tx = new TransactionImpl(txManagerService, nodeEngine, options, "dummy-uuid");
+        tx.begin();
+        tx.add(new MockTransactionLogRecord().failCommit());
+        tx.commit();
+    }
+
+    // ====================== rollback ===============================
+
+    @Test
+    public void rollback_whenEmpty() throws Exception {
+        TransactionImpl tx = new TransactionImpl(txManagerService, nodeEngine, options, "dummy-uuid");
+        tx.begin();
+        tx.rollback();
+
+        assertEquals(ROLLED_BACK, tx.getState());
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void rollback_whenNotActive() throws Exception {
+        TransactionImpl tx = new TransactionImpl(txManagerService, nodeEngine, options, "dummy-uuid");
+        tx.begin();
+        tx.rollback();
+
+        tx.rollback();
+    }
+
+    @Test
+    public void rollback_whenRollingBackCommitFailedTransaction() {
+        TransactionImpl tx = new TransactionImpl(txManagerService, nodeEngine, options, "dummy-uuid");
+        tx.begin();
+        tx.add(new MockTransactionLogRecord().failCommit());
+        try {
+            tx.commit();
+            fail();
+        }catch (TransactionException expected){
+        }
+
+        tx.rollback();
+        assertEquals(ROLLED_BACK, tx.getState());
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/transaction/impl/TransactionImpl_TwoPhaseIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/transaction/impl/TransactionImpl_TwoPhaseIntegrationTest.java
@@ -1,0 +1,296 @@
+package com.hazelcast.transaction.impl;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.transaction.TransactionException;
+import com.hazelcast.transaction.TransactionOptions;
+import com.hazelcast.transaction.impl.TransactionManagerServiceImpl.TxBackupLog;
+import com.hazelcast.util.UuidUtil;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static com.hazelcast.transaction.TransactionOptions.TransactionType.TWO_PHASE;
+import static com.hazelcast.transaction.impl.Transaction.State.COMMITTED;
+import static com.hazelcast.transaction.impl.Transaction.State.COMMITTING;
+import static com.hazelcast.transaction.impl.Transaction.State.COMMIT_FAILED;
+import static com.hazelcast.transaction.impl.Transaction.State.PREPARED;
+import static com.hazelcast.transaction.impl.Transaction.State.PREPARING;
+import static com.hazelcast.transaction.impl.Transaction.State.ROLLED_BACK;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class TransactionImpl_TwoPhaseIntegrationTest extends HazelcastTestSupport {
+
+    private HazelcastInstance[] cluster;
+    private TransactionManagerServiceImpl localTxService;
+    private TransactionManagerServiceImpl remoteTxService;
+    private NodeEngineImpl localNodeEngine;
+    private String txOwner;
+
+    @Before
+    public void setup() {
+        setLoggingLog4j();
+        cluster = createHazelcastInstanceFactory(2).newInstances();
+        localNodeEngine = getNodeEngineImpl(cluster[0]);
+        localTxService = getTransactionManagerService(cluster[0]);
+        remoteTxService = getTransactionManagerService(cluster[1]);
+        txOwner = UuidUtil.newUnsecureUuidString();
+    }
+
+    private void assertPrepared(TransactionImpl tx) {
+        assertEquals(PREPARED, tx.getState());
+    }
+
+    private void assertCommitted(TransactionImpl tx) {
+        assertEquals(COMMITTED, tx.getState());
+    }
+
+    private void assertRolledBack(TransactionImpl tx) {
+        assertEquals(ROLLED_BACK, tx.getState());
+    }
+
+    private void assertCommitFailed(TransactionImpl tx) {
+        assertEquals(COMMIT_FAILED, tx.getState());
+    }
+
+    private void assertPreparing(TransactionImpl tx) {
+        assertEquals(PREPARING, tx.getState());
+    }
+
+    private TransactionManagerServiceImpl getTransactionManagerService(HazelcastInstance hz) {
+        NodeEngineImpl nodeEngineImpl = getNodeEngineImpl(hz);
+        return (TransactionManagerServiceImpl) nodeEngineImpl.getTransactionManagerService();
+    }
+
+    // =================== prepare ===========================================
+
+    @Test
+    public void prepare_whenSingleItemAndDurabilityOne_thenNoBackupLog() {
+        TransactionOptions options = new TransactionOptions().setTransactionType(TWO_PHASE).setDurability(1);
+        TransactionImpl tx = new TransactionImpl(localTxService, localNodeEngine, options, txOwner);
+        tx.begin();
+        MockTransactionLogRecord record = new MockTransactionLogRecord();
+        tx.add(record);
+
+        tx.prepare();
+
+        assertPrepared(tx);
+        assertNoBackupLogOnRemote(tx);
+        record.assertPrepareCalled().assertCommitNotCalled().assertRollbackNotCalled();
+    }
+
+    private void assertNoBackupLogOnRemote(TransactionImpl tx) {
+        TxBackupLog log = remoteTxService.txBackupLogs.get(tx.getTxnId());
+        assertNull(log);
+    }
+
+    @Test
+    public void prepare_whenMultipleItemsAndDurabilityOne_thenBackupLog() {
+        TransactionOptions options = new TransactionOptions().setTransactionType(TWO_PHASE).setDurability(1);
+        TransactionImpl tx = new TransactionImpl(localTxService, localNodeEngine, options, txOwner);
+        tx.begin();
+        MockTransactionLogRecord record1 = new MockTransactionLogRecord();
+        tx.add(record1);
+        MockTransactionLogRecord record2 = new MockTransactionLogRecord();
+        tx.add(record2);
+
+        tx.prepare();
+
+        assertPrepared(tx);
+        TxBackupLog log = remoteTxService.txBackupLogs.get(tx.getTxnId());
+        assertNotNull(log);
+        assertEquals(COMMITTING, log.state);
+        record1.assertPrepareCalled().assertCommitNotCalled().assertRollbackNotCalled();
+        record2.assertPrepareCalled().assertCommitNotCalled().assertRollbackNotCalled();
+    }
+
+    @Test
+    public void prepare_whenMultipleItemsAndDurabilityZero_thenNoBackupLog() {
+        TransactionOptions options = new TransactionOptions().setTransactionType(TWO_PHASE).setDurability(0);
+        TransactionImpl tx = new TransactionImpl(localTxService, localNodeEngine, options, txOwner);
+        tx.begin();
+        MockTransactionLogRecord record1 = new MockTransactionLogRecord();
+        tx.add(record1);
+        MockTransactionLogRecord record2 = new MockTransactionLogRecord();
+        tx.add(record2);
+
+        tx.prepare();
+
+        assertPrepared(tx);
+        assertNoBackupLogOnRemote(tx);
+        record1.assertPrepareCalled().assertCommitNotCalled().assertRollbackNotCalled();
+        record2.assertPrepareCalled().assertCommitNotCalled().assertRollbackNotCalled();
+    }
+
+    @Test
+    public void testPrepareFailed() {
+        TransactionOptions options = new TransactionOptions().setTransactionType(TWO_PHASE).setDurability(1);
+        TransactionImpl tx = new TransactionImpl(localTxService, localNodeEngine, options, txOwner);
+        tx.begin();
+        MockTransactionLogRecord record = new MockTransactionLogRecord().failPrepare();
+        tx.add(record);
+
+        try {
+            tx.prepare();
+            fail();
+        } catch (TransactionException expected) {
+        }
+
+        assertPreparing(tx);
+        assertNoBackupLogOnRemote(tx);
+        record.assertPrepareCalled().assertCommitNotCalled().assertRollbackNotCalled();
+    }
+
+    // =================== commit ===========================================
+
+    @Test
+    public void commit_whenSingleItemAndDurabilityOne_thenNoBackupLog() {
+        TransactionOptions options = new TransactionOptions().setTransactionType(TWO_PHASE).setDurability(1);
+        TransactionImpl tx = new TransactionImpl(localTxService, localNodeEngine, options, txOwner);
+        tx.begin();
+        MockTransactionLogRecord record = new MockTransactionLogRecord();
+        tx.add(record);
+        tx.prepare();
+
+        tx.commit();
+
+        assertCommitted(tx);
+        assertNoBackupLogOnRemote(tx);
+        record.assertPrepareCalled().assertCommitCalled().assertRollbackNotCalled();
+    }
+
+    @Test
+    public void commit_whenMultipleItemsAndDurabilityOne_thenBackupLog() {
+        TransactionOptions options = new TransactionOptions().setTransactionType(TWO_PHASE).setDurability(1);
+        final TransactionImpl tx = new TransactionImpl(localTxService, localNodeEngine, options, txOwner);
+        tx.begin();
+        MockTransactionLogRecord record1 = new MockTransactionLogRecord();
+        tx.add(record1);
+        MockTransactionLogRecord record2 = new MockTransactionLogRecord();
+        tx.add(record2);
+        tx.prepare();
+
+        tx.commit();
+
+        assertCommitted(tx);
+        // it can take some time because the transaction doesn't sync on purging the backups.
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertNoBackupLogOnRemote(tx);
+            }
+        });
+        record1.assertPrepareCalled().assertCommitCalled().assertRollbackNotCalled();
+        record2.assertPrepareCalled().assertCommitCalled().assertRollbackNotCalled();
+    }
+
+    @Test
+    public void commit_whenMultipleItemsAndDurabilityZero_thenNoBackupLog() {
+        TransactionOptions options = new TransactionOptions().setTransactionType(TWO_PHASE).setDurability(0);
+        TransactionImpl tx = new TransactionImpl(localTxService, localNodeEngine, options, txOwner);
+        tx.begin();
+        MockTransactionLogRecord record1 = new MockTransactionLogRecord();
+        tx.add(record1);
+        MockTransactionLogRecord record2 = new MockTransactionLogRecord();
+        tx.add(record2);
+        tx.prepare();
+
+        tx.commit();
+
+        assertCommitted(tx);
+        assertNoBackupLogOnRemote(tx);
+        record1.assertPrepareCalled().assertCommitCalled().assertRollbackNotCalled();
+        record2.assertPrepareCalled().assertCommitCalled().assertRollbackNotCalled();
+    }
+
+    @Test
+    public void commit_whenPrepareSkippedButCommitRunsIntoConflict() {
+        TransactionOptions options = new TransactionOptions().setTransactionType(TWO_PHASE).setDurability(1);
+        TransactionImpl tx = new TransactionImpl(localTxService, localNodeEngine, options, txOwner);
+        tx.begin();
+        MockTransactionLogRecord record = new MockTransactionLogRecord().failCommit();
+        tx.add(record);
+
+        try {
+            tx.commit();
+            fail();
+        } catch (TransactionException expected) {
+        }
+
+        assertCommitFailed(tx);
+        assertNoBackupLogOnRemote(tx);
+        record.assertPrepareNotCalled().assertCommitCalled().assertRollbackNotCalled();
+    }
+
+    // =================== rollback ===========================================
+
+    @Test
+    public void rollback_whenSingleItemAndDurabilityOne_thenNoBackupLog() {
+        TransactionOptions options = new TransactionOptions().setTransactionType(TWO_PHASE).setDurability(1);
+        TransactionImpl tx = new TransactionImpl(localTxService, localNodeEngine, options, txOwner);
+        tx.begin();
+        MockTransactionLogRecord record = new MockTransactionLogRecord();
+        tx.add(record);
+        tx.prepare();
+
+        tx.rollback();
+
+        assertRolledBack(tx);
+        assertNoBackupLogOnRemote(tx);
+        record.assertPrepareCalled().assertCommitNotCalled().assertRollbackCalled();
+    }
+
+    @Test
+    public void rollback_whenMultipleItemsAndDurabilityOne_thenBackupLog() {
+        TransactionOptions options = new TransactionOptions().setTransactionType(TWO_PHASE).setDurability(1);
+        final TransactionImpl tx = new TransactionImpl(localTxService, localNodeEngine, options, txOwner);
+        tx.begin();
+        MockTransactionLogRecord record1 = new MockTransactionLogRecord();
+        tx.add(record1);
+        MockTransactionLogRecord record2 = new MockTransactionLogRecord();
+        tx.add(record2);
+        tx.prepare();
+
+        tx.rollback();
+
+        assertRolledBack(tx);
+        // it can take some time because the transaction doesn't sync on purging the backups.
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertNoBackupLogOnRemote(tx);
+            }
+        });
+        record1.assertPrepareCalled().assertCommitNotCalled().assertRollbackCalled();
+        record2.assertPrepareCalled().assertCommitNotCalled().assertRollbackCalled();
+    }
+
+    @Test
+    public void rollback_whenMultipleItemsAndDurabilityZero_thenNoBackupLog() {
+        TransactionOptions options = new TransactionOptions().setTransactionType(TWO_PHASE).setDurability(0);
+        TransactionImpl tx = new TransactionImpl(localTxService, localNodeEngine, options, txOwner);
+        tx.begin();
+        MockTransactionLogRecord record1 = new MockTransactionLogRecord();
+        tx.add(record1);
+        MockTransactionLogRecord record2 = new MockTransactionLogRecord();
+        tx.add(record2);
+        tx.prepare();
+
+        tx.rollback();
+
+        assertRolledBack(tx);
+        assertNoBackupLogOnRemote(tx);
+        record1.assertPrepareCalled().assertCommitNotCalled().assertRollbackCalled();
+        record2.assertPrepareCalled().assertCommitNotCalled().assertRollbackCalled();
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/transaction/impl/TransactionManagerServiceImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/transaction/impl/TransactionManagerServiceImplTest.java
@@ -1,0 +1,131 @@
+package com.hazelcast.transaction.impl;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.transaction.TransactionException;
+import com.hazelcast.transaction.impl.TransactionManagerServiceImpl.TxBackupLog;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import static com.hazelcast.transaction.impl.Transaction.State.ACTIVE;
+import static com.hazelcast.transaction.impl.Transaction.State.COMMITTING;
+import static com.hazelcast.transaction.impl.Transaction.State.ROLLED_BACK;
+import static com.hazelcast.transaction.impl.Transaction.State.ROLLING_BACK;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category(QuickTest.class)
+public class TransactionManagerServiceImplTest extends HazelcastTestSupport {
+
+    private TransactionManagerServiceImpl txService;
+
+    @Before
+    public void setup() {
+        HazelcastInstance hz = createHazelcastInstance();
+        NodeEngineImpl nodeEngine = getNodeEngineImpl(hz);
+        txService = new TransactionManagerServiceImpl(nodeEngine);
+    }
+
+    // ================= createBackupLog ===================================
+
+    @Test
+    public void createBackupLog_whenNotCreated() {
+        String callerUuid = "somecaller";
+        String txId = "tx1";
+        txService.createBackupLog(callerUuid, txId);
+
+        assertTxLogState(txId, ACTIVE);
+    }
+
+    @Test(expected = TransactionException.class)
+    public void createBackupLog_whenAlreadyExist() {
+        String callerUuid = "somecaller";
+        String txId = "tx1";
+        txService.createBackupLog(callerUuid, txId);
+
+        txService.createBackupLog(callerUuid, txId);
+    }
+
+    // ================= rollbackBackupLog ===================================
+
+    @Test(expected = TransactionException.class)
+    public void replicaBackupLog_whenNotExist_thenTransactionException() {
+        List<TransactionLogRecord> records = new LinkedList<TransactionLogRecord>();
+        txService.replicaBackupLog(records, "notexist", "notexist", 1, 1);
+    }
+
+    @Test
+    public void replicaBackupLog_whenExist() {
+        String callerUuid = "somecaller";
+        String txId = "tx1";
+        txService.createBackupLog(callerUuid, txId);
+
+        List<TransactionLogRecord> records = new LinkedList<TransactionLogRecord>();
+        txService.replicaBackupLog(records, callerUuid, txId, 1, 1);
+
+        assertTxLogState(txId, COMMITTING);
+    }
+
+    @Test(expected = TransactionException.class)
+    public void replicaBackupLog_whenNotActive() {
+        String callerUuid = "somecaller";
+        String txId = "tx1";
+        txService.createBackupLog(callerUuid, txId);
+        txService.txBackupLogs.get(txId).state = ROLLED_BACK;
+
+        List<TransactionLogRecord> records = new LinkedList<TransactionLogRecord>();
+        txService.replicaBackupLog(records, callerUuid, txId, 1, 1);
+    }
+
+    private void assertTxLogState(String txId, Transaction.State state) {
+        TxBackupLog backupLog = txService.txBackupLogs.get(txId);
+        assertNotNull(backupLog);
+        assertEquals(state, backupLog.state);
+    }
+
+    // ================= rollbackBackupLog ===================================
+
+    @Test
+    public void rollbackBackupLog_whenExist() {
+        String callerUuid = "somecaller";
+        String txId = "tx1";
+        txService.createBackupLog(callerUuid, txId);
+
+        txService.rollbackBackupLog(txId);
+
+        assertTxLogState(txId, ROLLING_BACK);
+    }
+
+    @Test
+    public void rollbackBackupLog_whenNotExist_thenIgnored() {
+        txService.rollbackBackupLog("notexist");
+    }
+
+    // ================= purgeBackupLog ===================================
+
+    @Test
+    public void purgeBackupLog_whenExist_thenRemoved() {
+        String callerUuid = "somecaller";
+        String txId = "tx1";
+        txService.createBackupLog(callerUuid, txId);
+
+        txService.purgeBackupLog(txId);
+
+        assertFalse(txService.txBackupLogs.containsKey(txId));
+    }
+
+    @Test
+    public void purgeBackupLog_whenNotExist_thenIgnored() {
+        txService.purgeBackupLog("notexist");
+    }
+}


### PR DESCRIPTION
Single item transaction don't need to be prepared. The txlog doesn't
need to be replicated since a single item transaction log can't be
partially written.

And it doesn't need to be prepared, since the commit will fail if
it tries to write something it doesn't own.