### PR TITLE
Minor fixes in GroupProperties

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/instance/GroupProperties.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/GroupProperties.java
@@ -300,6 +300,11 @@ public class GroupProperties {
                 properties[groupProperty.ordinal()] = propertyValue;
                 continue;
             }
+            GroupProperty parent = groupProperty.getParent();
+            if (parent != null) {
+                properties[groupProperty.ordinal()] = properties[parent.ordinal()];
+                continue;
+            }
             properties[groupProperty.ordinal()] = groupProperty.getDefaultValue();
         }
     }
@@ -395,25 +400,23 @@ public class GroupProperties {
 
     /**
      * Returns the configured enum value of a {@link GroupProperty}.
-     *
+     * <p/>
      * The case of the enum is ignored.
      *
      * @param groupProperty the {@link GroupProperty} to get the value from
      * @return the enum
      * @throws IllegalArgumentException if the enum value can't be found
      */
-    public <E extends Enum> E getEnum(GroupProperty groupProperty, Class<? extends Enum> enumClazz) {
+    public <E extends Enum> E getEnum(GroupProperty groupProperty, Class<E> enumClazz) {
         String value = getString(groupProperty);
 
-        for (Enum e : enumClazz.getEnumConstants()) {
-            if (e.name().equalsIgnoreCase(value)) {
-                return (E) e;
+        for (E enumConstant : enumClazz.getEnumConstants()) {
+            if (enumConstant.name().equalsIgnoreCase(value)) {
+                return enumConstant;
             }
         }
 
-        throw new IllegalArgumentException(
-                format("value '%s' for property '%s' is not a valid %s value",
-                        value, groupProperty.getName(), enumClazz.getName()));
+        throw new IllegalArgumentException(format("value '%s' for property '%s' is not a valid %s value",
+                value, groupProperty.getName(), enumClazz.getName()));
     }
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/instance/GroupProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/GroupProperty.java
@@ -543,6 +543,7 @@ public enum GroupProperty implements HazelcastProperty {
     private final String name;
     private final String defaultValue;
     private final TimeUnit timeUnit;
+    private final GroupProperty parent;
 
     GroupProperty(String name) {
         this(name, (String) null);
@@ -560,10 +561,6 @@ public enum GroupProperty implements HazelcastProperty {
         this(name, defaultValue, null);
     }
 
-    GroupProperty(String name, GroupProperty groupProperty) {
-        this(name, groupProperty.defaultValue, groupProperty.timeUnit);
-    }
-
     GroupProperty(String name, Integer defaultValue, TimeUnit timeUnit) {
         this(name, String.valueOf(defaultValue), timeUnit);
     }
@@ -573,11 +570,20 @@ public enum GroupProperty implements HazelcastProperty {
     }
 
     GroupProperty(String name, String defaultValue, TimeUnit timeUnit) {
+        this(name, defaultValue, timeUnit, null);
+    }
+
+    GroupProperty(String name, GroupProperty groupProperty) {
+        this(name, groupProperty.getDefaultValue(), groupProperty.timeUnit, groupProperty);
+    }
+
+    GroupProperty(String name, String defaultValue, TimeUnit timeUnit, GroupProperty parent) {
         checkHasText(name, "The property name cannot be null or empty!");
 
         this.name = name;
         this.defaultValue = defaultValue;
         this.timeUnit = timeUnit;
+        this.parent = parent;
     }
 
     /**
@@ -608,6 +614,14 @@ public enum GroupProperty implements HazelcastProperty {
     }
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    public GroupProperty getParent() {
+        return parent;
+    }
+
+    /**
      * Sets the environmental value of the property.
      *
      * @param value the value to set
@@ -628,7 +642,6 @@ public enum GroupProperty implements HazelcastProperty {
     /**
      * Clears the environmental value of the property.
      */
-    @SuppressWarnings("unused")
     public String clearSystemProperty() {
         return System.clearProperty(name);
     }

--- a/hazelcast/src/main/java/com/hazelcast/instance/HazelcastProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/HazelcastProperty.java
@@ -44,4 +44,11 @@ public interface HazelcastProperty {
      * @throws IllegalArgumentException if no {@link TimeUnit} is defined
      */
     TimeUnit getTimeUnit();
+
+    /**
+     * Returns the parent {@link GroupProperty} of the property.
+     *
+     * @return the parent {@link GroupProperty} or <tt>null</tt> if none is defined
+     */
+    GroupProperty getParent();
 }

--- a/hazelcast/src/test/java/com/hazelcast/instance/GroupPropertiesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/GroupPropertiesTest.java
@@ -8,33 +8,154 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import java.util.concurrent.TimeUnit;
+
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category(QuickTest.class)
 public class GroupPropertiesTest {
 
+    private final Config config = new Config();
+    private final GroupProperties defaultGroupProperties = new GroupProperties(config);
+
     @Test
-    public void getEnum_default() {
-        GroupProperties groupProperties = new GroupProperties(new Config());
+    public void setProperty_ensureHighestPriorityOfConfig() {
+        config.setProperty(GroupProperty.ELASTIC_MEMORY_TOTAL_SIZE, "configValue");
+        GroupProperty.ELASTIC_MEMORY_TOTAL_SIZE.setSystemProperty("systemValue");
 
-        ProbeLevel level = groupProperties.getEnum(GroupProperty.PERFORMANCE_METRICS_LEVEL, ProbeLevel.class);
+        GroupProperties groupProperties = new GroupProperties(config);
+        String loggingType = groupProperties.getString(GroupProperty.ELASTIC_MEMORY_TOTAL_SIZE);
 
-        assertEquals(ProbeLevel.MANDATORY, level);
+        GroupProperty.ELASTIC_MEMORY_TOTAL_SIZE.clearSystemProperty();
+
+        assertEquals("configValue", loggingType);
+    }
+
+    @Test
+    public void setProperty_ensureUsageOfSystemProperty() {
+        GroupProperty.ELASTIC_MEMORY_TOTAL_SIZE.setSystemProperty("systemValue");
+
+        GroupProperties groupProperties = new GroupProperties(config);
+        String loggingType = groupProperties.getString(GroupProperty.ELASTIC_MEMORY_TOTAL_SIZE);
+
+        GroupProperty.ELASTIC_MEMORY_TOTAL_SIZE.clearSystemProperty();
+
+        assertEquals("systemValue", loggingType);
+    }
+
+    @Test
+    public void setProperty_ensureUsageOfSystemProperty_withNullConfig() {
+        GroupProperty.ELASTIC_MEMORY_TOTAL_SIZE.setSystemProperty("systemValue");
+
+        GroupProperties groupProperties = new GroupProperties(null);
+        String loggingType = groupProperties.getString(GroupProperty.ELASTIC_MEMORY_TOTAL_SIZE);
+
+        GroupProperty.ELASTIC_MEMORY_TOTAL_SIZE.clearSystemProperty();
+
+        assertEquals("systemValue", loggingType);
+    }
+
+    @Test
+    public void setProperty_ensureUsageOfDefaultValue() {
+        String loggingType = defaultGroupProperties.getString(GroupProperty.ELASTIC_MEMORY_TOTAL_SIZE);
+
+        assertEquals("128M", loggingType);
+    }
+
+    @Test
+    public void setProperty_ensureUsageOfDefaultValue_withNullConfig() {
+        GroupProperties groupProperties = new GroupProperties(null);
+        String loggingType = groupProperties.getString(GroupProperty.ELASTIC_MEMORY_TOTAL_SIZE);
+
+        assertEquals("128M", loggingType);
+    }
+
+    @Test
+    public void setProperty_inheritDefaultValueOfParentProperty() {
+        String inputIOThreadCount = defaultGroupProperties.getString(GroupProperty.IO_INPUT_THREAD_COUNT);
+
+        assertEquals(GroupProperty.IO_THREAD_COUNT.getDefaultValue(), inputIOThreadCount);
+    }
+
+    @Test
+    public void setProperty_inheritActualValueOfParentProperty() {
+        config.setProperty(GroupProperty.IO_THREAD_COUNT, "1");
+        GroupProperties groupProperties = new GroupProperties(config);
+
+        String inputIOThreadCount = groupProperties.getString(GroupProperty.IO_INPUT_THREAD_COUNT);
+
+        assertEquals("1", inputIOThreadCount);
+        assertNotEquals(GroupProperty.IO_THREAD_COUNT.getDefaultValue(), inputIOThreadCount);
+    }
+
+    @Test
+    public void getSystemProperty() {
+        GroupProperty.APPLICATION_VALIDATION_TOKEN.setSystemProperty("token");
+
+        assertEquals("token", GroupProperty.APPLICATION_VALIDATION_TOKEN.getSystemProperty());
+
+        GroupProperty.APPLICATION_VALIDATION_TOKEN.clearSystemProperty();
+    }
+
+    @Test
+    public void getBoolean() {
+        boolean isHumanReadable = defaultGroupProperties.getBoolean(GroupProperty.PERFORMANCE_MONITOR_HUMAN_FRIENDLY_FORMAT);
+
+        assertTrue(isHumanReadable);
+    }
+
+    @Test
+    public void getInteger() {
+        int ioThreadCount = defaultGroupProperties.getInteger(GroupProperty.IO_THREAD_COUNT);
+
+        assertEquals(3, ioThreadCount);
+    }
+
+    @Test
+    public void getLong() {
+        long lockMaxLeaseTimeSeconds = defaultGroupProperties.getLong(GroupProperty.LOCK_MAX_LEASE_TIME_SECONDS);
+
+        assertEquals(Long.MAX_VALUE, lockMaxLeaseTimeSeconds);
+    }
+
+    @Test
+    public void getFloat() {
+        float maxFileSize = defaultGroupProperties.getFloat(GroupProperty.PERFORMANCE_MONITOR_MAX_ROLLED_FILE_SIZE_MB);
+
+        assertEquals(10, maxFileSize, 0.0001);
+    }
+
+    @Test
+    public void getTimeUnit() {
+        config.setProperty(GroupProperty.PARTITION_TABLE_SEND_INTERVAL, "300");
+        GroupProperties groupProperties = new GroupProperties(config);
+
+        assertEquals(300, groupProperties.getSeconds(GroupProperty.PARTITION_TABLE_SEND_INTERVAL));
+    }
+
+    @Test
+    public void getTimeUnit_default() {
+        long expectedSeconds = 15;
+
+        long intervalNanos = defaultGroupProperties.getNanos(GroupProperty.PARTITION_TABLE_SEND_INTERVAL);
+        long intervalMillis = defaultGroupProperties.getMillis(GroupProperty.PARTITION_TABLE_SEND_INTERVAL);
+        long intervalSeconds = defaultGroupProperties.getSeconds(GroupProperty.PARTITION_TABLE_SEND_INTERVAL);
+
+        assertEquals(TimeUnit.SECONDS.toNanos(expectedSeconds), intervalNanos);
+        assertEquals(TimeUnit.SECONDS.toMillis(expectedSeconds), intervalMillis);
+        assertEquals(expectedSeconds, intervalSeconds);
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void getEnum_nonExistingEnum() {
-        Config config = new Config();
-        config.setProperty(GroupProperty.PERFORMANCE_METRICS_LEVEL, "notexist");
-        GroupProperties groupProperties = new GroupProperties(config);
-        groupProperties.getEnum(GroupProperty.PERFORMANCE_METRICS_LEVEL, ProbeLevel.class);
-
+    public void getTimeUnit_noTimeUnitProperty() {
+        defaultGroupProperties.getMillis(GroupProperty.APPLICATION_VALIDATION_TOKEN);
     }
 
     @Test
     public void getEnum() {
-        Config config = new Config();
         config.setProperty(GroupProperty.PERFORMANCE_METRICS_LEVEL, ProbeLevel.DEBUG.toString());
         GroupProperties groupProperties = new GroupProperties(config);
 
@@ -44,8 +165,21 @@ public class GroupPropertiesTest {
     }
 
     @Test
+    public void getEnum_default() {
+        ProbeLevel level = defaultGroupProperties.getEnum(GroupProperty.PERFORMANCE_METRICS_LEVEL, ProbeLevel.class);
+
+        assertEquals(ProbeLevel.MANDATORY, level);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void getEnum_nonExistingEnum() {
+        config.setProperty(GroupProperty.PERFORMANCE_METRICS_LEVEL, "notExist");
+        GroupProperties groupProperties = new GroupProperties(config);
+        groupProperties.getEnum(GroupProperty.PERFORMANCE_METRICS_LEVEL, ProbeLevel.class);
+    }
+
+    @Test
     public void getEnum_ignoredName() {
-        Config config = new Config();
         config.setProperty(GroupProperty.PERFORMANCE_METRICS_LEVEL, "dEbUg");
         GroupProperties groupProperties = new GroupProperties(config);
 


### PR DESCRIPTION
* Fixed inheritance of values for `GroupProperties`.
* Fixed unchecked warning in `GroupProperties.getEnum()`.
* Increased code coverage of `GroupProperty` and `GroupProperties`.

Fixes #6174.