### PR TITLE
[Backport] QuorumService ignores member attribute change events

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/core/MembershipEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/MembershipEvent.java
@@ -22,8 +22,11 @@ import java.util.Set;
 import static java.lang.String.format;
 
 /**
- * Membership event fired when a new member is added
- * to the cluster and/or when a member leaves the cluster.
+ * Membership event fired when a new member is added to the cluster and/or when a member leaves the cluster
+ * or when there is a member attribute change via {@link Member#setBooleanAttribute(String, boolean)}
+ * and similar methods.
+ *
+ * Warning: If the event is triggered by a member attribute change then {@link #members} is <code>null</code>!
  *
  * @see MembershipListener
  */

--- a/hazelcast/src/main/java/com/hazelcast/quorum/impl/QuorumServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/quorum/impl/QuorumServiceImpl.java
@@ -157,7 +157,9 @@ public class QuorumServiceImpl implements EventPublishingService<QuorumEvent, Qu
 
     @Override
     public void memberAttributeChanged(MemberAttributeServiceEvent event) {
-        updateQuorums(event);
+        // nop
+        // MemberAttributeServiceEvent does NOT contain set of members
+        // They cannot change quorum state
     }
 
     private void updateQuorums(MembershipEvent event) {

--- a/hazelcast/src/test/java/com/hazelcast/quorum/QuorumTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/QuorumTest.java
@@ -22,6 +22,10 @@ import com.hazelcast.config.QuorumConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.core.Member;
+import com.hazelcast.quorum.impl.QuorumServiceImpl;
+import com.hazelcast.spi.MemberAttributeServiceEvent;
+import com.hazelcast.spi.MembershipAwareService;
+import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
@@ -34,11 +38,28 @@ import org.junit.runner.RunWith;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
 public class QuorumTest extends HazelcastTestSupport {
 
+    @Test
+    public void testQuorumIgnoresMemberAttributeEvents() throws Exception {
+        Config config = new Config();
+        QuorumConfig quorumConfig = new QuorumConfig().setName(randomString()).setEnabled(true);
+        RecordingQuorumFunction function = new RecordingQuorumFunction();
+        quorumConfig.setQuorumFunctionImplementation(function);
+        config.addQuorumConfig(quorumConfig);
+        HazelcastInstance hazelcastInstance = createHazelcastInstance(config);
+        NodeEngineImpl nodeEngine = getNodeEngineImpl(hazelcastInstance);
+        MembershipAwareService service = nodeEngine.getService(QuorumServiceImpl.SERVICE_NAME);
+
+        MemberAttributeServiceEvent event = mock(MemberAttributeServiceEvent.class);
+        service.memberAttributeChanged(event);
+
+        assertFalse(function.wasCalled);
+    }
 
     @Test(expected = QuorumException.class)
     public void testCustomQuorumFunctionFails() throws Exception {
@@ -202,6 +223,17 @@ public class QuorumTest extends HazelcastTestSupport {
             fail();
         } catch (Exception e) {
         }
+    }
+
+    private static class RecordingQuorumFunction implements QuorumFunction {
+        private volatile boolean wasCalled;
+
+        @Override
+        public boolean apply(Collection<Member> members) {
+            wasCalled = true;
+            return false;
+        }
+
     }
 
 }


### PR DESCRIPTION
Backport of #6225, Fixes #6223

There is no member set in MemberAttributeServiceEvent.
(cherry picked from commit eea2e7c)