### PR TITLE
Fixed logging when Level = OFF

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/logging/Log4j2Factory.java
+++ b/hazelcast/src/main/java/com/hazelcast/logging/Log4j2Factory.java
@@ -67,8 +67,10 @@ public class Log4j2Factory extends LoggerFactorySupport {
                 return Level.INFO;
             } else if (logger.isWarnEnabled()) {
                 return Level.WARNING;
-            } else {
+            } else if (logger.isFatalEnabled()) {
                 return Level.SEVERE;
+            } else {
+                return Level.OFF;
             }
         }
 
@@ -98,6 +100,8 @@ public class Log4j2Factory extends LoggerFactorySupport {
                 return org.apache.logging.log4j.Level.DEBUG;
             } else if (Level.FINEST == level) {
                 return org.apache.logging.log4j.Level.DEBUG;
+            } else if (Level.OFF == level) {
+                return org.apache.logging.log4j.Level.OFF;
             } else {
                 return org.apache.logging.log4j.Level.INFO;
             }

--- a/hazelcast/src/main/java/com/hazelcast/logging/Log4jFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/logging/Log4jFactory.java
@@ -36,16 +36,19 @@ public class Log4jFactory extends LoggerFactorySupport implements LoggerFactory 
 
         public Log4jLogger(Logger logger) {
             this.logger = logger;
-            if (logger.getLevel() == org.apache.log4j.Level.DEBUG) {
-                level = Level.FINEST;
-            } else if (logger.getLevel() == org.apache.log4j.Level.INFO) {
-                level = Level.INFO;
-            } else if (logger.getLevel() == org.apache.log4j.Level.WARN) {
-                level = Level.WARNING;
-            } else if (logger.getLevel() == org.apache.log4j.Level.FATAL) {
-                level = Level.SEVERE;
+            org.apache.log4j.Level log4jLevel = logger.getLevel();
+            if (log4jLevel == org.apache.log4j.Level.DEBUG) {
+                this.level = Level.FINEST;
+            } else if (log4jLevel == org.apache.log4j.Level.INFO) {
+                this.level = Level.INFO;
+            } else if (log4jLevel == org.apache.log4j.Level.WARN) {
+                this.level = Level.WARNING;
+            } else if (log4jLevel == org.apache.log4j.Level.FATAL) {
+                this.level = Level.SEVERE;
+            } else if (log4jLevel == org.apache.log4j.Level.OFF) {
+                this.level = Level.OFF;
             } else {
-                level = Level.INFO;
+                this.level = Level.INFO;
             }
         }
 
@@ -57,7 +60,7 @@ public class Log4jFactory extends LoggerFactorySupport implements LoggerFactory 
                 logger.fatal(message);
             } else if (Level.WARNING == level) {
                 logger.warn(message);
-            } else {
+            } else if (level != Level.OFF) {
                 logger.info(message);
             }
         }
@@ -77,6 +80,8 @@ public class Log4jFactory extends LoggerFactorySupport implements LoggerFactory 
                 return logger.isEnabledFor(org.apache.log4j.Level.WARN);
             } else if (Level.SEVERE == level) {
                 return logger.isEnabledFor(org.apache.log4j.Level.FATAL);
+            } else if (Level.OFF == level) {
+                return false;
             } else {
                 return logger.isEnabledFor(org.apache.log4j.Level.INFO);
             }
@@ -90,7 +95,7 @@ public class Log4jFactory extends LoggerFactorySupport implements LoggerFactory 
                 logger.warn(message, thrown);
             } else if (Level.SEVERE == level) {
                 logger.fatal(message, thrown);
-            } else {
+            } else if (Level.OFF != level) {
                 logger.info(message, thrown);
             }
         }
@@ -109,6 +114,8 @@ public class Log4jFactory extends LoggerFactorySupport implements LoggerFactory 
                 level = org.apache.log4j.Level.WARN;
             } else if (logRecord.getLevel() == Level.SEVERE) {
                 level = org.apache.log4j.Level.FATAL;
+            } else if (logRecord.getLevel() == Level.OFF) {
+                return;
             } else {
                 level = org.apache.log4j.Level.INFO;
             }

--- a/hazelcast/src/main/java/com/hazelcast/logging/Slf4jFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/logging/Slf4jFactory.java
@@ -45,21 +45,23 @@ public class Slf4jFactory extends LoggerFactorySupport {
                 logger.error(message);
             } else if (Level.WARNING == level) {
                 logger.warn(message);
-            } else {
+            } else if (Level.OFF != level) {
                 logger.info(message);
             }
         }
 
         @Override
         public Level getLevel() {
-            if (logger.isErrorEnabled()) {
-                return Level.SEVERE;
-            } else if (logger.isWarnEnabled()) {
-                return Level.WARNING;
+            if (logger.isDebugEnabled()) {
+                return Level.FINEST;
             } else if (logger.isInfoEnabled()) {
                 return Level.INFO;
+            } else if (logger.isWarnEnabled()) {
+                return Level.WARNING;
+            } else if (logger.isErrorEnabled()) {
+                return Level.SEVERE;
             } else {
-                return Level.FINEST;
+                return Level.OFF;
             }
         }
 
@@ -90,7 +92,7 @@ public class Slf4jFactory extends LoggerFactorySupport {
                 logger.warn(message, thrown);
             } else if (Level.SEVERE == level) {
                 logger.error(message, thrown);
-            } else {
+            } else if (Level.OFF != level) {
                 logger.info(message, thrown);
             }
         }

--- a/hazelcast/src/test/java/com/hazelcast/logging/Log4jLoggerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/logging/Log4jLoggerTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.logging;
+
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.logging.Level;
+
+import static org.junit.Assert.assertFalse;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyZeroInteractions;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class Log4jLoggerTest {
+
+    private org.apache.log4j.Logger mockLogger;
+    private ILogger hazelcastLogger;
+
+    @Before
+    public void setUp() {
+        mockLogger = mock(org.apache.log4j.Logger.class);
+        hazelcastLogger = new Log4jFactory.Log4jLogger(mockLogger);
+    }
+
+    @Test
+    public void logLevelAndMessage_whenOffLevel_thenDoNotLogMessage() {
+        hazelcastLogger.log(Level.OFF, "message");
+        verifyZeroInteractions(mockLogger);
+    }
+
+    @Test
+    public void logLevelAndMessageAndThrowable_whenOffLevel_thenDoNotLogMessage() {
+        hazelcastLogger.log(Level.OFF, "message", new Exception());
+        verifyZeroInteractions(mockLogger);
+    }
+
+    @Test
+    public void isLoggable_whenOffLevel_thenReturnFalse() {
+        boolean loggable = hazelcastLogger.isLoggable(Level.OFF);
+        assertFalse(loggable);
+    }
+
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/logging/Slf4jLoggerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/logging/Slf4jLoggerTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.logging;
+
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.slf4j.Logger;
+
+import java.util.logging.Level;
+
+import static org.junit.Assert.assertFalse;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyZeroInteractions;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class Slf4jLoggerTest {
+
+    private Logger mockLogger;
+    private ILogger hazelcastLogger;
+
+    @Before
+    public void setUp() {
+        mockLogger = mock(Logger.class);
+        hazelcastLogger = new Slf4jFactory.Slf4jLogger(mockLogger);
+    }
+
+    @Test
+    public void logLevelAndMessage_whenOffLevel_thenDoNotLogMessage() {
+        hazelcastLogger.log(Level.OFF, "message");
+        verifyZeroInteractions(mockLogger);
+    }
+
+    @Test
+    public void logLevelAndMessageAndThrowable_whenOffLevel_thenDoNotLogMessage() {
+        hazelcastLogger.log(Level.OFF, "message", new Exception());
+        verifyZeroInteractions(mockLogger);
+    }
+
+    @Test
+    public void isLoggable_whenOffLevel_thenReturnFalse() {
+        boolean loggable = hazelcastLogger.isLoggable(Level.OFF);
+        assertFalse(loggable);
+    }
+
+
+}


### PR DESCRIPTION
The OFF level was interpreted as INFO in some cases.
The led to unnecessary logging noise.