### PR TITLE
IdentifyConverter converts NULL-values into NULL-objects

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -225,6 +225,7 @@
     <suppress checks="CyclomaticComplexity" files="com/hazelcast/query/impl/getters/ReflectionHelper"/>
     <suppress checks="NPathComplexity" files="com/hazelcast/query/impl/getters/ReflectionHelper"/>
     <suppress checks="ReturnCount" files="com/hazelcast/query/impl/getters/ReflectionHelper"/>
+    <suppress checks="ClassDataAbstractionCoupling" files="com/hazelcast/query/impl/TypeConverters"/>
 
     <!-- hazelcast-wm -->
     <suppress checks="JavadocMethod" files="com/hazelcast/web/"/>

--- a/hazelcast-client-new/src/test/java/com/hazelcast/client/map/impl/query/ClientQueryAdvancedTest.java
+++ b/hazelcast-client-new/src/test/java/com/hazelcast/client/map/impl/query/ClientQueryAdvancedTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.map.impl.query;
+
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.query.Predicate;
+import com.hazelcast.query.SampleObjects;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Collection;
+
+import static com.hazelcast.query.Predicates.equal;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertThat;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ClientQueryAdvancedTest {
+
+    private final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
+
+    @After
+    public void tearDown() {
+        hazelcastFactory.terminateAll();
+    }
+
+
+    @Test
+    public void queryIndexedComparableField_whenEqualsPredicateWithNullValueIsUsed_thenConverterUsesNullObject() {
+        //issue 5807
+        hazelcastFactory.newHazelcastInstance();
+        HazelcastInstance client = hazelcastFactory.newHazelcastClient();
+        final IMap<Integer, SampleObjects.Value> map = client.getMap("default");
+
+        map.addIndex("type", false);
+
+        SampleObjects.ValueType valueType = new SampleObjects.ValueType("name");
+        SampleObjects.Value valueWithoutNull = new SampleObjects.Value("notNull", valueType, 1);
+        SampleObjects.Value valueWithNull = new SampleObjects.Value("null", null, 1);
+        map.put(1, valueWithoutNull);
+        map.put(2, valueWithNull);
+
+        final Predicate nullPredicate = equal("type", null);
+        final Collection<SampleObjects.Value> emptyFieldValues = map.values(nullPredicate);
+        assertThat(emptyFieldValues, hasSize(1));
+        assertThat(emptyFieldValues, contains(valueWithNull));
+    }
+}

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/query/ClientQueryAdvancedTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/query/ClientQueryAdvancedTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.map.impl.query;
+
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.query.Predicate;
+import com.hazelcast.query.SampleObjects;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Collection;
+
+import static com.hazelcast.query.Predicates.equal;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertThat;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ClientQueryAdvancedTest {
+
+    private final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
+
+    @After
+    public void tearDown() {
+        hazelcastFactory.terminateAll();
+    }
+
+
+    @Test
+    public void queryIndexedComparableField_whenEqualsPredicateWithNullValueIsUsed_thenConverterUsesNullObject() {
+        //issue 5807
+        hazelcastFactory.newHazelcastInstance();
+        HazelcastInstance client = hazelcastFactory.newHazelcastClient();
+        final IMap<Integer, SampleObjects.Value> map = client.getMap("default");
+
+        map.addIndex("type", false);
+
+        SampleObjects.ValueType valueType = new SampleObjects.ValueType("name");
+        SampleObjects.Value valueWithoutNull = new SampleObjects.Value("notNull", valueType, 1);
+        SampleObjects.Value valueWithNull = new SampleObjects.Value("null", null, 1);
+        map.put(1, valueWithoutNull);
+        map.put(2, valueWithNull);
+
+        final Predicate nullPredicate = equal("type", null);
+        final Collection<SampleObjects.Value> emptyFieldValues = map.values(nullPredicate);
+        assertThat(emptyFieldValues, hasSize(1));
+        assertThat(emptyFieldValues, contains(valueWithNull));
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/AttributeType.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/AttributeType.java
@@ -83,11 +83,11 @@ public enum AttributeType {
     /**
      * UUID
      */
-    UUID(UUIDConverter.INSTANCE);
+    UUID(TypeConverters.UUID_CONVERTER);
 
     private final TypeConverters.TypeConverter converter;
 
-    private AttributeType(TypeConverters.TypeConverter converter) {
+    AttributeType(TypeConverters.TypeConverter converter) {
         this.converter = converter;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/IdentityConverter.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/IdentityConverter.java
@@ -21,10 +21,10 @@ import com.hazelcast.query.impl.TypeConverters.TypeConverter;
 /**
  * Converts to the same value
  **/
-public class IdentityConverter implements TypeConverter {
+class IdentityConverter extends TypeConverter {
 
     @Override
-    public Comparable convert(final Comparable value) {
+    Comparable convertInternal(final Comparable value) {
         return value;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/IndexImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/IndexImpl.java
@@ -81,7 +81,7 @@ public class IndexImpl implements Index {
         if (converter == null) {
             // Initialize attribute type by using entry index
             AttributeType attributeType = e.getAttributeType(attribute);
-            converter = attributeType == null ? new IdentityConverter() : attributeType.getConverter();
+            converter = attributeType == null ? TypeConverters.IDENTITY_CONVERTER : attributeType.getConverter();
         }
 
         Data key = e.getIndexKey();

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/TypeConverters.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/TypeConverters.java
@@ -41,16 +41,20 @@ final class TypeConverters {
     private TypeConverters() {
     }
 
-    public interface TypeConverter {
-        Comparable convert(Comparable value);
-    }
+    public abstract static class TypeConverter {
+        abstract Comparable convertInternal(Comparable value);
 
-    static class EnumConverter implements TypeConverter {
-        @Override
         public Comparable convert(Comparable value) {
             if (value == null) {
                 return IndexImpl.NULL;
             }
+            return convertInternal(value);
+        }
+    }
+
+    static class EnumConverter extends TypeConverter {
+        @Override
+        Comparable convertInternal(Comparable value) {
             String enumString = value.toString();
             if (enumString.contains(".")) {
                 // there is a dot  in the value specifier, keep part after last dot
@@ -60,12 +64,9 @@ final class TypeConverters {
         }
     }
 
-    static class SqlDateConverter implements TypeConverter {
+    static class SqlDateConverter extends TypeConverter {
         @Override
-        public Comparable convert(Comparable value) {
-            if (value == null) {
-                return IndexImpl.NULL;
-            }
+        Comparable convertInternal(Comparable value) {
             if (value instanceof java.sql.Date) {
                 return value;
             }
@@ -80,12 +81,9 @@ final class TypeConverters {
         }
     }
 
-    static class SqlTimestampConverter implements TypeConverter {
+    static class SqlTimestampConverter extends TypeConverter {
         @Override
-        public Comparable convert(Comparable value) {
-            if (value == null) {
-                return IndexImpl.NULL;
-            }
+        Comparable convertInternal(Comparable value) {
             if (value instanceof Timestamp) {
                 return value;
             }
@@ -100,12 +98,9 @@ final class TypeConverters {
         }
     }
 
-    static class DateConverter implements TypeConverter {
+    static class DateConverter extends TypeConverter {
         @Override
-        public Comparable convert(Comparable value) {
-            if (value == null) {
-                return IndexImpl.NULL;
-            }
+        Comparable convertInternal(Comparable value) {
             if (value instanceof Date) {
                 return value;
             }
@@ -120,12 +115,9 @@ final class TypeConverters {
         }
     }
 
-    static class DoubleConverter implements TypeConverter {
+    static class DoubleConverter extends TypeConverter {
         @Override
-        public Comparable convert(Comparable value) {
-            if (value == null) {
-                return IndexImpl.NULL;
-            }
+        Comparable convertInternal(Comparable value) {
             if (value instanceof Double) {
                 return value;
             }
@@ -140,12 +132,9 @@ final class TypeConverters {
         }
     }
 
-    static class LongConverter implements TypeConverter {
+    static class LongConverter extends TypeConverter {
         @Override
-        public Comparable convert(Comparable value) {
-            if (value == null) {
-                return IndexImpl.NULL;
-            }
+        Comparable convertInternal(Comparable value) {
             if (value instanceof Long) {
                 return value;
             }
@@ -160,12 +149,9 @@ final class TypeConverters {
         }
     }
 
-    static class BigIntegerConverter implements TypeConverter {
+    static class BigIntegerConverter extends TypeConverter {
         @Override
-        public Comparable convert(Comparable value) {
-            if (value == null) {
-                return IndexImpl.NULL;
-            }
+        Comparable convertInternal(Comparable value) {
             if (value instanceof BigInteger) {
                 return value;
             }
@@ -173,12 +159,9 @@ final class TypeConverters {
         }
     }
 
-    static class BigDecimalConverter implements TypeConverter {
+    static class BigDecimalConverter extends TypeConverter {
         @Override
-        public Comparable convert(Comparable value) {
-            if (value == null) {
-                return IndexImpl.NULL;
-            }
+        Comparable convertInternal(Comparable value) {
             if (value instanceof BigDecimal) {
                 return value;
             }
@@ -189,12 +172,9 @@ final class TypeConverters {
         }
     }
 
-    static class IntegerConverter implements TypeConverter {
+    static class IntegerConverter extends TypeConverter {
         @Override
-        public Comparable convert(Comparable value) {
-            if (value == null) {
-                return IndexImpl.NULL;
-            }
+        Comparable convertInternal(Comparable value) {
             if (value instanceof Integer) {
                 return value;
             }
@@ -209,25 +189,19 @@ final class TypeConverters {
         }
     }
 
-    static class StringConverter implements TypeConverter {
+    static class StringConverter extends TypeConverter {
         @Override
-        public Comparable convert(Comparable value) {
+        Comparable convertInternal(Comparable value) {
             if (value instanceof String) {
                 return value;
-            }
-            if (value == null) {
-                return IndexImpl.NULL;
             }
             return value.toString();
         }
     }
 
-    static class FloatConverter implements TypeConverter {
+    static class FloatConverter extends TypeConverter {
         @Override
-        public Comparable convert(Comparable value) {
-            if (value == null) {
-                return IndexImpl.NULL;
-            }
+        Comparable convertInternal(Comparable value) {
             if (value instanceof Float) {
                 return value;
             }
@@ -242,12 +216,9 @@ final class TypeConverters {
         }
     }
 
-    static class ShortConverter implements TypeConverter {
+    static class ShortConverter extends TypeConverter {
         @Override
-        public Comparable convert(Comparable value) {
-            if (value == null) {
-                return IndexImpl.NULL;
-            }
+        Comparable convertInternal(Comparable value) {
             if (value instanceof Short) {
                 return value;
             }
@@ -262,12 +233,9 @@ final class TypeConverters {
         }
     }
 
-    static class BooleanConverter implements TypeConverter {
+    static class BooleanConverter extends TypeConverter {
         @Override
-        public Comparable convert(Comparable value) {
-            if (value == null) {
-                return IndexImpl.NULL;
-            }
+        Comparable convertInternal(Comparable value) {
             if (value instanceof Boolean) {
                 return value;
             }
@@ -282,12 +250,9 @@ final class TypeConverters {
         }
     }
 
-    static class ByteConverter implements TypeConverter {
+    static class ByteConverter extends TypeConverter {
         @Override
-        public Comparable convert(Comparable value) {
-            if (value == null) {
-                return IndexImpl.NULL;
-            }
+        Comparable convertInternal(Comparable value) {
             if (value instanceof Byte) {
                 return value;
             }
@@ -302,12 +267,9 @@ final class TypeConverters {
         }
     }
 
-    static class CharConverter implements TypeConverter {
+    static class CharConverter extends TypeConverter {
         @Override
-        public Comparable convert(Comparable value) {
-            if (value == null) {
-                return IndexImpl.NULL;
-            }
+        Comparable convertInternal(Comparable value) {
             if (value.getClass() == char.class) {
                 return value;
             }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/TypeConverters.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/TypeConverters.java
@@ -37,6 +37,7 @@ final class TypeConverters {
     public static final TypeConverter SQL_DATE_CONVERTER = new SqlDateConverter();
     public static final TypeConverter SQL_TIMESTAMP_CONVERTER = new SqlTimestampConverter();
     public static final TypeConverter DATE_CONVERTER = new DateConverter();
+    public static final TypeConverter IDENTITY_CONVERTER = new IdentityConverter();
 
     private TypeConverters() {
     }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/TypeConverters.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/TypeConverters.java
@@ -38,6 +38,7 @@ final class TypeConverters {
     public static final TypeConverter SQL_TIMESTAMP_CONVERTER = new SqlTimestampConverter();
     public static final TypeConverter DATE_CONVERTER = new DateConverter();
     public static final TypeConverter IDENTITY_CONVERTER = new IdentityConverter();
+    public static final TypeConverter UUID_CONVERTER = new UUIDConverter();
 
     private TypeConverters() {
     }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/TypeConverters.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/TypeConverters.java
@@ -46,7 +46,7 @@ final class TypeConverters {
     public abstract static class TypeConverter {
         abstract Comparable convertInternal(Comparable value);
 
-        public Comparable convert(Comparable value) {
+        public final Comparable convert(Comparable value) {
             if (value == null) {
                 return IndexImpl.NULL;
             }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/UUIDConverter.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/UUIDConverter.java
@@ -23,14 +23,6 @@ import java.util.UUID;
  */
 final class UUIDConverter extends TypeConverters.TypeConverter {
 
-    /**
-     * Singleton
-     */
-    public static final TypeConverters.TypeConverter INSTANCE = new UUIDConverter();
-
-    private UUIDConverter() {
-    }
-
     @Override
     Comparable convertInternal(Comparable value) {
         if (value instanceof UUID) {

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/UUIDConverter.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/UUIDConverter.java
@@ -21,7 +21,7 @@ import java.util.UUID;
 /**
  * TypeConverter to handle UUID
  */
-public final class UUIDConverter implements TypeConverters.TypeConverter {
+final class UUIDConverter extends TypeConverters.TypeConverter {
 
     /**
      * Singleton
@@ -32,7 +32,7 @@ public final class UUIDConverter implements TypeConverters.TypeConverter {
     }
 
     @Override
-    public Comparable convert(Comparable value) {
+    Comparable convertInternal(Comparable value) {
         if (value instanceof UUID) {
             return value;
         }

--- a/hazelcast/src/test/java/com/hazelcast/query/SampleObjects.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/SampleObjects.java
@@ -77,7 +77,7 @@ public final class SampleObjects {
         }
     }
 
-    public static class ValueType implements Serializable {
+    public static class ValueType implements Serializable, Comparable<ValueType> {
         String typeName;
 
         public ValueType(String typeName) {
@@ -89,6 +89,40 @@ public final class SampleObjects {
 
         public String getTypeName() {
             return typeName;
+        }
+
+        @Override
+        public int compareTo(ValueType o) {
+            if (o == null) {
+                return 1;
+            }
+            if (typeName == null) {
+                if (o.typeName == null) {
+                    return 0;
+                } else {
+                    return -1;
+                }
+            }
+            if (o.typeName == null) {
+                return 1;
+            }
+            return typeName.compareTo(o.typeName);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            ValueType valueType = (ValueType) o;
+
+            return !(typeName != null ? !typeName.equals(valueType.typeName) : valueType.typeName != null);
+
+        }
+
+        @Override
+        public int hashCode() {
+            return typeName != null ? typeName.hashCode() : 0;
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/TypeConverterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/TypeConverterTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.query.impl;
+
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class TypeConverterTest {
+
+    @Test
+    public void testConvert_whenPassedNullValue_thenConvertToNullObject() {
+        TypeConverters.TypeConverter converter = new TypeConverters.TypeConverter() {
+            @Override
+            Comparable convertInternal(Comparable value) {
+                return value;
+            }
+        };
+        assertEquals(IndexImpl.NULL, converter.convert(null));
+    }
+}


### PR DESCRIPTION
Fixed #5807

It changes TypeConverter to be an abstract class instead of interface. It's not part of user API and it's the simplest way to make sure all converters deal with NULL input values correctly. 


Also a few small consistency related clean-ups. See commits for more informations.