### PR TITLE
Timeout original operation when no response is received for IsStillEx…

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/IsStillRunningService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/IsStillRunningService.java
@@ -105,7 +105,9 @@ public class IsStillRunningService {
      */
     public void timeoutInvocationIfNotExecuting(Invocation invocation) {
         if (isStillRunningOperation(invocation)) {
-            // we don't want to is-still-running-operations; it can lead to a explosion of such invocations
+            // timeout the original invocation since IsStillExecutingOperation is timed out
+            final InvocationFuture future = invocation.invocationFuture;
+            future.set(false);
             return;
         }
 
@@ -215,7 +217,7 @@ public class IsStillRunningService {
         return true;
     }
 
-    private static class IsOperationStillRunningCallback implements ExecutionCallback<Object> {
+    static class IsOperationStillRunningCallback implements ExecutionCallback<Object> {
 
         private final Invocation invocation;
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/operations/IsStillExecutingOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/operations/IsStillExecutingOperation.java
@@ -34,7 +34,7 @@ public class IsStillExecutingOperation extends AbstractOperation implements Urge
     private long operationCallId;
     private int operationPartitionId;
 
-    IsStillExecutingOperation() {
+    public IsStillExecutingOperation() {
     }
 
     public IsStillExecutingOperation(long operationCallId, int operationPartitionId) {


### PR DESCRIPTION
…ecutingOperation

The problem is as follows: IsStillExecutingOperation is used to timeout a remote invocation by InvocationRegistry or making the call sync by calling .get() on the future reference. If no response is received for the IsStillExecutingOperation invocation, then the original invocation does not time out.

Fixes #6250