### PR TITLE
Query Optimizations, part 1

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -226,6 +226,7 @@
     <suppress checks="NPathComplexity" files="com/hazelcast/query/impl/getters/ReflectionHelper"/>
     <suppress checks="ReturnCount" files="com/hazelcast/query/impl/getters/ReflectionHelper"/>
     <suppress checks="ClassDataAbstractionCoupling" files="com/hazelcast/query/impl/TypeConverters"/>
+    <suppress checks="NPathComplexity" files="com/hazelcast/query/impl/predicates/BetweenVisitor"/>
 
     <!-- hazelcast-wm -->
     <suppress checks="JavadocMethod" files="com/hazelcast/web/"/>

--- a/hazelcast/src/main/java/com/hazelcast/instance/GroupProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/GroupProperty.java
@@ -22,6 +22,7 @@ import com.hazelcast.internal.monitors.HealthMonitorLevel;
 import com.hazelcast.map.QueryResultSizeExceededException;
 import com.hazelcast.map.impl.query.QueryResultSizeLimiter;
 import com.hazelcast.query.TruePredicate;
+import com.hazelcast.query.impl.predicates.QueryOptimizerFactory;
 
 import java.util.concurrent.TimeUnit;
 
@@ -533,6 +534,19 @@ public enum GroupProperty implements HazelcastProperty {
      * @see #QUERY_RESULT_SIZE_LIMIT
      */
     QUERY_MAX_LOCAL_PARTITION_LIMIT_FOR_PRE_CHECK("hazelcast.query.max.local.partition.limit.for.precheck", 3),
+
+    /**
+     * Type of Query Optimizer.
+     * Valid Values:
+     * <ul>
+     *     <li>RULES - for optimizations based on static rules</li>
+     *     <li>NONE - optimization are disabled</li>
+     * </ul>
+     *
+     * Values are case sensitive
+     *
+     */
+    QUERY_OPTIMIZER_TYPE("hazelcast.query.optimizer.type", QueryOptimizerFactory.Type.RULES.toString()),
 
     /**
      * Forces the JCache provider, which can have values client or server, to force the provider type.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
@@ -58,6 +58,7 @@ import java.util.LinkedHashSet;
 
 import static com.hazelcast.map.impl.ListenerAdapters.createListenerAdapter;
 import static com.hazelcast.map.impl.MapService.SERVICE_NAME;
+import static com.hazelcast.query.impl.predicates.QueryOptimizerFactory.newOptimizer;
 
 /**
  * Default implementation of map service context.
@@ -106,7 +107,7 @@ class MapServiceContextImpl implements MapServiceContext {
         this.localMapStatsProvider = new LocalMapStatsProvider(this, nodeEngine);
         this.mergePolicyProvider = new MergePolicyProvider(nodeEngine);
         this.mapEventPublisher = createMapEventPublisherSupport();
-        this.mapQueryEngine = new MapQueryEngineImpl(this);
+        this.mapQueryEngine = new MapQueryEngineImpl(this, newOptimizer(nodeEngine.getGroupProperties()));
     }
 
     MapEventPublisherImpl createMapEventPublisherSupport() {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/MapQueryEngine.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/MapQueryEngine.java
@@ -18,6 +18,7 @@ package com.hazelcast.map.impl.query;
 
 import com.hazelcast.query.PagingPredicate;
 import com.hazelcast.query.Predicate;
+import com.hazelcast.query.impl.Indexes;
 import com.hazelcast.query.impl.QueryableEntry;
 import com.hazelcast.util.IterationType;
 
@@ -93,4 +94,15 @@ public interface MapQueryEngine {
      * @return {@link QueryResult}
      */
     QueryResult newQueryResult(int numberOfPartitions);
+
+
+    /**
+     * Return optimized version of the query. The input predicate itself must not be modified in anyway.
+     * If no optimization is done then it may return the original instanceg.
+     *
+     * @param predicate
+     * @param indexes
+     * @return optimized version of input predicate or the predicate itself if no optimization was performed
+     */
+    Predicate optimize(Predicate predicate, Indexes indexes);
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryOperation.java
@@ -26,6 +26,7 @@ import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.partition.InternalPartitionService;
 import com.hazelcast.query.PagingPredicate;
 import com.hazelcast.query.Predicate;
+import com.hazelcast.query.impl.Indexes;
 import com.hazelcast.query.impl.QueryableEntry;
 import com.hazelcast.spi.ExceptionAction;
 import com.hazelcast.spi.NodeEngine;
@@ -84,12 +85,15 @@ public class QueryOperation extends AbstractMapOperation implements ReadonlyOper
         MapServiceContext mapServiceContext = mapService.getMapServiceContext();
         MapQueryEngine queryEngine = mapServiceContext.getMapQueryEngine();
 
+        Indexes indexes = mapContainer.getIndexes();
+        predicate = queryEngine.optimize(predicate, indexes);
+
         int initialPartitionStateVersion = partitionService.getPartitionStateVersion();
         Collection<Integer> initialPartitions = mapServiceContext.getOwnedPartitions();
 
         Set<QueryableEntry> entries = null;
         if (!partitionService.hasOnGoingMigrationLocal()) {
-            entries = mapContainer.getIndexes().query(predicate);
+            entries = indexes.query(predicate);
         }
 
         result = queryEngine.newQueryResult(initialPartitions.size());

--- a/hazelcast/src/main/java/com/hazelcast/query/SqlPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/SqlPredicate.java
@@ -18,7 +18,7 @@ package com.hazelcast.query;
 
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.query.impl.IndexImpl;
+import com.hazelcast.query.impl.Indexes;
 import com.hazelcast.query.impl.QueryContext;
 import com.hazelcast.query.impl.QueryableEntry;
 
@@ -30,6 +30,8 @@ import java.util.Map;
 import java.util.Set;
 
 import com.hazelcast.query.impl.predicates.AbstractPredicate;
+import com.hazelcast.query.impl.predicates.Visitor;
+
 import static com.hazelcast.query.Predicates.and;
 import static com.hazelcast.query.Predicates.between;
 import static com.hazelcast.query.Predicates.equal;
@@ -47,11 +49,11 @@ import static com.hazelcast.query.Predicates.regex;
  * This class contains methods related to conversion of sql query to predicate.
  */
 
-public class SqlPredicate extends AbstractPredicate implements IndexAwarePredicate {
+public class SqlPredicate extends AbstractPredicate implements IndexAwarePredicate, VisitablePredicate {
 
     private static final long serialVersionUID = 1;
 
-    private transient Predicate predicate;
+    transient Predicate predicate;
     private String sql;
 
     public SqlPredicate(String sql) {
@@ -261,7 +263,7 @@ public class SqlPredicate extends AbstractPredicate implements IndexAwarePredica
         if (value != null) {
             return value;
         } else if (key instanceof String && ("null".equalsIgnoreCase((String) key))) {
-            return IndexImpl.NULL;
+            return null;
         } else {
             return key;
         }
@@ -320,5 +322,18 @@ public class SqlPredicate extends AbstractPredicate implements IndexAwarePredica
     @Override
     public int hashCode() {
         return sql.hashCode();
+    }
+
+    @Override
+    public Predicate accept(Visitor visitor, Indexes indexes) {
+        Predicate target = predicate;
+        if (predicate instanceof VisitablePredicate) {
+            target = ((VisitablePredicate) predicate).accept(visitor, indexes);
+        }
+        return target;
+    }
+
+    public Predicate getPredicate() {
+        return predicate;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/query/VisitablePredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/VisitablePredicate.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.query;
+
+import com.hazelcast.query.impl.Indexes;
+import com.hazelcast.query.impl.predicates.Visitor;
+
+/**
+ * Predicates which can be visited by optimizer.
+ *
+ */
+public interface VisitablePredicate {
+
+    /**
+     * Accept visitor. Predicate can either return it's own instance if no modification
+     * was done as a result of the visit. In the case there is a change needed then
+     * the predicate has to return changed copy of itself. Predicates has to be treated
+     * as immutable for optimization purposes.
+     *
+     * @param visitor visitor to accept
+     * @param indexes indexes
+     * @return itself or its changed copy
+     */
+    Predicate accept(Visitor visitor, Indexes indexes);
+}

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/FalsePredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/FalsePredicate.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.query.impl;
+
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.DataSerializable;
+import com.hazelcast.query.IndexAwarePredicate;
+import com.hazelcast.query.Predicate;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+
+public class FalsePredicate implements DataSerializable, Predicate, IndexAwarePredicate {
+    /**
+     * An instance of the FalsePredicate.
+     */
+    public static final FalsePredicate INSTANCE = new FalsePredicate();
+
+    @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) throws IOException {
+    }
+
+    @Override
+    public boolean apply(Map.Entry mapEntry) {
+        return false;
+    }
+
+    @Override
+    public String toString() {
+        return "FalsePredicate{}";
+    }
+
+    @Override
+    public Set<QueryableEntry> filter(QueryContext queryContext) {
+        return Collections.emptySet();
+    }
+
+    @Override
+    public boolean isIndexed(QueryContext queryContext) {
+        return true;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/Index.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/Index.java
@@ -29,6 +29,14 @@ public interface Index {
 
     void clear();
 
+    /**
+     * Return converter associated with this Index.
+     * It can return <code>null</code> if no entry has been saved yet.
+     *
+     * @return
+     */
+    TypeConverters.TypeConverter getConverter();
+
     void removeEntryIndex(Data indexKey);
 
     Set<QueryableEntry> getRecords(Comparable[] values);

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/IndexImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/IndexImpl.java
@@ -16,10 +16,14 @@
 
 package com.hazelcast.query.impl;
 
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.nio.serialization.DataSerializable;
 import com.hazelcast.query.QueryException;
 import com.hazelcast.query.impl.TypeConverters.TypeConverter;
 
+import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -47,6 +51,11 @@ public class IndexImpl implements Index {
         this.attribute = attribute;
         this.ordered = ordered;
         indexStore = (ordered) ? new SortedIndexStore() : new UnsortedIndexStore();
+    }
+
+    @Override
+    public TypeConverter getConverter() {
+        return converter;
     }
 
     @Override
@@ -171,7 +180,7 @@ public class IndexImpl implements Index {
     /**
      * Provides comparable null object.
      */
-    public static final class NullObject implements Comparable {
+    public static final class NullObject implements Comparable, DataSerializable {
         @Override
         public int compareTo(Object o) {
             if (o == this || o instanceof NullObject) {
@@ -194,6 +203,16 @@ public class IndexImpl implements Index {
                 return false;
             }
             return true;
+        }
+
+        @Override
+        public void writeData(ObjectDataOutput out) throws IOException {
+
+        }
+
+        @Override
+        public void readData(ObjectDataInput in) throws IOException {
+
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/Indexes.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/Indexes.java
@@ -84,7 +84,13 @@ public class Indexes {
         }
     }
 
-    Index getIndex(String attribute) {
+    /**
+     * Get index for a given attribute. If the index does not exist then returns null.
+     *
+     * @param attribute
+     * @return Index for attribute or null if the index does not exist.
+     */
+    public Index getIndex(String attribute) {
         return mapIndexes.get(attribute);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/TypeConverters.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/TypeConverters.java
@@ -21,7 +21,7 @@ import java.math.BigInteger;
 import java.sql.Timestamp;
 import java.util.Date;
 
-final class TypeConverters {
+public final class TypeConverters {
     public static final TypeConverter BIG_INTEGER_CONVERTER = new BigIntegerConverter();
     public static final TypeConverter BIG_DECIMAL_CONVERTER = new BigDecimalConverter();
     public static final TypeConverter DOUBLE_CONVERTER = new DoubleConverter();

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/AbstractVisitor.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/AbstractVisitor.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.query.impl.predicates;
+
+import com.hazelcast.query.Predicate;
+import com.hazelcast.query.impl.Indexes;
+
+/**
+ * Base class for all visitors. It returns the original predicate without touching.
+ * Concrete Visitor can just override the method for predicate the visitor is interested in.
+ */
+public abstract class AbstractVisitor implements Visitor {
+
+    @Override
+    public Predicate visit(AndPredicate predicate, Indexes indexes) {
+        return predicate;
+    }
+
+    @Override
+    public Predicate visit(OrPredicate predicate, Indexes indexes) {
+        return predicate;
+    }
+
+    @Override
+    public Predicate visit(NotPredicate predicate, Indexes indexes) {
+        return predicate;
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/BetweenPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/BetweenPredicate.java
@@ -30,8 +30,8 @@ import java.util.Set;
  * Between Predicate
  */
 public class BetweenPredicate extends AbstractPredicate {
-    private Comparable to;
-    private Comparable from;
+    Comparable to;
+    Comparable from;
 
     public BetweenPredicate() {
     }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/BetweenVisitor.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/BetweenVisitor.java
@@ -1,0 +1,265 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.query.impl.predicates;
+
+import com.hazelcast.query.impl.Index;
+import com.hazelcast.query.impl.Indexes;
+import com.hazelcast.query.impl.TypeConverters;
+import com.hazelcast.util.collection.ArrayUtils;
+import com.hazelcast.util.collection.InternalMultiMap;
+import com.hazelcast.query.Predicate;
+import com.hazelcast.query.impl.FalsePredicate;
+
+import java.util.List;
+import java.util.Map;
+
+import static com.hazelcast.util.collection.ArrayUtils.createCopy;
+
+/**
+ * Replaces expression from (age >= X and age <= Y) into (age between X Y)
+ * It detects some predicates which are trivally false.
+ *
+ * Imagine this: (age >= 5 and age <= 4) This predicate is always false.
+ *
+ * It also eliminates some conditions. Imagine this: (age >= 10 and age <= 20 and age < 40).
+ * In this case the condition (age < 40) can be eliminated safely and the predicate
+ * be be rewritten as (age between 10 20)
+ *
+ * When resulting AndPredicate contains only a single inner predicate then it returns
+ * only the inner predicate. In other words: (and p) is rewritten as (p). I used prefix
+ * notation here as it's easier to understand.
+ *
+ */
+public class BetweenVisitor extends AbstractVisitor {
+
+    @Override
+    public Predicate visit(AndPredicate andPredicate, Indexes indexes) {
+        final Predicate[] originalPredicates = andPredicate.predicates;
+        InternalMultiMap<String, GreaterLessPredicate> candidates =
+                findCandidatesAndGroupByAttribute(originalPredicates, indexes);
+
+        if (candidates == null) {
+            return andPredicate;
+        }
+
+        //how many predicates is eliminated
+        int toBeRemovedCounter = 0;
+        boolean modified = false;
+        Predicate[] target = originalPredicates;
+        for (Map.Entry<String, List<GreaterLessPredicate>> entry : candidates.entrySet()) {
+            List<GreaterLessPredicate> predicates = entry.getValue();
+            if (predicates.size() == 1) {
+                continue;
+            }
+            String attributeName = entry.getKey();
+            Boundaries boundaries = findBoundaryOrNull(attributeName, predicates, indexes);
+            if (boundaries == null) {
+                //no boundaries were found. it's not in the form `foo >= X and foo <= Y`
+                continue;
+            }
+
+            if (boundaries.isOverlapping()) {
+                // the predicate is never true. imagine this: `foo >= 5 and foo <= 4`
+                // it can never be true, we can't replace the whole AND Node with FalsePredicate
+
+                // We can return FalsePredicate even if there are additional predicate
+                // as `foo >= 5 and foo <= 5 and bar = 3` is still always false. the `bar = 3` can
+                // be eliminated too.
+                return FalsePredicate.INSTANCE;
+            }
+            if (!modified) {
+                modified = true;
+                target = createCopy(target);
+            }
+            toBeRemovedCounter = rewriteAttribute(boundaries, target, toBeRemovedCounter);
+        }
+        Predicate[] newPredicates = removeEliminatedPredicates(target, toBeRemovedCounter);
+        if (newPredicates == originalPredicates) {
+            return andPredicate;
+        }
+        if (newPredicates.length == 1) {
+            return newPredicates[0];
+        }
+        return new AndPredicate(newPredicates);
+    }
+
+    private Boundaries findBoundaryOrNull(String attributeName,
+                                          List<GreaterLessPredicate> predicates, Indexes indexes) {
+        GreaterLessPredicate mostRightGreaterOrEquals = null;
+        GreaterLessPredicate mostLeftLessThanOrEquals = null;
+        Index index = indexes.getIndex(attributeName);
+        TypeConverters.TypeConverter converter = index.getConverter();
+        for (GreaterLessPredicate predicate : predicates) {
+            if (predicate.less) {
+                if (mostLeftLessThanOrEquals == null || isLessThan(mostLeftLessThanOrEquals, predicate, converter)) {
+                    mostLeftLessThanOrEquals = predicate;
+                }
+            } else {
+                if (mostRightGreaterOrEquals == null || isGreaterThan(mostRightGreaterOrEquals, predicate, converter)) {
+                    mostRightGreaterOrEquals = predicate;
+                }
+            }
+        }
+        if (mostRightGreaterOrEquals == null || mostLeftLessThanOrEquals == null) {
+            return null;
+        }
+        return new Boundaries(mostRightGreaterOrEquals, mostLeftLessThanOrEquals, converter);
+    }
+
+    private Predicate[] removeEliminatedPredicates(Predicate[] originalPredicates, int toBeRemoved) {
+        if (toBeRemoved == 0) {
+            return originalPredicates;
+        }
+        int newSize = originalPredicates.length - toBeRemoved;
+        Predicate[] newPredicates = new Predicate[newSize];
+        ArrayUtils.copyWithoutNulls(originalPredicates, newPredicates);
+        return newPredicates;
+    }
+
+
+    private int rewriteAttribute(Boundaries boundaries,
+                                 Predicate[] originalPredicates, int toBeRemovedCount) {
+        GreaterLessPredicate leftBoundary = boundaries.leftBoundary;
+        GreaterLessPredicate rightBoundary = boundaries.rightBoundary;
+
+        Predicate rewritten = boundaries.createEquivalentPredicate();
+        for (int i = 0; i < originalPredicates.length; i++) {
+            Predicate currentPredicate = originalPredicates[i];
+            if (currentPredicate == leftBoundary) {
+                originalPredicates[i] = rewritten;
+            } else if (currentPredicate == rightBoundary) {
+                originalPredicates[i] = null;
+                toBeRemovedCount++;
+            } else if (boundaries.canBeEliminated(currentPredicate)) {
+                originalPredicates[i] = null;
+                toBeRemovedCount++;
+            }
+        }
+        return toBeRemovedCount;
+    }
+
+    /**
+     * Find GreaterLessPredicates with equal flag set to true and group them by attribute name
+     */
+    private InternalMultiMap<String, GreaterLessPredicate> findCandidatesAndGroupByAttribute(Predicate[] predicates,
+                                                                                             Indexes indexService) {
+        InternalMultiMap<String, GreaterLessPredicate> candidates = null;
+        for (Predicate predicate : predicates) {
+            if (!(predicate instanceof GreaterLessPredicate)) {
+                continue;
+            }
+            GreaterLessPredicate greaterLessPredicate = (GreaterLessPredicate) predicate;
+            if (!(greaterLessPredicate.equal)) {
+                continue;
+            }
+            String attributeName = greaterLessPredicate.attribute;
+            Index index = indexService.getIndex(attributeName);
+            if (index == null || index.getConverter() == null) {
+                continue;
+            }
+            candidates = addIntoCandidates(greaterLessPredicate, candidates);
+        }
+        return candidates;
+    }
+
+    private InternalMultiMap<String, GreaterLessPredicate> addIntoCandidates(
+            GreaterLessPredicate predicate, InternalMultiMap<String, GreaterLessPredicate> currentCandidates) {
+        if (currentCandidates == null) {
+            currentCandidates = new InternalMultiMap<String, GreaterLessPredicate>();
+        }
+        String attributeName = predicate.attribute;
+        currentCandidates.put(attributeName, predicate);
+        return currentCandidates;
+    }
+
+    /**
+     * Represent a boundary of series of GreatLessPredicates connected by AND
+     *
+     * Example:
+     * (age >= 5 and age >= 6 and age <= 10)
+     * has a left boundary (age >= 6)
+     * and a right boundary (age <= 10)
+     *
+     */
+    private class Boundaries {
+        private final GreaterLessPredicate leftBoundary;
+        private final GreaterLessPredicate rightBoundary;
+        private final TypeConverters.TypeConverter typeConverter;
+
+        Boundaries(GreaterLessPredicate leftBoundary, GreaterLessPredicate rightBoundary,
+                   TypeConverters.TypeConverter converter) {
+            this.leftBoundary = leftBoundary;
+            this.rightBoundary = rightBoundary;
+            this.typeConverter = converter;
+        }
+
+        /**
+         * Overlapping boundaries has a form of (age >= 5 and age <= 4) - predicates with overlaps
+         * are always evaluated as false.
+         *
+         * @return
+         */
+        boolean isOverlapping() {
+            return (isGreaterThan(rightBoundary, leftBoundary, typeConverter));
+        }
+
+        Predicate createEquivalentPredicate() {
+            String attributeName = leftBoundary.attribute;
+            if (isSame()) {
+                return new EqualPredicate(attributeName, leftBoundary.value);
+            } else {
+                return new BetweenPredicate(attributeName, leftBoundary.value, rightBoundary.value);
+            }
+        }
+
+        boolean isSame() {
+            return leftBoundary.value == rightBoundary.value;
+        }
+
+        private boolean canBeEliminated(Predicate predicate) {
+            if (!(predicate instanceof GreaterLessPredicate)) {
+                return false;
+            }
+            GreaterLessPredicate greaterLessPredicate = (GreaterLessPredicate) predicate;
+            if (!greaterLessPredicate.attribute.equals(leftBoundary.attribute)) {
+                return false;
+            }
+
+            if (greaterLessPredicate.less) {
+                return isGreaterThan(rightBoundary, greaterLessPredicate, typeConverter);
+            } else {
+                return isLessThan(leftBoundary, greaterLessPredicate, typeConverter);
+            }
+        }
+    }
+
+    private boolean isGreaterThan(GreaterLessPredicate leftPredicate,
+                                  GreaterLessPredicate rightPredicate, TypeConverters.TypeConverter converter) {
+        Comparable rightValue = converter.convert(rightPredicate.value);
+        Comparable leftValue = converter.convert(leftPredicate.value);
+        return rightValue.compareTo(leftValue) > 0;
+    }
+
+    private boolean isLessThan(GreaterLessPredicate leftPredicate, GreaterLessPredicate rightPredicate,
+                               TypeConverters.TypeConverter converter) {
+        Comparable rightValue = converter.convert(rightPredicate.value);
+        Comparable leftValue = converter.convert(leftPredicate.value);
+        return rightValue.compareTo(leftValue) < 0;
+    }
+
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/EmptyOptimizer.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/EmptyOptimizer.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.query.impl.predicates;
+
+import com.hazelcast.query.Predicate;
+import com.hazelcast.query.impl.Indexes;
+
+/**
+ * Optimizer which just returns the original predicate.
+ * It's useful when optimizer is disabled.
+ *
+ */
+public class EmptyOptimizer implements QueryOptimizer {
+    @Override
+    public <K, V> Predicate<K, V> optimize(Predicate<K, V> predicate, Indexes indexes) {
+        return predicate;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/EqualPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/EqualPredicate.java
@@ -18,6 +18,7 @@ package com.hazelcast.query.impl.predicates;
 
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.query.Predicate;
 import com.hazelcast.query.impl.Index;
 import com.hazelcast.query.impl.IndexImpl;
 import com.hazelcast.query.impl.QueryContext;
@@ -30,7 +31,7 @@ import java.util.Set;
 /**
  * Equal Predicate
  */
-public class EqualPredicate extends AbstractPredicate {
+public class EqualPredicate extends AbstractPredicate implements NegatablePredicate {
     protected Comparable value;
 
     public EqualPredicate() {
@@ -76,5 +77,10 @@ public class EqualPredicate extends AbstractPredicate {
     @Override
     public String toString() {
         return attribute + "=" + value;
+    }
+
+    @Override
+    public Predicate negate() {
+        return new NotEqualPredicate(attribute, value);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/FlatteningVisitor.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/FlatteningVisitor.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.query.impl.predicates;
+
+
+import com.hazelcast.query.Predicate;
+import com.hazelcast.query.impl.Indexes;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.hazelcast.util.collection.ArrayUtils.createCopy;
+
+/**
+ * Rewrites predicates:
+ *
+ * 1. AndPredicates flattening:
+ * (a = 1 and (b = 2 and c = 3)) into (a = 1 and b = 2 and c = 3)
+ *
+ * 2. OrPredicate flattening:
+ * (a = 1 or (b = 2 or c = 3)) into (a = 1 or b = 2 or c = 3)
+ *
+ * 3. NotElimination
+ * (not(P)) when P is {@link NegatablePredicate} is rewritten as P.negate()
+ *
+ *
+ */
+public class FlatteningVisitor extends AbstractVisitor {
+
+    @Override
+    public Predicate visit(AndPredicate andPredicate, Indexes indexes) {
+        Predicate[] originalPredicates = andPredicate.predicates;
+        List<Predicate> toBeAdded = null;
+        boolean modified = false;
+        Predicate[] target = originalPredicates;
+        for (int i = 0; i < target.length; i++) {
+            Predicate predicate = target[i];
+            if (predicate instanceof AndPredicate) {
+                Predicate[] subPredicates = ((AndPredicate) predicate).predicates;
+                if (!modified) {
+                    modified = true;
+                    target = createCopy(target);
+                }
+                toBeAdded = replaceFirstAndStoreOthers(target, subPredicates, i, toBeAdded);
+            }
+        }
+        Predicate[] newInners = createNewInners(target, toBeAdded);
+        if (newInners == originalPredicates) {
+            return andPredicate;
+        }
+        return new AndPredicate(newInners);
+    }
+
+    @Override
+    public Predicate visit(OrPredicate orPredicate, Indexes indexes) {
+        Predicate[] originalPredicates = orPredicate.predicates;
+        List<Predicate> toBeAdded = null;
+        boolean modified = false;
+        Predicate[] target = originalPredicates;
+        for (int i = 0; i < target.length; i++) {
+            Predicate predicate = target[i];
+            if (predicate instanceof OrPredicate) {
+                Predicate[] subPredicates = ((OrPredicate) predicate).predicates;
+                if (!modified) {
+                    modified = true;
+                    target = createCopy(target);
+                }
+                toBeAdded = replaceFirstAndStoreOthers(target, subPredicates, i, toBeAdded);
+            }
+        }
+        Predicate[] newInners = createNewInners(target, toBeAdded);
+        if (newInners == originalPredicates) {
+            return orPredicate;
+        }
+        return new OrPredicate(newInners);
+    }
+
+    private List<Predicate> replaceFirstAndStoreOthers(Predicate[] predicates, Predicate[] subPredicates,
+                                                       int position, List<Predicate> store) {
+        if (subPredicates == null || subPredicates.length == 0) {
+            return store;
+        }
+
+        predicates[position] = subPredicates[0];
+        for (int j = 1; j < subPredicates.length; j++) {
+            if (store == null) {
+                store = new ArrayList<Predicate>();
+            }
+            store.add(subPredicates[j]);
+        }
+        return store;
+    }
+
+    private Predicate[] createNewInners(Predicate[] predicates, List<Predicate> toBeAdded) {
+        if (toBeAdded == null || toBeAdded.size() == 0) {
+            return predicates;
+        }
+
+        int newSize = predicates.length + toBeAdded.size();
+        Predicate[] newPredicates = new Predicate[newSize];
+        System.arraycopy(predicates, 0, newPredicates, 0, predicates.length);
+        for (int i = predicates.length; i < newSize; i++) {
+            newPredicates[i] = toBeAdded.get(i - predicates.length);
+        }
+        return newPredicates;
+    }
+
+    @Override
+    public Predicate visit(NotPredicate predicate, Indexes indexes) {
+        Predicate inner = predicate.predicate;
+        if (inner instanceof NegatablePredicate) {
+            return ((NegatablePredicate) inner).negate();
+        }
+        return predicate;
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/GreaterLessPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/GreaterLessPredicate.java
@@ -18,6 +18,7 @@ package com.hazelcast.query.impl.predicates;
 
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.query.Predicate;
 import com.hazelcast.query.impl.ComparisonType;
 import com.hazelcast.query.impl.Index;
 import com.hazelcast.query.impl.QueryContext;
@@ -30,7 +31,8 @@ import java.util.Set;
 /**
  * Greater Less Predicate
  */
-public class GreaterLessPredicate extends EqualPredicate {
+public final class GreaterLessPredicate extends AbstractPredicate implements NegatablePredicate {
+    protected Comparable value;
     boolean equal;
     boolean less;
 
@@ -75,6 +77,7 @@ public class GreaterLessPredicate extends EqualPredicate {
     @Override
     public void readData(ObjectDataInput in) throws IOException {
         super.readData(in);
+        value = in.readObject();
         equal = in.readBoolean();
         less = in.readBoolean();
     }
@@ -82,6 +85,7 @@ public class GreaterLessPredicate extends EqualPredicate {
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
         super.writeData(out);
+        out.writeObject(value);
         out.writeBoolean(equal);
         out.writeBoolean(less);
     }
@@ -96,5 +100,10 @@ public class GreaterLessPredicate extends EqualPredicate {
         }
         sb.append(value);
         return sb.toString();
+    }
+
+    @Override
+    public Predicate negate() {
+        return new GreaterLessPredicate(attribute, value, !equal, !less);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/InPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/InPredicate.java
@@ -31,7 +31,7 @@ import java.util.Set;
  * In Predicate
  */
 public class InPredicate extends AbstractPredicate {
-    private Comparable[] values;
+    Comparable[] values;
     private volatile Set<Comparable> convertedInValues;
 
     public InPredicate() {

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/NegatablePredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/NegatablePredicate.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.query.impl.predicates;
+
+import com.hazelcast.query.Predicate;
+
+/**
+ * Predicates can implement this interface if they can convert itself into logical negation
+ *
+ */
+public interface NegatablePredicate {
+
+    /**
+     * Create logical negation of itself.
+     *
+     * @return A predicate which is a logical negation of itself.
+     */
+    Predicate negate();
+}

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/NotEqualPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/NotEqualPredicate.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.query.impl.predicates;
 
+import com.hazelcast.query.Predicate;
 import com.hazelcast.query.impl.QueryContext;
 import com.hazelcast.query.impl.QueryableEntry;
 
@@ -25,7 +26,7 @@ import java.util.Set;
 /**
  * Not Equal Predicate
  */
-public class NotEqualPredicate extends EqualPredicate {
+public final class NotEqualPredicate extends EqualPredicate {
     public NotEqualPredicate() {
     }
 
@@ -51,5 +52,10 @@ public class NotEqualPredicate extends EqualPredicate {
     @Override
     public String toString() {
         return attribute + " != " + value;
+    }
+
+    @Override
+    public Predicate negate() {
+        return new EqualPredicate(attribute, value);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/OrToInVisitor.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/OrToInVisitor.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.query.impl.predicates;
+
+import com.hazelcast.query.Predicate;
+import com.hazelcast.query.impl.Indexes;
+import com.hazelcast.util.collection.InternalMultiMap;
+
+import java.util.List;
+import java.util.Map;
+
+import static com.hazelcast.util.collection.ArrayUtils.createCopy;
+
+/**
+ * Transforms predicate (attribute = 1 or attribute = 2 or attribute = 3) into
+ * (attribute in (1, 2, 3)
+ *
+ * InPredicate is easier to evaluate in both indexed and non-indexed scenarios.
+ *
+ * When index is not used then {@link Predicate} require just a single reflective call
+ * the extract an attribute for {@link com.hazelcast.query.impl.QueryableEntry} while
+ * disjunction of equalPredicate(s) requires one reflective call for each equalPredicate.
+ *
+ * The performance is even more significant when tha {@link InPredicate#attribute} is indexed.
+ * As then the InPrecicate can be evaluated by just a single hit into index.
+ *
+ *
+ * When index is used then
+ *
+ *
+ */
+public class OrToInVisitor extends AbstractVisitor {
+
+    private static final int MINIMUM_NUMBER_OF_OR_TO_REPLACE = 5;
+
+    @Override
+    public Predicate visit(OrPredicate orPredicate, Indexes indexes) {
+        Predicate[] originalInnerPredicates = orPredicate.predicates;
+        if (originalInnerPredicates == null || originalInnerPredicates.length < MINIMUM_NUMBER_OF_OR_TO_REPLACE) {
+            return orPredicate;
+        }
+
+        InternalMultiMap<String, Integer> candidates = findAndGroupCandidates(originalInnerPredicates);
+        if (candidates == null) {
+            return orPredicate;
+        }
+        int toBeRemoved = 0;
+        boolean modified = false;
+        Predicate[] target = originalInnerPredicates;
+        for (Map.Entry<String, List<Integer>> candidate : candidates.entrySet()) {
+            String attribute = candidate.getKey();
+            List<Integer> positions = candidate.getValue();
+            if (positions.size() < MINIMUM_NUMBER_OF_OR_TO_REPLACE) {
+                continue;
+            }
+            if (!modified) {
+                modified = true;
+                target = createCopy(target);
+            }
+            toBeRemoved = replaceForAttribute(attribute, target, positions, toBeRemoved);
+        }
+        Predicate[] newInnerPredicates = replaceInnerPredicates(target, toBeRemoved);
+        return getOrCreateFinalPredicate(orPredicate, originalInnerPredicates, newInnerPredicates);
+    }
+
+    private Predicate getOrCreateFinalPredicate(OrPredicate predicate, Predicate[] innerPredicates, Predicate[] newPredicates) {
+        if (newPredicates == innerPredicates) {
+            return predicate;
+        }
+        if (newPredicates.length == 1) {
+            return newPredicates[0];
+        }
+        return new OrPredicate(newPredicates);
+    }
+
+    private int replaceForAttribute(String attribute, Predicate[] innerPredicates, List<Integer> positions, int toBeRemoved) {
+        Comparable[] values = new Comparable[positions.size()];
+        for (int i = 0; i < positions.size(); i++) {
+            int position = positions.get(i);
+            EqualPredicate equalPredicate = ((EqualPredicate) innerPredicates[position]);
+            values[i] = equalPredicate.value;
+            innerPredicates[position] = null;
+            toBeRemoved++;
+        }
+        InPredicate inPredicate = new InPredicate(attribute, values);
+        innerPredicates[positions.get(0)] = inPredicate;
+        toBeRemoved--;
+        return toBeRemoved;
+    }
+
+    private Predicate[] replaceInnerPredicates(Predicate[] innerPredicates, int toBeRemoved) {
+        if (toBeRemoved == 0) {
+            return innerPredicates;
+        }
+
+        int removed = 0;
+        int newSize = innerPredicates.length - toBeRemoved;
+        Predicate[] newPredicates = new Predicate[newSize];
+        for (int i = 0; i < innerPredicates.length; i++) {
+            Predicate p = innerPredicates[i];
+            if (p != null) {
+                newPredicates[i - removed] = p;
+            } else {
+                removed++;
+            }
+        }
+        return newPredicates;
+    }
+
+    private InternalMultiMap<String, Integer> findAndGroupCandidates(Predicate[] innerPredicates) {
+        InternalMultiMap<String, Integer> candidates = null;
+        for (int i = 0; i < innerPredicates.length; i++) {
+            Predicate p = innerPredicates[i];
+            if (p.getClass().equals(EqualPredicate.class)) {
+                EqualPredicate equalPredicate = (EqualPredicate) p;
+                String attribute = equalPredicate.attribute;
+                if (candidates == null) {
+                    candidates = new InternalMultiMap<String, Integer>();
+                }
+                candidates.put(attribute, i);
+            }
+        }
+        return candidates;
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/QueryOptimizer.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/QueryOptimizer.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.query.impl.predicates;
+
+import com.hazelcast.query.Predicate;
+import com.hazelcast.query.impl.Indexes;
+
+/**
+ * Optimizes predicate for faster execution.
+ * It has to treat input predicate as immutable. It may the same instance
+ * if no optimization has been performed.
+ *
+*/
+public interface QueryOptimizer {
+    <K, V> Predicate<K, V> optimize(Predicate<K, V> predicate, Indexes indexes);
+}

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/QueryOptimizerFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/QueryOptimizerFactory.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.query.impl.predicates;
+
+import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.instance.GroupProperty;
+
+import java.util.Arrays;
+
+/**
+ * Creates {@link QueryOptimizer} according to GroupProperties configuration.
+ *
+ */
+public final class QueryOptimizerFactory {
+    public enum Type {
+        NONE,
+        RULES
+    }
+
+    private QueryOptimizerFactory() {
+    }
+
+    /**
+     * Creates new QueryOptimizer. The exact implementation depends on
+     * GroupProperties.
+     *
+     * @param properties
+     * @return
+     */
+    public static QueryOptimizer newOptimizer(GroupProperties properties) {
+        GroupProperty property = GroupProperty.QUERY_OPTIMIZER_TYPE;
+        String string = properties.getString(property);
+        Type type;
+        try {
+            type = Type.valueOf(string);
+        } catch (IllegalArgumentException e) {
+            throw onInvalidOptimizerType(string);
+        }
+        switch (type) {
+            case RULES:
+                return new RuleBasedQueryOptimizer();
+            default:
+                return new EmptyOptimizer();
+        }
+    }
+
+    private static IllegalArgumentException onInvalidOptimizerType(String type) {
+        StringBuilder sb = new StringBuilder("Unknown Optimizer Type: ")
+                .append(type)
+                .append(". Use property '")
+                .append(GroupProperty.QUERY_OPTIMIZER_TYPE.getName())
+                .append("' to select optimizer. ")
+                .append("Available optimizers: ");
+        Type[] values = Type.values();
+        sb.append(Arrays.toString(values));
+        return new IllegalArgumentException(sb.toString());
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/RuleBasedQueryOptimizer.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/RuleBasedQueryOptimizer.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.query.impl.predicates;
+
+import com.hazelcast.query.Predicate;
+import com.hazelcast.query.VisitablePredicate;
+import com.hazelcast.query.impl.Indexes;
+
+/**
+ * Rule based optimizer. It chains {@link Visitor}s to rewrite query.
+ *
+ */
+public final class RuleBasedQueryOptimizer implements QueryOptimizer {
+    private final Visitor betweenVisitor = new BetweenVisitor();
+    private final Visitor flatteningVisitor = new FlatteningVisitor();
+    private final Visitor orToInVisitor = new OrToInVisitor();
+
+    public <K, V> Predicate<K, V> optimize(Predicate<K, V> predicate, Indexes indexes) {
+        Predicate optimized = predicate;
+        if (optimized instanceof VisitablePredicate) {
+            optimized = ((VisitablePredicate) optimized).accept(flatteningVisitor, indexes);
+        }
+        if (optimized instanceof VisitablePredicate) {
+            optimized = ((VisitablePredicate) optimized).accept(betweenVisitor, indexes);
+        }
+        if (optimized instanceof VisitablePredicate) {
+            optimized = ((VisitablePredicate) optimized).accept(orToInVisitor, indexes);
+        }
+        return optimized;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/Visitor.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/Visitor.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.query.impl.predicates;
+
+
+import com.hazelcast.query.Predicate;
+import com.hazelcast.query.impl.Indexes;
+
+/**
+ * Visitor can inspect internal state of a node,
+ * but it's not allowed to mutate its internal state.
+ *
+ * Visitor can return a new instance of predicate
+ * if modification is needed
+ *
+ *
+ */
+public interface Visitor {
+    Predicate visit(AndPredicate predicate, Indexes indexes);
+
+    Predicate visit(OrPredicate predicate, Indexes indexes);
+
+    Predicate visit(NotPredicate predicate, Indexes indexes);
+}

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/VisitorUtils.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/VisitorUtils.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.query.impl.predicates;
+
+import com.hazelcast.query.Predicate;
+import com.hazelcast.query.VisitablePredicate;
+import com.hazelcast.query.impl.Indexes;
+
+import static com.hazelcast.util.collection.ArrayUtils.createCopy;
+
+public final class VisitorUtils {
+    private VisitorUtils() {
+
+    }
+
+    /**
+     * Accept visitor by all predicates. It treats the input array as immutable.
+     *
+     * It's Copy-On-Write: If at least one predicate returns a different instance
+     * then this method returns a copy of the passed arrays.
+     *
+     * @param predicates
+     * @param visitor
+     * @return
+     */
+    public static Predicate[] acceptVisitor(Predicate[] predicates, Visitor visitor, Indexes indexes) {
+        Predicate[] target = predicates;
+        boolean copyCreated = false;
+        for (int i = 0; i < predicates.length; i++) {
+            Predicate predicate = predicates[i];
+            if (predicate instanceof VisitablePredicate) {
+                Predicate transformed = ((VisitablePredicate) predicate).accept(visitor, indexes);
+                if (transformed != predicate) {
+                    if (!copyCreated) {
+                        copyCreated = true;
+                        target = createCopy(target);
+                    }
+                    target[i] = transformed;
+                }
+            }
+        }
+        return target;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/util/collection/ArrayUtils.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/collection/ArrayUtils.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.util.collection;
+
+import java.util.Arrays;
+
+/**
+ * Convenient method for array manipulations.
+ *
+ */
+public final class ArrayUtils {
+    private ArrayUtils() {
+
+    }
+
+    /**
+     * Create copy of the src array.
+     *
+     * @param src
+     * @param <T>
+     * @return copy of the original array
+     */
+    public static <T> T[] createCopy(T[] src) {
+        return Arrays.copyOf(src, src.length);
+    }
+
+    /**
+     * Copy src array into destination and skip null values.
+     * Warning: It does not do any validation. It expect the dst[] is
+     * created with right capacity.
+     *
+     * You can calculate required capacity as <code>src.length - getNoOfNullItems(src)</code>
+     *
+     * @param src source array
+     * @param dst destination. It has to have the right capacity
+     * @param <T>
+     */
+    public static <T> void copyWithoutNulls(T[] src, T[] dst) {
+        int skipped = 0;
+        for (int i = 0; i < src.length; i++) {
+            T object = src[i];
+            if (object == null) {
+                skipped++;
+            } else {
+                dst[i - skipped] = object;
+            }
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/util/collection/InternalMultiMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/collection/InternalMultiMap.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.util.collection;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Simplistic implementation of MultiMap.
+ * It's not thread-safe, concurrent access has to be externally synchronized.
+ *
+ * It allows duplicates: The same value can be associated with the same key multiple times
+ *
+ * The name has a prefix Internal- to avoid confusion with {@link com.hazelcast.core.MultiMap}
+ *
+ * @param <K>
+ * @param <V>
+ */
+public class InternalMultiMap<K, V> {
+    private final Map<K, List<V>> backingMap;
+
+    public InternalMultiMap() {
+        this.backingMap = new HashMap<K, List<V>>();
+    }
+
+    /**
+     * Put value to a given key. It allows duplicates under the same key
+     *
+     * @param key
+     * @param value
+     */
+    public void put(K key, V value) {
+        List<V> values = backingMap.get(key);
+        if (values == null) {
+            values = new ArrayList<V>();
+            backingMap.put(key, values);
+        }
+        values.add(value);
+    }
+
+    /**
+     * Return collection of values associated with a given key
+     *
+     * @param key
+     * @return
+     */
+    public Collection<V> get(K key) {
+        return backingMap.get(key);
+    }
+
+    public Set<Map.Entry<K, List<V>>> entrySet() {
+        return backingMap.entrySet();
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryOperationTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryOperationTestSupport.java
@@ -8,11 +8,13 @@ import com.hazelcast.map.impl.MapServiceContext;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.internal.serialization.impl.HeapData;
 import com.hazelcast.partition.InternalPartitionService;
+import com.hazelcast.query.Predicate;
 import com.hazelcast.query.TruePredicate;
 import com.hazelcast.query.impl.Indexes;
 import com.hazelcast.query.impl.QueryableEntry;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.Operation;
+import org.mockito.internal.stubbing.answers.ReturnsArgumentAt;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
@@ -23,6 +25,7 @@ import java.util.Random;
 import java.util.Set;
 
 import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyObject;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -60,6 +63,7 @@ public abstract class QueryOperationTestSupport {
         when(mapQueryEngine.newQueryResult(anyInt())).thenReturn(queryResult);
         when(mapQueryEngine.queryOnPartition(MAP_NAME, TruePredicate.INSTANCE, Operation.GENERIC_PARTITION_ID))
                 .thenReturn(queryEntries);
+        when(mapQueryEngine.optimize((Predicate) anyObject(), (Indexes)anyObject())).thenAnswer(new ReturnsArgumentAt(0));
 
         Indexes indexes = mock(Indexes.class);
         when(indexes.query(TruePredicate.INSTANCE)).thenReturn(queryEntrySet);

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/AndPredicateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/AndPredicateTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.query.impl.predicates;
+
+import com.hazelcast.query.Predicate;
+import com.hazelcast.query.impl.Indexes;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static com.hazelcast.query.Predicates.and;
+import static com.hazelcast.query.impl.predicates.PredicateTestUtils.createDelegatingVisitor;
+import static com.hazelcast.query.impl.predicates.PredicateTestUtils.createMockNegatablePredicate;
+import static com.hazelcast.query.impl.predicates.PredicateTestUtils.createMockVisitablePredicate;
+import static com.hazelcast.query.impl.predicates.PredicateTestUtils.createPassthroughVisitor;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.Matchers.arrayContainingInAnyOrder;
+import static org.hamcrest.Matchers.arrayWithSize;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.hamcrest.CoreMatchers.sameInstance;
+
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class AndPredicateTest {
+
+    @Test
+    public void negate_whenContainsNegatablePredicate_thenReturnOrPredicateWithNegationInside() {
+        // ~(foo and bar)  -->  (~foo or ~bar)
+        // this is testing the case where the inner predicate implements {@link Negatable}
+
+        Predicate negated = mock(Predicate.class);
+        Predicate negatable = createMockNegatablePredicate(negated);
+
+        AndPredicate and = (AndPredicate) and(negatable);
+        OrPredicate result = (OrPredicate) and.negate();
+
+        Predicate[] inners = result.predicates;
+        assertThat(inners, arrayWithSize(1));
+        assertThat(inners, arrayContainingInAnyOrder(negated));
+    }
+
+    @Test
+    public void negate_whenContainsNonNegatablePredicate_thenReturnOrPredicateWithNotInside() {
+        // ~(foo and bar)  -->  (~foo or ~bar)
+        // this is testing the case where the inner predicate does NOT implement {@link Negatable}
+
+        Predicate nonNegatable = mock(Predicate.class);
+
+        AndPredicate and = (AndPredicate) and(nonNegatable);
+        OrPredicate result = (OrPredicate) and.negate();
+
+        Predicate[] inners = result.predicates;
+        assertThat(inners, arrayWithSize(1));
+
+        NotPredicate notPredicate = (NotPredicate) inners[0];
+        assertThat(nonNegatable, sameInstance(notPredicate.predicate));
+    }
+
+    @Test
+    public void accept_whenEmptyPredicate_thenReturnItself() {
+        Visitor mockVisitor = createPassthroughVisitor();
+        Indexes mockIndexes = mock(Indexes.class);
+
+        AndPredicate andPredicate = new AndPredicate(new Predicate[0]);
+        AndPredicate result = (AndPredicate) andPredicate.accept(mockVisitor, mockIndexes);
+
+        assertThat(result, sameInstance(andPredicate));
+    }
+
+    @Test
+    public void accept_whenInnerPredicateChangedOnAccept_thenReturnAndNewAndPredicate() {
+        Visitor mockVisitor = createPassthroughVisitor();
+        Indexes mockIndexes = mock(Indexes.class);
+
+        Predicate transformed = mock(Predicate.class);
+        Predicate innerPredicate = createMockVisitablePredicate(transformed);
+        Predicate[] innerPredicates = new Predicate[1];
+        innerPredicates[0] = innerPredicate;
+
+
+        AndPredicate andPredicate = new AndPredicate(innerPredicates);
+        AndPredicate result = (AndPredicate) andPredicate.accept(mockVisitor, mockIndexes);
+
+        assertThat(result, not(sameInstance(andPredicate)));
+        Predicate[] newInnerPredicates = result.predicates;
+        assertThat(newInnerPredicates, arrayWithSize(1));
+        assertThat(newInnerPredicates[0], equalTo(transformed));
+    }
+
+    @Test
+    public void accept_whenVisitorReturnsNewInstance_thenReturnTheNewInstance() {
+        Predicate delegate = mock(Predicate.class);
+        Visitor mockVisitor = createDelegatingVisitor(delegate);
+        Indexes mockIndexes = mock(Indexes.class);
+        Predicate innerPredicate = mock(Predicate.class);
+        Predicate[] innerPredicates = new Predicate[1];
+        innerPredicates[0] = innerPredicate;
+
+        AndPredicate andPredicate = new AndPredicate(innerPredicates);
+        Predicate result = andPredicate.accept(mockVisitor, mockIndexes);
+
+        assertThat(result, sameInstance(delegate));
+    }
+
+
+
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/BetweenVisitorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/BetweenVisitorTest.java
@@ -1,0 +1,208 @@
+package com.hazelcast.query.impl.predicates;
+
+import com.hazelcast.query.Predicate;
+import com.hazelcast.query.impl.FalsePredicate;
+import com.hazelcast.query.impl.Index;
+import com.hazelcast.query.impl.Indexes;
+import com.hazelcast.query.impl.TypeConverters;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static com.hazelcast.query.Predicates.*;
+import static com.hazelcast.query.impl.TypeConverters.INTEGER_CONVERTER;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.hamcrest.Matchers.*;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class BetweenVisitorTest {
+
+    private BetweenVisitor visitor;
+    private Indexes mockIndexes;
+    private Index mockIndex;
+
+    @Before
+    public void setUp() {
+        mockIndexes = mock(Indexes.class);
+        mockIndex = mock(Index.class);
+        when(mockIndexes.getIndex(anyString())).thenReturn(mockIndex);
+        visitor = new BetweenVisitor();
+        useConverter(INTEGER_CONVERTER);
+    }
+
+    @Test
+    public void whenGreaterOrEqualsThanXandLessOrEqualsThanY_thenRewriteToBetweenXandY() {
+        //(age >= 5 and age <= 6)  --> (age between 5 6)
+        Predicate left = greaterEqual("attribute", 5);
+        Predicate right = lessEqual("attribute", 6);
+        Predicate and = and(left, right);
+
+        Predicate result = visitor.visit((AndPredicate) and, mockIndexes);
+        assertBetweenPredicate(result, 5, 6);
+    }
+
+    @Test
+    public void whenPredicatesOutsideTheRangeFromRightExist_thenEliminateThem() {
+        //(age >= 5 and age <= 6 and age < 10)  -->  (age between 5 6)
+        Predicate left = greaterEqual("attribute", 5);
+        Predicate right = lessEqual("attribute", 6);
+        Predicate other = lessEqual("attribute", 10);
+        Predicate and = and(left, right, other);
+
+        Predicate result = visitor.visit((AndPredicate) and, mockIndexes);
+        assertBetweenPredicate(result, 5, 6);
+    }
+
+    @Test
+    public void whenPredicatesOutsideTheRangeFromLeftExist_thenEliminateThem() {
+        //(age >= 5 and age <= 6 and age > 4)  -->  (age between 5 6)
+        Predicate left = greaterEqual("attribute", 5);
+        Predicate right = lessEqual("attribute", 6);
+        Predicate other = greaterEqual("attribute", 4);
+        Predicate and = and(left, right, other);
+
+        Predicate result = visitor.visit((AndPredicate) and, mockIndexes);
+        assertBetweenPredicate(result, 5, 6);
+    }
+
+    @Test
+    public void whenBothBoundariesAreSame_thenRewriteItAsEquals() {
+        //(age >= 5 and age <= 5)  -->  (age = 5)
+        Predicate left = greaterEqual("attribute", 5);
+        Predicate right = lessEqual("attribute", 5);
+        Predicate and = and(left, right);
+
+        EqualPredicate p = (EqualPredicate) visitor.visit((AndPredicate) and, mockIndexes);
+        assertEquals("attribute", p.attribute);
+        assertEquals(5, p.value);
+    }
+
+    @Test
+    public void whenPredicatesOtherThenGreatLess_thenDoNotAttemptToEliminateThem() {
+        //(age >= 5 and age <= 6 and age <> 4)  -->  ( (age between 5 6) and (age <> 5) )
+        Predicate left = greaterEqual("attribute", 5);
+        Predicate right = lessEqual("attribute", 6);
+        Predicate other = notEqual("attribute", 4);
+        Predicate and = and(left, right, other);
+
+        AndPredicate result = (AndPredicate) visitor.visit((AndPredicate) and, mockIndexes);
+        Predicate[] inners = result.predicates;
+        assertThat(inners, hasItemInArray(other));
+        BetweenPredicate betweenPredicate = findFirstBetweenPredicate(inners);
+        assertBetweenPredicate(betweenPredicate, 5, 6);
+    }
+
+    @Test
+    public void whenPredicateIsExclusive_thenIsNotUsedToBuildBetween() {
+        //(age >= 5 and age < 6)  -->  (age >= 5 and age < 6)
+        Predicate left = greaterThan("attribute", 5);
+        Predicate right = lessEqual("attribute", 6);
+        Predicate and = and(left, right);
+
+        Predicate result = visitor.visit((AndPredicate) and, mockIndexes);
+        assertSame(and, result);
+    }
+
+    @Test
+    public void whenPredicateIsNotGreaterLessPredicate_thenIsNotUsedToBuildBetween() {
+        Predicate left = equal("attribute", 5);
+        Predicate right = lessEqual("attribute", 6);
+        Predicate and = and(left, right);
+
+        Predicate result = visitor.visit((AndPredicate) and, mockIndexes);
+        assertSame(and, result);
+    }
+
+    @Test
+    public void whenGreatesOrEqualsThanXandLessOrEqualsThanYAndSomeOtherPredicate_thenRewriteToBetweenXandYAndSomeOtherPredicate() {
+        Predicate left = greaterEqual("attribute", 5);
+        Predicate right = lessEqual("attribute", 6);
+        Predicate other = lessEqual("otherAttribute", 6);
+        Predicate and = and(left, right, other);
+
+        AndPredicate result = (AndPredicate) visitor.visit((AndPredicate) and, mockIndexes);
+
+        Predicate[] innerPredicates = result.predicates;
+        assertThat(innerPredicates, hasItemInArray(other));
+        BetweenPredicate betweenPredicate = findFirstBetweenPredicate(innerPredicates);
+        assertBetweenPredicate(betweenPredicate, 5, 6);
+    }
+
+    @Test
+    public void whenNoConverterExist_thenReturnOriginalPredicate() {
+        disableConverter();
+        Predicate left = greaterEqual("attribute", 5);
+        Predicate right = lessEqual("attribute", 6);
+        Predicate and = and(left, right);
+
+        Predicate result = visitor.visit((AndPredicate) and, mockIndexes);
+        assertSame(and, result);
+    }
+
+    @Test
+    public void whenOnlyOneSideFound_thenReturnOriginalPredicate() {
+        Predicate p1 = greaterEqual("attribute1", 5);
+        Predicate p2 = lessEqual("attribute2", 6);
+        Predicate and = and(p1, p2);
+
+        Predicate result = visitor.visit((AndPredicate) and, mockIndexes);
+        assertSame(and, result);
+    }
+
+    @Test
+    public void whenOnlyOneBoundaryFound_thenReturnOriginalPredicate() {
+        Predicate p1 = greaterEqual("attribute1", 5);
+        Predicate p2 = greaterEqual("attribute1", 6);
+        Predicate and = and(p1, p2);
+
+        Predicate result = visitor.visit((AndPredicate) and, mockIndexes);
+        assertSame(and, result);
+    }
+
+    @Test
+    public void whenSideAreOverlapping_thenReturnFalsePredicate() {
+        Predicate p1 = greaterEqual("attribute1", 5);
+        Predicate p2 = lessEqual("attribute1", 4);
+        Predicate and = and(p1, p2);
+
+        Predicate result = visitor.visit((AndPredicate) and, mockIndexes);
+        assertEquals(FalsePredicate.INSTANCE, result);
+    }
+
+    private void useConverter(TypeConverters.TypeConverter converter) {
+        when(mockIndex.getConverter()).thenReturn(converter);
+    }
+
+    private void disableConverter() {
+        when(mockIndex.getConverter()).thenReturn(null);
+    }
+
+    private void assertBetweenPredicate(Predicate p, Comparable from, Comparable to) {
+        assertEquals(BetweenPredicate.class, p.getClass());
+        BetweenPredicate bp = (BetweenPredicate) p;
+        assertEquals(from, bp.from);
+        assertEquals(to, bp.to);
+    }
+
+    private BetweenPredicate findFirstBetweenPredicate(Predicate[] innerPredicates) {
+        for (Predicate p : innerPredicates) {
+            if (p instanceof BetweenPredicate) {
+                return (BetweenPredicate) p;
+            }
+        }
+        return null;
+    }
+
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/EqualPredicateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/EqualPredicateTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.query.impl.predicates;
+
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class EqualPredicateTest {
+
+    @Test
+    public void negate_thenReturnNotEqualPredicate() {
+        EqualPredicate equalPredicate = new EqualPredicate("foo", 1);
+        NotEqualPredicate negate = (NotEqualPredicate) equalPredicate.negate();
+
+        assertEquals("foo", negate.attribute);
+        assertEquals(1, negate.value);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/FlatteningVisitorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/FlatteningVisitorTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.query.impl.predicates;
+
+import com.hazelcast.query.Predicate;
+import com.hazelcast.query.impl.Index;
+import com.hazelcast.query.impl.Indexes;
+import com.hazelcast.query.impl.TypeConverters;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static com.hazelcast.query.Predicates.and;
+import static com.hazelcast.query.Predicates.equal;
+import static com.hazelcast.query.Predicates.not;
+import static com.hazelcast.query.Predicates.or;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static com.hazelcast.query.impl.TypeConverters.INTEGER_CONVERTER;
+import static org.mockito.Mockito.withSettings;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class FlatteningVisitorTest {
+
+    private FlatteningVisitor visitor;
+    private Indexes mockIndexes;
+    private Index mockIndex;
+
+    @Before
+    public void setUp() {
+        mockIndexes = mock(Indexes.class);
+        mockIndex = mock(Index.class);
+        when(mockIndexes.getIndex(anyString())).thenReturn(mockIndex);
+        visitor = new FlatteningVisitor();
+        useConverter(INTEGER_CONVERTER);
+    }
+
+
+    @Test
+    public void visitAndPredicate_whenHasInnerAndPredicate_thenFlattenIt() {
+        //(a1 = 1 and (a2 = 2 and a3 = 3))  -->  (a1 = 1 and a2 = 2 and a3 = 3)
+
+        Predicate a1 = equal("a1", 1);
+        Predicate a2 = equal("a2", 2);
+        Predicate a3 = equal("a3", 3);
+
+        AndPredicate innerAnd = (AndPredicate) and(a2, a3);
+        AndPredicate outerAnd = (AndPredicate) and(a1, innerAnd);
+
+        AndPredicate result = (AndPredicate) visitor.visit(outerAnd, mockIndexes);
+        Predicate[] inners = result.predicates;
+        assertEquals(3, inners.length);
+    }
+
+    @Test
+    public void visitOrPredicate_whenHasInnerOrPredicate_thenFlattenIt() {
+        //(a1 = 1 or (a2 = 2 or a3 = 3))  -->  (a1 = 1 or a2 = 2 or a3 = 3)
+
+        Predicate a1 = equal("a1", 1);
+        Predicate a2 = equal("a2", 2);
+        Predicate a3 = equal("a3", 3);
+
+        OrPredicate innerOr = (OrPredicate) or(a2, a3);
+        OrPredicate outerOr = (OrPredicate) or(a1, innerOr);
+
+        OrPredicate result = (OrPredicate) visitor.visit(outerOr, mockIndexes);
+        Predicate[] inners = result.predicates;
+        assertEquals(3, inners.length);
+    }
+
+    @Test
+    public void visitNotPredicate_whenContainsNegatablePredicate_thenFlattenIt() {
+        //(not(equals(foo, 1)))  -->  (notEquals(foo, 1))
+
+        Predicate negated = mock(Predicate.class);
+        NegatablePredicate negatablePredicate = mock(NegatablePredicate.class, withSettings().extraInterfaces(Predicate.class));
+        when(negatablePredicate.negate()).thenReturn(negated);
+
+        NotPredicate outerPredicate = (NotPredicate) not((Predicate) negatablePredicate);
+
+        Predicate result = visitor.visit(outerPredicate, mockIndexes);
+        assertEquals(negated, result);
+    }
+
+    private void useConverter(TypeConverters.TypeConverter converter) {
+        when(mockIndex.getConverter()).thenReturn(converter);
+    }
+
+    private void disbledConverter() {
+        when(mockIndex.getConverter()).thenReturn(null);
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/GreaterLessPredicateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/GreaterLessPredicateTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.query.impl.predicates;
+
+import com.hazelcast.query.Predicate;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.junit.Assert.assertThat;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class GreaterLessPredicateTest {
+
+    @Test
+    public void negate_whenEqualsTrueAndLessTrue_thenReturnNewInstanceWithEqualsFalseAndLessFalse() {
+        String attribute = "attribute";
+        Comparable value = 1;
+
+        GreaterLessPredicate original = new GreaterLessPredicate(attribute, value, true, true);
+        GreaterLessPredicate negate = (GreaterLessPredicate) original.negate();
+
+        assertThat(negate, not(sameInstance(original)));
+        assertThat(negate.attribute, equalTo(attribute));
+        assertThat(negate.equal, is(false));
+        assertThat(negate.less, is(false));
+    }
+
+    @Test
+    public void negate_whenEqualsFalseAndLessFalse_thenReturnNewInstanceWithEqualsTrueAndLessTrue() {
+        String attribute = "attribute";
+        Comparable value = 1;
+
+        GreaterLessPredicate original = new GreaterLessPredicate(attribute, value, false, false);
+        GreaterLessPredicate negate = (GreaterLessPredicate) original.negate();
+
+        assertThat(negate, not(sameInstance(original)));
+        assertThat(negate.attribute, equalTo(attribute));
+        assertThat(negate.equal, is(true));
+        assertThat(negate.less, is(true));
+    }
+
+    @Test
+    public void negate_whenEqualsTrueAndLessFalse_thenReturnNewInstanceWithEqualsFalseAndLessTrue() {
+        String attribute = "attribute";
+        Comparable value = 1;
+
+        GreaterLessPredicate original = new GreaterLessPredicate(attribute, value, true, false);
+        GreaterLessPredicate negate = (GreaterLessPredicate) original.negate();
+
+        assertThat(negate, not(sameInstance(original)));
+        assertThat(negate.attribute, equalTo(attribute));
+        assertThat(negate.equal, is(false));
+        assertThat(negate.less, is(true));
+    }
+
+    @Test
+    public void negate_whenEqualsFalseAndLessTrue_thenReturnNewInstanceWithEqualsTrueAndLessFalse() {
+        String attribute = "attribute";
+        Comparable value = 1;
+
+        GreaterLessPredicate original = new GreaterLessPredicate(attribute, value, false, true);
+        GreaterLessPredicate negate = (GreaterLessPredicate) original.negate();
+
+        assertThat(negate, not(sameInstance(original)));
+        assertThat(negate.attribute, equalTo(attribute));
+        assertThat(negate.equal, is(true));
+        assertThat(negate.less, is(false));
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/NotEqualPredicateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/NotEqualPredicateTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.query.impl.predicates;
+
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class NotEqualPredicateTest {
+
+    @Test
+    public void negate_thenReturnEqualPredicate() {
+        NotEqualPredicate notEqualPredicate = new NotEqualPredicate("foo", 1);
+        EqualPredicate negate = (EqualPredicate) notEqualPredicate.negate();
+
+        assertEquals("foo", negate.attribute);
+        assertEquals(1, negate.value);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/NotPredicateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/NotPredicateTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.query.impl.predicates;
+
+import com.hazelcast.query.Predicate;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class NotPredicateTest {
+
+    @Test
+    public void negate_thenReturnInnerPredicate() {
+        Predicate inner = mock(Predicate.class);
+        NotPredicate notPredicate = new NotPredicate(inner);
+        Predicate negate = notPredicate.negate();
+
+        assertThat(negate, sameInstance(inner));
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/OrPredicateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/OrPredicateTest.java
@@ -1,0 +1,56 @@
+package com.hazelcast.query.impl.predicates;
+
+import com.hazelcast.query.Predicate;
+import com.hazelcast.query.Predicates;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static com.hazelcast.query.Predicates.or;
+import static com.hazelcast.query.impl.predicates.PredicateTestUtils.createMockNegatablePredicate;
+import static org.hamcrest.Matchers.arrayContainingInAnyOrder;
+import static org.hamcrest.Matchers.arrayWithSize;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class OrPredicateTest {
+
+    @Test
+    public void negate_whenContainsNegatablePredicate_thenReturnAndPredicateWithNegationInside() {
+        // ~(foo or bar)  -->  (~foo and ~bar)
+        // this is testing the case where the inner predicate implements {@link Negatable}
+
+        Predicate negated = mock(Predicate.class);
+        Predicate negatable = createMockNegatablePredicate(negated);
+
+        OrPredicate or = (OrPredicate) or(negatable);
+        AndPredicate result = (AndPredicate) or.negate();
+
+        Predicate[] inners = result.predicates;
+        assertThat(inners, arrayWithSize(1));
+        assertThat(inners, arrayContainingInAnyOrder(negated));
+    }
+
+    @Test
+    public void negate_whenContainsNonNegatablePredicate_thenReturnAndPredicateWithNotInside() {
+        // ~(foo or bar)  -->  (~foo and ~bar)
+        // this is testing the case where the inner predicate does NOT implement {@link Negatable}
+
+        Predicate nonNegatable = mock(Predicate.class);
+
+        OrPredicate or = (OrPredicate) or(nonNegatable);
+        AndPredicate result = (AndPredicate) or.negate();
+
+        Predicate[] inners = result.predicates;
+        assertThat(inners, arrayWithSize(1));
+
+        NotPredicate notPredicate = (NotPredicate) inners[0];
+        assertThat(nonNegatable, sameInstance(notPredicate.predicate));
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/OrToInVisitorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/OrToInVisitorTest.java
@@ -1,0 +1,63 @@
+package com.hazelcast.query.impl.predicates;
+
+import com.hazelcast.query.Predicate;
+import com.hazelcast.query.impl.Index;
+import com.hazelcast.query.impl.Indexes;
+import com.hazelcast.query.impl.TypeConverters;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.hamcrest.Matchers;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static com.hazelcast.query.Predicates.equal;
+import static com.hazelcast.query.Predicates.or;
+import static com.hazelcast.query.impl.TypeConverters.INTEGER_CONVERTER;
+import static org.hamcrest.Matchers.arrayWithSize;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class OrToInVisitorTest {
+
+    private OrToInVisitor visitor;
+    private Indexes mockIndexes;
+    private Index mockIndex;
+
+    @Before
+    public void setUp() {
+        mockIndexes = mock(Indexes.class);
+        mockIndex = mock(Index.class);
+        when(mockIndexes.getIndex(anyString())).thenReturn(mockIndex);
+        visitor = new OrToInVisitor();
+        useConverter(INTEGER_CONVERTER);
+    }
+
+    @Test
+    public void whenThresholdExceeded_thenRewriteToInPredicate() {
+        //(age = 1 or age = 2 or age = 3 or age = 4 or age = 5)  -->  (age in (1, 2, 3, 4, 5))
+        Predicate p1 = equal("age", 1);
+        Predicate p2 = equal("age", 2);
+        Predicate p3 = equal("age", 3);
+        Predicate p4 = equal("age", 4);
+        Predicate p5 = equal("age", 5);
+        OrPredicate or = (OrPredicate) or(p1, p2, p3, p4, p5);
+        InPredicate result = (InPredicate) visitor.visit(or, mockIndexes);
+        Comparable[] values = result.values;
+        assertThat(values, arrayWithSize(5));
+        assertThat(values, Matchers.is(Matchers.<Comparable>arrayContainingInAnyOrder(1, 2, 3, 4, 5)));
+
+    }
+
+
+
+    private void useConverter(TypeConverters.TypeConverter converter) {
+        when(mockIndex.getConverter()).thenReturn(converter);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/PredicateTestUtils.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/PredicateTestUtils.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.query.impl.predicates;
+
+import com.hazelcast.query.Predicate;
+import com.hazelcast.query.VisitablePredicate;
+import com.hazelcast.query.impl.Indexes;
+import org.mockito.internal.stubbing.answers.ReturnsArgumentAt;
+
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
+
+/**
+ * Convenient utility methods to create mock predicates
+ *
+ */
+class PredicateTestUtils {
+
+    /**
+     * Create a negatable mock predicate. The created mock predicate returns passed the predicate
+     * passed as negation argument
+     *
+     * @param negation predicate to be return by created mock predicate on negate()
+     * @return negatable predicate.
+     */
+    static Predicate createMockNegatablePredicate(Predicate negation) {
+        NegatablePredicate negatablePredicate = mock(NegatablePredicate.class, withSettings().extraInterfaces(Predicate.class));
+        when(negatablePredicate.negate()).thenReturn(negation);
+        return (Predicate) negatablePredicate;
+    }
+
+    static Predicate createMockVisitablePredicate() {
+        VisitablePredicate visitablePredicate = mock(VisitablePredicate.class, withSettings().extraInterfaces(Predicate.class));
+        when(visitablePredicate.accept((Visitor) anyObject(), (Indexes) anyObject())).thenReturn((Predicate) visitablePredicate);
+        return (Predicate) visitablePredicate;
+    }
+
+    static Predicate createMockVisitablePredicate(Predicate transformed) {
+        VisitablePredicate visitablePredicate = mock(VisitablePredicate.class, withSettings().extraInterfaces(Predicate.class));
+        when(visitablePredicate.accept((Visitor)anyObject(), (Indexes)anyObject())).thenReturn(transformed);
+        return (Predicate) visitablePredicate;
+    }
+
+    static Visitor createPassthroughVisitor() {
+        Visitor visitor = mock(Visitor.class);
+        when(visitor.visit((AndPredicate) anyObject(), (Indexes)anyObject())).thenAnswer(new ReturnsArgumentAt(0));
+        when(visitor.visit((OrPredicate) anyObject(), (Indexes)anyObject())).thenAnswer(new ReturnsArgumentAt(0));
+        when(visitor.visit((NotPredicate) anyObject(), (Indexes) anyObject())).thenAnswer(new ReturnsArgumentAt(0));
+
+        return visitor;
+    }
+
+    static Visitor createDelegatingVisitor(Predicate delegate) {
+        Visitor visitor = mock(Visitor.class);
+        when(visitor.visit((AndPredicate) anyObject(), (Indexes)anyObject())).thenReturn(delegate);
+        when(visitor.visit((OrPredicate) anyObject(), (Indexes)anyObject())).thenReturn(delegate);
+        when(visitor.visit((NotPredicate) anyObject(), (Indexes)anyObject())).thenReturn(delegate);
+
+        return visitor;
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/QueryOptimizerFactoryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/QueryOptimizerFactoryTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.query.impl.predicates;
+
+import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.instance.GroupProperty;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static com.hazelcast.instance.GroupProperty.QUERY_OPTIMIZER_TYPE;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class QueryOptimizerFactoryTest {
+
+    @Test(expected = IllegalArgumentException.class)
+    public void newOptimizer_whenUnknownValue_thenThrowIllegalArgumentException() {
+        GroupProperties groupProperties = createMockGroupProperties(QUERY_OPTIMIZER_TYPE, "foo");
+        QueryOptimizerFactory.newOptimizer(groupProperties);
+    }
+
+    @Test
+    public void newOptimizer_whenPropertyContainsRule_thenCreateRulesBasedOptimizer() {
+        GroupProperties groupProperties = createMockGroupProperties(QUERY_OPTIMIZER_TYPE, "RULES");
+        QueryOptimizer queryOptimizer = QueryOptimizerFactory.newOptimizer(groupProperties);
+
+        assertThat(queryOptimizer, instanceOf(RuleBasedQueryOptimizer.class));
+    }
+
+    @Test
+    public void newOptimizer_whenPropertyContainsNone_thenCreateEmptyOptimizer() {
+        GroupProperties groupProperties = createMockGroupProperties(QUERY_OPTIMIZER_TYPE, "NONE");
+        QueryOptimizer queryOptimizer = QueryOptimizerFactory.newOptimizer(groupProperties);
+
+        assertThat(queryOptimizer, instanceOf(EmptyOptimizer.class));
+    }
+
+    private GroupProperties createMockGroupProperties(GroupProperty property, String stringValue) {
+        GroupProperties properties = mock(GroupProperties.class);
+        when(properties.getString(property)).thenReturn(stringValue);
+        return properties;
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/VisitorUtilsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/VisitorUtilsTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.query.impl.predicates;
+
+import com.hazelcast.query.Predicate;
+import com.hazelcast.query.impl.Index;
+import com.hazelcast.query.impl.Indexes;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static com.hazelcast.query.impl.predicates.PredicateTestUtils.createMockVisitablePredicate;
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.hamcrest.Matchers.arrayContainingInAnyOrder;
+import static org.hamcrest.Matchers.arrayWithSize;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class VisitorUtilsTest {
+
+    private Indexes mockIndexes;
+
+    @Before
+    public void setUp() {
+        mockIndexes = mock(Indexes.class);
+    }
+
+    @Test
+    public void acceptVisitor_whenEmptyInputArray_thenReturnOriginalArray() {
+        Visitor mockVisitor = mock(Visitor.class);
+        Predicate[] predicates = new Predicate[0];
+        Predicate[] result = VisitorUtils.acceptVisitor(predicates, mockVisitor, mockIndexes);
+
+        assertThat(result, sameInstance(predicates));
+
+    }
+
+    @Test
+    public void acceptVisitor_whenNoChange_thenReturnOriginalArray() {
+        Visitor mockVisitor = mock(Visitor.class);
+
+        Predicate[] predicates = new Predicate[1];
+        Predicate predicate = createMockVisitablePredicate();
+        predicates[0] = predicate;
+
+        Predicate[] result = VisitorUtils.acceptVisitor(predicates, mockVisitor, mockIndexes);
+        assertThat(result, sameInstance(predicates));
+    }
+
+    @Test
+    public void acceptVisitor_whenThereIsChange_thenReturnNewArray() {
+        Visitor mockVisitor = mock(Visitor.class);
+
+        Predicate[] predicates = new Predicate[2];
+        Predicate p1 = createMockVisitablePredicate();
+        predicates[0] = p1;
+
+        Predicate transformed = mock(Predicate.class);
+        Predicate p2 = createMockVisitablePredicate(transformed);
+        predicates[1] = p2;
+
+        Predicate[] result = VisitorUtils.acceptVisitor(predicates, mockVisitor, mockIndexes);
+        assertThat(result, not(sameInstance(predicates)));
+        assertThat(result, arrayWithSize(2));
+        assertThat(result, arrayContainingInAnyOrder(p1, transformed));
+    }
+
+    @Test
+    public void acceptVisitor_whenThereIsNonVisitablePredicateAndNewArraysIsCreated_thenJustCopyTheNonVisitablePredicate() {
+        Visitor mockVisitor = mock(Visitor.class);
+
+        Predicate[] predicates = new Predicate[3];
+        Predicate p1 = mock(Predicate.class);
+        predicates[0] = p1;
+
+        Predicate transformed = mock(Predicate.class);
+        Predicate p2 = createMockVisitablePredicate(transformed);
+        predicates[1] = p2;
+
+        Predicate p3 = mock(Predicate.class);
+        predicates[2] = p3;
+
+        Predicate[] result = VisitorUtils.acceptVisitor(predicates, mockVisitor, mockIndexes);
+        assertThat(result, not(sameInstance(predicates)));
+        assertThat(result, arrayWithSize(3));
+        assertThat(result, arrayContainingInAnyOrder(p1, transformed, p3));
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/util/collection/ArrayUtilsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/collection/ArrayUtilsTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.util.collection;
+
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.hamcrest.Matchers.arrayWithSize;
+import static org.hamcrest.Matchers.emptyArray;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.Assert.assertThat;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ArrayUtilsTest {
+
+    @Test
+    public void createCopy_whenZeroLengthArray_thenReturnDifferentZeroLengthArray() {
+        Object[] original = new Object[0];
+        Object[] result = ArrayUtils.createCopy(original);
+
+        assertThat(result, not(sameInstance(original)));
+        assertThat(result, emptyArray());
+    }
+
+    @Test
+    public void createCopy_whenNonZeroLengthArray_thenReturnDifferentArrayWithItems() {
+        Object[] original = new Object[1];
+        Object o = new Object();
+        original[0] = o;
+
+        Object[] result = ArrayUtils.createCopy(original);
+        assertThat(result, not(sameInstance(original)));
+        assertThat(result, arrayWithSize(1));
+        assertThat(result[0], sameInstance(o));
+    }
+
+
+    @Test
+    public void copyWithoutNulls_whenSrcHasNullItem_thenDoNotCopyItIntoTarget() {
+        Object[] src = new Object[1];
+        src[0] = null;
+        Object[] dst = new Object[0];
+
+        ArrayUtils.copyWithoutNulls(src, dst);
+        assertThat(dst, emptyArray());
+    }
+
+
+    @Test
+    public void copyWithoutNulls_whenSrcHasNonNullItem_thenCopyItIntoTarget() {
+        Object[] src = new Object[1];
+        Object o = new Object();
+        src[0] = o;
+        Object[] dst = new Object[1];
+
+        ArrayUtils.copyWithoutNulls(src, dst);
+        assertThat(dst, arrayWithSize(1));
+        assertThat(dst[0], sameInstance(o));
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/util/collection/InternalMultiMapTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/collection/InternalMultiMapTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.util.collection;
+
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertThat;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class InternalMultiMapTest {
+
+    private InternalMultiMap<Integer, String> multiMap;
+
+    @Before
+    public void setUp() {
+        this.multiMap = new InternalMultiMap<Integer, String>();
+    }
+
+    @Test
+    public void put_whenEmpty_thenInsertItIntoCollection() {
+        multiMap.put(1, "value");
+        Collection<String> results = multiMap.get(1);
+
+        assertThat(results, hasSize(1));
+        assertThat(results, contains("value"));
+    }
+
+    @Test
+    public void put_whenKeyIsAlreadyAssociated_thenAppendItIntoCollection() {
+        multiMap.put(1, "value");
+        multiMap.put(1, "value");
+        Collection<String> results = multiMap.get(1);
+
+        assertThat(results, hasSize(2));
+        assertThat(results, contains("value", "value"));
+    }
+
+    @Test
+    public void entrySet_whenEmpty_thenReturnEmptySet() {
+        Set<Map.Entry<Integer, List<String>>> entries = multiMap.entrySet();
+        assertThat(entries, hasSize(0));
+    }
+}


### PR DESCRIPTION
Introduces Query Optimizer based on static rewriting rules. It treats
Predicates as immutable and returns a modifed copy when optimized is
found. This is the first part where only a handful of predicates are
optimized. Other PRs will follow.

Optimized can be disabled by setting property
hazelcast.query.optimizer.type to "none"