### PR TITLE
[BACK-PORT] lock eviction scheduler changed to FOR_EACH from POSTPONE

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockServiceImpl.java
@@ -68,7 +68,7 @@ public final class LockServiceImpl implements LockService, ManagedService, Remot
                     ScheduledExecutorService scheduledExecutor =
                             nodeEngine.getExecutionService().getDefaultScheduledExecutor();
                     return EntryTaskSchedulerFactory
-                            .newScheduler(scheduledExecutor, entryProcessor, ScheduleType.POSTPONE);
+                            .newScheduler(scheduledExecutor, entryProcessor, ScheduleType.FOR_EACH);
                 }
             };
 

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/lock/LockBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/lock/LockBasicTest.java
@@ -300,6 +300,18 @@ public abstract class LockBasicTest extends HazelcastTestSupport {
 
     // ========================= lease time ==============================================
 
+    @Test
+    public void testLockLeaseTime_whenLockAcquiredTwice() {
+        lock.lock(1000, TimeUnit.MILLISECONDS);
+        lock.lock(1000, TimeUnit.MILLISECONDS);
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertFalse(lock.isLocked());
+            }
+        }, 5);
+    }
+
     @Test(expected = NullPointerException.class, timeout = 60000)
     public void testLockLeaseTime_whenNullTimeout() {
         lock.lock(1000, null);


### PR DESCRIPTION
back-port of https://github.com/hazelcast/hazelcast/pull/6146

fixes #6141