### PR TITLE
Fixes a deadlock in client listeners

### DIFF
--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
@@ -543,6 +543,7 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
 
     public void doShutdown() {
         proxyManager.destroy();
+        clusterService.shutdown();
         executionService.shutdown();
         partitionService.stop();
         transactionManager.shutdown();

--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/spi/ClientExecutionService.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/spi/ClientExecutionService.java
@@ -28,6 +28,11 @@ import java.util.concurrent.TimeUnit;
  */
 public interface ClientExecutionService {
 
+    /**
+     * Execute alien(user code) on execution service
+     *
+     * @param command to run
+     */
     void execute(Runnable command);
 
     ICompletableFuture<?> submit(Runnable task);
@@ -40,6 +45,9 @@ public interface ClientExecutionService {
 
     ScheduledFuture<?> scheduleWithFixedDelay(Runnable command, long initialDelay, long period, TimeUnit unit);
 
+    /**
+     * @return executorService that alien(user code) runs on
+     */
     ExecutorService getAsyncExecutor();
 
 }

--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/spi/impl/ClientExecutionServiceImpl.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/spi/impl/ClientExecutionServiceImpl.java
@@ -77,7 +77,7 @@ public final class ClientExecutionServiceImpl implements ClientExecutionService 
 
     public <T> ICompletableFuture<T> submitInternal(Runnable runnable) {
         CompletableFutureTask futureTask = new CompletableFutureTask(runnable, null, getAsyncExecutor());
-        executor.submit(futureTask);
+        internalExecutor.submit(futureTask);
         return futureTask;
     }
 
@@ -93,14 +93,14 @@ public final class ClientExecutionServiceImpl implements ClientExecutionService 
     @Override
     public ICompletableFuture<?> submit(Runnable task) {
         CompletableFutureTask futureTask = new CompletableFutureTask(task, null, getAsyncExecutor());
-        executor.submit(futureTask);
+        internalExecutor.submit(futureTask);
         return futureTask;
     }
 
     @Override
     public <T> ICompletableFuture<T> submit(Callable<T> task) {
         CompletableFutureTask<T> futureTask = new CompletableFutureTask<T>(task, getAsyncExecutor());
-        executor.submit(futureTask);
+        internalExecutor.submit(futureTask);
         return futureTask;
     }
 
@@ -108,7 +108,7 @@ public final class ClientExecutionServiceImpl implements ClientExecutionService 
     public ScheduledFuture<?> schedule(final Runnable command, long delay, TimeUnit unit) {
         return scheduledExecutor.schedule(new Runnable() {
             public void run() {
-                execute(command);
+                executeInternal(command);
             }
         }, delay, unit);
     }

--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/spi/impl/ClientInvocation.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/spi/impl/ClientInvocation.java
@@ -206,7 +206,7 @@ public class ClientInvocation implements Runnable {
 
         try {
             sleep();
-            executionService.execute(this);
+            ((ClientExecutionServiceImpl) executionService).executeInternal(this);
         } catch (RejectedExecutionException e) {
             if (LOGGER.isFinestEnabled()) {
                 LOGGER.finest("Retry could not be scheduled ", e);

--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/spi/impl/ClientInvocationServiceSupport.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/spi/impl/ClientInvocationServiceSupport.java
@@ -222,7 +222,7 @@ abstract class ClientInvocationServiceSupport implements ClientInvocationService
     public void cleanConnectionResources(ClientConnection connection) {
         if (connectionManager.isAlive()) {
             try {
-                executionService.execute(new CleanResourcesTask(connection));
+                ((ClientExecutionServiceImpl) executionService).executeInternal(new CleanResourcesTask(connection));
             } catch (RejectedExecutionException e) {
                 logger.warning("Execution rejected ", e);
             }

--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/spi/impl/ClusterListenerSupport.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/spi/impl/ClusterListenerSupport.java
@@ -29,6 +29,7 @@ import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.ClientAuthenticationCodec;
 import com.hazelcast.client.impl.protocol.codec.ClientAuthenticationCustomCodec;
 import com.hazelcast.client.spi.ClientClusterService;
+import com.hazelcast.client.spi.ClientExecutionService;
 import com.hazelcast.core.LifecycleEvent;
 import com.hazelcast.core.Member;
 import com.hazelcast.logging.ILogger;
@@ -42,6 +43,7 @@ import com.hazelcast.security.Credentials;
 import com.hazelcast.security.UsernamePasswordCredentials;
 import com.hazelcast.util.Clock;
 import com.hazelcast.util.ExceptionUtil;
+import com.hazelcast.util.executor.PoolExecutorThreadFactory;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -51,17 +53,22 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 
 public abstract class ClusterListenerSupport implements ConnectionListener, ConnectionHeartbeatListener,
         ClientClusterService {
 
     private static final ILogger LOGGER = Logger.getLogger(ClusterListenerSupport.class);
+    private static final long TERMINATE_TIMEOUT_SECONDS = 30;
 
     protected final HazelcastClientInstanceImpl client;
     private final Collection<AddressProvider> addressProviders;
     private final ManagerAuthenticator managerAuthenticator = new ManagerAuthenticator();
+    private final ExecutorService clusterExecutor;
     private final boolean shuffleMemberList;
 
     private Credentials credentials;
@@ -74,7 +81,16 @@ public abstract class ClusterListenerSupport implements ConnectionListener, Conn
     public ClusterListenerSupport(HazelcastClientInstanceImpl client, Collection<AddressProvider> addressProviders) {
         this.client = client;
         this.addressProviders = addressProviders;
-        shuffleMemberList = client.getClientProperties().getShuffleMemberList().getBoolean();
+        this.shuffleMemberList = client.getClientProperties().getShuffleMemberList().getBoolean();
+        this.clusterExecutor = createSingleThreadExecutorService(client);
+    }
+
+    private ExecutorService createSingleThreadExecutorService(HazelcastClientInstanceImpl client) {
+        ThreadGroup threadGroup = client.getThreadGroup();
+        ClassLoader classLoader = client.getClientConfig().getClassLoader();
+        PoolExecutorThreadFactory threadFactory =
+                new PoolExecutorThreadFactory(threadGroup, client.getName() + ".cluster-", classLoader);
+        return Executors.newSingleThreadExecutor(threadFactory);
     }
 
     protected void init() {
@@ -88,6 +104,19 @@ public abstract class ClusterListenerSupport implements ConnectionListener, Conn
 
     public Address getOwnerConnectionAddress() {
         return ownerConnectionAddress;
+    }
+
+    public void shutdown() {
+        clusterExecutor.shutdown();
+        try {
+            boolean success = clusterExecutor.awaitTermination(TERMINATE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            if (!success) {
+                LOGGER.warning("ClientClusterService shutdown could not completed in "
+                        + TERMINATE_TIMEOUT_SECONDS + " seconds");
+            }
+        } catch (InterruptedException e) {
+            LOGGER.warning("ClientClusterService shutdown is interrupted", e);
+        }
     }
 
     private class ManagerAuthenticator implements Authenticator {
@@ -223,9 +252,15 @@ public abstract class ClusterListenerSupport implements ConnectionListener, Conn
         return false;
     }
 
-    private void fireConnectionEvent(LifecycleEvent.LifecycleState state) {
-        final LifecycleServiceImpl lifecycleService = (LifecycleServiceImpl) client.getLifecycleService();
-        lifecycleService.fireLifecycleEvent(state);
+    private void fireConnectionEvent(final LifecycleEvent.LifecycleState state) {
+        ClientExecutionService executionService = client.getClientExecutionService();
+        executionService.execute(new Runnable() {
+            @Override
+            public void run() {
+                final LifecycleServiceImpl lifecycleService = (LifecycleServiceImpl) client.getLifecycleService();
+                lifecycleService.fireLifecycleEvent(state);
+            }
+        });
     }
 
     @Override
@@ -235,10 +270,9 @@ public abstract class ClusterListenerSupport implements ConnectionListener, Conn
 
     @Override
     public void connectionRemoved(Connection connection) {
-        ClientExecutionServiceImpl executionService = (ClientExecutionServiceImpl) client.getClientExecutionService();
         if (connection.getEndPoint().equals(ownerConnectionAddress)) {
             if (client.getLifecycleService().isRunning()) {
-                executionService.executeInternal(new Runnable() {
+                clusterExecutor.execute(new Runnable() {
                     @Override
                     public void run() {
                         try {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
@@ -539,6 +539,7 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
 
     public void doShutdown() {
         proxyManager.destroy();
+        clusterService.shutdown();
         executionService.shutdown();
         partitionService.stop();
         transactionManager.shutdown();

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/ClientExecutionService.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/ClientExecutionService.java
@@ -28,6 +28,11 @@ import java.util.concurrent.TimeUnit;
  */
 public interface ClientExecutionService {
 
+    /**
+     * Execute alien(user code) on execution service
+     *
+     * @param command to run
+     */
     void execute(Runnable command);
 
     ICompletableFuture<?> submit(Runnable task);
@@ -40,6 +45,9 @@ public interface ClientExecutionService {
 
     ScheduledFuture<?> scheduleWithFixedDelay(Runnable command, long initialDelay, long period, TimeUnit unit);
 
+    /**
+     * @return executorService that alien(user code) runs on
+     */
     ExecutorService getAsyncExecutor();
 
 }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientExecutionServiceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientExecutionServiceImpl.java
@@ -77,7 +77,7 @@ public final class ClientExecutionServiceImpl implements ClientExecutionService 
 
     public <T> ICompletableFuture<T> submitInternal(Runnable runnable) {
         CompletableFutureTask futureTask = new CompletableFutureTask(runnable, null, getAsyncExecutor());
-        executor.submit(futureTask);
+        internalExecutor.submit(futureTask);
         return futureTask;
     }
 
@@ -93,14 +93,14 @@ public final class ClientExecutionServiceImpl implements ClientExecutionService 
     @Override
     public ICompletableFuture<?> submit(Runnable task) {
         CompletableFutureTask futureTask = new CompletableFutureTask(task, null, getAsyncExecutor());
-        executor.submit(futureTask);
+        internalExecutor.submit(futureTask);
         return futureTask;
     }
 
     @Override
     public <T> ICompletableFuture<T> submit(Callable<T> task) {
         CompletableFutureTask<T> futureTask = new CompletableFutureTask<T>(task, getAsyncExecutor());
-        executor.submit(futureTask);
+        internalExecutor.submit(futureTask);
         return futureTask;
     }
 
@@ -108,7 +108,7 @@ public final class ClientExecutionServiceImpl implements ClientExecutionService 
     public ScheduledFuture<?> schedule(final Runnable command, long delay, TimeUnit unit) {
         return scheduledExecutor.schedule(new Runnable() {
             public void run() {
-                execute(command);
+                executeInternal(command);
             }
         }, delay, unit);
     }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocation.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocation.java
@@ -229,7 +229,7 @@ public class ClientInvocation implements Runnable {
 
         try {
             sleep();
-            executionService.execute(this);
+            ((ClientExecutionServiceImpl) executionService).executeInternal(this);
         } catch (RejectedExecutionException e) {
             if (LOGGER.isFinestEnabled()) {
                 LOGGER.finest("Retry could not be scheduled ", e);

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocationServiceSupport.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocationServiceSupport.java
@@ -222,7 +222,7 @@ abstract class ClientInvocationServiceSupport implements ClientInvocationService
     public void cleanConnectionResources(ClientConnection connection) {
         if (connectionManager.isAlive()) {
             try {
-                executionService.execute(new CleanResourcesTask(connection));
+                ((ClientExecutionServiceImpl) executionService).executeInternal(new CleanResourcesTask(connection));
             } catch (RejectedExecutionException e) {
                 logger.warning("Execution rejected ", e);
             }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClusterListenerSupport.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClusterListenerSupport.java
@@ -27,6 +27,7 @@ import com.hazelcast.client.impl.LifecycleServiceImpl;
 import com.hazelcast.client.impl.client.AuthenticationRequest;
 import com.hazelcast.client.impl.client.ClientPrincipal;
 import com.hazelcast.client.spi.ClientClusterService;
+import com.hazelcast.client.spi.ClientExecutionService;
 import com.hazelcast.core.LifecycleEvent;
 import com.hazelcast.core.Member;
 import com.hazelcast.logging.ILogger;
@@ -40,6 +41,7 @@ import com.hazelcast.security.Credentials;
 import com.hazelcast.spi.impl.SerializableCollection;
 import com.hazelcast.util.Clock;
 import com.hazelcast.util.ExceptionUtil;
+import com.hazelcast.util.executor.PoolExecutorThreadFactory;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -50,17 +52,22 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 
 public abstract class ClusterListenerSupport implements ConnectionListener, ConnectionHeartbeatListener,
         ClientClusterService {
 
     private static final ILogger LOGGER = Logger.getLogger(ClusterListenerSupport.class);
+    private static final long TERMINATE_TIMEOUT_SECONDS = 30;
 
     protected final HazelcastClientInstanceImpl client;
     private final Collection<AddressProvider> addressProviders;
     private final ManagerAuthenticator managerAuthenticator = new ManagerAuthenticator();
+    private final ExecutorService clusterExecutor;
     private final boolean shuffleMemberList;
 
     private Credentials credentials;
@@ -73,7 +80,16 @@ public abstract class ClusterListenerSupport implements ConnectionListener, Conn
     public ClusterListenerSupport(HazelcastClientInstanceImpl client, Collection<AddressProvider> addressProviders) {
         this.client = client;
         this.addressProviders = addressProviders;
-        shuffleMemberList = client.getClientProperties().getShuffleMemberList().getBoolean();
+        this.shuffleMemberList = client.getClientProperties().getShuffleMemberList().getBoolean();
+        this.clusterExecutor = createSingleThreadExecutorService(client);
+    }
+
+    private ExecutorService createSingleThreadExecutorService(HazelcastClientInstanceImpl client) {
+        ThreadGroup threadGroup = client.getThreadGroup();
+        ClassLoader classLoader = client.getClientConfig().getClassLoader();
+        PoolExecutorThreadFactory threadFactory =
+                new PoolExecutorThreadFactory(threadGroup, client.getName() + ".cluster-", classLoader);
+        return Executors.newSingleThreadExecutor(threadFactory);
     }
 
     protected void init() {
@@ -87,6 +103,19 @@ public abstract class ClusterListenerSupport implements ConnectionListener, Conn
 
     public Address getOwnerConnectionAddress() {
         return ownerConnectionAddress;
+    }
+
+    public void shutdown() {
+        clusterExecutor.shutdown();
+        try {
+            boolean success = clusterExecutor.awaitTermination(TERMINATE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            if (!success) {
+                LOGGER.warning("ClientClusterService shutdown could not completed in "
+                        + TERMINATE_TIMEOUT_SECONDS + " seconds");
+            }
+        } catch (InterruptedException e) {
+            LOGGER.warning("ClientClusterService shutdown is interrupted", e);
+        }
     }
 
     private class ManagerAuthenticator implements Authenticator {
@@ -208,9 +237,15 @@ public abstract class ClusterListenerSupport implements ConnectionListener, Conn
         return false;
     }
 
-    private void fireConnectionEvent(LifecycleEvent.LifecycleState state) {
-        final LifecycleServiceImpl lifecycleService = (LifecycleServiceImpl) client.getLifecycleService();
-        lifecycleService.fireLifecycleEvent(state);
+    private void fireConnectionEvent(final LifecycleEvent.LifecycleState state) {
+        ClientExecutionService executionService = client.getClientExecutionService();
+        executionService.execute(new Runnable() {
+            @Override
+            public void run() {
+                final LifecycleServiceImpl lifecycleService = (LifecycleServiceImpl) client.getLifecycleService();
+                lifecycleService.fireLifecycleEvent(state);
+            }
+        });
     }
 
     @Override
@@ -220,10 +255,9 @@ public abstract class ClusterListenerSupport implements ConnectionListener, Conn
 
     @Override
     public void connectionRemoved(Connection connection) {
-        ClientExecutionServiceImpl executionService = (ClientExecutionServiceImpl) client.getClientExecutionService();
         if (connection.getEndPoint().equals(ownerConnectionAddress)) {
             if (client.getLifecycleService().isRunning()) {
-                executionService.executeInternal(new Runnable() {
+                clusterExecutor.execute(new Runnable() {
                     @Override
                     public void run() {
                         try {


### PR DESCRIPTION
After a straight forward fix made to offload listener call
to Executor, I came across more problem in the design.
Since most of remote requests are blocking if client is not
connected to remote(if client has connected to node with saying you
are my owner), the operation that trying to connect to cluster and
others should be in separate executor pool. We have two executor pools
one is for internal operations and other for alien code to hazelcast
like listeners and CompletableFuture.andThen calls. Since these
two are doing a remote call that can potentially block on waiting owner
address to be determined, cluster thread is moved to singleThreadExecutor
to its own. And more cleanup done to differentiate alien and internal
executor usage.

fixes https://github.com/hazelcast/hazelcast/issues/6168