### PR TITLE
Introduced map.impl.event package

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/DefaultMapServiceFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/DefaultMapServiceFactory.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.map.impl;
 
+import com.hazelcast.map.impl.event.MapEventPublishingService;
 import com.hazelcast.spi.ClientAwareService;
 import com.hazelcast.spi.EventPublishingService;
 import com.hazelcast.spi.ManagedService;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapService.java
@@ -17,6 +17,8 @@
 package com.hazelcast.map.impl;
 
 import com.hazelcast.core.DistributedObject;
+import com.hazelcast.map.impl.event.EventData;
+import com.hazelcast.map.impl.event.MapEventPublishingService;
 import com.hazelcast.monitor.LocalMapStats;
 import com.hazelcast.partition.InternalPartitionLostEvent;
 import com.hazelcast.spi.ClientAwareService;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContext.java
@@ -17,6 +17,7 @@
 package com.hazelcast.map.impl;
 
 import com.hazelcast.core.PartitioningStrategy;
+import com.hazelcast.map.impl.event.MapEventPublisher;
 import com.hazelcast.map.impl.eviction.EvictionOperator;
 import com.hazelcast.map.impl.eviction.ExpirationManager;
 import com.hazelcast.map.impl.nearcache.NearCacheProvider;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
@@ -20,6 +20,8 @@ import com.hazelcast.config.Config;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.core.PartitioningStrategy;
 import com.hazelcast.map.MapInterceptor;
+import com.hazelcast.map.impl.event.MapEventPublisher;
+import com.hazelcast.map.impl.event.MapEventPublisherImpl;
 import com.hazelcast.map.impl.eviction.EvictionOperator;
 import com.hazelcast.map.impl.eviction.ExpirationManager;
 import com.hazelcast.map.impl.nearcache.NearCacheProvider;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/event/AbstractEventData.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/event/AbstractEventData.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.hazelcast.map.impl;
+package com.hazelcast.map.impl.event;
 
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/event/EntryEventData.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/event/EntryEventData.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.hazelcast.map.impl;
+package com.hazelcast.map.impl.event;
 
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/event/EventData.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/event/EventData.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.hazelcast.map.impl;
+package com.hazelcast.map.impl.event;
 
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.serialization.DataSerializable;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/event/MapEventData.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/event/MapEventData.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.hazelcast.map.impl;
+package com.hazelcast.map.impl.event;
 
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
@@ -23,43 +23,41 @@ import com.hazelcast.nio.ObjectDataOutput;
 import java.io.IOException;
 
 /**
- * Contains the data related to a map partition event
+ * Map wide event's data.
  */
-public class MapPartitionEventData extends AbstractEventData {
+public class MapEventData extends AbstractEventData {
 
-    private int partitionId;
+    protected int numberOfEntries;
 
-    public MapPartitionEventData() {
+    public MapEventData() {
     }
 
-    public MapPartitionEventData(String source, String mapName, Address caller, int partitionId) {
-        super(source, mapName, caller, -1);
-        this.partitionId = partitionId;
+    public MapEventData(String source, String mapName, Address caller, int eventType, int numberOfEntries) {
+        super(source, mapName, caller, eventType);
+        this.numberOfEntries = numberOfEntries;
     }
 
-    public int getPartitionId() {
-        return partitionId;
+    public int getNumberOfEntries() {
+        return numberOfEntries;
     }
 
     @Override
-    public void writeData(ObjectDataOutput out)
-            throws IOException {
+    public void writeData(ObjectDataOutput out) throws IOException {
         super.writeData(out);
-        out.writeInt(partitionId);
+        out.writeInt(numberOfEntries);
     }
 
     @Override
-    public void readData(ObjectDataInput in)
-            throws IOException {
+    public void readData(ObjectDataInput in) throws IOException {
         super.readData(in);
-        partitionId = in.readInt();
+        numberOfEntries = in.readInt();
     }
 
     @Override
     public String toString() {
-        return "MapPartitionEventData{"
+        return "MapEventData{"
                 + super.toString()
-                + ", partitionId=" + partitionId
+                + ", numberOfEntries=" + numberOfEntries
                 + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/event/MapEventPublisher.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/event/MapEventPublisher.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.hazelcast.map.impl;
+package com.hazelcast.map.impl.event;
 
 import com.hazelcast.core.EntryEventType;
 import com.hazelcast.core.EntryView;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/event/MapEventPublisherImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/event/MapEventPublisherImpl.java
@@ -14,10 +14,16 @@
  * limitations under the License.
  */
 
-package com.hazelcast.map.impl;
+package com.hazelcast.map.impl.event;
 
 import com.hazelcast.core.EntryEventType;
 import com.hazelcast.core.EntryView;
+import com.hazelcast.map.impl.EntryEventFilter;
+import com.hazelcast.map.impl.MapContainer;
+import com.hazelcast.map.impl.MapPartitionLostEventFilter;
+import com.hazelcast.map.impl.MapServiceContext;
+import com.hazelcast.map.impl.QueryEventFilter;
+import com.hazelcast.map.impl.SyntheticEventFilter;
 import com.hazelcast.map.impl.wan.MapReplicationRemove;
 import com.hazelcast.map.impl.wan.MapReplicationUpdate;
 import com.hazelcast.nio.Address;
@@ -39,11 +45,11 @@ import java.util.List;
 
 import static com.hazelcast.map.impl.MapService.SERVICE_NAME;
 
-class MapEventPublisherImpl implements MapEventPublisher {
+public class MapEventPublisherImpl implements MapEventPublisher {
 
     protected final MapServiceContext mapServiceContext;
 
-    protected MapEventPublisherImpl(MapServiceContext mapServiceContext) {
+    public MapEventPublisherImpl(MapServiceContext mapServiceContext) {
         this.mapServiceContext = mapServiceContext;
     }
 
@@ -93,7 +99,6 @@ class MapEventPublisherImpl implements MapEventPublisher {
     public void publishEvent(Address caller, String mapName, EntryEventType eventType, boolean syntheticEvent,
                              final Data dataKey, Data dataOldValue, Data dataValue) {
         publishEvent(caller, mapName, eventType, syntheticEvent, dataKey, dataOldValue, dataValue, null);
-
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/event/MapEventPublishingService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/event/MapEventPublishingService.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.hazelcast.map.impl;
+package com.hazelcast.map.impl.event;
 
 import com.hazelcast.core.EntryEvent;
 import com.hazelcast.core.IMapEvent;
@@ -22,6 +22,10 @@ import com.hazelcast.core.MapEvent;
 import com.hazelcast.map.MapPartitionLostEvent;
 import com.hazelcast.core.Member;
 import com.hazelcast.instance.MemberImpl;
+import com.hazelcast.map.impl.DataAwareEntryEvent;
+import com.hazelcast.map.impl.ListenerAdapter;
+import com.hazelcast.map.impl.MapContainer;
+import com.hazelcast.map.impl.MapServiceContext;
 import com.hazelcast.spi.EventPublishingService;
 import com.hazelcast.spi.NodeEngine;
 
@@ -30,12 +34,12 @@ import com.hazelcast.spi.NodeEngine;
  *
  * @see com.hazelcast.spi.EventPublishingService
  */
-class MapEventPublishingService implements EventPublishingService<EventData, ListenerAdapter> {
+public class MapEventPublishingService implements EventPublishingService<EventData, ListenerAdapter> {
 
     private final MapServiceContext mapServiceContext;
     private final NodeEngine nodeEngine;
 
-    protected MapEventPublishingService(MapServiceContext mapServiceContext) {
+    public MapEventPublishingService(MapServiceContext mapServiceContext) {
         this.mapServiceContext = mapServiceContext;
         this.nodeEngine = mapServiceContext.getNodeEngine();
     }
@@ -75,15 +79,14 @@ class MapEventPublishingService implements EventPublishingService<EventData, Lis
     }
 
 
-    private void dispatchMapPartitionLostEventData(MapPartitionEventData mapPartitionEventData, ListenerAdapter listener) {
-        Member member = getMember(mapPartitionEventData);
-        MapPartitionLostEvent event = createMapPartitionLostEventData(mapPartitionEventData, member);
+    private void dispatchMapPartitionLostEventData(MapPartitionEventData eventData, ListenerAdapter listener) {
+        Member member = getMember(eventData);
+        MapPartitionLostEvent event = createMapPartitionLostEventData(eventData, member);
         callListener(listener, event);
     }
 
-    private MapPartitionLostEvent createMapPartitionLostEventData(MapPartitionEventData mapPartitionEventData, Member member) {
-        return new MapPartitionLostEvent(mapPartitionEventData.getMapName(), member,
-                    mapPartitionEventData.getEventType(), mapPartitionEventData.getPartitionId());
+    private MapPartitionLostEvent createMapPartitionLostEventData(MapPartitionEventData eventData, Member member) {
+        return new MapPartitionLostEvent(eventData.getMapName(), member, eventData.getEventType(), eventData.getPartitionId());
     }
 
     private void callListener(ListenerAdapter listener, IMapEvent event) {
@@ -115,6 +118,4 @@ class MapEventPublishingService implements EventPublishingService<EventData, Lis
                 entryEventData.getDataKey(), entryEventData.getDataNewValue(), entryEventData.getDataOldValue(),
                 entryEventData.getDataMergingValue(), nodeEngine.getSerializationService());
     }
-
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/event/MapPartitionEventData.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/event/MapPartitionEventData.java
@@ -14,49 +14,50 @@
  * limitations under the License.
  */
 
-package com.hazelcast.map.impl;
+package com.hazelcast.map.impl.event;
 
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
+
 import java.io.IOException;
 
 /**
- * Map wide event's data.
+ * Contains the data related to a map partition event
  */
-public class MapEventData extends AbstractEventData {
+public class MapPartitionEventData extends AbstractEventData {
 
-    protected int numberOfEntries;
+    private int partitionId;
 
-    public MapEventData() {
+    public MapPartitionEventData() {
     }
 
-    public MapEventData(String source, String mapName, Address caller, int eventType, int numberOfEntries) {
-        super(source, mapName, caller, eventType);
-        this.numberOfEntries = numberOfEntries;
+    public MapPartitionEventData(String source, String mapName, Address caller, int partitionId) {
+        super(source, mapName, caller, -1);
+        this.partitionId = partitionId;
     }
 
-    public int getNumberOfEntries() {
-        return numberOfEntries;
+    public int getPartitionId() {
+        return partitionId;
     }
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
         super.writeData(out);
-        out.writeInt(numberOfEntries);
+        out.writeInt(partitionId);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
         super.readData(in);
-        numberOfEntries = in.readInt();
+        partitionId = in.readInt();
     }
 
     @Override
     public String toString() {
-        return "MapEventData{"
+        return "MapPartitionEventData{"
                 + super.toString()
-                + ", numberOfEntries=" + numberOfEntries
+                + ", partitionId=" + partitionId
                 + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/eviction/EvictionOperator.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/eviction/EvictionOperator.java
@@ -20,7 +20,7 @@ import com.hazelcast.config.EvictionPolicy;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.config.MaxSizeConfig;
 import com.hazelcast.core.EntryEventType;
-import com.hazelcast.map.impl.MapEventPublisher;
+import com.hazelcast.map.impl.event.MapEventPublisher;
 import com.hazelcast.map.impl.MapServiceContext;
 import com.hazelcast.map.impl.recordstore.RecordStore;
 import com.hazelcast.map.impl.record.Record;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/AbstractMultipleEntryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/AbstractMultipleEntryOperation.java
@@ -26,7 +26,7 @@ import com.hazelcast.map.impl.LazyMapEntry;
 import com.hazelcast.map.impl.LocalMapStatsProvider;
 import com.hazelcast.map.impl.MapContainer;
 import com.hazelcast.map.impl.MapEntrySet;
-import com.hazelcast.map.impl.MapEventPublisher;
+import com.hazelcast.map.impl.event.MapEventPublisher;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.map.impl.MapServiceContext;
 import com.hazelcast.map.impl.nearcache.NearCacheProvider;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/BasePutOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/BasePutOperation.java
@@ -19,7 +19,7 @@ package com.hazelcast.map.impl.operation;
 import com.hazelcast.core.EntryEventType;
 import com.hazelcast.core.EntryView;
 import com.hazelcast.map.impl.EntryViews;
-import com.hazelcast.map.impl.MapEventPublisher;
+import com.hazelcast.map.impl.event.MapEventPublisher;
 import com.hazelcast.map.impl.MapServiceContext;
 import com.hazelcast.map.impl.mapstore.MapDataStore;
 import com.hazelcast.map.impl.record.Record;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/BaseRemoveOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/BaseRemoveOperation.java
@@ -17,7 +17,7 @@
 package com.hazelcast.map.impl.operation;
 
 import com.hazelcast.core.EntryEventType;
-import com.hazelcast.map.impl.MapEventPublisher;
+import com.hazelcast.map.impl.event.MapEventPublisher;
 import com.hazelcast.map.impl.MapServiceContext;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.BackupAwareOperation;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ClearOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ClearOperation.java
@@ -17,7 +17,7 @@
 package com.hazelcast.map.impl.operation;
 
 import com.hazelcast.core.EntryEventType;
-import com.hazelcast.map.impl.MapEventPublisher;
+import com.hazelcast.map.impl.event.MapEventPublisher;
 import com.hazelcast.map.impl.MapServiceContext;
 import com.hazelcast.map.impl.recordstore.RecordStore;
 import com.hazelcast.spi.BackupAwareOperation;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOperation.java
@@ -26,7 +26,7 @@ import com.hazelcast.map.EntryProcessor;
 import com.hazelcast.map.impl.LazyMapEntry;
 import com.hazelcast.map.impl.LocalMapStatsProvider;
 import com.hazelcast.map.impl.MapContainer;
-import com.hazelcast.map.impl.MapEventPublisher;
+import com.hazelcast.map.impl.event.MapEventPublisher;
 import com.hazelcast.map.impl.MapServiceContext;
 import com.hazelcast.map.impl.record.Record;
 import com.hazelcast.monitor.impl.LocalMapStatsImpl;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EvictAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EvictAllOperation.java
@@ -17,7 +17,7 @@
 package com.hazelcast.map.impl.operation;
 
 import com.hazelcast.core.EntryEventType;
-import com.hazelcast.map.impl.MapEventPublisher;
+import com.hazelcast.map.impl.event.MapEventPublisher;
 import com.hazelcast.map.impl.MapServiceContext;
 import com.hazelcast.map.impl.recordstore.RecordStore;
 import com.hazelcast.nio.ObjectDataInput;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MergeOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MergeOperation.java
@@ -18,7 +18,7 @@ package com.hazelcast.map.impl.operation;
 
 import com.hazelcast.core.EntryEventType;
 import com.hazelcast.core.EntryView;
-import com.hazelcast.map.impl.MapEventPublisher;
+import com.hazelcast.map.impl.event.MapEventPublisher;
 import com.hazelcast.map.impl.MapServiceContext;
 import com.hazelcast.map.impl.record.Record;
 import com.hazelcast.map.impl.record.RecordInfo;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutAllOperation.java
@@ -20,7 +20,7 @@ import com.hazelcast.core.EntryEventType;
 import com.hazelcast.core.EntryView;
 import com.hazelcast.map.impl.EntryViews;
 import com.hazelcast.map.impl.MapEntrySet;
-import com.hazelcast.map.impl.MapEventPublisher;
+import com.hazelcast.map.impl.event.MapEventPublisher;
 import com.hazelcast.map.impl.MapServiceContext;
 import com.hazelcast.map.impl.nearcache.NearCacheProvider;
 import com.hazelcast.map.impl.recordstore.RecordStore;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutFromLoadAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutFromLoadAllOperation.java
@@ -19,7 +19,7 @@ package com.hazelcast.map.impl.operation;
 import com.hazelcast.core.EntryEventType;
 import com.hazelcast.core.EntryView;
 import com.hazelcast.map.impl.EntryViews;
-import com.hazelcast.map.impl.MapEventPublisher;
+import com.hazelcast.map.impl.event.MapEventPublisher;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.map.impl.MapServiceContext;
 import com.hazelcast.map.impl.nearcache.NearCacheProvider;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
@@ -42,7 +42,7 @@ import com.hazelcast.map.impl.LocalMapStatsProvider;
 import com.hazelcast.map.impl.MapContainer;
 import com.hazelcast.map.impl.MapContextQuerySupport;
 import com.hazelcast.map.impl.MapEntrySet;
-import com.hazelcast.map.impl.MapEventPublisher;
+import com.hazelcast.map.impl.event.MapEventPublisher;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.map.impl.MapServiceContext;
 import com.hazelcast.map.impl.PartitionContainer;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/event/QueryCacheEventData.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/event/QueryCacheEventData.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.map.impl.querycache.event;
 
-import com.hazelcast.map.impl.EventData;
+import com.hazelcast.map.impl.event.EventData;
 import com.hazelcast.map.impl.querycache.event.sequence.Sequenced;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.internal.serialization.SerializationService;

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapEventsDispatcher.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapEventsDispatcher.java
@@ -25,9 +25,9 @@ import com.hazelcast.core.Member;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.map.impl.DataAwareEntryEvent;
-import com.hazelcast.map.impl.EntryEventData;
-import com.hazelcast.map.impl.EventData;
-import com.hazelcast.map.impl.MapEventData;
+import com.hazelcast.map.impl.event.EntryEventData;
+import com.hazelcast.map.impl.event.EventData;
+import com.hazelcast.map.impl.event.MapEventData;
 
 import java.util.logging.Level;
 

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapEventsPublisher.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapEventsPublisher.java
@@ -17,8 +17,8 @@
 package com.hazelcast.multimap.impl;
 
 import com.hazelcast.core.EntryEventType;
-import com.hazelcast.map.impl.EntryEventData;
-import com.hazelcast.map.impl.MapEventData;
+import com.hazelcast.map.impl.event.EntryEventData;
+import com.hazelcast.map.impl.event.MapEventData;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.EventRegistration;

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapService.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapService.java
@@ -24,7 +24,7 @@ import com.hazelcast.core.DistributedObject;
 import com.hazelcast.core.EntryEventType;
 import com.hazelcast.core.EntryListener;
 import com.hazelcast.logging.ILogger;
-import com.hazelcast.map.impl.EventData;
+import com.hazelcast.map.impl.event.EventData;
 import com.hazelcast.monitor.LocalMultiMapStats;
 import com.hazelcast.monitor.impl.LocalMultiMapStatsImpl;
 import com.hazelcast.multimap.impl.operations.MultiMapMigrationOperation;

--- a/hazelcast/src/test/java/com/hazelcast/map/ListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/ListenerTest.java
@@ -26,7 +26,7 @@ import com.hazelcast.core.EntryListener;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.core.MapEvent;
-import com.hazelcast.map.impl.MapPartitionEventData;
+import com.hazelcast.map.impl.event.MapPartitionEventData;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.map.listener.EntryUpdatedListener;
 import com.hazelcast.map.listener.MapPartitionLostListener;


### PR DESCRIPTION
To reduce the size of the map.impl package, a subpackage is created where the event
logic is copied into.

See for Enteprise PR:
https://github.com/hazelcast/hazelcast-enterprise/pull/369