### PR TITLE
Using assertClusterSizeEventually in failing tests

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/map/mapstore/MapLoaderFailoverTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/mapstore/MapLoaderFailoverTest.java
@@ -108,7 +108,7 @@ public class MapLoaderFailoverTest extends HazelcastTestSupport {
         assertSizeAndLoadCount(map);
 
         hz3.getLifecycleService().terminate();
-        assertClusterSize(2, nodes[0]);
+        assertClusterSizeEventually(2, nodes[0]);
         map.loadAll(true);
 
         assertSizeEventually(MAP_STORE_ENTRY_COUNT, map);
@@ -132,7 +132,7 @@ public class MapLoaderFailoverTest extends HazelcastTestSupport {
         pausingLoader.awaitPause();
 
         hz3.getLifecycleService().terminate();
-        assertClusterSize(2, nodes[0]);
+        assertClusterSizeEventually(2, nodes[0]);
 
         pausingLoader.resume();
 

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
@@ -681,7 +681,7 @@ public abstract class HazelcastTestSupport {
             @Override
             public void run()
                     throws Exception {
-                assertEquals("the size of the cluster is not correct", expectedSize, instance.getCluster().getMembers().size());
+                assertClusterSize(expectedSize, instance);
             }
         }, timeoutSeconds);
     }


### PR DESCRIPTION
Sometimes assertClusterSize fails after terminating a node. Couldn't reproduce the failure locally so switching to assertClusterSizeEventually to see if it helps

Fixes #6056
