### PR TITLE
Adding missing client cache tests

### DIFF
--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/HazelcastClientNotActiveException.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/HazelcastClientNotActiveException.java
@@ -5,10 +5,6 @@ package com.hazelcast.client;
  */
 public class HazelcastClientNotActiveException extends IllegalStateException {
 
-    public HazelcastClientNotActiveException() {
-        super("Hazelcast client is not active!");
-    }
-
     public HazelcastClientNotActiveException(String message) {
         super(message);
     }

--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/cache/impl/AbstractClientInternalCacheProxy.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/cache/impl/AbstractClientInternalCacheProxy.java
@@ -491,6 +491,16 @@ abstract class AbstractClientInternalCacheProxy<K, V>
         return regs.remove(cacheEntryListenerConfiguration);
     }
 
+    protected String getListenerIdLocal(CacheEntryListenerConfiguration<K, V> cacheEntryListenerConfiguration) {
+        final ConcurrentMap<CacheEntryListenerConfiguration, String> regs;
+        if (cacheEntryListenerConfiguration.isSynchronous()) {
+            regs = syncListenerRegistrations;
+        } else {
+            regs = asyncListenerRegistrations;
+        }
+        return regs.get(cacheEntryListenerConfiguration);
+    }
+
     private void deregisterAllCacheEntryListener(Collection<String> listenerRegistrations) {
         ClientListenerService listenerService = clientContext.getListenerService();
 

--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/cache/impl/ClientCacheProxy.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/cache/impl/ClientCacheProxy.java
@@ -326,7 +326,7 @@ public class ClientCacheProxy<K, V>
         if (cacheEntryListenerConfiguration == null) {
             throw new NullPointerException("CacheEntryListenerConfiguration can't be null");
         }
-        final String regId = removeListenerLocally(cacheEntryListenerConfiguration);
+        final String regId = getListenerIdLocal(cacheEntryListenerConfiguration);
         if (regId == null) {
             return;
         }
@@ -345,11 +345,10 @@ public class ClientCacheProxy<K, V>
         });
 
         if (isDeregistered) {
+            removeListenerLocally(cacheEntryListenerConfiguration);
             cacheConfig.removeCacheEntryListenerConfiguration(cacheEntryListenerConfiguration);
             //REMOVE ON OTHERS TOO
             updateCacheListenerConfigOnOtherNodes(cacheEntryListenerConfiguration, false);
-        } else {
-            addListenerLocally(regId, cacheEntryListenerConfiguration);
         }
     }
 

--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/cache/impl/HazelcastClientCacheManager.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/cache/impl/HazelcastClientCacheManager.java
@@ -21,9 +21,7 @@ import com.hazelcast.cache.impl.AbstractHazelcastCacheManager;
 import com.hazelcast.cache.impl.CacheProxyUtil;
 import com.hazelcast.cache.impl.CacheService;
 import com.hazelcast.cache.impl.ICacheInternal;
-import com.hazelcast.cache.impl.nearcache.NearCacheManager;
 import com.hazelcast.client.impl.HazelcastClientInstanceImpl;
-import com.hazelcast.client.impl.HazelcastClientProxy;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.CacheCreateConfigCodec;
 import com.hazelcast.client.impl.protocol.codec.CacheGetConfigCodec;
@@ -209,21 +207,6 @@ public final class HazelcastClientCacheManager
     protected void postClose() {
         if (properties.getProperty(HazelcastCachingProvider.HAZELCAST_CONFIG_LOCATION) != null) {
             hazelcastInstance.shutdown();
-        }
-    }
-
-    public NearCacheManager getNearCacheManager() {
-        if (hazelcastInstance instanceof HazelcastClientInstanceImpl) {
-            return ((HazelcastClientInstanceImpl) hazelcastInstance).getNearCacheManager();
-        } else if (hazelcastInstance instanceof HazelcastClientProxy) {
-            HazelcastClientInstanceImpl clientInstance = ((HazelcastClientProxy) hazelcastInstance).client;
-            if (clientInstance != null) {
-                return clientInstance.getNearCacheManager();
-            } else {
-                return null;
-            }
-        } else {
-            return null;
         }
     }
 

--- a/hazelcast-client-new/src/test/java/com/hazelcast/client/cache/CacheBasicClientTest.java
+++ b/hazelcast-client-new/src/test/java/com/hazelcast/client/cache/CacheBasicClientTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.cache;
+
+import com.hazelcast.cache.CacheBasicAbstractTest;
+import com.hazelcast.client.cache.impl.HazelcastClientCachingProvider;
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import javax.cache.spi.CachingProvider;
+
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category(QuickTest.class)
+public class CacheBasicClientTest extends CacheBasicAbstractTest {
+
+    private TestHazelcastFactory factory = new TestHazelcastFactory();
+
+    @Override
+    protected void onSetup() {
+        factory.newHazelcastInstance();
+    }
+
+    @Override
+    protected void onTearDown() {
+        factory.terminateAll();
+    }
+
+    @Override
+    protected CachingProvider getCachingProvider() {
+        return HazelcastClientCachingProvider.createCachingProvider(getHazelcastInstance());
+    }
+
+    @Override
+    protected HazelcastInstance getHazelcastInstance() {
+        return factory.newHazelcastClient();
+    }
+
+}
+

--- a/hazelcast-client-new/src/test/java/com/hazelcast/client/cache/ClientCacheIteratorTest.java
+++ b/hazelcast-client-new/src/test/java/com/hazelcast/client/cache/ClientCacheIteratorTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.cache;
+
+import com.hazelcast.cache.CacheIteratorAbstractTest;
+import com.hazelcast.client.cache.impl.HazelcastClientCachingProvider;
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import javax.cache.spi.CachingProvider;
+
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category(QuickTest.class)
+public class ClientCacheIteratorTest extends CacheIteratorAbstractTest {
+
+    private TestHazelcastFactory factory = new TestHazelcastFactory();
+
+    @Override
+    protected CachingProvider createCachingProvider() {
+        factory.newHazelcastInstance();
+        HazelcastInstance hazelcastInstance = factory.newHazelcastClient();
+        return HazelcastClientCachingProvider.createCachingProvider(hazelcastInstance);
+    }
+
+
+    @After
+    public void tear() {
+        factory.shutdownAll();
+    }
+
+}
+

--- a/hazelcast-client-new/src/test/java/com/hazelcast/client/cache/nearcache/ClientNearCacheTest.java
+++ b/hazelcast-client-new/src/test/java/com/hazelcast/client/cache/nearcache/ClientNearCacheTest.java
@@ -77,4 +77,9 @@ public class ClientNearCacheTest extends ClientNearCacheTestSupport {
         putToCacheAndClearOrDestroyThenCantGetAnyRecordFromClientNearCache(InMemoryFormat.OBJECT);
     }
 
+    @Test
+    public void testGetAllReturnsFromNearCache() {
+        doTestGetAllReturnsFromNearCache();
+    }
+
 }

--- a/hazelcast-client-new/src/test/java/com/hazelcast/client/cache/nearcache/ClientNearCacheTestSupport.java
+++ b/hazelcast-client-new/src/test/java/com/hazelcast/client/cache/nearcache/ClientNearCacheTestSupport.java
@@ -35,7 +35,6 @@ import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.SerializationService;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastTestSupport;
-
 import org.junit.After;
 import org.junit.Before;
 
@@ -43,6 +42,7 @@ import javax.cache.spi.CachingProvider;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 public abstract class ClientNearCacheTestSupport {
 
@@ -80,14 +80,14 @@ public abstract class ClientNearCacheTestSupport {
 
     protected CacheConfig createCacheConfig(InMemoryFormat inMemoryFormat) {
         return new CacheConfig()
-                        .setName(DEFAULT_CACHE_NAME)
-                        .setInMemoryFormat(inMemoryFormat);
+                .setName(DEFAULT_CACHE_NAME)
+                .setInMemoryFormat(inMemoryFormat);
     }
 
     protected NearCacheConfig createNearCacheConfig(InMemoryFormat inMemoryFormat) {
         return new NearCacheConfig()
-                        .setName(DEFAULT_CACHE_NAME)
-                        .setInMemoryFormat(inMemoryFormat);
+                .setName(DEFAULT_CACHE_NAME)
+                .setInMemoryFormat(inMemoryFormat);
     }
 
     protected class NearCacheTestContext {
@@ -154,7 +154,7 @@ public abstract class ClientNearCacheTestSupport {
 
         for (int i = 0; i < DEFAULT_RECORD_COUNT; i++) {
             assertNull(nearCacheTestContext.nearCache.get(
-                            nearCacheTestContext.serializationService.toData(i)));
+                    nearCacheTestContext.serializationService.toData(i)));
         }
 
         for (int i = 0; i < DEFAULT_RECORD_COUNT; i++) {
@@ -186,8 +186,8 @@ public abstract class ClientNearCacheTestSupport {
 
         for (int i = 0; i < DEFAULT_RECORD_COUNT; i++) {
             assertEquals(generateValueFromKey(i),
-                         nearCacheTestContext.nearCache.get(
-                                nearCacheTestContext.serializationService.toData(i)));
+                    nearCacheTestContext.nearCache.get(
+                            nearCacheTestContext.serializationService.toData(i)));
         }
 
         nearCacheTestContext.close();
@@ -354,6 +354,30 @@ public abstract class ClientNearCacheTestSupport {
 
         nearCacheTestContext1.close();
         nearCacheTestContext2.close();
+    }
+
+    protected void doTestGetAllReturnsFromNearCache() {
+        NearCacheConfig nearCacheConfig = createNearCacheConfig(InMemoryFormat.OBJECT);
+        final NearCacheTestContext nearCacheTestContext =
+                createNearCacheTestAndFillWithData(DEFAULT_CACHE_NAME, nearCacheConfig);
+
+        for (int i = 0; i < DEFAULT_RECORD_COUNT; i++) {
+            assertNull(nearCacheTestContext.nearCache.get(
+                    nearCacheTestContext.serializationService.toData(i)));
+        }
+
+        for (int i = 0; i < DEFAULT_RECORD_COUNT; i++) {
+            // Get records so they will be stored in near-cache
+            nearCacheTestContext.cache.get(i);
+        }
+
+        for (int i = 0; i < DEFAULT_RECORD_COUNT; i++) {
+            final Data keyData = nearCacheTestContext.serializationService.toData(i);
+            //check if same reference to verify data coming from near cache
+            assertTrue(nearCacheTestContext.cache.get(i) == nearCacheTestContext.nearCache.get(keyData));
+        }
+
+        nearCacheTestContext.close();
     }
 
 }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/AbstractClientCacheProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/AbstractClientCacheProxy.java
@@ -218,11 +218,8 @@ abstract class AbstractClientCacheProxy<K, V>
             keySet.add(k);
         }
         Map<K, V> result = getAllFromNearCache(keySet);
-        if (keySet.isEmpty()) {
-            return result;
-        }
         final CacheGetAllRequest request = new CacheGetAllRequest(nameWithPrefix, keySet, expiryPolicy);
-        final MapEntrySet mapEntrySet = toObject(invoke(request));
+        final MapEntrySet mapEntrySet = invoke(request);
         final Set<Map.Entry<Data, Data>> entrySet = mapEntrySet.getEntrySet();
         for (Map.Entry<Data, Data> dataEntry : entrySet) {
             final Data keyData = dataEntry.getKey();
@@ -265,7 +262,7 @@ abstract class AbstractClientCacheProxy<K, V>
     public V getAndPut(K key, V value, ExpiryPolicy expiryPolicy) {
         final ICompletableFuture<V> f = putAsyncInternal(key, value, expiryPolicy, true, true);
         try {
-            return toObject(f.get());
+            return f.get();
         } catch (Throwable e) {
             throw ExceptionUtil.rethrowAllowedTypeFirst(e, CacheException.class);
         }
@@ -285,7 +282,7 @@ abstract class AbstractClientCacheProxy<K, V>
     public boolean putIfAbsent(K key, V value, ExpiryPolicy expiryPolicy) {
         final Future<Boolean> f = putIfAbsentAsyncInternal(key, value, expiryPolicy, true);
         try {
-            return (Boolean) toObject(f.get());
+            return f.get();
         } catch (Throwable e) {
             throw ExceptionUtil.rethrowAllowedTypeFirst(e, CacheException.class);
         }
@@ -295,7 +292,7 @@ abstract class AbstractClientCacheProxy<K, V>
     public boolean replace(K key, V oldValue, V newValue, ExpiryPolicy expiryPolicy) {
         final Future<Boolean> f = replaceAsyncInternal(key, oldValue, newValue, expiryPolicy, true, false, true);
         try {
-            return (Boolean) toObject(f.get());
+            return f.get();
         } catch (Throwable e) {
             throw ExceptionUtil.rethrowAllowedTypeFirst(e, CacheException.class);
         }
@@ -305,7 +302,7 @@ abstract class AbstractClientCacheProxy<K, V>
     public boolean replace(K key, V value, ExpiryPolicy expiryPolicy) {
         final Future<Boolean> f = replaceAsyncInternal(key, null, value, expiryPolicy, false, false, true);
         try {
-            return (Boolean) toObject(f.get());
+            return f.get();
         } catch (Throwable e) {
             throw ExceptionUtil.rethrowAllowedTypeFirst(e, CacheException.class);
         }
@@ -315,7 +312,7 @@ abstract class AbstractClientCacheProxy<K, V>
     public V getAndReplace(K key, V value, ExpiryPolicy expiryPolicy) {
         final Future<V> f = replaceAsyncInternal(key, null, value, expiryPolicy, false, true, true);
         try {
-            return toObject(f.get());
+            return f.get();
         } catch (Throwable e) {
             throw ExceptionUtil.rethrowAllowedTypeFirst(e, CacheException.class);
         }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/AbstractClientInternalCacheProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/AbstractClientInternalCacheProxy.java
@@ -46,6 +46,7 @@ import com.hazelcast.client.spi.ClientContext;
 import com.hazelcast.client.spi.ClientExecutionService;
 import com.hazelcast.client.spi.EventHandler;
 import com.hazelcast.client.spi.impl.ClientInvocation;
+import com.hazelcast.client.spi.impl.ClientInvocationFuture;
 import com.hazelcast.config.CacheConfig;
 import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.config.NearCacheConfig;
@@ -137,8 +138,8 @@ abstract class AbstractClientInternalCacheProxy<K, V>
             cacheOnUpdate = nearCacheConfig.getLocalUpdatePolicy() == NearCacheConfig.LocalUpdatePolicy.CACHE;
             NearCacheContext nearCacheContext =
                     new NearCacheContext(nearCacheManager,
-                                         clientContext.getSerializationService(),
-                                         createNearCacheExecutor(clientContext.getExecutionService()));
+                            clientContext.getSerializationService(),
+                            createNearCacheExecutor(clientContext.getExecutionService()));
             nearCache = nearCacheManager.getOrCreateNearCache(nameWithPrefix, nearCacheConfig, nearCacheContext);
             registerInvalidationListener();
         }
@@ -194,7 +195,8 @@ abstract class AbstractClientInternalCacheProxy<K, V>
             int partitionId = clientContext.getPartitionService().getPartitionId(keyData);
             HazelcastClientInstanceImpl client = (HazelcastClientInstanceImpl) clientContext.getHazelcastInstance();
             final ClientInvocation clientInvocation = new ClientInvocation(client, req, partitionId);
-            final ICompletableFuture<T> f = clientInvocation.invoke();
+            final ClientInvocationFuture<T> f = clientInvocation.invoke();
+            f.setResponseDeserialized(true);
             if (completionOperation) {
                 waitCompletionLatch(completionId, f);
             }
@@ -411,6 +413,16 @@ abstract class AbstractClientInternalCacheProxy<K, V>
             regs = asyncListenerRegistrations;
         }
         return regs.remove(cacheEntryListenerConfiguration);
+    }
+
+    protected String getListenerIdLocal(CacheEntryListenerConfiguration<K, V> cacheEntryListenerConfiguration) {
+        final ConcurrentMap<CacheEntryListenerConfiguration, String> regs;
+        if (cacheEntryListenerConfiguration.isSynchronous()) {
+            regs = syncListenerRegistrations;
+        } else {
+            regs = asyncListenerRegistrations;
+        }
+        return regs.get(cacheEntryListenerConfiguration);
     }
 
     private void deregisterAllCacheEntryListener(Collection<String> listenerRegistrations) {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/ClientCacheProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/ClientCacheProxy.java
@@ -38,6 +38,7 @@ import com.hazelcast.nio.Address;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.impl.SerializableCollection;
 import com.hazelcast.util.ExceptionUtil;
+import com.hazelcast.util.Preconditions;
 
 import javax.cache.CacheException;
 import javax.cache.CacheManager;
@@ -101,7 +102,7 @@ public class ClientCacheProxy<K, V>
         ICompletableFuture future;
         try {
             future = invoke(request, keyData, false);
-            return (Boolean) toObject(future.get());
+            return (Boolean) future.get();
         } catch (Exception e) {
             throw ExceptionUtil.rethrow(e);
         }
@@ -174,7 +175,7 @@ public class ClientCacheProxy<K, V>
     public V getAndRemove(K key) {
         final ICompletableFuture<V> f = removeAsyncInternal(key, null, false, true, true);
         try {
-            return toObject(f.get());
+            return f.get();
         } catch (Throwable e) {
             throw ExceptionUtil.rethrowAllowedTypeFirst(e, CacheException.class);
         }
@@ -234,9 +235,8 @@ public class ClientCacheProxy<K, V>
         final CacheEntryProcessorRequest request = new CacheEntryProcessorRequest(nameWithPrefix, keyData, entryProcessor,
                 cacheConfig.getInMemoryFormat(), arguments);
         try {
-            final ICompletableFuture<Data> f = invoke(request, keyData, true);
-            final Data data = getSafely(f);
-            return toObject(data);
+            final ICompletableFuture f = invoke(request, keyData, true);
+            return (T) getSafely(f);
         } catch (CacheException ce) {
             throw ce;
         } catch (Exception e) {
@@ -290,9 +290,7 @@ public class ClientCacheProxy<K, V>
     @Override
     public void registerCacheEntryListener(CacheEntryListenerConfiguration<K, V> cacheEntryListenerConfiguration) {
         ensureOpen();
-        if (cacheEntryListenerConfiguration == null) {
-            throw new NullPointerException("CacheEntryListenerConfiguration can't be null");
-        }
+        Preconditions.checkNotNull(cacheEntryListenerConfiguration, "CacheEntryListenerConfiguration can't be null");
         final CacheEventListenerAdaptor<K, V> adaptor = new CacheEventListenerAdaptor<K, V>(this, cacheEntryListenerConfiguration,
                 clientContext.getSerializationService());
         final EventHandler<Object> handler = createHandler(adaptor);
@@ -308,20 +306,16 @@ public class ClientCacheProxy<K, V>
 
     @Override
     public void deregisterCacheEntryListener(CacheEntryListenerConfiguration<K, V> cacheEntryListenerConfiguration) {
-        if (cacheEntryListenerConfiguration == null) {
-            throw new NullPointerException("CacheEntryListenerConfiguration can't be null");
-        }
-        final String regId = removeListenerLocally(cacheEntryListenerConfiguration);
+        Preconditions.checkNotNull(cacheEntryListenerConfiguration, "CacheEntryListenerConfiguration can't be null");
+        final String regId = getListenerIdLocal(cacheEntryListenerConfiguration);
         if (regId != null) {
             CacheRemoveEntryListenerRequest removeReq = new CacheRemoveEntryListenerRequest(nameWithPrefix, regId);
             boolean isDeregistered = clientContext.getListenerService().stopListening(removeReq, regId);
-
             if (isDeregistered) {
+                removeListenerLocally(cacheEntryListenerConfiguration);
                 cacheConfig.removeCacheEntryListenerConfiguration(cacheEntryListenerConfiguration);
                 //REMOVE ON OTHERS TOO
                 updateCacheListenerConfigOnOtherNodes(cacheEntryListenerConfiguration, false);
-            } else {
-                addListenerLocally(regId, cacheEntryListenerConfiguration);
             }
         }
     }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/HazelcastClientCacheManager.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/HazelcastClientCacheManager.java
@@ -24,9 +24,7 @@ import com.hazelcast.cache.impl.ICacheInternal;
 import com.hazelcast.cache.impl.client.CacheCreateConfigRequest;
 import com.hazelcast.cache.impl.client.CacheGetConfigRequest;
 import com.hazelcast.cache.impl.client.CacheManagementConfigRequest;
-import com.hazelcast.cache.impl.nearcache.NearCacheManager;
 import com.hazelcast.client.impl.HazelcastClientInstanceImpl;
-import com.hazelcast.client.impl.HazelcastClientProxy;
 import com.hazelcast.client.impl.client.ClientRequest;
 import com.hazelcast.client.spi.ClientContext;
 import com.hazelcast.client.spi.impl.ClientInvocation;
@@ -202,21 +200,6 @@ public final class HazelcastClientCacheManager extends AbstractHazelcastCacheMan
     protected void postClose() {
         if (properties.getProperty(HazelcastCachingProvider.HAZELCAST_CONFIG_LOCATION) != null) {
             hazelcastInstance.shutdown();
-        }
-    }
-
-    public NearCacheManager getNearCacheManager() {
-        if (hazelcastInstance instanceof HazelcastClientInstanceImpl) {
-            return ((HazelcastClientInstanceImpl) hazelcastInstance).getNearCacheManager();
-        } else if (hazelcastInstance instanceof HazelcastClientProxy) {
-            HazelcastClientInstanceImpl clientInstance = ((HazelcastClientProxy) hazelcastInstance).client;
-            if (clientInstance != null) {
-                return clientInstance.getNearCacheManager();
-            } else {
-                return null;
-            }
-        } else {
-            return null;
         }
     }
 

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/CacheBasicClientTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/CacheBasicClientTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.cache;
+
+import com.hazelcast.cache.CacheBasicAbstractTest;
+import com.hazelcast.client.cache.impl.HazelcastClientCachingProvider;
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import javax.cache.spi.CachingProvider;
+
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category(QuickTest.class)
+public class CacheBasicClientTest extends CacheBasicAbstractTest {
+
+    private TestHazelcastFactory factory = new TestHazelcastFactory();
+
+    @Override
+    protected HazelcastInstance getHazelcastInstance() {
+        return factory.newHazelcastClient();
+    }
+
+    @Override
+    protected void onSetup() {
+        factory.newHazelcastInstance();
+    }
+
+    @Override
+    protected void onTearDown() {
+        factory.terminateAll();
+    }
+
+    @Override
+    protected CachingProvider getCachingProvider() {
+        return HazelcastClientCachingProvider.createCachingProvider(getHazelcastInstance());
+    }
+
+}
+

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/ClientCacheIteratorTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/ClientCacheIteratorTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.cache;
+
+import com.hazelcast.cache.CacheIteratorAbstractTest;
+import com.hazelcast.client.cache.impl.HazelcastClientCachingProvider;
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import javax.cache.spi.CachingProvider;
+
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category(QuickTest.class)
+public class ClientCacheIteratorTest extends CacheIteratorAbstractTest {
+
+    private TestHazelcastFactory factory = new TestHazelcastFactory();
+
+    @Override
+    protected CachingProvider createCachingProvider() {
+        factory.newHazelcastInstance();
+        HazelcastInstance hazelcastInstance = factory.newHazelcastClient();
+        return HazelcastClientCachingProvider.createCachingProvider(hazelcastInstance);
+    }
+
+
+    @After
+    public void tear() {
+        factory.shutdownAll();
+    }
+
+}
+

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientNearCacheTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientNearCacheTest.java
@@ -79,4 +79,9 @@ public class ClientNearCacheTest extends ClientNearCacheTestSupport {
         putToCacheAndClearOrDestroyThenCantGetAnyRecordFromClientNearCache(InMemoryFormat.OBJECT);
     }
 
+    @Test
+    public void testGetAllReturnsFromNearCache() {
+        doTestGetAllReturnsFromNearCache();
+    }
+
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientNearCacheTestSupport.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientNearCacheTestSupport.java
@@ -35,7 +35,6 @@ import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.SerializationService;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastTestSupport;
-
 import org.junit.After;
 import org.junit.Before;
 
@@ -43,6 +42,7 @@ import javax.cache.spi.CachingProvider;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 public abstract class ClientNearCacheTestSupport {
 
@@ -354,6 +354,30 @@ public abstract class ClientNearCacheTestSupport {
 
         nearCacheTestContext1.close();
         nearCacheTestContext2.close();
+    }
+
+    protected void doTestGetAllReturnsFromNearCache() {
+        NearCacheConfig nearCacheConfig = createNearCacheConfig(InMemoryFormat.OBJECT);
+        final NearCacheTestContext nearCacheTestContext =
+                createNearCacheTestAndFillWithData(DEFAULT_CACHE_NAME, nearCacheConfig);
+
+        for (int i = 0; i < DEFAULT_RECORD_COUNT; i++) {
+            assertNull(nearCacheTestContext.nearCache.get(
+                    nearCacheTestContext.serializationService.toData(i)));
+        }
+
+        for (int i = 0; i < DEFAULT_RECORD_COUNT; i++) {
+            // Get records so they will be stored in near-cache
+            nearCacheTestContext.cache.get(i);
+        }
+
+        for (int i = 0; i < DEFAULT_RECORD_COUNT; i++) {
+            final Data keyData = nearCacheTestContext.serializationService.toData(i);
+            //check if same reference to verify data coming from near cache
+            assertTrue(nearCacheTestContext.cache.get(i) == nearCacheTestContext.nearCache.get(keyData));
+        }
+
+        nearCacheTestContext.close();
     }
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractInternalCacheProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractInternalCacheProxy.java
@@ -257,6 +257,16 @@ abstract class AbstractInternalCacheProxy<K, V>
         return regs.remove(cacheEntryListenerConfiguration);
     }
 
+    protected String getListenerIdLocal(CacheEntryListenerConfiguration<K, V> cacheEntryListenerConfiguration) {
+        final ConcurrentMap<CacheEntryListenerConfiguration, String> regs;
+        if (cacheEntryListenerConfiguration.isSynchronous()) {
+            regs = syncListenerRegistrations;
+        } else {
+            regs = asyncListenerRegistrations;
+        }
+        return regs.get(cacheEntryListenerConfiguration);
+    }
+
     private void deregisterAllCacheEntryListener(Collection<String> listenerRegistrations) {
         final ICacheService service = getService();
         for (String regId : listenerRegistrations) {

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheProxy.java
@@ -310,11 +310,10 @@ public class CacheProxy<K, V>
         checkNotNull(cacheEntryListenerConfiguration, "CacheEntryListenerConfiguration can't be null");
 
         final ICacheService service = getService();
-        final String regId = removeListenerLocally(cacheEntryListenerConfiguration);
+        final String regId = getListenerIdLocal(cacheEntryListenerConfiguration);
         if (regId != null) {
-            if (!service.deregisterListener(getDistributedObjectName(), regId)) {
-                addListenerLocally(regId, cacheEntryListenerConfiguration);
-            } else {
+            if (service.deregisterListener(getDistributedObjectName(), regId)) {
+                removeListenerLocally(cacheEntryListenerConfiguration);
                 cacheConfig.removeCacheEntryListenerConfiguration(cacheEntryListenerConfiguration);
                 //REMOVE ON OTHERS TOO
                 updateCacheListenerConfigOnOtherNodes(cacheEntryListenerConfiguration, false);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheEventDataCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/CacheEventDataCodec.java
@@ -32,7 +32,11 @@ public final class CacheEventDataCodec {
     public static CacheEventData decode(ClientMessage clientMessage) {
         int typeId = clientMessage.getInt();
         String name = clientMessage.getStringUtf8();
-        Data key = clientMessage.getData();
+        boolean key_isNull = clientMessage.getBoolean();
+        Data key = null;
+        if (!key_isNull) {
+            key = clientMessage.getData();
+        }
         boolean value_isNull = clientMessage.getBoolean();
         Data value = null;
         if (!value_isNull) {
@@ -51,7 +55,12 @@ public final class CacheEventDataCodec {
     public static void encode(CacheEventData cacheEventData, ClientMessage clientMessage) {
         clientMessage.set(cacheEventData.getCacheEventType().getType());
         clientMessage.set(cacheEventData.getName());
-        clientMessage.set(cacheEventData.getDataKey());
+        Data dataKey = cacheEventData.getDataKey();
+        boolean dataKey_isNull = dataKey == null;
+        clientMessage.set(dataKey_isNull);
+        if (!dataKey_isNull) {
+            clientMessage.set(dataKey);
+        }
 
         Data dataValue = cacheEventData.getDataValue();
         boolean dataValue_isNull = dataValue == null;
@@ -72,7 +81,12 @@ public final class CacheEventDataCodec {
     public static int calculateDataSize(CacheEventData cacheEventData) {
         int dataSize = Bits.INT_SIZE_IN_BYTES;
         dataSize += ParameterUtil.calculateStringDataSize(cacheEventData.getName());
-        dataSize += ParameterUtil.calculateDataSize(cacheEventData.getDataKey());
+        Data dataKey = cacheEventData.getDataKey();
+        if (dataKey == null) {
+            dataSize += Bits.BOOLEAN_SIZE_IN_BYTES;
+        } else {
+            dataSize += ParameterUtil.calculateDataSize(dataKey);
+        }
         Data dataValue = cacheEventData.getDataValue();
         if (dataValue == null) {
             dataSize += Bits.BOOLEAN_SIZE_IN_BYTES;

--- a/hazelcast/src/test/java/com/hazelcast/cache/CacheBasicAbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CacheBasicAbstractTest.java
@@ -1,0 +1,706 @@
+package com.hazelcast.cache;
+
+import com.hazelcast.cache.impl.CacheKeyIteratorResult;
+import com.hazelcast.config.CacheConfig;
+import com.hazelcast.core.ICompletableFuture;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.nio.serialization.DefaultSerializationServiceBuilder;
+import com.hazelcast.nio.serialization.SerializationService;
+import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.util.CacheConcurrentHashMap;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import javax.cache.Cache;
+import javax.cache.configuration.FactoryBuilder;
+import javax.cache.configuration.MutableCacheEntryListenerConfiguration;
+import javax.cache.configuration.MutableConfiguration;
+import javax.cache.expiry.Duration;
+import javax.cache.expiry.ExpiryPolicy;
+import javax.cache.expiry.ModifiedExpiryPolicy;
+import javax.cache.processor.EntryProcessor;
+import javax.cache.processor.EntryProcessorException;
+import javax.cache.processor.EntryProcessorResult;
+import javax.cache.processor.MutableEntry;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.LockSupport;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category(QuickTest.class)
+public abstract class CacheBasicAbstractTest extends CacheTestSupport {
+
+    @Test
+    public void testPutGetRemoveReplace() throws InterruptedException, ExecutionException {
+        ICache cache = createCache();
+
+        cache.put("key1", "value1");
+        assertEquals("value1", cache.get("key1"));
+
+        assertEquals("value1", cache.getAndPut("key1", "value2"));
+        assertEquals(1, cache.size());
+
+        assertTrue(cache.remove("key1"));
+
+        cache.put("key1", "value3");
+        assertFalse(cache.remove("key1", "xx"));
+        assertTrue(cache.remove("key1", "value3"));
+        assertNull(cache.get("key1"));
+
+        assertTrue(cache.putIfAbsent("key1", "value1"));
+        assertFalse(cache.putIfAbsent("key1", "value1"));
+        assertEquals("value1", cache.getAndRemove("key1"));
+        assertNull(cache.get("key1"));
+
+        cache.put("key1", "value1");
+        assertTrue(cache.containsKey("key1"));
+
+        assertFalse(cache.replace("key2", "value2"));
+        assertTrue(cache.replace("key1", "value2"));
+        assertEquals("value2", cache.get("key1"));
+
+        assertFalse(cache.replace("key1", "xx", "value3"));
+        assertTrue(cache.replace("key1", "value2", "value3"));
+        assertEquals("value3", cache.get("key1"));
+
+        assertEquals("value3", cache.getAndReplace("key1", "value4"));
+        assertEquals("value4", cache.get("key1"));
+    }
+
+    @Test
+    public void testAsyncGetPutRemove() throws InterruptedException, ExecutionException {
+        final ICache cache = createCache();
+        final String key = "key";
+        cache.put(key, "value1");
+        Future f = cache.getAsync(key);
+        assertEquals("value1", f.get());
+
+        cache.putAsync(key, "value2");
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertEquals("value2", cache.get(key));
+            }
+        });
+
+        f = cache.getAndPutAsync(key, "value3");
+        assertEquals("value2", f.get());
+        assertEquals("value3", cache.get(key));
+
+        f = cache.removeAsync("key2");
+        assertFalse((Boolean) f.get());
+        f = cache.removeAsync(key);
+        assertTrue((Boolean) f.get());
+
+        cache.put(key, "value4");
+        f = cache.getAndRemoveAsync("key2");
+        assertNull(f.get());
+        f = cache.getAndRemoveAsync(key);
+        assertEquals("value4", f.get());
+    }
+
+    @Test
+    public void testPutIfAbsentAsync_success() throws InterruptedException, ExecutionException {
+        ICache cache = createCache();
+        String key = randomString();
+        ICompletableFuture<Boolean> iCompletableFuture = cache.putIfAbsentAsync(key, randomString());
+        assertTrue(iCompletableFuture.get());
+    }
+
+    @Test
+    public void testPutIfAbsentAsync_fail() throws InterruptedException, ExecutionException {
+        ICache cache = createCache();
+        String key = randomString();
+        cache.put(key, randomString());
+        ICompletableFuture<Boolean> iCompletableFuture = cache.putIfAbsentAsync(key, randomString());
+        assertFalse(iCompletableFuture.get());
+    }
+
+    @Test
+    public void testPutIfAbsentAsync_withExpiryPolicy() throws InterruptedException, ExecutionException {
+        final ICache cache = createCache();
+        final String key = randomString();
+        HazelcastExpiryPolicy expiryPolicy = new HazelcastExpiryPolicy(1, 1, 1);
+        cache.putIfAbsentAsync(key, randomString(), expiryPolicy);
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertNull(cache.get(key));
+            }
+        });
+    }
+
+    @Test
+    public void testGetAndReplaceAsync() throws InterruptedException, ExecutionException {
+        ICache cache = createCache();
+        String key = randomString();
+        String oldValue = randomString();
+        String newValue = randomString();
+        cache.put(key, oldValue);
+
+        ICompletableFuture<String> iCompletableFuture = cache.getAndReplaceAsync(key, newValue);
+
+        assertEquals(iCompletableFuture.get(), oldValue);
+        assertEquals(cache.get(key), newValue);
+    }
+
+    @Test
+    public void testGetAll_withEmptySet() throws InterruptedException, ExecutionException {
+        ICache cache = createCache();
+        Map map = cache.getAll(Collections.emptySet());
+        assertEquals(0, map.size());
+    }
+
+    @Test
+    public void testClear() {
+        ICache cache = createCache();
+        for (int i = 0; i < 10; i++) {
+            cache.put("key" + i, "value" + i);
+        }
+        cache.clear();
+        assertEquals(0, cache.size());
+    }
+
+    @Test
+    public void testRemoveAll() {
+        ICache cache = createCache();
+        for (int i = 0; i < 10; i++) {
+            cache.put("key" + i, "value" + i);
+        }
+        cache.removeAll();
+        assertEquals(0, cache.size());
+    }
+
+    protected ExpiryPolicy ttlToExpiryPolicy(long ttl, TimeUnit timeUnit) {
+        return new ModifiedExpiryPolicy(new Duration(timeUnit, ttl));
+    }
+
+    @Test
+    public void testPutWithTtl() throws ExecutionException, InterruptedException {
+        final ICache cache = createCache();
+        final String key = "key";
+        cache.put(key, "value1", ttlToExpiryPolicy(1, TimeUnit.SECONDS));
+
+        assertTrueEventually(new AssertTask() {
+            public void run() throws Exception {
+                assertNull(cache.get(key));
+            }
+        });
+        assertEquals(0, cache.size());
+
+        cache.putAsync(key, "value1", ttlToExpiryPolicy(1, TimeUnit.SECONDS));
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertNull(cache.get(key));
+            }
+        });
+        assertEquals(0, cache.size());
+
+        cache.put(key, "value2");
+        Object o = cache.getAndPut(key, "value3", ttlToExpiryPolicy(1, TimeUnit.SECONDS));
+        assertEquals("value2", o);
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertNull(cache.get(key));
+            }
+        });
+        assertEquals(0, cache.size());
+
+        cache.put(key, "value4");
+        Future f = cache.getAndPutAsync(key, "value5", ttlToExpiryPolicy(1, TimeUnit.SECONDS));
+        assertEquals("value4", f.get());
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertNull(cache.get(key));
+            }
+        });
+        assertEquals(0, cache.size());
+    }
+
+    @Test
+    public void testIterator() {
+        ICache cache = createCache();
+        int size = 1111;
+        int multiplier = 11;
+        for (int i = 0; i < size; i++) {
+            cache.put(i, i * multiplier);
+        }
+
+        int[] keys = new int[size];
+        int k = 0;
+        Iterator<Cache.Entry<Integer, Integer>> iter = cache.iterator();
+        while (iter.hasNext()) {
+            Cache.Entry<Integer, Integer> e = iter.next();
+            int key = e.getKey();
+            int value = e.getValue();
+            assertEquals(key * multiplier, value);
+            keys[k++] = key;
+        }
+        assertEquals(size, k);
+
+        Arrays.sort(keys);
+        for (int i = 0; i < size; i++) {
+            assertEquals(i, keys[i]);
+        }
+    }
+
+    @Test
+    public void testIteratorRemove() {
+        ICache cache = createCache();
+        int size = 1111;
+        for (int i = 0; i < size; i++) {
+            cache.put(i, i);
+        }
+
+        Iterator<Cache.Entry<Integer, Integer>> iter = cache.iterator();
+        while (iter.hasNext()) {
+            iter.next();
+            iter.remove();
+        }
+        assertEquals(0, cache.size());
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testIteratorIllegalRemove() {
+        ICache cache = createCache();
+        int size = 10;
+        for (int i = 0; i < size; i++) {
+            cache.put(i, i);
+        }
+
+        Iterator<Cache.Entry<Integer, Integer>> iter = cache.iterator();
+        if (iter.hasNext()) {
+            iter.remove();
+        }
+    }
+
+    @Test
+    public void testIteratorDuringInsertion() throws InterruptedException {
+        final AtomicBoolean stop = new AtomicBoolean(false);
+        final ICache cache = createCache();
+        int size = 1111;
+        for (int i = 0; i < size; i++) {
+            cache.put(i, i);
+        }
+
+        final Thread thread = new Thread() {
+            public void run() {
+                Random rand = new Random();
+                while (!stop.get()) {
+                    int i = rand.nextInt();
+                    try {
+                        cache.put(i, i);
+                        LockSupport.parkNanos(1);
+                    } catch (Throwable ignored) {
+                    }
+                }
+            }
+        };
+        thread.start();
+
+        // Give chance to thread for starting
+        sleepSeconds(1);
+
+        try {
+            int k = 0;
+            Iterator<Cache.Entry<Integer, Integer>> iter = cache.iterator();
+            while (iter.hasNext()) {
+                Cache.Entry<Integer, Integer> e = iter.next();
+                int key = e.getKey();
+                int value = e.getValue();
+                assertEquals(key, value);
+                k++;
+            }
+            assertTrue(k >= size);
+        } finally {
+            stop.set(true);
+            thread.join();
+        }
+    }
+
+    @Test
+    public void testIteratorDuringUpdate() throws InterruptedException {
+        final AtomicBoolean stop = new AtomicBoolean(false);
+        final ICache cache = createCache();
+        final int size = 1111;
+        for (int i = 0; i < size; i++) {
+            cache.put(i, i);
+        }
+
+        final Thread thread = new Thread() {
+            public void run() {
+                Random rand = new Random();
+                while (!stop.get()) {
+                    int i = rand.nextInt(size);
+                    try {
+                        cache.put(i, -i);
+                        LockSupport.parkNanos(1);
+                    } catch (Throwable ignored) {
+                    }
+                }
+            }
+        };
+        thread.start();
+
+        // Give chance to thread for starting
+        sleepSeconds(1);
+
+        try {
+            int k = 0;
+            Iterator<Cache.Entry<Integer, Integer>> iter = cache.iterator();
+            while (iter.hasNext()) {
+                Cache.Entry<Integer, Integer> e = iter.next();
+                int key = e.getKey();
+                int value = e.getValue();
+                assertTrue("Key: " + key + ", Value: " + value, key == Math.abs(value));
+                k++;
+            }
+            assertEquals(size, k);
+        } finally {
+            stop.set(true);
+            thread.join();
+        }
+    }
+
+    @Test
+    public void testIteratorDuringRemoval() throws InterruptedException {
+        final AtomicBoolean stop = new AtomicBoolean(false);
+        final ICache cache = createCache();
+        final int size = 2222;
+        for (int i = 0; i < size; i++) {
+            cache.put(i, i);
+        }
+
+        final Thread thread = new Thread() {
+            public void run() {
+                Random rand = new Random();
+                while (!stop.get()) {
+                    int i = rand.nextInt(size);
+                    try {
+                        cache.remove(i);
+                        LockSupport.parkNanos(1);
+                    } catch (Throwable ignored) {
+                    }
+                }
+            }
+        };
+        thread.start();
+
+        // Give chance to thread for starting
+        sleepSeconds(1);
+
+        try {
+            int k = 0;
+            Iterator<Cache.Entry<Integer, Integer>> iter = cache.iterator();
+            while (iter.hasNext()) {
+                Cache.Entry<Integer, Integer> e = iter.next();
+                int key = e.getKey();
+                Integer value = e.getValue();
+                if (value != null) {
+                    assertEquals(key, value.intValue());
+                }
+                k++;
+            }
+            assertTrue(k <= size);
+        } finally {
+            stop.set(true);
+            thread.join();
+        }
+    }
+
+
+    @Test
+    public void testRemoveAsync() throws ExecutionException, InterruptedException {
+        ICache cache = createCache();
+
+        String key = randomString();
+        String value = randomString();
+        cache.put(key, value);
+        ICompletableFuture<Boolean> future = cache.removeAsync(key);
+        assertTrue(future.get());
+    }
+
+    @Test
+    public void testRemoveAsyncWhenEntryNotFound() throws ExecutionException, InterruptedException {
+        ICache cache = createCache();
+        ICompletableFuture<Boolean> future = cache.removeAsync(randomString());
+        assertFalse(future.get());
+    }
+
+    @Test
+    public void testRemoveAsync_withOldValue() throws ExecutionException, InterruptedException {
+        ICache cache = createCache();
+
+        String key = randomString();
+        String value = randomString();
+        cache.put(key, value);
+        ICompletableFuture<Boolean> future = cache.removeAsync(key, value);
+        assertTrue(future.get());
+    }
+
+    @Test
+    public void testRemoveAsyncWhenEntryNotFound_withOldValue() throws ExecutionException, InterruptedException {
+        ICache cache = createCache();
+        ICompletableFuture<Boolean> future = cache.removeAsync(randomString(), randomString());
+        assertFalse(future.get());
+
+    }
+
+    @Test
+    public void testCompletionEvent() {
+        String cacheName = randomString();
+
+        CacheConfig config = createCacheConfig();
+        final CacheFromDifferentNodesTest.SimpleEntryListener<Integer, String> listener =
+                new CacheFromDifferentNodesTest.SimpleEntryListener<Integer, String>();
+        MutableCacheEntryListenerConfiguration<Integer, String> listenerConfiguration =
+                new MutableCacheEntryListenerConfiguration<Integer, String>(
+                        FactoryBuilder.factoryOf(listener), null, true, true);
+
+        config.addCacheEntryListenerConfiguration(listenerConfiguration);
+
+        Cache<Integer, String> cache = cacheManager.createCache(cacheName, config);
+
+        assertNotNull(cache);
+
+        Integer key1 = 1;
+        String value1 = "value1";
+        cache.put(key1, value1);
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertEquals(1, listener.created.get());
+            }
+        });
+
+        Integer key2 = 2;
+        String value2 = "value2";
+        cache.put(key2, value2);
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertEquals(2, listener.created.get());
+            }
+        });
+
+        Set<Integer> keys = new HashSet<Integer>();
+        keys.add(key1);
+        keys.add(key2);
+        cache.removeAll(keys);
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertEquals(2, listener.removed.get());
+            }
+        });
+    }
+
+    @Test
+    public void testJSRCreateDestroyCreate()
+            throws InterruptedException {
+        String cacheName = randomString();
+
+        assertNull(cacheManager.getCache(cacheName));
+
+        CacheConfig<Integer, String> config = new CacheConfig<Integer, String>();
+        Cache<Integer, String> cache = cacheManager.createCache(cacheName, config);
+        assertNotNull(cache);
+
+        Thread.sleep(1000);
+
+        Integer key = 1;
+        String value1 = "value";
+        cache.put(key, value1);
+
+        String value2 = cache.get(key);
+        assertEquals(value1, value2);
+        cache.remove(key);
+        assertNull(cache.get(key));
+
+        cacheManager.destroyCache(cacheName);
+        assertNull(cacheManager.getCache(cacheName));
+
+        Cache<Integer, String> cache1 = cacheManager.createCache(cacheName, config);
+        assertNotNull(cache1);
+    }
+
+    @Test
+    public void testCaches_NotEmpty() {
+
+        ArrayList<String> expected = new ArrayList<String>();
+        ArrayList<String> real = new ArrayList<String>();
+        cacheManager.createCache("c1", new MutableConfiguration());
+        cacheManager.createCache("c2", new MutableConfiguration());
+        cacheManager.createCache("c3", new MutableConfiguration());
+        expected.add(cacheManager.getCache("c1").getName());
+        expected.add(cacheManager.getCache("c2").getName());
+        expected.add(cacheManager.getCache("c3").getName());
+
+        Iterable<String> cacheNames = cacheManager.getCacheNames();
+        for (String cacheName : cacheNames) {
+            real.add(cacheName);
+        }
+        expected.removeAll(real);
+        assertTrue(expected.isEmpty());
+
+    }
+
+    @Test
+    public void testInitableIterator() {
+        int testSize = 3007;
+        SerializationService ss = new DefaultSerializationServiceBuilder().build();
+        for (int fetchSize = 1; fetchSize < 102; fetchSize++) {
+            CacheConcurrentHashMap<Data, String> cmap = new CacheConcurrentHashMap<Data, String>(1000);
+            for (int i = 0; i < testSize; i++) {
+                Integer key = i;
+                Data data = ss.toData(key);
+                String value1 = "value" + i;
+                cmap.put(data, value1);
+            }
+
+            int nti = Integer.MAX_VALUE;
+            int total = 0;
+            int remaining = testSize;
+            while (remaining > 0 && nti > 0) {
+                int fsize = remaining > fetchSize ? fetchSize : remaining;
+                CacheKeyIteratorResult iteratorResult = cmap.fetchNext(nti, fsize);
+                List<Data> keys = iteratorResult.getKeys();
+                nti = iteratorResult.getTableIndex();
+                remaining -= keys.size();
+                total += keys.size();
+            }
+            assertEquals(testSize, total);
+        }
+    }
+
+    @Test
+    public void testCachesTypedConfig() {
+
+        CacheConfig config = createCacheConfig();
+        String cacheName = randomString();
+        config.setName(cacheName);
+        config.setTypes(Integer.class, Long.class);
+
+        Cache<Integer, Long> cache = cacheManager.createCache(cacheName, config);
+        Cache<Integer, Long> cache2 =
+                cacheManager.getCache(cacheName, config.getKeyType(), config.getValueType());
+
+        assertNotNull(cache);
+        assertNotNull(cache2);
+    }
+
+    @Test
+    public void getAndOperateOnCacheAfterClose() {
+        String cacheName = randomString();
+        ICache cache = createCache(cacheName);
+        cache.close();
+        assertTrue(cache.isClosed());
+        assertFalse(cache.isDestroyed());
+
+        Cache<Object, Object> cacheAfterClose = cacheManager.getCache(cacheName);
+        assertNotNull(cacheAfterClose);
+        assertFalse(cacheAfterClose.isClosed());
+
+        cache.put(1, 1);
+    }
+
+    @Test
+    public void getButCantOperateOnCacheAfterDestroy() {
+        String cacheName = randomString();
+        ICache cache = createCache(cacheName);
+        cache.destroy();
+        assertTrue(cache.isClosed());
+        assertTrue(cache.isDestroyed());
+
+        Cache<Object, Object> cacheAfterClose = cacheManager.getCache(cacheName);
+        assertNotNull(cacheAfterClose);
+        assertTrue(cache.isClosed());
+        assertTrue(cache.isDestroyed());
+
+        try {
+            cache.put(1, 1);
+            fail("Since cache is destroyed, operation on cache must with failed with 'IllegalStateException'");
+        } catch (IllegalStateException e) {
+            // Expect this exception since cache is closed and destroyed
+        } catch (Throwable t) {
+            t.printStackTrace();
+            fail("Since cache is destroyed, operation on cache must with failed with 'IllegalStateException', " +
+                    "not with " + t.getMessage());
+        }
+    }
+
+    @Test
+    public void testEntryProcessor_invoke() throws ExecutionException, InterruptedException {
+        ICache cache = createCache();
+        String value = randomString();
+        String key = randomString();
+        String postFix = randomString();
+        cache.put(key, value);
+        String result = (String) cache.invoke(key, new AppendEntryProcessor(), postFix);
+        String expectedResult = value + postFix;
+        assertEquals(expectedResult, result);
+        assertEquals(expectedResult, cache.get(key));
+    }
+
+    @Test
+    public void testEntryProcessor_invokeAll() throws ExecutionException, InterruptedException {
+        ICache cache = createCache();
+        int entryCount = 10;
+        Map<String, String> localMap = new HashMap<String, String>();
+        for (int i = 0; i < entryCount; i++) {
+            localMap.put(randomString(), randomString());
+        }
+        cache.putAll(localMap);
+        String postFix = randomString();
+        Map<String, EntryProcessorResult<String>> resultMap = cache.invokeAll(localMap.keySet(), new AppendEntryProcessor(), postFix);
+        for (Map.Entry<String, String> localEntry : localMap.entrySet()) {
+            EntryProcessorResult<String> entryProcessorResult = resultMap.get(localEntry.getKey());
+            assertEquals(localEntry.getValue() + postFix, entryProcessorResult.get());
+            assertEquals(localEntry.getValue() + postFix, cache.get(localEntry.getKey()));
+        }
+    }
+
+    public static class AppendEntryProcessor
+            implements EntryProcessor<String, String, String>, Serializable {
+
+        private static final long serialVersionUID = -396575576353368113L;
+
+        @Override
+        public String process(MutableEntry<String, String> entry, Object... arguments)
+                throws EntryProcessorException {
+
+            String postFix = (String) arguments[0];
+            String value = entry.getValue();
+            String result = value + postFix;
+            entry.setValue(result);
+            return result;
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/cache/CacheBasicServerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CacheBasicServerTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.cache;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+
+public class CacheBasicServerTest extends CacheBasicAbstractTest {
+
+    TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+
+    @Override
+    protected void onSetup() {
+
+    }
+
+    @Override
+    protected void onTearDown() {
+        factory.terminateAll();
+    }
+
+    @Override
+    protected HazelcastInstance getHazelcastInstance() {
+        return factory.newHazelcastInstance(createConfig());
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/cache/CacheFromDifferentNodesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CacheFromDifferentNodesTest.java
@@ -1,0 +1,273 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.cache;
+
+import com.hazelcast.cache.impl.HazelcastServerCachingProvider;
+import com.hazelcast.config.CacheConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import javax.cache.Cache;
+import javax.cache.CacheManager;
+import javax.cache.configuration.FactoryBuilder;
+import javax.cache.configuration.MutableCacheEntryListenerConfiguration;
+import javax.cache.configuration.MutableConfiguration;
+import javax.cache.event.CacheEntryCreatedListener;
+import javax.cache.event.CacheEntryEvent;
+import javax.cache.event.CacheEntryExpiredListener;
+import javax.cache.event.CacheEntryListener;
+import javax.cache.event.CacheEntryListenerException;
+import javax.cache.event.CacheEntryRemovedListener;
+import javax.cache.event.CacheEntryUpdatedListener;
+import java.io.Serializable;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class CacheFromDifferentNodesTest
+        extends HazelcastTestSupport {
+
+    private TestHazelcastInstanceFactory factory;
+
+    private HazelcastServerCachingProvider cachingProvider1;
+    private HazelcastServerCachingProvider cachingProvider2;
+
+    @Before
+    public void init() {
+        factory = new TestHazelcastInstanceFactory(2);
+        HazelcastInstance hz1 = factory.newHazelcastInstance();
+        HazelcastInstance hz2 = factory.newHazelcastInstance();
+        cachingProvider1 = HazelcastServerCachingProvider.createCachingProvider(hz1);
+        cachingProvider2 = HazelcastServerCachingProvider.createCachingProvider(hz2);
+    }
+
+    @After
+    public void tear() {
+        cachingProvider1.close();
+        cachingProvider2.close();
+        factory.shutdownAll();
+    }
+
+    @Test
+    public void testJSRExample1()
+            throws InterruptedException {
+        final String cacheName = randomString();
+
+        CacheManager cacheManager = cachingProvider1.getCacheManager();
+        assertNotNull(cacheManager);
+
+        assertNull(cacheManager.getCache(cacheName));
+
+        CacheConfig<Integer, String> config = new CacheConfig<Integer, String>();
+        Cache<Integer, String> cache = cacheManager.createCache(cacheName, config);
+        assertNotNull(cache);
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                CacheManager cm2 = cachingProvider2.getCacheManager();
+                assertNotNull(cm2.getCache(cacheName));
+            }
+        });
+
+        Integer key = 1;
+        String value1 = "value";
+        cache.put(key, value1);
+
+        String value2 = cache.get(key);
+        assertEquals(value1, value2);
+        cache.remove(key);
+        assertNull(cache.get(key));
+
+        Cache<Integer, String> cache2 = cacheManager.getCache(cacheName);
+        assertNotNull(cache2);
+
+        key = 1;
+        value1 = "value";
+        cache.put(key, value1);
+
+        value2 = cache.get(key);
+        assertEquals(value1, value2);
+        cache.remove(key);
+        assertNull(cache.get(key));
+
+        cacheManager.destroyCache(cacheName);
+        cacheManager.close();
+    }
+
+
+    // Issue https://github.com/hazelcast/hazelcast/issues/5865
+    @Test
+    public void testCompletionTestByPuttingAndRemovingFromDifferentNodes()
+            throws InterruptedException {
+        String cacheName = "simpleCache";
+
+        CacheManager cacheManager1 = cachingProvider1.getCacheManager();
+        CacheManager cacheManager2 = cachingProvider2.getCacheManager();
+
+        CacheConfig<Integer, String> config = new CacheConfig<Integer, String>();
+        final SimpleEntryListener<Integer, String> listener = new SimpleEntryListener<Integer, String>();
+        MutableCacheEntryListenerConfiguration<Integer, String> listenerConfiguration =
+                new MutableCacheEntryListenerConfiguration<Integer, String>(
+                        FactoryBuilder.factoryOf(listener), null, true, true);
+
+        config.addCacheEntryListenerConfiguration(listenerConfiguration);
+
+        Cache<Integer, String> cache1 = cacheManager1.createCache(cacheName, config);
+        Cache<Integer, String> cache2 = cacheManager2.getCache(cacheName);
+
+        assertNotNull(cache1);
+        assertNotNull(cache2);
+
+        Integer key1 = 1;
+        String value1 = "value1";
+        cache1.put(key1, value1);
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertEquals(1, listener.created.get());
+            }
+        });
+
+        Integer key2 = 2;
+        String value2 = "value2";
+        cache1.put(key2, value2);
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertEquals(2, listener.created.get());
+            }
+        });
+
+        Set<Integer> keys = new HashSet<Integer>();
+        keys.add(key1);
+        keys.add(key2);
+        cache2.removeAll(keys);
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertEquals(2, listener.removed.get());
+            }
+        });
+    }
+
+    @Test
+    public void testCachesDestroy() {
+        CacheManager cacheManager = cachingProvider1.getCacheManager();
+        CacheManager cacheManager2 = cachingProvider2.getCacheManager();
+        MutableConfiguration configuration = new MutableConfiguration();
+        final Cache c1 = cacheManager.createCache("c1", configuration);
+        final Cache c2 = cacheManager2.getCache("c1");
+        c1.put("key", "value");
+        cacheManager.destroyCache("c1");
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                try {
+                    c2.get("key");
+                    throw new AssertionError("get should throw IllegalStateException");
+                } catch (IllegalStateException e) {
+                    //ignored as expected
+                }
+            }
+        });
+    }
+
+    @Test
+    public void testCachesDestroyFromOtherManagers() {
+        CacheManager cacheManager = cachingProvider1.getCacheManager();
+        CacheManager cacheManager2 = cachingProvider2.getCacheManager();
+        MutableConfiguration configuration = new MutableConfiguration();
+        final Cache c1 = cacheManager.createCache("c1", configuration);
+        final Cache c2 = cacheManager2.createCache("c2", configuration);
+        c1.put("key", "value");
+        c2.put("key", "value");
+        cacheManager.close();
+        assertTrueAllTheTime(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                c2.get("key");
+            }
+        }, 10);
+    }
+
+    public static class SimpleEntryListener<K, V>
+            implements CacheEntryListener<K, V>,
+            CacheEntryCreatedListener<K, V>,
+            CacheEntryUpdatedListener<K, V>,
+            CacheEntryRemovedListener<K, V>,
+            CacheEntryExpiredListener<K, V>,
+            Serializable {
+
+        public AtomicInteger created = new AtomicInteger();
+        public AtomicInteger expired = new AtomicInteger();
+        public AtomicInteger removed = new AtomicInteger();
+        public AtomicInteger updated = new AtomicInteger();
+
+        public SimpleEntryListener() {
+        }
+
+        @Override
+        public void onCreated(Iterable<CacheEntryEvent<? extends K, ? extends V>> cacheEntryEvents)
+                throws CacheEntryListenerException {
+            for (CacheEntryEvent<? extends K, ? extends V> cacheEntryEvent : cacheEntryEvents) {
+                created.incrementAndGet();
+            }
+        }
+
+        @Override
+        public void onExpired(Iterable<CacheEntryEvent<? extends K, ? extends V>> cacheEntryEvents)
+                throws CacheEntryListenerException {
+            for (CacheEntryEvent<? extends K, ? extends V> cacheEntryEvent : cacheEntryEvents) {
+                expired.incrementAndGet();
+            }
+        }
+
+        @Override
+        public void onRemoved(Iterable<CacheEntryEvent<? extends K, ? extends V>> cacheEntryEvents)
+                throws CacheEntryListenerException {
+            for (CacheEntryEvent<? extends K, ? extends V> cacheEntryEvent : cacheEntryEvents) {
+                removed.incrementAndGet();
+            }
+        }
+
+        @Override
+        public void onUpdated(Iterable<CacheEntryEvent<? extends K, ? extends V>> cacheEntryEvents)
+                throws CacheEntryListenerException {
+            for (CacheEntryEvent<? extends K, ? extends V> cacheEntryEvent : cacheEntryEvents) {
+                updated.incrementAndGet();
+            }
+        }
+    }
+
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/cache/CacheIteratorAbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CacheIteratorAbstractTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.cache;
+
+import com.hazelcast.config.CacheConfig;
+import com.hazelcast.test.HazelcastTestSupport;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.cache.Cache;
+import javax.cache.CacheManager;
+import javax.cache.spi.CachingProvider;
+import java.util.Arrays;
+import java.util.Iterator;
+
+import static org.junit.Assert.assertEquals;
+
+public abstract class CacheIteratorAbstractTest extends HazelcastTestSupport {
+
+    private CachingProvider cachingProvider;
+
+    @Before
+    public void init() {
+        cachingProvider = createCachingProvider();
+    }
+
+    protected abstract CachingProvider createCachingProvider();
+
+    @After
+    public void tear() {
+        cachingProvider.close();
+    }
+
+    private Cache<Integer, Integer> getCache() {
+        String cacheName = randomString();
+        CacheManager cacheManager = cachingProvider.getCacheManager();
+        CacheConfig<Integer, Integer> config = new CacheConfig<Integer, Integer>();
+        return cacheManager.createCache(cacheName, config);
+
+    }
+
+    @Test
+    public void testIterator() {
+        ICache<Integer, Integer> cache = (ICache<Integer, Integer>) getCache();
+        int size = 1111;
+        int multiplier = 11;
+        for (int i = 0; i < size; i++) {
+            cache.put(i, i * multiplier);
+        }
+
+        int[] keys = new int[size];
+        int k = 0;
+        Iterator<Cache.Entry<Integer, Integer>> iter = cache.iterator();
+        while (iter.hasNext()) {
+            Cache.Entry<Integer, Integer> e = iter.next();
+            int key = e.getKey();
+            int value = e.getValue();
+            assertEquals(key * multiplier, value);
+            keys[k++] = key;
+        }
+        assertEquals(size, k);
+
+        Arrays.sort(keys);
+        for (int i = 0; i < size; i++) {
+            assertEquals(i, keys[i]);
+        }
+    }
+
+    @Test
+    public void testIteratorRemove() {
+        ICache<Integer, Integer> cache = (ICache<Integer, Integer>) getCache();
+        int size = 1111;
+        for (int i = 0; i < size; i++) {
+            cache.put(i, i);
+        }
+
+        Iterator<Cache.Entry<Integer, Integer>> iter = cache.iterator();
+        while (iter.hasNext()) {
+            iter.next();
+            iter.remove();
+        }
+        assertEquals(0, cache.size());
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testIteratorIllegalRemove() {
+        ICache<Integer, Integer> cache = (ICache<Integer, Integer>) getCache();
+        int size = 10;
+        for (int i = 0; i < size; i++) {
+            cache.put(i, i);
+        }
+
+        Iterator<Cache.Entry<Integer, Integer>> iter = cache.iterator();
+        if (iter.hasNext()) {
+            iter.remove();
+        }
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/cache/CacheIteratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CacheIteratorTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.cache;
+
+import com.hazelcast.cache.impl.HazelcastServerCachingProvider;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import javax.cache.spi.CachingProvider;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category(QuickTest.class)
+public class CacheIteratorTest extends CacheIteratorAbstractTest {
+
+    @Override
+    protected CachingProvider createCachingProvider() {
+        HazelcastInstance hazelcastInstance = createHazelcastInstance();
+        return HazelcastServerCachingProvider.createCachingProvider(hazelcastInstance);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/cache/CacheTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CacheTestSupport.java
@@ -1,0 +1,81 @@
+package com.hazelcast.cache;
+
+import com.hazelcast.cache.impl.HazelcastServerCachingProvider;
+import com.hazelcast.config.CacheConfig;
+import com.hazelcast.config.Config;
+import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.test.HazelcastTestSupport;
+import org.junit.After;
+import org.junit.Before;
+
+import javax.cache.Cache;
+import javax.cache.CacheManager;
+import javax.cache.spi.CachingProvider;
+
+/**
+ * @author mdogan 02/06/14
+ */
+public abstract class CacheTestSupport extends HazelcastTestSupport {
+
+    protected CachingProvider cachingProvider;
+    protected CacheManager cacheManager;
+
+    protected abstract HazelcastInstance getHazelcastInstance();
+
+    @Before
+    public void setup() {
+        onSetup();
+        cachingProvider = getCachingProvider();
+        cacheManager = cachingProvider.getCacheManager();
+    }
+
+    @After
+    public void tearDown() {
+        if (cacheManager != null) {
+            Iterable<String> cacheNames = cacheManager.getCacheNames();
+            for (String name : cacheNames) {
+                cacheManager.destroyCache(name);
+            }
+            cacheManager.close();
+        }
+        if (cachingProvider != null) {
+            cachingProvider.close();
+        }
+        onTearDown();
+    }
+
+
+    protected abstract void onSetup();
+
+    protected abstract void onTearDown();
+
+    protected ICache createCache() {
+        String cacheName = randomString();
+        Cache<Object, Object> cache = cacheManager.createCache(cacheName, createCacheConfig());
+        return cache.unwrap(ICache.class);
+    }
+
+    protected ICache createCache(String cacheName) {
+        Cache<Object, Object> cache = cacheManager.createCache(cacheName, createCacheConfig());
+        return cache.unwrap(ICache.class);
+    }
+
+    public Config createConfig() {
+        return new Config();
+    }
+
+    public CacheConfig createCacheConfig() {
+        CacheConfig cacheConfig = new CacheConfig();
+        cacheConfig.setInMemoryFormat(InMemoryFormat.BINARY);
+        cacheConfig.setStatisticsEnabled(true);
+        return cacheConfig;
+    }
+
+
+    protected CachingProvider getCachingProvider() {
+        return HazelcastServerCachingProvider
+                .createCachingProvider(getHazelcastInstance());
+    }
+
+}


### PR DESCRIPTION
Beside adding tests a couple if minor fixes added where new added
tests failed
1)deregisterCacheEntryListener removes from local map if only remote
deregistration is succesfull. Old way can lead to memory leaks when
there is an exception on remote call.
2)CacheEventDataCodec is updated so that it can handle null keys.
This issue has seen in testCompletionEvent
3)Response deserialization is fixed for async methods on old client
cache.

backport of https://github.com/hazelcast/hazelcast/pull/6157