### PR TITLE
Makes all listener remove requests retryable

### DIFF
--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/spi/impl/ClientListenerServiceImpl.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/spi/impl/ClientListenerServiceImpl.java
@@ -93,8 +93,9 @@ public final class ClientListenerServiceImpl implements ClientListenerService {
                 return false;
             }
             ClientMessage removeRequest = listenerRemoveCodec.encodeRequest(realRegistrationId);
-            final Future future = new ClientInvocation(client, removeRequest).invoke();
-            return listenerRemoveCodec.decodeResponse((ClientMessage) future.get());
+            Future future = new ClientInvocation(client, removeRequest).invoke();
+            future.get();
+            return true;
         } catch (Exception e) {
             throw ExceptionUtil.rethrow(e);
         }

--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/spi/impl/ClientMembershipListener.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/spi/impl/ClientMembershipListener.java
@@ -179,11 +179,11 @@ class ClientMembershipListener extends ClientMembershipListenerCodec.AbstractEve
 
     private void memberRemoved(Member member) {
         members.remove(member);
+        applyMemberListChanges();
         final Connection connection = connectionManager.getConnection(((AbstractMember) member).getAddress());
         if (connection != null) {
             connectionManager.destroyConnection(connection);
         }
-        applyMemberListChanges();
         MembershipEvent event = new MembershipEvent(client.getCluster(), member, ClientInitialMembershipEvent.MEMBER_REMOVED,
                 Collections.unmodifiableSet(new LinkedHashSet<Member>(members)));
         clusterService.fireMembershipEvent(event);

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientListenerServiceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientListenerServiceImpl.java
@@ -96,8 +96,9 @@ public final class ClientListenerServiceImpl implements ClientListenerService {
                 return false;
             }
             request.setRegistrationId(realRegistrationId);
-            final Future<Boolean> future = new ClientInvocation(client, request).invoke();
-            return (Boolean) serializationService.toObject(future.get());
+            Future<Boolean> future = new ClientInvocation(client, request).invoke();
+            future.get();
+            return true;
         } catch (Exception e) {
             throw ExceptionUtil.rethrow(e);
         }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientMembershipListener.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientMembershipListener.java
@@ -144,11 +144,11 @@ class ClientMembershipListener implements EventHandler<ClientInitialMembershipEv
 
     private void memberRemoved(Member member) {
         members.remove(member);
+        applyMemberListChanges();
         final Connection connection = connectionManager.getConnection(((AbstractMember) member).getAddress());
         if (connection != null) {
             connectionManager.destroyConnection(connection);
         }
-        applyMemberListChanges();
         MembershipEvent event = new MembershipEvent(client.getCluster(), member,
                 ClientInitialMembershipEvent.MEMBER_REMOVED,
                 Collections.unmodifiableSet(new LinkedHashSet<Member>(members)));

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/client/BaseClientRemoveListenerRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/client/BaseClientRemoveListenerRequest.java
@@ -21,7 +21,7 @@ import com.hazelcast.nio.serialization.PortableWriter;
 
 import java.io.IOException;
 
-public abstract class BaseClientRemoveListenerRequest extends CallableClientRequest {
+public abstract class BaseClientRemoveListenerRequest extends CallableClientRequest implements RetryableRequest {
 
     protected String name;
     protected String registrationId;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/CacheCodecTemplate.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/CacheCodecTemplate.java
@@ -90,10 +90,10 @@ public interface CacheCodecTemplate {
     @Request(id = 20, retryable = false, response = ResponseMessageConst.DATA)
     void put(String name, Data key, Data value, @Nullable Data expiryPolicy, boolean get, int completionId);
 
-    @Request(id = 21, retryable = false, response = ResponseMessageConst.BOOLEAN)
+    @Request(id = 21, retryable = true, response = ResponseMessageConst.BOOLEAN)
     void removeEntryListener(String name, String registrationId);
 
-    @Request(id = 22, retryable = false, response = ResponseMessageConst.BOOLEAN)
+    @Request(id = 22, retryable = true, response = ResponseMessageConst.BOOLEAN)
     void removeInvalidationListener(String name, String registrationId);
 
     @Request(id = 23, retryable = false, response = ResponseMessageConst.DATA)

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/ClientMessageTemplate.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/ClientMessageTemplate.java
@@ -51,7 +51,7 @@ public interface ClientMessageTemplate {
     @Request(id = 10, retryable = true, response = ResponseMessageConst.STRING, event = {EventMessageConst.EVENT_PARTITIONLOST})
     void addPartitionLostListener();
 
-    @Request(id = 11, retryable = false, response = ResponseMessageConst.BOOLEAN)
+    @Request(id = 11, retryable = true, response = ResponseMessageConst.BOOLEAN)
     void removePartitionLostListener(String registrationId);
 
     @Request(id = 12, retryable = false, response = ResponseMessageConst.DISTRIBUTED_OBJECT)
@@ -60,7 +60,7 @@ public interface ClientMessageTemplate {
     @Request(id = 13, retryable = true, response = ResponseMessageConst.STRING, event = {EventMessageConst.EVENT_DISTRIBUTEDOBJECT})
     void addDistributedObjectListener();
 
-    @Request(id = 14, retryable = false, response = ResponseMessageConst.BOOLEAN)
+    @Request(id = 14, retryable = true, response = ResponseMessageConst.BOOLEAN)
     void removeDistributedObjectListener(String registrationId);
 
     @Request(id = 15, retryable = true, response = ResponseMessageConst.VOID)

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/ListCodecTemplate.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/ListCodecTemplate.java
@@ -63,7 +63,7 @@ public interface ListCodecTemplate {
             , event = {EventMessageConst.EVENT_ITEM})
     void addListener(String name, boolean includeValue);
 
-    @Request(id = 12, retryable = false, response = ResponseMessageConst.BOOLEAN)
+    @Request(id = 12, retryable = true, response = ResponseMessageConst.BOOLEAN)
     void removeListener(String name, String registrationId);
 
     @Request(id = 13, retryable = true, response = ResponseMessageConst.BOOLEAN)

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/MapCodecTemplate.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/MapCodecTemplate.java
@@ -116,14 +116,14 @@ public interface MapCodecTemplate {
     @Request(id = 29, retryable = true, response = ResponseMessageConst.STRING, event = EventMessageConst.EVENT_ENTRY)
     void addNearCacheEntryListener(String name, boolean includeValue);
 
-    @Request(id = 30, retryable = false, response = ResponseMessageConst.BOOLEAN)
+    @Request(id = 30, retryable = true, response = ResponseMessageConst.BOOLEAN)
     void removeEntryListener(String name, String registrationId);
 
     @Request(id = 31, retryable = true, response = ResponseMessageConst.STRING,
             event = EventMessageConst.EVENT_MAPPARTITIONLOST)
     void addPartitionLostListener(String name);
 
-    @Request(id = 32, retryable = false, response = ResponseMessageConst.BOOLEAN)
+    @Request(id = 32, retryable = true, response = ResponseMessageConst.BOOLEAN)
     void removePartitionLostListener(String name, String registrationId);
 
     @Request(id = 33, retryable = true, response = ResponseMessageConst.ENTRY_VIEW)

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/MultiMapCodecTemplate.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/MultiMapCodecTemplate.java
@@ -69,7 +69,7 @@ public interface MultiMapCodecTemplate {
             event = {EventMessageConst.EVENT_ENTRY})
     void addEntryListener(String name, boolean includeValue);
 
-    @Request(id = 15, retryable = false, response = ResponseMessageConst.BOOLEAN)
+    @Request(id = 15, retryable = true, response = ResponseMessageConst.BOOLEAN)
     void removeEntryListener(String name, String registrationId);
 
     @Request(id = 16, retryable = false, response = ResponseMessageConst.VOID)

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/QueueCodecTemplate.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/QueueCodecTemplate.java
@@ -79,7 +79,7 @@ public interface QueueCodecTemplate {
             event = {EventMessageConst.EVENT_ITEM})
     void addListener(String name, boolean includeValue);
 
-    @Request(id = 18, retryable = false, response = ResponseMessageConst.BOOLEAN)
+    @Request(id = 18, retryable = true, response = ResponseMessageConst.BOOLEAN)
     void removeListener(String name, String registrationId);
 
     @Request(id = 19, retryable = false, response = ResponseMessageConst.INTEGER)

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/ReplicatedMapCodecTemplate.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/ReplicatedMapCodecTemplate.java
@@ -71,7 +71,7 @@ public interface ReplicatedMapCodecTemplate {
             , event = {EventMessageConst.EVENT_ENTRY})
     void addEntryListener(String name);
 
-    @Request(id = 14, retryable = false, response = ResponseMessageConst.BOOLEAN)
+    @Request(id = 14, retryable = true, response = ResponseMessageConst.BOOLEAN)
     void removeEntryListener(String name, String registrationId);
 
     @Request(id = 15, retryable = true, response = ResponseMessageConst.LIST_DATA)

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/SetCodecTemplate.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/SetCodecTemplate.java
@@ -62,7 +62,7 @@ public interface SetCodecTemplate {
     event = {EventMessageConst.EVENT_ITEM})
     void addListener(String name, boolean includeValue);
 
-    @Request(id = 12, retryable = false, response = ResponseMessageConst.BOOLEAN)
+    @Request(id = 12, retryable = true, response = ResponseMessageConst.BOOLEAN)
     void removeListener(String name, String registrationId);
 
     @Request(id = 13, retryable = false, response = ResponseMessageConst.BOOLEAN)

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/TopicCodecTemplate.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/TopicCodecTemplate.java
@@ -32,7 +32,7 @@ public interface TopicCodecTemplate {
             , event = {EventMessageConst.EVENT_TOPIC})
     void addMessageListener(String name);
 
-    @Request(id = 3, retryable = false, response = ResponseMessageConst.BOOLEAN)
+    @Request(id = 3, retryable = true, response = ResponseMessageConst.BOOLEAN)
     void removeMessageListener(String name, String registrationId);
 
 }


### PR DESCRIPTION
Issue seen in https://github.com/hazelcast/hazelcast/issues/6264
An internal listener remove fails with exception because the node that it tries to run the request on is no longer available. I decided to make client listener remove requests retryable to solve the problem. In hazelcast client, only idempotent operations are retryable. Listener remove request are also idempotent since they run twice they do not get any exception and second call just returns silently, except when they are not. Only thing that is changes when remove request runs twice is its response. If first call is successfull and then we lose the connection, the second retry will return false. This will lead to wrong response to user when request is made retryable. To overcome that, a second change is made so that remove listener is always returns true to user without looking at what is returned from remote. Any response other than exception means listener is removed successfully.

A second small fix in ClientMembershipListener. The call applying 'member remove' to the member list is moved before related connections are destroyed, because when a connection is destroyed it will be retried(if retryable), on a member in memberlist And we don't want to retry on a member that will already know that is dead.

fixes https://github.com/hazelcast/hazelcast/issues/6264

backport of https://github.com/hazelcast/hazelcast/pull/6267