### PR TITLE
`EvictionPolicy` of `EvictionConfig` can be `NONE` but JCache doesn't allow `NONE` for itself. 

### DIFF
--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastConfigBeanDefinitionParser.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastConfigBeanDefinitionParser.java
@@ -27,6 +27,8 @@ import com.hazelcast.config.CacheSimpleEntryListenerConfig;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.CredentialsFactoryConfig;
 import com.hazelcast.config.EntryListenerConfig;
+import com.hazelcast.config.EvictionConfig;
+import com.hazelcast.config.EvictionPolicy;
 import com.hazelcast.config.ExecutorConfig;
 import com.hazelcast.config.GroupConfig;
 import com.hazelcast.config.InMemoryFormat;
@@ -690,7 +692,12 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
             fillAttributeValues(node, cacheConfigBuilder);
             for (Node childNode : new IterableNodeList(node.getChildNodes(), Node.ELEMENT_NODE)) {
                 if ("eviction".equals(cleanNodeName(childNode))) {
-                    cacheConfigBuilder.addPropertyValue("evictionConfig", getEvictionConfig(childNode));
+                    EvictionConfig evictionConfig = getEvictionConfig(childNode);
+                    EvictionPolicy evictionPolicy = evictionConfig.getEvictionPolicy();
+                    if (evictionPolicy == null || evictionPolicy == EvictionPolicy.NONE) {
+                        throw new InvalidConfigurationException("Eviction policy of cache cannot be null or \"NONE\"");
+                    }
+                    cacheConfigBuilder.addPropertyValue("evictionConfig", evictionConfig);
                 } else if ("expiry-policy-factory".equals(cleanNodeName(childNode))) {
                     cacheConfigBuilder.addPropertyValue("expiryPolicyFactoryConfig", getExpiryPolicyFactoryConfig(childNode));
                 } else if ("cache-entry-listeners".equals(cleanNodeName(childNode))) {

--- a/hazelcast/src/main/java/com/hazelcast/config/EvictionConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/EvictionConfig.java
@@ -26,7 +26,6 @@ import com.hazelcast.nio.serialization.DataSerializable;
 import java.io.IOException;
 import java.io.Serializable;
 
-import static com.hazelcast.util.Preconditions.checkFalse;
 import static com.hazelcast.util.Preconditions.checkNotNull;
 import static com.hazelcast.util.Preconditions.checkPositive;
 
@@ -72,8 +71,8 @@ public class EvictionConfig
         if (maxSizePolicy != null) {
             this.maxSizePolicy = maxSizePolicy;
         }
-        // Eviction policy cannot be null or NONE
-        if (evictionPolicy != null && evictionPolicy != EvictionPolicy.NONE) {
+        // Eviction policy cannot be null
+        if (evictionPolicy != null) {
             this.evictionPolicy = evictionPolicy;
         }
     }
@@ -94,8 +93,8 @@ public class EvictionConfig
         if (config.maxSizePolicy != null) {
             this.maxSizePolicy = config.maxSizePolicy;
         }
-        // Eviction policy cannot be null or NONE
-        if (config.evictionPolicy != null && config.evictionPolicy != EvictionPolicy.NONE) {
+        // Eviction policy cannot be null
+        if (config.evictionPolicy != null) {
             this.evictionPolicy = config.evictionPolicy;
         }
     }
@@ -157,7 +156,6 @@ public class EvictionConfig
 
     public EvictionConfig setEvictionPolicy(EvictionPolicy evictionPolicy) {
         checkNotNull(evictionPolicy, "Eviction policy cannot be null !");
-        checkFalse(EvictionPolicy.NONE == evictionPolicy, "Eviction policy cannot be \"NONE\" !");
 
         this.evictionPolicy = evictionPolicy;
         return this;

--- a/hazelcast/src/test/java/com/hazelcast/config/InvalidConfigurationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/InvalidConfigurationTest.java
@@ -104,9 +104,9 @@ public class InvalidConfigurationTest {
         buildConfig("map-max-idle-seconds", "-1");
     }
 
-    @Test(expected = InvalidConfigurationException.class)
-    public void testWhenInvalid_MapEvictionPolicy() {
-        buildConfig("map-eviction-policy", "none");
+    @Test
+    public void testWhenValid_MapEvictionPolicy() {
+        buildConfig("map-eviction-policy", "NONE");
     }
 
     @Test(expected = InvalidConfigurationException.class)
@@ -295,6 +295,11 @@ public class InvalidConfigurationTest {
     @Test
     public void testWhenValid_CacheEvictionSize() {
         buildConfig("cache-eviction-size", "100");
+    }
+
+    @Test(expected = InvalidConfigurationException.class)
+    public void testWhenInvalid_CacheEvictionPolicy() {
+        buildConfig("cache-eviction-policy", "NONE");
     }
 
     String getDraftXml() {


### PR DESCRIPTION
Without this PR, `EvictionPolicy` of `EvictionConfig` cannot be `NONE` due to check in `EvictionConfig`. But in fact, non-allowed `NONE` value is specific to JCache and this check should not be handled in common place like `EvictionConfig` since this can be used by other data structures like `IMap`.

Fixes #5251