### PR TITLE
Added NodeStates [ACTIVE, SHUTTING_DOWN, SHUTDOWN]

### DIFF
--- a/hazelcast-client-new/src/test/java/com/hazelcast/client/test/TestClientRegistry.java
+++ b/hazelcast-client-new/src/test/java/com/hazelcast/client/test/TestClientRegistry.java
@@ -244,7 +244,7 @@ public class TestClientRegistry {
         @Override
         public boolean write(OutboundFrame frame) {
             final ClientMessage packet = (ClientMessage) frame;
-            if (nodeEngine.getNode().isActive()) {
+            if (nodeEngine.isActive()) {
                 ClientMessage newPacket = readFromPacket(packet);
                 responseConnection.handleClientMessage(newPacket);
                 return true;

--- a/hazelcast-client/src/test/java/com/hazelcast/client/test/TestClientRegistry.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/test/TestClientRegistry.java
@@ -265,7 +265,7 @@ public class TestClientRegistry {
         @Override
         public boolean write(OutboundFrame frame) {
             final Packet packet = (Packet) frame;
-            if (nodeEngine.getNode().isActive()) {
+            if (nodeEngine.isActive()) {
                 Packet newPacket = readFromPacket(packet);
                 responseConnection.handlePacket(newPacket);
                 return true;

--- a/hazelcast-wm/src/test/java/com/hazelcast/wm/test/AbstractWebFilterTest.java
+++ b/hazelcast-wm/src/test/java/com/hazelcast/wm/test/AbstractWebFilterTest.java
@@ -21,6 +21,7 @@ import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.instance.Node;
+import com.hazelcast.instance.NodeState;
 import com.hazelcast.instance.TestUtil;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestEnvironment;
@@ -177,11 +178,7 @@ public abstract class AbstractWebFilterTest extends HazelcastTestSupport {
             return true;
         }
         Node node = TestUtil.getNode(hz);
-        if (node == null) {
-            return true;
-        } else {
-            return !node.isActive();
-        }
+        return node == null || node.getState() != NodeState.ACTIVE;
     }
 
     @AfterClass

--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/AbstractJoiner.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/AbstractJoiner.java
@@ -25,6 +25,7 @@ import com.hazelcast.config.Config;
 import com.hazelcast.core.Member;
 import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.instance.Node;
+import com.hazelcast.instance.NodeState;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.Connection;
@@ -109,7 +110,7 @@ public abstract class AbstractJoiner implements Joiner {
         if (logger.isFinestEnabled()) {
             logger.finest("PostJoin master: " + node.getMasterAddress() + ", isMaster: " + node.isMaster());
         }
-        if (!node.isActive()) {
+        if (node.getState() != NodeState.ACTIVE) {
             return;
         }
         if (tryCount.incrementAndGet() == 5) {

--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/ClusterServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/ClusterServiceImpl.java
@@ -48,6 +48,7 @@ import com.hazelcast.instance.HazelcastInstanceImpl;
 import com.hazelcast.instance.LifecycleServiceImpl;
 import com.hazelcast.instance.MemberImpl;
 import com.hazelcast.instance.Node;
+import com.hazelcast.instance.NodeState;
 import com.hazelcast.internal.metrics.MetricsRegistry;
 import com.hazelcast.internal.metrics.Probe;
 import com.hazelcast.logging.ILogger;
@@ -335,7 +336,7 @@ public final class ClusterServiceImpl implements ClusterService, ConnectionListe
     }
 
     private void heartBeater() {
-        if (!node.joined() || !node.isActive()) {
+        if (!node.joined()) {
             return;
         }
 
@@ -495,7 +496,7 @@ public final class ClusterServiceImpl implements ClusterService, ConnectionListe
     }
 
     public void sendMasterConfirmation() {
-        if (!node.joined() || !node.isActive() || isMaster()) {
+        if (!node.joined() || node.getState() == NodeState.SHUT_DOWN || isMaster()) {
             return;
         }
         Address masterAddress = getMasterAddress();
@@ -682,7 +683,7 @@ public final class ClusterServiceImpl implements ClusterService, ConnectionListe
     }
 
     private boolean ensureNodeIsReady() {
-        if (node.joined() && node.isActive()) {
+        if (node.joined() && node.getState() == NodeState.ACTIVE) {
             return true;
         }
         if (logger.isFinestEnabled()) {
@@ -1500,7 +1501,7 @@ public final class ClusterServiceImpl implements ClusterService, ConnectionListe
 
             executeMergeTasks(tasks);
 
-            if (node.isActive() && node.joined()) {
+            if (node.getState() == NodeState.ACTIVE && node.joined()) {
                 lifecycleService.fireLifecycleEvent(MERGED);
             }
         }
@@ -1544,7 +1545,7 @@ public final class ClusterServiceImpl implements ClusterService, ConnectionListe
             // start connection-manager to setup and accept new connections
             node.connectionManager.start();
             // re-join to the target cluster
-            node.rejoin();
+            node.join();
         }
 
         private void executeMergeTasks(Collection<Runnable> tasks) {
@@ -1580,7 +1581,7 @@ public final class ClusterServiceImpl implements ClusterService, ConnectionListe
                     if (deadline <= 0) {
                         throw t;
                     }
-                    if (!node.isActive()) {
+                    if (node.getState() != NodeState.ACTIVE) {
                         future.cancel(true);
                         throw new HazelcastInstanceNotActiveException();
                     }

--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/MulticastJoiner.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/MulticastJoiner.java
@@ -19,6 +19,7 @@ package com.hazelcast.cluster.impl;
 import com.hazelcast.config.NetworkConfig;
 import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.instance.Node;
+import com.hazelcast.instance.NodeState;
 import com.hazelcast.nio.Address;
 import com.hazelcast.util.Clock;
 import com.hazelcast.util.EmptyStatement;
@@ -48,7 +49,9 @@ public class MulticastJoiner extends AbstractJoiner {
         long maxJoinMillis = getMaxJoinMillis();
         Address thisAddress = node.getThisAddress();
 
-        while (node.isActive() && !node.joined() && (Clock.currentTimeMillis() - joinStartTime < maxJoinMillis)) {
+        while (node.getState() == NodeState.ACTIVE && !node.joined()
+                && (Clock.currentTimeMillis() - joinStartTime < maxJoinMillis)) {
+
             // clear master node
             node.setMasterAddress(null);
 
@@ -72,7 +75,9 @@ public class MulticastJoiner extends AbstractJoiner {
         long maxMasterJoinTime = getMaxJoinTimeToMasterNode();
         long start = Clock.currentTimeMillis();
 
-        while (node.isActive() && !node.joined() && Clock.currentTimeMillis() - start < maxMasterJoinTime) {
+        while (node.getState() == NodeState.ACTIVE  && !node.joined()
+                && Clock.currentTimeMillis() - start < maxMasterJoinTime) {
+
             Address master = node.getMasterAddress();
             if (master != null) {
                 if (logger.isFinestEnabled()) {
@@ -155,7 +160,7 @@ public class MulticastJoiner extends AbstractJoiner {
                 logger.finest("Searching for master node. Max tries: " + maxTryCount.get());
             }
             JoinRequest joinRequest = node.createJoinRequest(false);
-            while (node.isActive() && currentTryCount.incrementAndGet() <= maxTryCount.get()) {
+            while (node.getState() == NodeState.ACTIVE  && currentTryCount.incrementAndGet() <= maxTryCount.get()) {
                 joinRequest.setTryCount(currentTryCount.get());
                 node.multicastService.send(joinRequest);
                 if (node.getMasterAddress() == null) {

--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/NodeMulticastListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/NodeMulticastListener.java
@@ -19,6 +19,7 @@ package com.hazelcast.cluster.impl;
 import com.hazelcast.cluster.Joiner;
 import com.hazelcast.core.Member;
 import com.hazelcast.instance.Node;
+import com.hazelcast.instance.NodeState;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.Packet;
@@ -51,7 +52,7 @@ public class NodeMulticastListener implements MulticastListener {
         }
 
         JoinMessage joinMessage = (JoinMessage) msg;
-        if (node.isActive() && node.joined()) {
+        if (node.getState() == NodeState.ACTIVE && node.joined()) {
             handleActiveAndJoined(joinMessage);
         } else {
             handleNotActiveOrNotJoined(joinMessage);

--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/TcpIpJoiner.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/TcpIpJoiner.java
@@ -23,6 +23,7 @@ import com.hazelcast.config.NetworkConfig;
 import com.hazelcast.config.TcpIpConfig;
 import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.instance.Node;
+import com.hazelcast.instance.NodeState;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.util.AddressUtil;
@@ -99,7 +100,9 @@ public class TcpIpJoiner extends AbstractJoiner {
             }
             long joinStartTime = Clock.currentTimeMillis();
             Connection connection;
-            while (node.isActive() && !node.joined() && (Clock.currentTimeMillis() - joinStartTime < maxJoinMillis)) {
+            while (node.getState() == NodeState.ACTIVE && !node.joined()
+                    && (Clock.currentTimeMillis() - joinStartTime < maxJoinMillis)) {
+
                 connection = node.connectionManager.getOrConnect(targetAddress);
                 if (connection == null) {
                     //noinspection BusyWait
@@ -133,7 +136,8 @@ public class TcpIpJoiner extends AbstractJoiner {
             long maxJoinMillis = getMaxJoinMillis();
             long startTime = Clock.currentTimeMillis();
 
-            while (node.isActive() && !node.joined() && (Clock.currentTimeMillis() - startTime < maxJoinMillis)) {
+            while (node.getState() == NodeState.ACTIVE && !node.joined()
+                    && (Clock.currentTimeMillis() - startTime < maxJoinMillis)) {
 
                 tryToJoinPossibleAddresses(possibleAddresses);
                 if (node.joined()) {
@@ -309,7 +313,9 @@ public class TcpIpJoiner extends AbstractJoiner {
         long maxMasterJoinTime = getMaxJoinTimeToMasterNode();
         long start = Clock.currentTimeMillis();
 
-        while (node.isActive() && !node.joined() && Clock.currentTimeMillis() - start < maxMasterJoinTime) {
+        while (node.getState() == NodeState.ACTIVE && !node.joined()
+                && Clock.currentTimeMillis() - start < maxMasterJoinTime) {
+
             Address master = node.getMasterAddress();
             if (master != null) {
                 if (logger.isFinestEnabled()) {

--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/operations/HeartbeatOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/operations/HeartbeatOperation.java
@@ -23,11 +23,12 @@ import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.spi.impl.AllowedDuringShutdown;
 
 import java.io.IOException;
 
 public final class HeartbeatOperation extends AbstractClusterOperation
-        implements JoinOperation, IdentifiedDataSerializable {
+        implements JoinOperation, IdentifiedDataSerializable, AllowedDuringShutdown {
 
     private long timestamp;
 

--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/operations/JoinCheckOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/operations/JoinCheckOperation.java
@@ -19,6 +19,7 @@ package com.hazelcast.cluster.impl.operations;
 import com.hazelcast.cluster.impl.ClusterServiceImpl;
 import com.hazelcast.cluster.impl.JoinMessage;
 import com.hazelcast.instance.Node;
+import com.hazelcast.instance.NodeState;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
@@ -111,7 +112,7 @@ public class JoinCheckOperation extends AbstractOperation implements JoinOperati
             return false;
         }
 
-        if (!node.isActive()) {
+        if (node.getState() != NodeState.ACTIVE) {
             logger.info("Ignoring join check from " + getCallerAddress() + ", because this node is not active...");
             return false;
         }

--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/operations/MasterConfirmationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/operations/MasterConfirmationOperation.java
@@ -23,10 +23,11 @@ import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.spi.OperationService;
+import com.hazelcast.spi.impl.AllowedDuringShutdown;
 
 import java.io.IOException;
 
-public class MasterConfirmationOperation extends AbstractClusterOperation {
+public class MasterConfirmationOperation extends AbstractClusterOperation implements AllowedDuringShutdown {
 
     private long timestamp;
 

--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/operations/MemberRemoveOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/operations/MemberRemoveOperation.java
@@ -21,10 +21,11 @@ import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.spi.impl.AllowedDuringShutdown;
 
 import java.io.IOException;
 
-public class MemberRemoveOperation extends AbstractClusterOperation {
+public class MemberRemoveOperation extends AbstractClusterOperation implements AllowedDuringShutdown {
 
     private Address deadAddress;
 

--- a/hazelcast/src/main/java/com/hazelcast/core/OutOfMemoryHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/OutOfMemoryHandler.java
@@ -58,7 +58,6 @@ public abstract class OutOfMemoryHandler {
      * and Hazelcast may not be informed about <tt>OutOfMemoryError</tt>.
      * </p>
      *
-     * @see OutOfMemoryHandler#inactivate(HazelcastInstance)
      * @see OutOfMemoryHandler#tryCloseConnections(HazelcastInstance)
      * @see OutOfMemoryHandler#tryStopThreads(HazelcastInstance)
      * @see OutOfMemoryHandler#tryShutdown(HazelcastInstance)
@@ -79,15 +78,6 @@ public abstract class OutOfMemoryHandler {
      */
     public boolean shouldHandle(OutOfMemoryError oome) {
         return true;
-    }
-
-    /**
-     * Inactivates <tt>HazelcastInstance</tt>; leaves threads, the connections are untouched.
-     *
-     * @param hazelcastInstance the Hazelcast instance to inactivate
-     */
-    protected final void inactivate(final HazelcastInstance hazelcastInstance) {
-        OutOfMemoryHandlerHelper.inactivate(hazelcastInstance);
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/instance/HazelcastInstanceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/HazelcastInstanceImpl.java
@@ -129,7 +129,7 @@ public class HazelcastInstanceImpl implements HazelcastInstance {
             lifecycleService.fireLifecycleEvent(STARTING);
 
             node.start();
-            if (!node.isActive()) {
+            if (node.getState() != NodeState.ACTIVE) {
                 throw new IllegalStateException("Node failed to start!");
             }
 

--- a/hazelcast/src/main/java/com/hazelcast/instance/LifecycleServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/LifecycleServiceImpl.java
@@ -73,8 +73,8 @@ public class LifecycleServiceImpl implements LifecycleService {
 
     @Override
     public boolean isRunning() {
-        //no synchronization needed since isActive is threadsafe.
-        return instance.node.isActive();
+        //no synchronization needed since getState() is atomic.
+        return instance.node.getState() == NodeState.ACTIVE;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/instance/NodeShutdownLatch.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/NodeShutdownLatch.java
@@ -50,7 +50,7 @@ final class NodeShutdownLatch {
                 final MemberImpl member = entry.getKey();
                 if (members.contains(member)) {
                     HazelcastInstanceImpl instance = entry.getValue();
-                    if (instance.node.isActive()) {
+                    if (instance.node.getState() == NodeState.ACTIVE) {
                         try {
                             ClusterServiceImpl clusterService = instance.node.clusterService;
                             final String id = clusterService.addMembershipListener(new ShutdownMembershipListener());
@@ -71,7 +71,7 @@ final class NodeShutdownLatch {
 
         int permits = registrations.size();
         for (HazelcastInstanceImpl instance : registrations.values()) {
-            if (!instance.node.isActive()) {
+            if (instance.node.getState() == NodeState.ACTIVE) {
                 permits--;
             }
         }

--- a/hazelcast/src/main/java/com/hazelcast/instance/NodeState.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/NodeState.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.instance;
+
+/**
+ * Possible states of a {@link Node} during its lifecycle.
+ * Some actions/operations may be allowed or denied
+ * according to current state of the {@link Node}.
+ *
+ * @see Node#start()
+ * @see Node#shutdown(boolean)
+ * @see com.hazelcast.spi.impl.AllowedDuringShutdown
+ *
+ * @since 3.6
+ */
+public enum NodeState {
+
+    /**
+     * Initial state of the Node. An {@code ACTIVE} node is allowed
+     * to execute/process all kinds of operations.
+     */
+    ACTIVE,
+
+    /**
+     * When {@link Node#shutdown(boolean)} is called, node will go into {@code SHUTTING_DOWN}
+     * until shutdown process completes.
+     * <p/>
+     * In {@code SHUTTING_DOWN} state, all operations will be rejected except replication/migration
+     * operations and heartbeat operations. Operations those are to be allowed during {@code SHUTTING_DOWN}
+     * state should be marked as {@link com.hazelcast.spi.impl.AllowedDuringShutdown}.
+     * <p/>
+     * Once shutdown completes, state will become {@link #SHUT_DOWN}.
+     */
+    SHUTTING_DOWN,
+
+    /**
+     * After {@link Node#shutdown(boolean)} call ends, node's state will be {@code SHUT_DOWN}. In {@code SHUT_DOWN}
+     * state node will be completely inactive. All operations/invocations will be rejected. Once a node is shutdown,
+     * it cannot be restarted.
+     */
+    SHUT_DOWN
+}

--- a/hazelcast/src/main/java/com/hazelcast/instance/OutOfMemoryHandlerHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/OutOfMemoryHandlerHelper.java
@@ -62,14 +62,6 @@ public final class OutOfMemoryHandlerHelper {
         }
     }
 
-    public static void inactivate(HazelcastInstance hazelcastInstance) {
-        if (hazelcastInstance == null) {
-            return;
-        }
-        final HazelcastInstanceImpl factory = (HazelcastInstanceImpl) hazelcastInstance;
-        factory.node.inactivate();
-    }
-
     public static void tryStopThreads(HazelcastInstance hazelcastInstance) {
         if (hazelcastInstance == null) {
             return;

--- a/hazelcast/src/main/java/com/hazelcast/internal/monitors/HealthMonitor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/monitors/HealthMonitor.java
@@ -18,6 +18,7 @@ package com.hazelcast.internal.monitors;
 
 import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.instance.Node;
+import com.hazelcast.instance.NodeState;
 import com.hazelcast.instance.OutOfMemoryErrorDispatcher;
 import com.hazelcast.internal.metrics.DoubleGauge;
 import com.hazelcast.internal.metrics.LongGauge;
@@ -111,7 +112,7 @@ public class HealthMonitor {
         @Override
         public void run() {
             try {
-                while (node.isActive()) {
+                while (node.getState() == NodeState.ACTIVE) {
                     switch (monitorLevel) {
                         case NOISY:
                             if (healthMetrics.exceedsThreshold()) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/monitors/PerformanceMonitor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/monitors/PerformanceMonitor.java
@@ -20,6 +20,7 @@ import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.instance.HazelcastInstanceImpl;
 import com.hazelcast.instance.HazelcastThreadGroup;
 import com.hazelcast.instance.Node;
+import com.hazelcast.instance.NodeState;
 import com.hazelcast.internal.metrics.MetricsRegistry;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.spi.impl.operationservice.InternalOperationService;
@@ -94,7 +95,7 @@ public class PerformanceMonitor {
         @Override
         public void run() {
             try {
-                while (node.isActive()) {
+                while (node.getState() == NodeState.ACTIVE) {
                     performanceLogFile.render();
                     sleep();
                 }

--- a/hazelcast/src/main/java/com/hazelcast/nio/NodeIOService.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/NodeIOService.java
@@ -24,6 +24,7 @@ import com.hazelcast.config.SymmetricEncryptionConfig;
 import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.instance.HazelcastThreadGroup;
 import com.hazelcast.instance.Node;
+import com.hazelcast.instance.NodeState;
 import com.hazelcast.instance.OutOfMemoryErrorDispatcher;
 import com.hazelcast.internal.ascii.TextCommandService;
 import com.hazelcast.logging.ILogger;
@@ -57,7 +58,7 @@ public class NodeIOService implements IOService {
 
     @Override
     public boolean isActive() {
-        return node.isActive();
+        return node.getState() != NodeState.SHUT_DOWN;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/partition/PartitionServiceProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/PartitionServiceProxy.java
@@ -22,6 +22,7 @@ import com.hazelcast.core.Partition;
 import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.instance.MemberImpl;
 import com.hazelcast.instance.Node;
+import com.hazelcast.instance.NodeState;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Address;
 import com.hazelcast.partition.impl.InternalPartitionServiceImpl;
@@ -176,7 +177,7 @@ public class PartitionServiceProxy implements com.hazelcast.core.PartitionServic
 
     private boolean nodeActive() {
         final Node node = getNode();
-        return node.isActive();
+        return node.getState() == NodeState.ACTIVE ;
     }
 
     private Node getNode() {

--- a/hazelcast/src/main/java/com/hazelcast/partition/impl/CheckReplicaVersion.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/impl/CheckReplicaVersion.java
@@ -21,13 +21,14 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.partition.InternalPartitionService;
 import com.hazelcast.partition.ReplicaErrorLogger;
+import com.hazelcast.spi.impl.AllowedDuringShutdown;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.PartitionAwareOperation;
 
 import java.io.IOException;
 
 // should not be an urgent operation. required to be in order with backup operations on target node
-public final class CheckReplicaVersion extends Operation implements PartitionAwareOperation {
+public final class CheckReplicaVersion extends Operation implements PartitionAwareOperation, AllowedDuringShutdown {
 
     private long version;
     private boolean returnResponse;

--- a/hazelcast/src/main/java/com/hazelcast/partition/impl/HasOngoingMigration.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/impl/HasOngoingMigration.java
@@ -18,11 +18,12 @@ package com.hazelcast.partition.impl;
 
 import com.hazelcast.core.MemberLeftException;
 import com.hazelcast.partition.InternalPartitionService;
+import com.hazelcast.spi.impl.AllowedDuringShutdown;
 import com.hazelcast.spi.AbstractOperation;
 import com.hazelcast.spi.ExceptionAction;
 import com.hazelcast.spi.exception.TargetNotMemberException;
 
-public final class HasOngoingMigration extends AbstractOperation {
+public final class HasOngoingMigration extends AbstractOperation implements AllowedDuringShutdown {
 
     private Object response;
 

--- a/hazelcast/src/main/java/com/hazelcast/partition/impl/ReplicaSyncResponse.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/impl/ReplicaSyncResponse.java
@@ -22,6 +22,7 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.partition.InternalPartitionService;
 import com.hazelcast.partition.ReplicaErrorLogger;
+import com.hazelcast.spi.impl.AllowedDuringShutdown;
 import com.hazelcast.spi.BackupOperation;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.Operation;
@@ -41,7 +42,7 @@ import static com.hazelcast.spi.impl.OperationResponseHandlerFactory.createError
 
 @SuppressFBWarnings("EI_EXPOSE_REP")
 public class ReplicaSyncResponse extends Operation
-        implements PartitionAwareOperation, BackupOperation, UrgentSystemOperation {
+        implements PartitionAwareOperation, BackupOperation, UrgentSystemOperation, AllowedDuringShutdown {
 
     private List<Operation> tasks;
     private long[] replicaVersions;

--- a/hazelcast/src/main/java/com/hazelcast/partition/impl/ReplicaSyncRetryResponse.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/impl/ReplicaSyncRetryResponse.java
@@ -26,12 +26,11 @@ import com.hazelcast.partition.ReplicaErrorLogger;
 import com.hazelcast.spi.BackupOperation;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.PartitionAwareOperation;
-import com.hazelcast.spi.UrgentSystemOperation;
 
 import java.io.IOException;
 
 public class ReplicaSyncRetryResponse extends Operation
-        implements PartitionAwareOperation, BackupOperation, UrgentSystemOperation, MigrationCycleOperation {
+        implements PartitionAwareOperation, BackupOperation, MigrationCycleOperation {
 
     public ReplicaSyncRetryResponse() {
     }

--- a/hazelcast/src/main/java/com/hazelcast/partition/impl/SyncReplicaVersion.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/impl/SyncReplicaVersion.java
@@ -23,6 +23,7 @@ import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.partition.InternalPartition;
 import com.hazelcast.partition.InternalPartitionService;
 import com.hazelcast.partition.ReplicaErrorLogger;
+import com.hazelcast.spi.impl.AllowedDuringShutdown;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.OperationService;
@@ -32,7 +33,8 @@ import com.hazelcast.spi.UrgentSystemOperation;
 import java.io.IOException;
 
 // runs locally
-final class SyncReplicaVersion extends Operation implements PartitionAwareOperation, UrgentSystemOperation {
+final class SyncReplicaVersion extends Operation implements PartitionAwareOperation,
+        UrgentSystemOperation, AllowedDuringShutdown {
 
     public static final int OPERATION_TRY_COUNT = 10;
     public static final int OPERATION_TRY_PAUSE_MILLIS = 250;

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/AllowedDuringShutdown.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/AllowedDuringShutdown.java
@@ -14,10 +14,16 @@
  * limitations under the License.
  */
 
-package com.hazelcast.partition;
+package com.hazelcast.spi.impl;
 
-import com.hazelcast.spi.UrgentSystemOperation;
-import com.hazelcast.spi.impl.AllowedDuringShutdown;
-
-public interface MigrationCycleOperation extends UrgentSystemOperation, AllowedDuringShutdown {
+/**
+ * Marker interface for operations those are allowed to be executed or invoked during
+ * {@link com.hazelcast.instance.Node}'s {@link com.hazelcast.instance.NodeState#SHUTTING_DOWN} state.
+ * <p/>
+ * By default, only replication/migration and cluster heartbeat operations are allowed during shutdown.
+ *
+ * @see com.hazelcast.instance.NodeState
+ * @since 3.6
+ */
+public interface AllowedDuringShutdown {
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
@@ -22,6 +22,7 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.instance.GroupProperties;
 import com.hazelcast.instance.MemberImpl;
 import com.hazelcast.instance.Node;
+import com.hazelcast.instance.NodeState;
 import com.hazelcast.internal.management.ManagementCenterService;
 import com.hazelcast.internal.metrics.MetricsRegistry;
 import com.hazelcast.internal.metrics.ProbeLevel;
@@ -234,7 +235,7 @@ public class NodeEngineImpl implements NodeEngine {
 
     @Override
     public boolean isActive() {
-        return node.isActive();
+        return node.getState() == NodeState.ACTIVE;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/Invocation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/Invocation.java
@@ -20,6 +20,7 @@ import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.core.HazelcastInstanceNotActiveException;
 import com.hazelcast.core.OperationTimeoutException;
 import com.hazelcast.instance.MemberImpl;
+import com.hazelcast.instance.NodeState;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.Connection;
@@ -269,7 +270,8 @@ abstract class Invocation implements OperationResponseHandler, Runnable {
     }
 
     private boolean engineActive() {
-        if (nodeEngine.isActive()) {
+        final NodeState state = nodeEngine.getNode().getState();
+        if (state == NodeState.ACTIVE) {
             return true;
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImpl.java
@@ -39,7 +39,9 @@ import com.hazelcast.spi.exception.CallerNotMemberException;
 import com.hazelcast.spi.exception.PartitionMigratingException;
 import com.hazelcast.spi.exception.ResponseAlreadySentException;
 import com.hazelcast.spi.exception.RetryableException;
+import com.hazelcast.spi.exception.RetryableHazelcastException;
 import com.hazelcast.spi.exception.WrongTargetException;
+import com.hazelcast.spi.impl.AllowedDuringShutdown;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.impl.operationexecutor.OperationRunner;
 import com.hazelcast.spi.impl.operationservice.impl.responses.CallTimeoutResponse;
@@ -145,6 +147,8 @@ class OperationRunnerImpl extends OperationRunner {
         }
 
         try {
+            checkNodeState(op);
+
             if (timeout(op)) {
                 return;
             }
@@ -169,6 +173,27 @@ class OperationRunnerImpl extends OperationRunner {
                 currentTask = null;
             }
         }
+    }
+
+    private void checkNodeState(Operation op) {
+        final NodeState state = node.getState();
+        if (state == NodeState.ACTIVE) {
+            return;
+        }
+
+        if (state == NodeState.SHUT_DOWN) {
+            throw new HazelcastInstanceNotActiveException("This node is shut down! Operation: " + op);
+        }
+
+        if (op instanceof AllowedDuringShutdown) {
+            return;
+        }
+
+        if (op.getPartitionId() < 0) {
+            throw new HazelcastInstanceNotActiveException("This node is currently shutting down! Operation: " + op);
+        }
+
+        throw new RetryableHazelcastException("This node is currently shutting down! Operation: " + op);
     }
 
     private void ensureQuorumPresent(Operation op) {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImpl.java
@@ -20,6 +20,7 @@ import com.hazelcast.core.HazelcastException;
 import com.hazelcast.core.HazelcastInstanceNotActiveException;
 import com.hazelcast.instance.MemberImpl;
 import com.hazelcast.instance.Node;
+import com.hazelcast.instance.NodeState;
 import com.hazelcast.instance.OutOfMemoryErrorDispatcher;
 import com.hazelcast.internal.metrics.Probe;
 import com.hazelcast.logging.ILogger;
@@ -303,7 +304,7 @@ class OperationRunnerImpl extends OperationRunner {
         OperationResponseHandler responseHandler = operation.getOperationResponseHandler();
         if (operation.returnsResponse() && responseHandler != null) {
             try {
-                if (node.isActive()) {
+                if (node.getState() == NodeState.ACTIVE) {
                     responseHandler.sendResponse(operation, e);
                 } else if (responseHandler.isLocal()) {
                     responseHandler.sendResponse(operation, new HazelcastInstanceNotActiveException());

--- a/hazelcast/src/test/java/com/hazelcast/client/ClientTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/ClientTestSupport.java
@@ -20,6 +20,7 @@ import com.hazelcast.client.impl.ClientEngineImpl;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.instance.Node;
+import com.hazelcast.instance.NodeState;
 import com.hazelcast.instance.TestUtil;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
@@ -77,7 +78,7 @@ public abstract class ClientTestSupport extends HazelcastTestSupport {
     }
 
     public static SimpleClient newClient(Node node) throws IOException {
-        if (node.isActive()) {
+        if (node.getState() == NodeState.ACTIVE) {
             if (TestEnvironment.isMockNetwork()) {
                 ClientEngineImpl engine = node.clientEngine;
                 return new MockSimpleClient(engine, node.getSerializationService());

--- a/hazelcast/src/test/java/com/hazelcast/instance/NodeStateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/NodeStateTest.java
@@ -1,0 +1,284 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.instance;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.ServiceConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.HazelcastInstanceNotActiveException;
+import com.hazelcast.spi.AbstractOperation;
+import com.hazelcast.spi.ManagedService;
+import com.hazelcast.spi.NodeEngine;
+import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.impl.AllowedDuringShutdown;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.util.ExceptionUtil;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Properties;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class NodeStateTest extends HazelcastTestSupport {
+
+    @Test
+    public void nodeState_isActive_whenInstanceStarted() {
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+        HazelcastInstance hz = factory.newHazelcastInstance();
+        assertEquals(NodeState.ACTIVE, getNode(hz).getState());
+    }
+
+    @Test
+    public void nodeState_isShutdown_whenInstanceShutdown() {
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+        HazelcastInstance hz = factory.newHazelcastInstance();
+        Node node = getNode(hz);
+        hz.shutdown();
+        assertEquals(NodeState.SHUT_DOWN, node.getState());
+    }
+
+    @Test
+    public void nodeState_isShutdown_whenInstanceTerminated() {
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+        HazelcastInstance hz = factory.newHazelcastInstance();
+        Node node = getNode(hz);
+        hz.shutdown();
+        assertEquals(NodeState.SHUT_DOWN, node.getState());
+    }
+
+    @Test
+    public void multipleShutdowns_Allowed() throws InterruptedException {
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+        HazelcastInstance hz = factory.newHazelcastInstance();
+        Node node = getNode(hz);
+
+        for (int i = 0; i < 3; i++) {
+            node.shutdown(false);
+        }
+    }
+
+    @Test
+    public void concurrentShutdowns_Allowed() throws InterruptedException {
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+        HazelcastInstance hz = factory.newHazelcastInstance();
+        final Node node = getNode(hz);
+
+        Thread[] shutdownThreads = new Thread[3];
+        for (int i = 0; i < shutdownThreads.length; i++) {
+            Thread thread = new Thread() {
+                public void run() {
+                    node.shutdown(false);
+                }
+            };
+            thread.start();
+            shutdownThreads[i] = thread;
+        }
+
+        for (Thread thread : shutdownThreads) {
+            thread.join(TimeUnit.MINUTES.toMillis(1));
+        }
+    }
+
+    @Test
+    public void shouldReject_NormalOperationInvocation_whileShuttingDown() throws Exception {
+        InvocationTask task = new InvocationTask() {
+            @Override
+            public void invoke(NodeEngine nodeEngine) throws Exception {
+                Future<Object> future = nodeEngine.getOperationService()
+                        .invokeOnPartition(null, new DummyOperation(), 1);
+                try {
+                    future.get();
+                    fail("Invocation should fail while node is shutting down!");
+                } catch (ExecutionException e) {
+                    Throwable cause = e.getCause();
+                    assertTrue("Cause: " + cause, cause instanceof HazelcastInstanceNotActiveException);
+                }
+            }
+        };
+
+        testInvocation_whileShuttingDown(task);
+    }
+
+    @Test
+    public void shouldReject_NormalOperationExecution_whileShuttingDown() throws Exception {
+        InvocationTask task = new InvocationTask() {
+            @Override
+            public void invoke(NodeEngine nodeEngine) throws Exception {
+                final CountDownLatch latch = new CountDownLatch(1);
+                Operation op = new DummyOperation() {
+                    @Override
+                    public void onExecutionFailure(Throwable e) {
+                        latch.countDown();
+                    }
+
+                    @Override
+                    public boolean returnsResponse() {
+                        return false;
+                    }
+                };
+
+                nodeEngine.getOperationService().runOperationOnCallingThread(op);
+                assertOpenEventually(latch);
+            }
+        };
+
+        testInvocation_whileShuttingDown(task);
+    }
+
+    @Test
+    public void shouldAllow_AllowedOperationInvocation_whileShuttingDown() throws Exception {
+        InvocationTask task = new InvocationTask() {
+            @Override
+            public void invoke(NodeEngine nodeEngine) throws Exception {
+                Future<Object> future = nodeEngine.getOperationService()
+                        .invokeOnTarget(null, new DummyAllowedDuringShutdownOperation(), nodeEngine.getThisAddress());
+                future.get(1, TimeUnit.MINUTES);
+            }
+        };
+
+        testInvocation_whileShuttingDown(task);
+    }
+
+    @Test
+    public void shouldAllow_AllowedOperationExecution_whileShuttingDown() throws Exception {
+        InvocationTask task = new InvocationTask() {
+            @Override
+            public void invoke(NodeEngine nodeEngine) throws Exception {
+                final CountDownLatch latch = new CountDownLatch(1);
+                Operation op = new DummyAllowedDuringShutdownOperation() {
+                    @Override
+                    public void afterRun() throws Exception {
+                        latch.countDown();
+                    }
+
+                    @Override
+                    public boolean returnsResponse() {
+                        return false;
+                    }
+                };
+
+                nodeEngine.getOperationService().runOperationOnCallingThread(op);
+                assertOpenEventually(latch);
+            }
+        };
+
+        testInvocation_whileShuttingDown(task);
+    }
+
+    private void testInvocation_whileShuttingDown(InvocationTask invocationTask) throws Exception {
+        CountDownLatch latch = new CountDownLatch(1);
+        Config config = new Config();
+        config.getServicesConfig().addServiceConfig(
+                new ServiceConfig().setEnabled(true)
+                        .setName("bs").setServiceImpl(new BlockingService(latch)));
+
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+        final HazelcastInstance hz = factory.newHazelcastInstance(config);
+        final Node node = getNode(hz);
+
+        final Thread shutdownThread = new Thread() {
+            public void run() {
+                hz.shutdown();
+            }
+        };
+        shutdownThread.start();
+
+        waitNodeStateToBeShuttingDown(node);
+
+        try {
+            invocationTask.invoke(getNodeEngineImpl(hz));
+        } catch (Throwable e) {
+            // countdown-latch on failure
+            latch.countDown();
+            throw ExceptionUtil.rethrow(e);
+        }
+
+        assertEquals(NodeState.SHUTTING_DOWN, node.getState());
+        latch.countDown();
+        shutdownThread.join(TimeUnit.MINUTES.toMillis(1));
+
+        assertEquals(NodeState.SHUT_DOWN, node.getState());
+    }
+
+    private interface InvocationTask {
+        void invoke(NodeEngine nodeEngine) throws Exception;
+    }
+
+    private static void waitNodeStateToBeShuttingDown(final Node node) {
+        assertEqualsEventually(new Callable<NodeState>() {
+            @Override
+            public NodeState call() throws Exception {
+                return node.getState();
+            }
+        }, NodeState.SHUTTING_DOWN);
+    }
+
+    private static class BlockingService implements ManagedService {
+
+        private final CountDownLatch latch;
+
+        BlockingService(CountDownLatch latch) {
+            this.latch = latch;
+        }
+
+        @Override
+        public void init(NodeEngine nodeEngine, Properties properties) {
+        }
+
+        @Override
+        public void reset() {
+        }
+
+        @Override
+        public void shutdown(boolean terminate) {
+            try {
+                latch.await(1, TimeUnit.MINUTES);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+    private static class DummyOperation extends AbstractOperation {
+        @Override
+        public void run() throws Exception {
+        }
+    }
+
+    private static class DummyAllowedDuringShutdownOperation
+            extends AbstractOperation implements AllowedDuringShutdown {
+        @Override
+        public void run() throws Exception {
+        }
+    }
+
+}


### PR DESCRIPTION
Before there was only an `active` flag in Node. It was set to `false` after partition information check during shutdown. Problem is, during shutdown, before Node itself becomes inactive, all operations are allowed to execute (including operations mutating the data). This can lead to modification of partition data after partition is synced with its backups.

Now, we have one state to separate begin (`SHUTTING_DOWN`) and end (`SHUTDOWN`) of shutdown process. In `SHUTTING_DOWN` state, only certain operations are allowed to run. These operations are (should be) marked with `AllowedDuringShutdown` interface.