### PR TITLE
Renamed EventPacket to EventEnvelope

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
@@ -292,10 +292,10 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
 
     @Override
     public void handlePacket(Packet packet) {
-        final ClientConnection conn = (ClientConnection) packet.getConn();
+        ClientConnection conn = (ClientConnection) packet.getConn();
         conn.incrementPacketCount();
         if (packet.isHeaderSet(Packet.HEADER_EVENT)) {
-            final ClientListenerServiceImpl listenerService = (ClientListenerServiceImpl) client.getListenerService();
+            ClientListenerServiceImpl listenerService = (ClientListenerServiceImpl) client.getListenerService();
             listenerService.handleEventPacket(packet);
         } else {
             ClientInvocationService invocationService = client.getInvocationService();

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientListenerServiceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientListenerServiceImpl.java
@@ -117,6 +117,7 @@ public final class ClientListenerServiceImpl implements ClientListenerService {
         }
     }
 
+    @Override
     public void registerListener(String uuid, Integer callId) {
         registrationAliasMap.put(uuid, uuid);
         registrationMap.put(uuid, callId);
@@ -130,6 +131,7 @@ public final class ClientListenerServiceImpl implements ClientListenerService {
         }
     }
 
+    @Override
     public String deRegisterListener(String alias) {
         final String uuid = registrationAliasMap.remove(alias);
         if (uuid != null) {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/SpiDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/SpiDataSerializerHook.java
@@ -20,7 +20,7 @@ import com.hazelcast.nio.serialization.DataSerializableFactory;
 import com.hazelcast.internal.serialization.DataSerializerHook;
 import com.hazelcast.internal.serialization.impl.FactoryIdHelper;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.spi.impl.eventservice.impl.EventPacket;
+import com.hazelcast.spi.impl.eventservice.impl.EventEnvelope;
 import com.hazelcast.spi.impl.operationservice.impl.operations.PartitionIteratingOperation;
 import com.hazelcast.spi.impl.operationservice.impl.operations.PartitionIteratingOperation.PartitionResponse;
 import com.hazelcast.spi.impl.operationservice.impl.operations.Backup;
@@ -42,7 +42,7 @@ public final class SpiDataSerializerHook implements DataSerializerHook {
     public static final int PARTITION_ITERATOR = 3;
     public static final int PARTITION_RESPONSE = 4;
     public static final int PARALLEL_OPERATION_FACTORY = 5;
-    public static final int EVENT_PACKET = 6;
+    public static final int EVENT_ENVELOPE = 6;
     public static final int COLLECTION = 7;
     public static final int CALL_TIMEOUT_RESPONSE = 8;
     public static final int ERROR_RESPONSE = 9;
@@ -65,8 +65,8 @@ public final class SpiDataSerializerHook implements DataSerializerHook {
                         return new PartitionResponse();
                     case PARALLEL_OPERATION_FACTORY:
                         return new BinaryOperationFactory();
-                    case EVENT_PACKET:
-                        return new EventPacket();
+                    case EVENT_ENVELOPE:
+                        return new EventEnvelope();
                     case COLLECTION:
                         return new SerializableList();
                     case CALL_TIMEOUT_RESPONSE:

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/EventEnvelope.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/EventEnvelope.java
@@ -24,16 +24,19 @@ import com.hazelcast.spi.impl.SpiDataSerializerHook;
 
 import java.io.IOException;
 
-public final class EventPacket implements IdentifiedDataSerializable {
+/**
+ * An Envelope around an event object. The envelope adds some additional metadata to the event.
+ */
+public final class EventEnvelope implements IdentifiedDataSerializable {
 
     private String id;
     private String serviceName;
     private Object event;
 
-    public EventPacket() {
+    public EventEnvelope() {
     }
 
-    EventPacket(String id, String serviceName, Object event) {
+    EventEnvelope(String id, String serviceName, Object event) {
         this.event = event;
         this.id = id;
         this.serviceName = serviceName;
@@ -58,7 +61,7 @@ public final class EventPacket implements IdentifiedDataSerializable {
 
     @Override
     public int getId() {
-        return SpiDataSerializerHook.EVENT_PACKET;
+        return SpiDataSerializerHook.EVENT_ENVELOPE;
     }
 
     @Override
@@ -88,7 +91,7 @@ public final class EventPacket implements IdentifiedDataSerializable {
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder("EventPacket{");
+        final StringBuilder sb = new StringBuilder("EventEnvelope{");
         sb.append("id='").append(id).append('\'');
         sb.append(", serviceName='").append(serviceName).append('\'');
         sb.append(", event=").append(event);

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/RemoteEventProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/RemoteEventProcessor.java
@@ -19,11 +19,11 @@ package com.hazelcast.spi.impl.eventservice.impl;
 import com.hazelcast.nio.Packet;
 import com.hazelcast.util.executor.StripedRunnable;
 
-public class RemoteEventPacketProcessor extends EventPacketProcessor implements StripedRunnable {
+public class RemoteEventProcessor extends EventProcessor implements StripedRunnable {
     private EventServiceImpl eventService;
     private Packet packet;
 
-    public RemoteEventPacketProcessor(EventServiceImpl eventService, Packet packet) {
+    public RemoteEventProcessor(EventServiceImpl eventService, Packet packet) {
         super(eventService, null, packet.getPartitionId());
         this.eventService = eventService;
         this.packet = packet;
@@ -32,8 +32,8 @@ public class RemoteEventPacketProcessor extends EventPacketProcessor implements 
     @Override
     public void run() {
         try {
-            EventPacket eventPacket = (EventPacket) eventService.nodeEngine.toObject(packet);
-            process(eventPacket);
+            EventEnvelope eventEnvelope = (EventEnvelope) eventService.nodeEngine.toObject(packet);
+            process(eventEnvelope);
         } catch (Exception e) {
             eventService.logger.warning("Error while logging processing event", e);
         }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/operations/SendEventOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/operations/SendEventOperation.java
@@ -19,42 +19,42 @@ package com.hazelcast.spi.impl.eventservice.impl.operations;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.spi.AbstractOperation;
-import com.hazelcast.spi.impl.eventservice.impl.EventPacket;
-import com.hazelcast.spi.impl.eventservice.impl.EventPacketProcessor;
+import com.hazelcast.spi.impl.eventservice.impl.EventEnvelope;
+import com.hazelcast.spi.impl.eventservice.impl.EventProcessor;
 import com.hazelcast.spi.impl.eventservice.impl.EventServiceImpl;
 
 import java.io.IOException;
 
 public class SendEventOperation extends AbstractOperation {
-    private EventPacket eventPacket;
+    private EventEnvelope eventEnvelope;
     private int orderKey;
 
     public SendEventOperation() {
     }
 
-    public SendEventOperation(EventPacket eventPacket, int orderKey) {
-        this.eventPacket = eventPacket;
+    public SendEventOperation(EventEnvelope eventEnvelope, int orderKey) {
+        this.eventEnvelope = eventEnvelope;
         this.orderKey = orderKey;
     }
 
     @Override
     public void run() throws Exception {
         EventServiceImpl eventService = (EventServiceImpl) getNodeEngine().getEventService();
-        eventService.executeEventCallback(new EventPacketProcessor(eventService, eventPacket, orderKey));
+        eventService.executeEventCallback(new EventProcessor(eventService, eventEnvelope, orderKey));
     }
 
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
-        eventPacket.writeData(out);
+        eventEnvelope.writeData(out);
         out.writeInt(orderKey);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
-        eventPacket = new EventPacket();
-        eventPacket.readData(in);
+        eventEnvelope = new EventEnvelope();
+        eventEnvelope.readData(in);
         orderKey = in.readInt();
     }
 }


### PR DESCRIPTION
EventPacket is not a correct name since it isn't a type of a Packet.
Envelope is more clear since it is placed around an arbitrary event
object and some meta-data is added.