### PR TITLE
lock eviction scheduler changed to FOR_EACH from POSTPONE

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockServiceImpl.java
@@ -73,7 +73,7 @@ public final class LockServiceImpl implements InternalLockService, ManagedServic
                     ScheduledExecutorService scheduledExecutor =
                             nodeEngine.getExecutionService().getDefaultScheduledExecutor();
                     return EntryTaskSchedulerFactory
-                            .newScheduler(scheduledExecutor, entryProcessor, ScheduleType.POSTPONE);
+                            .newScheduler(scheduledExecutor, entryProcessor, ScheduleType.FOR_EACH);
                 }
             };
 

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/lock/LockBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/lock/LockBasicTest.java
@@ -301,6 +301,18 @@ public abstract class LockBasicTest extends HazelcastTestSupport {
 
     // ========================= lease time ==============================================
 
+    @Test
+    public void testLockLeaseTime_whenLockAcquiredTwice() {
+        lock.lock(1000, TimeUnit.MILLISECONDS);
+        lock.lock(1000, TimeUnit.MILLISECONDS);
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertFalse(lock.isLocked());
+            }
+        }, 5);
+    }
+
     @Test(expected = NullPointerException.class, timeout = 60000)
     public void testLockLeaseTime_whenNullTimeout() {
         lock.lock(1000, null);
@@ -349,6 +361,18 @@ public abstract class LockBasicTest extends HazelcastTestSupport {
     }
 
     // ========================= tryLock with lease time ==============================================
+
+    @Test
+    public void testTryLockLeaseTime_whenLockAcquiredTwice() throws InterruptedException {
+        lock.tryLock(1000, TimeUnit.MILLISECONDS, 1000, TimeUnit.MILLISECONDS);
+        lock.tryLock(1000, TimeUnit.MILLISECONDS, 1000, TimeUnit.MILLISECONDS);
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertFalse(lock.isLocked());
+            }
+        }, 5);
+    }
 
     @Test(expected = NullPointerException.class, timeout = 60000)
     public void testTryLockLeaseTime_whenNullTimeout() throws InterruptedException {


### PR DESCRIPTION
When a lock is locked twice with a lease time, we don't schedule a new `LockEvictionProcessor` but postpone it. Since we use `version` while evicting the lock the postponed processor will not be able to evict the lock. 

This issue manifested itself with a simulator run, please see for more info https://github.com/hazelcast/hazelcast/issues/6141

fixes #6141