### PR TITLE
refactored document builder factory

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/config/XmlClientConfigBuilder.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/config/XmlClientConfigBuilder.java
@@ -131,6 +131,7 @@ public class XmlClientConfigBuilder extends AbstractConfigBuilder {
     protected Document parse(InputStream inputStream) throws Exception {
         DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
         dbf.setNamespaceAware(true);
+        dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
         final DocumentBuilder builder = dbf.newDocumentBuilder();
         try {
             return builder.parse(inputStream);

--- a/hazelcast-cloud/src/main/java/com/hazelcast/aws/utility/CloudyUtility.java
+++ b/hazelcast-cloud/src/main/java/com/hazelcast/aws/utility/CloudyUtility.java
@@ -64,7 +64,9 @@ public final class CloudyUtility {
     private static Map<String, String> parseAddresses(InputStream in, AwsConfig awsConfig) {
         final DocumentBuilder builder;
         try {
-            builder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+            DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+            dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            builder = dbf.newDocumentBuilder();
             Document doc = builder.parse(in);
             Element element = doc.getDocumentElement();
             NodeHolder elementNodeHolder = new NodeHolder(element);

--- a/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
@@ -218,6 +218,7 @@ public class XmlConfigBuilder extends AbstractConfigBuilder implements ConfigBui
     protected Document parse(InputStream is) throws Exception {
         DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
         dbf.setNamespaceAware(true);
+        dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
         final DocumentBuilder builder = dbf.newDocumentBuilder();
         Document doc;
         try {

--- a/hazelcast/src/test/java/com/hazelcast/config/InvalidConfigurationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/InvalidConfigurationTest.java
@@ -215,6 +215,15 @@ public class InvalidConfigurationTest {
     }
 
     @Test(expected = InvalidConfigurationException.class)
+    public void testWhenDoctypeAddedToXml() {
+        String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                "<!DOCTYPE data [\n" +
+                "<!ENTITY e1 \"0123456789\" > ] >" +
+                "<hazelcast></hazelcast>";
+        buildConfig(xml);
+    }
+    
+    @Test(expected = InvalidConfigurationException.class)
     public void testWanConfigSnapshotEnabledForWrongPublisher() {
         String xml =
                 "<hazelcast xmlns=\"http://www.hazelcast.com/schema/config\">\n" +

--- a/hazelcast/src/test/java/com/hazelcast/config/IterableNodeListTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/IterableNodeListTest.java
@@ -17,7 +17,6 @@
 package com.hazelcast.config;
 
 import com.hazelcast.test.HazelcastParallelClassRunner;
-import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
@@ -35,7 +34,9 @@ import javax.xml.parsers.ParserConfigurationException;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  *


### PR DESCRIPTION
XML parser should be configured so that it does not allow external entities as part of an incoming XML document. so i disabled the doctype declaration which is enough according to my researches.