### PR TITLE
Introduction to local and thread-local system properties for serial and parallel test runners

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastParallelClassRunner.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastParallelClassRunner.java
@@ -22,19 +22,34 @@ import org.junit.runners.model.FrameworkMethod;
 import org.junit.runners.model.InitializationError;
 import org.junit.runners.model.Statement;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.PrintStream;
+import java.io.PrintWriter;
+import java.io.Reader;
+import java.io.Writer;
 import java.lang.reflect.Constructor;
+import java.util.Collection;
+import java.util.Enumeration;
+import java.util.InvalidPropertiesFormatException;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static java.lang.Math.max;
 import static java.lang.Runtime.getRuntime;
 
-
 /**
  * Runs the tests in parallel with multiple threads.
  */
 public class HazelcastParallelClassRunner extends AbstractHazelcastClassRunner {
-    private static final boolean SPAWN_MULTIPLE_THREADS = TestEnvironment.isMockNetwork() && !Boolean.getBoolean("multipleJVM");
-    private static final int MAX_THREADS = max(getRuntime().availableProcessors(), 8);
+
+    private static final boolean SPAWN_MULTIPLE_THREADS
+            = TestEnvironment.isMockNetwork() && !Boolean.getBoolean("multipleJVM");
+    private static final int MAX_THREADS
+            = max(getRuntime().availableProcessors(), 8);
 
     private final AtomicInteger numThreads = new AtomicInteger(0);
     private final int maxThreads;
@@ -91,16 +106,26 @@ public class HazelcastParallelClassRunner extends AbstractHazelcastClassRunner {
         return new Statement() {
             @Override
             public void evaluate() throws Throwable {
-                HazelcastParallelClassRunner.super.childrenInvoker(notifier).evaluate();
-                // wait for all child threads (tests) to complete
-                while (numThreads.get() > 0) {
-                    Thread.sleep(25);
+                // Save the current system properties
+                final Properties currentSystemProperties = System.getProperties();
+                try {
+                    // Use thread-local based system properties so parallel tests don't effect each other
+                    System.setProperties(new ThreadLocalProperties(currentSystemProperties));
+                    HazelcastParallelClassRunner.super.childrenInvoker(notifier).evaluate();
+                    // Wait for all child threads (tests) to complete
+                    while (numThreads.get() > 0) {
+                        Thread.sleep(25);
+                    }
+                } finally {
+                    // Restore the system properties
+                    System.setProperties(currentSystemProperties);
                 }
             }
         };
     }
 
     private class TestRunner implements Runnable {
+
         private final FrameworkMethod method;
         private final RunNotifier notifier;
 
@@ -124,5 +149,185 @@ public class HazelcastParallelClassRunner extends AbstractHazelcastClassRunner {
                 FRAMEWORK_METHOD_THREAD_LOCAL.remove();
             }
         }
+
     }
+
+    private static class ThreadLocalProperties extends Properties {
+
+        private final Properties globalProperties;
+
+        private final ThreadLocal<Properties> localProperties = new InheritableThreadLocal<Properties>() {
+            @Override
+            protected Properties initialValue() {
+                return init(new Properties());
+            }
+        };
+
+        private ThreadLocalProperties(Properties properties) {
+            this.globalProperties = properties;
+        }
+
+        private Properties init(Properties properties) {
+            for (Map.Entry entry : globalProperties.entrySet()) {
+                properties.put(entry.getKey(), entry.getValue());
+            }
+            return properties;
+        }
+
+        private Properties getThreadLocal() {
+            return localProperties.get();
+        }
+
+        @Override
+        public String getProperty(String key) {
+            return getThreadLocal().getProperty(key);
+        }
+
+        @Override
+        public Object setProperty(String key, String value) {
+            return getThreadLocal().setProperty(key, value);
+        }
+
+        @Override
+        public Enumeration<?> propertyNames() {
+            return getThreadLocal().propertyNames();
+        }
+
+        @Override
+        public Set<String> stringPropertyNames() {
+            return getThreadLocal().stringPropertyNames();
+        }
+
+        @Override
+        public int size() {
+            return getThreadLocal().size();
+        }
+
+        @Override
+        public boolean isEmpty() {
+            return getThreadLocal().isEmpty();
+        }
+
+        @Override
+        public Enumeration<Object> keys() {
+            return getThreadLocal().keys();
+        }
+
+        @Override
+        public Enumeration<Object> elements() {
+            return getThreadLocal().elements();
+        }
+
+        @Override
+        public boolean contains(Object value) {
+            return getThreadLocal().contains(value);
+        }
+
+        @Override
+        public boolean containsValue(Object value) {
+            return getThreadLocal().containsValue(value);
+        }
+
+        @Override
+        public boolean containsKey(Object key) {
+            return getThreadLocal().containsKey(key);
+        }
+
+        @Override
+        public Object get(Object key) {
+            return getThreadLocal().get(key);
+        }
+
+        @Override
+        public Object put(Object key, Object value) {
+            return getThreadLocal().put(key, value);
+        }
+
+        @Override
+        public Object remove(Object key) {
+            return getThreadLocal().remove(key);
+        }
+
+        @Override
+        public void putAll(Map<?, ?> t) {
+            getThreadLocal().putAll(t);
+        }
+
+        @Override
+        public void clear() {
+            getThreadLocal().clear();
+        }
+
+        @Override
+        public Set<Object> keySet() {
+            return getThreadLocal().keySet();
+        }
+
+        @Override
+        public Set<Map.Entry<Object, Object>> entrySet() {
+            return getThreadLocal().entrySet();
+        }
+
+        @Override
+        public Collection<Object> values() {
+            return getThreadLocal().values();
+        }
+
+        @Override
+        public void load(Reader reader) throws IOException {
+            getThreadLocal().load(reader);
+        }
+
+        @Override
+        public void load(InputStream inStream) throws IOException {
+            getThreadLocal().load(inStream);
+        }
+
+        @Override
+        public void save(OutputStream out, String comments) {
+            getThreadLocal().save(out, comments);
+        }
+
+        @Override
+        public void store(Writer writer, String comments) throws IOException {
+            getThreadLocal().store(writer, comments);
+        }
+
+        @Override
+        public void store(OutputStream out, String comments) throws IOException {
+            getThreadLocal().store(out, comments);
+        }
+
+        @Override
+        public void loadFromXML(InputStream in) throws IOException, InvalidPropertiesFormatException {
+            getThreadLocal().loadFromXML(in);
+        }
+
+        @Override
+        public void storeToXML(OutputStream os, String comment) throws IOException {
+            getThreadLocal().storeToXML(os, comment);
+        }
+
+        @Override
+        public void storeToXML(OutputStream os, String comment, String encoding) throws IOException {
+            getThreadLocal().storeToXML(os, comment, encoding);
+        }
+
+        @Override
+        public String getProperty(String key, String defaultValue) {
+            return getThreadLocal().getProperty(key, defaultValue);
+        }
+
+        @Override
+        public void list(PrintStream out) {
+            getThreadLocal().list(out);
+        }
+
+        @Override
+        public void list(PrintWriter out) {
+            getThreadLocal().list(out);
+        }
+
+    }
+
 }


### PR DESCRIPTION
With this PR:
- `HazelcastSerialClassRunner` uses local system properties for each serial test so even a test sets a system property, this doesn't effect other tests.
- `HazelcastParallelClassRunner` uses thread-local system properties (`InheritableThreadLocal` is used so child threads share same thread-local system properties with their parents) for each parallel test so parallel tests don't effect other test's system properties even they run at the same time.

Inspired by this test failure (https://hazelcast-l337.ci.cloudbees.com/job/Hazelcast-3.x/com.hazelcast$hazelcast/3736/testReport/junit/com.hazelcast.instance/GroupPropertiesTest/setProperty_ensureUsageOfDefaultValue/) due to shared system properties between parallel test runs.