### PR TITLE
Added ProbeLevel to reduce memory overhead

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEndpointManagerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEndpointManagerImpl.java
@@ -35,6 +35,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
 
+import static com.hazelcast.internal.metrics.ProbeLevel.MANDATORY;
 import static com.hazelcast.util.Preconditions.checkNotNull;
 import static com.hazelcast.util.counters.MwCounter.newMwCounter;
 
@@ -49,11 +50,11 @@ public class ClientEndpointManagerImpl implements ClientEndpointManager {
     private final ClientEngineImpl clientEngine;
     private final NodeEngine nodeEngine;
 
-    @Probe(name = "count")
+    @Probe(name = "count", level = MANDATORY)
     private final ConcurrentMap<Connection, ClientEndpoint> endpoints =
             new ConcurrentHashMap<Connection, ClientEndpoint>();
 
-    @Probe(name = "totalRegistrations")
+    @Probe(name = "totalRegistrations", level = MANDATORY)
     private MwCounter totalRegistrations = newMwCounter();
 
     public ClientEndpointManagerImpl(ClientEngineImpl clientEngine, NodeEngine nodeEngine) {

--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/ClusterClockImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/ClusterClockImpl.java
@@ -21,6 +21,8 @@ import com.hazelcast.internal.metrics.Probe;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.util.Clock;
 
+import static com.hazelcast.internal.metrics.ProbeLevel.MANDATORY;
+
 
 public class ClusterClockImpl implements ClusterClock {
 
@@ -51,7 +53,7 @@ public class ClusterClockImpl implements ClusterClock {
         this.clusterTimeDiff = Long.MAX_VALUE;
     }
 
-    @Probe(name = "clusterTimeDiff")
+    @Probe(name = "clusterTimeDiff", level = MANDATORY)
     @Override
     public long getClusterTimeDiff() {
         return (clusterTimeDiff == Long.MAX_VALUE) ? 0 : clusterTimeDiff;

--- a/hazelcast/src/main/java/com/hazelcast/instance/GroupProperties.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/GroupProperties.java
@@ -20,6 +20,8 @@ import com.hazelcast.config.Config;
 
 import java.util.concurrent.TimeUnit;
 
+import static java.lang.String.format;
+
 /**
  * Container for configured Hazelcast properties ({@see GroupProperty}).
  * <p/>
@@ -390,4 +392,28 @@ public class GroupProperties {
         TimeUnit timeUnit = groupProperty.getTimeUnit();
         return (int) timeUnit.toSeconds(getLong(groupProperty));
     }
+
+    /**
+     * Returns the configured enum value of a {@link GroupProperty}.
+     *
+     * The case of the enum is ignored.
+     *
+     * @param groupProperty the {@link GroupProperty} to get the value from
+     * @return the enum
+     * @throws IllegalArgumentException if the enum value can't be found
+     */
+    public <E extends Enum> E getEnum(GroupProperty groupProperty, Class<? extends Enum> enumClazz) {
+        String value = getString(groupProperty);
+
+        for (Enum e : enumClazz.getEnumConstants()) {
+            if (e.name().equalsIgnoreCase(value)) {
+                return (E) e;
+            }
+        }
+
+        throw new IllegalArgumentException(
+                format("value '%s' for property '%s' is not a valid %s value",
+                        value, groupProperty.getName(), enumClazz.getName()));
+    }
+
 }

--- a/hazelcast/src/main/java/com/hazelcast/instance/GroupProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/GroupProperty.java
@@ -17,6 +17,7 @@
 package com.hazelcast.instance;
 
 import com.hazelcast.core.IMap;
+import com.hazelcast.internal.metrics.ProbeLevel;
 import com.hazelcast.internal.monitors.HealthMonitorLevel;
 import com.hazelcast.map.QueryResultSizeExceededException;
 import com.hazelcast.map.impl.QueryResultSizeLimiter;
@@ -96,9 +97,19 @@ public enum GroupProperty implements HazelcastProperty {
      * <p/>
      * The performance monitor logs all metrics into the log file.
      * <p/>
+     * For more detailed information, please check the PERFORMANCE_METRICS_LEVEL.
+     * <p/>
      * The default is false.
      */
     PERFORMANCE_MONITOR_ENABLED("hazelcast.performance.monitoring.enabled", false),
+
+    /**
+     * The minimum level for probes is MANDATORY, but it can be changed to INFO or DEBUG. A lower level will increase
+     * memory usage (probably just a few 100KB) and provides much greater detail on what is going on inside a HazelcastInstance.
+     *
+     * By default only mandatory probes are being tracked
+     */
+    PERFORMANCE_METRICS_LEVEL("hazelcast.performance.metric.level", ProbeLevel.MANDATORY.name()),
 
     /**
      * The delay in seconds between monitor of the performance.

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricsRegistry.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricsRegistry.java
@@ -113,10 +113,11 @@ public interface MetricsRegistry {
      * If a probe for the given name exists, it will be overwritten.
      *
      * @param name  the name of the probe.
+     * @param level the ProbeLevel
      * @param probe the probe
-     * @throws NullPointerException if source, name or probe is null.
+     * @throws NullPointerException if source, name, level or probe is null.
      */
-    <S> void register(S source, String name, LongProbeFunction<S> probe);
+    <S> void register(S source, String name, ProbeLevel level, LongProbeFunction<S> probe);
 
     /**
      * Registers a probe
@@ -124,10 +125,11 @@ public interface MetricsRegistry {
      * If a probe for the given name exists, it will be overwritten.
      *
      * @param name  the name of the probe
+     * @param level the ProbeLevel
      * @param probe the probe
-     * @throws NullPointerException if name or probe is null.
+     * @throws NullPointerException if source, name, level or probe is null.
      */
-    <S> void register(S source, String name, DoubleProbeFunction<S> probe);
+    <S> void register(S source, String name, ProbeLevel level, DoubleProbeFunction<S> probe);
 
     /**
      * Deregisters all probes for a given source object.

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/Probe.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/Probe.java
@@ -19,6 +19,7 @@ package com.hazelcast.internal.metrics;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import static com.hazelcast.internal.metrics.ProbeLevel.INFO;
 import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
@@ -68,4 +69,14 @@ public @interface Probe {
      * @return the name of the Probe.
      */
     String name() default "";
+
+    /**
+     * Returns the ProbeLevel.
+     *
+     * Using ProbeLevel one can indicate how 'important' this Probe is. This is useful to reduce memory overhead due
+     * to tracking of probes.
+     *
+     * @return the ProbeLevel.
+     */
+    ProbeLevel level() default INFO;
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/ProbeLevel.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/ProbeLevel.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.metrics;
+
+/**
+ * With the probe level one can control which probes are being tracked by the MetricsRegistry and which ones are not.
+ */
+public enum ProbeLevel {
+
+    /**
+     * Indicates that a probe is mandatory. E.g. memory usage, since other parts of the system rely on it (e.g the health monitor)
+     */
+    MANDATORY(2),
+
+    /**
+     * Indicates that it is a regular probe.
+     */
+    INFO(1),
+
+    /**
+     * Indicates that is a probe for debugging purposes.
+     */
+    DEBUG(0);
+
+    private final int precedence;
+
+    ProbeLevel(int precedence) {
+        this.precedence = precedence;
+    }
+
+    /**
+     * Checks if the this ProbeLevel has a precedence equal or higher than the minimumLevel.
+     *
+     * @param minimumLevel the minimum ProbeLevel
+     * @return true if it is trackable, false otherwise.
+     */
+    public boolean isEnabled(ProbeLevel minimumLevel) {
+        return precedence >= minimumLevel.precedence;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/FieldProbe.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/FieldProbe.java
@@ -57,7 +57,7 @@ abstract class FieldProbe implements ProbeFunction {
 
     void register(MetricsRegistryImpl metricsRegistry, Object source, String namePrefix) {
         String name = getName(namePrefix);
-        metricsRegistry.registerInternal(source, name, this);
+        metricsRegistry.registerInternal(source, name, probe.level(), this);
     }
 
     private String getName(String namePrefix) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MethodProbe.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MethodProbe.java
@@ -57,7 +57,7 @@ abstract class MethodProbe implements ProbeFunction {
 
     void register(MetricsRegistryImpl metricsRegistry, Object source, String namePrefix) {
         String name = getName(namePrefix);
-        metricsRegistry.registerInternal(source, name, this);
+        metricsRegistry.registerInternal(source, name, probe.level(), this);
     }
 
     private String getName(String namePrefix) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsRegistryImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsRegistryImpl.java
@@ -21,6 +21,7 @@ import com.hazelcast.internal.metrics.DoubleProbeFunction;
 import com.hazelcast.internal.metrics.LongProbeFunction;
 import com.hazelcast.internal.metrics.MetricsRegistry;
 import com.hazelcast.internal.metrics.ProbeFunction;
+import com.hazelcast.internal.metrics.ProbeLevel;
 import com.hazelcast.internal.metrics.metricsets.ClassLoadingMetricSet;
 import com.hazelcast.internal.metrics.metricsets.GarbageCollectionMetricSet;
 import com.hazelcast.internal.metrics.metricsets.OperatingSystemMetricsSet;
@@ -50,6 +51,7 @@ import static java.lang.String.format;
 public class MetricsRegistryImpl implements MetricsRegistry {
 
     final ILogger logger;
+    final ProbeLevel minimumLevel;
 
     private final ScheduledExecutorService scheduledExecutorService = new ScheduledThreadPoolExecutor(2);
     private final AtomicInteger modCount = new AtomicInteger();
@@ -70,8 +72,14 @@ public class MetricsRegistryImpl implements MetricsRegistry {
      * @param logger the ILogger used
      * @throws NullPointerException if logger is null
      */
-    public MetricsRegistryImpl(ILogger logger) {
+    public MetricsRegistryImpl(ILogger logger, ProbeLevel minimumLevel) {
         this.logger = checkNotNull(logger, "logger can't be null");
+        this.minimumLevel = checkNotNull(minimumLevel, "minimumLevel can't be null");
+
+        System.out.println(minimumLevel);
+        if (logger.isFinestEnabled()) {
+            logger.finest("MetricsRegistry minimumLevel:" + minimumLevel);
+        }
 
         RuntimeMetricSet.register(this);
         GarbageCollectionMetricSet.register(this);
@@ -117,21 +125,23 @@ public class MetricsRegistryImpl implements MetricsRegistry {
     }
 
     @Override
-    public <S> void register(S source, String name, LongProbeFunction<S> function) {
+    public <S> void register(S source, String name, ProbeLevel level, LongProbeFunction<S> function) {
         checkNotNull(source, "source can't be null");
         checkNotNull(name, "name can't be null");
         checkNotNull(function, "function can't be null");
+        checkNotNull(level, "level can't be null");
 
-        registerInternal(source, name, function);
+        registerInternal(source, name, level, function);
     }
 
     @Override
-    public <S> void register(S source, String name, DoubleProbeFunction<S> function) {
+    public <S> void register(S source, String name, ProbeLevel level, DoubleProbeFunction<S> function) {
         checkNotNull(source, "source can't be null");
         checkNotNull(name, "name can't be null");
         checkNotNull(function, "function can't be null");
+        checkNotNull(level, "level can't be null");
 
-        registerInternal(source, name, function);
+        registerInternal(source, name, level, function);
     }
 
     public ProbeInstance getProbeInstance(String name) {
@@ -140,7 +150,11 @@ public class MetricsRegistryImpl implements MetricsRegistry {
         return probeInstances.get(name);
     }
 
-    <S> void registerInternal(S source, String name, ProbeFunction function) {
+    <S> void registerInternal(S source, String name, ProbeLevel probeLevel, ProbeFunction function) {
+        if (!probeLevel.isEnabled(minimumLevel)) {
+            return;
+        }
+
         synchronized (lockStripe.getLock(source)) {
             ProbeInstance probeInstance = probeInstances.get(name);
             if (probeInstance == null) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/SourceMetadata.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/SourceMetadata.java
@@ -23,9 +23,9 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.hazelcast.internal.metrics.impl.ProbeUtils.flatten;
 import static com.hazelcast.internal.metrics.impl.FieldProbe.createFieldProbe;
 import static com.hazelcast.internal.metrics.impl.MethodProbe.createMethodProbe;
+import static com.hazelcast.internal.metrics.impl.ProbeUtils.flatten;
 
 /**
  * Contains the metadata for an object with @Probe fields/methods.

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/metricsets/ClassLoadingMetricSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/metricsets/ClassLoadingMetricSet.java
@@ -16,12 +16,13 @@
 
 package com.hazelcast.internal.metrics.metricsets;
 
-import com.hazelcast.internal.metrics.MetricsRegistry;
 import com.hazelcast.internal.metrics.LongProbeFunction;
+import com.hazelcast.internal.metrics.MetricsRegistry;
 
 import java.lang.management.ClassLoadingMXBean;
 import java.lang.management.ManagementFactory;
 
+import static com.hazelcast.internal.metrics.ProbeLevel.MANDATORY;
 import static com.hazelcast.util.Preconditions.checkNotNull;
 
 /**
@@ -42,7 +43,7 @@ public final class ClassLoadingMetricSet {
 
         ClassLoadingMXBean mxBean = ManagementFactory.getClassLoadingMXBean();
 
-        metricsRegistry.register(mxBean, "classloading.loadedClassesCount",
+        metricsRegistry.register(mxBean, "classloading.loadedClassesCount", MANDATORY,
                 new LongProbeFunction<ClassLoadingMXBean>() {
                     @Override
                     public long get(ClassLoadingMXBean classLoadingMXBean) {
@@ -51,7 +52,7 @@ public final class ClassLoadingMetricSet {
                 }
         );
 
-        metricsRegistry.register(mxBean, "classloading.totalLoadedClassesCount",
+        metricsRegistry.register(mxBean, "classloading.totalLoadedClassesCount", MANDATORY,
                 new LongProbeFunction<ClassLoadingMXBean>() {
                     @Override
                     public long get(ClassLoadingMXBean classLoadingMXBean) {
@@ -60,7 +61,7 @@ public final class ClassLoadingMetricSet {
                 }
         );
 
-        metricsRegistry.register(mxBean, "classloading.unloadedClassCount",
+        metricsRegistry.register(mxBean, "classloading.unloadedClassCount", MANDATORY,
                 new LongProbeFunction<ClassLoadingMXBean>() {
                     @Override
                     public long get(ClassLoadingMXBean classLoadingMXBean) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/metricsets/GarbageCollectionMetricSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/metricsets/GarbageCollectionMetricSet.java
@@ -26,6 +26,7 @@ import java.lang.management.ManagementFactory;
 import java.util.HashSet;
 import java.util.Set;
 
+import static com.hazelcast.internal.metrics.ProbeLevel.MANDATORY;
 import static com.hazelcast.util.Preconditions.checkNotNull;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
@@ -67,17 +68,17 @@ public final class GarbageCollectionMetricSet {
 
     @SuppressFBWarnings(value = "URF_UNREAD_FIELD", justification = "used by instrumentation tools")
     static class GcStats implements Runnable {
-        @Probe
+        @Probe(level = MANDATORY)
         volatile long minorCount;
-        @Probe
+        @Probe(level = MANDATORY)
         volatile long minorTime;
-        @Probe
+        @Probe(level = MANDATORY)
         volatile long majorCount;
-        @Probe
+        @Probe(level = MANDATORY)
         volatile long majorTime;
-        @Probe
+        @Probe(level = MANDATORY)
         volatile long unknownCount;
-        @Probe
+        @Probe(level = MANDATORY)
         volatile long unknownTime;
 
         @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/metricsets/OperatingSystemMetricsSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/metricsets/OperatingSystemMetricsSet.java
@@ -16,14 +16,15 @@
 
 package com.hazelcast.internal.metrics.metricsets;
 
-import com.hazelcast.internal.metrics.MetricsRegistry;
 import com.hazelcast.internal.metrics.DoubleProbeFunction;
 import com.hazelcast.internal.metrics.LongProbeFunction;
+import com.hazelcast.internal.metrics.MetricsRegistry;
 
 import java.lang.management.ManagementFactory;
 import java.lang.management.OperatingSystemMXBean;
 import java.lang.reflect.Method;
 
+import static com.hazelcast.internal.metrics.ProbeLevel.MANDATORY;
 import static com.hazelcast.util.Preconditions.checkNotNull;
 
 /**
@@ -57,7 +58,7 @@ public final class OperatingSystemMetricsSet {
         registerMethod(metricsRegistry, mxBean, "getProcessCpuLoad", "os.processCpuLoad");
         registerMethod(metricsRegistry, mxBean, "getSystemCpuLoad", "os.systemCpuLoad");
 
-        metricsRegistry.register(mxBean, "os.systemLoadAverage",
+        metricsRegistry.register(mxBean, "os.systemLoadAverage", MANDATORY,
                 new DoubleProbeFunction<OperatingSystemMXBean>() {
                     @Override
                     public double get(OperatingSystemMXBean bean) {
@@ -78,7 +79,7 @@ public final class OperatingSystemMetricsSet {
         }
 
         if (long.class.equals(method.getReturnType())) {
-            metricsRegistry.register(osBean, name,
+            metricsRegistry.register(osBean, name, MANDATORY,
                     new LongProbeFunction() {
                         @Override
                         public long get(Object bean) throws Exception {
@@ -86,7 +87,7 @@ public final class OperatingSystemMetricsSet {
                         }
                     });
         } else {
-            metricsRegistry.register(osBean, name,
+            metricsRegistry.register(osBean, name, MANDATORY,
                     new DoubleProbeFunction() {
                         @Override
                         public double get(Object bean) throws Exception {
@@ -99,7 +100,7 @@ public final class OperatingSystemMetricsSet {
     /**
      * Returns a method from the given source object.
      *
-     * @param source the source object.
+     * @param source     the source object.
      * @param methodName the name of the method to retrieve.
      * @return the method
      */

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/metricsets/RuntimeMetricSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/metricsets/RuntimeMetricSet.java
@@ -16,12 +16,13 @@
 
 package com.hazelcast.internal.metrics.metricsets;
 
-import com.hazelcast.internal.metrics.MetricsRegistry;
 import com.hazelcast.internal.metrics.LongProbeFunction;
+import com.hazelcast.internal.metrics.MetricsRegistry;
 
 import java.lang.management.ManagementFactory;
 import java.lang.management.RuntimeMXBean;
 
+import static com.hazelcast.internal.metrics.ProbeLevel.MANDATORY;
 import static com.hazelcast.util.Preconditions.checkNotNull;
 
 /**
@@ -43,7 +44,8 @@ public final class RuntimeMetricSet {
         Runtime runtime = Runtime.getRuntime();
         RuntimeMXBean mxBean = ManagementFactory.getRuntimeMXBean();
 
-        metricsRegistry.register(runtime, "runtime.freeMemory", new LongProbeFunction<Runtime>() {
+        metricsRegistry.register(runtime, "runtime.freeMemory", MANDATORY,
+                new LongProbeFunction<Runtime>() {
                     @Override
                     public long get(Runtime runtime) {
                         return runtime.freeMemory();
@@ -51,7 +53,8 @@ public final class RuntimeMetricSet {
                 }
         );
 
-        metricsRegistry.register(runtime, "runtime.totalMemory", new LongProbeFunction<Runtime>() {
+        metricsRegistry.register(runtime, "runtime.totalMemory", MANDATORY,
+                new LongProbeFunction<Runtime>() {
                     @Override
                     public long get(Runtime runtime) {
                         return runtime.totalMemory();
@@ -59,7 +62,8 @@ public final class RuntimeMetricSet {
                 }
         );
 
-        metricsRegistry.register(runtime, "runtime.maxMemory", new LongProbeFunction<Runtime>() {
+        metricsRegistry.register(runtime, "runtime.maxMemory", MANDATORY,
+                new LongProbeFunction<Runtime>() {
                     @Override
                     public long get(Runtime runtime) {
                         return runtime.maxMemory();
@@ -67,7 +71,8 @@ public final class RuntimeMetricSet {
                 }
         );
 
-        metricsRegistry.register(runtime, "runtime.usedMemory", new LongProbeFunction<Runtime>() {
+        metricsRegistry.register(runtime, "runtime.usedMemory", MANDATORY,
+                new LongProbeFunction<Runtime>() {
                     @Override
                     public long get(Runtime runtime) {
                         return runtime.totalMemory() - runtime.freeMemory();
@@ -75,7 +80,8 @@ public final class RuntimeMetricSet {
                 }
         );
 
-        metricsRegistry.register(runtime, "runtime.availableProcessors", new LongProbeFunction<Runtime>() {
+        metricsRegistry.register(runtime, "runtime.availableProcessors", MANDATORY,
+                new LongProbeFunction<Runtime>() {
                     @Override
                     public long get(Runtime runtime) {
                         return runtime.availableProcessors();
@@ -83,7 +89,8 @@ public final class RuntimeMetricSet {
                 }
         );
 
-        metricsRegistry.register(mxBean, "runtime.uptime", new LongProbeFunction<RuntimeMXBean>() {
+        metricsRegistry.register(mxBean, "runtime.uptime", MANDATORY,
+                new LongProbeFunction<RuntimeMXBean>() {
                     @Override
                     public long get(RuntimeMXBean runtimeMXBean) {
                         return runtimeMXBean.getUptime();

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/metricsets/ThreadMetricSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/metricsets/ThreadMetricSet.java
@@ -16,12 +16,13 @@
 
 package com.hazelcast.internal.metrics.metricsets;
 
-import com.hazelcast.internal.metrics.MetricsRegistry;
 import com.hazelcast.internal.metrics.LongProbeFunction;
+import com.hazelcast.internal.metrics.MetricsRegistry;
 
 import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadMXBean;
 
+import static com.hazelcast.internal.metrics.ProbeLevel.MANDATORY;
 import static com.hazelcast.util.Preconditions.checkNotNull;
 
 /**
@@ -42,7 +43,8 @@ public final class ThreadMetricSet {
 
         ThreadMXBean mxBean = ManagementFactory.getThreadMXBean();
 
-        metricsRegistry.register(mxBean, "thread.threadCount", new LongProbeFunction<ThreadMXBean>() {
+        metricsRegistry.register(mxBean, "thread.threadCount", MANDATORY,
+                new LongProbeFunction<ThreadMXBean>() {
                     @Override
                     public long get(ThreadMXBean threadMXBean) {
                         return threadMXBean.getThreadCount();
@@ -50,7 +52,8 @@ public final class ThreadMetricSet {
                 }
         );
 
-        metricsRegistry.register(mxBean, "thread.peakThreadCount", new LongProbeFunction<ThreadMXBean>() {
+        metricsRegistry.register(mxBean, "thread.peakThreadCount", MANDATORY,
+                new LongProbeFunction<ThreadMXBean>() {
                     @Override
                     public long get(ThreadMXBean threadMXBean) {
                         return threadMXBean.getPeakThreadCount();
@@ -58,7 +61,8 @@ public final class ThreadMetricSet {
                 }
         );
 
-        metricsRegistry.register(mxBean, "thread.daemonThreadCount", new LongProbeFunction<ThreadMXBean>() {
+        metricsRegistry.register(mxBean, "thread.daemonThreadCount", MANDATORY,
+                new LongProbeFunction<ThreadMXBean>() {
                     @Override
                     public long get(ThreadMXBean threadMXBean) {
                         return threadMXBean.getDaemonThreadCount();
@@ -66,7 +70,8 @@ public final class ThreadMetricSet {
                 }
         );
 
-        metricsRegistry.register(mxBean, "thread.totalStartedThreadCount", new LongProbeFunction<ThreadMXBean>() {
+        metricsRegistry.register(mxBean, "thread.totalStartedThreadCount", MANDATORY,
+                new LongProbeFunction<ThreadMXBean>() {
                     @Override
                     public long get(ThreadMXBean threadMXBean) {
                         return threadMXBean.getTotalStartedThreadCount();

--- a/hazelcast/src/main/java/com/hazelcast/internal/monitors/HealthMonitor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/monitors/HealthMonitor.java
@@ -450,14 +450,6 @@ public class HealthMonitor {
                     .append(executorClusterQueueSize.read()).append(", ");
         }
 
-
-        /*
-
-            sb.append("operations.remote.size=").append(remoteOperationsCount).append(", ");
- sb.append("operations.running.size=").append(runningOperationsCount).append(", ");
-
-         */
-
         private void renderOperationService() {
             sb.append("executor.q.response.size=")
                     .append(operationServiceResponseQueueSize.read()).append(", ");

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnectionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnectionManager.java
@@ -53,6 +53,7 @@ import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static com.hazelcast.internal.metrics.ProbeLevel.MANDATORY;
 import static com.hazelcast.nio.IOService.KILO_BYTE;
 import static com.hazelcast.nio.IOUtil.closeResource;
 import static com.hazelcast.util.Preconditions.checkNotNull;
@@ -79,7 +80,7 @@ public class TcpIpConnectionManager implements ConnectionManager, PacketHandler 
 
     private final ILogger logger;
 
-    @Probe(name = "count")
+    @Probe(name = "count", level = MANDATORY)
     private final ConcurrentHashMap<Address, Connection> connectionsMap = new ConcurrentHashMap<Address, Connection>(100);
 
     @Probe(name = "monitorCount")
@@ -90,15 +91,15 @@ public class TcpIpConnectionManager implements ConnectionManager, PacketHandler 
     private final Set<Address> connectionsInProgress =
             Collections.newSetFromMap(new ConcurrentHashMap<Address, Boolean>());
 
-    @Probe(name = "acceptedSocketCount")
+    @Probe(name = "acceptedSocketCount", level = MANDATORY)
     private final Set<SocketChannelWrapper> acceptedSockets =
             Collections.newSetFromMap(new ConcurrentHashMap<SocketChannelWrapper, Boolean>());
 
-    @Probe(name = "activeCount")
+    @Probe(name = "activeCount", level = MANDATORY)
     private final Set<TcpIpConnection> activeConnections =
             Collections.newSetFromMap(new ConcurrentHashMap<TcpIpConnection, Boolean>());
 
-    @Probe(name = "textCount")
+    @Probe(name = "textCount", level = MANDATORY)
     private final AtomicInteger allTextConnections = new AtomicInteger();
 
     private final AtomicInteger connectionIdGen = new AtomicInteger();
@@ -522,7 +523,7 @@ public class TcpIpConnectionManager implements ConnectionManager, PacketHandler 
         }
     }
 
-    @Probe(name = "clientCount")
+    @Probe(name = "clientCount", level = MANDATORY)
     @Override
     public int getCurrentClientConnections() {
         int count = 0;

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/NonBlockingSocketReader.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/NonBlockingSocketReader.java
@@ -35,6 +35,7 @@ import java.net.SocketException;
 import java.nio.ByteBuffer;
 import java.nio.channels.SelectionKey;
 
+import static com.hazelcast.internal.metrics.ProbeLevel.DEBUG;
 import static com.hazelcast.nio.ConnectionType.MEMBER;
 import static com.hazelcast.nio.IOService.KILO_BYTE;
 import static com.hazelcast.nio.Protocols.CLIENT_BINARY;
@@ -77,18 +78,18 @@ public final class NonBlockingSocketReader extends AbstractHandler implements So
         metricRegistry.scanAndRegister(this, "tcp.connection[" + connection.getMetricsId() + "]");
     }
 
-    @Probe(name = "in.idleTimeMs")
+    @Probe(name = "in.idleTimeMs", level = DEBUG)
     private long idleTimeMs() {
         return Math.max(System.currentTimeMillis() - lastReadTime, 0);
     }
 
-    @Probe(name = "in.interestedOps")
+    @Probe(name = "in.interestedOps", level = DEBUG)
     private long interestOps() {
         SelectionKey selectionKey = this.selectionKey;
         return selectionKey == null ? -1 : selectionKey.interestOps();
     }
 
-    @Probe(name = "in.readyOps")
+    @Probe(name = "in.readyOps", level = DEBUG)
     private long readyOps() {
         SelectionKey selectionKey = this.selectionKey;
         return selectionKey == null ? -1 : selectionKey.readyOps();

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/NonBlockingSocketWriter.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/NonBlockingSocketWriter.java
@@ -39,6 +39,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 
+import static com.hazelcast.internal.metrics.ProbeLevel.DEBUG;
 import static com.hazelcast.nio.IOService.KILO_BYTE;
 import static com.hazelcast.nio.Protocols.CLIENT_BINARY;
 import static com.hazelcast.nio.Protocols.CLIENT_BINARY_NEW;
@@ -47,6 +48,7 @@ import static com.hazelcast.util.Clock.currentTimeMillis;
 import static com.hazelcast.util.EmptyStatement.ignore;
 import static com.hazelcast.util.StringUtil.stringToBytes;
 import static com.hazelcast.util.counters.SwCounter.newSwCounter;
+import static java.lang.Math.max;
 
 /**
  * The writing side of the {@link TcpIpConnection}.
@@ -89,13 +91,13 @@ public final class NonBlockingSocketWriter extends AbstractHandler implements Ru
         metricsRegistry.scanAndRegister(this, "tcp.connection[" + connection.getMetricsId() + "]");
     }
 
-    @Probe(name = "out.interestedOps")
+    @Probe(name = "out.interestedOps", level = DEBUG)
     private long interestOps() {
         SelectionKey selectionKey = this.selectionKey;
         return selectionKey == null ? -1 : selectionKey.interestOps();
     }
 
-    @Probe(name = "out.readyOps")
+    @Probe(name = "out.readyOps", level = DEBUG)
     private long readyOps() {
         SelectionKey selectionKey = this.selectionKey;
         return selectionKey == null ? -1 : selectionKey.readyOps();
@@ -116,12 +118,12 @@ public final class NonBlockingSocketWriter extends AbstractHandler implements Ru
         return writeHandler;
     }
 
-    @Probe(name = "out.writeQueuePendingBytes")
+    @Probe(name = "out.writeQueuePendingBytes", level = DEBUG)
     public long bytesPending() {
         return bytesPending(writeQueue);
     }
 
-    @Probe(name = "out.priorityWriteQueuePendingBytes")
+    @Probe(name = "out.priorityWriteQueuePendingBytes", level = DEBUG)
     public long priorityBytesPending() {
         return bytesPending(urgentWriteQueue);
     }
@@ -136,12 +138,12 @@ public final class NonBlockingSocketWriter extends AbstractHandler implements Ru
         return bytesPending;
     }
 
-    @Probe(name = "out.idleTimeMs")
+    @Probe(name = "out.idleTimeMs", level = DEBUG)
     private long idleTimeMs() {
-        return Math.max(System.currentTimeMillis() - lastWriteTime, 0);
+        return max(System.currentTimeMillis() - lastWriteTime, 0);
     }
 
-    @Probe(name = "out.isScheduled")
+    @Probe(name = "out.isScheduled", level = DEBUG)
     private long isScheduled() {
         return scheduled.get() ? 1 : 0;
     }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
@@ -24,7 +24,9 @@ import com.hazelcast.instance.MemberImpl;
 import com.hazelcast.instance.Node;
 import com.hazelcast.internal.management.ManagementCenterService;
 import com.hazelcast.internal.metrics.MetricsRegistry;
+import com.hazelcast.internal.metrics.ProbeLevel;
 import com.hazelcast.internal.metrics.impl.MetricsRegistryImpl;
+import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.internal.storage.DataRef;
 import com.hazelcast.internal.storage.Storage;
 import com.hazelcast.logging.ILogger;
@@ -32,7 +34,6 @@ import com.hazelcast.logging.LoggingServiceImpl;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.Packet;
 import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.partition.InternalPartitionService;
 import com.hazelcast.partition.MigrationInfo;
 import com.hazelcast.quorum.impl.QuorumServiceImpl;
@@ -60,6 +61,8 @@ import com.hazelcast.wan.WanReplicationService;
 
 import java.util.Collection;
 import java.util.LinkedList;
+
+import static com.hazelcast.instance.GroupProperty.PERFORMANCE_METRICS_LEVEL;
 
 /**
  * The NodeEngineImpl is the where the construction of the Hazelcast dependencies take place. It can be
@@ -93,7 +96,8 @@ public class NodeEngineImpl implements NodeEngine {
         this.loggingService = node.loggingService;
         this.serializationService = node.getSerializationService();
         this.logger = node.getLogger(NodeEngine.class.getName());
-        this.metricsRegistry = new MetricsRegistryImpl(node.getLogger(MetricsRegistryImpl.class));
+        ProbeLevel probeLevel = node.getGroupProperties().getEnum(PERFORMANCE_METRICS_LEVEL, ProbeLevel.class);
+        this.metricsRegistry = new MetricsRegistryImpl(node.getLogger(MetricsRegistryImpl.class), probeLevel);
         this.proxyService = new ProxyServiceImpl(this);
         this.serviceManager = new ServiceManagerImpl(this);
         this.executionService = new ExecutionServiceImpl(this);

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationRegistry.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationRegistry.java
@@ -43,6 +43,7 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.instance.OutOfMemoryErrorDispatcher.inspectOutputMemoryError;
+import static com.hazelcast.internal.metrics.ProbeLevel.MANDATORY;
 import static com.hazelcast.spi.Operation.CALL_ID_LOCAL_SKIPPED;
 import static com.hazelcast.spi.OperationAccessor.setCallId;
 import static com.hazelcast.util.counters.MwCounter.newMwCounter;
@@ -72,7 +73,7 @@ public class InvocationRegistry {
 
     private final long backupTimeoutMillis;
 
-    @Probe(name = "invocations.pending")
+    @Probe(name = "invocations.pending", level = MANDATORY)
     private final ConcurrentMap<Long, Invocation> invocations;
     private final NodeEngineImpl nodeEngine;
     private final ILogger logger;
@@ -80,17 +81,17 @@ public class InvocationRegistry {
     private final CallIdSequence callIdSequence;
     private final long slowInvocationThresholdMs;
 
-    @Probe(name = "response.normal.count")
+    @Probe(name = "response.normal.count", level = MANDATORY)
     private final SwCounter responseNormalCounter = newSwCounter();
-    @Probe(name = "response.timeout.count")
+    @Probe(name = "response.timeout.count", level = MANDATORY)
     private final SwCounter responseTimeoutCounter = newSwCounter();
-    @Probe(name = "response.backup.count")
+    @Probe(name = "response.backup.count", level = MANDATORY)
     private final MwCounter responseBackupCounter = newMwCounter();
-    @Probe(name = "response.error.count")
+    @Probe(name = "response.error.count", level = MANDATORY)
     private final SwCounter responseErrorCounter = newSwCounter();
-    @Probe(name = "invocations.backupTimeouts")
+    @Probe(name = "invocations.backupTimeouts", level = MANDATORY)
     private final SwCounter backupTimeoutsCount = newSwCounter();
-    @Probe(name = "invocations.normalTimeouts")
+    @Probe(name = "invocations.normalTimeouts", level = MANDATORY)
     private final SwCounter normalTimeoutsCount = newSwCounter();
 
     public InvocationRegistry(NodeEngineImpl nodeEngine, ILogger logger, BackpressureRegulator backpressureRegulator,
@@ -197,7 +198,7 @@ public class InvocationRegistry {
      * Notifies the invocation that a Response is available.
      *
      * @param response The response that is available.
-     * @param sender Endpoint who sent the response
+     * @param sender   Endpoint who sent the response
      */
     public void notify(Response response, Address sender) {
         if (response instanceof NormalResponse) {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImpl.java
@@ -50,6 +50,7 @@ import com.hazelcast.util.counters.Counter;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Level;
 
+import static com.hazelcast.internal.metrics.ProbeLevel.DEBUG;
 import static com.hazelcast.nio.IOUtil.extractOperationCallId;
 import static com.hazelcast.spi.Operation.CALL_ID_LOCAL_SKIPPED;
 import static com.hazelcast.spi.OperationAccessor.setCallerAddress;
@@ -76,7 +77,7 @@ class OperationRunnerImpl extends OperationRunner {
     private final NodeEngineImpl nodeEngine;
     private final AtomicLong executedOperationsCount;
 
-    @Probe
+    @Probe(level = DEBUG)
     private final Counter count;
 
     // This field doesn't need additional synchronization, since a partition-specific OperationRunner

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
@@ -25,12 +25,12 @@ import com.hazelcast.instance.Node;
 import com.hazelcast.internal.management.dto.SlowOperationDTO;
 import com.hazelcast.internal.metrics.MetricsRegistry;
 import com.hazelcast.internal.metrics.Probe;
+import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.ConnectionManager;
 import com.hazelcast.nio.Packet;
-import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.partition.InternalPartitionService;
 import com.hazelcast.spi.ExecutionService;
 import com.hazelcast.spi.InternalCompletableFuture;
@@ -60,14 +60,15 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
+import static com.hazelcast.internal.metrics.ProbeLevel.MANDATORY;
 import static com.hazelcast.spi.InvocationBuilder.DEFAULT_CALL_TIMEOUT;
 import static com.hazelcast.spi.InvocationBuilder.DEFAULT_DESERIALIZE_RESULT;
 import static com.hazelcast.spi.InvocationBuilder.DEFAULT_REPLICA_INDEX;
 import static com.hazelcast.spi.InvocationBuilder.DEFAULT_TRY_COUNT;
 import static com.hazelcast.spi.InvocationBuilder.DEFAULT_TRY_PAUSE_MILLIS;
+import static com.hazelcast.spi.impl.operationutil.Operations.isJoinOperation;
 import static com.hazelcast.util.Preconditions.checkNotNull;
 import static com.hazelcast.util.Preconditions.checkTrue;
-import static com.hazelcast.spi.impl.operationutil.Operations.isJoinOperation;
 
 /**
  * This is the implementation of the {@link com.hazelcast.spi.impl.operationservice.InternalOperationService}.
@@ -101,16 +102,16 @@ public final class OperationServiceImpl implements InternalOperationService, Pac
     final ILogger invocationLogger;
     final ManagedExecutorService asyncExecutor;
 
-    @Probe(name = "completed.count")
+    @Probe(name = "completed.count", level = MANDATORY)
     final AtomicLong completedOperationsCount = new AtomicLong();
 
-    @Probe(name = "operationTimeoutCount")
+    @Probe(name = "operationTimeoutCount", level = MANDATORY)
     final MwCounter operationTimeoutCount = MwCounter.newMwCounter();
 
-    @Probe(name = "callTimeoutCount")
+    @Probe(name = "callTimeoutCount", level = MANDATORY)
     final MwCounter callTimeoutCount = MwCounter.newMwCounter();
 
-    @Probe(name = "retryCount")
+    @Probe(name = "retryCount", level = MANDATORY)
     final MwCounter retryCount = MwCounter.newMwCounter();
 
     final NodeEngineImpl nodeEngine;
@@ -223,13 +224,13 @@ public final class OperationServiceImpl implements InternalOperationService, Pac
         return invocationsRegistry.size();
     }
 
-    @Probe(name = "queue.size")
+    @Probe(name = "queue.size", level = MANDATORY)
     @Override
     public int getOperationExecutorQueueSize() {
         return operationExecutor.getOperationExecutorQueueSize();
     }
 
-    @Probe(name = "priority-queue.size")
+    @Probe(name = "priority-queue.size", level = MANDATORY)
     @Override
     public int getPriorityOperationExecutorQueueSize() {
         return operationExecutor.getPriorityOperationExecutorQueueSize();
@@ -239,7 +240,7 @@ public final class OperationServiceImpl implements InternalOperationService, Pac
         return operationExecutor;
     }
 
-    @Probe(name = "response-queue.size")
+    @Probe(name = "response-queue.size", level = MANDATORY)
     @Override
     public int getResponseQueueSize() {
         return responsePacketExecutor.getQueueSize();

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/ProxyServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/ProxyServiceImpl.java
@@ -50,6 +50,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 
 import static com.hazelcast.core.DistributedObjectEvent.EventType.CREATED;
+import static com.hazelcast.internal.metrics.ProbeLevel.MANDATORY;
 import static com.hazelcast.util.ConcurrencyUtil.getOrPutIfAbsent;
 import static com.hazelcast.util.FutureUtil.logAllExceptions;
 import static com.hazelcast.util.FutureUtil.waitWithDeadline;
@@ -81,9 +82,9 @@ public class ProxyServiceImpl
     private final ConcurrentMap<String, ProxyRegistry> registries =
             new ConcurrentHashMap<String, ProxyRegistry>();
 
-    @Probe(name = "createdCount")
+    @Probe(name = "createdCount", level = MANDATORY)
     private final MwCounter createdCounter = newMwCounter();
-    @Probe(name = "destroyedCount")
+    @Probe(name = "destroyedCount", level = MANDATORY)
     private final MwCounter destroyedCounter = newMwCounter();
 
     public ProxyServiceImpl(NodeEngineImpl nodeEngine) {

--- a/hazelcast/src/main/java/com/hazelcast/util/executor/ManagedExecutorService.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/executor/ManagedExecutorService.java
@@ -20,6 +20,8 @@ import com.hazelcast.internal.metrics.Probe;
 
 import java.util.concurrent.ExecutorService;
 
+import static com.hazelcast.internal.metrics.ProbeLevel.MANDATORY;
+
 public interface ManagedExecutorService extends ExecutorService {
 
     String getName();
@@ -33,7 +35,7 @@ public interface ManagedExecutorService extends ExecutorService {
     @Probe(name = "poolSize")
     int getPoolSize();
 
-    @Probe(name = "queueSize")
+    @Probe(name = "queueSize", level = MANDATORY)
     int getQueueSize();
 
     @Probe(name = "remainingQueueCapacity")

--- a/hazelcast/src/test/java/com/hazelcast/instance/GroupPropertiesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/GroupPropertiesTest.java
@@ -1,0 +1,56 @@
+package com.hazelcast.instance;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.internal.metrics.ProbeLevel;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category(QuickTest.class)
+public class GroupPropertiesTest {
+
+    @Test
+    public void getEnum_default() {
+        GroupProperties groupProperties = new GroupProperties(new Config());
+
+        ProbeLevel level = groupProperties.getEnum(GroupProperty.PERFORMANCE_METRICS_LEVEL, ProbeLevel.class);
+
+        assertEquals(ProbeLevel.MANDATORY, level);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void getEnum_nonExistingEnum() {
+        Config config = new Config();
+        config.setProperty(GroupProperty.PERFORMANCE_METRICS_LEVEL, "notexist");
+        GroupProperties groupProperties = new GroupProperties(config);
+        groupProperties.getEnum(GroupProperty.PERFORMANCE_METRICS_LEVEL, ProbeLevel.class);
+
+    }
+
+    @Test
+    public void getEnum() {
+        Config config = new Config();
+        config.setProperty(GroupProperty.PERFORMANCE_METRICS_LEVEL, ProbeLevel.DEBUG.toString());
+        GroupProperties groupProperties = new GroupProperties(config);
+
+        ProbeLevel level = groupProperties.getEnum(GroupProperty.PERFORMANCE_METRICS_LEVEL, ProbeLevel.class);
+
+        assertEquals(ProbeLevel.DEBUG, level);
+    }
+
+    @Test
+    public void getEnum_ignoredName() {
+        Config config = new Config();
+        config.setProperty(GroupProperty.PERFORMANCE_METRICS_LEVEL, "dEbUg");
+        GroupProperties groupProperties = new GroupProperties(config);
+
+        ProbeLevel level = groupProperties.getEnum(GroupProperty.PERFORMANCE_METRICS_LEVEL, ProbeLevel.class);
+
+        assertEquals(ProbeLevel.DEBUG, level);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/ProbeLevelTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/ProbeLevelTest.java
@@ -1,0 +1,33 @@
+package com.hazelcast.internal.metrics;
+
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static com.hazelcast.internal.metrics.ProbeLevel.DEBUG;
+import static com.hazelcast.internal.metrics.ProbeLevel.INFO;
+import static com.hazelcast.internal.metrics.ProbeLevel.MANDATORY;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category(QuickTest.class)
+public class ProbeLevelTest {
+
+    @Test
+    public void isEnabled() {
+        assertTrue(MANDATORY.isEnabled(MANDATORY));
+        assertTrue(MANDATORY.isEnabled(INFO));
+        assertTrue(MANDATORY.isEnabled(DEBUG));
+
+        assertFalse(INFO.isEnabled(MANDATORY));
+        assertTrue(INFO.isEnabled(INFO));
+        assertTrue(INFO.isEnabled(DEBUG));
+
+        assertFalse(DEBUG.isEnabled(MANDATORY));
+        assertFalse(DEBUG.isEnabled(INFO));
+        assertTrue(DEBUG.isEnabled(DEBUG));
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/DoubleGaugeImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/DoubleGaugeImplTest.java
@@ -4,6 +4,7 @@ import com.hazelcast.internal.metrics.DoubleGauge;
 import com.hazelcast.internal.metrics.DoubleProbeFunction;
 import com.hazelcast.internal.metrics.LongProbeFunction;
 import com.hazelcast.internal.metrics.Probe;
+import com.hazelcast.internal.metrics.ProbeLevel;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
@@ -12,6 +13,8 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import static com.hazelcast.internal.metrics.ProbeLevel.INFO;
+import static com.hazelcast.internal.metrics.ProbeLevel.MANDATORY;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastSerialClassRunner.class)
@@ -21,7 +24,7 @@ public class DoubleGaugeImplTest {
 
     @Before
     public void setup() {
-        metricsRegistry = new MetricsRegistryImpl(Logger.getLogger(MetricsRegistryImpl.class));
+        metricsRegistry = new MetricsRegistryImpl(Logger.getLogger(MetricsRegistryImpl.class), INFO);
     }
 
     class SomeObject {
@@ -44,12 +47,13 @@ public class DoubleGaugeImplTest {
 
     @Test
     public void whenProbeThrowsException() {
-        metricsRegistry.register(this, "foo", new DoubleProbeFunction() {
-            @Override
-            public double get(Object o) {
-                throw new RuntimeException();
-            }
-        });
+        metricsRegistry.register(this, "foo", MANDATORY,
+                new DoubleProbeFunction() {
+                    @Override
+                    public double get(Object o) {
+                        throw new RuntimeException();
+                    }
+                });
 
         DoubleGauge gauge = metricsRegistry.newDoubleGauge("foo");
 
@@ -60,12 +64,13 @@ public class DoubleGaugeImplTest {
 
     @Test
     public void whenDoubleProbe() {
-        metricsRegistry.register(this, "foo", new DoubleProbeFunction() {
-            @Override
-            public double get(Object o) {
-                return 10;
-            }
-        });
+        metricsRegistry.register(this, "foo", MANDATORY,
+                new DoubleProbeFunction() {
+                    @Override
+                    public double get(Object o) {
+                        return 10;
+                    }
+                });
         DoubleGauge gauge = metricsRegistry.newDoubleGauge("foo");
 
         double actual = gauge.read();
@@ -75,12 +80,13 @@ public class DoubleGaugeImplTest {
 
     @Test
     public void whenLongProbe() {
-        metricsRegistry.register(this, "foo", new LongProbeFunction() {
-            @Override
-            public long get(Object o) throws Exception {
-                return 10;
-            }
-        });
+        metricsRegistry.register(this, "foo", MANDATORY,
+                new LongProbeFunction() {
+                    @Override
+                    public long get(Object o) throws Exception {
+                        return 10;
+                    }
+                });
         DoubleGauge gauge = metricsRegistry.newDoubleGauge("foo");
 
         double actual = gauge.read();

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/LongGaugeImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/LongGaugeImplTest.java
@@ -12,6 +12,8 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import static com.hazelcast.internal.metrics.ProbeLevel.INFO;
+import static com.hazelcast.internal.metrics.ProbeLevel.MANDATORY;
 import static java.lang.Math.round;
 import static org.junit.Assert.assertEquals;
 
@@ -23,7 +25,7 @@ public class LongGaugeImplTest {
 
     @Before
     public void setup() {
-        metricsRegistry = new MetricsRegistryImpl(Logger.getLogger(MetricsRegistryImpl.class));
+        metricsRegistry = new MetricsRegistryImpl(Logger.getLogger(MetricsRegistryImpl.class), INFO);
     }
 
     class SomeObject {
@@ -55,12 +57,13 @@ public class LongGaugeImplTest {
 
     @Test
     public void whenDoubleProbe() {
-        metricsRegistry.register(this, "foo", new DoubleProbeFunction<LongGaugeImplTest>() {
-            @Override
-            public double get(LongGaugeImplTest source) throws Exception {
-                return 10;
-            }
-        });
+        metricsRegistry.register(this, "foo", MANDATORY,
+                new DoubleProbeFunction<LongGaugeImplTest>() {
+                    @Override
+                    public double get(LongGaugeImplTest source) throws Exception {
+                        return 10;
+                    }
+                });
 
         LongGauge gauge = metricsRegistry.newLongGauge("foo");
 
@@ -71,12 +74,13 @@ public class LongGaugeImplTest {
 
     @Test
     public void whenLongProbe() {
-        metricsRegistry.register(this, "foo", new LongProbeFunction() {
-            @Override
-            public long get(Object o) throws Exception {
-                return 10;
-            }
-        });
+        metricsRegistry.register(this, "foo", MANDATORY,
+                new LongProbeFunction() {
+                    @Override
+                    public long get(Object o) throws Exception {
+                        return 10;
+                    }
+                });
 
         LongGauge gauge = metricsRegistry.newLongGauge("foo");
         assertEquals(10, gauge.read());
@@ -84,12 +88,13 @@ public class LongGaugeImplTest {
 
     @Test
     public void whenProbeThrowsException() {
-        metricsRegistry.register(this, "foo", new LongProbeFunction() {
-            @Override
-            public long get(Object o) {
-                throw new RuntimeException();
-            }
-        });
+        metricsRegistry.register(this, "foo", MANDATORY,
+                new LongProbeFunction() {
+                    @Override
+                    public long get(Object o) {
+                        throw new RuntimeException();
+                    }
+                });
 
         LongGauge gauge = metricsRegistry.newLongGauge("foo");
 
@@ -117,24 +122,26 @@ public class LongGaugeImplTest {
     }
 
     @Test
-    public void whenReregister(){
-        metricsRegistry.register(this, "foo", new LongProbeFunction() {
-            @Override
-            public long get(Object o) throws Exception {
-                return 10;
-            }
-        });
+    public void whenReregister() {
+        metricsRegistry.register(this, "foo", MANDATORY,
+                new LongProbeFunction() {
+                    @Override
+                    public long get(Object o) throws Exception {
+                        return 10;
+                    }
+                });
 
         LongGauge gauge = metricsRegistry.newLongGauge("foo");
 
         gauge.read();
 
-        metricsRegistry.register(this, "foo", new LongProbeFunction() {
-            @Override
-            public long get(Object o) throws Exception {
-                return 11;
-            }
-        });
+        metricsRegistry.register(this, "foo", MANDATORY,
+                new LongProbeFunction() {
+                    @Override
+                    public long get(Object o) throws Exception {
+                        return 11;
+                    }
+                });
 
         assertEquals(11, gauge.read());
     }

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/MetricsRegistryImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/MetricsRegistryImplTest.java
@@ -1,6 +1,7 @@
 package com.hazelcast.internal.metrics.impl;
 
 import com.hazelcast.internal.metrics.LongProbeFunction;
+import com.hazelcast.internal.metrics.ProbeLevel;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
@@ -13,6 +14,7 @@ import org.junit.runner.RunWith;
 import java.util.HashSet;
 import java.util.Set;
 
+import static com.hazelcast.internal.metrics.ProbeLevel.INFO;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
@@ -26,18 +28,19 @@ public class MetricsRegistryImplTest extends HazelcastTestSupport {
 
     @Before
     public void setup() {
-        metricsRegistry = new MetricsRegistryImpl(Logger.getLogger(MetricsRegistryImpl.class));
+        metricsRegistry = new MetricsRegistryImpl(Logger.getLogger(MetricsRegistryImpl.class), INFO);
     }
 
     @Test
     public void modCount() {
         long modCount = metricsRegistry.modCount();
-        metricsRegistry.register(this, "foo", new LongProbeFunction() {
-            @Override
-            public long get(Object obj) throws Exception {
-                return 1;
-            }
-        });
+        metricsRegistry.register(this, "foo", ProbeLevel.MANDATORY,
+                new LongProbeFunction() {
+                    @Override
+                    public long get(Object obj) throws Exception {
+                        return 1;
+                    }
+                });
         assertEquals(modCount + 1, metricsRegistry.modCount());
 
         metricsRegistry.deregister(this);
@@ -78,12 +81,13 @@ public class MetricsRegistryImplTest extends HazelcastTestSupport {
         expected.add("third");
 
         for (String name : expected) {
-            metricsRegistry.register(this, name, new LongProbeFunction() {
-                @Override
-                public long get(Object obj) throws Exception {
-                    return 0;
-                }
-            });
+            metricsRegistry.register(this, name, ProbeLevel.MANDATORY,
+                    new LongProbeFunction() {
+                        @Override
+                        public long get(Object obj) throws Exception {
+                            return 0;
+                        }
+                    });
         }
 
         Set<String> names = metricsRegistry.getNames();

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/ProbeLevelTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/ProbeLevelTest.java
@@ -1,0 +1,74 @@
+package com.hazelcast.internal.metrics.impl;
+
+import com.hazelcast.internal.metrics.LongProbeFunction;
+import com.hazelcast.internal.metrics.ProbeLevel;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static com.hazelcast.internal.metrics.ProbeLevel.DEBUG;
+import static com.hazelcast.internal.metrics.ProbeLevel.INFO;
+import static com.hazelcast.internal.metrics.ProbeLevel.MANDATORY;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class ProbeLevelTest {
+
+    private ILogger logger;
+
+    @Before
+    public void setup() {
+        logger = Logger.getLogger(MetricsRegistryImpl.class);
+    }
+
+    @Test
+    public void test() {
+        assertProbeExist(MANDATORY, MANDATORY);
+        assertNotProbeExist(INFO, MANDATORY);
+        assertNotProbeExist(DEBUG, MANDATORY);
+
+        assertProbeExist(MANDATORY, INFO);
+        assertProbeExist(INFO, INFO);
+        assertNotProbeExist(DEBUG, INFO);
+
+        assertProbeExist(MANDATORY, DEBUG);
+        assertProbeExist(INFO, DEBUG);
+        assertProbeExist(DEBUG, DEBUG);
+    }
+
+    public void assertProbeExist(ProbeLevel probeLevel, ProbeLevel minimumLevel) {
+        MetricsRegistryImpl metricsRegistry = new MetricsRegistryImpl(logger, minimumLevel);
+
+        metricsRegistry.register(this, "foo", probeLevel, new LongProbeFunction<ProbeLevelTest>() {
+            @Override
+            public long get(ProbeLevelTest source) throws Exception {
+                return 10;
+            }
+        });
+
+        assertTrue(metricsRegistry.getNames().contains("foo"));
+        assertEquals(10, metricsRegistry.newLongGauge("foo").read());
+    }
+
+    public void assertNotProbeExist(ProbeLevel probeLevel, ProbeLevel minimumLevel) {
+        MetricsRegistryImpl metricsRegistry = new MetricsRegistryImpl(logger, minimumLevel);
+
+        metricsRegistry.register(this, "foo", probeLevel, new LongProbeFunction<ProbeLevelTest>() {
+            @Override
+            public long get(ProbeLevelTest source) throws Exception {
+                return 10;
+            }
+        });
+
+        assertFalse(metricsRegistry.getNames().contains("foo"));
+        assertEquals(0, metricsRegistry.newLongGauge("foo").read());
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/RegisterAnnotatedFieldsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/RegisterAnnotatedFieldsTest.java
@@ -16,6 +16,7 @@ import org.junit.runner.RunWith;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static com.hazelcast.internal.metrics.ProbeLevel.INFO;
 import static com.hazelcast.util.counters.SwCounter.newSwCounter;
 import static org.junit.Assert.assertEquals;
 
@@ -27,7 +28,7 @@ public class RegisterAnnotatedFieldsTest extends HazelcastTestSupport {
 
     @Before
     public void setup() {
-        metricsRegistry = new MetricsRegistryImpl(Logger.getLogger(MetricsRegistryImpl.class));
+        metricsRegistry = new MetricsRegistryImpl(Logger.getLogger(MetricsRegistryImpl.class), INFO);
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/RegisterAnnotatedMethodsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/RegisterAnnotatedMethodsTest.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
+import static com.hazelcast.internal.metrics.ProbeLevel.INFO;
 import static com.hazelcast.util.counters.SwCounter.newSwCounter;
 import static org.junit.Assert.assertEquals;
 
@@ -34,7 +35,7 @@ public class RegisterAnnotatedMethodsTest extends HazelcastTestSupport {
 
     @Before
     public void setup() {
-        metricsRegistry = new MetricsRegistryImpl(Logger.getLogger(MetricsRegistryImpl.class));
+        metricsRegistry = new MetricsRegistryImpl(Logger.getLogger(MetricsRegistryImpl.class), INFO);
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/RegisterMetricTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/RegisterMetricTest.java
@@ -16,6 +16,7 @@ import java.io.OutputStream;
 import java.util.LinkedList;
 import java.util.Set;
 
+import static com.hazelcast.internal.metrics.ProbeLevel.INFO;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
@@ -27,7 +28,7 @@ public class RegisterMetricTest extends HazelcastTestSupport {
 
     @Before
     public void setup() {
-        metricsRegistry = new MetricsRegistryImpl(Logger.getLogger(MetricsRegistryImpl.class));
+        metricsRegistry = new MetricsRegistryImpl(Logger.getLogger(MetricsRegistryImpl.class), INFO);
     }
 
     @Test(expected = NullPointerException.class)

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/RenderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/RenderTest.java
@@ -2,6 +2,7 @@ package com.hazelcast.internal.metrics.impl;
 
 import com.hazelcast.internal.metrics.DoubleProbeFunction;
 import com.hazelcast.internal.metrics.LongProbeFunction;
+import com.hazelcast.internal.metrics.ProbeLevel;
 import com.hazelcast.internal.metrics.renderers.ProbeRenderer;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.test.ExpectedRuntimeException;
@@ -26,7 +27,7 @@ public class RenderTest {
 
     @Before
     public void setup() {
-        metricsRegistry = new MetricsRegistryImpl(Logger.getLogger(MetricsRegistryImpl.class));
+        metricsRegistry = new MetricsRegistryImpl(Logger.getLogger(MetricsRegistryImpl.class), ProbeLevel.INFO);
 
         for (String name : metricsRegistry.getNames()) {
             ProbeInstance probeInstance = metricsRegistry.getProbeInstance(name);
@@ -37,22 +38,24 @@ public class RenderTest {
     }
 
     private void registerLongMetric(String name, final int value) {
-        metricsRegistry.register(this, name, new LongProbeFunction<RenderTest>() {
-            @Override
-            public long get(RenderTest source) throws Exception {
-                return value;
-            }
-        });
+        metricsRegistry.register(this, name, ProbeLevel.INFO,
+                new LongProbeFunction<RenderTest>() {
+                    @Override
+                    public long get(RenderTest source) throws Exception {
+                        return value;
+                    }
+                });
     }
 
 
     private void registerDoubleMetric(String name, final int value) {
-        metricsRegistry.register(this, name, new DoubleProbeFunction<RenderTest>() {
-            @Override
-            public double get(RenderTest source) throws Exception {
-                return value;
-            }
-        });
+        metricsRegistry.register(this, name, ProbeLevel.INFO,
+                new DoubleProbeFunction<RenderTest>() {
+                    @Override
+                    public double get(RenderTest source) throws Exception {
+                        return value;
+                    }
+                });
     }
 
     @Test(expected = NullPointerException.class)
@@ -98,12 +101,13 @@ public class RenderTest {
 
         final ExpectedRuntimeException ex = new ExpectedRuntimeException();
 
-        metricsRegistry.register(this, "foo", new LongProbeFunction<RenderTest>() {
-            @Override
-            public long get(RenderTest source) throws Exception {
-                throw ex;
-            }
-        });
+        metricsRegistry.register(this, "foo", ProbeLevel.MANDATORY,
+                new LongProbeFunction<RenderTest>() {
+                    @Override
+                    public long get(RenderTest source) throws Exception {
+                        throw ex;
+                    }
+                });
 
         metricsRegistry.render(renderer);
 
@@ -128,7 +132,7 @@ public class RenderTest {
     public void getSortedProbes_whenNoChange() {
         SortedProbesInstances instances1 = metricsRegistry.getSortedProbeInstances();
 
-         SortedProbesInstances instances2 = metricsRegistry.getSortedProbeInstances();
+        SortedProbesInstances instances2 = metricsRegistry.getSortedProbeInstances();
 
         assertSame(instances1, instances2);
     }

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/metricsets/ClassLoadingMetricSetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/metricsets/ClassLoadingMetricSetTest.java
@@ -15,6 +15,7 @@ import org.junit.runner.RunWith;
 import java.lang.management.ClassLoadingMXBean;
 import java.lang.management.ManagementFactory;
 
+import static com.hazelcast.internal.metrics.ProbeLevel.INFO;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastSerialClassRunner.class)
@@ -23,11 +24,11 @@ public class ClassLoadingMetricSetTest extends HazelcastTestSupport {
 
     private static final ClassLoadingMXBean BEAN = ManagementFactory.getClassLoadingMXBean();
 
-    private MetricsRegistryImpl blackbox;
+    private MetricsRegistryImpl metricsRegistry;
 
     @Before
     public void setup() {
-        blackbox = new MetricsRegistryImpl(Logger.getLogger(MetricsRegistryImpl.class));
+        metricsRegistry = new MetricsRegistryImpl(Logger.getLogger(MetricsRegistryImpl.class), INFO);
     }
 
     @Test
@@ -37,7 +38,7 @@ public class ClassLoadingMetricSetTest extends HazelcastTestSupport {
 
     @Test
     public void loadedClassesCount() {
-        final LongGauge gauge = blackbox.newLongGauge("classloading.loadedClassesCount");
+        final LongGauge gauge = metricsRegistry.newLongGauge("classloading.loadedClassesCount");
 
         assertTrueEventually(new AssertTask() {
             @Override
@@ -49,7 +50,7 @@ public class ClassLoadingMetricSetTest extends HazelcastTestSupport {
 
     @Test
     public void totalLoadedClassesCount() {
-        final LongGauge gauge = blackbox.newLongGauge("classloading.totalLoadedClassesCount");
+        final LongGauge gauge = metricsRegistry.newLongGauge("classloading.totalLoadedClassesCount");
 
         assertTrueEventually(new AssertTask() {
             @Override
@@ -61,7 +62,7 @@ public class ClassLoadingMetricSetTest extends HazelcastTestSupport {
 
     @Test
     public void unloadedClassCount() {
-        final LongGauge gauge = blackbox.newLongGauge("classloading.unloadedClassCount");
+        final LongGauge gauge = metricsRegistry.newLongGauge("classloading.unloadedClassCount");
 
         assertTrueEventually(new AssertTask() {
             @Override

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/metricsets/GarbageCollectionMetricSetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/metricsets/GarbageCollectionMetricSetTest.java
@@ -12,6 +12,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import static com.hazelcast.internal.metrics.ProbeLevel.INFO;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.Assert.assertEquals;
 
@@ -19,12 +20,12 @@ import static org.junit.Assert.assertEquals;
 @Category(QuickTest.class)
 public class GarbageCollectionMetricSetTest extends HazelcastTestSupport {
 
-    private MetricsRegistryImpl blackbox;
+    private MetricsRegistryImpl metricsRegistry;
     private GarbageCollectionMetricSet.GcStats gcStats;
 
     @Before
     public void setup() {
-        blackbox = new MetricsRegistryImpl(Logger.getLogger(MetricsRegistryImpl.class));
+        metricsRegistry = new MetricsRegistryImpl(Logger.getLogger(MetricsRegistryImpl.class), INFO);
         gcStats = new GarbageCollectionMetricSet.GcStats();
     }
 
@@ -35,7 +36,7 @@ public class GarbageCollectionMetricSetTest extends HazelcastTestSupport {
 
     @Test
     public void minorCount() {
-        final LongGauge gauge = blackbox.newLongGauge("gc.minorCount");
+        final LongGauge gauge = metricsRegistry.newLongGauge("gc.minorCount");
         assertTrueEventually(new AssertTask() {
             @Override
             public void run() throws Exception {
@@ -47,7 +48,7 @@ public class GarbageCollectionMetricSetTest extends HazelcastTestSupport {
 
     @Test
     public void minorTime() throws InterruptedException {
-        final LongGauge gauge = blackbox.newLongGauge("gc.minorTime");
+        final LongGauge gauge = metricsRegistry.newLongGauge("gc.minorTime");
          assertTrueEventually(new AssertTask() {
             @Override
             public void run() throws Exception {
@@ -59,7 +60,7 @@ public class GarbageCollectionMetricSetTest extends HazelcastTestSupport {
 
     @Test
     public void majorCount() {
-        final LongGauge gauge = blackbox.newLongGauge("gc.majorCount");
+        final LongGauge gauge = metricsRegistry.newLongGauge("gc.majorCount");
         assertTrueEventually(new AssertTask() {
             @Override
             public void run() throws Exception {
@@ -71,7 +72,7 @@ public class GarbageCollectionMetricSetTest extends HazelcastTestSupport {
 
     @Test
     public void majorTime() {
-        final LongGauge gauge = blackbox.newLongGauge("gc.majorTime");
+        final LongGauge gauge = metricsRegistry.newLongGauge("gc.majorTime");
         assertTrueEventually(new AssertTask() {
             @Override
             public void run() throws Exception {
@@ -84,7 +85,7 @@ public class GarbageCollectionMetricSetTest extends HazelcastTestSupport {
 
     @Test
     public void unknownCount() {
-        final LongGauge gauge = blackbox.newLongGauge("gc.unknownCount");
+        final LongGauge gauge = metricsRegistry.newLongGauge("gc.unknownCount");
         assertTrueEventually(new AssertTask() {
             @Override
             public void run() throws Exception {
@@ -96,7 +97,7 @@ public class GarbageCollectionMetricSetTest extends HazelcastTestSupport {
 
     @Test
     public void unknownTime() {
-        final LongGauge gauge = blackbox.newLongGauge("gc.unknownTime");
+        final LongGauge gauge = metricsRegistry.newLongGauge("gc.unknownTime");
         assertTrueEventually(new AssertTask() {
             @Override
             public void run() throws Exception {

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/metricsets/OperatingSystemMetricSetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/metricsets/OperatingSystemMetricSetTest.java
@@ -2,6 +2,7 @@ package com.hazelcast.internal.metrics.metricsets;
 
 import com.hazelcast.internal.metrics.DoubleGauge;
 import com.hazelcast.internal.metrics.LongGauge;
+import com.hazelcast.internal.metrics.ProbeLevel;
 import com.hazelcast.internal.metrics.impl.MetricsRegistryImpl;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.test.HazelcastSerialClassRunner;
@@ -15,6 +16,7 @@ import org.junit.runner.RunWith;
 import java.lang.management.ManagementFactory;
 import java.lang.management.OperatingSystemMXBean;
 
+import static com.hazelcast.internal.metrics.ProbeLevel.INFO;
 import static com.hazelcast.internal.metrics.metricsets.OperatingSystemMetricsSet.registerMethod;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -27,11 +29,11 @@ import static org.junit.Assume.assumeTrue;
 @Category(QuickTest.class)
 public class OperatingSystemMetricSetTest extends HazelcastTestSupport {
 
-    private MetricsRegistryImpl blackbox;
+    private MetricsRegistryImpl metricsRegistry;
 
     @Before
     public void setup() {
-        blackbox = new MetricsRegistryImpl(Logger.getLogger(MetricsRegistryImpl.class));
+        metricsRegistry = new MetricsRegistryImpl(Logger.getLogger(MetricsRegistryImpl.class), INFO);
     }
 
     @Test
@@ -79,7 +81,7 @@ public class OperatingSystemMetricSetTest extends HazelcastTestSupport {
     }
 
     private void assertContainsSensor(String parameter) {
-        boolean contains = blackbox.getNames().contains(parameter);
+        boolean contains = metricsRegistry.getNames().contains(parameter);
         assertTrue("sensor:" + parameter + " is not found", contains);
     }
 
@@ -94,31 +96,31 @@ public class OperatingSystemMetricSetTest extends HazelcastTestSupport {
     @Test
     public void registerMethod_whenDouble() {
         FakeOperatingSystemBean fakeOperatingSystemBean = new FakeOperatingSystemBean();
-        registerMethod(blackbox, fakeOperatingSystemBean, "doubleMethod", "doubleMethod");
+        registerMethod(metricsRegistry, fakeOperatingSystemBean, "doubleMethod", "doubleMethod");
 
-        DoubleGauge gauge = blackbox.newDoubleGauge("doubleMethod");
+        DoubleGauge gauge = metricsRegistry.newDoubleGauge("doubleMethod");
         assertEquals(fakeOperatingSystemBean.doubleMethod(), gauge.read(), 0.1);
     }
 
     @Test
     public void registerMethod_whenLong() {
-        blackbox = new MetricsRegistryImpl(Logger.getLogger(MetricsRegistryImpl.class));
+        metricsRegistry = new MetricsRegistryImpl(Logger.getLogger(MetricsRegistryImpl.class), INFO);
 
         FakeOperatingSystemBean fakeOperatingSystemBean = new FakeOperatingSystemBean();
-        registerMethod(blackbox, fakeOperatingSystemBean, "longMethod", "longMethod");
+        registerMethod(metricsRegistry, fakeOperatingSystemBean, "longMethod", "longMethod");
 
-        LongGauge gauge = blackbox.newLongGauge("longMethod");
+        LongGauge gauge = metricsRegistry.newLongGauge("longMethod");
         assertEquals(fakeOperatingSystemBean.longMethod(), gauge.read());
     }
 
     @Test
     public void registerMethod_whenNotExist() {
-        blackbox = new MetricsRegistryImpl(Logger.getLogger(MetricsRegistryImpl.class));
+        metricsRegistry = new MetricsRegistryImpl(Logger.getLogger(MetricsRegistryImpl.class), INFO);
 
         FakeOperatingSystemBean fakeOperatingSystemBean = new FakeOperatingSystemBean();
-        registerMethod(blackbox, fakeOperatingSystemBean, "notexist", "notexist");
+        registerMethod(metricsRegistry, fakeOperatingSystemBean, "notexist", "notexist");
 
-        boolean parameterExist = blackbox.getNames().contains("notexist");
+        boolean parameterExist = metricsRegistry.getNames().contains("notexist");
         assertFalse(parameterExist);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/metricsets/RuntimeMetricSetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/metricsets/RuntimeMetricSetTest.java
@@ -1,6 +1,7 @@
 package com.hazelcast.internal.metrics.metricsets;
 
 import com.hazelcast.internal.metrics.LongGauge;
+import com.hazelcast.internal.metrics.ProbeLevel;
 import com.hazelcast.internal.metrics.impl.MetricsRegistryImpl;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.test.AssertTask;
@@ -23,23 +24,23 @@ public class RuntimeMetricSetTest extends HazelcastTestSupport {
 
     private final static int TEN_MB = 10 * 1024 * 1024;
 
-    private MetricsRegistryImpl blackbox;
+    private MetricsRegistryImpl metricsRegistry;
     private Runtime runtime;
 
     @Before
     public void setup() {
-        blackbox = new MetricsRegistryImpl(Logger.getLogger(MetricsRegistryImpl.class));
+        metricsRegistry = new MetricsRegistryImpl(Logger.getLogger(MetricsRegistryImpl.class), ProbeLevel.INFO);
         runtime = Runtime.getRuntime();
     }
 
     @Test
-    public void utilityConstructor(){
+    public void utilityConstructor() {
         assertUtilityConstructor(RuntimeMetricSet.class);
     }
 
     @Test
     public void freeMemory() {
-        final LongGauge gauge = blackbox.newLongGauge("runtime.freeMemory");
+        final LongGauge gauge = metricsRegistry.newLongGauge("runtime.freeMemory");
 
         assertTrueEventually(new AssertTask() {
             @Override
@@ -51,7 +52,7 @@ public class RuntimeMetricSetTest extends HazelcastTestSupport {
 
     @Test
     public void totalMemory() {
-        final LongGauge gauge = blackbox.newLongGauge("runtime.totalMemory");
+        final LongGauge gauge = metricsRegistry.newLongGauge("runtime.totalMemory");
         assertTrueEventually(new AssertTask() {
             @Override
             public void run() throws Exception {
@@ -62,7 +63,7 @@ public class RuntimeMetricSetTest extends HazelcastTestSupport {
 
     @Test
     public void maxMemory() {
-        final LongGauge gauge = blackbox.newLongGauge("runtime.maxMemory");
+        final LongGauge gauge = metricsRegistry.newLongGauge("runtime.maxMemory");
 
         assertTrueEventually(new AssertTask() {
             @Override
@@ -74,7 +75,7 @@ public class RuntimeMetricSetTest extends HazelcastTestSupport {
 
     @Test
     public void usedMemory() {
-        final LongGauge gauge = blackbox.newLongGauge("runtime.usedMemory");
+        final LongGauge gauge = metricsRegistry.newLongGauge("runtime.usedMemory");
 
         assertTrueEventually(new AssertTask() {
             @Override
@@ -87,13 +88,13 @@ public class RuntimeMetricSetTest extends HazelcastTestSupport {
 
     @Test
     public void availableProcessors() {
-        LongGauge gauge = blackbox.newLongGauge("runtime.availableProcessors");
+        LongGauge gauge = metricsRegistry.newLongGauge("runtime.availableProcessors");
         assertEquals(runtime.availableProcessors(), gauge.read());
     }
 
     @Test
     public void uptime() {
-        final LongGauge gauge = blackbox.newLongGauge("runtime.uptime");
+        final LongGauge gauge = metricsRegistry.newLongGauge("runtime.uptime");
         assertTrueEventually(new AssertTask() {
             @Override
             public void run() throws Exception {

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/metricsets/ThreadMetricSetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/metricsets/ThreadMetricSetTest.java
@@ -15,6 +15,7 @@ import org.junit.runner.RunWith;
 import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadMXBean;
 
+import static com.hazelcast.internal.metrics.ProbeLevel.INFO;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastSerialClassRunner.class)
@@ -23,11 +24,11 @@ public class ThreadMetricSetTest extends HazelcastTestSupport {
 
     private static final ThreadMXBean MX_BEAN = ManagementFactory.getThreadMXBean();
 
-    private MetricsRegistryImpl blackbox;
+    private MetricsRegistryImpl metricsRegistry;
 
     @Before
     public void setup() {
-        blackbox = new MetricsRegistryImpl(Logger.getLogger(MetricsRegistryImpl.class));
+        metricsRegistry = new MetricsRegistryImpl(Logger.getLogger(MetricsRegistryImpl.class), INFO);
     }
 
     @Test
@@ -37,7 +38,7 @@ public class ThreadMetricSetTest extends HazelcastTestSupport {
 
     @Test
     public void threadCount() {
-        final LongGauge gauge = blackbox.newLongGauge("thread.threadCount");
+        final LongGauge gauge = metricsRegistry.newLongGauge("thread.threadCount");
 
         assertTrueEventually(new AssertTask() {
             @Override
@@ -49,7 +50,7 @@ public class ThreadMetricSetTest extends HazelcastTestSupport {
 
     @Test
     public void peakThreadCount() {
-        final LongGauge gauge = blackbox.newLongGauge("thread.peakThreadCount");
+        final LongGauge gauge = metricsRegistry.newLongGauge("thread.peakThreadCount");
 
         assertTrueEventually(new AssertTask() {
             @Override
@@ -61,7 +62,7 @@ public class ThreadMetricSetTest extends HazelcastTestSupport {
 
     @Test
     public void daemonThreadCount() {
-        final LongGauge gauge = blackbox.newLongGauge("thread.daemonThreadCount");
+        final LongGauge gauge = metricsRegistry.newLongGauge("thread.daemonThreadCount");
 
         assertTrueEventually(new AssertTask() {
             @Override
@@ -73,7 +74,7 @@ public class ThreadMetricSetTest extends HazelcastTestSupport {
 
     @Test
     public void totalStartedThreadCount() {
-        final LongGauge gauge = blackbox.newLongGauge("thread.totalStartedThreadCount");
+        final LongGauge gauge = metricsRegistry.newLongGauge("thread.totalStartedThreadCount");
 
         assertTrueEventually(new AssertTask() {
             @Override

--- a/hazelcast/src/test/java/com/hazelcast/internal/monitors/HealthMonitorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/monitors/HealthMonitorTest.java
@@ -14,6 +14,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import static com.hazelcast.internal.metrics.ProbeLevel.MANDATORY;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -38,12 +39,13 @@ public class HealthMonitorTest extends HazelcastTestSupport {
     }
 
     private void registerMetric(Metric metric, final int value) {
-        metricsRegistry.register(this, metric.getName(), new DoubleProbeFunction<HealthMonitorTest>() {
-            @Override
-            public double get(HealthMonitorTest source) throws Exception {
-                return value;
-            }
-        });
+        metricsRegistry.register(this, metric.getName(), MANDATORY,
+                new DoubleProbeFunction<HealthMonitorTest>() {
+                    @Override
+                    public double get(HealthMonitorTest source) throws Exception {
+                        return value;
+                    }
+                });
     }
 
     @Test
@@ -92,13 +94,13 @@ public class HealthMonitorTest extends HazelcastTestSupport {
     public void render() {
         String s = metrics.render();
 
-        assertContains(s,"processors=");
+        assertContains(s, "processors=");
 
         //8, physical.memory.total= 9.8G, physical.memory.free=704.0M, swap.space.total=18.6G, swap.space.free=18.6G, heap.memory.used=26.3M, heap.memory.free=96.7M, heap.memory.total=123.0M, heap.memory.max=910.5M, heap.memory.used/total=0.00%, heap.memory.used/max=0.00%, minor.gc.count=0, minor.gc.time=0ms, major.gc.count=0, major.gc.time=0ms, os.processCpuLoad=0.33%, os.systemCpuLoad=1.00%, os.systemLoadAverage=34.00%, thread.count=31, thread.peakCount=31, cluster.timeDiff=9223372036854775807, event.q.size=0, executor.q.async.size=0, executor.q.client.size=0, executor.q.query.size=0, executor.q.scheduled.size=0, executor.q.io.size=0, executor.q.system.size=0, executor.q.mapLoad.size=0, executor.q.mapLoadAllKeys.size=0, executor.q.cluster.size=0, operations.completed.count=0, operations.executor.q.size=0, operations.executor.priority.q.size=0, operations.response.q.size=0, operations.running.count=0, operations.pending.invocations.percentage=0.00%, operations.pending.invocations.count=0, proxy.count=0, clientEndpoint.count=0, connection.active.count=0, client.connection.count=0, connection.count=0
         //System.out.println(s);
     }
 
-    private void assertContains(String s, String expected){
+    private void assertContains(String s, String expected) {
         boolean contains = s.contains(expected);
         assertTrue(contains);
     }

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/TcpIpConnection_AbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/TcpIpConnection_AbstractTest.java
@@ -1,6 +1,7 @@
 package com.hazelcast.nio.tcp;
 
 import com.hazelcast.instance.BuildInfoProvider;
+import com.hazelcast.internal.metrics.ProbeLevel;
 import com.hazelcast.internal.metrics.impl.MetricsRegistryImpl;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.LoggingServiceImpl;
@@ -17,6 +18,7 @@ import org.junit.Before;
 import java.net.SocketAddress;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static com.hazelcast.internal.metrics.ProbeLevel.INFO;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 
@@ -77,7 +79,7 @@ public abstract class TcpIpConnection_AbstractTest extends HazelcastTestSupport 
     }
 
     protected TcpIpConnectionManager newConnectionManager(int port) throws Exception {
-        MetricsRegistryImpl metricsRegistry = new MetricsRegistryImpl(loggingService.getLogger(MetricsRegistryImpl.class));
+        MetricsRegistryImpl metricsRegistry = new MetricsRegistryImpl(loggingService.getLogger(MetricsRegistryImpl.class), INFO);
         MockIOService ioService = new MockIOService(port);
 
         return new TcpIpConnectionManager(

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/classic/AbstractClassicOperationExecutorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/classic/AbstractClassicOperationExecutorTest.java
@@ -32,6 +32,7 @@ import java.io.IOException;
 import java.util.LinkedList;
 import java.util.List;
 
+import static com.hazelcast.internal.metrics.ProbeLevel.INFO;
 import static java.util.Collections.synchronizedList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -74,7 +75,7 @@ public abstract class AbstractClassicOperationExecutorTest extends HazelcastTest
         nodeExtension = new DefaultNodeExtension();
         handlerFactory = new DummyOperationRunnerFactory();
 
-        metricsRegistry = new MetricsRegistryImpl(Logger.getLogger(MetricsRegistry.class));
+        metricsRegistry = new MetricsRegistryImpl(Logger.getLogger(MetricsRegistry.class), INFO);
         responsePacketHandler = new DummyResponsePacketHandler();
     }
 


### PR DESCRIPTION
Added ProbeLevel to probes.

One can configure on each probe the probe level.

The Metricsregistry can be configured using a group property to have a minimum probe level (Mandatory by default). All probes that are registered with a too low probe level, are not being retained by the metrics registry. So you get some temporary litter, but the probe objects (especially strings) are not retained. 