### PR TITLE
Makes all listener remove requests retryable

### DIFF
--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/spi/impl/ClientListenerServiceImpl.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/spi/impl/ClientListenerServiceImpl.java
@@ -93,8 +93,9 @@ public final class ClientListenerServiceImpl implements ClientListenerService {
                 return false;
             }
             ClientMessage removeRequest = listenerRemoveCodec.encodeRequest(realRegistrationId);
-            final Future future = new ClientInvocation(client, removeRequest).invoke();
-            return listenerRemoveCodec.decodeResponse((ClientMessage) future.get());
+            Future future = new ClientInvocation(client, removeRequest).invoke();
+            future.get();
+            return true;
         } catch (Exception e) {
             throw ExceptionUtil.rethrow(e);
         }

--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/spi/impl/ClientMembershipListener.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/spi/impl/ClientMembershipListener.java
@@ -172,11 +172,11 @@ class ClientMembershipListener extends ClientMembershipListenerCodec.AbstractEve
 
     private void memberRemoved(Member member) {
         members.remove(member);
+        applyMemberListChanges();
         final Connection connection = connectionManager.getConnection(member.getAddress());
         if (connection != null) {
             connectionManager.destroyConnection(connection);
         }
-        applyMemberListChanges();
         MembershipEvent event = new MembershipEvent(client.getCluster(), member, ClientInitialMembershipEvent.MEMBER_REMOVED,
                 Collections.unmodifiableSet(new LinkedHashSet<Member>(members)));
         clusterService.fireMembershipEvent(event);

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientListenerServiceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientListenerServiceImpl.java
@@ -96,8 +96,9 @@ public final class ClientListenerServiceImpl implements ClientListenerService {
                 return false;
             }
             request.setRegistrationId(realRegistrationId);
-            final Future<Boolean> future = new ClientInvocation(client, request).invoke();
-            return (Boolean) serializationService.toObject(future.get());
+            Future<Boolean> future = new ClientInvocation(client, request).invoke();
+            future.get();
+            return true;
         } catch (Exception e) {
             throw ExceptionUtil.rethrow(e);
         }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientMembershipListener.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientMembershipListener.java
@@ -144,11 +144,11 @@ class ClientMembershipListener implements EventHandler<ClientInitialMembershipEv
 
     private void memberRemoved(Member member) {
         members.remove(member);
+        applyMemberListChanges();
         final Connection connection = connectionManager.getConnection(member.getAddress());
         if (connection != null) {
             connectionManager.destroyConnection(connection);
         }
-        applyMemberListChanges();
         MembershipEvent event = new MembershipEvent(client.getCluster(), member,
                 ClientInitialMembershipEvent.MEMBER_REMOVED,
                 Collections.unmodifiableSet(new LinkedHashSet<Member>(members)));

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/client/BaseClientRemoveListenerRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/client/BaseClientRemoveListenerRequest.java
@@ -21,7 +21,7 @@ import com.hazelcast.nio.serialization.PortableWriter;
 
 import java.io.IOException;
 
-public abstract class BaseClientRemoveListenerRequest extends CallableClientRequest {
+public abstract class BaseClientRemoveListenerRequest extends CallableClientRequest implements RetryableRequest {
 
     protected String name;
     protected String registrationId;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/CacheCodecTemplate.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/CacheCodecTemplate.java
@@ -282,7 +282,7 @@ public interface CacheCodecTemplate {
      * @param registrationId The id assigned during the registration for the listener which shall be removed.
      * @return true if the listener is de-registered, false otherwise
      */
-    @Request(id = 21, retryable = false, response = ResponseMessageConst.BOOLEAN)
+    @Request(id = 21, retryable = true, response = ResponseMessageConst.BOOLEAN)
     Object removeEntryListener(String name, String registrationId);
 
     /**
@@ -291,7 +291,7 @@ public interface CacheCodecTemplate {
      * @param registrationId The id assigned during the registration for the listener which shall be removed.
      * @return true if the listener is de-registered, false otherwise
      */
-    @Request(id = 22, retryable = false, response = ResponseMessageConst.BOOLEAN)
+    @Request(id = 22, retryable = true, response = ResponseMessageConst.BOOLEAN)
     Object removeInvalidationListener(String name, String registrationId);
 
     /**
@@ -357,7 +357,7 @@ public interface CacheCodecTemplate {
      * @return true if registration is removed, false otherwise.
      */
 
-    @Request(id = 27, retryable = false, response = ResponseMessageConst.BOOLEAN)
+    @Request(id = 27, retryable = true, response = ResponseMessageConst.BOOLEAN)
     Object removePartitionLostListener(String name, String registrationId);
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/ClientMessageTemplate.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/ClientMessageTemplate.java
@@ -137,7 +137,7 @@ public interface ClientMessageTemplate {
      * @param registrationId The id assigned during the listener registration.
      * @return true if the listener existed and removed, false otherwise.
      */
-    @Request(id = 11, retryable = false, response = ResponseMessageConst.BOOLEAN)
+    @Request(id = 11, retryable = true, response = ResponseMessageConst.BOOLEAN)
     Object removePartitionLostListener(String registrationId);
 
     /**
@@ -159,7 +159,7 @@ public interface ClientMessageTemplate {
      * @param registrationId The id assigned during the registration.
      * @return true if the listener existed and removed, false otherwise.
      */
-    @Request(id = 14, retryable = false, response = ResponseMessageConst.BOOLEAN)
+    @Request(id = 14, retryable = true, response = ResponseMessageConst.BOOLEAN)
     Object removeDistributedObjectListener(String registrationId);
 
     @Request(id = 15, retryable = true, response = ResponseMessageConst.VOID)

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/ListCodecTemplate.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/ListCodecTemplate.java
@@ -152,7 +152,7 @@ public interface ListCodecTemplate {
      * @param registrationId The id of the listener which was provided during registration.
      * @return True if unregistered, false otherwise.
      */
-    @Request(id = 12, retryable = false, response = ResponseMessageConst.BOOLEAN)
+    @Request(id = 12, retryable = true, response = ResponseMessageConst.BOOLEAN)
     Object removeListener(String name, String registrationId);
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/MapCodecTemplate.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/MapCodecTemplate.java
@@ -404,7 +404,7 @@ public interface MapCodecTemplate {
      * @param registrationId id of registered listener.
      * @return true if registration is removed, false otherwise.
      */
-    @Request(id = 30, retryable = false, response = ResponseMessageConst.BOOLEAN)
+    @Request(id = 30, retryable = true, response = ResponseMessageConst.BOOLEAN)
     Object removeEntryListener(String name, String registrationId);
 
     /**
@@ -429,7 +429,7 @@ public interface MapCodecTemplate {
      * @param registrationId id of register
      * @return true if registration is removed, false otherwise.
      */
-    @Request(id = 32, retryable = false, response = ResponseMessageConst.BOOLEAN)
+    @Request(id = 32, retryable = true, response = ResponseMessageConst.BOOLEAN)
     Object removePartitionLostListener(String name, String registrationId);
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/MultiMapCodecTemplate.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/MultiMapCodecTemplate.java
@@ -181,7 +181,7 @@ public interface MultiMapCodecTemplate {
      * @param registrationId Registration id of listener
      * @return True if registration is removed, false otherwise
      */
-    @Request(id = 15, retryable = false, response = ResponseMessageConst.BOOLEAN)
+    @Request(id = 15, retryable = true, response = ResponseMessageConst.BOOLEAN)
     Object removeEntryListener(String name, String registrationId);
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/QueueCodecTemplate.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/QueueCodecTemplate.java
@@ -219,7 +219,7 @@ public interface QueueCodecTemplate {
      * @param registrationId Id of the listener registration.
      * @return True if the item listener is removed, false otherwise
      */
-    @Request(id = 18, retryable = false, response = ResponseMessageConst.BOOLEAN)
+    @Request(id = 18, retryable = true, response = ResponseMessageConst.BOOLEAN)
     Object removeListener(String name, String registrationId);
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/ReplicatedMapCodecTemplate.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/ReplicatedMapCodecTemplate.java
@@ -185,7 +185,7 @@ public interface ReplicatedMapCodecTemplate {
      * @param registrationId ID of the registered entry listener.
      * @return True if registration is removed, false otherwise.
      */
-    @Request(id = 14, retryable = false, response = ResponseMessageConst.BOOLEAN)
+    @Request(id = 14, retryable = true, response = ResponseMessageConst.BOOLEAN)
     Object removeEntryListener(String name, String registrationId);
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/SetCodecTemplate.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/SetCodecTemplate.java
@@ -162,7 +162,7 @@ public interface SetCodecTemplate {
      * @param registrationId The id retrieved during registration.
      * @return true if the listener with the provided id existed and removed, false otherwise.
      */
-    @Request(id = 12, retryable = false, response = ResponseMessageConst.BOOLEAN)
+    @Request(id = 12, retryable = true, response = ResponseMessageConst.BOOLEAN)
     Object removeListener(String name, String registrationId);
     
     /**

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/TopicCodecTemplate.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/TopicCodecTemplate.java
@@ -51,7 +51,7 @@ public interface TopicCodecTemplate {
      * @param registrationId Id of listener registration.
      * @return True if registration is removed, false otherwise
      */
-    @Request(id = 3, retryable = false, response = ResponseMessageConst.BOOLEAN)
+    @Request(id = 3, retryable = true, response = ResponseMessageConst.BOOLEAN)
     Object removeMessageListener(String name, String registrationId);
 
 


### PR DESCRIPTION
Issue seen in https://github.com/hazelcast/hazelcast/issues/6264
An internal listener remove fails with exception because the node that it tries to run the request on is no longer available. I decided to make client listener remove requests retryable to solve the problem. In hazelcast client, only idempotent operations are retryable. Listener remove request are also idempotent since they run twice they do not get any exception and second call just returns silently, except when they are not. Only thing that is changes when remove request runs twice is its response. If first call is successfull and then we lose the connection, the second retry will return false. This will lead to wrong response to user when request is made retryable. To overcome that, a second change is made so that remove listener is always returns true to user without looking at what is returned from remote. Any response other than exception means listener is removed successfully.

A second small fix in ClientMembershipListener. The call applying 'member remove' to the member list is moved before related connections are destroyed, because when a connection is destroyed it will be retried(if retryable), on a member in memberlist And we don't want to retry on a member that will already know that is dead.

fixes https://github.com/hazelcast/hazelcast/issues/6264