### PR TITLE
Minor test cleanup in opservice.impl

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationFuture_AndThenTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationFuture_AndThenTest.java
@@ -1,0 +1,82 @@
+package com.hazelcast.spi.impl.operationservice.impl;
+
+import com.hazelcast.core.ExecutionCallback;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.spi.InternalCompletableFuture;
+import com.hazelcast.spi.impl.operationservice.InternalOperationService;
+import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+
+import static org.mockito.Matchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class InvocationFuture_AndThenTest extends HazelcastTestSupport {
+    private HazelcastInstance local;
+    private InternalOperationService operationService;
+
+    @Before
+    public void setup() {
+        local = createHazelcastInstance();
+        operationService = getOperationService(local);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void whenNullCallback() {
+        DummyOperation op = new DummyOperation(null);
+
+        InternalCompletableFuture future = operationService.invokeOnTarget(null, op, getAddress(local));
+
+        future.andThen(null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void whenNullCallback2() {
+        DummyOperation op = new DummyOperation(null);
+
+        InternalCompletableFuture future = operationService.invokeOnTarget(null, op, getAddress(local));
+
+        future.andThen(null, mock(Executor.class));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void whenNullExecutor() {
+        DummyOperation op = new DummyOperation(null);
+
+        InternalCompletableFuture future = operationService.invokeOnTarget(null, op, getAddress(local));
+
+        future.andThen(mock(ExecutionCallback.class), null);
+    }
+
+    // There is a bug: https://github.com/hazelcast/hazelcast/issues/5001
+    @Test
+    public void whenNullResponse_thenCallbackExecuted() throws ExecutionException, InterruptedException {
+        DummyOperation op = new DummyOperation(null);
+        final ExecutionCallback callback = mock(ExecutionCallback.class);
+        InternalCompletableFuture future = operationService.invokeOnTarget(null, op, getAddress(local));
+        future.get();
+
+        // Callback can be completed immediately since a response (NULL_RESPONSE) has been already set.
+        future.andThen(callback);
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                verify(callback, times(1)).onResponse(isNull());
+            }
+        });
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationFuture_CancelTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationFuture_CancelTest.java
@@ -1,0 +1,74 @@
+package com.hazelcast.spi.impl.operationservice.impl;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.ICompletableFuture;
+import com.hazelcast.spi.AbstractOperation;
+import com.hazelcast.spi.InternalCompletableFuture;
+import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.impl.operationservice.InternalOperationService;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class InvocationFuture_CancelTest extends HazelcastTestSupport {
+
+    private static int RESULT = 123;
+    private HazelcastInstance hz;
+    private InternalOperationService opService;
+
+    @Before
+    public void setup() {
+        hz = createHazelcastInstance();
+        opService = getOperationService(hz);
+    }
+
+    @Test
+    public void whenMayInterruptIfRunning_thenIgnore() throws Exception {
+        ICompletableFuture f = invoke();
+
+        boolean result = f.cancel(false);
+
+        assertFalse(result);
+        assertFalse(f.isCancelled());
+        assertFalse(f.isDone());
+        // we need to make sure that the future is still running.
+        assertEquals(RESULT, f.get());
+    }
+
+    @Test
+    public void whenMayNotInterruptIfRunning_thenIgnore() throws Exception {
+        ICompletableFuture f = invoke();
+
+        boolean result = f.cancel(true);
+
+        assertFalse(result);
+        assertFalse(f.isCancelled());
+        assertFalse(f.isDone());
+        assertEquals(RESULT, f.get());
+    }
+
+    private InternalCompletableFuture invoke() {
+        Operation op = new AbstractOperation() {
+            @Override
+            public void run() throws Exception {
+                sleepMillis(1000);
+            }
+
+            @Override
+            public Object getResponse() {
+                return RESULT;
+            }
+        };
+        return opService.invokeOnPartition(null, op, 0);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationFuture_GetNewInstanceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationFuture_GetNewInstanceTest.java
@@ -35,7 +35,7 @@ import org.junit.runner.RunWith;
  */
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class InvocationFutureGetNewInstanceTest extends HazelcastTestSupport {
+public class InvocationFuture_GetNewInstanceTest extends HazelcastTestSupport {
 
     private HazelcastInstance[] instances;
     private HazelcastInstance local;

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationFuture_IsDoneTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationFuture_IsDoneTest.java
@@ -1,10 +1,8 @@
 package com.hazelcast.spi.impl.operationservice.impl;
 
-import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.spi.InternalCompletableFuture;
 import com.hazelcast.spi.impl.operationservice.InternalOperationService;
-import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
@@ -18,14 +16,10 @@ import java.util.concurrent.ExecutionException;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.isNull;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class InvocationFutureTest extends HazelcastTestSupport {
+public class InvocationFuture_IsDoneTest extends HazelcastTestSupport {
 
     private HazelcastInstance local;
     private InternalOperationService operationService;
@@ -37,7 +31,7 @@ public class InvocationFutureTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void isDone_whenNullResponse() throws ExecutionException, InterruptedException {
+    public void whenNullResponse() throws ExecutionException, InterruptedException {
         DummyOperation op = new DummyOperation(null);
 
         InternalCompletableFuture future = operationService.invokeOnTarget(null, op, getAddress(local));
@@ -47,7 +41,7 @@ public class InvocationFutureTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void isDone_whenWaitResponse() {
+    public void whenWaitResponse() {
         DummyOperation op = new GetLostPartitionOperation();
 
         InvocationFuture future = (InvocationFuture) operationService.invokeOnTarget(null, op, getAddress(local));
@@ -57,7 +51,7 @@ public class InvocationFutureTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void isDone_whenInterruptedResponse() {
+    public void whenInterruptedResponse() {
         DummyOperation op = new GetLostPartitionOperation();
 
         InvocationFuture future = (InvocationFuture) operationService.invokeOnTarget(null, op, getAddress(local));
@@ -67,7 +61,7 @@ public class InvocationFutureTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void isDone_whenTimeoutResponse() {
+    public void whenTimeoutResponse() {
         DummyOperation op = new GetLostPartitionOperation();
 
         InvocationFuture future = (InvocationFuture) operationService.invokeOnTarget(null, op, getAddress(local));
@@ -94,24 +88,6 @@ public class InvocationFutureTest extends HazelcastTestSupport {
         assertTrue(future.isDone());
     }
 
-    // There is a bug: https://github.com/hazelcast/hazelcast/issues/5001
-    @Test
-    public void andThen_whenNullResponse_thenCallbackExecuted() throws ExecutionException, InterruptedException {
-        DummyOperation op = new DummyOperation(null);
-        final ExecutionCallback callback = mock(ExecutionCallback.class);
-        InternalCompletableFuture future = operationService.invokeOnTarget(null, op, getAddress(local));
-        future.get();
-
-        // Callback can be completed immediately since a response (NULL_RESPONSE) has been already set.
-        future.andThen(callback);
-
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run() throws Exception {
-                verify(callback, times(1)).onResponse(isNull());
-            }
-        });
-    }
 
     // Needed to have an invocation and this is the easiest way how to get one and do not bother with its result.
     private static class GetLostPartitionOperation extends DummyOperation {

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_InitInvocationTargetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_InitInvocationTargetTest.java
@@ -10,7 +10,7 @@ import org.junit.runner.RunWith;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class Invocation_initInvocationTargetTest {
+public class Invocation_InitInvocationTargetTest {
 
     @Test
     @Ignore//todo: needs to be implemented.

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_NestedLocalTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_NestedLocalTest.java
@@ -1,6 +1,8 @@
 package com.hazelcast.spi.impl.operationservice.impl;
 
+import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.spi.InternalCompletableFuture;
 import com.hazelcast.spi.OperationService;
 import com.hazelcast.test.HazelcastParallelClassRunner;
@@ -15,11 +17,10 @@ import org.junit.runner.RunWith;
 import java.util.concurrent.ExecutionException;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class InvocationNestedRemoteTest extends InvocationNestedTest {
+public class Invocation_NestedLocalTest extends Invocation_NestedTest {
 
     private static final String RESPONSE = "someresponse";
 
@@ -28,8 +29,7 @@ public class InvocationNestedRemoteTest extends InvocationNestedTest {
 
     @Test
     public void invokeOnPartition_outerGeneric_innerGeneric_forbidden() {
-        HazelcastInstance[] cluster = createHazelcastInstanceFactory(1).newInstances();
-        HazelcastInstance local = cluster[0];
+        HazelcastInstance local = createHazelcastInstance();
         OperationService operationService = getOperationService(local);
 
         InnerOperation innerOperation = new InnerOperation(RESPONSE, GENERIC_OPERATION);
@@ -40,27 +40,23 @@ public class InvocationNestedRemoteTest extends InvocationNestedTest {
     }
 
     @Test
-    public void invokeOnPartition_outerRemote_innerGeneric() {
-        HazelcastInstance[] cluster = createHazelcastInstanceFactory(2).newInstances();
-        HazelcastInstance local = cluster[0];
-        HazelcastInstance remote = cluster[1];
+    public void invokeOnPartition_outerLocal_innerGeneric() {
+        HazelcastInstance local = createHazelcastInstance();
         OperationService operationService = getOperationService(local);
 
         InnerOperation innerOperation = new InnerOperation(RESPONSE, GENERIC_OPERATION);
-        OuterOperation outerOperation = new OuterOperation(innerOperation, getPartitionId(remote));
+        OuterOperation outerOperation = new OuterOperation(innerOperation, getPartitionId(local));
         InternalCompletableFuture f = operationService.invokeOnPartition(null, outerOperation, outerOperation.getPartitionId());
 
         assertEquals(RESPONSE, f.getSafely());
     }
 
     @Test
-    public void invokeOnPartition_outerRemote_innerSameInstance_samePartition() {
-        HazelcastInstance[] cluster = createHazelcastInstanceFactory(2).newInstances();
-        HazelcastInstance local = cluster[0];
-        HazelcastInstance remote = cluster[1];
+    public void invokeOnPartition_outerLocal_innerSameInstance_samePartition() {
+        HazelcastInstance local = createHazelcastInstance();
         OperationService operationService = getOperationService(local);
 
-        int partitionId = getPartitionId(remote);
+        int partitionId = getPartitionId(local);
         InnerOperation innerOperation = new InnerOperation(RESPONSE, partitionId);
         OuterOperation outerOperation = new OuterOperation(innerOperation, partitionId);
         InternalCompletableFuture f = operationService.invokeOnPartition(null, outerOperation, outerOperation.getPartitionId());
@@ -69,52 +65,31 @@ public class InvocationNestedRemoteTest extends InvocationNestedTest {
     }
 
     @Test
-    public void invokeOnPartition_outerRemote_innerSameInstance_callsDifferentPartition_mappedToSameThread() throws ExecutionException, InterruptedException {
-        HazelcastInstance[] cluster = createHazelcastInstanceFactory(2).newInstances();
-        HazelcastInstance local = cluster[0];
-        HazelcastInstance remote = cluster[1];
-        OperationService operationService = getOperationService(local);
-
-        int outerPartitionId = getPartitionId(remote);
-        int innerPartitionId = randomPartitionIdMappedToSameThreadAsGivenPartitionIdOnInstance(outerPartitionId, remote, operationService);
-        InnerOperation innerOperation = new InnerOperation(RESPONSE, innerPartitionId);
-        OuterOperation outerOperation = new OuterOperation(innerOperation, outerPartitionId);
-        InternalCompletableFuture f = operationService.invokeOnPartition(null, outerOperation, outerOperation.getPartitionId());
-
-        expected.expect(IllegalThreadStateException.class);
-        expected.expectMessage("cannot make remote call");
-        f.getSafely();
-    }
-
-    @Test
-    public void invokeOnPartition_outerRemote_innerDifferentInstance_forbidden() {
-        HazelcastInstance[] cluster = createHazelcastInstanceFactory(2).newInstances();
-        HazelcastInstance local = cluster[0];
-        HazelcastInstance remote = cluster[1];
-        OperationService operationService = getOperationService(local);
-
-        int outerPartitionId = getPartitionId(remote);
-        int innerPartitionId = getPartitionId(local);
-        assertNotEquals("partitions should be different", innerPartitionId, outerPartitionId);
-        InnerOperation innerOperation = new InnerOperation(RESPONSE, innerPartitionId);
-        OuterOperation outerOperation = new OuterOperation(innerOperation, outerPartitionId);
-        InternalCompletableFuture f = operationService.invokeOnPartition(null, outerOperation, outerOperation.getPartitionId());
-
-        expected.expect(IllegalThreadStateException.class);
-        expected.expectMessage("cannot make remote call");
-        f.getSafely();
-    }
-
-    @Test
-    public void invokeOnPartition_outerLocal_innerDifferentInstance_forbidden() {
-        HazelcastInstance[] cluster = createHazelcastInstanceFactory(2).newInstances();
-        HazelcastInstance local = cluster[0];
-        HazelcastInstance remote = cluster[1];
+    public void invokeOnPartition_outerLocal_innerSameInstance_callsDifferentPartition() {
+        HazelcastInstance local = createHazelcastInstance();
         OperationService operationService = getOperationService(local);
 
         int outerPartitionId = getPartitionId(local);
-        int innerPartitionId = getPartitionId(remote);
-        assertNotEquals("partitions should be different", innerPartitionId, outerPartitionId);
+        int innerPartitionId = randomPartitionIdNotMappedToSameThreadAsGivenPartitionIdOnInstance(local, outerPartitionId);
+        InnerOperation innerOperation = new InnerOperation(RESPONSE, innerPartitionId);
+        OuterOperation outerOperation = new OuterOperation(innerOperation, outerPartitionId);
+        InternalCompletableFuture f = operationService.invokeOnPartition(null, outerOperation, outerOperation.getPartitionId());
+
+        expected.expect(IllegalThreadStateException.class);
+        expected.expectMessage("cannot make remote call");
+        f.getSafely();
+    }
+
+    @Test
+    public void invokeOnPartition_outerLocal_innerSameInstance_callsDifferentPartition_mappedToSameThread() throws Exception {
+        Config config = new Config();
+        config.setProperty(GroupProperty.PARTITION_COUNT, "2");
+        config.setProperty(GroupProperty.PARTITION_OPERATION_THREAD_COUNT, "1");
+        HazelcastInstance local = createHazelcastInstance(config);
+        final OperationService operationService = getOperationService(local);
+
+        int outerPartitionId = 1;
+        int innerPartitionId = 0;
         InnerOperation innerOperation = new InnerOperation(RESPONSE, innerPartitionId);
         OuterOperation outerOperation = new OuterOperation(innerOperation, outerPartitionId);
         InternalCompletableFuture f = operationService.invokeOnPartition(null, outerOperation, outerOperation.getPartitionId());
@@ -126,28 +101,25 @@ public class InvocationNestedRemoteTest extends InvocationNestedTest {
 
     @Test
     public void invokeOnTarget_outerGeneric_innerGeneric() {
-        HazelcastInstance[] cluster = createHazelcastInstanceFactory(2).newInstances();
-        HazelcastInstance local = cluster[0];
-        HazelcastInstance remote = cluster[1];
+        HazelcastInstance local = createHazelcastInstance();
         OperationService operationService = getOperationService(local);
 
         InnerOperation innerOperation = new InnerOperation(RESPONSE, GENERIC_OPERATION);
         OuterOperation outerOperation = new OuterOperation(innerOperation, GENERIC_OPERATION);
-        InternalCompletableFuture f = operationService.invokeOnTarget(null, outerOperation, getAddress(remote));
+        InternalCompletableFuture f = operationService.invokeOnTarget(null, outerOperation, getAddress(local));
 
         assertEquals(RESPONSE, f.getSafely());
     }
 
     @Test
     public void invokeOnTarget_outerGeneric_innerSameInstance() {
-        HazelcastInstance[] cluster = createHazelcastInstanceFactory(2).newInstances();
-        HazelcastInstance local = cluster[0];
-        HazelcastInstance remote = cluster[1];
+        HazelcastInstance local = createHazelcastInstance();
         OperationService operationService = getOperationService(local);
 
-        InnerOperation innerOperation = new InnerOperation(RESPONSE, 0);
+        int innerPartitionId = getPartitionId(local);
+        InnerOperation innerOperation = new InnerOperation(RESPONSE, innerPartitionId);
         OuterOperation outerOperation = new OuterOperation(innerOperation, GENERIC_OPERATION);
-        InternalCompletableFuture f = operationService.invokeOnTarget(null, outerOperation, getAddress(remote));
+        InternalCompletableFuture f = operationService.invokeOnTarget(null, outerOperation, getAddress(local));
 
         assertEquals(RESPONSE, f.getSafely());
     }

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_NestedTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_NestedTest.java
@@ -12,7 +12,7 @@ import com.hazelcast.test.HazelcastTestSupport;
 
 import java.io.IOException;
 
-public abstract class InvocationNestedTest extends HazelcastTestSupport {
+public abstract class Invocation_NestedTest extends HazelcastTestSupport {
 
     protected static final int GENERIC_OPERATION = -1;
 
@@ -102,7 +102,8 @@ public abstract class InvocationNestedTest extends HazelcastTestSupport {
         }
     }
 
-    protected static int randomPartitionIdNotMappedToSameThreadAsGivenPartitionIdOnInstance(HazelcastInstance hz, int givenPartitionId) {
+    protected static int randomPartitionIdNotMappedToSameThreadAsGivenPartitionIdOnInstance(
+            HazelcastInstance hz, int givenPartitionId) {
         int resultPartitionId;
         for (resultPartitionId = 0; resultPartitionId < hz.getPartitionService().getPartitions().size(); resultPartitionId++) {
             if (resultPartitionId == givenPartitionId) {
@@ -118,7 +119,8 @@ public abstract class InvocationNestedTest extends HazelcastTestSupport {
         return resultPartitionId;
     }
 
-    protected static int randomPartitionIdMappedToSameThreadAsGivenPartitionIdOnInstance(int givenPartitionId, HazelcastInstance instance, OperationService operationService) {
+    protected static int randomPartitionIdMappedToSameThreadAsGivenPartitionIdOnInstance(
+            int givenPartitionId, HazelcastInstance instance, OperationService operationService) {
         int resultPartitionId = 0;
         for (; resultPartitionId < instance.getPartitionService().getPartitions().size(); resultPartitionId++) {
             if (resultPartitionId == givenPartitionId) {

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_NetworkSplitTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_NetworkSplitTest.java
@@ -54,7 +54,7 @@ import static org.junit.Assert.fail;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class InvocationNetworkSplitTest extends HazelcastTestSupport {
+public class Invocation_NetworkSplitTest extends HazelcastTestSupport {
 
     @Test
     public void testWaitingInvocations_whenNodeSplitFromCluster() throws Exception {

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_RegressionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_RegressionTest.java
@@ -21,7 +21,7 @@ import java.util.concurrent.Future;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class InvocationRegressionTest extends HazelcastTestSupport {
+public class Invocation_RegressionTest extends HazelcastTestSupport {
     @Test(expected = ExecutionException.class, timeout = 120000)
     public void testIssue2509() throws Exception {
 

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_RetryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_RetryTest.java
@@ -23,7 +23,7 @@ import static org.junit.Assert.fail;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class InvocationRetryTest extends HazelcastTestSupport {
+public class Invocation_RetryTest extends HazelcastTestSupport {
 
     @Test
     public void whenPartitionTargetMemberDiesThenOperationSendToNewPartitionOwner() throws Exception {

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_TimeoutTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_TimeoutTest.java
@@ -48,7 +48,7 @@ import static org.junit.Assert.fail;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class InvocationTimeoutTest extends HazelcastTestSupport {
+public class Invocation_TimeoutTest extends HazelcastTestSupport {
 
     @Test
     public void testInterruptionDuringBlockingOp1() throws InterruptedException {

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl_asyncInvokeOnPartitionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl_asyncInvokeOnPartitionTest.java
@@ -27,7 +27,7 @@ import java.util.concurrent.CountDownLatch;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class AsyncInvocationTest extends HazelcastTestSupport {
+public class OperationServiceImpl_asyncInvokeOnPartitionTest extends HazelcastTestSupport {
 
     @Test
     public void testAsyncInvocation_SamePartitionThread_DifferentPartition() {


### PR DESCRIPTION
Mostly test class renaming to make grouping them a lot easier.

Also split of one test into its own testfile.