### PR TITLE
Cache stats improvement

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -79,6 +79,7 @@
     <suppress checks="MethodCount" files="com/hazelcast/cache/impl/nearcache/impl/store/AbstractNearCacheRecordStore"/>
     <suppress checks="MethodCount" files="com/hazelcast/cache/impl/AbstractHazelcastCacheManager"/>
     <suppress checks="ClassFanOutComplexityCheck" files="com/hazelcast/cache/impl/AbstractCacheService"/>
+    <suppress checks="MethodCount" files="com/hazelcast/cache/impl/CacheStatisticsImpl"/>
 
     <!-- Core -->
     <suppress checks="JavadocMethod" files="com/hazelcast/core/"/>

--- a/hazelcast/src/main/java/com/hazelcast/cache/CacheStatistics.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/CacheStatistics.java
@@ -38,6 +38,34 @@ package com.hazelcast.cache;
 public interface CacheStatistics {
 
     /**
+     * Gets the cache creation time.
+     *
+     * @return the cache creation time
+     */
+    long getCreationTime();
+
+    /**
+     * Gets the last access time to cache.
+     *
+     * @return the last access time to cache
+     */
+    long getLastAccessTime();
+
+    /**
+     * Gets the last update time to cache.
+     *
+     * @return the last update time to cache
+     */
+    long getLastUpdateTime();
+
+    /**
+     * Returns the owned entry count in the cache.
+     *
+     * @return the owned entry count in the cache
+     */
+    long getOwnedEntryCount();
+
+    /**
      * The number of get requests that were satisfied by the cache.
      * <p>
      * {@link javax.cache.Cache#containsKey(Object)} is not a get request for

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheService.java
@@ -39,6 +39,7 @@ import com.hazelcast.spi.PartitionMigrationEvent;
 import com.hazelcast.spi.PostJoinAwareService;
 import com.hazelcast.spi.QuorumAwareService;
 import com.hazelcast.spi.SplitBrainHandlerService;
+import com.hazelcast.util.Clock;
 import com.hazelcast.util.ConcurrencyUtil;
 import com.hazelcast.util.ConstructorFunction;
 
@@ -81,7 +82,9 @@ public abstract class AbstractCacheService
             new ConstructorFunction<String, CacheStatisticsImpl>() {
                 @Override
                 public CacheStatisticsImpl createNew(String name) {
-                    return new CacheStatisticsImpl();
+                    return new CacheStatisticsImpl(
+                            Clock.currentTimeMillis(),
+                            AbstractCacheService.this.getOrCreateCacheContext(name));
                 }
             };
 

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheContext.java
@@ -17,14 +17,40 @@
 package com.hazelcast.cache.impl;
 
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * Holds some specific informations for per cache in the node and shared by all partitions of that cache on the node.
  */
 public class CacheContext {
 
+    private final AtomicLong entryCount = new AtomicLong(0L);
     private final AtomicInteger cacheEntryListenerCount = new AtomicInteger(0);
     private final AtomicInteger invalidationListenerCount = new AtomicInteger(0);
+
+    public long getEntryCount() {
+        return entryCount.get();
+    }
+
+    public long increaseEntryCount() {
+        return entryCount.incrementAndGet();
+    }
+
+    public long increaseEntryCount(long count) {
+        return entryCount.addAndGet(count);
+    }
+
+    public long decreaseEntryCount() {
+        return entryCount.decrementAndGet();
+    }
+
+    public long decreaseEntryCount(long count) {
+        return entryCount.addAndGet(-count);
+    }
+
+    public void resetEntryCount() {
+        entryCount.set(0L);
+    }
 
     public int getCacheEntryListenerCount() {
         return cacheEntryListenerCount.get();
@@ -61,7 +87,8 @@ public class CacheContext {
     @Override
     public String toString() {
         return "CacheContext{"
-                + "cacheEntryListenerCount=" + cacheEntryListenerCount.get()
+                + "entryCount=" + entryCount.get()
+                + ", cacheEntryListenerCount=" + cacheEntryListenerCount.get()
                 + ", invalidationListenerCount=" + invalidationListenerCount.get()
                 + '}';
     }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheRecordStore.java
@@ -89,7 +89,11 @@ public class CacheRecordStore
 
     @Override
     protected CacheRecordHashMap createRecordCacheMap() {
-        return new CacheRecordHashMap(DEFAULT_INITIAL_CAPACITY);
+        if (isStatisticsEnabled())  {
+            return new CacheRecordHashMap(DEFAULT_INITIAL_CAPACITY, cacheContext);
+        } else  {
+            return new CacheRecordHashMap(DEFAULT_INITIAL_CAPACITY);
+        }
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/ICacheService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/ICacheService.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.cache.impl;
 
+import com.hazelcast.cache.CacheStatistics;
 import com.hazelcast.config.CacheConfig;
 import com.hazelcast.config.CacheSimpleConfig;
 import com.hazelcast.config.InMemoryFormat;
@@ -79,7 +80,7 @@ public interface ICacheService extends ManagedService, RemoteService, MigrationA
 
     void deregisterAllListener(String name);
 
-    CacheStatisticsImpl getStatistics(String name);
+    CacheStatistics getStatistics(String name);
 
     /**
      * Creates cache operations according to the storage-type of the cache

--- a/hazelcast/src/main/java/com/hazelcast/monitor/LocalCacheStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/LocalCacheStats.java
@@ -23,6 +23,27 @@ package com.hazelcast.monitor;
 public interface LocalCacheStats extends LocalInstanceStats {
 
     /**
+     * Gets the last access time to cache.
+     *
+     * @return the last access time to cache
+     */
+    long getLastAccessTime();
+
+    /**
+     * Gets the last update time to cache.
+     *
+     * @return the last update time to cache
+     */
+    long getLastUpdateTime();
+
+    /**
+     * Returns the owned entry count in the cache.
+     *
+     * @return the owned entry count in the cache
+     */
+    long getOwnedEntryCount();
+
+    /**
      * Returns the number of hits (successful get operations) on the cache.
      *
      * @return the number of hits (successful get operations) on the cache

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalCacheStatsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalCacheStatsImpl.java
@@ -19,7 +19,6 @@ package com.hazelcast.monitor.impl;
 import com.eclipsesource.json.JsonObject;
 import com.hazelcast.cache.CacheStatistics;
 import com.hazelcast.monitor.LocalCacheStats;
-import com.hazelcast.util.Clock;
 
 import static com.hazelcast.util.JsonUtil.getFloat;
 import static com.hazelcast.util.JsonUtil.getLong;
@@ -43,6 +42,9 @@ import static com.hazelcast.util.JsonUtil.getLong;
 public class LocalCacheStatsImpl implements LocalCacheStats {
 
     private long creationTime;
+    private long lastAccessTime;
+    private long lastUpdateTime;
+    private long ownedEntryCount;
     private long cacheHits;
     private float cacheHitPercentage;
     private long cacheMisses;
@@ -59,7 +61,10 @@ public class LocalCacheStatsImpl implements LocalCacheStats {
     }
 
     public LocalCacheStatsImpl(CacheStatistics cacheStatistics) {
-        creationTime = Clock.currentTimeMillis();
+        creationTime = cacheStatistics.getCreationTime();
+        lastAccessTime = cacheStatistics.getLastAccessTime();
+        lastUpdateTime = cacheStatistics.getLastUpdateTime();
+        ownedEntryCount = cacheStatistics.getOwnedEntryCount();
         cacheHits = cacheStatistics.getCacheHits();
         cacheHitPercentage = cacheStatistics.getCacheHitPercentage();
         cacheMisses = cacheStatistics.getCacheMisses();
@@ -71,6 +76,21 @@ public class LocalCacheStatsImpl implements LocalCacheStats {
         averageGetTime = cacheStatistics.getAverageGetTime();
         averagePutTime = cacheStatistics.getAveragePutTime();
         averageRemoveTime = cacheStatistics.getAverageRemoveTime();
+    }
+
+    @Override
+    public long getLastAccessTime() {
+        return lastAccessTime;
+    }
+
+    @Override
+    public long getLastUpdateTime() {
+        return lastUpdateTime;
+    }
+
+    @Override
+    public long getOwnedEntryCount() {
+        return ownedEntryCount;
     }
 
     @Override
@@ -137,6 +157,9 @@ public class LocalCacheStatsImpl implements LocalCacheStats {
     public JsonObject toJson() {
         JsonObject root = new JsonObject();
         root.add("creationTime", creationTime);
+        root.add("lastAccessTime", lastAccessTime);
+        root.add("lastUpdateTime", lastUpdateTime);
+        root.add("ownedEntryCount", ownedEntryCount);
         root.add("cacheHits", cacheHits);
         root.add("cacheHitPercentage", cacheHitPercentage);
         root.add("cacheMisses", cacheMisses);
@@ -154,6 +177,9 @@ public class LocalCacheStatsImpl implements LocalCacheStats {
     @Override
     public void fromJson(JsonObject json) {
         creationTime = getLong(json, "creationTime", -1L);
+        lastAccessTime = getLong(json, "lastAccessTime", -1L);
+        lastUpdateTime = getLong(json, "lastUpdateTime", -1L);
+        ownedEntryCount = getLong(json, "ownedEntryCount", -1L);
         cacheHits = getLong(json, "cacheHits", -1L);
         cacheHitPercentage = getFloat(json, "cacheHitPercentage", -1f);
         cacheMisses = getLong(json, "cacheMisses", -1L);
@@ -171,6 +197,9 @@ public class LocalCacheStatsImpl implements LocalCacheStats {
     public String toString() {
         return "LocalCacheStatsImpl{"
                 + "creationTime=" + creationTime
+                + ", lastAccessTime=" + lastAccessTime
+                + ", lastUpdateTime=" + lastUpdateTime
+                + ", ownedEntryCount=" + ownedEntryCount
                 + ", cacheHits=" + cacheHits
                 + ", cacheHitPercentage=" + cacheHitPercentage
                 + ", cacheMisses=" + cacheMisses

--- a/hazelcast/src/test/java/com/hazelcast/cache/CacheStatsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CacheStatsTest.java
@@ -1,0 +1,384 @@
+package com.hazelcast.cache;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class CacheStatsTest extends CacheTestSupport {
+
+    private TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+
+    @Override
+    protected void onSetup() {
+    }
+
+    @Override
+    protected void onTearDown() {
+        factory.terminateAll();
+    }
+
+    @Override
+    protected HazelcastInstance getHazelcastInstance() {
+        return factory.newHazelcastInstance(createConfig());
+    }
+
+    @Test
+    public void testCreationTime() {
+        long now = System.currentTimeMillis();
+
+        ICache<String, String> cache = createCache();
+        CacheStatistics stats = cache.getLocalCacheStatistics();
+
+        assertNotNull(stats);
+        assertTrue(stats.getCreationTime() >= now);
+    }
+
+    @Test
+    public void testPutStat() {
+        ICache<Integer, String> cache = createCache();
+        CacheStatistics stats = cache.getLocalCacheStatistics();
+
+        assertNotNull(stats);
+
+        final int ENTRY_COUNT = 100;
+
+        for (int i = 0; i < ENTRY_COUNT; i++) {
+            cache.put(i, "Value-" + i);
+        }
+
+        assertEquals(ENTRY_COUNT, stats.getCachePuts());
+    }
+
+    @Test
+    public void testAveragePutTimeStat() {
+        ICache<Integer, String> cache = createCache();
+        CacheStatistics stats = cache.getLocalCacheStatistics();
+
+        assertNotNull(stats);
+
+        final int ENTRY_COUNT = 100;
+
+        long start = System.nanoTime();
+        for (int i = 0; i < ENTRY_COUNT; i++) {
+            cache.put(i, "Value-" + i);
+        }
+        long end = System.nanoTime();
+
+        float avgPutTime = (end - start) / 1000;
+
+        assertTrue(stats.getAveragePutTime() > 0);
+        assertTrue(stats.getAveragePutTime() < avgPutTime);
+    }
+
+    @Test
+    public void testGetStat() {
+        ICache<Integer, String> cache = createCache();
+        CacheStatistics stats = cache.getLocalCacheStatistics();
+
+        assertNotNull(stats);
+
+        final int ENTRY_COUNT = 100;
+
+        for (int i = 0; i < ENTRY_COUNT; i++) {
+            cache.put(i, "Value-" + i);
+        }
+
+        for (int i = 0; i < 2 * ENTRY_COUNT; i++) {
+            cache.get(i);
+        }
+
+        assertEquals(2 * ENTRY_COUNT, stats.getCacheGets());
+    }
+
+    @Test
+    public void testAverageGetTimeStat() {
+        ICache<Integer, String> cache = createCache();
+        CacheStatistics stats = cache.getLocalCacheStatistics();
+
+        assertNotNull(stats);
+
+        final int ENTRY_COUNT = 100;
+
+        for (int i = 0; i < ENTRY_COUNT; i++) {
+            cache.put(i, "Value-" + i);
+        }
+
+        long start = System.nanoTime();
+        for (int i = 0; i < 2 * ENTRY_COUNT; i++) {
+            cache.get(i);
+        }
+        long end = System.nanoTime();
+
+        float avgGetTime = (end - start) / 1000;
+
+        assertTrue(stats.getAverageGetTime() > 0);
+        assertTrue(stats.getAverageGetTime() < avgGetTime);
+    }
+
+    @Test
+    public void testRemoveStat() {
+        ICache<Integer, String> cache = createCache();
+        CacheStatistics stats = cache.getLocalCacheStatistics();
+
+        assertNotNull(stats);
+
+        final int ENTRY_COUNT = 100;
+
+        for (int i = 0; i < ENTRY_COUNT; i++) {
+            cache.put(i, "Value-" + i);
+        }
+
+        for (int i = 0; i < 2 * ENTRY_COUNT; i++) {
+            cache.remove(i);
+        }
+
+        assertEquals(ENTRY_COUNT, stats.getCacheRemovals());
+    }
+
+    @Test
+    public void testAverageRemoveTimeStat() {
+        ICache<Integer, String> cache = createCache();
+        CacheStatistics stats = cache.getLocalCacheStatistics();
+
+        assertNotNull(stats);
+
+        final int ENTRY_COUNT = 100;
+
+        for (int i = 0; i < ENTRY_COUNT; i++) {
+            cache.put(i, "Value-" + i);
+        }
+
+        long start = System.nanoTime();
+        for (int i = 0; i < ENTRY_COUNT; i++) {
+            cache.remove(i);
+        }
+        long end = System.nanoTime();
+
+        float avgRemoveTime = (end - start) / 1000;
+
+        assertTrue(stats.getAverageRemoveTime() > 0);
+        assertTrue(stats.getAverageRemoveTime() < avgRemoveTime);
+
+        float currentAverageRemoveTime = stats.getAverageRemoveTime();
+        sleepAtLeastMillis(1);
+        for (int i = 0; i < ENTRY_COUNT; i++) {
+            cache.remove(i);
+        }
+
+        // Latest removes has no effect since keys are already removed at previous loop
+        assertEquals(currentAverageRemoveTime, stats.getAverageRemoveTime(), 0.0f);
+    }
+
+    @Test
+    public void testOwnedEntryCount() {
+        ICache<Integer, String> cache = createCache();
+        CacheStatistics stats = cache.getLocalCacheStatistics();
+
+        assertNotNull(stats);
+
+        final int ENTRY_COUNT = 100;
+
+        for (int i = 0; i < ENTRY_COUNT; i++) {
+            cache.put(i, "Value-" + i);
+        }
+
+        assertEquals(ENTRY_COUNT, stats.getOwnedEntryCount());
+
+        for (int i = 0; i < 10; i++) {
+            cache.remove(i);
+        }
+
+        assertEquals(ENTRY_COUNT - 10, stats.getOwnedEntryCount());
+
+        for (int i = 10; i < ENTRY_COUNT; i++) {
+            cache.remove(i);
+        }
+
+        assertEquals(0, stats.getOwnedEntryCount());
+    }
+
+    @Test
+    public void testHitStat() {
+        ICache<Integer, String> cache = createCache();
+        CacheStatistics stats = cache.getLocalCacheStatistics();
+
+        assertNotNull(stats);
+
+        final int ENTRY_COUNT = 100;
+        final int GET_COUNT = 3 * ENTRY_COUNT;
+
+        for (int i = 0; i < ENTRY_COUNT; i++) {
+            cache.put(i, "Value-" + i);
+        }
+
+        for (int i = 0; i < GET_COUNT; i++) {
+            cache.get(i);
+        }
+
+        assertEquals(ENTRY_COUNT, stats.getCacheHits());
+    }
+
+    @Test
+    public void testHitPercentageStat() {
+        ICache<Integer, String> cache = createCache();
+        CacheStatistics stats = cache.getLocalCacheStatistics();
+
+        assertNotNull(stats);
+
+        final int ENTRY_COUNT = 100;
+        final int GET_COUNT = 3 * ENTRY_COUNT;
+
+        for (int i = 0; i < ENTRY_COUNT; i++) {
+            cache.put(i, "Value-" + i);
+        }
+
+        for (int i = 0; i < GET_COUNT; i++) {
+            cache.get(i);
+        }
+
+        float expectedHitPercentage = (float) ENTRY_COUNT / GET_COUNT * 100.0f;
+        assertEquals(expectedHitPercentage, stats.getCacheHitPercentage(), 0.0f);
+    }
+
+    @Test
+    public void testMissStat() {
+        ICache<Integer, String> cache = createCache();
+        CacheStatistics stats = cache.getLocalCacheStatistics();
+
+        assertNotNull(stats);
+
+        final int ENTRY_COUNT = 100;
+        final int GET_COUNT = 3 * ENTRY_COUNT;
+
+        for (int i = 0; i < ENTRY_COUNT; i++) {
+            cache.put(i, "Value-" + i);
+        }
+
+        for (int i = 0; i < GET_COUNT; i++) {
+            cache.get(i);
+        }
+
+        assertEquals(GET_COUNT - ENTRY_COUNT, stats.getCacheMisses());
+    }
+
+    @Test
+    public void testMissPercentageStat() {
+        ICache<Integer, String> cache = createCache();
+        CacheStatistics stats = cache.getLocalCacheStatistics();
+
+        assertNotNull(stats);
+
+        final int ENTRY_COUNT = 100;
+        final int GET_COUNT = 3 * ENTRY_COUNT;
+
+        for (int i = 0; i < ENTRY_COUNT; i++) {
+            cache.put(i, "Value-" + i);
+        }
+
+        for (int i = 0; i < GET_COUNT; i++) {
+            cache.get(i);
+        }
+
+        float expectedMissPercentage = (float) (GET_COUNT - ENTRY_COUNT) / GET_COUNT * 100.0f;
+        System.out.println(expectedMissPercentage);
+        assertEquals(expectedMissPercentage, stats.getCacheMissPercentage(), 0.0f);
+    }
+
+    @Test
+    public void testLastAccessTimeStat() {
+        ICache<Integer, String> cache = createCache();
+        CacheStatistics stats = cache.getLocalCacheStatistics();
+
+        assertNotNull(stats);
+
+        final int ENTRY_COUNT = 100;
+        long start, end;
+
+        for (int i = 0; i < ENTRY_COUNT; i++) {
+            cache.put(i, "Value-" + i);
+        }
+
+        assertEquals(0, stats.getLastAccessTime());
+
+        start = System.currentTimeMillis();
+        for (int i = 0; i < ENTRY_COUNT; i++) {
+            cache.get(i);
+        }
+        end = System.currentTimeMillis();
+
+        // Hits effect last access time
+        assertTrue(stats.getLastAccessTime() >= start);
+        assertTrue(stats.getLastAccessTime() <= end);
+
+        long currentLastAccessTime = stats.getLastAccessTime();
+        sleepAtLeastMillis(1);
+        for (int i = 0; i < ENTRY_COUNT; i++) {
+            cache.remove(i);
+        }
+
+        // Removes has no effect on last access time
+        assertEquals(currentLastAccessTime, stats.getLastAccessTime());
+
+        sleepAtLeastMillis(1);
+        start = System.currentTimeMillis();
+        for (int i = 0; i < ENTRY_COUNT; i++) {
+            cache.get(i);
+        }
+        end = System.currentTimeMillis();
+
+        // Misses also effect last access time
+        assertTrue(stats.getLastAccessTime() >= start);
+        assertTrue(stats.getLastAccessTime() <= end);
+    }
+
+    @Test
+    public void testLastUpdateTimeStat() {
+        ICache<Integer, String> cache = createCache();
+        CacheStatistics stats = cache.getLocalCacheStatistics();
+
+        assertNotNull(stats);
+
+        final int ENTRY_COUNT = 100;
+        long start, end;
+
+        start = System.currentTimeMillis();
+        for (int i = 0; i < ENTRY_COUNT; i++) {
+            cache.put(i, "Value-" + i);
+        }
+        end = System.currentTimeMillis();
+
+        assertTrue(stats.getLastUpdateTime() >= start);
+        assertTrue(stats.getLastUpdateTime() <= end);
+
+        start = System.currentTimeMillis();
+        for (int i = 0; i < ENTRY_COUNT; i++) {
+            cache.remove(i);
+        }
+        end = System.currentTimeMillis();
+
+        assertTrue(stats.getLastUpdateTime() >= start);
+        assertTrue(stats.getLastUpdateTime() <= end);
+
+        long currentLastUpdateTime = stats.getLastUpdateTime();
+        sleepAtLeastMillis(1);
+        for (int i = 0; i < ENTRY_COUNT; i++) {
+            cache.remove(i);
+        }
+
+        // Latest removes has no effect since keys are already removed at previous loop
+        assertEquals(currentLastUpdateTime, stats.getLastUpdateTime());
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/monitor/impl/LocalCacheStatsImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/monitor/impl/LocalCacheStatsImplTest.java
@@ -21,6 +21,10 @@ public class LocalCacheStatsImplTest {
     public void testDefaultConstructor() {
         LocalCacheStatsImpl localCacheStats = new LocalCacheStatsImpl();
 
+        assertEquals(0, localCacheStats.getCreationTime());
+        assertEquals(0, localCacheStats.getLastUpdateTime());
+        assertEquals(0, localCacheStats.getLastAccessTime());
+        assertEquals(0, localCacheStats.getOwnedEntryCount());
         assertEquals(0, localCacheStats.getCacheHits());
         assertEquals(0, localCacheStats.getCacheHitPercentage(), 0.0001);
         assertEquals(0, localCacheStats.getCacheMisses());
@@ -39,6 +43,26 @@ public class LocalCacheStatsImplTest {
     @Test
     public void testSerialization() {
         CacheStatistics cacheStatistics = new CacheStatistics() {
+            @Override
+            public long getCreationTime() {
+                return 1986;
+            }
+
+            @Override
+            public long getLastUpdateTime() {
+                return 2014;
+            }
+
+            @Override
+            public long getLastAccessTime() {
+                return 2015;
+            }
+
+            @Override
+            public long getOwnedEntryCount() {
+                return 1000;
+            }
+
             @Override
             public long getCacheHits() {
                 return 127;
@@ -101,6 +125,10 @@ public class LocalCacheStatsImplTest {
         LocalCacheStatsImpl deserialized = new LocalCacheStatsImpl();
         deserialized.fromJson(serialized);
 
+        assertEquals(1986, deserialized.getCreationTime());
+        assertEquals(2014, deserialized.getLastUpdateTime());
+        assertEquals(2015, deserialized.getLastAccessTime());
+        assertEquals(1000, deserialized.getOwnedEntryCount());
         assertEquals(127, deserialized.getCacheHits());
         assertEquals(12.5f, deserialized.getCacheHitPercentage(), 0.0001);
         assertEquals(5, deserialized.getCacheMisses());


### PR DESCRIPTION
Added 
* `long getCreationTime()`
* `long getLastAccessTime()`
* `long getLastUpdateTime()` 
* `long getOwnedEntryCount()` 
methods to cache stats API

Also fixes https://github.com/hazelcast/hazelcast/issues/6314