### PR TITLE
[DONT MERGE] clusterService event execution in single thread

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/ClusterServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/ClusterServiceImpl.java
@@ -1389,6 +1389,7 @@ public final class ClusterServiceImpl implements ClusterService, ConnectionListe
 
     @Override
     public void shutdown(boolean terminate) {
+        executorService.shutdown();
         reset();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/ClusterServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/ClusterServiceImpl.java
@@ -189,13 +189,11 @@ public final class ClusterServiceImpl implements ClusterService, ConnectionListe
 
     @Probe(name = "lastHeartBeat")
     private volatile long lastHeartBeat;
-    private ExecutorService executorService;
+    private ExecutorService executorService = Executors.newFixedThreadPool(1);
 
     public ClusterServiceImpl(Node node) {
         this.node = node;
         nodeEngine = node.nodeEngine;
-        executorService = Executors.newFixedThreadPool(1);
-
 
         logger = node.getLogger(ClusterService.class.getName());
         clusterClock = new ClusterClockImpl(logger);
@@ -222,6 +220,10 @@ public final class ClusterServiceImpl implements ClusterService, ConnectionListe
         node.connectionManager.addConnectionListener(this);
 
         registerMetrics();
+    }
+
+    private void initConfigurations() {
+
     }
 
     private static long getHeartBeatInterval(GroupProperties groupProperties) {

--- a/hazelcast/src/main/java/com/hazelcast/quorum/impl/QuorumImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/quorum/impl/QuorumImpl.java
@@ -18,6 +18,7 @@ package com.hazelcast.quorum.impl;
 
 import com.hazelcast.config.QuorumConfig;
 import com.hazelcast.core.Member;
+import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.ClassLoaderUtil;
 import com.hazelcast.quorum.Quorum;
 import com.hazelcast.quorum.QuorumEvent;
@@ -48,10 +49,13 @@ public class QuorumImpl implements Quorum {
     private final InternalEventService eventService;
     private QuorumFunction quorumFunction;
 
+    private final ILogger logger;
+
     private volatile boolean initialized;
 
     public QuorumImpl(QuorumConfig config, NodeEngineImpl nodeEngine) {
         this.nodeEngine = nodeEngine;
+        this.logger = nodeEngine.getLogger(getClass());
         this.eventService = nodeEngine.getEventService();
         this.config = config;
         this.quorumName = config.getName();
@@ -60,6 +64,7 @@ public class QuorumImpl implements Quorum {
     }
 
     public void update(Collection<Member> members) {
+        logger.info("Update in quorum " + quorumName + " Member size: " + members.size());
         setLocalResult(quorumFunction.apply(members));
     }
 
@@ -85,6 +90,7 @@ public class QuorumImpl implements Quorum {
     }
 
     public void setLocalResult(boolean presence) {
+        logger.info("Quorum " + quorumName + " updated to: " + presence);
         setLocalResultInternal(presence);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/quorum/impl/QuorumServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/quorum/impl/QuorumServiceImpl.java
@@ -157,7 +157,8 @@ public class QuorumServiceImpl implements EventPublishingService<QuorumEvent, Qu
 
     @Override
     public void memberRemoved(MembershipServiceEvent event) {
-        logger.info("Remove member event fired: " + event.getMember() + " event.getMembers().size(): " + event.getMembers().size());
+        logger.info("Remove member event fired: " + event.getMember()
+                + " event.getMembers().size(): " + event.getMembers().size());
         updateQuorums(event);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/quorum/impl/QuorumServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/quorum/impl/QuorumServiceImpl.java
@@ -20,6 +20,7 @@ import com.hazelcast.config.QuorumConfig;
 import com.hazelcast.config.QuorumListenerConfig;
 import com.hazelcast.core.Member;
 import com.hazelcast.core.MembershipEvent;
+import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.ClassLoaderUtil;
 import com.hazelcast.quorum.Quorum;
 import com.hazelcast.quorum.QuorumEvent;
@@ -59,6 +60,8 @@ public class QuorumServiceImpl implements EventPublishingService<QuorumEvent, Qu
     private boolean inactive;
     private final Map<String, QuorumImpl> quorums = new HashMap<String, QuorumImpl>();
 
+    private final ILogger logger;
+
 
     public QuorumServiceImpl(NodeEngineImpl nodeEngine) {
         this.nodeEngine = nodeEngine;
@@ -66,6 +69,7 @@ public class QuorumServiceImpl implements EventPublishingService<QuorumEvent, Qu
         initializeQuorums();
         initializeListeners();
         this.inactive = quorums.isEmpty();
+        this.logger = nodeEngine.getLogger(getClass());
     }
 
     private void initializeQuorums() {
@@ -147,11 +151,13 @@ public class QuorumServiceImpl implements EventPublishingService<QuorumEvent, Qu
 
     @Override
     public void memberAdded(MembershipServiceEvent event) {
+        logger.info("Add member event fired: " + event.getMember() + " event.getMembers().size(): " + event.getMembers().size());
         updateQuorums(event);
     }
 
     @Override
     public void memberRemoved(MembershipServiceEvent event) {
+        logger.info("Remove member event fired: " + event.getMember() + " event.getMembers().size(): " + event.getMembers().size());
         updateQuorums(event);
     }
 


### PR DESCRIPTION
ClusterServiceImpl does not guarantee membership events' execution order. 
When 3rd node joins in a 2-node cluster, 3rd node gets two MembershipEvents with cluster size of 2 and 3. 
Node 3 sometimes finishes execution of the second event before the first event. If required quorum size of the cluster is 3, Node 3 begins with quorum state 'false', changes to 'true' and 'false' respectively. In the end, Node 3 thinks quorum is not present although cluster has 3 active nodes.

ClusterServiceImpl should guarantee membership events' execution order.
