### PR TITLE
Improved null checking ICountdownLatch.await

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/concurrent/countdownlatch/CountDownLatchProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/countdownlatch/CountDownLatchProxy.java
@@ -34,6 +34,7 @@ import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.util.ExceptionUtil.rethrowAllowInterrupted;
 import static com.hazelcast.util.Preconditions.checkNotNegative;
+import static com.hazelcast.util.Preconditions.checkNotNull;
 
 public class CountDownLatchProxy extends AbstractDistributedObject<CountDownLatchService> implements ICountDownLatch {
 
@@ -54,18 +55,15 @@ public class CountDownLatchProxy extends AbstractDistributedObject<CountDownLatc
 
     @Override
     public boolean await(long timeout, TimeUnit unit) throws InterruptedException {
-        AwaitOperation op = new AwaitOperation(name, getTimeInMillis(timeout, unit));
+        checkNotNull(unit, "unit can't be null");
+
+        AwaitOperation op = new AwaitOperation(name, unit.toMillis(timeout));
         Future<Boolean> f = invoke(op);
         try {
             return f.get();
         } catch (ExecutionException e) {
             throw rethrowAllowInterrupted(e);
         }
-    }
-
-    private static long getTimeInMillis(long time, TimeUnit timeunit) {
-        // todo: not fail fast
-        return timeunit != null ? timeunit.toMillis(time) : time;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/core/ICountDownLatch.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/ICountDownLatch.java
@@ -83,6 +83,7 @@ public interface ICountDownLatch extends DistributedObject {
      *         if the waiting time elapsed before the count reached zero
      * @throws InterruptedException if the current thread is interrupted
      * @throws IllegalStateException if the Hazelcast instance is shutdown while waiting
+     * @throws NullPointerException if unit is null
      */
     boolean await(long timeout, TimeUnit unit) throws InterruptedException;
 

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/countdownlatch/CountDownLatchBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/countdownlatch/CountDownLatchBasicTest.java
@@ -113,6 +113,12 @@ public abstract class CountDownLatchBasicTest extends HazelcastTestSupport {
 
 
     // ================= await =================================================
+
+    @Test(expected = NullPointerException.class)
+    public void testAwait_whenNullUnit() throws InterruptedException {
+        latch.await(1, null);
+    }
+
     @Test(timeout = 15000)
     public void testAwait() throws InterruptedException {
         latch.trySetCount(1);


### PR DESCRIPTION
The unit was not checked for null, but just ignored in case of null.
This is a violation of the fail fast principle.

Also the javadoc was updated + test was added.