### PR TITLE
Increase wait time in AtomicLongAdvancedTest

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/concurrent/atomiclong/AtomicLongAdvancedTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/atomiclong/AtomicLongAdvancedTest.java
@@ -42,7 +42,7 @@ public class AtomicLongAdvancedTest extends HazelcastTestSupport {
                 }
             }.start();
         }
-        assertOpenEventually(countDownLatch, 50);
+        assertOpenEventually(countDownLatch, 300);
         assertEquals(0, atomicLong.get());
     }
 


### PR DESCRIPTION
Related failures in the github issue have the same behavior:
- CountDownLatch times out before threads finish running.
- HazelcastInstance is stopped upon the failure.
- Still-running-threads fail with HazelcastInstanceNotActiveException

All failures are on IBM jdk. Since there are still running threads when the latch times out, I suspect that the timeout failure is related to gc load.

Fixes #6055