### PR TITLE
Fixes security issue on old client

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
@@ -737,7 +737,8 @@ public class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V> {
 
     @Override
     public Collection<V> values() {
-        return values(TruePredicate.INSTANCE);
+        // we pass null instead of TruePredicate.INSTANCE due to security. But null will be interpreted as TruePredicate.
+        return values(null);
     }
 
     @Override
@@ -758,7 +759,8 @@ public class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V> {
 
     @Override
     public Set<Entry<K, V>> entrySet() {
-        return entrySet(TruePredicate.INSTANCE);
+        // we pass null instead of TruePredicate.INSTANCE due to security. But null will be interpreted as TruePredicate.
+        return entrySet(null);
     }
 
     @Override
@@ -792,7 +794,8 @@ public class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V> {
 
     @Override
     public Set<K> keySet() {
-        return keySet(TruePredicate.INSTANCE);
+        // we pass null instead of TruePredicate.INSTANCE due to security. But null will be interpreted as TruePredicate.
+        return keySet(null);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/client/MapQueryRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/client/MapQueryRequest.java
@@ -22,10 +22,15 @@ import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.PortableReader;
 import com.hazelcast.nio.serialization.PortableWriter;
 import com.hazelcast.query.Predicate;
+import com.hazelcast.query.TruePredicate;
 import com.hazelcast.util.IterationType;
 
 import java.io.IOException;
 
+/**
+ * The MapQueryRequest can deal with a null predicate for the sake of security. So it will be processed as a TruePredicate,
+ * but for security purposes the argument is not seen.
+ */
 public final class MapQueryRequest extends AbstractMapQueryRequest {
 
     private Predicate predicate;
@@ -57,12 +62,12 @@ public final class MapQueryRequest extends AbstractMapQueryRequest {
 
     @Override
     public Object[] getParameters() {
-        return new Object[]{predicate};
+        return predicate == null ? null : new Object[]{predicate};
     }
 
     @Override
     protected Predicate getPredicate() {
-        return predicate;
+        return predicate == null ? TruePredicate.INSTANCE : predicate;
     }
 
     @Override


### PR DESCRIPTION
The security got the true predicate for method without explicit predicate like values().
This has been solved by using null as special true predicate. This is a local issue only
in the proxy and request.