### PR TITLE
Reduce index memory usage

### DIFF
--- a/hazelcast-client-new/src/test/java/com/hazelcast/client/map/ClientSortLimitTest.java
+++ b/hazelcast-client-new/src/test/java/com/hazelcast/client/map/ClientSortLimitTest.java
@@ -340,7 +340,7 @@ public class ClientSortLimitTest extends HazelcastTestSupport {
             set = map.entrySet(pagingPredicate);
             for (Map.Entry<Integer, Employee> entry : set) {
                 Employee e = entry.getValue();
-                QueryEntry qe = new QueryEntry(null, ss.toData(e.getId()), e.getId(), e);
+                QueryEntry qe = new QueryEntry(ss, ss.toData(e.getId()), e.getId(), e);
                 assertTrue(predicate.apply(qe));
                 results.add(e);
             }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientSortLimitTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientSortLimitTest.java
@@ -340,7 +340,7 @@ public class ClientSortLimitTest extends HazelcastTestSupport {
             set = map.entrySet(pagingPredicate);
             for (Map.Entry<Integer, Employee> entry : set) {
                 Employee e = entry.getValue();
-                QueryEntry qe = new QueryEntry(null, ss.toData(e.getId()), e.getId(), e);
+                QueryEntry qe = new QueryEntry(ss, ss.toData(e.getId()), e.getId(), e);
                 assertTrue(predicate.apply(qe));
                 results.add(e);
             }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapContainer.java
@@ -16,11 +16,19 @@
 
 package com.hazelcast.map.impl;
 
+import static com.hazelcast.map.impl.ExpirationTimeSetter.calculateMaxIdleMillis;
+import static com.hazelcast.map.impl.ExpirationTimeSetter.calculateTTLMillis;
+import static com.hazelcast.map.impl.ExpirationTimeSetter.pickTTL;
+import static com.hazelcast.map.impl.ExpirationTimeSetter.setExpirationTime;
+import static com.hazelcast.map.impl.SizeEstimators.createNearCacheSizeEstimator;
+import static com.hazelcast.map.impl.mapstore.MapStoreContextFactory.createMapStoreContext;
+
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.config.PartitioningStrategyConfig;
 import com.hazelcast.config.WanReplicationRef;
 import com.hazelcast.core.IFunction;
 import com.hazelcast.core.PartitioningStrategy;
+import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.map.MapInterceptor;
 import com.hazelcast.map.impl.mapstore.MapStoreContext;
 import com.hazelcast.map.impl.record.DataRecordFactory;
@@ -31,7 +39,6 @@ import com.hazelcast.map.impl.record.RecordFactory;
 import com.hazelcast.map.merge.MapMergePolicy;
 import com.hazelcast.nio.ClassLoaderUtil;
 import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.query.impl.Indexes;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.util.ExceptionUtil;
@@ -42,13 +49,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
-
-import static com.hazelcast.map.impl.ExpirationTimeSetter.calculateMaxIdleMillis;
-import static com.hazelcast.map.impl.ExpirationTimeSetter.calculateTTLMillis;
-import static com.hazelcast.map.impl.ExpirationTimeSetter.pickTTL;
-import static com.hazelcast.map.impl.ExpirationTimeSetter.setExpirationTime;
-import static com.hazelcast.map.impl.SizeEstimators.createNearCacheSizeEstimator;
-import static com.hazelcast.map.impl.mapstore.MapStoreContextFactory.createMapStoreContext;
 
 /**
  * Map container.
@@ -63,7 +63,7 @@ public class MapContainer {
 
     private final Map<String, MapInterceptor> interceptorMap;
 
-    private final Indexes indexes = new Indexes();
+    private final Indexes indexes;
 
     private final SizeEstimator nearCacheSizeEstimator;
 
@@ -108,6 +108,7 @@ public class MapContainer {
         nearCacheSizeEstimator = createNearCacheSizeEstimator();
         mapStoreContext = createMapStoreContext(this);
         mapStoreContext.start();
+        indexes = new Indexes(nodeEngine.getSerializationService());
     }
 
     private RecordFactory createRecordFactory(NodeEngine nodeEngine) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapMigrationAwareService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapMigrationAwareService.java
@@ -16,10 +16,10 @@
 
 package com.hazelcast.map.impl;
 
+import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.map.impl.operation.MapReplicationOperation;
 import com.hazelcast.map.impl.record.Record;
 import com.hazelcast.map.impl.recordstore.RecordStore;
-import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.partition.MigrationEndpoint;
 import com.hazelcast.query.impl.Indexes;
 import com.hazelcast.query.impl.QueryEntry;
@@ -94,12 +94,13 @@ class MapMigrationAwareService implements MigrationAwareService {
                 while (iterator.hasNext()) {
                     final Record record = iterator.next();
                     if (event.getMigrationEndpoint() == MigrationEndpoint.SOURCE) {
-                        indexes.removeEntryIndex(record.getKey());
+                        // was no old value
+                        indexes.removeEntryIndex(record);
                     } else {
                         Object value = record.getValue();
                         if (value != null) {
                             indexes.saveEntryIndex(new QueryEntry(serializationService, record.getKey(),
-                                    record.getKey(), value));
+                                    record.getKey(), value), null);
                         }
                     }
                 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/AddIndexOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/AddIndexOperation.java
@@ -16,21 +16,22 @@
 
 package com.hazelcast.map.impl.operation;
 
+import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.map.impl.MapContainer;
 import com.hazelcast.map.impl.MapService;
-import com.hazelcast.map.impl.recordstore.RecordStore;
 import com.hazelcast.map.impl.record.Record;
+import com.hazelcast.map.impl.recordstore.RecordStore;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.query.impl.Index;
 import com.hazelcast.query.impl.Indexes;
 import com.hazelcast.query.impl.QueryEntry;
-import com.hazelcast.spi.impl.MutatingOperation;
 import com.hazelcast.spi.PartitionAwareOperation;
 import com.hazelcast.spi.impl.AbstractNamedOperation;
+import com.hazelcast.spi.impl.MutatingOperation;
 import com.hazelcast.util.Clock;
+
 import java.io.IOException;
 import java.util.Iterator;
 
@@ -62,13 +63,14 @@ public class AddIndexOperation extends AbstractNamedOperation implements Partiti
         Indexes indexes = mapContainer.getIndexes();
         SerializationService ss = getNodeEngine().getSerializationService();
         Index index = indexes.addOrGetIndex(attributeName, ordered);
+
         final long now = getNow();
         final Iterator<Record> iterator = recordStore.iterator(now, false);
         while (iterator.hasNext()) {
             final Record record = iterator.next();
             Data key = record.getKey();
             Object value = record.getValue();
-            index.saveEntryIndex(new QueryEntry(ss, key, key, value));
+            index.saveEntryIndex(new QueryEntry(ss, key, key, value), null);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/MapQueryEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/MapQueryEngineImpl.java
@@ -16,6 +16,19 @@
 
 package com.hazelcast.map.impl.query;
 
+import static com.hazelcast.instance.GroupProperty.QUERY_PREDICATE_PARALLEL_EVALUATION;
+import static com.hazelcast.map.impl.record.Record.NOT_CACHED;
+import static com.hazelcast.query.PagingPredicateAccessor.getNearestAnchorEntry;
+import static com.hazelcast.spi.ExecutionService.QUERY_EXECUTOR;
+import static com.hazelcast.util.ExceptionUtil.rethrow;
+import static com.hazelcast.util.FutureUtil.RETHROW_EVERYTHING;
+import static com.hazelcast.util.FutureUtil.returnWithDeadline;
+import static com.hazelcast.util.SortingUtil.compareAnchor;
+import static com.hazelcast.util.SortingUtil.getSortedQueryResultSet;
+import static com.hazelcast.util.SortingUtil.getSortedSubList;
+import static java.util.Collections.singletonList;
+import static java.util.concurrent.TimeUnit.MINUTES;
+
 import com.hazelcast.cluster.ClusterService;
 import com.hazelcast.core.Member;
 import com.hazelcast.internal.serialization.SerializationService;
@@ -56,19 +69,6 @@ import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
-
-import static com.hazelcast.instance.GroupProperty.QUERY_PREDICATE_PARALLEL_EVALUATION;
-import static com.hazelcast.map.impl.record.Record.NOT_CACHED;
-import static com.hazelcast.query.PagingPredicateAccessor.getNearestAnchorEntry;
-import static com.hazelcast.spi.ExecutionService.QUERY_EXECUTOR;
-import static com.hazelcast.util.ExceptionUtil.rethrow;
-import static com.hazelcast.util.FutureUtil.RETHROW_EVERYTHING;
-import static com.hazelcast.util.FutureUtil.returnWithDeadline;
-import static com.hazelcast.util.SortingUtil.compareAnchor;
-import static com.hazelcast.util.SortingUtil.getSortedQueryResultSet;
-import static com.hazelcast.util.SortingUtil.getSortedSubList;
-import static java.util.Collections.singletonList;
-import static java.util.concurrent.TimeUnit.MINUTES;
 
 /**
  * The {@link MapQueryEngine} implementation.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryResultSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryResultSet.java
@@ -16,6 +16,9 @@
 
 package com.hazelcast.map.impl.query;
 
+import static com.hazelcast.util.IterationType.ENTRY;
+import static java.util.Collections.newSetFromMap;
+
 import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
@@ -29,9 +32,6 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-
-import static com.hazelcast.util.IterationType.ENTRY;
-import static java.util.Collections.newSetFromMap;
 
 /**
  * Collection(Set) class for result of query operations.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/AbstractRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/AbstractRecordStore.java
@@ -16,9 +16,12 @@
 
 package com.hazelcast.map.impl.recordstore;
 
+import static com.hazelcast.map.impl.SizeEstimators.createMapSizeEstimator;
+
 import com.hazelcast.concurrent.lock.LockService;
 import com.hazelcast.concurrent.lock.LockStore;
 import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.map.impl.MapContainer;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.map.impl.MapServiceContext;
@@ -27,7 +30,6 @@ import com.hazelcast.map.impl.mapstore.MapStoreContext;
 import com.hazelcast.map.impl.record.Record;
 import com.hazelcast.map.impl.record.RecordFactory;
 import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.query.impl.Indexes;
 import com.hazelcast.query.impl.QueryEntry;
 import com.hazelcast.query.impl.QueryableEntry;
@@ -41,8 +43,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-
-import static com.hazelcast.map.impl.SizeEstimators.createMapSizeEstimator;
 
 /**
  * Contains record store common parts.
@@ -151,31 +151,20 @@ abstract class AbstractRecordStore implements RecordStore {
         return partitionId;
     }
 
-
-    protected void saveIndex(Record record) {
+    protected void saveIndex(Record record, Object oldValue) {
         Data dataKey = record.getKey();
         final Indexes indexes = mapContainer.getIndexes();
         if (indexes.hasIndex()) {
             SerializationService ss = mapServiceContext.getNodeEngine().getSerializationService();
             QueryableEntry queryableEntry = new QueryEntry(ss, dataKey, dataKey, record.getValue());
-            indexes.saveEntryIndex(queryableEntry);
+            indexes.saveEntryIndex(queryableEntry, oldValue);
         }
     }
 
-
-    protected void removeIndex(Data key) {
-        final Indexes indexes = mapContainer.getIndexes();
-        if (indexes.hasIndex()) {
-            indexes.removeEntryIndex(key);
-        }
-    }
-
-    protected void removeIndex(Set<Data> keys) {
-        final Indexes indexes = mapContainer.getIndexes();
-        if (indexes.hasIndex()) {
-            for (Data key : keys) {
-                indexes.removeEntryIndex(key);
-            }
+    protected void removeIndex(Record record) {
+        final Indexes indexService = mapContainer.getIndexes();
+        if (indexService.hasIndex()) {
+            indexService.removeEntryIndex(record);
         }
     }
 
@@ -185,12 +174,13 @@ abstract class AbstractRecordStore implements RecordStore {
      * @param keysToRemove   remove these keys from index.
      * @param keysToPreserve do not remove these keys.
      */
-    protected void removeIndexByPreservingKeys(Set<Data> keysToRemove, Set<Data> keysToPreserve) {
+
+    protected void removeIndexByPreservingKeys(Collection<Record> keysToRemove, Set<Data> keysToPreserve) {
         final Indexes indexes = mapContainer.getIndexes();
         if (indexes.hasIndex()) {
-            for (Data key : keysToRemove) {
-                if (!keysToPreserve.contains(key)) {
-                    indexes.removeEntryIndex(key);
+            for (Record record : keysToRemove) {
+                if (!keysToPreserve.contains(record.getKey())) {
+                    indexes.removeEntryIndex(record);
                 }
             }
         }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/Index.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/Index.java
@@ -17,16 +17,23 @@
 package com.hazelcast.query.impl;
 
 import com.hazelcast.core.TypeConverter;
-import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.map.impl.record.Record;
 import com.hazelcast.query.QueryException;
 
 import java.util.Set;
+
 /**
  * This interface contains the methods related to index of Query.
  */
 public interface Index {
 
-    void saveEntryIndex(QueryableEntry e) throws QueryException;
+    /**
+     * Add entry to this index.
+     * @param e entry
+     * @param oldValue or null if there is no old value
+     * @throws QueryException
+     */
+    void saveEntryIndex(QueryableEntry e, Object oldValue) throws QueryException;
 
     void clear();
 
@@ -38,7 +45,7 @@ public interface Index {
      */
     TypeConverter getConverter();
 
-    void removeEntryIndex(Data indexKey);
+    void removeEntryIndex(Record record);
 
     Set<QueryableEntry> getRecords(Comparable[] values);
 

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/IndexImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/IndexImpl.java
@@ -17,6 +17,8 @@
 package com.hazelcast.query.impl;
 
 import com.hazelcast.core.TypeConverter;
+import com.hazelcast.internal.serialization.SerializationService;
+import com.hazelcast.map.impl.record.Record;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -26,7 +28,6 @@ import com.hazelcast.query.QueryException;
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
 /**
@@ -40,16 +41,18 @@ public class IndexImpl implements Index {
     public static final NullObject NULL = new NullObject();
 
     // indexKey -- indexValue
-    private final ConcurrentMap<Data, Comparable> recordValues = new ConcurrentHashMap<Data, Comparable>(1000);
     private final IndexStore indexStore;
     private final String attribute;
     private final boolean ordered;
 
     private volatile TypeConverter converter;
 
-    public IndexImpl(String attribute, boolean ordered) {
+    private SerializationService ss;
+
+    public IndexImpl(String attribute, boolean ordered, SerializationService ss) {
         this.attribute = attribute;
         this.ordered = ordered;
+        this.ss = ss;
         indexStore = (ordered) ? new SortedIndexStore() : new UnsortedIndexStore();
     }
 
@@ -59,16 +62,20 @@ public class IndexImpl implements Index {
     }
 
     @Override
-    public void removeEntryIndex(Data indexKey) {
-        Comparable oldValue = recordValues.remove(indexKey);
-        if (oldValue != null) {
-            indexStore.removeIndex(oldValue, indexKey);
+    public void removeEntryIndex(Record record) {
+        Comparable value = QueryEntry.extractAttribute(attribute, record.getKey(), record.getValue(), ss);
+
+        if (value.getClass().isEnum()) {
+            value = TypeConverters.ENUM_CONVERTER.convert(value);
+        }
+
+        if (value != null) {
+            indexStore.removeIndex(value, (Data) record.getKey());
         }
     }
 
     @Override
     public void clear() {
-        recordValues.clear();
         indexStore.clear();
         // Clear converter
         converter = null;
@@ -79,7 +86,7 @@ public class IndexImpl implements Index {
     }
 
     @Override
-    public void saveEntryIndex(QueryableEntry e) throws QueryException {
+    public void saveEntryIndex(QueryableEntry e, Object oldRecordValue) throws QueryException {
         /*
          * At first, check if converter is not initialized, initialize it before saving an entry index
          * Because, if entity index is saved before,
@@ -93,10 +100,15 @@ public class IndexImpl implements Index {
             converter = attributeType == null ? TypeConverters.IDENTITY_CONVERTER : attributeType.getConverter();
         }
 
-        Data key = e.getIndexKey();
-        Comparable newValue = e.getAttribute(attribute);
+        Comparable oldValue = null;
+        if (oldRecordValue != null) {
+            oldValue = QueryEntry.extractAttribute(attribute, e.getKey(), oldRecordValue, ss);
+            oldValue = sanitizeValue(oldValue);
+        }
+
+        Comparable newValue = QueryEntry.extractAttribute(attribute, e.getKey(), e.getValue(), ss);
         newValue = sanitizeValue(newValue);
-        Comparable oldValue = recordValues.put(key, newValue);
+
         if (oldValue == null) {
             // new
             indexStore.newIndex(newValue, e);
@@ -106,7 +118,7 @@ public class IndexImpl implements Index {
         }
     }
 
-    private Comparable sanitizeValue(Comparable value) {
+    private static Comparable sanitizeValue(Comparable value) {
         if (value == null) {
             return NULL;
         }
@@ -166,10 +178,6 @@ public class IndexImpl implements Index {
 
     private Comparable convert(Comparable value) {
         return converter.convert(value);
-    }
-
-    public ConcurrentMap<Data, Comparable> getRecordValues() {
-        return recordValues;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/Indexes.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/Indexes.java
@@ -16,7 +16,8 @@
 
 package com.hazelcast.query.impl;
 
-import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.internal.serialization.SerializationService;
+import com.hazelcast.map.impl.record.Record;
 import com.hazelcast.query.IndexAwarePredicate;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.QueryException;
@@ -34,6 +35,11 @@ public class Indexes {
     private final ConcurrentMap<String, Index> mapIndexes = new ConcurrentHashMap<String, Index>(3);
     private final AtomicReference<Index[]> indexes = new AtomicReference<Index[]>(EMPTY_INDEX);
     private volatile boolean hasIndex;
+    private SerializationService ss;
+
+    public Indexes(SerializationService ss) {
+        this.ss = ss;
+    }
 
     public synchronized Index destroyIndex(String attribute) {
         return mapIndexes.remove(attribute);
@@ -44,7 +50,7 @@ public class Indexes {
         if (index != null) {
             return index;
         }
-        index = new IndexImpl(attribute, ordered);
+        index = new IndexImpl(attribute, ordered, ss);
         mapIndexes.put(attribute, index);
         Object[] indexObjects = mapIndexes.values().toArray();
         Index[] newIndexes = new Index[indexObjects.length];
@@ -66,10 +72,10 @@ public class Indexes {
         hasIndex = false;
     }
 
-    public void removeEntryIndex(Data indexKey) throws QueryException {
+    public void removeEntryIndex(Record record) throws QueryException {
         Index[] indexes = getIndexes();
         for (Index index : indexes) {
-            index.removeEntryIndex(indexKey);
+            index.removeEntryIndex(record);
         }
     }
 
@@ -77,10 +83,10 @@ public class Indexes {
         return hasIndex;
     }
 
-    public void saveEntryIndex(QueryableEntry queryableEntry) throws QueryException {
+    public void saveEntryIndex(QueryableEntry queryableEntry, Object oldValue) throws QueryException {
         Index[] indexes = getIndexes();
         for (Index index : indexes) {
-            index.saveEntryIndex(queryableEntry);
+            index.saveEntryIndex(queryableEntry, oldValue);
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryIndexMigrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryIndexMigrationTest.java
@@ -16,6 +16,12 @@
 
 package com.hazelcast.map.impl.query;
 
+import static com.hazelcast.query.Predicates.equal;
+import static com.hazelcast.test.TimeConstants.MINUTE;
+import static java.lang.Thread.interrupted;
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
 import com.hazelcast.config.Config;
 import com.hazelcast.config.MapIndexConfig;
 import com.hazelcast.core.HazelcastInstance;
@@ -33,12 +39,6 @@ import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.util.Clock;
 import com.hazelcast.util.IterableUtil;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -51,13 +51,14 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
-import static com.hazelcast.query.Predicates.equal;
-import static com.hazelcast.test.TimeConstants.MINUTE;
-import static java.lang.Thread.interrupted;
-import static java.util.concurrent.TimeUnit.MINUTES;
-import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
@@ -135,7 +136,6 @@ public class QueryIndexMigrationTest extends HazelcastTestSupport {
         }, 3);
     }
 
-    @Ignore
     @Test
     public void testQueryWithIndexesWhileMigrating() throws Exception {
         HazelcastInstance instance = nodeFactory.newHazelcastInstance();
@@ -162,7 +162,6 @@ public class QueryIndexMigrationTest extends HazelcastTestSupport {
     /**
      * test for issue #359
      */
-    @Ignore
     @Test(timeout = MINUTE)
     public void testIndexCleanupOnMigration() throws Exception {
         int nodeCount = 6;

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryIndexTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryIndexTest.java
@@ -128,6 +128,19 @@ public class QueryIndexTest extends HazelcastTestSupport {
     }
 
     @Test(timeout = 1000 * 60)
+    public void testQueryDoesntMatchOldResults_whenEntriesAreUpdated() {
+        HazelcastInstance instance = createHazelcastInstance();
+        IMap<String, SampleObjects.Value> map = instance.getMap("default");
+        map.addIndex("name", true);
+
+        map.put("0", new Value("name"));
+        map.put("0", new Value("newName"));
+
+        Collection<SampleObjects.Value> values = map.values(new SqlPredicate("name='name'"));
+        assertEquals(0, values.size());
+    }
+
+    @Test(timeout = 1000 * 60)
         public void testOneIndexedFieldsWithTwoCriteriaField() throws Exception {
             HazelcastInstance h1 = createHazelcastInstance();
             IMap imap = h1.getMap("employees");

--- a/hazelcast/src/test/java/com/hazelcast/query/SqlPredicateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/SqlPredicateTest.java
@@ -16,6 +16,10 @@
 
 package com.hazelcast.query;
 
+import static com.hazelcast.instance.TestUtil.toData;
+
+import com.hazelcast.internal.serialization.SerializationService;
+import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
 import com.hazelcast.query.SampleObjects.Employee;
 import com.hazelcast.query.SampleObjects.ObjectWithBigDecimal;
 import com.hazelcast.query.SampleObjects.ObjectWithBoolean;
@@ -34,9 +38,6 @@ import com.hazelcast.query.impl.DateHelperTest;
 import com.hazelcast.query.impl.QueryEntry;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -48,15 +49,21 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
-import static com.hazelcast.instance.TestUtil.toData;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
 public class SqlPredicateTest {
+
+    final SerializationService ss = new DefaultSerializationServiceBuilder().build();
+
     @Test
     public void testEqualsWhenSqlMatches() throws Exception {
         SqlPredicate sql1 = new SqlPredicate("foo='bar'");
@@ -356,8 +363,8 @@ public class SqlPredicateTest {
         return new SqlPredicate(sql).toString();
     }
 
-    private static Map.Entry createEntry(final Object key, final Object value) {
-        return new QueryEntry(null, toData(key), key, value);
+    private Map.Entry createEntry(final Object key, final Object value) {
+        return new QueryEntry(ss, toData(key), key, value);
     }
 
     private void assertSqlTrue(String s, Object value) {

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/IndexTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/IndexTest.java
@@ -16,33 +16,44 @@
 
 package com.hazelcast.query.impl;
 
+import static com.hazelcast.instance.TestUtil.toData;
+import static java.util.Arrays.asList;
+
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.core.PartitioningStrategy;
+import com.hazelcast.internal.serialization.SerializationService;
+import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
+import com.hazelcast.map.impl.record.DataRecordFactory;
+import com.hazelcast.map.impl.record.Record;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.DataSerializable;
-import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
 import com.hazelcast.nio.serialization.Portable;
 import com.hazelcast.nio.serialization.PortableFactory;
 import com.hazelcast.nio.serialization.PortableReader;
 import com.hazelcast.nio.serialization.PortableWriter;
-import com.hazelcast.internal.serialization.SerializationService;
-import com.hazelcast.query.impl.predicates.AndPredicate;
-import com.hazelcast.query.impl.predicates.EqualPredicate;
+import com.hazelcast.partition.strategy.DefaultPartitioningStrategy;
+import com.hazelcast.query.QueryConstants;
 import com.hazelcast.query.QueryException;
 import com.hazelcast.query.impl.getters.ReflectionHelper;
+import com.hazelcast.query.impl.predicates.AndPredicate;
+import com.hazelcast.query.impl.predicates.EqualPredicate;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
 
 import java.io.IOException;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.concurrent.ConcurrentMap;
 
-import static com.hazelcast.instance.TestUtil.toData;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
@@ -52,6 +63,10 @@ public class IndexTest {
 
     final SerializationService ss = new DefaultSerializationServiceBuilder()
             .addPortableFactory(FACTORY_ID, new TestPortableFactory()).build();
+
+    private PartitioningStrategy partitionStrategy = new DefaultPartitioningStrategy();
+
+    final DataRecordFactory recordFactory = new DataRecordFactory(new MapConfig(), ss, partitionStrategy);
 
     @Test
     public void testBasics() {
@@ -65,51 +80,76 @@ public class IndexTest {
 
     @Test
     public void testRemoveEnumIndex() {
-        Indexes is = new Indexes();
+        Indexes is = new Indexes(ss);
         is.addOrGetIndex("favoriteCity", false);
         Data key = ss.toData(1);
         Data value = ss.toData(new SerializableWithEnum(SerializableWithEnum.City.Istanbul));
-        is.saveEntryIndex(new QueryEntry(ss, key, key, value));
+        is.saveEntryIndex(new QueryEntry(ss, key, key, value), null);
         assertNotNull(is.getIndex("favoriteCity"));
-        is.removeEntryIndex(key);
+        Record record = recordFactory.newRecord(key, value);
+        is.removeEntryIndex(record);
         assertEquals(0,is.getIndex("favoriteCity").getRecords(SerializableWithEnum.City.Istanbul).size());
     }
 
     @Test
+    public void testUpdateEnumIndex() {
+        Indexes is = new Indexes(ss);
+        is.addOrGetIndex("favoriteCity", false);
+        Data key = ss.toData(1);
+        Data value = ss.toData(new SerializableWithEnum(SerializableWithEnum.City.Istanbul));
+        is.saveEntryIndex(new QueryEntry(ss, key, key, value), null);
+
+        Data newValue = ss.toData(new SerializableWithEnum(SerializableWithEnum.City.Krakow));
+        is.saveEntryIndex(new QueryEntry(ss, key, key, newValue), value);
+
+        assertEquals(0, is.getIndex("favoriteCity").getRecords(SerializableWithEnum.City.Istanbul).size());
+        assertEquals(1, is.getIndex("favoriteCity").getRecords(SerializableWithEnum.City.Krakow).size());
+    }
+
+    @Test
     public void testIndex() throws QueryException {
-        Indexes is = new Indexes();
+        Indexes is = new Indexes(ss);
         Index dIndex = is.addOrGetIndex("d", false);
         Index boolIndex = is.addOrGetIndex("bool", false);
         Index strIndex = is.addOrGetIndex("str", false);
         for (int i = 0; i < 1000; i++) {
             Data key = ss.toData(i);
             Data value = ss.toData(new MainPortable(i % 2 == 0, -10.34d, "joe" + i));
-            is.saveEntryIndex(new QueryEntry(ss, key, key, value));
+            is.saveEntryIndex(new QueryEntry(ss, key, key, value), null);
         }
         assertEquals(1000, dIndex.getRecords(-10.34d).size());
         assertEquals(1, strIndex.getRecords("joe23").size());
         assertEquals(500, boolIndex.getRecords(true).size());
+
+        clearIndexes(dIndex, boolIndex, strIndex);
+
         for (int i = 0; i < 1000; i++) {
             Data key = ss.toData(i);
             Data value = ss.toData(new MainPortable(false, 11.34d, "joe"));
-            is.saveEntryIndex(new QueryEntry(ss, key, key, value));
+            is.saveEntryIndex(new QueryEntry(ss, key, key, value), null);
         }
+
         assertEquals(0, dIndex.getRecords(-10.34d).size());
         assertEquals(0, strIndex.getRecords("joe23").size());
         assertEquals(1000, strIndex.getRecords("joe").size());
         assertEquals(1000, boolIndex.getRecords(false).size());
         assertEquals(0, boolIndex.getRecords(true).size());
+
+        clearIndexes(dIndex, boolIndex, strIndex);
+
         for (int i = 0; i < 1000; i++) {
             Data key = ss.toData(i);
             Data value = ss.toData(new MainPortable(false, -1 * (i + 1), "joe" + i));
-            is.saveEntryIndex(new QueryEntry(ss, key, key, value));
+            is.saveEntryIndex(new QueryEntry(ss, key, key, value), null);
         }
         assertEquals(0, dIndex.getSubRecordsBetween(1d, 1001d).size());
         assertEquals(1000, dIndex.getSubRecordsBetween(-1d, -1001d).size());
+        clearIndexes(dIndex, boolIndex, strIndex);
+
         for (int i = 0; i < 1000; i++) {
             Data key = ss.toData(i);
             Data value = ss.toData(new MainPortable(false, 1 * (i + 1), "joe" + i));
-            is.saveEntryIndex(new QueryEntry(ss, key, key, value));
+            is.saveEntryIndex(new QueryEntry(ss, key, key, value), null);
         }
         assertEquals(1000, dIndex.getSubRecordsBetween(1d, 1001d).size());
         assertEquals(0, dIndex.getSubRecordsBetween(-1d, -1001d).size());
@@ -122,24 +162,30 @@ public class IndexTest {
         assertEquals(1, is.query(new AndPredicate(new EqualPredicate("d", "1"), new EqualPredicate("bool", false))).size());
     }
 
+    private void clearIndexes(Index ... indexes) {
+        for(Index index: indexes) {
+            index.clear();
+        }
+    }
+
     @Test
     public void testIndexWithNull() throws QueryException {
-        Indexes is = new Indexes();
+        Indexes is = new Indexes(ss);
         Index strIndex = is.addOrGetIndex("str", true);
 
         Data value = ss.toData(new MainPortable(false, 1, null));
         Data key1 = ss.toData(0);
-        is.saveEntryIndex(new QueryEntry(ss, key1, key1, value));
+        is.saveEntryIndex(new QueryEntry(ss, key1, key1, value), null);
 
         value = ss.toData(new MainPortable(false, 2, null));
         Data key2 = ss.toData(1);
-        is.saveEntryIndex(new QueryEntry(ss, key2, key2, value));
+        is.saveEntryIndex(new QueryEntry(ss, key2, key2, value), null);
 
 
         for (int i = 2; i < 1000; i++) {
             Data key = ss.toData(i);
             value = ss.toData(new MainPortable(false, 1 * (i + 1), "joe" + i));
-            is.saveEntryIndex(new QueryEntry(ss, key, key, value));
+            is.saveEntryIndex(new QueryEntry(ss, key, key, value), null);
         }
 
         Comparable c = null;
@@ -349,7 +395,7 @@ public class IndexTest {
         }
 
         public Object getValue() {
-            return null;
+            return attributeValue;
         }
 
         public Object setValue(Object value) {
@@ -365,33 +411,40 @@ public class IndexTest {
 
         public void readData(ObjectDataInput in) throws IOException {
         }
+
+        public Record toRecord() {
+            return recordFactory.newRecord(key, attributeValue);
+        }
     }
 
     private void testIt(boolean ordered) {
-        IndexImpl index = new IndexImpl(null, ordered);
+        IndexImpl index = new IndexImpl(QueryConstants.THIS_ATTRIBUTE_NAME, ordered, ss);
         assertEquals(0, index.getRecords(0L).size());
         assertEquals(0, index.getSubRecordsBetween(0L, 1000L).size());
         QueryRecord record5 = newRecord(5L, 55L);
-        index.saveEntryIndex(record5);
-        assertEquals(1, index.getRecordValues().size());
-        assertEquals(55L, index.getRecordValues().get(record5.getIndexKey()));
+        index.saveEntryIndex(record5, null);
+        assertEquals(Collections.<QueryableEntry>singleton(record5), index.getRecords(55L));
+
         QueryRecord record6 = newRecord(6L, 66L);
-        index.saveEntryIndex(record6);
-        assertEquals(2, index.getRecordValues().size());
-        assertEquals(new Long(66L), index.getRecordValues().get(record6.getIndexKey()));
-        record5.changeAttribute(555L);
-        index.saveEntryIndex(record5);
-        assertEquals(2, index.getRecordValues().size());
-        assertEquals(new Long(555L), index.getRecordValues().get(record5.getIndexKey()));
+        index.saveEntryIndex(record6, null);
+
+        assertEquals(Collections.<QueryableEntry>singleton(record6), index.getRecords(66L));
+
+        QueryRecord newRecord5 = newRecord(5L, 555L);
+        index.saveEntryIndex(newRecord5, record5.getValue());
+        record5 = newRecord5;
+
+        assertEquals(0, index.getRecords(55L).size());
+        assertEquals(Collections.<QueryableEntry>singleton(record5), index.getRecords(555L));
+
         assertEquals(1, index.getRecords(555L).size());
         assertEquals(2, index.getSubRecordsBetween(55L, 555L).size());
         assertEquals(2, index.getSubRecordsBetween(66L, 555L).size());
         assertEquals(1, index.getSubRecordsBetween(555L, 555L).size());
         QueryRecord record50 = newRecord(50L, 555L);
-        index.saveEntryIndex(record50);
-        assertEquals(3, index.getRecordValues().size());
-        assertEquals(new Long(555L), index.getRecordValues().get(record5.getIndexKey()));
-        assertEquals(new Long(555L), index.getRecordValues().get(record50.getIndexKey()));
+        index.saveEntryIndex(record50, null);
+        assertEquals(new HashSet(asList(record5, record50)), index.getRecords(555L));
+
         ConcurrentMap<Data, QueryableEntry> records = index.getRecordMap(555L);
         assertNotNull(records);
         assertEquals(2, records.size());
@@ -412,10 +465,11 @@ public class IndexTest {
         assertEquals(1, index.getSubRecords(ComparisonType.NOT_EQUAL, 555L).size());
         assertEquals(3, index.getRecords(new Comparable[]{66L, 555L, 34234L}).size());
         assertEquals(2, index.getRecords(new Comparable[]{555L, 34234L}).size());
-        index.removeEntryIndex(record5.getIndexKey());
-        assertEquals(2, index.getRecordValues().size());
-        assertEquals(new Long(555L), index.getRecordValues().get(record50.getIndexKey()));
-        assertEquals(null, index.getRecordValues().get(record5.getIndexKey()));
+
+        index.removeEntryIndex(record5.toRecord());
+
+        assertEquals(Collections.<QueryableEntry>singleton(record50), index.getRecords(555L));
+
         records = index.getRecordMap(555L);
         assertNotNull(records);
         assertEquals(null, records.get(5L));
@@ -430,18 +484,20 @@ public class IndexTest {
         assertEquals(1, index.getSubRecords(ComparisonType.GREATER, 66L).size());
         assertEquals(2, index.getSubRecords(ComparisonType.GREATER_EQUAL, 66L).size());
         assertEquals(2, index.getSubRecords(ComparisonType.GREATER_EQUAL, 61L).size());
-        index.removeEntryIndex(record50.getIndexKey());
-        assertEquals(1, index.getRecordValues().size());
-        assertEquals(null, index.getRecordValues().get(50L));
+        index.removeEntryIndex(record50.toRecord());
+
+        assertEquals(0, index.getRecords(555L).size());
+
         records = index.getRecordMap(555L);
         assertNull(records);
         assertEquals(0, index.getRecords(555L).size());
         assertEquals(1, index.getSubRecordsBetween(55L, 555L).size());
         assertEquals(1, index.getSubRecordsBetween(66L, 555L).size());
         assertEquals(0, index.getSubRecordsBetween(555L, 555L).size());
-        index.removeEntryIndex(record6.getIndexKey());
-        assertEquals(0, index.getRecordValues().size());
-        assertEquals(null, index.getRecordValues().get(6L));
+        index.removeEntryIndex(record6.toRecord());
+
+        assertEquals(0, index.getRecords(66L).size());
+
         assertNull(index.getRecordMap(66L));
         assertEquals(0, index.getRecords(555L).size());
         assertEquals(0, index.getSubRecordsBetween(55L, 555L).size());

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/PredicatesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/PredicatesTest.java
@@ -16,35 +16,7 @@
 
 package com.hazelcast.query.impl.predicates;
 
-import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.IMap;
-import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.query.EntryObject;
-import com.hazelcast.query.IndexAwarePredicate;
-import com.hazelcast.query.Predicate;
-import com.hazelcast.query.PredicateBuilder;
-import com.hazelcast.query.Predicates;
-import com.hazelcast.query.QueryException;
-import com.hazelcast.query.impl.AttributeType;
-import com.hazelcast.query.impl.Index;
-import com.hazelcast.query.impl.IndexImpl;
-import com.hazelcast.query.impl.QueryContext;
-import com.hazelcast.query.impl.QueryEntry;
-import com.hazelcast.query.impl.QueryableEntry;
-import com.hazelcast.query.impl.getters.ReflectionHelper;
-import com.hazelcast.test.HazelcastSerialClassRunner;
-import com.hazelcast.test.HazelcastTestSupport;
-import com.hazelcast.test.annotation.QuickTest;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
-
-import java.math.BigDecimal;
-import java.util.Map;
-import java.util.Set;
-
 import static com.hazelcast.instance.TestUtil.toData;
-
 import static com.hazelcast.query.Predicates.and;
 import static com.hazelcast.query.Predicates.between;
 import static com.hazelcast.query.Predicates.equal;
@@ -59,20 +31,53 @@ import static com.hazelcast.query.Predicates.like;
 import static com.hazelcast.query.Predicates.notEqual;
 import static com.hazelcast.query.Predicates.or;
 import static com.hazelcast.query.Predicates.regex;
-import static com.hazelcast.query.SampleObjects.Employee;
-import static com.hazelcast.query.SampleObjects.Value;
 import static java.lang.Boolean.FALSE;
 import static java.lang.Boolean.TRUE;
-import static java.util.Map.Entry;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.internal.serialization.SerializationService;
+import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.query.EntryObject;
+import com.hazelcast.query.IndexAwarePredicate;
+import com.hazelcast.query.Predicate;
+import com.hazelcast.query.PredicateBuilder;
+import com.hazelcast.query.Predicates;
+import com.hazelcast.query.QueryException;
+import com.hazelcast.query.SampleObjects.Employee;
+import com.hazelcast.query.SampleObjects.Value;
+import com.hazelcast.query.impl.AttributeType;
+import com.hazelcast.query.impl.Index;
+import com.hazelcast.query.impl.IndexImpl;
+import com.hazelcast.query.impl.QueryContext;
+import com.hazelcast.query.impl.QueryEntry;
+import com.hazelcast.query.impl.QueryableEntry;
+import com.hazelcast.query.impl.getters.ReflectionHelper;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.QuickTest;
+
+import java.math.BigDecimal;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
 public class PredicatesTest extends HazelcastTestSupport {
+
+    final SerializationService ss = new DefaultSerializationServiceBuilder().build();
 
     @Test
     public void testAndPredicate_whenFirstIndexAwarePredicateIsNotIndexed() throws Exception {
@@ -295,7 +300,7 @@ public class PredicatesTest extends HazelcastTestSupport {
 
     @Test
     public void testNotEqualsPredicateDoesNotUseIndex() {
-        Index dummyIndex = new IndexImpl("foo", false);
+        Index dummyIndex = new IndexImpl("foo", false, ss);
         QueryContext mockQueryContext = mock(QueryContext.class);
         when(mockQueryContext.getIndex(anyString())).
                 thenReturn(dummyIndex);
@@ -310,7 +315,7 @@ public class PredicatesTest extends HazelcastTestSupport {
     private class DummyEntry extends QueryEntry {
 
         DummyEntry(Comparable attribute) {
-            super(null, toData("1"), "1", attribute);
+            super(ss, toData("1"), "1", attribute);
         }
 
         @Override
@@ -381,8 +386,8 @@ public class PredicatesTest extends HazelcastTestSupport {
 
     }
 
-    private static Entry createEntry(final Object key, final Object value) {
-        return new QueryEntry(null, toData(key), key, value);
+    private Entry createEntry(final Object key, final Object value) {
+        return new QueryEntry(ss, toData(key), key, value);
     }
 
     private void assertPredicateTrue(Predicate p, Comparable comparable) {

--- a/hazelcast/src/test/java/com/hazelcast/test/TestHazelcastInstanceFactory.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/TestHazelcastInstanceFactory.java
@@ -16,8 +16,9 @@
 
 package com.hazelcast.test;
 
+import static com.hazelcast.util.Preconditions.checkNotNull;
+
 import com.hazelcast.config.Config;
-import com.hazelcast.config.XmlConfigBuilder;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.instance.GroupProperty;
@@ -31,8 +32,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicInteger;
-
-import static com.hazelcast.util.Preconditions.checkNotNull;
 
 public class TestHazelcastInstanceFactory {
 
@@ -187,7 +186,7 @@ public class TestHazelcastInstanceFactory {
 
     private static Config init(Config config) {
         if (config == null) {
-            config = new XmlConfigBuilder().build();
+            config = new Config(); //new XmlConfigBuilder().build();
         }
         config.setProperty(GroupProperty.WAIT_SECONDS_BEFORE_JOIN, "0");
         config.setProperty(GroupProperty.GRACEFUL_SHUTDOWN_MAX_WAIT, "120");


### PR DESCRIPTION
A few optimisations to reduce index memory usage:
- Avoiding storing value in serialized and unserialized form inside QueryEntry. Now only storing value in original form.
- Not storing old value in the index anymore (IndexImpl.recordValues). Instead fetching it from Record itself.



