### PR TITLE
Cleanup MemberLeftException serialization

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/instance/SimpleMemberImpl.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/SimpleMemberImpl.java
@@ -50,7 +50,7 @@ public class SimpleMemberImpl implements Member {
 
     @Override
     public Address getAddress() {
-        throw new UnsupportedOperationException();
+        return new Address(address);
     }
 
     @Override


### PR DESCRIPTION
Since Member interface has 'getAddress()' method since 3.6,
there is no need for MemberImpl cast anymore.