### PR TITLE
fix ordering of membership events execution

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/ClusterServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/ClusterServiceImpl.java
@@ -217,6 +217,7 @@ public final class ClusterServiceImpl implements ClusterService, ConnectionListe
 
         node.connectionManager.addConnectionListener(this);
 
+        //MEMBERSHIP_EVENT_EXECUTOR is a single threaded executor to ensure that events are executed in correct order.
         nodeEngine.getExecutionService().register(MEMBERSHIP_EVENT_EXECUTOR_NAME, 1, Integer.MAX_VALUE, ExecutorType.CACHED);
 
         registerMetrics();

--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/ClusterServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/ClusterServiceImpl.java
@@ -1292,7 +1292,6 @@ public final class ClusterServiceImpl implements ClusterService, ConnectionListe
         if (membershipAwareServices != null && !membershipAwareServices.isEmpty()) {
             final MembershipServiceEvent event = new MembershipServiceEvent(membershipEvent);
             for (final MembershipAwareService service : membershipAwareServices) {
-                // service events should not block each other
                 nodeEngine.getExecutionService().execute(MEMBERSHIP_EVENT_EXECUTOR_NAME, new Runnable() {
                     public void run() {
                         if (added) {

--- a/hazelcast/src/main/java/com/hazelcast/spi/MembershipAwareService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/MembershipAwareService.java
@@ -26,6 +26,7 @@ public interface MembershipAwareService {
 
     /**
      * Invoked when a new member is added to the cluster.
+     * Should be non-blocking.
      *
      * @param event the event for a new member added to the cluster
      */
@@ -33,6 +34,7 @@ public interface MembershipAwareService {
 
     /**
      * Invoked when an existing member leaves the cluster.
+     * Should be non-blocking.
      *
      * @param event the event for an existing member leaving the cluster
      */

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionManagerServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionManagerServiceImpl.java
@@ -22,6 +22,7 @@ import com.hazelcast.instance.MemberImpl;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Address;
 import com.hazelcast.spi.ClientAwareService;
+import com.hazelcast.spi.ExecutionService;
 import com.hazelcast.spi.ManagedService;
 import com.hazelcast.spi.MemberAttributeServiceEvent;
 import com.hazelcast.spi.MembershipAwareService;
@@ -139,8 +140,13 @@ public class TransactionManagerServiceImpl implements TransactionManagerService,
 
     @Override
     public void memberRemoved(MembershipServiceEvent event) {
-        String uuid = event.getMember().getUuid();
-        finalizeTransactionsOf(uuid);
+        final String uuid = event.getMember().getUuid();
+        nodeEngine.getExecutionService().execute(ExecutionService.SYSTEM_EXECUTOR, new Runnable() {
+            @Override
+            public void run() {
+                finalizeTransactionsOf(uuid);
+            }
+        });
     }
 
     @Override


### PR DESCRIPTION
ClusterServiceImpl does not guarantee membership events' execution order. We come across this behaviour when trying to solve recent quorum failures with @eminn .

Behaviour is as follows:
When 3rd node joins in a 2-node cluster, 3rd node gets two MembershipEvents with cluster size of 2 and 3. 
Node 3 sometimes finishes execution of the second event before the first event. If required quorum size of the cluster is 3, Node 3 begins with quorum state 'false', changes to 'true' and 'false' respectively. In the end, Node 3 thinks quorum is not present although cluster has 3 active nodes.

ClusterServiceImpl should guarantee membership events' execution order.