### PR TITLE
Rename of FieldUpdater fields

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheStatisticsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheStatisticsImpl.java
@@ -37,23 +37,23 @@ public class CacheStatisticsImpl
     private static final float FLOAT_HUNDRED = 100.0f;
     private static final long NANOSECONDS_IN_A_MICROSECOND = 1000L;
 
-    private static final AtomicLongFieldUpdater<CacheStatisticsImpl> REMOVALS_UPDATER =
+    private static final AtomicLongFieldUpdater<CacheStatisticsImpl> REMOVALS =
             AtomicLongFieldUpdater.newUpdater(CacheStatisticsImpl.class, "removals");
-    private static final AtomicLongFieldUpdater<CacheStatisticsImpl> EXPIRIES_UPDATER =
+    private static final AtomicLongFieldUpdater<CacheStatisticsImpl> EXPIRIES =
             AtomicLongFieldUpdater.newUpdater(CacheStatisticsImpl.class, "expiries");
-    private static final AtomicLongFieldUpdater<CacheStatisticsImpl> PUTS_UPDATER =
+    private static final AtomicLongFieldUpdater<CacheStatisticsImpl> PUTS =
             AtomicLongFieldUpdater.newUpdater(CacheStatisticsImpl.class, "puts");
-    private static final AtomicLongFieldUpdater<CacheStatisticsImpl> HITS_UPDATER =
+    private static final AtomicLongFieldUpdater<CacheStatisticsImpl> HITS =
             AtomicLongFieldUpdater.newUpdater(CacheStatisticsImpl.class, "hits");
-    private static final AtomicLongFieldUpdater<CacheStatisticsImpl> MISSES_UPDATER =
+    private static final AtomicLongFieldUpdater<CacheStatisticsImpl> MISSES =
             AtomicLongFieldUpdater.newUpdater(CacheStatisticsImpl.class, "misses");
-    private static final AtomicLongFieldUpdater<CacheStatisticsImpl> EVICTIONS_UPDATER =
+    private static final AtomicLongFieldUpdater<CacheStatisticsImpl> EVICTIONS =
             AtomicLongFieldUpdater.newUpdater(CacheStatisticsImpl.class, "evictions");
-    private static final AtomicLongFieldUpdater<CacheStatisticsImpl> PUT_TIME_TAKEN_NANOS_UPDATER =
+    private static final AtomicLongFieldUpdater<CacheStatisticsImpl> PUT_TIME_TAKEN_NANOS =
             AtomicLongFieldUpdater.newUpdater(CacheStatisticsImpl.class, "putTimeTakenNanos");
-    private static final AtomicLongFieldUpdater<CacheStatisticsImpl> GET_CACHE_TIME_TAKEN_NANOS_UPDATER =
+    private static final AtomicLongFieldUpdater<CacheStatisticsImpl> GET_CACHE_TIME_TAKEN_NANOS =
             AtomicLongFieldUpdater.newUpdater(CacheStatisticsImpl.class, "getCacheTimeTakenNanos");
-    private static final AtomicLongFieldUpdater<CacheStatisticsImpl> REMOVE_TIME_TAKEN_NANOS_UPDATER =
+    private static final AtomicLongFieldUpdater<CacheStatisticsImpl> REMOVE_TIME_TAKEN_NANOS =
             AtomicLongFieldUpdater.newUpdater(CacheStatisticsImpl.class, "removeTimeTakenNanos");
 
     private volatile long removals;
@@ -195,7 +195,7 @@ public class CacheStatisticsImpl
      * @param number the number by which the counter is increased.
      */
     public void increaseCacheRemovals(long number) {
-        REMOVALS_UPDATER.addAndGet(this, number);
+        REMOVALS.addAndGet(this, number);
     }
 
     /**
@@ -204,7 +204,7 @@ public class CacheStatisticsImpl
      * @param number the number by which the counter is increased.
      */
     public void increaseCacheExpiries(long number) {
-        EXPIRIES_UPDATER.addAndGet(this, number);
+        EXPIRIES.addAndGet(this, number);
     }
 
     /**
@@ -213,7 +213,7 @@ public class CacheStatisticsImpl
      * @param number the number by which the counter is increased.
      */
     public void increaseCachePuts(long number) {
-        PUTS_UPDATER.addAndGet(this, number);
+        PUTS.addAndGet(this, number);
     }
 
     /**
@@ -222,7 +222,7 @@ public class CacheStatisticsImpl
      * @param number the number by which the counter is increased.
      */
     public void increaseCacheHits(long number) {
-        HITS_UPDATER.addAndGet(this, number);
+        HITS.addAndGet(this, number);
     }
 
     /**
@@ -231,7 +231,7 @@ public class CacheStatisticsImpl
      * @param number the number by which the counter is increased.
      */
     public void increaseCacheMisses(long number) {
-        MISSES_UPDATER.addAndGet(this, number);
+        MISSES.addAndGet(this, number);
     }
 
     /**
@@ -240,7 +240,7 @@ public class CacheStatisticsImpl
      * @param number the number by which the counter is increased.
      */
     public void increaseCacheEvictions(long number) {
-        EVICTIONS_UPDATER.addAndGet(this, number);
+        EVICTIONS.addAndGet(this, number);
     }
 
     /**
@@ -252,12 +252,12 @@ public class CacheStatisticsImpl
         for (;;) {
             long nanos = getCacheTimeTakenNanos;
             if (nanos <= Long.MAX_VALUE - duration) {
-                if (GET_CACHE_TIME_TAKEN_NANOS_UPDATER.compareAndSet(this, nanos, nanos + duration)) {
+                if (GET_CACHE_TIME_TAKEN_NANOS.compareAndSet(this, nanos, nanos + duration)) {
                     return;
                 }
             } else {
                 //counter full. Just reset.
-                if (GET_CACHE_TIME_TAKEN_NANOS_UPDATER.compareAndSet(this, nanos, duration)) {
+                if (GET_CACHE_TIME_TAKEN_NANOS.compareAndSet(this, nanos, duration)) {
                     clear();
                     return;
                 }
@@ -274,12 +274,12 @@ public class CacheStatisticsImpl
         for (;;) {
             long nanos = putTimeTakenNanos;
             if (nanos <= Long.MAX_VALUE - duration) {
-                if (PUT_TIME_TAKEN_NANOS_UPDATER.compareAndSet(this, nanos, nanos + duration)) {
+                if (PUT_TIME_TAKEN_NANOS.compareAndSet(this, nanos, nanos + duration)) {
                     return;
                 }
             } else {
                 //counter full. Just reset.
-                if (PUT_TIME_TAKEN_NANOS_UPDATER.compareAndSet(this, nanos, duration)) {
+                if (PUT_TIME_TAKEN_NANOS.compareAndSet(this, nanos, duration)) {
                     clear();
                     return;
                 }
@@ -296,12 +296,12 @@ public class CacheStatisticsImpl
         for (;;) {
             long nanos = removeTimeTakenNanos;
             if (nanos <= Long.MAX_VALUE - duration) {
-                if (REMOVE_TIME_TAKEN_NANOS_UPDATER.compareAndSet(this, nanos, nanos + duration)) {
+                if (REMOVE_TIME_TAKEN_NANOS.compareAndSet(this, nanos, nanos + duration)) {
                     return;
                 }
             } else {
                 //counter full. Just reset.
-                if (REMOVE_TIME_TAKEN_NANOS_UPDATER.compareAndSet(this, nanos, duration)) {
+                if (REMOVE_TIME_TAKEN_NANOS.compareAndSet(this, nanos, duration)) {
                     clear();
                     return;
                 }
@@ -317,15 +317,15 @@ public class CacheStatisticsImpl
      * @return CacheStatisticsImpl with merged data.
      */
     public CacheStatisticsImpl accumulate(CacheStatisticsImpl other) {
-        PUTS_UPDATER.addAndGet(this, other.getCachePuts());
-        REMOVALS_UPDATER.addAndGet(this, other.getCacheRemovals());
-        EXPIRIES_UPDATER.addAndGet(this, other.getCacheExpiries());
-        EVICTIONS_UPDATER.addAndGet(this, other.getCacheEvictions());
-        HITS_UPDATER.addAndGet(this, other.getCacheHits());
-        MISSES_UPDATER.addAndGet(this, other.getCacheMisses());
-        PUT_TIME_TAKEN_NANOS_UPDATER.addAndGet(this, other.getCachePutTimeTakenNanos());
-        GET_CACHE_TIME_TAKEN_NANOS_UPDATER.addAndGet(this, other.getCacheGetTimeTakenNanos());
-        REMOVE_TIME_TAKEN_NANOS_UPDATER.addAndGet(this, other.getCacheRemoveTimeTakenNanos());
+        PUTS.addAndGet(this, other.getCachePuts());
+        REMOVALS.addAndGet(this, other.getCacheRemovals());
+        EXPIRIES.addAndGet(this, other.getCacheExpiries());
+        EVICTIONS.addAndGet(this, other.getCacheEvictions());
+        HITS.addAndGet(this, other.getCacheHits());
+        MISSES.addAndGet(this, other.getCacheMisses());
+        PUT_TIME_TAKEN_NANOS.addAndGet(this, other.getCachePutTimeTakenNanos());
+        GET_CACHE_TIME_TAKEN_NANOS.addAndGet(this, other.getCacheGetTimeTakenNanos());
+        REMOVE_TIME_TAKEN_NANOS.addAndGet(this, other.getCacheRemoveTimeTakenNanos());
         return this;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/nearcache/impl/record/AbstractNearCacheRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/nearcache/impl/record/AbstractNearCacheRecord.java
@@ -28,7 +28,7 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
  */
 public abstract class AbstractNearCacheRecord<V> implements NearCacheRecord<V> {
 
-    private static final AtomicIntegerFieldUpdater<AbstractNearCacheRecord> ACCESS_HIT_UPDATER =
+    private static final AtomicIntegerFieldUpdater<AbstractNearCacheRecord> ACCESS_HIT =
             AtomicIntegerFieldUpdater.newUpdater(AbstractNearCacheRecord.class, "accessHit");
 
     protected V value;
@@ -90,17 +90,17 @@ public abstract class AbstractNearCacheRecord<V> implements NearCacheRecord<V> {
 
     @Override
     public void setAccessHit(int accessHit) {
-        ACCESS_HIT_UPDATER.set(this, accessHit);
+        ACCESS_HIT.set(this, accessHit);
     }
 
     @Override
     public void incrementAccessHit() {
-        ACCESS_HIT_UPDATER.addAndGet(this, 1);
+        ACCESS_HIT.addAndGet(this, 1);
     }
 
     @Override
     public void resetAccessHit() {
-        ACCESS_HIT_UPDATER.set(this, 0);
+        ACCESS_HIT.set(this, 0);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/executor/impl/DistributedExecutorService.java
+++ b/hazelcast/src/main/java/com/hazelcast/executor/impl/DistributedExecutorService.java
@@ -51,7 +51,7 @@ public class DistributedExecutorService implements ManagedService, RemoteService
 
     //Updates the CallableProcessor.responseFlag field. An AtomicBoolean is simpler, but creates another unwanted
     //object. Using this approach, you don't create that object.
-    private static final AtomicReferenceFieldUpdater<CallableProcessor, Boolean> RESPONSE_FLAG_FIELD_UPDATER =
+    private static final AtomicReferenceFieldUpdater<CallableProcessor, Boolean> RESPONSE_FLAG =
             AtomicReferenceFieldUpdater.newUpdater(CallableProcessor.class, Boolean.class, "responseFlag");
 
     private NodeEngine nodeEngine;
@@ -174,7 +174,7 @@ public class DistributedExecutorService implements ManagedService, RemoteService
     }
 
     private final class CallableProcessor extends FutureTask implements Runnable {
-        //is being used through the RESPONSE_FLAG_FIELD_UPDATER. Can't be private due to reflection constraint.
+        //is being used through the RESPONSE_FLAG. Can't be private due to reflection constraint.
         volatile Boolean responseFlag = Boolean.FALSE;
 
         private final String name;
@@ -223,7 +223,7 @@ public class DistributedExecutorService implements ManagedService, RemoteService
         }
 
         private void sendResponse(Object result) {
-            if (RESPONSE_FLAG_FIELD_UPDATER.compareAndSet(this, Boolean.FALSE, Boolean.TRUE)) {
+            if (RESPONSE_FLAG.compareAndSet(this, Boolean.FALSE, Boolean.TRUE)) {
                 op.sendResponse(result);
             }
         }

--- a/hazelcast/src/main/java/com/hazelcast/executor/impl/ExecutionCallbackAdapterFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/executor/impl/ExecutionCallbackAdapterFactory.java
@@ -29,11 +29,14 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 
+import static java.lang.Boolean.FALSE;
+import static java.lang.Boolean.TRUE;
+
 class ExecutionCallbackAdapterFactory {
 
     //Updates the ExecutionCallbackAdapterFactory.done field. An AtomicBoolean is simpler, but creates another unwanted
     //object. Using this approach, you don't create that object.
-    private static final AtomicReferenceFieldUpdater<ExecutionCallbackAdapterFactory, Boolean> DONE_FIELD_UPDATER =
+    private static final AtomicReferenceFieldUpdater<ExecutionCallbackAdapterFactory, Boolean> DONE =
             AtomicReferenceFieldUpdater.newUpdater(ExecutionCallbackAdapterFactory.class, Boolean.class, "done");
 
     private final MultiExecutionCallback multiExecutionCallback;
@@ -41,7 +44,7 @@ class ExecutionCallbackAdapterFactory {
     private final Collection<Member> members;
     private final ILogger logger;
     @SuppressWarnings("CanBeFinal")
-    private volatile Boolean done = Boolean.FALSE;
+    private volatile Boolean done = FALSE;
 
     ExecutionCallbackAdapterFactory(ILogger logger, Collection<Member> members,
                                     MultiExecutionCallback multiExecutionCallback) {
@@ -74,7 +77,7 @@ class ExecutionCallbackAdapterFactory {
     }
 
     private boolean setDone() {
-        return DONE_FIELD_UPDATER.compareAndSet(this, Boolean.FALSE, Boolean.TRUE);
+        return DONE.compareAndSet(this, FALSE, TRUE);
     }
 
     private void triggerOnResponse(Member member, Object response) {

--- a/hazelcast/src/main/java/com/hazelcast/executor/impl/ExecutorServiceProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/executor/impl/ExecutorServiceProxy.java
@@ -71,7 +71,7 @@ public class ExecutorServiceProxy
     public static final int SYNC_FREQUENCY = 100;
     public static final int SYNC_DELAY_MS = 10;
 
-    private static final AtomicIntegerFieldUpdater<ExecutorServiceProxy> CONSECUTIVE_SUBMITS_UPDATER = AtomicIntegerFieldUpdater
+    private static final AtomicIntegerFieldUpdater<ExecutorServiceProxy> CONSECUTIVE_SUBMITS = AtomicIntegerFieldUpdater
             .newUpdater(ExecutorServiceProxy.class, "consecutiveSubmits");
 
     private static final ExceptionHandler WHILE_SHUTDOWN_EXCEPTION_HANDLER =
@@ -82,7 +82,7 @@ public class ExecutorServiceProxy
     private final int partitionCount;
     private final ILogger logger;
 
-    // This field is never accessed directly but by the CONSECUTIVE_SUBMITS_UPDATER above
+    // This field is never accessed directly but by the CONSECUTIVE_SUBMITS above
     private volatile int consecutiveSubmits;
 
     private volatile long lastSubmitTime;
@@ -264,8 +264,8 @@ public class ExecutorServiceProxy
         long last = lastSubmitTime;
         long now = Clock.currentTimeMillis();
         if (last + SYNC_DELAY_MS < now) {
-            CONSECUTIVE_SUBMITS_UPDATER.set(this, 0);
-        } else if (CONSECUTIVE_SUBMITS_UPDATER.incrementAndGet(this) % SYNC_FREQUENCY == 0) {
+            CONSECUTIVE_SUBMITS.set(this, 0);
+        } else if (CONSECUTIVE_SUBMITS.incrementAndGet(this) % SYNC_FREQUENCY == 0) {
             sync = true;
         }
         lastSubmitTime = now;

--- a/hazelcast/src/main/java/com/hazelcast/instance/Node.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/Node.java
@@ -72,7 +72,7 @@ import static com.hazelcast.util.UuidUtil.createMemberUuid;
 
 public class Node {
 
-    private static final AtomicReferenceFieldUpdater<Node, NodeState> NODE_STATE_UPDATER
+    private static final AtomicReferenceFieldUpdater<Node, NodeState> STATE
             = AtomicReferenceFieldUpdater.newUpdater(Node.class, NodeState.class, "state");
 
     private final ILogger logger;
@@ -317,7 +317,7 @@ public class Node {
             logger.finest("We are being asked to shutdown when state = " + state);
         }
 
-        if (!NODE_STATE_UPDATER.compareAndSet(this, NodeState.ACTIVE, NodeState.SHUTTING_DOWN)) {
+        if (!STATE.compareAndSet(this, NodeState.ACTIVE, NodeState.SHUTTING_DOWN)) {
             waitIfAlreadyShuttingDown();
             return;
         }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/NearCacheSizeEstimator.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/NearCacheSizeEstimator.java
@@ -26,7 +26,7 @@ import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 public class NearCacheSizeEstimator
         implements SizeEstimator<NearCacheRecord> {
 
-    private static final AtomicLongFieldUpdater<NearCacheSizeEstimator> SIZE_UPDATER = AtomicLongFieldUpdater
+    private static final AtomicLongFieldUpdater<NearCacheSizeEstimator> SIZE = AtomicLongFieldUpdater
             .newUpdater(NearCacheSizeEstimator.class, "size");
 
     private volatile long size;
@@ -61,11 +61,11 @@ public class NearCacheSizeEstimator
 
     @Override
     public void add(long size) {
-        SIZE_UPDATER.addAndGet(this, size);
+        SIZE.addAndGet(this, size);
     }
 
     @Override
     public void reset() {
-        SIZE_UPDATER.set(this, 0L);
+        SIZE.set(this, 0L);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/DefaultContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/DefaultContext.java
@@ -44,7 +44,7 @@ import static com.hazelcast.util.ConcurrentReferenceHashMap.ReferenceType.STRONG
 public class DefaultContext<KeyIn, ValueIn>
         implements Context<KeyIn, ValueIn> {
 
-    private static final AtomicIntegerFieldUpdater<DefaultContext> COLLECTED_UPDATER = AtomicIntegerFieldUpdater
+    private static final AtomicIntegerFieldUpdater<DefaultContext> COLLECTED = AtomicIntegerFieldUpdater
             .newUpdater(DefaultContext.class, "collected");
     private final IConcurrentMap<KeyIn, Combiner<ValueIn, ?>> combiners =
             new ConcurrentReferenceHashMap<KeyIn, Combiner<ValueIn, ?>>(STRONG, STRONG);
@@ -79,7 +79,7 @@ public class DefaultContext<KeyIn, ValueIn>
     public void emit(KeyIn key, ValueIn value) {
         Combiner<ValueIn, ?> combiner = getOrCreateCombiner(key);
         combiner.combine(value);
-        COLLECTED_UPDATER.incrementAndGet(this);
+        COLLECTED.incrementAndGet(this);
         mapCombineTask.onEmit(this, partitionId);
     }
 
@@ -95,7 +95,7 @@ public class DefaultContext<KeyIn, ValueIn>
                 chunkMap.put(entry.getKey(), chunk);
             }
         }
-        COLLECTED_UPDATER.set(this, 0);
+        COLLECTED.set(this, 0);
         return chunkMap;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/JobProcessInformationImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/JobProcessInformationImpl.java
@@ -36,9 +36,9 @@ public class JobProcessInformationImpl
         implements JobProcessInformation {
 
     private static final AtomicReferenceFieldUpdater<JobProcessInformationImpl, JobPartitionState[]>
-            PARTITION_STATE_UPDATER = AtomicReferenceFieldUpdater.newUpdater(JobProcessInformationImpl.class,
+            PARTITION_STATE = AtomicReferenceFieldUpdater.newUpdater(JobProcessInformationImpl.class,
             JobPartitionState[].class, "partitionStates");
-    private static final AtomicIntegerFieldUpdater<JobProcessInformationImpl> PROCESSED_RECORDS_UPDATER =
+    private static final AtomicIntegerFieldUpdater<JobProcessInformationImpl> PROCESSED_RECORDS =
             AtomicIntegerFieldUpdater.newUpdater(JobProcessInformationImpl.class, "processedRecords");
 
     private final JobSupervisor supervisor;
@@ -68,7 +68,7 @@ public class JobProcessInformationImpl
     }
 
     public void addProcessedRecords(int records) {
-        PROCESSED_RECORDS_UPDATER.addAndGet(this, records);
+        PROCESSED_RECORDS.addAndGet(this, records);
     }
 
     public void cancelPartitionState() {
@@ -114,7 +114,7 @@ public class JobProcessInformationImpl
         if (oldPartitionStates.length != newPartitionStates.length) {
             throw new IllegalArgumentException("partitionStates need to have same length");
         }
-        if (PARTITION_STATE_UPDATER.compareAndSet(this, oldPartitionStates, newPartitionStates)) {
+        if (PARTITION_STATE.compareAndSet(this, oldPartitionStates, newPartitionStates)) {
             supervisor.checkFullyProcessed(this);
             return true;
         }

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalExecutorStatsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalExecutorStatsImpl.java
@@ -26,17 +26,17 @@ import static com.hazelcast.util.JsonUtil.getLong;
 
 public class LocalExecutorStatsImpl implements LocalExecutorStats {
 
-    private static final AtomicLongFieldUpdater<LocalExecutorStatsImpl> PENDING_UPDATER = AtomicLongFieldUpdater
+    private static final AtomicLongFieldUpdater<LocalExecutorStatsImpl> PENDING = AtomicLongFieldUpdater
             .newUpdater(LocalExecutorStatsImpl.class, "pending");
-    private static final AtomicLongFieldUpdater<LocalExecutorStatsImpl> STARTED_UPDATER = AtomicLongFieldUpdater
+    private static final AtomicLongFieldUpdater<LocalExecutorStatsImpl> STARTED = AtomicLongFieldUpdater
             .newUpdater(LocalExecutorStatsImpl.class, "started");
-    private static final AtomicLongFieldUpdater<LocalExecutorStatsImpl> COMPLETED_UPDATER = AtomicLongFieldUpdater
+    private static final AtomicLongFieldUpdater<LocalExecutorStatsImpl> COMPLETED = AtomicLongFieldUpdater
             .newUpdater(LocalExecutorStatsImpl.class, "completed");
-    private static final AtomicLongFieldUpdater<LocalExecutorStatsImpl> CANCELLED_UPDATER = AtomicLongFieldUpdater
+    private static final AtomicLongFieldUpdater<LocalExecutorStatsImpl> CANCELLED = AtomicLongFieldUpdater
             .newUpdater(LocalExecutorStatsImpl.class, "cancelled");
-    private static final AtomicLongFieldUpdater<LocalExecutorStatsImpl> TOTAL_START_LATENCY_UPDATER = AtomicLongFieldUpdater
+    private static final AtomicLongFieldUpdater<LocalExecutorStatsImpl> TOTAL_START_LATENCY = AtomicLongFieldUpdater
             .newUpdater(LocalExecutorStatsImpl.class, "totalStartLatency");
-    private static final AtomicLongFieldUpdater<LocalExecutorStatsImpl> TOTAL_EXECUTION_TIME_UPDATER = AtomicLongFieldUpdater
+    private static final AtomicLongFieldUpdater<LocalExecutorStatsImpl> TOTAL_EXECUTION_TIME = AtomicLongFieldUpdater
             .newUpdater(LocalExecutorStatsImpl.class, "totalExecutionTime");
     private long creationTime;
 
@@ -53,26 +53,26 @@ public class LocalExecutorStatsImpl implements LocalExecutorStats {
     }
 
     public void startPending() {
-        PENDING_UPDATER.incrementAndGet(this);
+        PENDING.incrementAndGet(this);
     }
 
     public void startExecution(long elapsed) {
-        TOTAL_START_LATENCY_UPDATER.addAndGet(this, elapsed);
-        STARTED_UPDATER.incrementAndGet(this);
-        PENDING_UPDATER.decrementAndGet(this);
+        TOTAL_START_LATENCY.addAndGet(this, elapsed);
+        STARTED.incrementAndGet(this);
+        PENDING.decrementAndGet(this);
     }
 
     public void finishExecution(long elapsed) {
-        TOTAL_EXECUTION_TIME_UPDATER.addAndGet(this, elapsed);
-        COMPLETED_UPDATER.incrementAndGet(this);
+        TOTAL_EXECUTION_TIME.addAndGet(this, elapsed);
+        COMPLETED.incrementAndGet(this);
     }
 
     public void rejectExecution() {
-        PENDING_UPDATER.decrementAndGet(this);
+        PENDING.decrementAndGet(this);
     }
 
     public void cancelExecution() {
-        CANCELLED_UPDATER.incrementAndGet(this);
+        CANCELLED.incrementAndGet(this);
     }
 
     @Override
@@ -126,12 +126,12 @@ public class LocalExecutorStatsImpl implements LocalExecutorStats {
     @Override
     public void fromJson(JsonObject json) {
         creationTime = getLong(json, "creationTime", -1L);
-        PENDING_UPDATER.set(this, getLong(json, "pending", -1L));
-        STARTED_UPDATER.set(this, getLong(json, "started", -1L));
-        COMPLETED_UPDATER.set(this, getLong(json, "completed", -1L));
-        CANCELLED_UPDATER.set(this, getLong(json, "cancelled", -1L));
-        TOTAL_START_LATENCY_UPDATER.set(this, getLong(json, "totalStartLatency", -1L));
-        TOTAL_EXECUTION_TIME_UPDATER.set(this, getLong(json, "totalExecutionTime", -1L));
+        PENDING.set(this, getLong(json, "pending", -1L));
+        STARTED.set(this, getLong(json, "started", -1L));
+        COMPLETED.set(this, getLong(json, "completed", -1L));
+        CANCELLED.set(this, getLong(json, "cancelled", -1L));
+        TOTAL_START_LATENCY.set(this, getLong(json, "totalStartLatency", -1L));
+        TOTAL_EXECUTION_TIME.set(this, getLong(json, "totalExecutionTime", -1L));
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalMapStatsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalMapStatsImpl.java
@@ -25,38 +25,39 @@ import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 
 import static com.hazelcast.util.JsonUtil.getInt;
 import static com.hazelcast.util.JsonUtil.getLong;
+import static java.util.concurrent.atomic.AtomicLongFieldUpdater.newUpdater;
 
 /**
  * Default implementation of {@link LocalMapStats}
  */
 public class LocalMapStatsImpl implements LocalMapStats {
 
-    private static final AtomicLongFieldUpdater<LocalMapStatsImpl> LAST_ACCESS_TIME_UPDATER = AtomicLongFieldUpdater
-            .newUpdater(LocalMapStatsImpl.class, "lastAccessTime");
-    private static final AtomicLongFieldUpdater<LocalMapStatsImpl> LAST_UPDATE_TIME_UPDATER = AtomicLongFieldUpdater
-            .newUpdater(LocalMapStatsImpl.class, "lastUpdateTime");
-    private static final AtomicLongFieldUpdater<LocalMapStatsImpl> NUMBER_OF_OTHER_OPERATIONS_UPDATER = AtomicLongFieldUpdater
-            .newUpdater(LocalMapStatsImpl.class, "numberOfOtherOperations");
-    private static final AtomicLongFieldUpdater<LocalMapStatsImpl> NUMBER_OF_EVENTS_UPDATER = AtomicLongFieldUpdater
-            .newUpdater(LocalMapStatsImpl.class, "numberOfEvents");
-    private static final AtomicLongFieldUpdater<LocalMapStatsImpl> GET_COUNT_UPDATER = AtomicLongFieldUpdater
-            .newUpdater(LocalMapStatsImpl.class, "getCount");
-    private static final AtomicLongFieldUpdater<LocalMapStatsImpl> PUT_COUNT_UPDATER = AtomicLongFieldUpdater
-            .newUpdater(LocalMapStatsImpl.class, "putCount");
-    private static final AtomicLongFieldUpdater<LocalMapStatsImpl> REMOVE_COUNT_UPDATER = AtomicLongFieldUpdater
-            .newUpdater(LocalMapStatsImpl.class, "removeCount");
-    private static final AtomicLongFieldUpdater<LocalMapStatsImpl> TOTAL_GET_LATENCIES_UPDATER = AtomicLongFieldUpdater
-            .newUpdater(LocalMapStatsImpl.class, "totalGetLatencies");
-    private static final AtomicLongFieldUpdater<LocalMapStatsImpl> TOTAL_PUT_LATENCIES_UPDATER = AtomicLongFieldUpdater
-            .newUpdater(LocalMapStatsImpl.class, "totalPutLatencies");
-    private static final AtomicLongFieldUpdater<LocalMapStatsImpl> TOTAL_REMOVE_LATENCIES_UPDATER = AtomicLongFieldUpdater
-            .newUpdater(LocalMapStatsImpl.class, "totalRemoveLatencies");
-    private static final AtomicLongFieldUpdater<LocalMapStatsImpl> MAX_GET_LATENCY_UPDATER = AtomicLongFieldUpdater
-            .newUpdater(LocalMapStatsImpl.class, "maxGetLatency");
-    private static final AtomicLongFieldUpdater<LocalMapStatsImpl> MAX_PUT_LATENCY_UPDATER = AtomicLongFieldUpdater
-            .newUpdater(LocalMapStatsImpl.class, "maxPutLatency");
-    private static final AtomicLongFieldUpdater<LocalMapStatsImpl> MAX_REMOVE_LATENCY_UPDATER = AtomicLongFieldUpdater
-            .newUpdater(LocalMapStatsImpl.class, "maxRemoveLatency");
+    private static final AtomicLongFieldUpdater<LocalMapStatsImpl> LAST_ACCESS_TIME =
+            newUpdater(LocalMapStatsImpl.class, "lastAccessTime");
+    private static final AtomicLongFieldUpdater<LocalMapStatsImpl> LAST_UPDATE_TIME =
+            newUpdater(LocalMapStatsImpl.class, "lastUpdateTime");
+    private static final AtomicLongFieldUpdater<LocalMapStatsImpl> NUMBER_OF_OTHER_OPERATIONS =
+            newUpdater(LocalMapStatsImpl.class, "numberOfOtherOperations");
+    private static final AtomicLongFieldUpdater<LocalMapStatsImpl> NUMBER_OF_EVENTS =
+            newUpdater(LocalMapStatsImpl.class, "numberOfEvents");
+    private static final AtomicLongFieldUpdater<LocalMapStatsImpl> GET_COUNT =
+            newUpdater(LocalMapStatsImpl.class, "getCount");
+    private static final AtomicLongFieldUpdater<LocalMapStatsImpl> PUT_COUNT =
+            newUpdater(LocalMapStatsImpl.class, "putCount");
+    private static final AtomicLongFieldUpdater<LocalMapStatsImpl> REMOVE_COUNT =
+            newUpdater(LocalMapStatsImpl.class, "removeCount");
+    private static final AtomicLongFieldUpdater<LocalMapStatsImpl> TOTAL_GET_LATENCIES =
+            newUpdater(LocalMapStatsImpl.class, "totalGetLatencies");
+    private static final AtomicLongFieldUpdater<LocalMapStatsImpl> TOTAL_PUT_LATENCIES =
+            newUpdater(LocalMapStatsImpl.class, "totalPutLatencies");
+    private static final AtomicLongFieldUpdater<LocalMapStatsImpl> TOTAL_REMOVE_LATENCIES =
+            newUpdater(LocalMapStatsImpl.class, "totalRemoveLatencies");
+    private static final AtomicLongFieldUpdater<LocalMapStatsImpl> MAX_GET_LATENCY =
+            newUpdater(LocalMapStatsImpl.class, "maxGetLatency");
+    private static final AtomicLongFieldUpdater<LocalMapStatsImpl> MAX_PUT_LATENCY =
+            newUpdater(LocalMapStatsImpl.class, "maxPutLatency");
+    private static final AtomicLongFieldUpdater<LocalMapStatsImpl> MAX_REMOVE_LATENCY =
+            newUpdater(LocalMapStatsImpl.class, "maxRemoveLatency");
 
     // These fields are only accessed through the updaters
     private volatile long lastAccessTime;
@@ -149,7 +150,7 @@ public class LocalMapStatsImpl implements LocalMapStats {
     }
 
     public void setLastAccessTime(long lastAccessTime) {
-        LAST_ACCESS_TIME_UPDATER.set(this, Math.max(this.lastAccessTime, lastAccessTime));
+        LAST_ACCESS_TIME.set(this, Math.max(this.lastAccessTime, lastAccessTime));
     }
 
     @Override
@@ -158,7 +159,7 @@ public class LocalMapStatsImpl implements LocalMapStats {
     }
 
     public void setLastUpdateTime(long lastUpdateTime) {
-        LAST_UPDATE_TIME_UPDATER.set(this, Math.max(this.lastUpdateTime, lastUpdateTime));
+        LAST_UPDATE_TIME.set(this, Math.max(this.lastUpdateTime, lastUpdateTime));
     }
 
     @Override
@@ -199,15 +200,15 @@ public class LocalMapStatsImpl implements LocalMapStats {
     }
 
     public void incrementPuts(long delta, long latency) {
-        PUT_COUNT_UPDATER.addAndGet(this, delta);
-        TOTAL_PUT_LATENCIES_UPDATER.addAndGet(this, latency);
-        MAX_PUT_LATENCY_UPDATER.set(this, Math.max(maxPutLatency, latency / delta));
+        PUT_COUNT.addAndGet(this, delta);
+        TOTAL_PUT_LATENCIES.addAndGet(this, latency);
+        MAX_PUT_LATENCY.set(this, Math.max(maxPutLatency, latency / delta));
     }
 
     public void incrementPuts(long latency) {
-        PUT_COUNT_UPDATER.incrementAndGet(this);
-        TOTAL_PUT_LATENCIES_UPDATER.addAndGet(this, latency);
-        MAX_PUT_LATENCY_UPDATER.set(this, Math.max(maxPutLatency, latency));
+        PUT_COUNT.incrementAndGet(this);
+        TOTAL_PUT_LATENCIES.addAndGet(this, latency);
+        MAX_PUT_LATENCY.set(this, Math.max(maxPutLatency, latency));
     }
 
     @Override
@@ -216,9 +217,9 @@ public class LocalMapStatsImpl implements LocalMapStats {
     }
 
     public void incrementGets(long latency) {
-        GET_COUNT_UPDATER.incrementAndGet(this);
-        TOTAL_GET_LATENCIES_UPDATER.addAndGet(this, latency);
-        MAX_GET_LATENCY_UPDATER.set(this, Math.max(maxGetLatency, latency));
+        GET_COUNT.incrementAndGet(this);
+        TOTAL_GET_LATENCIES.addAndGet(this, latency);
+        MAX_GET_LATENCY.set(this, Math.max(maxGetLatency, latency));
     }
 
     @Override
@@ -227,9 +228,9 @@ public class LocalMapStatsImpl implements LocalMapStats {
     }
 
     public void incrementRemoves(long latency) {
-        REMOVE_COUNT_UPDATER.incrementAndGet(this);
-        TOTAL_REMOVE_LATENCIES_UPDATER.addAndGet(this, latency);
-        MAX_REMOVE_LATENCY_UPDATER.set(this, Math.max(maxRemoveLatency, latency));
+        REMOVE_COUNT.incrementAndGet(this);
+        TOTAL_REMOVE_LATENCIES.addAndGet(this, latency);
+        MAX_REMOVE_LATENCY.set(this, Math.max(maxRemoveLatency, latency));
     }
 
     @Override
@@ -268,7 +269,7 @@ public class LocalMapStatsImpl implements LocalMapStats {
     }
 
     public void incrementOtherOperations() {
-        NUMBER_OF_OTHER_OPERATIONS_UPDATER.incrementAndGet(this);
+        NUMBER_OF_OTHER_OPERATIONS.incrementAndGet(this);
     }
 
     @Override
@@ -277,7 +278,7 @@ public class LocalMapStatsImpl implements LocalMapStats {
     }
 
     public void incrementReceivedEvents() {
-        NUMBER_OF_EVENTS_UPDATER.incrementAndGet(this);
+        NUMBER_OF_EVENTS.incrementAndGet(this);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalQueueStatsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalQueueStatsImpl.java
@@ -24,21 +24,22 @@ import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 
 import static com.hazelcast.util.JsonUtil.getInt;
 import static com.hazelcast.util.JsonUtil.getLong;
+import static java.util.concurrent.atomic.AtomicLongFieldUpdater.newUpdater;
 
 public class LocalQueueStatsImpl implements LocalQueueStats {
 
-    private static final AtomicLongFieldUpdater<LocalQueueStatsImpl> NUMBER_OF_OFFERS_UPDATER = AtomicLongFieldUpdater
-            .newUpdater(LocalQueueStatsImpl.class, "numberOfOffers");
-    private static final AtomicLongFieldUpdater<LocalQueueStatsImpl> NUMBER_OF_REJECTED_OFFERS_UPDATER = AtomicLongFieldUpdater
-            .newUpdater(LocalQueueStatsImpl.class, "numberOfRejectedOffers");
-    private static final AtomicLongFieldUpdater<LocalQueueStatsImpl> NUMBER_OF_POLLS_UPDATER = AtomicLongFieldUpdater
-            .newUpdater(LocalQueueStatsImpl.class, "numberOfPolls");
-    private static final AtomicLongFieldUpdater<LocalQueueStatsImpl> NUMBER_OF_EMPTY_POLLS_UPDATER = AtomicLongFieldUpdater
-            .newUpdater(LocalQueueStatsImpl.class, "numberOfEmptyPolls");
-    private static final AtomicLongFieldUpdater<LocalQueueStatsImpl> NUMBER_OF_OTHER_OPERATIONS_UPDATER = AtomicLongFieldUpdater
-            .newUpdater(LocalQueueStatsImpl.class, "numberOfOtherOperations");
-    private static final AtomicLongFieldUpdater<LocalQueueStatsImpl> NUMBER_OF_EVENTS_UPDATER = AtomicLongFieldUpdater
-            .newUpdater(LocalQueueStatsImpl.class, "numberOfEvents");
+    private static final AtomicLongFieldUpdater<LocalQueueStatsImpl> NUMBER_OF_OFFERS =
+            newUpdater(LocalQueueStatsImpl.class, "numberOfOffers");
+    private static final AtomicLongFieldUpdater<LocalQueueStatsImpl> NUMBER_OF_REJECTED_OFFERS =
+            newUpdater(LocalQueueStatsImpl.class, "numberOfRejectedOffers");
+    private static final AtomicLongFieldUpdater<LocalQueueStatsImpl> NUMBER_OF_POLLS =
+            newUpdater(LocalQueueStatsImpl.class, "numberOfPolls");
+    private static final AtomicLongFieldUpdater<LocalQueueStatsImpl> NUMBER_OF_EMPTY_POLLS =
+            newUpdater(LocalQueueStatsImpl.class, "numberOfEmptyPolls");
+    private static final AtomicLongFieldUpdater<LocalQueueStatsImpl> NUMBER_OF_OTHER_OPERATIONS =
+            newUpdater(LocalQueueStatsImpl.class, "numberOfOtherOperations");
+    private static final AtomicLongFieldUpdater<LocalQueueStatsImpl> NUMBER_OF_EVENTS =
+            newUpdater(LocalQueueStatsImpl.class, "numberOfEvents");
 
     private int ownedItemCount;
     private int backupItemCount;
@@ -139,27 +140,27 @@ public class LocalQueueStatsImpl implements LocalQueueStats {
     }
 
     public void incrementOtherOperations() {
-        NUMBER_OF_OTHER_OPERATIONS_UPDATER.incrementAndGet(this);
+        NUMBER_OF_OTHER_OPERATIONS.incrementAndGet(this);
     }
 
     public void incrementOffers() {
-        NUMBER_OF_OFFERS_UPDATER.incrementAndGet(this);
+        NUMBER_OF_OFFERS.incrementAndGet(this);
     }
 
     public void incrementRejectedOffers() {
-        NUMBER_OF_REJECTED_OFFERS_UPDATER.incrementAndGet(this);
+        NUMBER_OF_REJECTED_OFFERS.incrementAndGet(this);
     }
 
     public void incrementPolls() {
-        NUMBER_OF_POLLS_UPDATER.incrementAndGet(this);
+        NUMBER_OF_POLLS.incrementAndGet(this);
     }
 
     public void incrementEmptyPolls() {
-        NUMBER_OF_EMPTY_POLLS_UPDATER.incrementAndGet(this);
+        NUMBER_OF_EMPTY_POLLS.incrementAndGet(this);
     }
 
     public void incrementReceivedEvents() {
-        NUMBER_OF_EVENTS_UPDATER.incrementAndGet(this);
+        NUMBER_OF_EVENTS.incrementAndGet(this);
     }
 
     @Override
@@ -193,12 +194,12 @@ public class LocalQueueStatsImpl implements LocalQueueStats {
         maxAge = getLong(json, "maxAge", -1L);
         aveAge = getLong(json, "aveAge", -1L);
         creationTime = getLong(json, "creationTime", -1L);
-        NUMBER_OF_OFFERS_UPDATER.set(this, getLong(json, "numberOfOffers", -1L));
-        NUMBER_OF_POLLS_UPDATER.set(this, getLong(json, "numberOfPolls", -1L));
-        NUMBER_OF_REJECTED_OFFERS_UPDATER.set(this, getLong(json, "numberOfRejectedOffers", -1L));
-        NUMBER_OF_EMPTY_POLLS_UPDATER.set(this, getLong(json, "numberOfEmptyPolls", -1L));
-        NUMBER_OF_OTHER_OPERATIONS_UPDATER.set(this, getLong(json, "numberOfOtherOperations", -1L));
-        NUMBER_OF_EVENTS_UPDATER.set(this, getLong(json, "numberOfEvents", -1L));
+        NUMBER_OF_OFFERS.set(this, getLong(json, "numberOfOffers", -1L));
+        NUMBER_OF_POLLS.set(this, getLong(json, "numberOfPolls", -1L));
+        NUMBER_OF_REJECTED_OFFERS.set(this, getLong(json, "numberOfRejectedOffers", -1L));
+        NUMBER_OF_EMPTY_POLLS.set(this, getLong(json, "numberOfEmptyPolls", -1L));
+        NUMBER_OF_OTHER_OPERATIONS.set(this, getLong(json, "numberOfOtherOperations", -1L));
+        NUMBER_OF_EVENTS.set(this, getLong(json, "numberOfEvents", -1L));
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalReplicatedMapStatsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalReplicatedMapStatsImpl.java
@@ -23,6 +23,7 @@ import com.hazelcast.util.Clock;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 
 import static com.hazelcast.util.JsonUtil.getLong;
+import static java.util.concurrent.atomic.AtomicLongFieldUpdater.newUpdater;
 
 /**
  * This class collects statistics about the replication map usage for management center and is
@@ -31,36 +32,36 @@ import static com.hazelcast.util.JsonUtil.getLong;
 public class LocalReplicatedMapStatsImpl implements LocalReplicatedMapStats {
 
     //CHECKSTYLE:OFF
-    private static final AtomicLongFieldUpdater<LocalReplicatedMapStatsImpl> LAST_ACCESS_TIME_UPDATER = AtomicLongFieldUpdater
-            .newUpdater(LocalReplicatedMapStatsImpl.class, "lastAccessTime");
-    private static final AtomicLongFieldUpdater<LocalReplicatedMapStatsImpl> LAST_UPDATE_TIME_UPDATER = AtomicLongFieldUpdater
-            .newUpdater(LocalReplicatedMapStatsImpl.class, "lastUpdateTime");
-    private static final AtomicLongFieldUpdater<LocalReplicatedMapStatsImpl> HITS_UPDATER = AtomicLongFieldUpdater
-            .newUpdater(LocalReplicatedMapStatsImpl.class, "hits");
-    private static final AtomicLongFieldUpdater<LocalReplicatedMapStatsImpl> NUMBER_OF_OTHER_OPERATIONS_UPDATER = AtomicLongFieldUpdater
-            .newUpdater(LocalReplicatedMapStatsImpl.class, "numberOfOtherOperations");
-    private static final AtomicLongFieldUpdater<LocalReplicatedMapStatsImpl> NUMBER_OF_EVENTS_UPDATER = AtomicLongFieldUpdater
-            .newUpdater(LocalReplicatedMapStatsImpl.class, "numberOfEvents");
-    private static final AtomicLongFieldUpdater<LocalReplicatedMapStatsImpl> NUMBER_OF_REPLICATION_EVENTS_UPDATER = AtomicLongFieldUpdater
-            .newUpdater(LocalReplicatedMapStatsImpl.class, "numberOfReplicationEvents");
-    private static final AtomicLongFieldUpdater<LocalReplicatedMapStatsImpl> GET_COUNT_UPDATER = AtomicLongFieldUpdater
-            .newUpdater(LocalReplicatedMapStatsImpl.class, "getCount");
-    private static final AtomicLongFieldUpdater<LocalReplicatedMapStatsImpl> PUT_COUNT_UPDATER = AtomicLongFieldUpdater
-            .newUpdater(LocalReplicatedMapStatsImpl.class, "putCount");
-    private static final AtomicLongFieldUpdater<LocalReplicatedMapStatsImpl> REMOVE_COUNT_UPDATER = AtomicLongFieldUpdater
-            .newUpdater(LocalReplicatedMapStatsImpl.class, "removeCount");
-    private static final AtomicLongFieldUpdater<LocalReplicatedMapStatsImpl> TOTAL_GET_LATENCIES_UPDATER = AtomicLongFieldUpdater
-            .newUpdater(LocalReplicatedMapStatsImpl.class, "totalGetLatencies");
-    private static final AtomicLongFieldUpdater<LocalReplicatedMapStatsImpl> TOTAL_PUT_LATENCIES_UPDATER = AtomicLongFieldUpdater
-            .newUpdater(LocalReplicatedMapStatsImpl.class, "totalPutLatencies");
-    private static final AtomicLongFieldUpdater<LocalReplicatedMapStatsImpl> TOTAL_REMOVE_LATENCIES_UPDATER = AtomicLongFieldUpdater
-            .newUpdater(LocalReplicatedMapStatsImpl.class, "totalRemoveLatencies");
-    private static final AtomicLongFieldUpdater<LocalReplicatedMapStatsImpl> MAX_GET_LATENCY_UPDATER = AtomicLongFieldUpdater
-            .newUpdater(LocalReplicatedMapStatsImpl.class, "maxGetLatency");
-    private static final AtomicLongFieldUpdater<LocalReplicatedMapStatsImpl> MAX_PUT_LATENCY_UPDATER = AtomicLongFieldUpdater
-            .newUpdater(LocalReplicatedMapStatsImpl.class, "maxPutLatency");
-    private static final AtomicLongFieldUpdater<LocalReplicatedMapStatsImpl> MAX_REMOVE_LATENCY_UPDATER = AtomicLongFieldUpdater
-            .newUpdater(LocalReplicatedMapStatsImpl.class, "maxRemoveLatency");
+    private static final AtomicLongFieldUpdater<LocalReplicatedMapStatsImpl> LAST_ACCESS_TIME =
+            newUpdater(LocalReplicatedMapStatsImpl.class, "lastAccessTime");
+    private static final AtomicLongFieldUpdater<LocalReplicatedMapStatsImpl> LAST_UPDATE_TIME =
+            newUpdater(LocalReplicatedMapStatsImpl.class, "lastUpdateTime");
+    private static final AtomicLongFieldUpdater<LocalReplicatedMapStatsImpl> HITS =
+            newUpdater(LocalReplicatedMapStatsImpl.class, "hits");
+    private static final AtomicLongFieldUpdater<LocalReplicatedMapStatsImpl> NUMBER_OF_OTHER_OPERATIONS =
+            newUpdater(LocalReplicatedMapStatsImpl.class, "numberOfOtherOperations");
+    private static final AtomicLongFieldUpdater<LocalReplicatedMapStatsImpl> NUMBER_OF_EVENTS =
+            newUpdater(LocalReplicatedMapStatsImpl.class, "numberOfEvents");
+    private static final AtomicLongFieldUpdater<LocalReplicatedMapStatsImpl> NUMBER_OF_REPLICATION_EVENTS =
+            newUpdater(LocalReplicatedMapStatsImpl.class, "numberOfReplicationEvents");
+    private static final AtomicLongFieldUpdater<LocalReplicatedMapStatsImpl> GET_COUNT =
+            newUpdater(LocalReplicatedMapStatsImpl.class, "getCount");
+    private static final AtomicLongFieldUpdater<LocalReplicatedMapStatsImpl> PUT_COUNT =
+            newUpdater(LocalReplicatedMapStatsImpl.class, "putCount");
+    private static final AtomicLongFieldUpdater<LocalReplicatedMapStatsImpl> REMOVE_COUNT =
+            newUpdater(LocalReplicatedMapStatsImpl.class, "removeCount");
+    private static final AtomicLongFieldUpdater<LocalReplicatedMapStatsImpl> TOTAL_GET_LATENCIES =
+            newUpdater(LocalReplicatedMapStatsImpl.class, "totalGetLatencies");
+    private static final AtomicLongFieldUpdater<LocalReplicatedMapStatsImpl> TOTAL_PUT_LATENCIES =
+            newUpdater(LocalReplicatedMapStatsImpl.class, "totalPutLatencies");
+    private static final AtomicLongFieldUpdater<LocalReplicatedMapStatsImpl> TOTAL_REMOVE_LATENCIES =
+            newUpdater(LocalReplicatedMapStatsImpl.class, "totalRemoveLatencies");
+    private static final AtomicLongFieldUpdater<LocalReplicatedMapStatsImpl> MAX_GET_LATENCY =
+            newUpdater(LocalReplicatedMapStatsImpl.class, "maxGetLatency");
+    private static final AtomicLongFieldUpdater<LocalReplicatedMapStatsImpl> MAX_PUT_LATENCY =
+            newUpdater(LocalReplicatedMapStatsImpl.class, "maxPutLatency");
+    private static final AtomicLongFieldUpdater<LocalReplicatedMapStatsImpl> MAX_REMOVE_LATENCY =
+            newUpdater(LocalReplicatedMapStatsImpl.class, "maxRemoveLatency");
     //CHECKSTYLE:ON
 
     // These fields are only accessed through the updaters
@@ -144,7 +145,7 @@ public class LocalReplicatedMapStatsImpl implements LocalReplicatedMapStats {
 
     public void setLastAccessTime(long lastAccessTime) {
         long max = Math.max(this.lastAccessTime, lastAccessTime);
-        LAST_ACCESS_TIME_UPDATER.set(this, max);
+        LAST_ACCESS_TIME.set(this, max);
     }
 
     @Override
@@ -154,7 +155,7 @@ public class LocalReplicatedMapStatsImpl implements LocalReplicatedMapStats {
 
     public void setLastUpdateTime(long lastUpdateTime) {
         long max = Math.max(this.lastUpdateTime, lastUpdateTime);
-        LAST_UPDATE_TIME_UPDATER.set(this, max);
+        LAST_UPDATE_TIME.set(this, max);
     }
 
     @Override
@@ -163,7 +164,7 @@ public class LocalReplicatedMapStatsImpl implements LocalReplicatedMapStats {
     }
 
     public void setHits(long hits) {
-        HITS_UPDATER.set(this, hits);
+        HITS.set(this, hits);
     }
 
     @Override
@@ -195,9 +196,9 @@ public class LocalReplicatedMapStatsImpl implements LocalReplicatedMapStats {
     }
 
     public void incrementPuts(long latency) {
-        PUT_COUNT_UPDATER.incrementAndGet(this);
-        TOTAL_PUT_LATENCIES_UPDATER.addAndGet(this, latency);
-        MAX_PUT_LATENCY_UPDATER.set(this, Math.max(maxPutLatency, latency));
+        PUT_COUNT.incrementAndGet(this);
+        TOTAL_PUT_LATENCIES.addAndGet(this, latency);
+        MAX_PUT_LATENCY.set(this, Math.max(maxPutLatency, latency));
     }
 
     @Override
@@ -206,9 +207,9 @@ public class LocalReplicatedMapStatsImpl implements LocalReplicatedMapStats {
     }
 
     public void incrementGets(long latency) {
-        GET_COUNT_UPDATER.incrementAndGet(this);
-        TOTAL_GET_LATENCIES_UPDATER.addAndGet(this, latency);
-        MAX_GET_LATENCY_UPDATER.set(this, Math.max(maxGetLatency, latency));
+        GET_COUNT.incrementAndGet(this);
+        TOTAL_GET_LATENCIES.addAndGet(this, latency);
+        MAX_GET_LATENCY.set(this, Math.max(maxGetLatency, latency));
     }
 
     @Override
@@ -217,9 +218,9 @@ public class LocalReplicatedMapStatsImpl implements LocalReplicatedMapStats {
     }
 
     public void incrementRemoves(long latency) {
-        REMOVE_COUNT_UPDATER.incrementAndGet(this);
-        TOTAL_REMOVE_LATENCIES_UPDATER.addAndGet(this, latency);
-        MAX_REMOVE_LATENCY_UPDATER.set(this, Math.max(maxRemoveLatency, latency));
+        REMOVE_COUNT.incrementAndGet(this);
+        TOTAL_REMOVE_LATENCIES.addAndGet(this, latency);
+        MAX_REMOVE_LATENCY.set(this, Math.max(maxRemoveLatency, latency));
     }
 
     @Override
@@ -258,7 +259,7 @@ public class LocalReplicatedMapStatsImpl implements LocalReplicatedMapStats {
     }
 
     public void incrementOtherOperations() {
-        NUMBER_OF_OTHER_OPERATIONS_UPDATER.incrementAndGet(this);
+        NUMBER_OF_OTHER_OPERATIONS.incrementAndGet(this);
     }
 
     @Override
@@ -267,7 +268,7 @@ public class LocalReplicatedMapStatsImpl implements LocalReplicatedMapStats {
     }
 
     public void incrementReceivedEvents() {
-        NUMBER_OF_EVENTS_UPDATER.incrementAndGet(this);
+        NUMBER_OF_EVENTS.incrementAndGet(this);
     }
 
     @Override
@@ -276,7 +277,7 @@ public class LocalReplicatedMapStatsImpl implements LocalReplicatedMapStats {
     }
 
     public void incrementReceivedReplicationEvents() {
-        NUMBER_OF_REPLICATION_EVENTS_UPDATER.incrementAndGet(this);
+        NUMBER_OF_REPLICATION_EVENTS.incrementAndGet(this);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalTopicStatsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalTopicStatsImpl.java
@@ -23,13 +23,14 @@ import com.hazelcast.util.Clock;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 
 import static com.hazelcast.util.JsonUtil.getLong;
+import static java.util.concurrent.atomic.AtomicLongFieldUpdater.newUpdater;
 
 public class LocalTopicStatsImpl implements LocalTopicStats {
 
-    private static final AtomicLongFieldUpdater<LocalTopicStatsImpl> TOTAL_PUBLISHES_UPDATER = AtomicLongFieldUpdater
-            .newUpdater(LocalTopicStatsImpl.class, "totalPublishes");
-    private static final AtomicLongFieldUpdater<LocalTopicStatsImpl> TOTAL_RECEIVED_MESSAGES_UPDATER = AtomicLongFieldUpdater
-            .newUpdater(LocalTopicStatsImpl.class, "totalReceivedMessages");
+    private static final AtomicLongFieldUpdater<LocalTopicStatsImpl> TOTAL_PUBLISHES =
+            newUpdater(LocalTopicStatsImpl.class, "totalPublishes");
+    private static final AtomicLongFieldUpdater<LocalTopicStatsImpl> TOTAL_RECEIVED_MESSAGES =
+            newUpdater(LocalTopicStatsImpl.class, "totalReceivedMessages");
     private long creationTime;
 
     // These fields are only accessed through the updaters
@@ -51,7 +52,7 @@ public class LocalTopicStatsImpl implements LocalTopicStats {
     }
 
     public void incrementPublishes() {
-        TOTAL_PUBLISHES_UPDATER.incrementAndGet(this);
+        TOTAL_PUBLISHES.incrementAndGet(this);
     }
 
     @Override
@@ -60,7 +61,7 @@ public class LocalTopicStatsImpl implements LocalTopicStats {
     }
 
     public void incrementReceives() {
-        TOTAL_RECEIVED_MESSAGES_UPDATER.incrementAndGet(this);
+        TOTAL_RECEIVED_MESSAGES.incrementAndGet(this);
     }
 
     @Override
@@ -75,8 +76,8 @@ public class LocalTopicStatsImpl implements LocalTopicStats {
     @Override
     public void fromJson(JsonObject json) {
         creationTime = getLong(json, "creationTime", -1L);
-        TOTAL_PUBLISHES_UPDATER.set(this, getLong(json, "totalPublishes", -1L));
-        TOTAL_RECEIVED_MESSAGES_UPDATER.set(this, getLong(json, "totalReceivedMessages", -1L));
+        TOTAL_PUBLISHES.set(this, getLong(json, "totalPublishes", -1L));
+        TOTAL_RECEIVED_MESSAGES.set(this, getLong(json, "totalReceivedMessages", -1L));
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/NearCacheStatsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/NearCacheStatsImpl.java
@@ -23,19 +23,20 @@ import com.hazelcast.util.Clock;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 
 import static com.hazelcast.util.JsonUtil.getLong;
+import static java.util.concurrent.atomic.AtomicLongFieldUpdater.newUpdater;
 
 public class NearCacheStatsImpl implements NearCacheStats {
 
     private static final double PERCENTAGE = 100.0;
 
-    private static final AtomicLongFieldUpdater<NearCacheStatsImpl> OWNED_ENTRY_COUNT_UPDATER =
-            AtomicLongFieldUpdater.newUpdater(NearCacheStatsImpl.class, "ownedEntryCount");
-    private static final AtomicLongFieldUpdater<NearCacheStatsImpl> OWNED_ENTRY_MEMORY_COST_UPDATER =
-            AtomicLongFieldUpdater.newUpdater(NearCacheStatsImpl.class, "ownedEntryMemoryCost");
-    private static final AtomicLongFieldUpdater<NearCacheStatsImpl> HITS_UPDATER =
-            AtomicLongFieldUpdater.newUpdater(NearCacheStatsImpl.class, "hits");
-    private static final AtomicLongFieldUpdater<NearCacheStatsImpl> MISSES_UPDATER =
-            AtomicLongFieldUpdater.newUpdater(NearCacheStatsImpl.class, "misses");
+    private static final AtomicLongFieldUpdater<NearCacheStatsImpl> OWNED_ENTRY_COUNT =
+            newUpdater(NearCacheStatsImpl.class, "ownedEntryCount");
+    private static final AtomicLongFieldUpdater<NearCacheStatsImpl> OWNED_ENTRY_MEMORY_COST =
+            newUpdater(NearCacheStatsImpl.class, "ownedEntryMemoryCost");
+    private static final AtomicLongFieldUpdater<NearCacheStatsImpl> HITS =
+            newUpdater(NearCacheStatsImpl.class, "hits");
+    private static final AtomicLongFieldUpdater<NearCacheStatsImpl> MISSES =
+            newUpdater(NearCacheStatsImpl.class, "misses");
 
     private volatile long creationTime;
     private volatile long ownedEntryCount;
@@ -58,15 +59,15 @@ public class NearCacheStatsImpl implements NearCacheStats {
     }
 
     public void setOwnedEntryCount(long ownedEntryCount) {
-        OWNED_ENTRY_COUNT_UPDATER.set(this, ownedEntryCount);
+        OWNED_ENTRY_COUNT.set(this, ownedEntryCount);
     }
 
     public void incrementOwnedEntryCount() {
-        OWNED_ENTRY_COUNT_UPDATER.incrementAndGet(this);
+        OWNED_ENTRY_COUNT.incrementAndGet(this);
     }
 
     public void decrementOwnedEntryCount() {
-        OWNED_ENTRY_COUNT_UPDATER.decrementAndGet(this);
+        OWNED_ENTRY_COUNT.decrementAndGet(this);
     }
 
     @Override
@@ -75,15 +76,15 @@ public class NearCacheStatsImpl implements NearCacheStats {
     }
 
     public void setOwnedEntryMemoryCost(long ownedEntryMemoryCost) {
-        OWNED_ENTRY_MEMORY_COST_UPDATER.set(this, ownedEntryMemoryCost);
+        OWNED_ENTRY_MEMORY_COST.set(this, ownedEntryMemoryCost);
     }
 
     public void incrementOwnedEntryMemoryCost(long ownedEntryMemoryCost) {
-        OWNED_ENTRY_MEMORY_COST_UPDATER.addAndGet(this, ownedEntryMemoryCost);
+        OWNED_ENTRY_MEMORY_COST.addAndGet(this, ownedEntryMemoryCost);
     }
 
     public void decrementOwnedEntryMemoryCost(long ownedEntryMemoryCost) {
-        OWNED_ENTRY_MEMORY_COST_UPDATER.addAndGet(this, -ownedEntryMemoryCost);
+        OWNED_ENTRY_MEMORY_COST.addAndGet(this, -ownedEntryMemoryCost);
     }
 
     @Override
@@ -92,11 +93,11 @@ public class NearCacheStatsImpl implements NearCacheStats {
     }
 
     public void incrementHits() {
-        HITS_UPDATER.incrementAndGet(this);
+        HITS.incrementAndGet(this);
     }
 
     public void setHits(long hits) {
-        HITS_UPDATER.set(this, hits);
+        HITS.set(this, hits);
     }
 
     @Override
@@ -105,11 +106,11 @@ public class NearCacheStatsImpl implements NearCacheStats {
     }
 
     public void setMisses(long misses) {
-        MISSES_UPDATER.set(this, misses);
+        MISSES.set(this, misses);
     }
 
     public void incrementMisses() {
-        MISSES_UPDATER.incrementAndGet(this);
+        MISSES.incrementAndGet(this);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/ReplicatedRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/ReplicatedRecord.java
@@ -35,9 +35,9 @@ import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
  */
 public class ReplicatedRecord<K, V> implements IdentifiedDataSerializable {
 
-    private static final AtomicLongFieldUpdater<ReplicatedRecord> HITS_UPDATER = AtomicLongFieldUpdater
+    private static final AtomicLongFieldUpdater<ReplicatedRecord> HITS = AtomicLongFieldUpdater
             .newUpdater(ReplicatedRecord.class, "hits");
-    private static final AtomicReferenceFieldUpdater<ReplicatedRecord, VectorClockTimestamp> VECTOR_CLOCK_UPDATER =
+    private static final AtomicReferenceFieldUpdater<ReplicatedRecord, VectorClockTimestamp> VECTOR_CLOCK =
             AtomicReferenceFieldUpdater.newUpdater(ReplicatedRecord.class, VectorClockTimestamp.class, "vectorClockTimestamp");
 
     // These fields are only accessed through the updaters
@@ -96,7 +96,7 @@ public class ReplicatedRecord<K, V> implements IdentifiedDataSerializable {
             VectorClockTimestamp vectorClockTimestampCopy = VectorClockTimestamp.copyVector(vectorClockTimestamp);
             vectorClockTimestampCopy = vectorClockTimestampCopy.applyVector(otherVectorClockTimestamp);
             vectorClockTimestampCopy = vectorClockTimestampCopy.incrementClock(member);
-            if (VECTOR_CLOCK_UPDATER.compareAndSet(this, vectorClockTimestamp, vectorClockTimestampCopy)) {
+            if (VECTOR_CLOCK.compareAndSet(this, vectorClockTimestamp, vectorClockTimestampCopy)) {
                 return vectorClockTimestampCopy;
             }
         }
@@ -107,7 +107,7 @@ public class ReplicatedRecord<K, V> implements IdentifiedDataSerializable {
             VectorClockTimestamp vectorClockTimestamp = this.vectorClockTimestamp;
             VectorClockTimestamp vectorClockTimestampCopy = VectorClockTimestamp.copyVector(vectorClockTimestamp);
             vectorClockTimestampCopy = vectorClockTimestampCopy.applyVector(otherVectorClockTimestamp);
-            if (VECTOR_CLOCK_UPDATER.compareAndSet(this, vectorClockTimestamp, vectorClockTimestampCopy)) {
+            if (VECTOR_CLOCK.compareAndSet(this, vectorClockTimestamp, vectorClockTimestampCopy)) {
                 return vectorClockTimestampCopy;
             }
         }
@@ -118,7 +118,7 @@ public class ReplicatedRecord<K, V> implements IdentifiedDataSerializable {
             VectorClockTimestamp vectorClockTimestamp = this.vectorClockTimestamp;
             VectorClockTimestamp vectorClockTimestampCopy = VectorClockTimestamp.copyVector(vectorClockTimestamp);
             vectorClockTimestampCopy = vectorClockTimestampCopy.incrementClock(member);
-            if (VECTOR_CLOCK_UPDATER.compareAndSet(this, vectorClockTimestamp, vectorClockTimestampCopy)) {
+            if (VECTOR_CLOCK.compareAndSet(this, vectorClockTimestamp, vectorClockTimestampCopy)) {
                 return vectorClockTimestampCopy;
             }
         }
@@ -159,7 +159,7 @@ public class ReplicatedRecord<K, V> implements IdentifiedDataSerializable {
     }
 
     private void access() {
-        HITS_UPDATER.incrementAndGet(this);
+        HITS.incrementAndGet(this);
         lastAccessTime = Clock.currentTimeMillis();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/Invocation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/Invocation.java
@@ -112,7 +112,7 @@ abstract class Invocation implements OperationResponseHandler, Runnable {
     final InvocationFuture invocationFuture;
     final OperationServiceImpl operationService;
 
-    // writes to that are normally handled through the INVOKE_COUNT_UPDATER to ensure atomic increments / decrements
+    // writes to that are normally handled through the INVOKE_COUNT to ensure atomic increments / decrements
     volatile int invokeCount;
 
     Invocation(NodeEngineImpl nodeEngine, String serviceName, Operation op, int partitionId,

--- a/hazelcast/src/main/java/com/hazelcast/util/executor/CachedExecutorServiceDelegate.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/executor/CachedExecutorServiceDelegate.java
@@ -37,12 +37,14 @@ import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
+import static java.util.concurrent.atomic.AtomicLongFieldUpdater.newUpdater;
+
 public final class CachedExecutorServiceDelegate implements ExecutorService, ManagedExecutorService {
 
     public static final long TIME = 250;
 
-    private static final AtomicLongFieldUpdater<CachedExecutorServiceDelegate> EXECUTED_COUNT_UPDATER = AtomicLongFieldUpdater
-            .newUpdater(CachedExecutorServiceDelegate.class, "executedCount");
+    private static final AtomicLongFieldUpdater<CachedExecutorServiceDelegate> EXECUTED_COUNT =
+            newUpdater(CachedExecutorServiceDelegate.class, "executedCount");
 
     private volatile long executedCount;
     private final String name;
@@ -208,7 +210,7 @@ public final class CachedExecutorServiceDelegate implements ExecutorService, Man
                     r = taskQ.poll(1, TimeUnit.MILLISECONDS);
                     if (r != null) {
                         r.run();
-                        EXECUTED_COUNT_UPDATER.incrementAndGet(CachedExecutorServiceDelegate.this);
+                        EXECUTED_COUNT.incrementAndGet(CachedExecutorServiceDelegate.this);
                     }
                 }
                 while (r != null);


### PR DESCRIPTION
Instead of having FOO_FIELD_UPDATER, it is now just FOO.

Also switched to static imports for the newUpdater method.