### PR TITLE
[DONT MERGE] Queries keyset not download values + other improvements

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -226,6 +226,7 @@
     <suppress checks="NPathComplexity" files="com/hazelcast/query/impl/getters/ReflectionHelper"/>
     <suppress checks="ReturnCount" files="com/hazelcast/query/impl/getters/ReflectionHelper"/>
     <suppress checks="ClassDataAbstractionCoupling" files="com/hazelcast/query/impl/TypeConverters"/>
+    <suppress checks="ReturnCount" files="com/hazelcast/query/impl/QueryResultIterator"/>
 
     <!-- hazelcast-wm -->
     <suppress checks="JavadocMethod" files="com/hazelcast/web/"/>

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
@@ -114,7 +114,7 @@ import com.hazelcast.spi.impl.PortableMapPartitionLostEvent;
 import com.hazelcast.util.ExceptionUtil;
 import com.hazelcast.util.IterationType;
 import com.hazelcast.util.Preconditions;
-import com.hazelcast.util.QueryResultSet;
+import com.hazelcast.query.impl.QueryResultSet;
 import com.hazelcast.util.ThreadUtil;
 import com.hazelcast.util.collection.InflatableSet;
 import com.hazelcast.util.executor.CompletedFuture;

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/SerializationServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/SerializationServiceImpl.java
@@ -20,12 +20,11 @@ import com.hazelcast.core.HazelcastInstanceNotActiveException;
 import com.hazelcast.core.ManagedContext;
 import com.hazelcast.core.PartitioningStrategy;
 import com.hazelcast.instance.OutOfMemoryErrorDispatcher;
-import com.hazelcast.nio.BufferObjectDataInput;
-import com.hazelcast.nio.BufferObjectDataOutput;
-import com.hazelcast.nio.ObjectDataInput;
-import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.ByteArraySerializer;
-import com.hazelcast.nio.serialization.ClassDefinition;
+import com.hazelcast.internal.serialization.InputOutputFactory;
+import com.hazelcast.internal.serialization.ObjectDataInputStream;
+import com.hazelcast.internal.serialization.ObjectDataOutputStream;
+import com.hazelcast.internal.serialization.PortableContext;
+import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.internal.serialization.impl.ConstantSerializers.BooleanSerializer;
 import com.hazelcast.internal.serialization.impl.ConstantSerializers.ByteSerializer;
 import com.hazelcast.internal.serialization.impl.ConstantSerializers.CharArraySerializer;
@@ -42,22 +41,6 @@ import com.hazelcast.internal.serialization.impl.ConstantSerializers.ShortArrayS
 import com.hazelcast.internal.serialization.impl.ConstantSerializers.ShortSerializer;
 import com.hazelcast.internal.serialization.impl.ConstantSerializers.StringSerializer;
 import com.hazelcast.internal.serialization.impl.ConstantSerializers.TheByteArraySerializer;
-import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.nio.serialization.DataSerializable;
-import com.hazelcast.nio.serialization.DataSerializableFactory;
-import com.hazelcast.nio.serialization.FieldDefinition;
-import com.hazelcast.nio.serialization.FieldType;
-import com.hazelcast.nio.serialization.HazelcastSerializationException;
-import com.hazelcast.internal.serialization.InputOutputFactory;
-import com.hazelcast.internal.serialization.ObjectDataInputStream;
-import com.hazelcast.internal.serialization.ObjectDataOutputStream;
-import com.hazelcast.nio.serialization.Portable;
-import com.hazelcast.internal.serialization.PortableContext;
-import com.hazelcast.nio.serialization.PortableFactory;
-import com.hazelcast.nio.serialization.PortableReader;
-import com.hazelcast.internal.serialization.SerializationService;
-import com.hazelcast.nio.serialization.Serializer;
-import com.hazelcast.nio.serialization.StreamSerializer;
 import com.hazelcast.internal.serialization.impl.DefaultSerializers.BigDecimalSerializer;
 import com.hazelcast.internal.serialization.impl.DefaultSerializers.BigIntegerSerializer;
 import com.hazelcast.internal.serialization.impl.DefaultSerializers.ClassSerializer;
@@ -68,6 +51,26 @@ import com.hazelcast.internal.serialization.impl.DefaultSerializers.ObjectSerial
 import com.hazelcast.internal.serialization.impl.bufferpool.BufferPool;
 import com.hazelcast.internal.serialization.impl.bufferpool.BufferPoolFactory;
 import com.hazelcast.internal.serialization.impl.bufferpool.BufferPoolThreadLocal;
+import com.hazelcast.map.impl.query.QueryResult;
+import com.hazelcast.nio.BufferObjectDataInput;
+import com.hazelcast.nio.BufferObjectDataOutput;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.ByteArraySerializer;
+import com.hazelcast.nio.serialization.ClassDefinition;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.nio.serialization.DataSerializable;
+import com.hazelcast.nio.serialization.DataSerializableFactory;
+import com.hazelcast.nio.serialization.FieldDefinition;
+import com.hazelcast.nio.serialization.FieldType;
+import com.hazelcast.nio.serialization.HazelcastSerializationException;
+import com.hazelcast.nio.serialization.Portable;
+import com.hazelcast.nio.serialization.PortableFactory;
+import com.hazelcast.nio.serialization.PortableReader;
+import com.hazelcast.nio.serialization.Serializer;
+import com.hazelcast.nio.serialization.StreamSerializer;
+import com.hazelcast.query.impl.QueryResultEntry;
+import com.hazelcast.spi.impl.operationservice.impl.responses.NormalResponse;
 
 import java.io.Externalizable;
 import java.io.IOException;
@@ -247,12 +250,52 @@ public class SerializationServiceImpl implements SerializationService {
                 out.writeInt(partitionHash, ByteOrder.BIG_ENDIAN);
             }
 
-            return out.toByteArray();
+            byte[] result = out.toByteArray();
+            if (result != null && result.length > 1000 * 1000) {
+                StringBuffer sb = new StringBuffer("fat packet:" + obj + " with size:" + result.length + "\n");
+                if (obj instanceof NormalResponse) {
+                    NormalResponse normalResponse = (NormalResponse) obj;
+                    if (normalResponse.getValue() instanceof QueryResult) {
+                        QueryResult queryResult = (QueryResult) normalResponse.getValue();
+                        sb.append(" query-result-size: " + queryResult.getResult().size() + "\n");
+                        int index = 1;
+                        for (QueryResultEntry entry : queryResult.getResult()) {
+                            sb.append("\titem: " + index + "\n");
+                            sb.append("\tkey " + details(entry.getKeyData()) + "\n");
+                            sb.append("\tvalue " + details(entry.getValueData()) + "\n");
+                            sb.append("\tindex " + details(entry.getIndexKey()) + "\n");
+                            sb.append("\n");
+                            index++;
+                        }
+                    }
+                }
+
+                try {
+                    throw new RuntimeException(sb.toString());
+                } catch (RuntimeException e) {
+                    e.printStackTrace();
+                }
+            }
+
+            return result;
         } catch (Throwable e) {
             throw handleException(e);
         } finally {
             pool.returnOutputBuffer(out);
         }
+    }
+
+    private String details(Data object) {
+        return "size:" + size(object) + " class:" + getClazz(object) + " value:" + toObject(object);
+    }
+
+    private String getClazz(Object object) {
+        Object o = toObject(object);
+        return o == null ? "null" : object.getClass().getName();
+    }
+
+    private int size(Data object) {
+        return object == null ? 0 : object.toByteArray().length;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/SerializationServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/SerializationServiceImpl.java
@@ -97,6 +97,8 @@ import static java.lang.Boolean.parseBoolean;
 
 public class SerializationServiceImpl implements SerializationService {
 
+    public static final int FAT_PACKET_SIZE = 1000 * 1000;
+
     protected static final PartitioningStrategy EMPTY_PARTITIONING_STRATEGY = new PartitioningStrategy() {
         public Object getPartitionKey(Object key) {
             return null;
@@ -251,7 +253,7 @@ public class SerializationServiceImpl implements SerializationService {
             }
 
             byte[] result = out.toByteArray();
-            if (result != null && result.length > 1000 * 1000) {
+            if (result != null && result.length > FAT_PACKET_SIZE) {
                 StringBuffer sb = new StringBuffer("fat packet:" + obj + " with size:" + result.length + "\n");
                 if (obj instanceof NormalResponse) {
                     NormalResponse normalResponse = (NormalResponse) obj;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapDataSerializerHook.java
@@ -28,7 +28,7 @@ import com.hazelcast.internal.serialization.impl.ArrayDataSerializableFactory;
 import com.hazelcast.internal.serialization.impl.FactoryIdHelper;
 import com.hazelcast.query.impl.QueryResultEntryImpl;
 import com.hazelcast.util.ConstructorFunction;
-import com.hazelcast.util.QueryResultSet;
+import com.hazelcast.query.impl.QueryResultSet;
 
 import static com.hazelcast.internal.serialization.impl.FactoryIdHelper.MAP_DS_FACTORY;
 import static com.hazelcast.internal.serialization.impl.FactoryIdHelper.MAP_DS_FACTORY_ID;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
@@ -570,14 +570,14 @@ public class MapProxyImpl<K, V> extends MapProxySupport implements IMap<K, V>, I
     public Set<K> keySet(Predicate predicate) {
         checkNotNull(predicate, NULL_PREDICATE_IS_NOT_ALLOWED);
 
-        return query(predicate, IterationType.KEY, false);
+        return (Set) query(predicate, IterationType.KEY, false, true);
     }
 
     @Override
     public Set entrySet(Predicate predicate) {
         checkNotNull(predicate, NULL_PREDICATE_IS_NOT_ALLOWED);
 
-        return query(predicate, IterationType.ENTRY, false);
+        return (Set) query(predicate, IterationType.ENTRY, false, true);
     }
 
     @Override
@@ -585,7 +585,7 @@ public class MapProxyImpl<K, V> extends MapProxySupport implements IMap<K, V>, I
     public Collection<V> values(Predicate predicate) {
         checkNotNull(predicate, NULL_PREDICATE_IS_NOT_ALLOWED);
 
-        return query(predicate, IterationType.VALUE, false);
+        return query(predicate, IterationType.VALUE, false, false);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
@@ -1065,18 +1065,18 @@ abstract class MapProxySupport extends AbstractDistributedObject<MapService> imp
         return serializationService.toData(o, partitioningStrategy);
     }
 
-    protected Set queryLocal(final Predicate predicate, final IterationType iterationType, final boolean dataResult) {
+    protected Set queryLocal(final Predicate predicate, final IterationType iterationType, final boolean binary) {
         if (predicate instanceof PagingPredicate) {
             return getMapQueryEngine().queryLocalMemberWithPagingPredicate(name, (PagingPredicate) predicate, iterationType);
         }
-        return getMapQueryEngine().queryLocalMember(name, predicate, iterationType, dataResult);
+        return getMapQueryEngine().queryLocalMember(name, predicate, iterationType, binary);
     }
 
-    protected Set query(Predicate predicate, IterationType iterationType, boolean dataResult) {
+    protected Collection query(Predicate predicate, IterationType iterationType, boolean binary, boolean unique) {
         if (predicate instanceof PagingPredicate) {
             return getMapQueryEngine().queryWithPagingPredicate(name, (PagingPredicate) predicate, iterationType);
         }
-        return getMapQueryEngine().query(name, predicate, iterationType, dataResult);
+        return getMapQueryEngine().query(name, predicate, iterationType, binary, unique);
     }
 
     public void addIndex(String attribute, boolean ordered) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/MapQueryEngine.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/MapQueryEngine.java
@@ -18,6 +18,7 @@ package com.hazelcast.map.impl.query;
 
 import com.hazelcast.query.PagingPredicate;
 import com.hazelcast.query.Predicate;
+import com.hazelcast.query.impl.QueryResultSet;
 import com.hazelcast.query.impl.QueryableEntry;
 import com.hazelcast.util.IterationType;
 
@@ -45,12 +46,12 @@ public interface MapQueryEngine {
      * @param mapName       map name.
      * @param predicate     except paging predicate.
      * @param iterationType type of {@link com.hazelcast.util.IterationType}
-     * @param dataResult    <code>true</code> if results should contain {@link com.hazelcast.nio.serialization.Data} types,
+     * @param binary    <code>true</code> if results should contain {@link com.hazelcast.nio.serialization.Data} types,
      *                      <code>false</code> for object types.
-     * @return {@link com.hazelcast.util.QueryResultSet}
+     * @return {@link QueryResultSet}
      */
     Set queryLocalMember(String mapName, Predicate predicate,
-                         IterationType iterationType, boolean dataResult);
+                         IterationType iterationType, boolean binary);
 
     /**
      * Used for paging predicate queries on node local entries.
@@ -79,12 +80,12 @@ public interface MapQueryEngine {
      * @param mapName       map name.
      * @param predicate     except paging predicate.
      * @param iterationType type of {@link IterationType}
-     * @param dataResult    <code>true</code> if results should contain {@link com.hazelcast.nio.serialization.Data} types,
+     * @param binary    <code>true</code> if results should contain {@link com.hazelcast.nio.serialization.Data} types,
      *                      <code>false</code> for object types.
-     * @return {@link com.hazelcast.util.QueryResultSet}
+     * @return {@link QueryResultSet}
      */
-    Set query(String mapName, Predicate predicate,
-              IterationType iterationType, boolean dataResult);
+    Collection query(String mapName, Predicate predicate,
+              IterationType iterationType, boolean binary, boolean unique);
 
     /**
      * Creates a {@link QueryResult} with configured result limit (according to the number of partitions) if feature is enabled.
@@ -92,5 +93,5 @@ public interface MapQueryEngine {
      * @param numberOfPartitions number of partitions to calculate result limit
      * @return {@link QueryResult}
      */
-    QueryResult newQueryResult(int numberOfPartitions);
+    QueryResult newQueryResult(IterationType iterationType, int numberOfPartitions);
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/MapQueryEngine.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/MapQueryEngine.java
@@ -18,7 +18,6 @@ package com.hazelcast.map.impl.query;
 
 import com.hazelcast.query.PagingPredicate;
 import com.hazelcast.query.Predicate;
-import com.hazelcast.query.impl.QueryResultSet;
 import com.hazelcast.query.impl.QueryableEntry;
 import com.hazelcast.util.IterationType;
 
@@ -46,9 +45,9 @@ public interface MapQueryEngine {
      * @param mapName       map name.
      * @param predicate     except paging predicate.
      * @param iterationType type of {@link com.hazelcast.util.IterationType}
-     * @param binary    <code>true</code> if results should contain {@link com.hazelcast.nio.serialization.Data} types,
+     * @param binary        <code>true</code> if results should contain {@link com.hazelcast.nio.serialization.Data} types,
      *                      <code>false</code> for object types.
-     * @return {@link QueryResultSet}
+     * @return the results
      */
     Set queryLocalMember(String mapName, Predicate predicate,
                          IterationType iterationType, boolean binary);
@@ -59,7 +58,7 @@ public interface MapQueryEngine {
      * @param mapName         map name.
      * @param pagingPredicate to queryOnMembers.
      * @param iterationType   type of {@link IterationType}
-     * @return {@link com.hazelcast.util.SortedQueryResultSet}
+     * @return the results
      */
     Set queryLocalMemberWithPagingPredicate(String mapName, PagingPredicate pagingPredicate,
                                             IterationType iterationType);
@@ -70,7 +69,7 @@ public interface MapQueryEngine {
      * @param mapName         map name.
      * @param pagingPredicate to queryOnMembers.
      * @param iterationType   type of {@link IterationType}
-     * @return {@link com.hazelcast.util.SortedQueryResultSet}
+     * @return the results
      */
     Set queryWithPagingPredicate(String mapName, PagingPredicate pagingPredicate, IterationType iterationType);
 
@@ -80,18 +79,18 @@ public interface MapQueryEngine {
      * @param mapName       map name.
      * @param predicate     except paging predicate.
      * @param iterationType type of {@link IterationType}
-     * @param binary    <code>true</code> if results should contain {@link com.hazelcast.nio.serialization.Data} types,
+     * @param binary        <code>true</code> if results should contain {@link com.hazelcast.nio.serialization.Data} types,
      *                      <code>false</code> for object types.
-     * @return {@link QueryResultSet}
+     * @return the results
      */
     Collection query(String mapName, Predicate predicate,
-              IterationType iterationType, boolean binary, boolean unique);
+                     IterationType iterationType, boolean binary, boolean unique);
 
     /**
      * Creates a {@link QueryResult} with configured result limit (according to the number of partitions) if feature is enabled.
      *
      * @param numberOfPartitions number of partitions to calculate result limit
-     * @return {@link QueryResult}
+     * @return results
      */
     QueryResult newQueryResult(IterationType iterationType, int numberOfPartitions);
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryResult.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryResult.java
@@ -101,7 +101,6 @@ public class QueryResult implements DataSerializable {
                     out.writeData(queryableEntry.getKeyData());
                     break;
                 case VALUE:
-                    out.writeData(queryableEntry.getKeyData());
                     out.writeData(queryableEntry.getValueData());
                     break;
                 default:
@@ -138,7 +137,6 @@ public class QueryResult implements DataSerializable {
                     key = in.readData();
                     break;
                 case VALUE:
-                    key = in.readData();
                     value = in.readData();
                     break;
                 default:

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TransactionalMapProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TransactionalMapProxy.java
@@ -27,7 +27,7 @@ import com.hazelcast.query.impl.QueryEntry;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.transaction.impl.Transaction;
 import com.hazelcast.util.IterationType;
-import com.hazelcast.util.QueryResultSet;
+import com.hazelcast.query.impl.QueryResultSet;
 
 import java.util.ArrayList;
 import java.util.Collection;

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/QueryResultEntryImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/QueryResultEntryImpl.java
@@ -25,9 +25,8 @@ import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import java.io.IOException;
 
 /**
- *  Multiple result set for Predicates
+ * Multiple result set for Predicates
  */
-
 public class QueryResultEntryImpl implements IdentifiedDataSerializable, QueryResultEntry {
     private Data indexKey;
     private Data keyData;
@@ -86,13 +85,21 @@ public class QueryResultEntryImpl implements IdentifiedDataSerializable, QueryRe
         if (this == o) {
             return true;
         }
+
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
 
         QueryResultEntryImpl that = (QueryResultEntryImpl) o;
+        if (!equals(this.keyData, that.keyData)) {
+            return false;
+        }
 
-        if (indexKey != null ? !indexKey.equals(that.indexKey) : that.indexKey != null) {
+        if (!equals(this.valueData, that.valueData)) {
+            return false;
+        }
+
+        if (!equals(this.indexKey, that.indexKey)) {
             return false;
         }
 
@@ -101,6 +108,18 @@ public class QueryResultEntryImpl implements IdentifiedDataSerializable, QueryRe
 
     @Override
     public int hashCode() {
-        return indexKey != null ? indexKey.hashCode() : 0;
+        return hash(keyData) + hash(valueData) + hash(indexKey);
+    }
+
+    private int hash(Data data) {
+        return data == null ? 0 : data.hashCode();
+    }
+
+    private boolean equals(Data thisData, Data thatData) {
+        if (thisData == null) {
+            return thatData == null;
+        } else {
+            return thisData.equals(thatData);
+        }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/QueryResultIterator.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/QueryResultIterator.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.query.impl;
+
+import com.hazelcast.internal.serialization.SerializationService;
+import com.hazelcast.query.impl.QueryResultEntry;
+import com.hazelcast.util.IterationType;
+
+import java.util.AbstractMap;
+import java.util.Iterator;
+
+/**
+ * Iterator for this set.
+ */
+final class QueryResultIterator implements Iterator {
+
+    private final Iterator<QueryResultEntry> iterator;
+    private final IterationType iteratorType;
+    private final boolean binary;
+    private final SerializationService serializationService;
+
+    QueryResultIterator(Iterator iterator, IterationType iteratorType, boolean binary,
+                        SerializationService serializationService) {
+        this.iteratorType = iteratorType;
+        this.iterator = iterator;
+        this.binary = binary;
+        this.serializationService = serializationService;
+   }
+
+    @Override
+    public boolean hasNext() {
+        return iterator.hasNext();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Object next() {
+        QueryResultEntry entry = iterator.next();
+        //System.out.println("iterator.next ikey: "+entry.getKeyData()
+        // +" index:"+entry.getIndexKey()+" value:"+entry.getValueData());
+
+        switch (iteratorType) {
+            case VALUE:
+                if (binary) {
+                    return entry.getValueData();
+                } else {
+                    return serializationService.toObject(entry.getValueData());
+                }
+            case KEY:
+                if (binary) {
+                    return entry.getKeyData();
+                } else {
+                    return serializationService.toObject(entry.getKeyData());
+                }
+            case ENTRY:
+                if (binary) {
+                    return new AbstractMap.SimpleImmutableEntry(entry.getKeyData(), entry.getValueData());
+                } else {
+                    Object key = serializationService.toObject(entry.getKeyData());
+                    Object value = serializationService.toObject(entry.getValueData());
+                    return new AbstractMap.SimpleImmutableEntry(key, value);
+                }
+            default:
+                throw new IllegalStateException("Unhandled iterationType:" + iteratorType);
+        }
+    }
+
+    public void remove() {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/QueryResultIterator.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/QueryResultIterator.java
@@ -17,14 +17,13 @@
 package com.hazelcast.query.impl;
 
 import com.hazelcast.internal.serialization.SerializationService;
-import com.hazelcast.query.impl.QueryResultEntry;
 import com.hazelcast.util.IterationType;
 
 import java.util.AbstractMap;
 import java.util.Iterator;
 
 /**
- * Iterator for this set.
+ * Iterator for QueryResultSet/QueryResultList
  */
 final class QueryResultIterator implements Iterator {
 

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/QueryResultSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/QueryResultSet.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.query.impl;
+
+import com.hazelcast.internal.serialization.SerializationService;
+import com.hazelcast.map.impl.MapDataSerializerHook;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.util.IterationType;
+
+import java.io.IOException;
+import java.util.AbstractSet;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static java.util.Collections.newSetFromMap;
+
+/**
+ * Collection(Set) class for result of query operations.
+ */
+public class QueryResultSet extends AbstractSet implements IdentifiedDataSerializable {
+
+    private final Set<QueryResultEntry> entries = newSetFromMap(new ConcurrentHashMap<QueryResultEntry, Boolean>());
+    private final SerializationService serializationService;
+
+    private IterationType iterationType;
+    private boolean binary;
+
+    public QueryResultSet() {
+        serializationService = null;
+    }
+
+    public QueryResultSet(SerializationService serializationService, IterationType iterationType, boolean binary) {
+        this.serializationService = serializationService;
+        this.iterationType = iterationType;
+        this.binary = binary;
+    }
+
+    @SuppressWarnings("unchecked")
+    public Iterator<Map.Entry> rawIterator() {
+        return new QueryResultIterator(entries.iterator(), IterationType.ENTRY, binary, serializationService);
+    }
+
+    public boolean add(QueryResultEntry entry) {
+        return entries.add(entry);
+    }
+
+    public boolean remove(QueryResultEntry entry) {
+        return entries.remove(entry);
+    }
+
+    public boolean contains(QueryResultEntry entry) {
+        return entries.contains(entry);
+    }
+
+    @Override
+    public boolean add(Object entry) {
+        return entries.add((QueryResultEntry) entry);
+    }
+
+    @Override
+    public Iterator iterator() {
+        return new QueryResultIterator(entries.iterator(), iterationType, binary, serializationService);
+    }
+
+    @Override
+    public int size() {
+        return entries.size();
+    }
+
+    @Override
+    public int getFactoryId() {
+        return MapDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return MapDataSerializerHook.QUERY_RESULT_SET;
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
+        out.writeBoolean(binary);
+        out.writeUTF(iterationType.toString());
+        out.writeInt(entries.size());
+        for (QueryResultEntry queryResultEntry : entries) {
+            out.writeObject(queryResultEntry);
+        }
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) throws IOException {
+        binary = in.readBoolean();
+        iterationType = IterationType.valueOf(in.readUTF());
+        int size = in.readInt();
+        for (int i = 0; i < size; i++) {
+            entries.add((QueryResultEntry) in.readObject());
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "QueryResultSet{"
+                + "entries=" + entriesToString()
+                + ", iterationType=" + iterationType
+                + ", binary=" + binary
+                + '}';
+
+    }
+
+    private String entriesToString() {
+        final Iterator i = iterator();
+        if (!i.hasNext()) {
+            return "[]";
+        }
+
+        StringBuilder sb = new StringBuilder();
+        sb.append('[');
+        for (; ; ) {
+            Object e = i.next();
+            sb.append(e == this ? "(this Collection)" : e);
+            if (!i.hasNext()) {
+                return sb.append(']').toString();
+            }
+            sb.append(", ");
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/util/IterationType.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/IterationType.java
@@ -24,13 +24,45 @@ public enum IterationType {
     /**
      * Iterate over keys
      */
-    KEY,
+    KEY((byte) 0),
     /**
      * Iterate over values
      */
-    VALUE,
+    VALUE((byte) 1),
     /**
      * Iterate over whole entry
      */
-    ENTRY
+    ENTRY((byte) 2);
+
+    private final byte id;
+
+    IterationType(byte id) {
+        this.id = id;
+    }
+
+    /**
+     * Gets the id for the given IterationType.
+     *
+     * This reason this id is used instead of an the ordinal value is that the ordinal value is more prone to changes due to
+     * reordering.
+     *
+     * @return the id.
+     */
+    public byte getId() {
+        return id;
+    }
+
+    /**
+     * Returns the IterationType for the given id.
+     *
+     * @return the IterationType found or null if not found
+     */
+    public static IterationType getById(final byte id) {
+        for (IterationType policy : values()) {
+            if (policy.id == id) {
+                return policy;
+            }
+        }
+        return null;
+    }
 }

--- a/hazelcast/src/test/java/com/hazelcast/Main.java
+++ b/hazelcast/src/test/java/com/hazelcast/Main.java
@@ -1,0 +1,75 @@
+package com.hazelcast;
+
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.DataSerializable;
+import com.hazelcast.query.Predicate;
+import com.hazelcast.query.Predicates;
+import com.hazelcast.test.HazelcastTestSupport;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Created by alarmnummer on 9/14/15.
+ */
+public class Main extends HazelcastTestSupport {
+
+    public static void main(String[] args){
+        HazelcastInstance hz1 = Hazelcast.newHazelcastInstance();
+        HazelcastInstance hz2 = Hazelcast.newHazelcastInstance();
+        IMap map = hz1.getMap("foo");
+
+
+        map.put(generateKeyOwnedBy(hz2), new Value());
+        map.put(generateKeyOwnedBy(hz2), new Value());
+        map.put(generateKeyOwnedBy(hz2), new Value());
+        map.put(generateKeyOwnedBy(hz2), new Value());
+
+        System.out.println("item placed");
+
+        System.out.println("executing query");
+        Collection<String> keys = map.keySet(new MyPredicate());
+        System.out.println("Printing keys");
+        for(String key:keys){
+            System.out.println(key);
+        }
+    }
+
+    static class MyPredicate implements Predicate {
+        @Override
+        public boolean apply(Map.Entry mapEntry) {
+            return true;
+        }
+    }
+
+    static class Key implements DataSerializable{
+        @Override
+        public void writeData(ObjectDataOutput out) throws IOException {
+            System.out.println("key serialize");
+        }
+
+        @Override
+        public void readData(ObjectDataInput in) throws IOException {
+            System.out.println("key deserialize");
+        }
+    }
+
+    static class Value implements DataSerializable{
+        @Override
+        public void writeData(ObjectDataOutput out) throws IOException {
+            System.out.println("value serialize");
+        }
+
+        @Override
+        public void readData(ObjectDataInput in) throws IOException {
+            System.out.println("value deserialize");
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/map/MapClientRequestTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapClientRequestTest.java
@@ -57,7 +57,7 @@ import com.hazelcast.query.SqlPredicate;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.util.IterationType;
-import com.hazelcast.util.QueryResultSet;
+import com.hazelcast.query.impl.QueryResultSet;
 import com.hazelcast.util.ThreadUtil;
 import org.junit.Ignore;
 import org.junit.Test;

--- a/hazelcast/src/test/java/com/hazelcast/map/MapPredicateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapPredicateTest.java
@@ -40,7 +40,7 @@ public class MapPredicateTest extends HazelcastTestSupport {
         listExpected.add("key2");
         listExpected.add("key3");
 
-        final List<String> list = new ArrayList<String>(map.keySet());
+        List<String> list = new ArrayList<String>(map.keySet());
 
         Collections.sort(list);
         Collections.sort(listExpected);
@@ -60,7 +60,7 @@ public class MapPredicateTest extends HazelcastTestSupport {
         listExpected.add("key2");
         listExpected.add("key3");
 
-        final List<String> list = new ArrayList<String>(map.keySet());
+        List<String> list = new ArrayList<String>(map.keySet());
 
         Collections.sort(list);
         Collections.sort(listExpected);
@@ -95,22 +95,22 @@ public class MapPredicateTest extends HazelcastTestSupport {
         map.put("c", "3");
         assertEquals(3, map.size());
         {
-            final Object[] values = map.values().toArray();
+            Object[] values = map.values().toArray();
             Arrays.sort(values);
             assertArrayEquals(new Object[]{"1", "2", "3"}, values);
         }
         {
-            final String[] values = map.values().toArray(new String[3]);
+            String[] values = map.values().toArray(new String[3]);
             Arrays.sort(values);
             assertArrayEquals(new String[]{"1", "2", "3"}, values);
         }
         {
-            final String[] values = map.values().toArray(new String[2]);
+            String[] values = map.values().toArray(new String[2]);
             Arrays.sort(values);
             assertArrayEquals(new String[]{"1", "2", "3"}, values);
         }
         {
-            final String[] values = map.values().toArray(new String[5]);
+            String[] values = map.values().toArray(new String[5]);
             Arrays.sort(values, 0, 3);
             assertArrayEquals(new String[]{"1", "2", "3", null, null}, values);
         }

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryOperationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryOperationTest.java
@@ -5,6 +5,7 @@ import com.hazelcast.map.impl.operation.AbstractMapOperation;
 import com.hazelcast.query.TruePredicate;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.util.IterationType;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -17,7 +18,7 @@ public class QueryOperationTest extends QueryOperationTestSupport {
 
     @Override
     protected AbstractMapOperation createQueryOperation() {
-        return new QueryOperation(MAP_NAME, TruePredicate.INSTANCE);
+        return new QueryOperation(MAP_NAME, TruePredicate.INSTANCE, IterationType.ENTRY);
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryOperationTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryOperationTestSupport.java
@@ -13,6 +13,7 @@ import com.hazelcast.query.impl.Indexes;
 import com.hazelcast.query.impl.QueryableEntry;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.Operation;
+import com.hazelcast.util.IterationType;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
@@ -55,9 +56,9 @@ public abstract class QueryOperationTestSupport {
             queryEntrySet.add(queryableEntry);
         }
 
-        QueryResult queryResult = new QueryResult(nodeResultLimit);
+        QueryResult queryResult = new QueryResult(IterationType.ENTRY, nodeResultLimit);
 
-        when(mapQueryEngine.newQueryResult(anyInt())).thenReturn(queryResult);
+        when(mapQueryEngine.newQueryResult(IterationType.ENTRY, anyInt())).thenReturn(queryResult);
         when(mapQueryEngine.queryOnPartition(MAP_NAME, TruePredicate.INSTANCE, Operation.GENERIC_PARTITION_ID))
                 .thenReturn(queryEntries);
 

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryPartitionOperationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryPartitionOperationTest.java
@@ -5,6 +5,7 @@ import com.hazelcast.map.impl.operation.AbstractMapOperation;
 import com.hazelcast.query.TruePredicate;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.util.IterationType;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -17,7 +18,7 @@ public class QueryPartitionOperationTest extends QueryOperationTestSupport {
 
     @Override
     protected AbstractMapOperation createQueryOperation() {
-        return new QueryPartitionOperation(MAP_NAME, TruePredicate.INSTANCE);
+        return new QueryPartitionOperation(MAP_NAME, TruePredicate.INSTANCE, IterationType.ENTRY);
     }
 
     @Test


### PR DESCRIPTION
IMap.keySet is implemented inefficiently since it also downloads the values. Also plenty of other not needed complexity that is removed; e.g. why force using a set to store results of a list can be used (e.g. map.values). 