### PR TITLE
Do not throw NPE when intermediate field is an interface

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/query/impl/getters/ReflectionHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/getters/ReflectionHelper.java
@@ -175,7 +175,7 @@ public final class ReflectionHelper {
                     }
                     if (localGetter == null) {
                         Class c = clazz;
-                        while (!Object.class.equals(c)) {
+                        while (!c.isInterface() && !Object.class.equals(c)) {
                             try {
                                 final Field field = c.getDeclaredField(name);
                                 field.setAccessible(true);

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/getters/ReflectionHelperTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/getters/ReflectionHelperTest.java
@@ -1,5 +1,6 @@
 package com.hazelcast.query.impl.getters;
 
+import com.hazelcast.query.QueryException;
 import com.hazelcast.query.impl.AttributeType;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
@@ -8,7 +9,9 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
@@ -20,4 +23,31 @@ public class ReflectionHelperTest {
 
         assertNull(attributeType);
     }
+
+
+    @Test
+    public void extractValue_whenIntermediateFieldIsInterfaceAndDoesNotContainField_thenThrowIllegalArgumentException() throws Exception {
+        OuterObject object = new OuterObject();
+        try {
+            ReflectionHelper.extractValue(object, "emptyInterface.doesNotExist");
+            fail("Non-existing field has been ignored");
+        } catch (QueryException e) {
+            // createGetter() method is catching everything throwable and wraps it in QueryException
+            // I don't think it's the right thing to do, but I don't want to change this behaviour.
+            // Hence I have to use try/catch in this test instead of just declaring
+            // IllegalArgumentException as expected exception.
+            assertEquals(IllegalArgumentException.class, e.getCause().getClass());
+        }
+    }
+
+
+
+    private static class OuterObject {
+        private EmptyInterface emptyInterface;
+    }
+
+    private interface EmptyInterface {
+
+    }
+
 }


### PR DESCRIPTION
and the interface does not contain a requested attribute

The issue was originally reported by @wimdeblauwe
 at #6151 Thanks to @serkan-ozal for analysis!