### PR TITLE
[BACKPORT] Cache stats improvement 

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -94,6 +94,7 @@
     <suppress checks="NPathComplexity"
               files="com.hazelcast.cache.impl.eviction.impl.evaluator.AbstractEvictionPolicyEvaluator"/>
     <suppress checks="MethodCount" files="com.hazelcast.cache.impl.AbstractHazelcastCacheManager"/>
+    <suppress checks="MethodCount" files="com/hazelcast/cache/impl/CacheStatisticsImpl"/>
 
     <!-- Core-->
     <suppress checks="JavadocMethod" files="com.hazelcast.core[\\/]"/>

--- a/hazelcast/src/main/java/com/hazelcast/cache/CacheStatistics.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/CacheStatistics.java
@@ -38,6 +38,34 @@ package com.hazelcast.cache;
 public interface CacheStatistics {
 
     /**
+     * Gets the cache creation time.
+     *
+     * @return the cache creation time
+     */
+    long getCreationTime();
+
+    /**
+     * Gets the last access time to cache.
+     *
+     * @return the last access time to cache
+     */
+    long getLastAccessTime();
+
+    /**
+     * Gets the last update time to cache.
+     *
+     * @return the last update time to cache
+     */
+    long getLastUpdateTime();
+
+    /**
+     * Returns the owned entry count in the cache.
+     *
+     * @return the owned entry count in the cache
+     */
+    long getOwnedEntryCount();
+
+    /**
      * The number of get requests that were satisfied by the cache.
      * <p>
      * {@link javax.cache.Cache#containsKey(Object)} is not a get request for

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheService.java
@@ -34,6 +34,7 @@ import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.OperationService;
 import com.hazelcast.spi.PartitionMigrationEvent;
 import com.hazelcast.spi.PostJoinAwareService;
+import com.hazelcast.util.Clock;
 import com.hazelcast.util.ConcurrencyUtil;
 import com.hazelcast.util.ConstructorFunction;
 
@@ -69,7 +70,9 @@ public abstract class AbstractCacheService
             new ConstructorFunction<String, CacheStatisticsImpl>() {
                 @Override
                 public CacheStatisticsImpl createNew(String name) {
-                    return new CacheStatisticsImpl();
+                    return new CacheStatisticsImpl(
+                            Clock.currentTimeMillis(),
+                            AbstractCacheService.this.getOrCreateCacheContext(name));
                 }
             };
 

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheContext.java
@@ -17,14 +17,40 @@
 package com.hazelcast.cache.impl;
 
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * Holds some specific informations for per cache in the node and shared by all partitions of that cache on the node.
  */
 public class CacheContext {
 
+    private final AtomicLong entryCount = new AtomicLong(0L);
     private final AtomicInteger cacheEntryListenerCount = new AtomicInteger(0);
     private final AtomicInteger invalidationListenerCount = new AtomicInteger(0);
+
+    public long getEntryCount() {
+        return entryCount.get();
+    }
+
+    public long increaseEntryCount() {
+        return entryCount.incrementAndGet();
+    }
+
+    public long increaseEntryCount(long count) {
+        return entryCount.addAndGet(count);
+    }
+
+    public long decreaseEntryCount() {
+        return entryCount.decrementAndGet();
+    }
+
+    public long decreaseEntryCount(long count) {
+        return entryCount.addAndGet(-count);
+    }
+
+    public void resetEntryCount() {
+        entryCount.set(0L);
+    }
 
     public int getCacheEntryListenerCount() {
         return cacheEntryListenerCount.get();
@@ -61,7 +87,8 @@ public class CacheContext {
     @Override
     public String toString() {
         return "CacheContext{"
-                + "cacheEntryListenerCount=" + cacheEntryListenerCount.get()
+                + "entryCount=" + entryCount.get()
+                + ", cacheEntryListenerCount=" + cacheEntryListenerCount.get()
                 + ", invalidationListenerCount=" + invalidationListenerCount.get()
                 + '}';
     }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheRecordStore.java
@@ -81,7 +81,11 @@ public class CacheRecordStore
 
     @Override
     protected CacheRecordHashMap createRecordCacheMap() {
-        return new CacheRecordHashMap(DEFAULT_INITIAL_CAPACITY);
+        if (isStatisticsEnabled())  {
+            return new CacheRecordHashMap(DEFAULT_INITIAL_CAPACITY, cacheContext);
+        } else  {
+            return new CacheRecordHashMap(DEFAULT_INITIAL_CAPACITY);
+        }
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheStatisticsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheStatisticsImpl.java
@@ -20,6 +20,7 @@ import com.hazelcast.cache.CacheStatistics;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.DataSerializable;
+import com.hazelcast.util.Clock;
 
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
@@ -37,6 +38,10 @@ public class CacheStatisticsImpl
     private static final float FLOAT_HUNDRED = 100.0f;
     private static final long NANOSECONDS_IN_A_MICROSECOND = 1000L;
 
+    private static final AtomicLongFieldUpdater<CacheStatisticsImpl> LAST_ACCESS_TIME =
+            AtomicLongFieldUpdater.newUpdater(CacheStatisticsImpl.class, "lastAccessTime");
+    private static final AtomicLongFieldUpdater<CacheStatisticsImpl> LAST_UPDATE_TIME =
+            AtomicLongFieldUpdater.newUpdater(CacheStatisticsImpl.class, "lastUpdateTime");
     private static final AtomicLongFieldUpdater<CacheStatisticsImpl> REMOVALS_UPDATER =
             AtomicLongFieldUpdater.newUpdater(CacheStatisticsImpl.class, "removals");
     private static final AtomicLongFieldUpdater<CacheStatisticsImpl> EXPIRIES_UPDATER =
@@ -56,6 +61,13 @@ public class CacheStatisticsImpl
     private static final AtomicLongFieldUpdater<CacheStatisticsImpl> REMOVE_TIME_TAKEN_NANOS_UPDATER =
             AtomicLongFieldUpdater.newUpdater(CacheStatisticsImpl.class, "removeTimeTakenNanos");
 
+    /**
+     * This field is not mutated (read only) so no need to define it as volatile.
+     */
+    private long creationTime;
+
+    private volatile long lastAccessTime;
+    private volatile long lastUpdateTime;
     private volatile long removals;
     private volatile long expiries;
     private volatile long puts;
@@ -66,7 +78,43 @@ public class CacheStatisticsImpl
     private volatile long getCacheTimeTakenNanos;
     private volatile long removeTimeTakenNanos;
 
+    /**
+     * This field is used when this stats instance is deserialized.
+     * So it is not mutated (read only) and no need to define it as volatile.
+     */
+    private long ownedEntryCount;
+    private transient CacheContext cacheContext;
+
     public CacheStatisticsImpl() {
+    }
+
+    public CacheStatisticsImpl(long creationTime, CacheContext cacheContext) {
+        this.creationTime = creationTime;
+        this.cacheContext = cacheContext;
+    }
+
+    @Override
+    public long getCreationTime() {
+        return creationTime;
+    }
+
+    @Override
+    public long getLastAccessTime() {
+        return lastAccessTime;
+    }
+
+    @Override
+    public long getLastUpdateTime() {
+        return lastUpdateTime;
+    }
+
+    @Override
+    public long getOwnedEntryCount() {
+        if (cacheContext != null) {
+            return cacheContext.getEntryCount();
+        } else  {
+            return ownedEntryCount;
+        }
     }
 
     @Override
@@ -166,11 +214,11 @@ public class CacheStatisticsImpl
     @Override
     public float getAverageRemoveTime() {
         final long cacheRemoveTimeTakenNanos = getCacheRemoveTimeTakenNanos();
-        final long cacheGets = getCacheGets();
-        if (cacheRemoveTimeTakenNanos == 0 || cacheGets == 0) {
+        final long cacheRemoves = getCacheRemovals();
+        if (cacheRemoveTimeTakenNanos == 0 || cacheRemoves == 0) {
             return 0;
         }
-        return ((1f * cacheRemoveTimeTakenNanos) / cacheGets) / NANOSECONDS_IN_A_MICROSECOND;
+        return ((1f * cacheRemoveTimeTakenNanos) / cacheRemoves) / NANOSECONDS_IN_A_MICROSECOND;
     }
 
     /**
@@ -178,6 +226,9 @@ public class CacheStatisticsImpl
      * @see javax.cache.management.CacheStatisticsMXBean#clear()
      */
     public void clear() {
+        // TODO Should we clear `creationTime` also? In fact, it doesn't make sense
+        // TODO Should we clear `ownedEntryCount` also? In fact, it doesn't make sense
+
         puts = 0;
         misses = 0;
         removals = 0;
@@ -190,12 +241,47 @@ public class CacheStatisticsImpl
     }
 
     /**
+     * Sets the cache last access time as atomic if the given time is bigger than it.
+     *
+     * @param time time to set the cache last access time
+     */
+    public void setLastAccessTime(long time) {
+        for (;;) {
+            if (time > lastAccessTime) {
+                if (LAST_ACCESS_TIME.compareAndSet(this, lastAccessTime, time)) {
+                    break;
+                }
+            } else {
+                break;
+            }
+        }
+    }
+
+    /**
+     * Sets the cache last update time as atomic if the given time is bigger than it.
+     *
+     * @param time time to set the cache last update time
+     */
+    public void setLastUpdateTime(long time) {
+        for (;;) {
+            if (time > lastUpdateTime) {
+                if (LAST_UPDATE_TIME.compareAndSet(this, lastUpdateTime, time)) {
+                    break;
+                }
+            } else {
+                break;
+            }
+        }
+    }
+
+    /**
      * Increases the counter by the number specified.
      *
      * @param number the number by which the counter is increased.
      */
     public void increaseCacheRemovals(long number) {
         REMOVALS_UPDATER.addAndGet(this, number);
+        setLastUpdateTime(Clock.currentTimeMillis());
     }
 
     /**
@@ -205,6 +291,7 @@ public class CacheStatisticsImpl
      */
     public void increaseCacheExpiries(long number) {
         EXPIRIES_UPDATER.addAndGet(this, number);
+        setLastUpdateTime(Clock.currentTimeMillis());
     }
 
     /**
@@ -214,6 +301,7 @@ public class CacheStatisticsImpl
      */
     public void increaseCachePuts(long number) {
         PUTS_UPDATER.addAndGet(this, number);
+        setLastUpdateTime(Clock.currentTimeMillis());
     }
 
     /**
@@ -223,6 +311,7 @@ public class CacheStatisticsImpl
      */
     public void increaseCacheHits(long number) {
         HITS_UPDATER.addAndGet(this, number);
+        setLastAccessTime(Clock.currentTimeMillis());
     }
 
     /**
@@ -232,6 +321,7 @@ public class CacheStatisticsImpl
      */
     public void increaseCacheMisses(long number) {
         MISSES_UPDATER.addAndGet(this, number);
+        setLastAccessTime(Clock.currentTimeMillis());
     }
 
     /**
@@ -241,6 +331,7 @@ public class CacheStatisticsImpl
      */
     public void increaseCacheEvictions(long number) {
         EVICTIONS_UPDATER.addAndGet(this, number);
+        setLastUpdateTime(Clock.currentTimeMillis());
     }
 
     /**
@@ -309,29 +400,15 @@ public class CacheStatisticsImpl
         }
     }
 
-    /**
-     *
-     * Simple CacheStatistics adder. Can be used to merge two statistics data,
-     * such as the ones collected from multiple nodes.
-     * @param other CacheStatisticsImpl to be merged.
-     * @return CacheStatisticsImpl with merged data.
-     */
-    public CacheStatisticsImpl accumulate(CacheStatisticsImpl other) {
-        PUTS_UPDATER.addAndGet(this, other.getCachePuts());
-        REMOVALS_UPDATER.addAndGet(this, other.getCacheRemovals());
-        EXPIRIES_UPDATER.addAndGet(this, other.getCacheExpiries());
-        EVICTIONS_UPDATER.addAndGet(this, other.getCacheEvictions());
-        HITS_UPDATER.addAndGet(this, other.getCacheHits());
-        MISSES_UPDATER.addAndGet(this, other.getCacheMisses());
-        PUT_TIME_TAKEN_NANOS_UPDATER.addAndGet(this, other.getCachePutTimeTakenNanos());
-        GET_CACHE_TIME_TAKEN_NANOS_UPDATER.addAndGet(this, other.getCacheGetTimeTakenNanos());
-        REMOVE_TIME_TAKEN_NANOS_UPDATER.addAndGet(this, other.getCacheRemoveTimeTakenNanos());
-        return this;
-    }
-
     @Override
     public void writeData(ObjectDataOutput out)
             throws IOException {
+        out.writeLong(creationTime);
+
+        out.writeLong(lastAccessTime);
+        out.writeLong(lastUpdateTime);
+        out.writeLong(getOwnedEntryCount());
+
         out.writeLong(puts);
         out.writeLong(removals);
         out.writeLong(expiries);
@@ -348,6 +425,12 @@ public class CacheStatisticsImpl
     @Override
     public void readData(ObjectDataInput in)
             throws IOException {
+        creationTime = in.readLong();
+
+        lastAccessTime = in.readLong();
+        lastUpdateTime = in.readLong();
+        ownedEntryCount = in.readLong();
+
         puts = in.readLong();
         removals = in.readLong();
         expiries = in.readLong();
@@ -359,5 +442,24 @@ public class CacheStatisticsImpl
         putTimeTakenNanos = in.readLong();
         getCacheTimeTakenNanos = in.readLong();
         removeTimeTakenNanos = in.readLong();
+    }
+
+    @Override
+    public String toString() {
+        return "CacheStatisticsImpl{"
+                    + "creationTime=" + creationTime
+                    + ", lastAccessTime=" + lastAccessTime
+                    + ", lastUpdateTime=" + lastUpdateTime
+                    + ", ownedEntryCount=" + getOwnedEntryCount()
+                    + ", removals=" + removals
+                    + ", expiries=" + expiries
+                    + ", puts=" + puts
+                    + ", hits=" + hits
+                    + ", misses=" + misses
+                    + ", evictions=" + evictions
+                    + ", putTimeTakenNanos=" + putTimeTakenNanos
+                    + ", getCacheTimeTakenNanos=" + getCacheTimeTakenNanos
+                    + ", removeTimeTakenNanos=" + removeTimeTakenNanos
+                + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/ICacheService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/ICacheService.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.cache.impl;
 
+import com.hazelcast.cache.CacheStatistics;
 import com.hazelcast.config.CacheConfig;
 import com.hazelcast.config.CacheSimpleConfig;
 import com.hazelcast.config.InMemoryFormat;
@@ -77,7 +78,7 @@ public interface ICacheService extends ManagedService, RemoteService, MigrationA
 
     void deregisterAllListener(String name);
 
-    CacheStatisticsImpl getStatistics(String name);
+    CacheStatistics getStatistics(String name);
 
     /**
      * Creates cache operations according to the storage-type of the cache

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/record/CacheRecordHashMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/record/CacheRecordHashMap.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.cache.impl.record;
 
+import com.hazelcast.cache.impl.CacheContext;
 import com.hazelcast.cache.impl.CacheKeyIteratorResult;
 import com.hazelcast.cache.impl.eviction.Evictable;
 import com.hazelcast.cache.impl.eviction.EvictionCandidate;
@@ -32,15 +33,85 @@ public class CacheRecordHashMap
         extends SampleableConcurrentHashMap<Data, CacheRecord>
         implements SampleableCacheRecordMap<Data, CacheRecord> {
 
+    private static final long serialVersionUID = 1L;
+
+    private final transient CacheContext cacheContext;
+
     public CacheRecordHashMap(int initialCapacity) {
         super(initialCapacity);
+        this.cacheContext = null;
+    }
+
+    public CacheRecordHashMap(int initialCapacity, CacheContext cacheContext) {
+        super(initialCapacity);
+        this.cacheContext = cacheContext;
     }
 
     public CacheRecordHashMap(int initialCapacity, float loadFactor, int concurrencyLevel,
             ConcurrentReferenceHashMap.ReferenceType keyType,
             ConcurrentReferenceHashMap.ReferenceType valueType,
-            EnumSet<Option> options) {
+            EnumSet<Option> options, CacheContext cacheContext) {
         super(initialCapacity, loadFactor, concurrencyLevel, keyType, valueType, options);
+        this.cacheContext = cacheContext;
+    }
+
+    @Override
+    public CacheRecord put(Data key, CacheRecord value) {
+        CacheRecord oldRecord = super.put(key, value);
+        if (cacheContext != null) {
+            if (oldRecord == null) {
+                // New put
+                cacheContext.increaseEntryCount();
+            }
+        }
+        return oldRecord;
+    }
+
+    @Override
+    public CacheRecord putIfAbsent(Data key, CacheRecord value) {
+        CacheRecord oldRecord = super.putIfAbsent(key, value);
+        if (cacheContext != null) {
+            if (oldRecord == null) {
+                // New put
+                cacheContext.increaseEntryCount();
+            }
+        }
+        return oldRecord;
+    }
+
+    @Override
+    public CacheRecord remove(Object key) {
+        CacheRecord removedRecord = super.remove(key);
+        if (cacheContext != null) {
+            if (removedRecord != null) {
+                // Removed
+                cacheContext.decreaseEntryCount();
+            }
+        }
+        return removedRecord;
+    }
+
+    @Override
+    public boolean remove(Object key, Object value) {
+        boolean removed = super.remove(key, value);
+        if (cacheContext != null) {
+            if (removed) {
+                // Removed
+                cacheContext.decreaseEntryCount();
+            }
+        }
+        return removed;
+    }
+
+    @Override
+    public void clear() {
+        if (cacheContext == null) {
+            super.clear();
+        } else {
+            final int sizeBeforeClear = size();
+            super.clear();
+            cacheContext.decreaseEntryCount(sizeBeforeClear);
+        }
     }
 
     public class EvictableSamplingEntry extends SamplingEntry implements EvictionCandidate {

--- a/hazelcast/src/main/java/com/hazelcast/monitor/LocalCacheStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/LocalCacheStats.java
@@ -23,6 +23,27 @@ package com.hazelcast.monitor;
 public interface LocalCacheStats extends LocalInstanceStats {
 
     /**
+     * Gets the last access time to cache.
+     *
+     * @return the last access time to cache
+     */
+    long getLastAccessTime();
+
+    /**
+     * Gets the last update time to cache.
+     *
+     * @return the last update time to cache
+     */
+    long getLastUpdateTime();
+
+    /**
+     * Returns the owned entry count in the cache.
+     *
+     * @return the owned entry count in the cache
+     */
+    long getOwnedEntryCount();
+
+    /**
      * Returns the number of hits (successful get operations) on the cache.
      *
      * @return the number of hits (successful get operations) on the cache

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalCacheStatsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalCacheStatsImpl.java
@@ -19,7 +19,6 @@ package com.hazelcast.monitor.impl;
 import com.eclipsesource.json.JsonObject;
 import com.hazelcast.cache.CacheStatistics;
 import com.hazelcast.monitor.LocalCacheStats;
-import com.hazelcast.util.Clock;
 
 import static com.hazelcast.util.JsonUtil.getFloat;
 import static com.hazelcast.util.JsonUtil.getLong;
@@ -43,6 +42,9 @@ import static com.hazelcast.util.JsonUtil.getLong;
 public class LocalCacheStatsImpl implements LocalCacheStats {
 
     private long creationTime;
+    private long lastAccessTime;
+    private long lastUpdateTime;
+    private long ownedEntryCount;
     private long cacheHits;
     private float cacheHitPercentage;
     private long cacheMisses;
@@ -59,7 +61,10 @@ public class LocalCacheStatsImpl implements LocalCacheStats {
     }
 
     public LocalCacheStatsImpl(CacheStatistics cacheStatistics) {
-        creationTime = Clock.currentTimeMillis();
+        creationTime = cacheStatistics.getCreationTime();
+        lastAccessTime = cacheStatistics.getLastAccessTime();
+        lastUpdateTime = cacheStatistics.getLastUpdateTime();
+        ownedEntryCount = cacheStatistics.getOwnedEntryCount();
         cacheHits = cacheStatistics.getCacheHits();
         cacheHitPercentage = cacheStatistics.getCacheHitPercentage();
         cacheMisses = cacheStatistics.getCacheMisses();
@@ -71,6 +76,21 @@ public class LocalCacheStatsImpl implements LocalCacheStats {
         averageGetTime = cacheStatistics.getAverageGetTime();
         averagePutTime = cacheStatistics.getAveragePutTime();
         averageRemoveTime = cacheStatistics.getAverageRemoveTime();
+    }
+
+    @Override
+    public long getLastAccessTime() {
+        return lastAccessTime;
+    }
+
+    @Override
+    public long getLastUpdateTime() {
+        return lastUpdateTime;
+    }
+
+    @Override
+    public long getOwnedEntryCount() {
+        return ownedEntryCount;
     }
 
     @Override
@@ -137,6 +157,9 @@ public class LocalCacheStatsImpl implements LocalCacheStats {
     public JsonObject toJson() {
         JsonObject root = new JsonObject();
         root.add("creationTime", creationTime);
+        root.add("lastAccessTime", lastAccessTime);
+        root.add("lastUpdateTime", lastUpdateTime);
+        root.add("ownedEntryCount", ownedEntryCount);
         root.add("cacheHits", cacheHits);
         root.add("cacheHitPercentage", cacheHitPercentage);
         root.add("cacheMisses", cacheMisses);
@@ -154,6 +177,9 @@ public class LocalCacheStatsImpl implements LocalCacheStats {
     @Override
     public void fromJson(JsonObject json) {
         creationTime = getLong(json, "creationTime", -1L);
+        lastAccessTime = getLong(json, "lastAccessTime", -1L);
+        lastUpdateTime = getLong(json, "lastUpdateTime", -1L);
+        ownedEntryCount = getLong(json, "ownedEntryCount", -1L);
         cacheHits = getLong(json, "cacheHits", -1L);
         cacheHitPercentage = getFloat(json, "cacheHitPercentage", -1f);
         cacheMisses = getLong(json, "cacheMisses", -1L);
@@ -239,6 +265,9 @@ public class LocalCacheStatsImpl implements LocalCacheStats {
     public String toString() {
         return "LocalCacheStatsImpl{"
                 + "creationTime=" + creationTime
+                + ", lastAccessTime=" + lastAccessTime
+                + ", lastUpdateTime=" + lastUpdateTime
+                + ", ownedEntryCount=" + ownedEntryCount
                 + ", cacheHits=" + cacheHits
                 + ", cacheHitPercentage=" + cacheHitPercentage
                 + ", cacheMisses=" + cacheMisses

--- a/hazelcast/src/test/java/com/hazelcast/cache/CacheStatsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CacheStatsTest.java
@@ -1,0 +1,383 @@
+package com.hazelcast.cache;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.QuickTest;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class})
+public class CacheStatsTest extends CacheTestSupport {
+
+    private TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+
+    @Override
+    protected void onSetup() {
+    }
+
+    @Override
+    protected void onTearDown() {
+        factory.terminateAll();
+    }
+
+    @Override
+    protected HazelcastInstance getHazelcastInstance() {
+        return factory.newHazelcastInstance(createConfig());
+    }
+
+    @Test
+    public void testCreationTime() {
+        long now = System.currentTimeMillis();
+
+        ICache<String, String> cache = createCache();
+        CacheStatistics stats = cache.getLocalCacheStatistics();
+
+        assertNotNull(stats);
+        assertTrue(stats.getCreationTime() >= now);
+    }
+
+    @Test
+    public void testPutStat() {
+        ICache<Integer, String> cache = createCache();
+        CacheStatistics stats = cache.getLocalCacheStatistics();
+
+        assertNotNull(stats);
+
+        final int ENTRY_COUNT = 100;
+
+        for (int i = 0; i < ENTRY_COUNT; i++) {
+            cache.put(i, "Value-" + i);
+        }
+
+        assertEquals(ENTRY_COUNT, stats.getCachePuts());
+    }
+
+    @Test
+    public void testAveragePutTimeStat() {
+        ICache<Integer, String> cache = createCache();
+        CacheStatistics stats = cache.getLocalCacheStatistics();
+
+        assertNotNull(stats);
+
+        final int ENTRY_COUNT = 100;
+
+        long start = System.nanoTime();
+        for (int i = 0; i < ENTRY_COUNT; i++) {
+            cache.put(i, "Value-" + i);
+        }
+        long end = System.nanoTime();
+
+        float avgPutTime = (end - start) / 1000;
+
+        assertTrue(stats.getAveragePutTime() > 0);
+        assertTrue(stats.getAveragePutTime() < avgPutTime);
+    }
+
+    @Test
+    public void testGetStat() {
+        ICache<Integer, String> cache = createCache();
+        CacheStatistics stats = cache.getLocalCacheStatistics();
+
+        assertNotNull(stats);
+
+        final int ENTRY_COUNT = 100;
+
+        for (int i = 0; i < ENTRY_COUNT; i++) {
+            cache.put(i, "Value-" + i);
+        }
+
+        for (int i = 0; i < 2 * ENTRY_COUNT; i++) {
+            cache.get(i);
+        }
+
+        assertEquals(2 * ENTRY_COUNT, stats.getCacheGets());
+    }
+
+    @Test
+    public void testAverageGetTimeStat() {
+        ICache<Integer, String> cache = createCache();
+        CacheStatistics stats = cache.getLocalCacheStatistics();
+
+        assertNotNull(stats);
+
+        final int ENTRY_COUNT = 100;
+
+        for (int i = 0; i < ENTRY_COUNT; i++) {
+            cache.put(i, "Value-" + i);
+        }
+
+        long start = System.nanoTime();
+        for (int i = 0; i < 2 * ENTRY_COUNT; i++) {
+            cache.get(i);
+        }
+        long end = System.nanoTime();
+
+        float avgGetTime = (end - start) / 1000;
+
+        assertTrue(stats.getAverageGetTime() > 0);
+        assertTrue(stats.getAverageGetTime() < avgGetTime);
+    }
+
+    @Test
+    public void testRemoveStat() {
+        ICache<Integer, String> cache = createCache();
+        CacheStatistics stats = cache.getLocalCacheStatistics();
+
+        assertNotNull(stats);
+
+        final int ENTRY_COUNT = 100;
+
+        for (int i = 0; i < ENTRY_COUNT; i++) {
+            cache.put(i, "Value-" + i);
+        }
+
+        for (int i = 0; i < 2 * ENTRY_COUNT; i++) {
+            cache.remove(i);
+        }
+
+        assertEquals(ENTRY_COUNT, stats.getCacheRemovals());
+    }
+
+    @Test
+    public void testAverageRemoveTimeStat() {
+        ICache<Integer, String> cache = createCache();
+        CacheStatistics stats = cache.getLocalCacheStatistics();
+
+        assertNotNull(stats);
+
+        final int ENTRY_COUNT = 100;
+
+        for (int i = 0; i < ENTRY_COUNT; i++) {
+            cache.put(i, "Value-" + i);
+        }
+
+        long start = System.nanoTime();
+        for (int i = 0; i < ENTRY_COUNT; i++) {
+            cache.remove(i);
+        }
+        long end = System.nanoTime();
+
+        float avgRemoveTime = (end - start) / 1000;
+
+        assertTrue(stats.getAverageRemoveTime() > 0);
+        assertTrue(stats.getAverageRemoveTime() < avgRemoveTime);
+
+        float currentAverageRemoveTime = stats.getAverageRemoveTime();
+        sleepAtLeastMillis(1);
+        for (int i = 0; i < ENTRY_COUNT; i++) {
+            cache.remove(i);
+        }
+
+        // Latest removes has no effect since keys are already removed at previous loop
+        assertEquals(currentAverageRemoveTime, stats.getAverageRemoveTime(), 0.0f);
+    }
+
+    @Test
+    public void testOwnedEntryCount() {
+        ICache<Integer, String> cache = createCache();
+        CacheStatistics stats = cache.getLocalCacheStatistics();
+
+        assertNotNull(stats);
+
+        final int ENTRY_COUNT = 100;
+
+        for (int i = 0; i < ENTRY_COUNT; i++) {
+            cache.put(i, "Value-" + i);
+        }
+
+        assertEquals(ENTRY_COUNT, stats.getOwnedEntryCount());
+
+        for (int i = 0; i < 10; i++) {
+            cache.remove(i);
+        }
+
+        assertEquals(ENTRY_COUNT - 10, stats.getOwnedEntryCount());
+
+        for (int i = 10; i < ENTRY_COUNT; i++) {
+            cache.remove(i);
+        }
+
+        assertEquals(0, stats.getOwnedEntryCount());
+    }
+
+    @Test
+    public void testHitStat() {
+        ICache<Integer, String> cache = createCache();
+        CacheStatistics stats = cache.getLocalCacheStatistics();
+
+        assertNotNull(stats);
+
+        final int ENTRY_COUNT = 100;
+        final int GET_COUNT = 3 * ENTRY_COUNT;
+
+        for (int i = 0; i < ENTRY_COUNT; i++) {
+            cache.put(i, "Value-" + i);
+        }
+
+        for (int i = 0; i < GET_COUNT; i++) {
+            cache.get(i);
+        }
+
+        assertEquals(ENTRY_COUNT, stats.getCacheHits());
+    }
+
+    @Test
+    public void testHitPercentageStat() {
+        ICache<Integer, String> cache = createCache();
+        CacheStatistics stats = cache.getLocalCacheStatistics();
+
+        assertNotNull(stats);
+
+        final int ENTRY_COUNT = 100;
+        final int GET_COUNT = 3 * ENTRY_COUNT;
+
+        for (int i = 0; i < ENTRY_COUNT; i++) {
+            cache.put(i, "Value-" + i);
+        }
+
+        for (int i = 0; i < GET_COUNT; i++) {
+            cache.get(i);
+        }
+
+        float expectedHitPercentage = (float) ENTRY_COUNT / GET_COUNT * 100.0f;
+        assertEquals(expectedHitPercentage, stats.getCacheHitPercentage(), 0.0f);
+    }
+
+    @Test
+    public void testMissStat() {
+        ICache<Integer, String> cache = createCache();
+        CacheStatistics stats = cache.getLocalCacheStatistics();
+
+        assertNotNull(stats);
+
+        final int ENTRY_COUNT = 100;
+        final int GET_COUNT = 3 * ENTRY_COUNT;
+
+        for (int i = 0; i < ENTRY_COUNT; i++) {
+            cache.put(i, "Value-" + i);
+        }
+
+        for (int i = 0; i < GET_COUNT; i++) {
+            cache.get(i);
+        }
+
+        assertEquals(GET_COUNT - ENTRY_COUNT, stats.getCacheMisses());
+    }
+
+    @Test
+    public void testMissPercentageStat() {
+        ICache<Integer, String> cache = createCache();
+        CacheStatistics stats = cache.getLocalCacheStatistics();
+
+        assertNotNull(stats);
+
+        final int ENTRY_COUNT = 100;
+        final int GET_COUNT = 3 * ENTRY_COUNT;
+
+        for (int i = 0; i < ENTRY_COUNT; i++) {
+            cache.put(i, "Value-" + i);
+        }
+
+        for (int i = 0; i < GET_COUNT; i++) {
+            cache.get(i);
+        }
+
+        float expectedMissPercentage = (float) (GET_COUNT - ENTRY_COUNT) / GET_COUNT * 100.0f;
+        System.out.println(expectedMissPercentage);
+        assertEquals(expectedMissPercentage, stats.getCacheMissPercentage(), 0.0f);
+    }
+
+    @Test
+    public void testLastAccessTimeStat() {
+        ICache<Integer, String> cache = createCache();
+        CacheStatistics stats = cache.getLocalCacheStatistics();
+
+        assertNotNull(stats);
+
+        final int ENTRY_COUNT = 100;
+        long start, end;
+
+        for (int i = 0; i < ENTRY_COUNT; i++) {
+            cache.put(i, "Value-" + i);
+        }
+
+        assertEquals(0, stats.getLastAccessTime());
+
+        start = System.currentTimeMillis();
+        for (int i = 0; i < ENTRY_COUNT; i++) {
+            cache.get(i);
+        }
+        end = System.currentTimeMillis();
+
+        // Hits effect last access time
+        assertTrue(stats.getLastAccessTime() >= start);
+        assertTrue(stats.getLastAccessTime() <= end);
+
+        long currentLastAccessTime = stats.getLastAccessTime();
+        sleepAtLeastMillis(1);
+        for (int i = 0; i < ENTRY_COUNT; i++) {
+            cache.remove(i);
+        }
+
+        // Removes has no effect on last access time
+        assertEquals(currentLastAccessTime, stats.getLastAccessTime());
+
+        sleepAtLeastMillis(1);
+        start = System.currentTimeMillis();
+        for (int i = 0; i < ENTRY_COUNT; i++) {
+            cache.get(i);
+        }
+        end = System.currentTimeMillis();
+
+        // Misses also effect last access time
+        assertTrue(stats.getLastAccessTime() >= start);
+        assertTrue(stats.getLastAccessTime() <= end);
+    }
+
+    @Test
+    public void testLastUpdateTimeStat() {
+        ICache<Integer, String> cache = createCache();
+        CacheStatistics stats = cache.getLocalCacheStatistics();
+
+        assertNotNull(stats);
+
+        final int ENTRY_COUNT = 100;
+        long start, end;
+
+        start = System.currentTimeMillis();
+        for (int i = 0; i < ENTRY_COUNT; i++) {
+            cache.put(i, "Value-" + i);
+        }
+        end = System.currentTimeMillis();
+
+        assertTrue(stats.getLastUpdateTime() >= start);
+        assertTrue(stats.getLastUpdateTime() <= end);
+
+        start = System.currentTimeMillis();
+        for (int i = 0; i < ENTRY_COUNT; i++) {
+            cache.remove(i);
+        }
+        end = System.currentTimeMillis();
+
+        assertTrue(stats.getLastUpdateTime() >= start);
+        assertTrue(stats.getLastUpdateTime() <= end);
+
+        long currentLastUpdateTime = stats.getLastUpdateTime();
+        sleepAtLeastMillis(1);
+        for (int i = 0; i < ENTRY_COUNT; i++) {
+            cache.remove(i);
+        }
+
+        // Latest removes has no effect since keys are already removed at previous loop
+        assertEquals(currentLastUpdateTime, stats.getLastUpdateTime());
+    }
+
+}


### PR DESCRIPTION
Backport of https://github.com/hazelcast/hazelcast/pull/6331

I have added new fields to `readData` and `writeData` methods of `CacheStatisticsImpl` but in fact this class is not serialized/deserialized between nodes since it is local. So there is no backward compatibility problem.