### PR TITLE
Using an operation to communicate load status (forward port)

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapKeyLoader.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapKeyLoader.java
@@ -76,6 +76,7 @@ public class MapKeyLoader {
     private int maxSizePerNode;
     private int maxBatch;
     private int mapNamePartition;
+    private int partitionId;
     private boolean hasBackup;
 
     private LoadFinishedFuture loadFinished = new LoadFinishedFuture(true);
@@ -117,6 +118,7 @@ public class MapKeyLoader {
 
     public Future startInitialLoad(MapStoreContext mapStoreContext, int partitionId) {
 
+        this.partitionId = partitionId;
         this.mapNamePartition = partitionService.getPartitionId(toData.apply(mapName));
         Role newRole = assignRole(partitionService, mapNamePartition, partitionId);
 
@@ -321,18 +323,22 @@ public class MapKeyLoader {
     private ExecutionCallback<Boolean> ifLoadedCallback() {
         return new ExecutionCallback<Boolean>() {
             @Override
-            public void onResponse(Boolean loaded) {
-                if (loaded) {
-                    state.nextOrStay(State.LOADED);
-                    loadFinished.setResult(true);
+            public void onResponse(Boolean response) {
+                if (response) {
+                    sendLoadCompleted(null);
                 }
             }
 
             @Override
             public void onFailure(Throwable t) {
-                loadFinished.setResult(t);
+                sendLoadCompleted(t);
             }
         };
+    }
+
+    private void sendLoadCompleted(Throwable t) {
+        Operation op = new LoadStatusOperation(mapName, t);
+        opService.invokeOnPartition(SERVICE_NAME, op, partitionId);
     }
 
     private static final class LoadFinishedFuture extends AbstractCompletableFuture<Boolean>


### PR DESCRIPTION
Ensures its run on partition thread
