### PR TITLE
Don't convert backup operation to `Data` before serializing `Backup` if there is only one backup for preventing unnecessary temporary memory allocation and copy

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationBackupHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationBackupHandler.java
@@ -149,14 +149,57 @@ final class OperationBackupHandler {
 
     private int makeBackups(BackupAwareOperation backupAwareOp, int partitionId, long[] replicaVersions,
                             int syncBackups, int asyncBackups) {
-        int sendSyncBackups = 0;
+        int sendSyncBackups;
+        int totalBackups = syncBackups + asyncBackups;
 
         InternalPartitionService partitionService = node.getPartitionService();
         InternalPartition partition = partitionService.getPartition(partitionId);
 
-        Data backupOpData = getBackupOperationData(backupAwareOp);
+        if (totalBackups == 1) {
+            sendSyncBackups = sendSingleBackup(backupAwareOp, partition, replicaVersions, syncBackups);
+        } else {
+            sendSyncBackups = sendMultipleBackups(backupAwareOp, partition, replicaVersions, syncBackups, totalBackups);
+        }
+        return sendSyncBackups;
+    }
 
-        for (int replicaIndex = 1; replicaIndex <= syncBackups + asyncBackups; replicaIndex++) {
+    private int sendSingleBackup(BackupAwareOperation backupAwareOp, InternalPartition partition,
+                                 long[] replicaVersions, int syncBackups) {
+        // Since there is only one replica, replica index is `1`
+        Address target = partition.getReplicaAddress(1);
+        if (target != null) {
+            // Since there is only one backup, backup operation is sent to only one node.
+            // If backup operation is converted to `Data`, there will be these operations as below:
+            //      - a temporary memory allocation (byte[]) for `Data`
+            //      - serialize backup operation to allocated memory
+            //      - copy the temporary allocated memory (backup operation data) to output while serializing `Backup`
+            // In this flow, there are two redundant operations (allocating temporary memory and copying it to output).
+            // So in this case (there is only one backup), we don't convert backup operation to `Data` as temporary
+            // before `Backup` is serialized but backup operation is already serialized directly into output
+            // without any unnecessary memory allocation and copy when it is used as object inside `Backup`.
+            Operation backupOp = getBackupOperation(backupAwareOp);
+
+            assertNoBackupOnPrimaryMember(partition, target);
+
+            boolean isSyncBackup = syncBackups == 1;
+
+            Backup backup = newBackup(backupAwareOp, backupOp, replicaVersions, 1, isSyncBackup);
+            operationService.send(backup, target);
+
+            if (isSyncBackup) {
+                return 1;
+            }
+        }
+        return 0;
+    }
+
+    private int sendMultipleBackups(BackupAwareOperation backupAwareOp, InternalPartition partition,
+                                    long[] replicaVersions, int syncBackups, int totalBackups) {
+        int sendSyncBackups = 0;
+        Operation backupOp = getBackupOperation(backupAwareOp);
+        Data backupOpData = nodeEngine.getSerializationService().toData(backupOp);
+
+        for (int replicaIndex = 1; replicaIndex <= totalBackups; replicaIndex++) {
             Address target = partition.getReplicaAddress(replicaIndex);
 
             if (target == null) {
@@ -178,7 +221,7 @@ final class OperationBackupHandler {
         return sendSyncBackups;
     }
 
-    private Data getBackupOperationData(BackupAwareOperation backupAwareOp) {
+    private Operation getBackupOperation(BackupAwareOperation backupAwareOp) {
         Operation backupOp = backupAwareOp.getBackupOperation();
         if (backupOp == null) {
             throw new IllegalArgumentException("Backup operation should not be null! " + backupAwareOp);
@@ -188,14 +231,21 @@ final class OperationBackupHandler {
         // if getServiceName() method is overridden to return the same name
         // then this will have no effect.
         backupOp.setServiceName(op.getServiceName());
-        return nodeEngine.getSerializationService().toData(backupOp);
+        return backupOp;
     }
 
-    private Backup newBackup(BackupAwareOperation backupAwareOp, Data backupOpData, long[] replicaVersions,
+    private Backup newBackup(BackupAwareOperation backupAwareOp, Object backupOp, long[] replicaVersions,
             int replicaIndex, boolean respondBack) {
-
         Operation op = (Operation) backupAwareOp;
-        Backup backup = new Backup(backupOpData, op.getCallerAddress(), replicaVersions, respondBack);
+        Backup backup;
+        if (backupOp instanceof Operation) {
+            backup = new Backup((Operation) backupOp, op.getCallerAddress(), replicaVersions, respondBack);
+        } else if (backupOp instanceof Data) {
+            backup = new Backup((Data) backupOp, op.getCallerAddress(), replicaVersions, respondBack);
+        } else {
+            throw new IllegalArgumentException("Only 'Data' or 'Operation' typed backup operation is supported!");
+        }
+
         backup.setPartitionId(op.getPartitionId())
                 .setReplicaIndex(replicaIndex)
                 .setCallerUuid(nodeEngine.getLocalMember().getUuid());

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/operations/Backup.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/operations/Backup.java
@@ -43,25 +43,38 @@ import static com.hazelcast.spi.impl.OperationResponseHandlerFactory.createEmpty
 
 public final class Backup extends Operation implements BackupOperation, IdentifiedDataSerializable {
 
-    private Data backupOpData;
     private Address originalCaller;
     private long[] replicaVersions;
     private boolean sync;
 
     private Operation backupOp;
+    private Data backupOpData;
     private boolean valid = true;
 
     public Backup() {
     }
 
     @SuppressFBWarnings("EI_EXPOSE_REP")
-    public Backup(Data backupOp, Address originalCaller, long[] replicaVersions, boolean sync) {
-        this.backupOpData = backupOp;
+    public Backup(Operation backupOp, Address originalCaller, long[] replicaVersions, boolean sync) {
+        this.backupOp = backupOp;
         this.originalCaller = originalCaller;
         this.sync = sync;
         this.replicaVersions = replicaVersions;
         if (sync && originalCaller == null) {
-            throw new IllegalArgumentException("Sync backup requires original caller address, Op: " + backupOp);
+            throw new IllegalArgumentException("Sync backup requires original caller address, Backup operation: "
+                    + backupOp);
+        }
+    }
+
+    @SuppressFBWarnings("EI_EXPOSE_REP")
+    public Backup(Data backupOpData, Address originalCaller, long[] replicaVersions, boolean sync) {
+        this.backupOpData = backupOpData;
+        this.originalCaller = originalCaller;
+        this.sync = sync;
+        this.replicaVersions = replicaVersions;
+        if (sync && originalCaller == null) {
+            throw new IllegalArgumentException("Sync backup requires original caller address, Backup operation data: "
+                    + backupOpData);
         }
     }
 
@@ -89,8 +102,12 @@ public final class Backup extends Operation implements BackupOperation, Identifi
         }
 
         NodeEngine nodeEngine = getNodeEngine();
-        if (backupOpData != null) {
+
+        if (backupOp == null && backupOpData != null) {
             backupOp = nodeEngine.getSerializationService().toObject(backupOpData);
+        }
+
+        if (backupOp != null) {
             backupOp.setPartitionId(getPartitionId()).setReplicaIndex(getReplicaIndex());
             backupOp.setNodeEngine(nodeEngine);
             backupOp.setCallerUuid(getCallerUuid());
@@ -172,7 +189,13 @@ public final class Backup extends Operation implements BackupOperation, Identifi
 
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
-        out.writeData(backupOpData);
+        if (backupOpData != null) {
+            out.writeBoolean(true);
+            out.writeData(backupOpData);
+        } else {
+            out.writeBoolean(false);
+            out.writeObject(backupOp);
+        }
         if (originalCaller != null) {
             out.writeBoolean(true);
             originalCaller.writeData(out);
@@ -185,7 +208,11 @@ public final class Backup extends Operation implements BackupOperation, Identifi
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
-        backupOpData = in.readData();
+        if (in.readBoolean()) {
+            backupOpData = in.readData();
+        } else {
+            backupOp = in.readObject();
+        }
         if (in.readBoolean()) {
             originalCaller = new Address();
             originalCaller.readData(in);
@@ -198,7 +225,8 @@ public final class Backup extends Operation implements BackupOperation, Identifi
     public String toString() {
         final StringBuilder sb = new StringBuilder();
         sb.append("Backup");
-        sb.append("{backupOpBinary=").append(backupOpData);
+        sb.append("{backupOp=").append(backupOp);
+        sb.append(", backupOpData=").append(backupOpData);
         sb.append(", originalCaller=").append(originalCaller);
         sb.append(", version=").append(Arrays.toString(replicaVersions));
         sb.append(", sync=").append(sync);

--- a/hazelcast/src/test/java/com/hazelcast/cache/CacheBackupTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CacheBackupTest.java
@@ -1,0 +1,108 @@
+package com.hazelcast.cache;
+
+import com.hazelcast.cache.impl.HazelcastServerCachingProvider;
+import com.hazelcast.cache.impl.ICacheRecordStore;
+import com.hazelcast.cache.impl.ICacheService;
+import com.hazelcast.config.CacheConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.instance.Node;
+import com.hazelcast.internal.serialization.SerializationService;
+import com.hazelcast.partition.InternalPartitionService;
+import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import javax.cache.Cache;
+import javax.cache.CacheManager;
+import javax.cache.spi.CachingProvider;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class CacheBackupTest extends HazelcastTestSupport {
+
+    private void entrySuccessfullyRetrievedFromBackup(int backupCount, boolean sync) {
+        final String KEY = "key";
+        final String VALUE = "value";
+
+        final int nodeCount = backupCount + 1;
+        final TestHazelcastInstanceFactory instanceFactory = createHazelcastInstanceFactory(nodeCount);
+        final HazelcastInstance[] instances = new HazelcastInstance[nodeCount];
+        for (int i = 0; i < instances.length; i++) {
+            instances[i] = instanceFactory.newHazelcastInstance();
+        }
+        final HazelcastInstance hz = instances[0];
+
+        final CachingProvider cachingProvider = HazelcastServerCachingProvider.createCachingProvider(hz);
+        final CacheManager cacheManager = cachingProvider.getCacheManager();
+        final String cacheName = randomName();
+        final CacheConfig cacheConfig = new CacheConfig().setName(cacheName);
+        if (sync) {
+            cacheConfig.setBackupCount(backupCount);
+        } else {
+            cacheConfig.setAsyncBackupCount(backupCount);
+        }
+        final Cache cache = cacheManager.createCache(cacheName, cacheConfig);
+
+        cache.put(KEY, VALUE);
+
+        final Node node = getNode(hz);
+        final InternalPartitionService partitionService = node.getPartitionService();
+        final int keyPartitionId = partitionService.getPartitionId(KEY);
+
+        for (int i = 1; i <= backupCount; i++) {
+            final Node backupNode = getNode(instances[i]);
+            final SerializationService serializationService = backupNode.getSerializationService();
+            final ICacheService cacheService = backupNode.getNodeEngine().getService(ICacheService.SERVICE_NAME);
+            if (sync) {
+                checkSavedRecordOnBackup(KEY, VALUE, cacheName, keyPartitionId, serializationService, cacheService);
+            } else {
+                assertTrueEventually(new AssertTask() {
+                    @Override
+                    public void run() throws Exception {
+                        checkSavedRecordOnBackup(KEY, VALUE, cacheName, keyPartitionId, serializationService, cacheService);
+                    }
+                });
+            }
+        }
+    }
+
+    private void checkSavedRecordOnBackup(String key, String expectedValue, String cacheName, int keyPartitionId,
+                                          SerializationService serializationService, ICacheService cacheService) {
+        ICacheRecordStore recordStore = cacheService.getRecordStore("/hz/" + cacheName, keyPartitionId);
+        assertNotNull(recordStore);
+        assertEquals(expectedValue,
+                serializationService.toObject(recordStore.get(serializationService.toData(key), null)));
+    }
+
+    @Test
+    public void entrySuccessfullyRetrievedFromBackupWhenThereIsOneSyncBackup() {
+        entrySuccessfullyRetrievedFromBackup(1, true);
+    }
+
+    @Test
+    public void entrySuccessfullyRetrievedFromBackupWhenThereIsOneAsyncBackup() {
+        entrySuccessfullyRetrievedFromBackup(1, false);
+    }
+
+    @Test
+    public void entrySuccessfullyRetrievedFromBackupWhenThereIsTwoSyncBackup() {
+        entrySuccessfullyRetrievedFromBackup(2, true);
+    }
+
+    @Test
+    public void entrySuccessfullyRetrievedFromBackupWhenThereIsTwoAsyncBackup() {
+        entrySuccessfullyRetrievedFromBackup(2, false);
+    }
+
+}


### PR DESCRIPTION
By default, Hazelcast uses only one backup.
If there is only one backup, backup operation is sent to only one backup node.
If backup operation is converted to `Data`, there will be these operations as below:
* a temporary memory allocation (`byte[]`) for `Data`
* serialize backup operation to allocated memory
* copy the temporary allocated memory (backup operation data) to output while serializing `Backup`

In this flow, there are two redundant operations (allocating temporary memory and copying it to output). So in this case (there is only one backup), we don't convert backup operation to `Data` as temporary before `Backup` is serialized but backup operation is already serialized directly into output without any unnecessary memory allocation and copy when it is used as object inside `Backup`.