### PR TITLE
Send MigrationOperation even when there's no migration task

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/partition/impl/MigrationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/impl/MigrationOperation.java
@@ -36,6 +36,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.logging.Level;
 
 @SuppressFBWarnings("EI_EXPOSE_REP")
@@ -229,6 +230,8 @@ public final class MigrationOperation extends BaseMigrationOperation {
                 Operation op = in.readObject();
                 tasks.add(op);
             }
+        } else {
+            tasks = Collections.emptyList();
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/partition/impl/MigrationRequestOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/impl/MigrationRequestOperation.java
@@ -87,13 +87,9 @@ public final class MigrationRequestOperation extends BaseMigrationOperation {
             verifyOwner(source, partition, owner);
             partitionService.addActiveMigration(migrationInfo);
             Collection<Operation> tasks = prepareMigrationTasks();
-            if (tasks.size() > 0) {
-                long[] replicaVersions = partitionService.getPartitionReplicaVersions(migrationInfo.getPartitionId());
-                invokeMigrationOperation(destination, replicaVersions, tasks);
-                returnResponse = false;
-            } else {
-                success = true;
-            }
+            long[] replicaVersions = partitionService.getPartitionReplicaVersions(migrationInfo.getPartitionId());
+            invokeMigrationOperation(destination, replicaVersions, tasks);
+            returnResponse = false;
         } catch (Throwable e) {
             logThrowable(e);
             success = false;
@@ -143,8 +139,6 @@ public final class MigrationRequestOperation extends BaseMigrationOperation {
 
         NodeEngine nodeEngine = getNodeEngine();
         InternalPartitionServiceImpl partitionService = getService();
-
-
 
         nodeEngine.getOperationService()
                 .createInvocationBuilder(InternalPartitionService.SERVICE_NAME, operation, destination)


### PR DESCRIPTION
MigrationOperation should be sent even when none of the services
provides a migration task to be executed on destination. This is
required to commit or rollback migration on destination when migration
completes. Otherwise, MigrationAwareService.commitMigration() is not
called on destination when no data is migrated.