### PR TITLE
QuorumService ignores member attribute change events

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/core/MembershipEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/MembershipEvent.java
@@ -24,8 +24,11 @@ import java.util.Set;
 import static java.lang.String.format;
 
 /**
- * Membership event fired when a new member is added
- * to the cluster and/or when a member leaves the cluster.
+ * Membership event fired when a new member is added to the cluster and/or when a member leaves the cluster
+ * or when there is a member attribute change via {@link Member#setBooleanAttribute(String, boolean)}
+ * and similar methods.
+ *
+ * Warning: If the event is triggered by a member attribute change then {@link #members} is <code>null</code>!
  *
  * @see MembershipListener
  */

--- a/hazelcast/src/main/java/com/hazelcast/quorum/impl/QuorumServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/quorum/impl/QuorumServiceImpl.java
@@ -157,7 +157,9 @@ public class QuorumServiceImpl implements EventPublishingService<QuorumEvent, Qu
 
     @Override
     public void memberAttributeChanged(MemberAttributeServiceEvent event) {
-        updateQuorums(event);
+        // nop
+        // MemberAttributeServiceEvent does NOT contain set of members
+        // They cannot change quorum state
     }
 
     private void updateQuorums(MembershipEvent event) {


### PR DESCRIPTION
Fixed #6223
There is no member set in  MemberAttributeServiceEvent.

This is fixing the very problem. However I still find it a bit odd `MemberAttributeEvent ` is a subclass of `MembershipEvent`.