### PR TITLE
Added EntryExpiredListener in order to listen expired map entries.

### DIFF
--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
@@ -1413,6 +1413,7 @@ public class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V> {
                 case REMOVED:
                 case UPDATED:
                 case EVICTED:
+                case EXPIRED:
                 case MERGED:
                     iMapEvent = createEntryEvent(key, value, oldValue, mergingValue, eventType, member);
                     break;
@@ -1503,6 +1504,7 @@ public class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V> {
                 case UPDATED:
                 case MERGED:
                 case EVICTED:
+                case EXPIRED:
                     nearCache.remove(key);
                     break;
                 case CLEAR_ALL:

--- a/hazelcast-client-new/src/test/java/com/hazelcast/client/map/impl/listener/ClientExpirationListenerTest.java
+++ b/hazelcast-client-new/src/test/java/com/hazelcast/client/map/impl/listener/ClientExpirationListenerTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.map.impl.listener;
+
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.core.EntryEvent;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.map.listener.EntryEvictedListener;
+import com.hazelcast.map.listener.EntryExpiredListener;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ClientExpirationListenerTest extends HazelcastTestSupport {
+
+    private final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
+    private HazelcastInstance client;
+    private IMap map;
+
+    @Before
+    public void setup() {
+        hazelcastFactory.newHazelcastInstance();
+        client = hazelcastFactory.newHazelcastClient();
+        map = client.getMap(randomName());
+    }
+
+    @After
+    public void tearDown() {
+        hazelcastFactory.terminateAll();
+    }
+
+    @Test
+    public void testExpirationListener_notified_afterExpirationOfEntries() throws Exception {
+        int numberOfPutOperations = 1000;
+        CountDownLatch expirationEventArrivalCount = new CountDownLatch(numberOfPutOperations);
+
+        map.addEntryListener(new ExpirationListener(expirationEventArrivalCount), true);
+
+        for (int i = 0; i < numberOfPutOperations; i++) {
+            map.put(i, i, 100, TimeUnit.MILLISECONDS);
+        }
+
+        // wait expiration of entries.
+        sleepAtLeastMillis(200);
+
+        // trigger immediate fire of expiration events by touching them.
+        for (int i = 0; i < numberOfPutOperations; i++) {
+            map.get(i);
+        }
+
+        assertOpenEventually(expirationEventArrivalCount);
+    }
+
+    private static class ExpirationListener implements EntryExpiredListener {
+
+        private final CountDownLatch expirationEventCount;
+
+        public ExpirationListener(CountDownLatch expirationEventCount) {
+            this.expirationEventCount = expirationEventCount;
+        }
+
+        @Override
+        public void entryExpired(EntryEvent event) {
+            expirationEventCount.countDown();
+        }
+    }
+
+
+    @Test
+    public void testExpirationAndEvictionListener_bothNotified_afterExpirationOfEntries() throws Exception {
+        int numberOfPutOperations = 1000;
+        CountDownLatch expirationEventCount = new CountDownLatch(numberOfPutOperations);
+        CountDownLatch evictionEventCount = new CountDownLatch(numberOfPutOperations);
+
+        map.addEntryListener(new ExpirationAndEvictionListener(expirationEventCount, evictionEventCount), true);
+
+        for (int i = 0; i < numberOfPutOperations; i++) {
+            map.put(i, i, 100, TimeUnit.MILLISECONDS);
+        }
+
+        // wait expiration of entries.
+        sleepAtLeastMillis(200);
+
+        // trigger immediate fire of expiration events by touching them.
+        for (int i = 0; i < numberOfPutOperations; i++) {
+            map.get(i);
+        }
+
+        assertOpenEventually(evictionEventCount);
+        assertOpenEventually(expirationEventCount);
+    }
+
+
+    private static class ExpirationAndEvictionListener implements EntryExpiredListener, EntryEvictedListener {
+
+        private final CountDownLatch expirationEventArrivalCount;
+        private final CountDownLatch evictionEventArrivalCount;
+
+        public ExpirationAndEvictionListener(CountDownLatch expirationEventArrivalCount, CountDownLatch evictionEventArrivalCount) {
+            this.expirationEventArrivalCount = expirationEventArrivalCount;
+            this.evictionEventArrivalCount = evictionEventArrivalCount;
+        }
+
+        @Override
+        public void entryExpired(EntryEvent event) {
+            expirationEventArrivalCount.countDown();
+        }
+
+        @Override
+        public void entryEvicted(EntryEvent event) {
+            evictionEventArrivalCount.countDown();
+        }
+    }
+
+}

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
@@ -1190,6 +1190,7 @@ public class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V> {
                 case REMOVED:
                 case UPDATED:
                 case EVICTED:
+                case EXPIRED:
                 case MERGED:
                     iMapEvent = createEntryEvent(event, member);
                     break;

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/listener/ClientExpirationListenerTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/listener/ClientExpirationListenerTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.map.impl.listener;
+
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.core.EntryEvent;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.map.listener.EntryEvictedListener;
+import com.hazelcast.map.listener.EntryExpiredListener;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ClientExpirationListenerTest extends HazelcastTestSupport {
+
+    private final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
+    private HazelcastInstance client;
+    private IMap map;
+
+    @Before
+    public void setup() {
+        hazelcastFactory.newHazelcastInstance();
+        client = hazelcastFactory.newHazelcastClient();
+        map = client.getMap(randomName());
+    }
+
+    @After
+    public void tearDown() {
+        hazelcastFactory.terminateAll();
+    }
+
+    @Test
+    public void testExpirationListener_notified_afterExpirationOfEntries() throws Exception {
+        int numberOfPutOperations = 1000;
+        CountDownLatch expirationEventArrivalCount = new CountDownLatch(numberOfPutOperations);
+
+        map.addEntryListener(new ExpirationListener(expirationEventArrivalCount), true);
+
+        for (int i = 0; i < numberOfPutOperations; i++) {
+            map.put(i, i, 100, TimeUnit.MILLISECONDS);
+        }
+
+        // wait expiration of entries.
+        sleepAtLeastMillis(200);
+
+        // trigger immediate fire of expiration events by touching them.
+        for (int i = 0; i < numberOfPutOperations; i++) {
+            map.get(i);
+        }
+
+        assertOpenEventually(expirationEventArrivalCount);
+    }
+
+    private static class ExpirationListener implements EntryExpiredListener {
+
+        private final CountDownLatch expirationEventCount;
+
+        public ExpirationListener(CountDownLatch expirationEventCount) {
+            this.expirationEventCount = expirationEventCount;
+        }
+
+        @Override
+        public void entryExpired(EntryEvent event) {
+            expirationEventCount.countDown();
+        }
+    }
+
+
+    @Test
+    public void testExpirationAndEvictionListener_bothNotified_afterExpirationOfEntries() throws Exception {
+        int numberOfPutOperations = 1000;
+        CountDownLatch expirationEventCount = new CountDownLatch(numberOfPutOperations);
+        CountDownLatch evictionEventCount = new CountDownLatch(numberOfPutOperations);
+
+        map.addEntryListener(new ExpirationAndEvictionListener(expirationEventCount, evictionEventCount), true);
+
+        for (int i = 0; i < numberOfPutOperations; i++) {
+            map.put(i, i, 100, TimeUnit.MILLISECONDS);
+        }
+
+        // wait expiration of entries.
+        sleepAtLeastMillis(200);
+
+        // trigger immediate fire of expiration events by touching them.
+        for (int i = 0; i < numberOfPutOperations; i++) {
+            map.get(i);
+        }
+
+        assertOpenEventually(evictionEventCount);
+        assertOpenEventually(expirationEventCount);
+    }
+
+
+    private static class ExpirationAndEvictionListener implements EntryExpiredListener, EntryEvictedListener {
+
+        private final CountDownLatch expirationEventArrivalCount;
+        private final CountDownLatch evictionEventArrivalCount;
+
+        public ExpirationAndEvictionListener(CountDownLatch expirationEventArrivalCount, CountDownLatch evictionEventArrivalCount) {
+            this.expirationEventArrivalCount = expirationEventArrivalCount;
+            this.evictionEventArrivalCount = evictionEventArrivalCount;
+        }
+
+        @Override
+        public void entryExpired(EntryEvent event) {
+            expirationEventArrivalCount.countDown();
+        }
+
+        @Override
+        public void entryEvicted(EntryEvent event) {
+            evictionEventArrivalCount.countDown();
+        }
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/AbstractMapAddEntryListenerMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/AbstractMapAddEntryListenerMessageTask.java
@@ -19,10 +19,10 @@ package com.hazelcast.client.impl.protocol.task.map;
 import com.hazelcast.client.ClientEndpoint;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.task.AbstractCallableMessageTask;
-import com.hazelcast.core.EntryAdapter;
 import com.hazelcast.core.EntryEvent;
 import com.hazelcast.core.EntryEventType;
 import com.hazelcast.core.MapEvent;
+import com.hazelcast.map.impl.MapListenerAdapter;
 import com.hazelcast.instance.Node;
 import com.hazelcast.map.impl.DataAwareEntryEvent;
 import com.hazelcast.map.impl.MapService;
@@ -47,7 +47,7 @@ public abstract class AbstractMapAddEntryListenerMessageTask<Parameter>
         final ClientEndpoint endpoint = getEndpoint();
         final MapService mapService = getService(MapService.SERVICE_NAME);
 
-        EntryAdapter<Object, Object> listener = new MapListener();
+        MapListenerAdapter<Object, Object> listener = new MapListener();
         MapServiceContext mapServiceContext = mapService.getMapServiceContext();
         final String name = getDistributedObjectName();
         final String registrationId = mapServiceContext.addEventListener(listener, getEventFilter(), name);
@@ -72,7 +72,7 @@ public abstract class AbstractMapAddEntryListenerMessageTask<Parameter>
         return new MapPermission(getDistributedObjectName(), ActionConstants.ACTION_LISTEN);
     }
 
-    private class MapListener extends EntryAdapter<Object, Object> {
+    private class MapListener extends MapListenerAdapter<Object, Object> {
 
         @Override
         public void onEntryEvent(EntryEvent<Object, Object> event) {

--- a/hazelcast/src/main/java/com/hazelcast/core/EntryEventType.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/EntryEventType.java
@@ -27,11 +27,12 @@ public enum EntryEventType {
     EVICTED(4),
     EVICT_ALL(5),
     CLEAR_ALL(6),
-    MERGED(7);
+    MERGED(7),
+    EXPIRED(8);
 
     private int type;
 
-    private EntryEventType(final int type) {
+    EntryEventType(final int type) {
         this.type = type;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapListenerAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapListenerAdapter.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl;
+
+import com.hazelcast.core.EntryAdapter;
+import com.hazelcast.core.EntryEvent;
+import com.hazelcast.core.MapEvent;
+import com.hazelcast.map.listener.EntryAddedListener;
+import com.hazelcast.map.listener.EntryEvictedListener;
+import com.hazelcast.map.listener.EntryExpiredListener;
+import com.hazelcast.map.listener.EntryMergedListener;
+import com.hazelcast.map.listener.EntryRemovedListener;
+import com.hazelcast.map.listener.EntryUpdatedListener;
+import com.hazelcast.map.listener.MapClearedListener;
+import com.hazelcast.map.listener.MapEvictedListener;
+
+/**
+ *
+ * Internal usage only adapter for {@link com.hazelcast.map.listener.MapListener}.
+ *
+ * The difference between this adapter and {@link EntryAdapter} is,
+ * {@link EntryAdapter} is deprecated form of this one and it doesn't implement newly added listener interfaces.
+ *
+ *
+ * @param <K> key of the map entry
+ * @param <V> value of the map entry.
+ *
+ * @see com.hazelcast.map.listener.MapListener
+ * @since 3.6
+ */
+
+public class MapListenerAdapter<K, V> implements EntryAddedListener<K, V>, EntryUpdatedListener<K, V>,
+        EntryRemovedListener<K, V>, EntryEvictedListener<K, V>, EntryExpiredListener<K, V>, EntryMergedListener<K, V>,
+        MapClearedListener, MapEvictedListener {
+
+    @Override
+    public void entryAdded(EntryEvent<K, V> event) {
+        onEntryEvent(event);
+    }
+
+    @Override
+    public void entryRemoved(EntryEvent<K, V> event) {
+        onEntryEvent(event);
+    }
+
+    @Override
+    public void entryUpdated(EntryEvent<K, V> event) {
+        onEntryEvent(event);
+    }
+
+    @Override
+    public void entryEvicted(EntryEvent<K, V> event) {
+        onEntryEvent(event);
+    }
+
+    @Override
+    public void entryExpired(EntryEvent<K, V> event) {
+        onEntryEvent(event);
+    }
+
+    @Override
+    public void entryMerged(EntryEvent<K, V> event) {
+        onEntryEvent(event);
+    }
+
+    @Override
+    public void mapEvicted(MapEvent event) {
+        onMapEvent(event);
+    }
+
+    @Override
+    public void mapCleared(MapEvent event) {
+        onMapEvent(event);
+    }
+
+    /**
+     * This method is called when an one of the methods of the {@link com.hazelcast.core.EntryListener} is not
+     * overridden. It can be practical if you want to bundle some/all of the methods to a single method.
+     *
+     * @param event the EntryEvent.
+     */
+    public void onEntryEvent(EntryEvent<K, V> event) {
+    }
+
+    /**
+     * This method is called when an one of the methods of the {@link com.hazelcast.core.EntryListener} is not
+     * overridden. It can be practical if you want to bundle some/all of the methods to a single method.
+     *
+     * @param event the MapEvent.
+     */
+    public void onMapEvent(MapEvent event) {
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapListenerAdaptors.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapListenerAdaptors.java
@@ -22,6 +22,7 @@ import com.hazelcast.core.IMapEvent;
 import com.hazelcast.core.MapEvent;
 import com.hazelcast.map.listener.EntryAddedListener;
 import com.hazelcast.map.listener.EntryEvictedListener;
+import com.hazelcast.map.listener.EntryExpiredListener;
 import com.hazelcast.map.listener.EntryMergedListener;
 import com.hazelcast.map.listener.EntryRemovedListener;
 import com.hazelcast.map.listener.EntryUpdatedListener;
@@ -192,6 +193,26 @@ public final class MapListenerAdaptors {
 
 
     /**
+     * Converts an {@link EntryExpiredListener} to a {@link com.hazelcast.map.impl.ListenerAdapter}.
+     */
+    private static final ConstructorFunction<MapListener, ListenerAdapter> ENTRY_EXPIRED_LISTENER_ADAPTER_CONSTRUCTOR =
+            new ConstructorFunction<MapListener, ListenerAdapter>() {
+                @Override
+                public ListenerAdapter createNew(MapListener mapListener) {
+                    if (!(mapListener instanceof EntryExpiredListener)) {
+                        return null;
+                    }
+                    final EntryExpiredListener listener = (EntryExpiredListener) mapListener;
+                    return new ListenerAdapter() {
+                        @Override
+                        public void onEvent(IMapEvent event) {
+                            listener.entryExpired((EntryEvent) event);
+                        }
+                    };
+                }
+            };
+
+    /**
      * Register all {@link com.hazelcast.map.impl.ListenerAdapter} constructors
      * according to {@link com.hazelcast.core.EntryEventType}s.
      */
@@ -200,9 +221,10 @@ public final class MapListenerAdaptors {
         CONSTRUCTORS.put(EntryEventType.REMOVED, ENTRY_REMOVED_LISTENER_ADAPTER_CONSTRUCTOR);
         CONSTRUCTORS.put(EntryEventType.EVICTED, ENTRY_EVICTED_LISTENER_ADAPTER_CONSTRUCTOR);
         CONSTRUCTORS.put(EntryEventType.UPDATED, ENTRY_UPDATED_LISTENER_ADAPTER_CONSTRUCTOR);
+        CONSTRUCTORS.put(EntryEventType.MERGED, ENTRY_MERGED_LISTENER_ADAPTER_CONSTRUCTOR);
+        CONSTRUCTORS.put(EntryEventType.EXPIRED, ENTRY_EXPIRED_LISTENER_ADAPTER_CONSTRUCTOR);
         CONSTRUCTORS.put(EntryEventType.EVICT_ALL, MAP_EVICTED_LISTENER_ADAPTER_CONSTRUCTOR);
         CONSTRUCTORS.put(EntryEventType.CLEAR_ALL, MAP_CLEARED_LISTENER_ADAPTER_CONSTRUCTOR);
-        CONSTRUCTORS.put(EntryEventType.MERGED, ENTRY_MERGED_LISTENER_ADAPTER_CONSTRUCTOR);
     }
 
     private MapListenerAdaptors() {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/client/AbstractMapAddEntryListenerRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/client/AbstractMapAddEntryListenerRequest.java
@@ -19,12 +19,12 @@ package com.hazelcast.map.impl.client;
 import com.hazelcast.client.ClientEndpoint;
 import com.hazelcast.client.impl.client.CallableClientRequest;
 import com.hazelcast.client.impl.client.RetryableRequest;
-import com.hazelcast.core.EntryAdapter;
 import com.hazelcast.core.EntryEvent;
 import com.hazelcast.core.EntryEventType;
 import com.hazelcast.core.MapEvent;
 import com.hazelcast.map.impl.DataAwareEntryEvent;
 import com.hazelcast.map.impl.EntryEventFilter;
+import com.hazelcast.map.impl.MapListenerAdapter;
 import com.hazelcast.map.impl.MapPortableHook;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.map.impl.query.QueryEventFilter;
@@ -66,7 +66,7 @@ public abstract class AbstractMapAddEntryListenerRequest extends CallableClientR
         final ClientEndpoint endpoint = getEndpoint();
         final MapService mapService = getService();
 
-        EntryAdapter<Object, Object> listener = new EntryAdapter<Object, Object>() {
+        MapListenerAdapter<Object, Object> listener = new MapListenerAdapter<Object, Object>() {
             @Override
             public void onEntryEvent(EntryEvent<Object, Object> event) {
                 if (endpoint.isAlive()) {
@@ -80,7 +80,7 @@ public abstract class AbstractMapAddEntryListenerRequest extends CallableClientR
                     Data oldValue = dataAwareEntryEvent.getOldValueData();
                     Data mergingValue = dataAwareEntryEvent.getMergingValueData();
                     PortableEntryEvent portableEntryEvent = new PortableEntryEvent(key, value, oldValue, mergingValue,
-                            event.getEventType(), event.getMember().getUuid());
+                             event.getEventType(), event.getMember().getUuid());
                     endpoint.sendEvent(key, portableEntryEvent, getCallId());
                 }
             }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/event/MapEventPublisherImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/event/MapEventPublisherImpl.java
@@ -18,6 +18,7 @@ package com.hazelcast.map.impl.event;
 
 import com.hazelcast.core.EntryEventType;
 import com.hazelcast.core.EntryView;
+import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.map.impl.EntryEventFilter;
 import com.hazelcast.map.impl.MapContainer;
 import com.hazelcast.map.impl.MapPartitionLostEventFilter;
@@ -28,7 +29,6 @@ import com.hazelcast.map.impl.wan.MapReplicationRemove;
 import com.hazelcast.map.impl.wan.MapReplicationUpdate;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.query.impl.QueryEntry;
 import com.hazelcast.spi.EventFilter;
 import com.hazelcast.spi.EventRegistration;
@@ -291,7 +291,7 @@ public class MapEventPublisherImpl implements MapEventPublisher {
         final NodeEngine nodeEngine = mapServiceContext.getNodeEngine();
         final SerializationService serializationService = nodeEngine.getSerializationService();
         Data testValue;
-        if (eventType == EntryEventType.REMOVED || eventType == EntryEventType.EVICTED) {
+        if (eventType == EntryEventType.REMOVED || eventType == EntryEventType.EVICTED || eventType == EntryEventType.EXPIRED) {
             testValue = dataOldValue;
         } else {
             testValue = dataValue;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStore.java
@@ -261,6 +261,16 @@ public interface RecordStore {
     boolean isExpirable();
 
     /**
+     * Checks whether a record is expired or not.
+     *
+     * @param record the record from record-store.
+     * @param now    current time in millis
+     * @param backup <code>true</code> if a backup partition, otherwise <code>false</code>.
+     * @return <code>true</code> if the record is expired, <code>false</code> otherwise.
+     */
+    boolean isExpired(Record record, long now, boolean backup);
+
+    /**
      * Loads all given keys from defined map store.
      *
      * @param keys                  keys to be loaded.

--- a/hazelcast/src/main/java/com/hazelcast/map/listener/EntryExpiredListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/listener/EntryExpiredListener.java
@@ -19,10 +19,8 @@ package com.hazelcast.map.listener;
 import com.hazelcast.core.EntryEvent;
 
 /**
- * Invoked upon eviction of an entry.
- *
- * Implementations of this interface receive events after removal of the entry. Removals can be caused by
- * one of size-based-eviction, time-to-live based expiration or max-idle-seconds based expiration.
+ * Listener which is notified after removal of an entry due to the expiration-based-eviction.
+ * There are two sources of expiration based eviction, they are max-idle-seconds and time-to-live-seconds.
  *
  * Note that if your listener implements both {@link EntryExpiredListener} and {@link EntryEvictedListener} together,
  * there is a probability that the listener may receive both expiration and eviction events for the same entry. This is because,
@@ -31,16 +29,16 @@ import com.hazelcast.core.EntryEvent;
  * @param <K> the type of key.
  * @param <V> the type of value.
  *
- * @see EntryExpiredListener
+ * @see EntryEvictedListener
  *
- * @since 3.5
+ * @since 3.6
  */
-public interface EntryEvictedListener<K, V> extends MapListener {
+public interface EntryExpiredListener<K, V> extends MapListener {
 
     /**
-     * Invoked upon eviction of an entry.
+     * Invoked upon expiration of an entry.
      *
-     * @param event the event invoked when an entry is evicted
+     * @param event the event invoked when an entry is expired.
      */
-    void entryEvicted(EntryEvent<K, V> event);
+    void entryExpired(EntryEvent<K, V> event);
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/listener/MapListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/listener/MapListener.java
@@ -43,6 +43,7 @@ import java.util.EventListener;
  * @see EntryRemovedListener
  * @see EntryMergedListener
  * @see EntryUpdatedListener
+ *
  * @since 3.5
  */
 public interface MapListener extends EventListener {

--- a/hazelcast/src/test/java/com/hazelcast/core/MapListenerAdapterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/core/MapListenerAdapterTest.java
@@ -1,0 +1,62 @@
+package com.hazelcast.core;
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import com.hazelcast.config.Config;
+import com.hazelcast.map.impl.MapListenerAdapter;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class MapListenerAdapterTest extends HazelcastTestSupport {
+
+    @Test
+    public void testMapListenerAdapter_whenEntryExpired() {
+        String mapName = randomMapName();
+        Config cfg = new Config();
+
+        TestHazelcastInstanceFactory instanceFactory = createHazelcastInstanceFactory(1);
+        HazelcastInstance instance = instanceFactory.newHazelcastInstance(cfg);
+
+        IMap map = instance.getMap(mapName);
+
+        final CountDownLatch expirationLatch = new CountDownLatch(1);
+        map.addEntryListener(new MapListenerAdapter() {
+            public void onEntryEvent(EntryEvent event) {
+                expirationLatch.countDown();
+            }
+        }, false);
+
+        map.put(1, 1, 100, TimeUnit.MILLISECONDS);
+        sleepSeconds(1);
+
+        // trigger immediate expiration.
+        map.get(1);
+
+        assertOpenEventually(expirationLatch);
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/map/ExpirationListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/ExpirationListenerTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.core.EntryEvent;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.map.listener.EntryEvictedListener;
+import com.hazelcast.map.listener.EntryExpiredListener;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Random;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ExpirationListenerTest extends HazelcastTestSupport {
+
+    private static final int instanceCount = 3;
+    private static final Random rand = new Random();
+
+    private static HazelcastInstance[] instances;
+    private IMap map;
+
+    @Before
+    public void init() {
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(instanceCount);
+        Config config = new Config();
+        instances = factory.newInstances(config);
+        HazelcastInstance node = getInstance();
+        map = node.getMap(randomMapName());
+    }
+
+    private HazelcastInstance getInstance() {
+        return instances[rand.nextInt(instanceCount)];
+    }
+
+
+    @Test
+    public void testExpirationListener_notified_afterExpirationOfEntries() throws Exception {
+        int numberOfPutOperations = 1000;
+        CountDownLatch expirationEventArrivalCount = new CountDownLatch(numberOfPutOperations);
+
+        map.addEntryListener(new ExpirationListener(expirationEventArrivalCount), true);
+
+        for (int i = 0; i < numberOfPutOperations; i++) {
+            map.put(i, i, 100, TimeUnit.MILLISECONDS);
+        }
+
+        // wait expiration of entries.
+        sleepAtLeastMillis(200);
+
+        // trigger immediate fire of expiration events by touching them.
+        for (int i = 0; i < numberOfPutOperations; i++) {
+            map.get(i);
+        }
+
+        assertOpenEventually(expirationEventArrivalCount);
+    }
+
+    private static class ExpirationListener implements EntryExpiredListener {
+
+        private final CountDownLatch expirationEventCount;
+
+        public ExpirationListener(CountDownLatch expirationEventCount) {
+            this.expirationEventCount = expirationEventCount;
+        }
+
+        @Override
+        public void entryExpired(EntryEvent event) {
+            expirationEventCount.countDown();
+        }
+    }
+
+
+    @Test
+    public void testExpirationAndEvictionListener_bothNotified_afterExpirationOfEntries() throws Exception {
+        int numberOfPutOperations = 1000;
+        CountDownLatch expirationEventCount = new CountDownLatch(numberOfPutOperations);
+        CountDownLatch evictionEventCount = new CountDownLatch(numberOfPutOperations);
+
+        map.addEntryListener(new ExpirationAndEvictionListener(expirationEventCount, evictionEventCount), true);
+
+        for (int i = 0; i < numberOfPutOperations; i++) {
+            map.put(i, i, 100, TimeUnit.MILLISECONDS);
+        }
+
+        // wait expiration of entries.
+        sleepAtLeastMillis(200);
+
+        // trigger immediate fire of expiration events by touching them.
+        for (int i = 0; i < numberOfPutOperations; i++) {
+            map.get(i);
+        }
+
+        assertOpenEventually(expirationEventCount);
+        assertOpenEventually(evictionEventCount);
+    }
+
+
+    private static class ExpirationAndEvictionListener implements EntryExpiredListener, EntryEvictedListener {
+
+        private final CountDownLatch expirationEventArrivalCount;
+        private final CountDownLatch evictionEventArrivalCount;
+
+        public ExpirationAndEvictionListener(CountDownLatch expirationEventArrivalCount, CountDownLatch evictionEventArrivalCount) {
+            this.expirationEventArrivalCount = expirationEventArrivalCount;
+            this.evictionEventArrivalCount = evictionEventArrivalCount;
+        }
+
+        @Override
+        public void entryExpired(EntryEvent event) {
+            expirationEventArrivalCount.countDown();
+        }
+
+        @Override
+        public void entryEvicted(EntryEvent event) {
+            evictionEventArrivalCount.countDown();
+        }
+    }
+
+}


### PR DESCRIPTION
closes https://github.com/hazelcast/hazelcast/issues/6311

- Created an `EntryExpiredListener` which extends `MapListener`. 
- Kept current `EntryEvictedListener` notification mechanism as is; means it will be receiving both expiration and eviction events as in now. If one implements both `EntryExpiredListener` and `EntryEvictedListener` interfaces, there is a probability that more than one event per entry at the same time may be seen. So you may receive both EVICTED and EXPIRED events for the same entry. This is because, eviction may also sweep expired entries. This may be appear when both size-based-eviction and expiration are configured for the same `IMap`.