### PR TITLE
Forward port of #6212 - Fix thread interruption time in QueueAdvancedTest

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/QueueAdvancedTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/QueueAdvancedTest.java
@@ -581,9 +581,11 @@ public class QueueAdvancedTest extends HazelcastTestSupport {
 
         final AtomicBoolean interrupted = new AtomicBoolean();
 
+        final CountDownLatch latch = new CountDownLatch(1);
         Thread t = new Thread() {
             public void run() {
                 try {
+                    latch.countDown();
                     queue.take();
                 } catch (InterruptedException e) {
                     interrupted.set(true);
@@ -592,7 +594,7 @@ public class QueueAdvancedTest extends HazelcastTestSupport {
         };
         t.start();
 
-        sleepSeconds(1);
+        latch.await(10, TimeUnit.SECONDS);
         t.interrupt();
         t.join(5000);
 
@@ -611,9 +613,11 @@ public class QueueAdvancedTest extends HazelcastTestSupport {
 
         assertTrue(queue.offer("item"));
 
+        final CountDownLatch latch = new CountDownLatch(1);
         Thread t = new Thread() {
             public void run() {
                 try {
+                    latch.countDown();
                     queue.put("item");
                 } catch (InterruptedException e) {
                     interrupted.set(true);
@@ -622,7 +626,7 @@ public class QueueAdvancedTest extends HazelcastTestSupport {
         };
         t.start();
 
-        sleepSeconds(1);
+        latch.await(10, TimeUnit.SECONDS);
         t.interrupt();
         t.join(5000);
 


### PR DESCRIPTION
It happens that thread is interrupted before it goes into the try-catch block. This change ensures that it will be interrupted after it runs into the try-catch block.

Fixes #6125