### PR TITLE
Send MigrationOperation even when there's no migration task

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/partition/impl/MigrationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/impl/MigrationOperation.java
@@ -35,6 +35,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.logging.Level;
 
 @edu.umd.cs.findbugs.annotations.SuppressWarnings("EI_EXPOSE_REP")
@@ -228,6 +229,8 @@ public final class MigrationOperation extends BaseMigrationOperation {
                 Operation op = in.readObject();
                 tasks.add(op);
             }
+        } else {
+            tasks = Collections.emptyList();
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/partition/impl/MigrationRequestOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/impl/MigrationRequestOperation.java
@@ -87,13 +87,9 @@ public final class MigrationRequestOperation extends BaseMigrationOperation {
             verifyOwner(source, partition, owner);
             partitionService.addActiveMigration(migrationInfo);
             Collection<Operation> tasks = prepareMigrationTasks();
-            if (tasks.size() > 0) {
-                long[] replicaVersions = partitionService.getPartitionReplicaVersions(migrationInfo.getPartitionId());
-                invokeMigrationOperation(destination, replicaVersions, tasks);
-                returnResponse = false;
-            } else {
-                success = true;
-            }
+            long[] replicaVersions = partitionService.getPartitionReplicaVersions(migrationInfo.getPartitionId());
+            invokeMigrationOperation(destination, replicaVersions, tasks);
+            returnResponse = false;
         } catch (Throwable e) {
             logThrowable(e);
             success = false;

--- a/hazelcast/src/test/java/com/hazelcast/spi/MigrationAwareServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/MigrationAwareServiceTest.java
@@ -22,6 +22,7 @@ import com.hazelcast.core.HazelcastException;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.instance.Node;
 import com.hazelcast.instance.TestUtil;
+import com.hazelcast.partition.InternalPartitionService;
 import com.hazelcast.partition.MigrationEndpoint;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
@@ -42,6 +43,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.LockSupport;
 
 import static com.hazelcast.instance.GroupProperties.PROP_PARTITION_COUNT;
@@ -374,4 +376,63 @@ public class MigrationAwareServiceTest extends HazelcastTestSupport {
         }
     }
 
+    @Test
+    public void migrationCommitEvents_shouldBeEqual_onSource_and_onDestination() throws Exception {
+        Config config = new Config();
+        final MigrationEventCounterService counter = new MigrationEventCounterService();
+        ServiceConfig serviceConfig = new ServiceConfig()
+                .setEnabled(true).setName("event-counter")
+                .setServiceImpl(counter);
+        config.getServicesConfig().addServiceConfig(serviceConfig);
+
+        final HazelcastInstance hz = factory.newHazelcastInstance(config);
+        warmUpPartitions(hz);
+
+        final AssertTask assertTask = new AssertTask() {
+            final InternalPartitionService partitionService = getNode(hz).getPartitionService();
+            @Override
+            public void run() throws Exception {
+                assertEquals(0, partitionService.getMigrationQueueSize());
+                assertEquals(counter.sourceCommits.get(), counter.destinationCommits.get());
+            }
+        };
+
+        factory.newHazelcastInstance(config);
+        assertTrueEventually(assertTask);
+
+        factory.newHazelcastInstance(config);
+        assertTrueEventually(assertTask);
+    }
+
+    private static class MigrationEventCounterService implements MigrationAwareService {
+
+        final AtomicInteger sourceCommits = new AtomicInteger();
+        final AtomicInteger destinationCommits = new AtomicInteger();
+
+        @Override
+        public Operation prepareReplicationOperation(PartitionReplicationEvent event) {
+            return null;
+        }
+
+        @Override
+        public void beforeMigration(PartitionMigrationEvent event) {
+        }
+
+        @Override
+        public void commitMigration(PartitionMigrationEvent event) {
+            if (event.getMigrationEndpoint() == MigrationEndpoint.SOURCE) {
+                sourceCommits.incrementAndGet();
+            } else {
+                destinationCommits.incrementAndGet();
+            }
+        }
+
+        @Override
+        public void rollbackMigration(PartitionMigrationEvent event) {
+        }
+
+        @Override
+        public void clearPartitionReplica(int partitionId) {
+        }
+    }
 }


### PR DESCRIPTION
MigrationOperation should be sent even when none of the services
provides a migration task to be executed on destination. This is
required to commit or rollback migration on destination when migration
completes. Otherwise, MigrationAwareService.commitMigration() is not
called on destination when no data is migrated.

(cherry picked from commit 2f450db8684cc8897064164064b39d7f43d94cf6)

backport of #6337