### PR TITLE
[DONT MERGE] Performance: reduce QueryResult litter

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -485,6 +485,7 @@
     <suppress checks="MethodCount|ClassDataAbstractionCoupling" files="com/hazelcast/map/impl/MapServiceContextImpl"/>
     <suppress checks="MethodCount" files="com/hazelcast/map/impl/MapServiceContext"/>
     <suppress checks="ClassDataAbstractionCoupling" files="com/hazelcast/map/impl/tx/TransactionalMapProxySupport"/>
+    <suppress checks="NPathComplexity" files="com/hazelcast/map/impl/query/QueryResult"/>
 
     <!-- Util -->
     <suppress checks="" files="com/hazelcast/util/Base64"/>

--- a/hazelcast-client-legacy/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
+++ b/hazelcast-client-legacy/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
@@ -751,8 +751,10 @@ public class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V> {
         QueryResult result = invoke(request);
 
         List<V> values = new ArrayList<V>(result.size());
-        for (QueryResultRow row : result) {
-            values.add((V) toObject(row.getValue()));
+
+        for (QueryResult.Cursor cursor = result.openCursor(); cursor.next(); ) {
+            V value = (V) toObject(cursor.getValue());
+            values.add(value);
         }
         return values;
     }
@@ -777,16 +779,17 @@ public class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V> {
         if (pagingPredicate == null) {
             SerializationService serializationService = getContext().getSerializationService();
             InflatableSet.Builder<Entry<K, V>> setBuilder = InflatableSet.newBuilder(result.size());
-            for (QueryResultRow row : result) {
-                LazyMapEntry entry = new LazyMapEntry(row.getKey(), row.getValue(), serializationService);
+
+            for (QueryResult.Cursor cursor = result.openCursor(); cursor.next(); ) {
+                LazyMapEntry entry = new LazyMapEntry(cursor.getKey(), cursor.getValue(), serializationService);
                 setBuilder.add(entry);
             }
             return setBuilder.build();
         }
         ArrayList<Map.Entry> resultList = new ArrayList<Map.Entry>();
-        for (QueryResultRow data : result) {
-            K key = toObject(data.getKey());
-            V value = toObject(data.getValue());
+        for (QueryResult.Cursor cursor = result.openCursor(); cursor.next(); ) {
+            K key = toObject(cursor.getKey());
+            V value = toObject(cursor.getValue());
             resultList.add(new AbstractMap.SimpleEntry<K, V>(key, value));
         }
         return (Set) getSortedQueryResultSet(resultList, pagingPredicate, IterationType.ENTRY);
@@ -810,16 +813,16 @@ public class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V> {
         QueryResult result = invoke(request);
         if (pagingPredicate == null) {
             InflatableSet.Builder<K> setBuilder = InflatableSet.newBuilder(result.size());
-            for (QueryResultRow row : result) {
-                K key = toObject(row.getKey());
+            for (QueryResult.Cursor cursor = result.openCursor(); cursor.next(); ) {
+                K key = toObject(cursor.getKey());
                 setBuilder.add(key);
             }
             return setBuilder.build();
         }
 
         ArrayList<Map.Entry> resultList = new ArrayList<Map.Entry>(result.size());
-        for (QueryResultRow row : result) {
-            K key = toObject(row.getKey());
+        for (QueryResult.Cursor cursor = result.openCursor(); cursor.next(); ) {
+            K key = toObject(cursor.getKey());
             resultList.add(new AbstractMap.SimpleImmutableEntry<K, V>(key, null));
         }
         return (Set<K>) getSortedQueryResultSet(resultList, pagingPredicate, IterationType.KEY);
@@ -832,9 +835,9 @@ public class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V> {
         QueryResult result = invoke(request);
 
         List<Entry> resultList = new ArrayList<Entry>(result.size());
-        for (QueryResultRow row : result) {
-            K key = toObject(row.getKey());
-            V value = toObject(row.getValue());
+        for (QueryResult.Cursor cursor = result.openCursor(); cursor.next(); ) {
+            K key = toObject(cursor.getKey());
+            V value = toObject(cursor.getValue());
             resultList.add(new AbstractMap.SimpleImmutableEntry<Object, V>(key, value));
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/client/AbstractMapQueryRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/client/AbstractMapQueryRequest.java
@@ -130,7 +130,7 @@ abstract class AbstractMapQueryRequest extends InvocationClientRequest implement
                     //running. In this case we discard all results from this member and will target the missing
                     //partition separately later.
                     BitSetUtils.setBits(finishedPartitions, partitionIds);
-                    result.addAllRows(queryResult.getRows());
+                    result.addAllFrom(queryResult);
                 }
             }
         }
@@ -170,7 +170,7 @@ abstract class AbstractMapQueryRequest extends InvocationClientRequest implement
             throws InterruptedException, ExecutionException {
         for (Future future : futures) {
             QueryResult queryResult = (QueryResult) future.get();
-            result.addAllRows(queryResult.getRows());
+            result.addAllFrom(queryResult);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
@@ -589,7 +589,7 @@ public class MapProxyImpl<K, V> extends MapProxySupport implements IMap<K, V>, I
         } else {
             QueryResult result = queryEngine.invokeQueryAllPartitions(name, predicate, IterationType.KEY);
             return new QueryResultCollection<K>(
-                    getNodeEngine().getSerializationService(), IterationType.KEY, false, true, result);
+                    getNodeEngine().getSerializationService(), IterationType.KEY, false, result);
         }
     }
 
@@ -608,7 +608,7 @@ public class MapProxyImpl<K, V> extends MapProxySupport implements IMap<K, V>, I
         } else {
             QueryResult result = queryEngine.invokeQueryAllPartitions(name, predicate, IterationType.ENTRY);
             return new QueryResultCollection<Map.Entry<K, V>>(
-                    getNodeEngine().getSerializationService(), IterationType.ENTRY, false, true, result);
+                    getNodeEngine().getSerializationService(), IterationType.ENTRY, false, result);
         }
     }
 
@@ -628,7 +628,7 @@ public class MapProxyImpl<K, V> extends MapProxySupport implements IMap<K, V>, I
         } else {
             QueryResult result = queryEngine.invokeQueryAllPartitions(name, predicate, IterationType.VALUE);
             return new QueryResultCollection<V>(
-                    getNodeEngine().getSerializationService(), IterationType.VALUE, false, false, result);
+                    getNodeEngine().getSerializationService(), IterationType.VALUE, false, result);
         }
     }
 
@@ -649,7 +649,7 @@ public class MapProxyImpl<K, V> extends MapProxySupport implements IMap<K, V>, I
             QueryResult result = queryEngine.invokeQueryLocalPartitions(name, predicate, IterationType.KEY);
             // todo: uqique is not needed since map keys are unique by nature.
             return new QueryResultCollection<K>(
-                    getNodeEngine().getSerializationService(), IterationType.KEY, false, true, result);
+                    getNodeEngine().getSerializationService(), IterationType.KEY, false, result);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/MapQueryEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/MapQueryEngineImpl.java
@@ -283,8 +283,7 @@ public class MapQueryEngineImpl implements MapQueryEngine {
         Iterator<Record> iterator = container.getRecordStore(name).loadAwareIterator(getNow(), false);
 
         // we recycle this entry to prevent litter.
-        // todo: extractors is not set correctly.
-        QueryEntry entry = new QueryEntry(serializationService, Extractors.empty());
+        QueryEntry predicateEntry = new QueryEntry(serializationService, mapServiceContext.getExtractors(name));
 
         while (iterator.hasNext()) {
             Record record = iterator.next();
@@ -294,10 +293,10 @@ public class MapQueryEngineImpl implements MapQueryEngine {
                 continue;
             }
 
-            entry.init(key, value);
+            predicateEntry.init(key, value);
 
-            if (predicate.apply(entry)) {
-                queryResult.addFrom(entry);
+            if (predicate.apply(predicateEntry)) {
+                queryResult.addFrom(predicateEntry);
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryResultCollection.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryResultCollection.java
@@ -19,59 +19,87 @@ package com.hazelcast.map.impl.query;
 import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.util.IterationType;
 
+import java.util.AbstractMap;
 import java.util.AbstractSet;
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.Iterator;
+import java.util.NoSuchElementException;
 
 public class QueryResultCollection<E> extends AbstractSet<E> {
 
-    private final Collection<QueryResultRow> rows;
+    private final QueryResult queryResult;
     private final SerializationService serializationService;
     private final IterationType iterationType;
     private final boolean binary;
 
     public QueryResultCollection(SerializationService serializationService, IterationType iterationType, boolean binary,
-                                 boolean unique) {
+                                 QueryResult queryResult) {
         this.serializationService = serializationService;
         this.iterationType = iterationType;
         this.binary = binary;
-        if (unique) {
-            rows = new HashSet<QueryResultRow>();
-        } else {
-            rows = new ArrayList<QueryResultRow>();
-        }
+        this.queryResult = queryResult;
     }
-
-    public QueryResultCollection(SerializationService serializationService, IterationType iterationType, boolean binary,
-                                 boolean unique, QueryResult queryResult) {
-
-        this(serializationService, iterationType, binary, unique);
-        addAllRows(queryResult.getRows());
-    }
-
 
     // just for testing
     Collection<QueryResultRow> getRows() {
-        return rows;
+        return queryResult.getRows();
     }
 
     public IterationType getIterationType() {
         return iterationType;
     }
 
-    public void addAllRows(Collection<QueryResultRow> collection) {
-        rows.addAll(collection);
-    }
-
     @Override
     public Iterator<E> iterator() {
-        return new QueryResultIterator(rows.iterator(), iterationType, binary, serializationService);
+        return new QueryResultIterator();
     }
 
     @Override
     public int size() {
-        return rows.size();
+        return queryResult.size();
+    }
+
+    private final class QueryResultIterator implements Iterator {
+
+        private final QueryResult.Cursor cursor;
+
+        private QueryResultIterator() {
+            this.cursor = queryResult.openCursor();
+        }
+
+        @Override
+        public boolean hasNext() {
+            return cursor.hasNext();
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public Object next() {
+            if (!cursor.next()) {
+                throw new NoSuchElementException();
+            }
+
+            switch (iterationType) {
+                case VALUE:
+                    return binary ? cursor.getValue() : serializationService.toObject(cursor.getValue());
+                case KEY:
+                    return binary ? cursor.getKey() : serializationService.toObject(cursor.getKey());
+                case ENTRY:
+                    if (binary) {
+                        return new AbstractMap.SimpleImmutableEntry(cursor.getKey(), cursor.getValue());
+                    } else {
+                        Object key = serializationService.toObject(cursor.getKey());
+                        Object value = serializationService.toObject(cursor.getValue());
+                        return new AbstractMap.SimpleImmutableEntry(key, value);
+                    }
+                default:
+                    throw new IllegalStateException("Unrecognized iteratorType:" + iterationType);
+            }
+        }
+
+        @Override
+        public void remove() {
+            throw new UnsupportedOperationException();
+        }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TransactionalMapProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TransactionalMapProxy.java
@@ -317,7 +317,7 @@ public class TransactionalMapProxy extends TransactionalMapProxySupport implemen
         SerializationService serializationService = getNodeEngine().getSerializationService();
 
         QueryResult result = queryEngine.invokeQueryAllPartitions(name, predicate, IterationType.KEY);
-        Set<Object> queryResult = new QueryResultCollection(serializationService, IterationType.KEY, false, true, result);
+        Set<Object> queryResult = new QueryResultCollection(serializationService, IterationType.KEY, false, result);
 
         // TODO: Can't we just use the original set?
         Set<Object> keySet = new HashSet<Object>(queryResult);
@@ -363,7 +363,7 @@ public class TransactionalMapProxy extends TransactionalMapProxySupport implemen
 
         QueryResult result = queryEngine.invokeQueryAllPartitions(name, predicate, IterationType.ENTRY);
         QueryResultCollection<Map.Entry> queryResult
-                = new QueryResultCollection<Map.Entry>(serializationService, IterationType.ENTRY, false, true, result);
+                = new QueryResultCollection<Map.Entry>(serializationService, IterationType.ENTRY, false, result);
 
         // TODO: Can't we just use the original set?
         List<Object> valueSet = new ArrayList<Object>();

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/QueryEntry.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/QueryEntry.java
@@ -18,6 +18,7 @@ package com.hazelcast.query.impl;
 
 import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.query.QueryException;
 
 /**
  * Entry of the Query.
@@ -27,11 +28,9 @@ public class QueryEntry extends QueryableEntry {
     private Data key;
     private Object value;
 
-    public QueryEntry() {
-    }
-
-    public QueryEntry(SerializationService serializationService, Data key, Object value, Extractors extractors) {
-        init(serializationService, key, value, extractors);
+    public QueryEntry(SerializationService serializationService, Extractors extractors) {
+        this.serializationService = serializationService;
+        this.extractors = extractors;
     }
 
     /**
@@ -51,16 +50,13 @@ public class QueryEntry extends QueryableEntry {
      * </code>
      * </pre>
      */
-    public void init(SerializationService serializationService, Data key, Object value, Extractors extractors) {
+    public void init(Data key, Object value) {
         if (key == null) {
-            throw new IllegalArgumentException("keyData cannot be null");
+            throw new IllegalArgumentException("key cannot be null");
         }
-
-        this.serializationService = serializationService;
 
         this.key = key;
         this.value = value;
-        this.extractors = extractors;
     }
 
     @Override
@@ -81,6 +77,11 @@ public class QueryEntry extends QueryableEntry {
     @Override
     public Data getValueData() {
         return serializationService.toData(value);
+    }
+
+    @Override
+    public Comparable getAttribute(String attributeName) throws QueryException {
+        return QueryEntryUtils.extractAttribute(attributeName, key, value, serializationService);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/QueryEntry.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/QueryEntry.java
@@ -18,7 +18,6 @@ package com.hazelcast.query.impl;
 
 import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.query.QueryException;
 
 /**
  * Entry of the Query.
@@ -77,11 +76,6 @@ public class QueryEntry extends QueryableEntry {
     @Override
     public Data getValueData() {
         return serializationService.toData(value);
-    }
-
-    @Override
-    public Comparable getAttribute(String attributeName) throws QueryException {
-        return QueryEntryUtils.extractAttribute(attributeName, key, value, serializationService);
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryResult_CursorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryResult_CursorTest.java
@@ -1,0 +1,92 @@
+package com.hazelcast.map.impl.query;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.internal.serialization.SerializationService;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.util.IterationType;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class QueryResult_CursorTest extends HazelcastTestSupport {
+
+    private SerializationService serializationService;
+
+    @Before
+    public void setup() {
+        HazelcastInstance hz = createHazelcastInstance();
+        serializationService = getSerializationService(hz);
+    }
+
+    @Test
+    public void testWhenEmpty() {
+        QueryResult queryResult = new QueryResult(IterationType.ENTRY, Long.MAX_VALUE);
+
+        QueryResult.Cursor cursor = queryResult.openCursor();
+
+        assertFalse(cursor.hasNext());
+        assertFalse(cursor.next());
+    }
+
+    @Test
+    public void testSingleItem() {
+        QueryResult queryResult = new QueryResult(IterationType.ENTRY, Long.MAX_VALUE);
+        Data key = toData("1");
+        Data value = toData("a");
+        queryResult.add(key, value);
+
+        QueryResult.Cursor cursor = queryResult.openCursor();
+        assertTrue(cursor.hasNext());
+        assertTrue(cursor.next());
+
+        assertEquals(key, cursor.getKey());
+        assertEquals(value, cursor.getValue());
+
+        assertFalse(cursor.hasNext());
+        assertFalse(cursor.next());
+    }
+
+    @Test
+    public void testManyItems() {
+        QueryResult queryResult = new QueryResult(IterationType.ENTRY, Long.MAX_VALUE);
+
+        int count = 100;
+
+        Data[] keys = new Data[count];
+        Data[] values = new Data[count];
+        for (int k = 0; k < count; k++) {
+            keys[k] = toData("key-" + k);
+            values[k] = toData("value-" + k);
+            queryResult.add(keys[k], values[k]);
+        }
+
+
+        QueryResult.Cursor cursor = queryResult.openCursor();
+        for (int k = 0; k < count; k++) {
+            assertTrue(cursor.hasNext());
+            assertTrue(cursor.next());
+
+            assertEquals(keys[k], cursor.getKey());
+            assertEquals(values[k], cursor.getValue());
+        }
+
+        assertFalse(cursor.hasNext());
+        assertFalse(cursor.next());
+    }
+
+    private Data toData(Object item) {
+        return serializationService.toData(item);
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryResult_SerializationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryResult_SerializationTest.java
@@ -18,7 +18,7 @@ import static org.junit.Assert.assertNotNull;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class QueryResultTest extends HazelcastTestSupport {
+public class QueryResult_SerializationTest extends HazelcastTestSupport {
 
     private SerializationService serializationService;
 
@@ -29,21 +29,53 @@ public class QueryResultTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void serialization() {
+    public void whenIterationTypeEntry() {
         QueryResult expected = new QueryResult(IterationType.ENTRY, 100);
-        QueryResultRow row = new QueryResultRow(serializationService.toData("1"), serializationService.toData("row"));
-        expected.addRow(row);
+        QueryResultRow row = new QueryResultRow(toData("key"), toData("valu"));
+        expected.addFrom(row);
 
         QueryResult actual = clone(expected);
 
         assertNotNull(actual);
         assertEquals(expected.getIterationType(), actual.getIterationType());
         assertEquals(1, actual.size());
-        assertEquals(row, actual.iterator().next());
+        assertEquals(expected.getRows(), actual.getRows());
+    }
+
+    @Test
+    public void whenIterationTypeValue() {
+        QueryResult expected = new QueryResult(IterationType.VALUE, 100);
+        QueryResultRow row = new QueryResultRow(null, toData("value"));
+        expected.addFrom(row);
+
+        QueryResult actual = clone(expected);
+
+        assertNotNull(actual);
+        assertEquals(expected.getIterationType(), actual.getIterationType());
+        assertEquals(1, actual.size());
+        assertEquals(expected.getRows(), actual.getRows());
+    }
+
+    @Test
+    public void whenIterationTypeKey() {
+        QueryResult expected = new QueryResult(IterationType.KEY, 100);
+        QueryResultRow row = new QueryResultRow(toData("key"), null);
+        expected.addFrom(row);
+
+        QueryResult actual = clone(expected);
+
+        assertNotNull(actual);
+        assertEquals(expected.getIterationType(), actual.getIterationType());
+        assertEquals(1, actual.size());
+        assertEquals(expected.getRows(), actual.getRows());
     }
 
     private QueryResult clone(QueryResult result) {
         Data data = serializationService.toData(result);
         return serializationService.toObject(data);
+    }
+
+    private Data toData(Object item) {
+        return serializationService.toData(item);
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryResult_SizeExceededExceptionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryResult_SizeExceededExceptionTest.java
@@ -14,7 +14,7 @@ import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class QueryResultSizeExceededExceptionTest {
+public class QueryResult_SizeExceededExceptionTest {
 
     @Test
     public void testStringConstructor() throws Exception {

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryResult_SizeLimiterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryResult_SizeLimiterTest.java
@@ -35,7 +35,7 @@ import static org.mockito.Mockito.when;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class QueryResultSizeLimiterTest {
+public class QueryResult_SizeLimiterTest {
 
     private static final String ANY_MAP_NAME = "foobar";
     private static final int DEFAULT_PARTITION_COUNT = 271;
@@ -237,7 +237,7 @@ public class QueryResultSizeLimiterTest {
         when(mapServiceContext.getRecordStore(anyInt(), anyString())).thenReturn(recordStore);
         when(mapServiceContext.getOwnedPartitions()).thenReturn(localPartitions.keySet());
 
-        limiter = new QueryResultSizeLimiter(mapServiceContext, Logger.getLogger(QueryResultSizeLimiterTest.class));
+        limiter = new QueryResultSizeLimiter(mapServiceContext, Logger.getLogger(QueryResult_SizeLimiterTest.class));
     }
 
     private void populatePartitions(int[] localPartitionSize) {

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryResult_Test.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryResult_Test.java
@@ -1,0 +1,95 @@
+package com.hazelcast.map.impl.query;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.internal.serialization.SerializationService;
+import com.hazelcast.map.QueryResultSizeExceededException;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.util.IterationType;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class QueryResult_Test extends HazelcastTestSupport {
+
+    private SerializationService serializationService;
+
+    @Before
+    public void setup() {
+        HazelcastInstance hz = createHazelcastInstance();
+        serializationService = getSerializationService(hz);
+    }
+
+    @Test
+    public void isEmpty_whenNotEmpty() {
+        QueryResult queryResult = new QueryResult(IterationType.ENTRY, 100);
+
+        boolean result = queryResult.isEmpty();
+
+        assertTrue(result);
+    }
+
+    @Test
+    public void isEmpty_whenEmpty() {
+        QueryResult queryResult = new QueryResult(IterationType.ENTRY, 100);
+        queryResult.add(toData("1"),toData("1"));
+
+        boolean result = queryResult.isEmpty();
+
+        assertFalse(result);
+    }
+
+    @Test
+    public void limit() {
+        QueryResult queryResult = new QueryResult(IterationType.KEY, 2);
+        queryResult.addFrom(new QueryResultRow(toData(1), null));
+        queryResult.addFrom(new QueryResultRow(toData(2), null));
+
+        try {
+            queryResult.addFrom(new QueryResultRow(toData(3), null));
+            fail();
+        } catch (QueryResultSizeExceededException e) {
+
+        }
+    }
+
+    private Data toData(Object item) {
+        return serializationService.toData(item);
+    }
+
+    @Test
+    public void test() {
+        QueryResult queryResult = new QueryResult(IterationType.KEY, Long.MAX_VALUE);
+
+        int itemCount = 1000;
+
+        Data[] keys = new Data[itemCount];
+        for (int k = 0; k < itemCount; k++) {
+            Data key = serializationService.toData(k);
+            keys[k] = key;
+            queryResult.addFrom(new QueryResultRow(key, null));
+        }
+
+        QueryResult.Cursor cursor = queryResult.openCursor();
+        for (int k = 0; k < 1000; k++) {
+            assertTrue(cursor.next());
+            assertEquals(keys[k], cursor.getKey());
+            assertNull(cursor.getValue());
+        }
+
+        assertFalse(cursor.next());
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/QueryEntryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/QueryEntryTest.java
@@ -19,6 +19,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import javax.management.Query;
 import java.io.IOException;
 
 import static org.junit.Assert.assertEquals;
@@ -45,9 +46,9 @@ public class QueryEntryTest extends HazelcastTestSupport {
     @Test
     public void getAttribute_whenValueIsPortableObject_thenConvertedToData() {
         Data key = serializationService.toData("indexedKey");
-
         Portable value = new SampleObjects.PortableEmployee(30, "peter");
-        QueryEntry queryEntry = new QueryEntry(serializationService, key, value, Extractors.empty());
+        QueryEntry queryEntry = new QueryEntry(serializationService, Extractors.empty());
+        queryEntry.init(key, value);
 
         // in the portable-data, the attribute 'name' is called 'n'. So if we can retrieve on n
         // correctly it shows that we have used the Portable data, not the actual Portable object
@@ -61,7 +62,8 @@ public class QueryEntryTest extends HazelcastTestSupport {
         Data key = serializationService.toData(new SampleObjects.PortableEmployee(30, "peter"));
 
         SerializableObject value = new SerializableObject();
-        QueryEntry queryEntry = new QueryEntry(serializationService, key, value, Extractors.empty());
+        QueryEntry queryEntry = new QueryEntry(serializationService,Extractors.empty());
+        queryEntry.init(key, value);
 
         // in the portable-data, the attribute 'name' is called 'n'. So if we can retrieve on n
         // correctly it shows that we have used the Portable data, not the actual Portable object
@@ -75,7 +77,8 @@ public class QueryEntryTest extends HazelcastTestSupport {
         Data key = serializationService.toData(new SampleObjects.PortableEmployee(30, "peter"));
 
         SerializableObject value = new SerializableObject();
-        QueryEntry queryEntry = new QueryEntry(serializationService, key, value, Extractors.empty());
+        QueryEntry queryEntry = new QueryEntry(serializationService, Extractors.empty());
+        queryEntry.init(key, value);
 
         Object result = queryEntry.getAttributeValue(QueryConstants.KEY_ATTRIBUTE_NAME.value() + ".n");
 
@@ -87,7 +90,8 @@ public class QueryEntryTest extends HazelcastTestSupport {
         Data key = serializationService.toData(new SerializableObject());
         SerializableObject value = new SerializableObject();
         value.name = "somename";
-        QueryEntry queryEntry = new QueryEntry(serializationService, key, value, Extractors.empty());
+        QueryEntry queryEntry = new QueryEntry(serializationService, Extractors.empty());
+        queryEntry.init(key, value);
 
         Object result = queryEntry.getAttributeValue("name");
 
@@ -100,12 +104,13 @@ public class QueryEntryTest extends HazelcastTestSupport {
     public void test_init() throws Exception {
         Data dataKey = serializationService.toData("dataKey");
         Data dataValue = serializationService.toData("dataValue");
-        QueryEntry queryEntry = new QueryEntry(serializationService, dataKey, dataValue, Extractors.empty());
+        QueryEntry queryEntry = new QueryEntry(serializationService, Extractors.empty());
+        queryEntry.init(dataKey, dataValue);
 
         Object objectValue = queryEntry.getValue();
         Object objectKey = queryEntry.getKey();
 
-        queryEntry.init(serializationService, serializationService.toData(objectKey), objectValue, Extractors.empty());
+        queryEntry.init( serializationService.toData(objectKey), objectValue);
 
         // compare references of objects since they should be cloned after QueryEntry#init call.
         assertTrue("Old dataKey should not be here", dataKey != queryEntry.getKeyData());


### PR DESCRIPTION
In the old approach a linkedlist is used to store each row.

In the new approach there are one or two arrays of data (2 arrays if key+value is stored). But the QueryResultRow is not forced to be created. Also no linkedlist node per result item.

Also in the QueryEngine for regular predicates object litter has been reduced. Instead of creating a QueryEntry per item to check, the QueryEntry is created once for a partition and then recycled.