### PR TITLE
No need to explicitly call recordValues.remove()

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/query/impl/IndexImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/IndexImpl.java
@@ -94,14 +94,9 @@ public class IndexImpl implements Index {
         }
 
         Data key = e.getIndexKey();
-        Comparable oldValue = recordValues.remove(key);
         Comparable newValue = e.getAttribute(attribute);
-        if (newValue == null) {
-            newValue = NULL;
-        } else if (newValue.getClass().isEnum()) {
-            newValue = TypeConverters.ENUM_CONVERTER.convert(newValue);
-        }
-        recordValues.put(key, newValue);
+        newValue = sanitizeValue(newValue);
+        Comparable oldValue = recordValues.put(key, newValue);
         if (oldValue == null) {
             // new
             indexStore.newIndex(newValue, e);
@@ -109,6 +104,16 @@ public class IndexImpl implements Index {
             // update
             indexStore.updateIndex(oldValue, newValue, e);
         }
+    }
+
+    private Comparable sanitizeValue(Comparable value) {
+        if (value == null) {
+            return NULL;
+        }
+        if (value.getClass().isEnum()) {
+            return TypeConverters.ENUM_CONVERTER.convert(value);
+        }
+        return value;
     }
 
     @Override


### PR DESCRIPTION
Minor Improvement - no need to explicitly call `recordValues.remove()` as the old value will be replaced anyway

+ value sanitization extracted into its own method.