### PR TITLE
Cleanup of basic cache tests and temporary fix of test failure

### DIFF
--- a/hazelcast-client-new/src/test/java/com/hazelcast/client/cache/CacheBasicClientTest.java
+++ b/hazelcast-client-new/src/test/java/com/hazelcast/client/cache/CacheBasicClientTest.java
@@ -28,7 +28,6 @@ import org.junit.runner.RunWith;
 
 import javax.cache.spi.CachingProvider;
 
-
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class CacheBasicClientTest extends CacheBasicAbstractTest {
@@ -46,14 +45,12 @@ public class CacheBasicClientTest extends CacheBasicAbstractTest {
     }
 
     @Override
-    protected CachingProvider getCachingProvider() {
-        return HazelcastClientCachingProvider.createCachingProvider(getHazelcastInstance());
-    }
-
-    @Override
     protected HazelcastInstance getHazelcastInstance() {
         return factory.newHazelcastClient();
     }
 
+    @Override
+    protected CachingProvider getCachingProvider() {
+        return HazelcastClientCachingProvider.createCachingProvider(getHazelcastInstance());
+    }
 }
-

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/CacheBasicClientTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/CacheBasicClientTest.java
@@ -28,17 +28,11 @@ import org.junit.runner.RunWith;
 
 import javax.cache.spi.CachingProvider;
 
-
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class CacheBasicClientTest extends CacheBasicAbstractTest {
 
     private TestHazelcastFactory factory = new TestHazelcastFactory();
-
-    @Override
-    protected HazelcastInstance getHazelcastInstance() {
-        return factory.newHazelcastClient();
-    }
 
     @Override
     protected void onSetup() {
@@ -51,9 +45,12 @@ public class CacheBasicClientTest extends CacheBasicAbstractTest {
     }
 
     @Override
+    protected HazelcastInstance getHazelcastInstance() {
+        return factory.newHazelcastClient();
+    }
+
+    @Override
     protected CachingProvider getCachingProvider() {
         return HazelcastClientCachingProvider.createCachingProvider(getHazelcastInstance());
     }
-
 }
-

--- a/hazelcast/src/test/java/com/hazelcast/cache/CacheBasicServerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CacheBasicServerTest.java
@@ -17,15 +17,21 @@
 package com.hazelcast.cache;
 
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class CacheBasicServerTest extends CacheBasicAbstractTest {
 
     TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
 
     @Override
     protected void onSetup() {
-
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/cache/CacheTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CacheTestSupport.java
@@ -11,11 +11,9 @@ import org.junit.Before;
 
 import javax.cache.Cache;
 import javax.cache.CacheManager;
+import javax.cache.configuration.Configuration;
 import javax.cache.spi.CachingProvider;
 
-/**
- * @author mdogan 02/06/14
- */
 public abstract class CacheTestSupport extends HazelcastTestSupport {
 
     protected CachingProvider cachingProvider;
@@ -24,14 +22,14 @@ public abstract class CacheTestSupport extends HazelcastTestSupport {
     protected abstract HazelcastInstance getHazelcastInstance();
 
     @Before
-    public void setup() {
+    public final void setup() {
         onSetup();
         cachingProvider = getCachingProvider();
         cacheManager = cachingProvider.getCacheManager();
     }
 
     @After
-    public void tearDown() {
+    public final void tearDown() {
         if (cacheManager != null) {
             Iterable<String> cacheNames = cacheManager.getCacheNames();
             for (String name : cacheNames) {
@@ -45,37 +43,33 @@ public abstract class CacheTestSupport extends HazelcastTestSupport {
         onTearDown();
     }
 
-
     protected abstract void onSetup();
 
     protected abstract void onTearDown();
 
-    protected ICache createCache() {
+    protected <K, V> ICache<K, V> createCache() {
         String cacheName = randomString();
-        Cache<Object, Object> cache = cacheManager.createCache(cacheName, createCacheConfig());
-        return cache.unwrap(ICache.class);
+        Cache<K, V> cache = cacheManager.<K, V, Configuration>createCache(cacheName, createCacheConfig());
+        return (ICache<K, V>) cache;
     }
 
-    protected ICache createCache(String cacheName) {
-        Cache<Object, Object> cache = cacheManager.createCache(cacheName, createCacheConfig());
-        return cache.unwrap(ICache.class);
+    protected <K, V> ICache<K, V> createCache(String cacheName) {
+        Cache<K, V> cache = cacheManager.<K, V, Configuration>createCache(cacheName, createCacheConfig());
+        return (ICache<K, V>) cache;
     }
 
-    public Config createConfig() {
+    protected Config createConfig() {
         return new Config();
     }
 
-    public CacheConfig createCacheConfig() {
-        CacheConfig cacheConfig = new CacheConfig();
+    protected <K, V> CacheConfig<K, V> createCacheConfig() {
+        CacheConfig<K, V> cacheConfig = new CacheConfig<K, V>();
         cacheConfig.setInMemoryFormat(InMemoryFormat.BINARY);
         cacheConfig.setStatisticsEnabled(true);
         return cacheConfig;
     }
 
-
     protected CachingProvider getCachingProvider() {
-        return HazelcastServerCachingProvider
-                .createCachingProvider(getHazelcastInstance());
+        return HazelcastServerCachingProvider.createCachingProvider(getHazelcastInstance());
     }
-
 }


### PR DESCRIPTION
Most of this PR is cleanup of the tests to get rid of the "yellow alert" due to missing generics. Also we got rid of the sleep calls to make the tests more predictable.

This PR also temporary fixes a test failure (#6234) due to a race between cache eviction and cache iterator. The fix is to ensure no eviction happens (by limiting a random put to size of the pre-filled cache). The underlying issue will be resolved later and will need new tests which enforce the eviction to happen.

I know that this PR is quite noisy, due to the cleanups. I recommend to review it commit by commit.