### PR TITLE
NotEquals predicate is again just a negated Equals predicate

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/NotEqualPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/NotEqualPredicate.java
@@ -16,8 +16,6 @@
 
 package com.hazelcast.query.impl.predicates;
 
-import com.hazelcast.query.impl.ComparisonType;
-import com.hazelcast.query.impl.Index;
 import com.hazelcast.query.impl.QueryContext;
 import com.hazelcast.query.impl.QueryableEntry;
 
@@ -37,11 +35,6 @@ public class NotEqualPredicate extends EqualPredicate {
 
     @Override
     public boolean apply(Map.Entry entry) {
-        Comparable entryValue = readAttribute(entry);
-        if (entryValue == null) {
-            return false;
-        }
-
         return !super.apply(entry);
     }
 
@@ -52,12 +45,7 @@ public class NotEqualPredicate extends EqualPredicate {
 
     @Override
     public Set<QueryableEntry> filter(QueryContext queryContext) {
-        Index index = getIndex(queryContext);
-        if (index != null) {
-            return index.getSubRecords(ComparisonType.NOT_EQUAL, value);
-        } else {
-            return null;
-        }
+        return null;
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryNullIndexingTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryNullIndexingTest.java
@@ -83,9 +83,9 @@ public class QueryNullIndexingTest extends HazelcastTestSupport {
         final List<Long> dates =
                 queryIndexedDateFieldAsNullValue(false,
                                                  Predicates.notEqual("date", 2000000L));
-        assertEquals(4, dates.size());
+        assertEquals(9, dates.size());
         assertTrue(dates.containsAll(
-                Arrays.asList(4000000L, 6000000L, 8000000L, 10000000L)));
+                Arrays.asList(4000000L, 6000000L, 8000000L, 10000000L, null)));
     }
 
     @Test
@@ -129,9 +129,9 @@ public class QueryNullIndexingTest extends HazelcastTestSupport {
         final List<Long> dates =
                 queryIndexedDateFieldAsNullValue(true,
                                                  Predicates.notEqual("date", 2000000L));
-        assertEquals(4, dates.size());
+        assertEquals(9, dates.size());
         assertTrue(dates.containsAll(
-                Arrays.asList(4000000L, 6000000L, 8000000L, 10000000L)));
+                Arrays.asList(4000000L, 6000000L, 8000000L, 10000000L, null)));
     }
 
     private List<Long> queryIndexedDateFieldAsNullValue(boolean ordered, Predicate pred) {
@@ -151,7 +151,8 @@ public class QueryNullIndexingTest extends HazelcastTestSupport {
 
         final List<Long> dates = new ArrayList<Long>();
         for (SampleObjects.Employee employee : map.values(pred)) {
-            dates.add(employee.getDate().getTime());
+            Timestamp date = employee.getDate();
+            dates.add(date == null ? null : date.getTime());
         }
 
         return dates;

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/PredicatesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/PredicatesTest.java
@@ -45,11 +45,6 @@ import java.util.Set;
 
 import static com.hazelcast.instance.TestUtil.toData;
 
-import com.hazelcast.query.impl.predicates.AndPredicate;
-
-import com.hazelcast.query.impl.predicates.EqualPredicate;
-import org.mockito.Mockito;
-
 import static com.hazelcast.query.Predicates.and;
 import static com.hazelcast.query.Predicates.between;
 import static com.hazelcast.query.Predicates.equal;
@@ -190,11 +185,11 @@ public class PredicatesTest extends HazelcastTestSupport {
         assertFalse_withNullEntry(greaterThan("nullField", 1));
         assertFalse_withNullEntry(equal("nullField", 1));
         assertFalse_withNullEntry(notEqual("nullField", null));
-        assertFalse_withNullEntry(notEqual("nullField", 1));
         assertFalse_withNullEntry(between("nullField", 1, 1));
         assertTrue_withNullEntry(like("nullField", null));
         assertTrue_withNullEntry(ilike("nullField", null));
         assertTrue_withNullEntry(regex("nullField", null));
+        assertTrue_withNullEntry(notEqual("nullField", 1));
     }
 
     @Test


### PR DESCRIPTION
In other words: not(equals(p)) <-> notEquals(p)
Fixes #6124

It's partially reverting a changeset #5023.
The original change was introduced to treat NULL-values more like relational databases do.
SQL standard mandates special treating of NULL values, but it order to be compliant we'd
need to introduce three-values logic as specified in SQL. Having just a single predicate
behaving like SQL mandates creates inconsistencies and logical paradoxes.

The #5023 was also fixing a NPE when NotEquals used an index, however this revert will not
re-introduce the NPE  indexes are no longer used for NotEquals predicate. See #5847