### PR TITLE
MapQueryEngine cleanup

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/MapQueryEngine.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/MapQueryEngine.java
@@ -59,7 +59,7 @@ public interface MapQueryEngine {
      * @param predicate     except paging predicate.
      * @param result    the collection where the results are going to be stored.
      */
-    void queryLocalPartitions(String mapName, Predicate predicate, QueryResultCollection result);
+    QueryResult invokeQueryLocalPartitions(String mapName, Predicate predicate, IterationType iterationType);
 
     /**
      * Queries all partitions. Paging predicates are not allowed.
@@ -68,7 +68,7 @@ public interface MapQueryEngine {
      * @param predicate except paging predicate.
      * @param result    the collection where the results are going to be stored.
      */
-    void queryAllPartitions(String mapName, Predicate predicate, QueryResultCollection result);
+    QueryResult invokeQueryAllPartitions(String mapName, Predicate predicate, IterationType iterationType);
 
     /**
      * Query all local partitions with a paging predicate.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryPartitionOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryPartitionOperation.java
@@ -46,7 +46,6 @@ public class QueryPartitionOperation extends AbstractMapOperation implements Par
     public void run() {
         MapServiceContext mapServiceContext = mapService.getMapServiceContext();
         MapQueryEngine queryEngine = mapServiceContext.getMapQueryEngine();
-
         result = queryEngine.queryLocalPartition(name, predicate, getPartitionId(), iterationType);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryResult.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryResult.java
@@ -27,6 +27,7 @@ import com.hazelcast.util.IterationType;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.LinkedList;
 
 /**
@@ -34,7 +35,7 @@ import java.util.LinkedList;
  *
  * A QueryResults is a collections of {@link QueryResultRow} instances.
  */
-public class QueryResult implements DataSerializable {
+public class QueryResult implements DataSerializable, Iterable<QueryResultRow> {
 
     // todo: probably arraylist cheaper.
     private final Collection<QueryResultRow> rows = new LinkedList<QueryResultRow>();
@@ -54,9 +55,30 @@ public class QueryResult implements DataSerializable {
         this.iterationType = iterationType;
     }
 
+    @Override
+    public Iterator<QueryResultRow> iterator() {
+        return rows.iterator();
+    }
+
+    public int size() {
+        return rows.size();
+    }
+
+    public boolean isEmpty() {
+        return rows.isEmpty();
+    }
+
     // just for testing
     long getResultLimit() {
         return resultLimit;
+    }
+
+    public void addAllRows(Collection<QueryResultRow> r) {
+        rows.addAll(r);
+    }
+
+    public void addRow(QueryResultRow row) {
+        rows.add(row);
     }
 
     public void addAll(Collection<QueryableEntry> entries) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryResultCollection.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryResultCollection.java
@@ -44,6 +44,14 @@ public class QueryResultCollection<E> extends AbstractSet<E> {
         }
     }
 
+    public QueryResultCollection(SerializationService serializationService, IterationType iterationType, boolean binary,
+                                 boolean unique, QueryResult queryResult) {
+
+        this(serializationService, iterationType, binary, unique);
+        allAllRows(queryResult.getRows());
+    }
+
+
     // just for testing
     Collection<QueryResultRow> getRows() {
         return rows;


### PR DESCRIPTION
Instead of injecting a collection to store the result, the QueryEngine returns a QueryResult and it is up to the caller to copy it in the right collection e.g. set. This is needed to deal with enterprise + is cleaner.