### PR TITLE
Prevents sending of not requested events to a MapListener

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -453,6 +453,7 @@
     <suppress checks="MethodCountCheck" files="com/hazelcast/map/impl/proxy/MapProxyImpl"/>
     <suppress checks="MethodCountCheck" files="com/hazelcast/map/impl/proxy/MapProxySupport"/>
     <suppress checks="ClassFanOutComplexityCheck" files="com/hazelcast/map/impl/proxy/MapProxySupport"/>
+    <suppress checks="ClassFanOutComplexityCheck" files="com/hazelcast/map/impl/MapServiceContextImpl"/>
     <suppress checks="ClassDataAbstractionCoupling" files="com/hazelcast/map/impl/proxy/MapProxySupport"/>
     <suppress checks="CyclomaticComplexity" files="com/hazelcast/map/impl/client/AbstractTxnMapRequest"/>
     <suppress checks="MethodCount|ClassDataAbstractionCoupling" files="com/hazelcast/map/impl/MapServiceContextImpl"/>

--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
@@ -148,6 +148,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import static com.hazelcast.cluster.memberselector.MemberSelectors.LITE_MEMBER_SELECTOR;
 import static com.hazelcast.map.impl.ListenerAdapters.createListenerAdapter;
+import static com.hazelcast.map.impl.MapListenerFlagOperator.ALL_LISTENER_FLAGS;
+import static com.hazelcast.map.impl.MapListenerFlagOperator.setAndGetListenerFlags;
 import static com.hazelcast.util.Preconditions.checkNotNull;
 import static com.hazelcast.util.SortingUtil.getSortedQueryResultSet;
 
@@ -621,8 +623,11 @@ public class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V> {
 
     @Override
     public String addEntryListener(MapListener listener, boolean includeValue) {
-        ClientMessage request = MapAddEntryListenerCodec.encodeRequest(name, includeValue);
-        EventHandler<ClientMessage> handler = createHandler(listener, includeValue);
+        ListenerAdapter listenerAdaptor = createListenerAdapter(listener);
+        int listenerFlags = setAndGetListenerFlags(listenerAdaptor);
+
+        ClientMessage request = MapAddEntryListenerCodec.encodeRequest(name, includeValue, listenerFlags);
+        EventHandler<ClientMessage> handler = createHandler(listenerAdaptor, includeValue);
         ClientMessageDecoder responseDecoder = new ClientMessageDecoder() {
             @Override
             public <T> T decodeClientMessage(ClientMessage clientMessage) {
@@ -634,8 +639,11 @@ public class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V> {
 
     @Override
     public String addEntryListener(EntryListener listener, boolean includeValue) {
-        ClientMessage request = MapAddEntryListenerCodec.encodeRequest(name, includeValue);
-        EventHandler<ClientMessage> handler = createHandler(listener, includeValue);
+        ListenerAdapter listenerAdaptor = createListenerAdapter(listener);
+        int listenerFlags = setAndGetListenerFlags(listenerAdaptor);
+
+        ClientMessage request = MapAddEntryListenerCodec.encodeRequest(name, includeValue, listenerFlags);
+        EventHandler<ClientMessage> handler = createHandler(listenerAdaptor, includeValue);
         ClientMessageDecoder responseDecoder = new ClientMessageDecoder() {
             @Override
             public <T> T decodeClientMessage(ClientMessage clientMessage) {
@@ -690,9 +698,12 @@ public class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V> {
 
     @Override
     public String addEntryListener(MapListener listener, K key, boolean includeValue) {
+        ListenerAdapter listenerAdaptor = createListenerAdapter(listener);
+        int listenerFlags = setAndGetListenerFlags(listenerAdaptor);
+
         Data keyData = toData(key);
-        ClientMessage request = MapAddEntryListenerToKeyCodec.encodeRequest(name, keyData, includeValue);
-        EventHandler<ClientMessage> handler = createHandler(listener, includeValue);
+        ClientMessage request = MapAddEntryListenerToKeyCodec.encodeRequest(name, keyData, includeValue, listenerFlags);
+        EventHandler<ClientMessage> handler = createHandler(listenerAdaptor, includeValue);
         ClientMessageDecoder responseDecoder = new ClientMessageDecoder() {
             @Override
             public <T> T decodeClientMessage(ClientMessage clientMessage) {
@@ -704,9 +715,12 @@ public class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V> {
 
     @Override
     public String addEntryListener(EntryListener listener, K key, boolean includeValue) {
+        ListenerAdapter listenerAdaptor = createListenerAdapter(listener);
+        int listenerFlags = setAndGetListenerFlags(listenerAdaptor);
+
         final Data keyData = toData(key);
-        ClientMessage request = MapAddEntryListenerToKeyCodec.encodeRequest(name, keyData, includeValue);
-        EventHandler<ClientMessage> handler = createHandler(listener, includeValue);
+        ClientMessage request = MapAddEntryListenerToKeyCodec.encodeRequest(name, keyData, includeValue, listenerFlags);
+        EventHandler<ClientMessage> handler = createHandler(listenerAdaptor, includeValue);
         ClientMessageDecoder responseDecoder = new ClientMessageDecoder() {
             @Override
             public <T> T decodeClientMessage(ClientMessage clientMessage) {
@@ -718,11 +732,14 @@ public class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V> {
 
     @Override
     public String addEntryListener(MapListener listener, Predicate<K, V> predicate, K key, boolean includeValue) {
+        ListenerAdapter listenerAdaptor = createListenerAdapter(listener);
+        int listenerFlags = setAndGetListenerFlags(listenerAdaptor);
+
         final Data keyData = toData(key);
         final Data predicateData = toData(predicate);
         ClientMessage request =
-                MapAddEntryListenerToKeyWithPredicateCodec.encodeRequest(name, keyData, predicateData, includeValue);
-        EventHandler<ClientMessage> handler = createHandler(listener, includeValue);
+                MapAddEntryListenerToKeyWithPredicateCodec.encodeRequest(name, keyData, predicateData, includeValue, listenerFlags);
+        EventHandler<ClientMessage> handler = createHandler(listenerAdaptor, includeValue);
         ClientMessageDecoder responseDecoder = new ClientMessageDecoder() {
             @Override
             public <T> T decodeClientMessage(ClientMessage clientMessage) {
@@ -734,12 +751,15 @@ public class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V> {
 
     @Override
     public String addEntryListener(EntryListener listener, Predicate<K, V> predicate, K key, boolean includeValue) {
+        ListenerAdapter listenerAdaptor = createListenerAdapter(listener);
+        int listenerFlags = setAndGetListenerFlags(listenerAdaptor);
+
         final Data keyData = toData(key);
         final Data predicateData = toData(predicate);
         ClientMessage request =
-                MapAddEntryListenerToKeyWithPredicateCodec.encodeRequest(name, keyData, predicateData, includeValue);
+                MapAddEntryListenerToKeyWithPredicateCodec.encodeRequest(name, keyData, predicateData, includeValue, listenerFlags);
 
-        EventHandler<ClientMessage> handler = createHandler(listener, includeValue);
+        EventHandler<ClientMessage> handler = createHandler(listenerAdaptor, includeValue);
         ClientMessageDecoder responseDecoder = new ClientMessageDecoder() {
             @Override
             public <T> T decodeClientMessage(ClientMessage clientMessage) {
@@ -751,11 +771,14 @@ public class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V> {
 
     @Override
     public String addEntryListener(MapListener listener, Predicate<K, V> predicate, boolean includeValue) {
+        ListenerAdapter listenerAdaptor = createListenerAdapter(listener);
+        int listenerFlags = setAndGetListenerFlags(listenerAdaptor);
+
         final Data predicateData = toData(predicate);
         ClientMessage request =
-                MapAddEntryListenerWithPredicateCodec.encodeRequest(name, predicateData, includeValue);
+                MapAddEntryListenerWithPredicateCodec.encodeRequest(name, predicateData, includeValue, listenerFlags);
 
-        EventHandler<ClientMessage> handler = createHandler(listener, includeValue);
+        EventHandler<ClientMessage> handler = createHandler(listenerAdaptor, includeValue);
         ClientMessageDecoder responseDecoder = new ClientMessageDecoder() {
             @Override
             public <T> T decodeClientMessage(ClientMessage clientMessage) {
@@ -767,11 +790,14 @@ public class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V> {
 
     @Override
     public String addEntryListener(EntryListener listener, Predicate<K, V> predicate, boolean includeValue) {
+        ListenerAdapter listenerAdaptor = createListenerAdapter(listener);
+        int listenerFlags = setAndGetListenerFlags(listenerAdaptor);
+
         final Data predicateData = toData(predicate);
         ClientMessage request =
-                MapAddEntryListenerWithPredicateCodec.encodeRequest(name, predicateData, includeValue);
+                MapAddEntryListenerWithPredicateCodec.encodeRequest(name, predicateData, includeValue, listenerFlags);
 
-        EventHandler<ClientMessage> handler = createHandler(listener, includeValue);
+        EventHandler<ClientMessage> handler = createHandler(listenerAdaptor, includeValue);
         ClientMessageDecoder responseDecoder = new ClientMessageDecoder() {
             @Override
             public <T> T decodeClientMessage(ClientMessage clientMessage) {
@@ -1239,16 +1265,16 @@ public class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V> {
     public void putAll(Map<? extends K, ? extends V> m) {
         ClientPartitionService partitionService = getContext().getPartitionService();
         Map<Integer, Map<Data, Data>> entryMap = new HashMap<Integer, Map<Data, Data>>(partitionService.getPartitionCount());
-        
+
         for (Entry<? extends K, ? extends V> entry : m.entrySet()) {
             checkNotNull(entry.getKey(), NULL_KEY_IS_NOT_ALLOWED);
             checkNotNull(entry.getValue(), NULL_VALUE_IS_NOT_ALLOWED);
-            
+
             final Data keyData = toData(entry.getKey());
             invalidateNearCache(keyData);
-            
+
             int partitionId = partitionService.getPartitionId(keyData);
-            Map<Data, Data> partition = entryMap.get(partitionId); 
+            Map<Data, Data> partition = entryMap.get(partitionId);
             if (partition == null) {
                 partition = new HashMap<Data, Data>();
                 entryMap.put(partitionId, partition);
@@ -1256,7 +1282,7 @@ public class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V> {
 
             partition.put(keyData, toData(entry.getValue()));
         }
-        
+
         List<Future<?>> futures = new ArrayList<Future<?>>(entryMap.size());
         for (final Map.Entry<Integer, Map<Data, Data>> entry : entryMap.entrySet()) {
             final Integer partitionId = entry.getKey();
@@ -1273,7 +1299,7 @@ public class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V> {
         } catch (Exception e) {
             ExceptionUtil.rethrow(e);
         }
-        
+
     }
 
     @Override
@@ -1314,9 +1340,8 @@ public class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V> {
         return timeunit != null ? timeunit.toMillis(time) : time;
     }
 
-    private EventHandler<ClientMessage> createHandler(final Object listener, final boolean includeValue) {
-        final ListenerAdapter listenerAdaptor = createListenerAdapter(listener);
-        return new ClientMapEventHandler(listenerAdaptor, includeValue);
+    private EventHandler<ClientMessage> createHandler(final ListenerAdapter listenerAdapter, final boolean includeValue) {
+        return new ClientMapEventHandler(listenerAdapter, includeValue);
     }
 
     private void invalidateNearCache(Data key) {
@@ -1358,7 +1383,7 @@ public class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V> {
 
     private void addNearCacheInvalidateListener() {
         try {
-            ClientMessage request = MapAddNearCacheEntryListenerCodec.encodeRequest(name, false);
+            ClientMessage request = MapAddNearCacheEntryListenerCodec.encodeRequest(name, false, ALL_LISTENER_FLAGS);
             EventHandler handler = new ClientMapAddNearCacheEventHandler();
             String registrationId = getContext().getListenerService().startListening(request, null, handler,
                     new ClientMessageDecoder() {

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/AbstractMapAddEntryListenerMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/AbstractMapAddEntryListenerMessageTask.java
@@ -22,9 +22,9 @@ import com.hazelcast.client.impl.protocol.task.AbstractCallableMessageTask;
 import com.hazelcast.core.EntryEvent;
 import com.hazelcast.core.EntryEventType;
 import com.hazelcast.core.MapEvent;
-import com.hazelcast.map.impl.MapListenerAdapter;
 import com.hazelcast.instance.Node;
 import com.hazelcast.map.impl.DataAwareEntryEvent;
+import com.hazelcast.map.impl.MapListenerAdapter;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.map.impl.MapServiceContext;
 import com.hazelcast.nio.Connection;
@@ -49,8 +49,9 @@ public abstract class AbstractMapAddEntryListenerMessageTask<Parameter>
 
         MapListenerAdapter<Object, Object> listener = new MapListener();
         MapServiceContext mapServiceContext = mapService.getMapServiceContext();
-        final String name = getDistributedObjectName();
-        final String registrationId = mapServiceContext.addEventListener(listener, getEventFilter(), name);
+        String name = getDistributedObjectName();
+        EventFilter eventFilter = getEventFilter();
+        String registrationId = mapServiceContext.addEventListener(listener, eventFilter, name);
         endpoint.addListenerDestroyAction(MapService.SERVICE_NAME, name, registrationId);
         return registrationId;
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapAddEntryListenerMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapAddEntryListenerMessageTask.java
@@ -20,6 +20,7 @@ import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.MapAddEntryListenerCodec;
 import com.hazelcast.instance.Node;
 import com.hazelcast.map.impl.EntryEventFilter;
+import com.hazelcast.map.impl.EventListenerFilter;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.EventFilter;
@@ -33,7 +34,8 @@ public class MapAddEntryListenerMessageTask
 
     @Override
     protected EventFilter getEventFilter() {
-        return new EntryEventFilter(parameters.includeValue, null);
+        EntryEventFilter eventFilter = new EntryEventFilter(parameters.includeValue, null);
+        return new EventListenerFilter(parameters.listenerFlags, eventFilter);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapAddEntryListenerToKeyMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapAddEntryListenerToKeyMessageTask.java
@@ -21,6 +21,7 @@ import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.MapAddEntryListenerToKeyCodec;
 import com.hazelcast.instance.Node;
 import com.hazelcast.map.impl.EntryEventFilter;
+import com.hazelcast.map.impl.EventListenerFilter;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.EventFilter;
@@ -56,7 +57,8 @@ public class MapAddEntryListenerToKeyMessageTask
 
     @Override
     protected EventFilter getEventFilter() {
-        return new EntryEventFilter(parameters.includeValue, parameters.key);
+        EntryEventFilter eventFilter = new EntryEventFilter(parameters.includeValue, parameters.key);
+        return new EventListenerFilter(parameters.listenerFlags, eventFilter);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapAddEntryListenerToKeyWithPredicateMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapAddEntryListenerToKeyWithPredicateMessageTask.java
@@ -19,6 +19,7 @@ package com.hazelcast.client.impl.protocol.task.map;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.MapAddEntryListenerToKeyWithPredicateCodec;
 import com.hazelcast.instance.Node;
+import com.hazelcast.map.impl.EventListenerFilter;
 import com.hazelcast.map.impl.query.QueryEventFilter;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.serialization.Data;
@@ -34,8 +35,9 @@ public class MapAddEntryListenerToKeyWithPredicateMessageTask
 
     @Override
     protected EventFilter getEventFilter() {
-        final Predicate predicate = serializationService.toObject(parameters.predicate);
-        return new QueryEventFilter(parameters.includeValue, parameters.key, predicate);
+        Predicate predicate = serializationService.toObject(parameters.predicate);
+        QueryEventFilter eventFilter = new QueryEventFilter(parameters.includeValue, parameters.key, predicate);
+        return new EventListenerFilter(parameters.listenerFlags, eventFilter);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapAddEntryListenerWithPredicateMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapAddEntryListenerWithPredicateMessageTask.java
@@ -19,6 +19,7 @@ package com.hazelcast.client.impl.protocol.task.map;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.MapAddEntryListenerWithPredicateCodec;
 import com.hazelcast.instance.Node;
+import com.hazelcast.map.impl.EventListenerFilter;
 import com.hazelcast.map.impl.query.QueryEventFilter;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.serialization.Data;
@@ -34,8 +35,9 @@ public class MapAddEntryListenerWithPredicateMessageTask
 
     @Override
     protected EventFilter getEventFilter() {
-        final Predicate predicate = serializationService.toObject(parameters.predicate);
-        return new QueryEventFilter(parameters.includeValue, null, predicate);
+        Predicate predicate = serializationService.toObject(parameters.predicate);
+        QueryEventFilter eventFilter = new QueryEventFilter(parameters.includeValue, null, predicate);
+        return new EventListenerFilter(parameters.listenerFlags, eventFilter);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapAddNearCacheEntryListenerMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapAddNearCacheEntryListenerMessageTask.java
@@ -20,6 +20,7 @@ import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.MapAddNearCacheEntryListenerCodec;
 import com.hazelcast.instance.Node;
 import com.hazelcast.map.impl.EntryEventFilter;
+import com.hazelcast.map.impl.EventListenerFilter;
 import com.hazelcast.map.impl.SyntheticEventFilter;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.serialization.Data;
@@ -35,7 +36,8 @@ public class MapAddNearCacheEntryListenerMessageTask
     @Override
     protected EventFilter getEventFilter() {
         EntryEventFilter eventFilter = new EntryEventFilter(parameters.includeValue, null);
-        return new SyntheticEventFilter(eventFilter);
+        SyntheticEventFilter syntheticEventFilter = new SyntheticEventFilter(eventFilter);
+        return new EventListenerFilter(parameters.listenerFlags, syntheticEventFilter);
     }
 
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/MapCodecTemplate.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/MapCodecTemplate.java
@@ -34,11 +34,11 @@ public interface MapCodecTemplate {
      * (identically equal) value previously put into the map.Time resolution for TTL is seconds. The given TTL value is
      * rounded to the next closest second value.
      *
-     * @param name Name of the map.
-     * @param key Key for the map entry.
-     * @param value Value for the map entry.
+     * @param name     Name of the map.
+     * @param key      Key for the map entry.
+     * @param value    Value for the map entry.
      * @param threadId The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
-     * @param ttl The duration in milliseconds after which this entry shall be deleted. O means infinite.
+     * @param ttl      The duration in milliseconds after which this entry shall be deleted. O means infinite.
      * @return old value of the entry
      */
     @Request(id = 1, retryable = false, response = ResponseMessageConst.DATA)
@@ -48,8 +48,8 @@ public interface MapCodecTemplate {
      * This method returns a clone of the original value, so modifying the returned value does not change the actual
      * value in the map. You should put the modified value back to make changes visible to all nodes.
      *
-     * @param name Name of the map.
-     * @param key Key for the map entry.
+     * @param name     Name of the map.
+     * @param key      Key for the map entry.
      * @param threadId The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
      * @return The value for the key if exists
      */
@@ -63,8 +63,8 @@ public interface MapCodecTemplate {
      * possible that the map explicitly mapped the key to null. The map will not contain a mapping for the specified key once the
      * call returns.
      *
-     * @param name Name of the map.
-     * @param key Key for the map entry.
+     * @param name     Name of the map.
+     * @param key      Key for the map entry.
      * @param threadId The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
      * @return Clone of the removed value, not the original (identically equal) value previously put into the map.
      */
@@ -74,9 +74,9 @@ public interface MapCodecTemplate {
     /**
      * Replaces the entry for a key only if currently mapped to a given value.
      *
-     * @param name Name of the map.
-     * @param key Key for the map entry.
-     * @param value New value for the map entry.
+     * @param name     Name of the map.
+     * @param key      Key for the map entry.
+     * @param value    New value for the map entry.
      * @param threadId The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
      * @return Clone of the previous value, not the original (identically equal) value previously put into the map.
      */
@@ -86,11 +86,11 @@ public interface MapCodecTemplate {
     /**
      * Replaces the the entry for a key only if existing values equal to the testValue
      *
-     * @param name Name of the map.
-     * @param key Key for the map entry.
+     * @param name      Name of the map.
+     * @param key       Key for the map entry.
      * @param testValue Test the existing value against this value to find if equal to this value.
-     * @param value New value for the map entry. Only replace with this value if existing value is equal to the testValue.
-     * @param threadId The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
+     * @param value     New value for the map entry. Only replace with this value if existing value is equal to the testValue.
+     * @param threadId  The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
      * @return true if value is replaced with new one, false otherwise
      */
     @Request(id = 5, retryable = false, response = ResponseMessageConst.BOOLEAN)
@@ -101,11 +101,11 @@ public interface MapCodecTemplate {
      * and get evicted after the ttl. If ttl is 0, then the entry lives forever. Time resolution for TTL is seconds.
      * The given TTL value is rounded to the next closest second value.
      *
-     * @param name Name of the map.
-     * @param key Key for the map entry.
-     * @param value New value for the map entry.
+     * @param name     Name of the map.
+     * @param key      Key for the map entry.
+     * @param value    New value for the map entry.
      * @param threadId The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
-     * @param ttl The duration in milliseconds after which this entry shall be deleted. O means infinite.
+     * @param ttl      The duration in milliseconds after which this entry shall be deleted. O means infinite.
      * @return Clone of the previous value, not the original (identically equal) value previously put into the map.
      */
     @Request(id = 6, retryable = false, response = ResponseMessageConst.DATA)
@@ -115,8 +115,8 @@ public interface MapCodecTemplate {
     /**
      * Asynchronously gets the given key.
      *
-     * @param name Name of the map.
-     * @param key Key for the map entry.
+     * @param name     Name of the map.
+     * @param key      Key for the map entry.
      * @param threadId The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
      * @return Clone of the value if exists, not the original (identically equal) value previously put into the map.
      */
@@ -126,8 +126,8 @@ public interface MapCodecTemplate {
     /**
      * Asynchronously removes the given key.
      *
-     * @param name Name of the map.
-     * @param key Key for the map entry.
+     * @param name     Name of the map.
+     * @param key      Key for the map entry.
      * @param threadId The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
      * @return Clone of the removed value, not the original (identically equal) value previously put into the map.
      */
@@ -137,8 +137,8 @@ public interface MapCodecTemplate {
     /**
      * Returns true if this map contains a mapping for the specified key.
      *
-     * @param name Name of the map.
-     * @param key Key for the map entry.
+     * @param name     Name of the map.
+     * @param key      Key for the map entry.
      * @param threadId The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
      * @return Returns true if the key exists, otherwise returns false.
      */
@@ -149,7 +149,7 @@ public interface MapCodecTemplate {
      * Returns true if this map maps one or more keys to the specified value.This operation will probably require time
      * linear in the map size for most implementations of the Map interface.
      *
-     * @param name Name of the map.
+     * @param name  Name of the map.
      * @param value Value to check if exists in the map.
      * @return Returns true if the value exists, otherwise returns false.
      */
@@ -159,9 +159,9 @@ public interface MapCodecTemplate {
     /**
      * Removes the mapping for a key from this map if existing value equal to the this value
      *
-     * @param name Name of the map.
-     * @param key Key for the map entry.
-     * @param value Test the existing value against this value to find if equal to this value. Only remove the entry from the map if the value is equal to this value.
+     * @param name     Name of the map.
+     * @param key      Key for the map entry.
+     * @param value    Test the existing value against this value to find if equal to this value. Only remove the entry from the map if the value is equal to this value.
      * @param threadId The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
      * @return Returns true if the key exists and removed, otherwise returns false.
      */
@@ -176,8 +176,8 @@ public interface MapCodecTemplate {
      * This method breaks the contract of EntryListener. When an entry is removed by delete(), it fires an EntryEvent
      * with a null oldValue. Also, a listener with predicates will have null values, so only keys can be queried via predicates
      *
-     * @param name Name of the map.
-     * @param key Key for the map entry.
+     * @param name     Name of the map.
+     * @param key      Key for the map entry.
      * @param threadId The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
      */
     @Request(id = 12, retryable = false, response = ResponseMessageConst.VOID)
@@ -197,10 +197,10 @@ public interface MapCodecTemplate {
      * If the key is already locked by another thread and/or member, then this operation will wait the timeout
      * amount for acquiring the lock.
      *
-     * @param name Name of the map.
-     * @param key Key for the map entry.
+     * @param name     Name of the map.
+     * @param key      Key for the map entry.
      * @param threadId The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
-     * @param timeout maximum time in milliseconds to wait for acquiring the lock for the key.
+     * @param timeout  maximum time in milliseconds to wait for acquiring the lock for the key.
      * @return Returns true if successful, otherwise returns false
      */
     @Request(id = 14, retryable = false, response = ResponseMessageConst.BOOLEAN)
@@ -211,11 +211,11 @@ public interface MapCodecTemplate {
      * it means that the caller thread could not acquire the lock for the key within the timeout duration,
      * thus the put operation is not successful.
      *
-     * @param name Name of the map.
-     * @param key Key for the map entry.
-     * @param value New value for the map entry.
+     * @param name     Name of the map.
+     * @param key      Key for the map entry.
+     * @param value    New value for the map entry.
      * @param threadId The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
-     * @param timeout maximum time in milliseconds to wait for acquiring the lock for the key.
+     * @param timeout  maximum time in milliseconds to wait for acquiring the lock for the key.
      * @return Returns true if successful, otherwise returns false
      */
     @Request(id = 15, retryable = false, response = ResponseMessageConst.BOOLEAN)
@@ -225,11 +225,11 @@ public interface MapCodecTemplate {
      * Same as put except that MapStore, if defined, will not be called to store/persist the entry.
      * If ttl is 0, then the entry lives forever.
      *
-     * @param name Name of the map.
-     * @param key Key for the map entry.
-     * @param value New value for the map entry.
+     * @param name     Name of the map.
+     * @param key      Key for the map entry.
+     * @param value    New value for the map entry.
      * @param threadId The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
-     * @param ttl The duration in milliseconds after which this entry shall be deleted. O means infinite.
+     * @param ttl      The duration in milliseconds after which this entry shall be deleted. O means infinite.
      */
     @Request(id = 16, retryable = false, response = ResponseMessageConst.VOID)
     void putTransient(String name, Data key, Data value, long threadId, long ttl);
@@ -238,11 +238,11 @@ public interface MapCodecTemplate {
      * Puts an entry into this map with a given ttl (time to live) value if the specified key is not already associated
      * with a value. Entry will expire and get evicted after the ttl.
      *
-     * @param name Name of the map.
-     * @param key Key for the map entry.
-     * @param value New value for the map entry.
+     * @param name     Name of the map.
+     * @param key      Key for the map entry.
+     * @param value    New value for the map entry.
      * @param threadId The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
-     * @param ttl The duration in milliseconds after which this entry shall be deleted. O means infinite.
+     * @param ttl      The duration in milliseconds after which this entry shall be deleted. O means infinite.
      * @return returns a clone of the previous value, not the original (identically equal) value previously put into the map.
      */
     @Request(id = 17, retryable = false, response = ResponseMessageConst.DATA)
@@ -253,11 +253,11 @@ public interface MapCodecTemplate {
      * If ttl is 0, then the entry lives forever. Similar to the put operation except that set doesn't
      * return the old value, which is more efficient.
      *
-     * @param name Name of the map.
-     * @param key Key for the map entry.
-     * @param value New value for the map entry.
+     * @param name     Name of the map.
+     * @param key      Key for the map entry.
+     * @param value    New value for the map entry.
      * @param threadId The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
-     * @param ttl The duration in milliseconds after which this entry shall be deleted. O means infinite.
+     * @param ttl      The duration in milliseconds after which this entry shall be deleted. O means infinite.
      */
     @Request(id = 18, retryable = false, response = ResponseMessageConst.VOID)
     void set(String name, Data key, Data value, long threadId, long ttl);
@@ -269,10 +269,10 @@ public interface MapCodecTemplate {
      * Scope of the lock is this map only. Acquired lock is only for the key in this map. Locks are re-entrant,
      * so if the key is locked N times then it should be unlocked N times before another thread can acquire it.
      *
-     * @param name Name of the map.
-     * @param key Key for the map entry.
+     * @param name     Name of the map.
+     * @param key      Key for the map entry.
      * @param threadId The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
-     * @param ttl The duration in milliseconds after which this entry shall be deleted. O means infinite.
+     * @param ttl      The duration in milliseconds after which this entry shall be deleted. O means infinite.
      */
     @Request(id = 19, retryable = false, response = ResponseMessageConst.VOID)
     void lock(String name, Data key, long threadId, long ttl);
@@ -283,11 +283,11 @@ public interface MapCodecTemplate {
      * purposes and lies dormant until one of two things happens the lock is acquired by the current thread, or
      * the specified waiting time elapses.
      *
-     * @param name Name of the map.
-     * @param key Key for the map entry.
+     * @param name     Name of the map.
+     * @param key      Key for the map entry.
      * @param threadId The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
-     * @param lease time in milliseconds to wait before releasing the lock.
-     * @param timeout maximum time to wait for getting the lock.
+     * @param lease    time in milliseconds to wait before releasing the lock.
+     * @param timeout  maximum time to wait for getting the lock.
      * @return Returns true if successful, otherwise returns false
      */
     @Request(id = 20, retryable = false, response = ResponseMessageConst.BOOLEAN)
@@ -297,7 +297,7 @@ public interface MapCodecTemplate {
      * Checks the lock for the specified key.If the lock is acquired then returns true, else returns false.
      *
      * @param name name of map
-     * @param key Key for the map entry to check if it is locked.
+     * @param key  Key for the map entry to check if it is locked.
      * @return Returns true if the entry is locked, otherwise returns false
      */
     @Request(id = 21, retryable = true, response = ResponseMessageConst.BOOLEAN)
@@ -309,8 +309,8 @@ public interface MapCodecTemplate {
      * then the lock is released.  If the current thread is not the holder of this lock,
      * then ILLEGAL_MONITOR_STATE is thrown.
      *
-     * @param name name of map
-     * @param key Key for the map entry to unlock
+     * @param name     name of map
+     * @param key      Key for the map entry to unlock
      * @param threadId The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
      */
     @Request(id = 22, retryable = false, response = ResponseMessageConst.VOID)
@@ -320,7 +320,7 @@ public interface MapCodecTemplate {
      * Adds an interceptor for this map. Added interceptor will intercept operations
      * and execute user defined methods and will cancel operations if user defined method throw exception.
      *
-     * @param name name of map
+     * @param name        name of map
      * @param interceptor interceptor to add
      * @return id of registered interceptor.
      */
@@ -331,9 +331,8 @@ public interface MapCodecTemplate {
      * Removes the given interceptor for this map so it will not intercept operations anymore.
      *
      * @param name name of map
-     * @param id of interceptor
+     * @param id   of interceptor
      * @return Returns true if successful, otherwise returns false
-     *
      */
     @Request(id = 24, retryable = false, response = ResponseMessageConst.BOOLEAN)
     Object removeInterceptor(String name, String id);
@@ -342,66 +341,71 @@ public interface MapCodecTemplate {
      * Adds a MapListener for this map. To receive an event, you should implement a corresponding MapListener
      * sub-interface for that event.
      *
-     * @param name name of map
-     * @param key Key for the map entry.
-     * @param predicate predicate for filtering entries.
-     * @param includeValue <tt>true</tt> if <tt>EntryEvent</tt> should
-     *                     contain the value.
+     * @param name          name of map
+     * @param key           Key for the map entry.
+     * @param predicate     predicate for filtering entries.
+     * @param includeValue  <tt>true</tt> if <tt>EntryEvent</tt> should
+     *                      contain the value.
+     * @param listenerFlags flags of enabled listeners.
      * @return A unique string which is used as a key to remove the listener.
      */
     @Request(id = 25, retryable = true, response = ResponseMessageConst.STRING, event = EventMessageConst.EVENT_ENTRY)
-    Object addEntryListenerToKeyWithPredicate(String name, Data key, Data predicate, boolean includeValue);
+    Object addEntryListenerToKeyWithPredicate(String name, Data key, Data predicate, boolean includeValue, int listenerFlags);
 
     /**
      * Adds an continuous entry listener for this map. Listener will get notified for map add/remove/update/evict events
      * filtered by the given predicate.
      *
-     * @param name name of map
-     * @param predicate predicate for filtering entries.
-     * @param includeValue <tt>true</tt> if <tt>EntryEvent</tt> should
-     *                     contain the value.
+     * @param name          name of map
+     * @param predicate     predicate for filtering entries.
+     * @param includeValue  <tt>true</tt> if <tt>EntryEvent</tt> should
+     *                      contain the value.
+     * @param listenerFlags flags of enabled listeners.
      * @return A unique string which is used as a key to remove the listener.
      */
     @Request(id = 26, retryable = true, response = ResponseMessageConst.STRING, event = EventMessageConst.EVENT_ENTRY)
-    Object addEntryListenerWithPredicate(String name, Data predicate, boolean includeValue);
+    Object addEntryListenerWithPredicate(String name, Data predicate, boolean includeValue, int listenerFlags);
 
     /**
      * Adds a MapListener for this map. To receive an event, you should implement a corresponding MapListener
      * sub-interface for that event.
      *
-     * @param name name of map
-     * @param key Key for the map entry.
-     * @param includeValue <tt>true</tt> if <tt>EntryEvent</tt> should contain the value.
+     * @param name          name of map
+     * @param key           Key for the map entry.
+     * @param includeValue  <tt>true</tt> if <tt>EntryEvent</tt> should contain the value.
+     * @param listenerFlags flags of enabled listeners.
      * @return A unique string which is used as a key to remove the listener.
      */
     @Request(id = 27, retryable = true, response = ResponseMessageConst.STRING, event = EventMessageConst.EVENT_ENTRY)
-    Object addEntryListenerToKey(String name, Data key, boolean includeValue);
+    Object addEntryListenerToKey(String name, Data key, boolean includeValue, int listenerFlags);
 
     /**
      * Adds a MapListener for this map. To receive an event, you should implement a corresponding MapListener
      * sub-interface for that event.
      *
-     * @param name name of map
-     * @param includeValue <tt>true</tt> if <tt>EntryEvent</tt> should contain the value.
+     * @param name          name of map
+     * @param includeValue  <tt>true</tt> if <tt>EntryEvent</tt> should contain the value.
+     * @param listenerFlags flags of enabled listeners.
      * @return A unique string which is used as a key to remove the listener.
      */
     @Request(id = 28, retryable = true, response = ResponseMessageConst.STRING, event = EventMessageConst.EVENT_ENTRY)
-    Object addEntryListener(String name, boolean includeValue);
+    Object addEntryListener(String name, boolean includeValue, int listenerFlags);
 
     /**
      * Adds an entry listener for this map. Listener will get notified for all map add/remove/update/evict events.
      *
-     * @param name name of map
-     * @param includeValue <tt>true</tt> if <tt>EntryEvent</tt> should contain the value.
+     * @param name          name of map
+     * @param includeValue  <tt>true</tt> if <tt>EntryEvent</tt> should contain the value.
+     * @param listenerFlags flags of enabled listeners.
      * @return A unique string which is used as a key to remove the listener.
      */
     @Request(id = 29, retryable = true, response = ResponseMessageConst.STRING, event = EventMessageConst.EVENT_ENTRY)
-    Object addNearCacheEntryListener(String name, boolean includeValue);
+    Object addNearCacheEntryListener(String name, boolean includeValue, int listenerFlags);
 
     /**
      * Removes the specified entry listener. Returns silently if there is no such listener added before.
      *
-     * @param name name of map
+     * @param name           name of map
      * @param registrationId id of registered listener.
      * @return true if registration is removed, false otherwise.
      */
@@ -426,7 +430,7 @@ public interface MapCodecTemplate {
     /**
      * Removes the specified map partition lost listener. Returns silently if there is no such listener added before.
      *
-     * @param name name of map
+     * @param name           name of map
      * @param registrationId id of register
      * @return true if registration is removed, false otherwise.
      */
@@ -438,8 +442,8 @@ public interface MapCodecTemplate {
      * This method returns a clone of original mapping, modifying the returned value does not change the actual value
      * in the map. One should put modified value back to make changes visible to all nodes.
      *
-     * @param name name of map
-     * @param key the key of the entry.
+     * @param name     name of map
+     * @param key      the key of the entry.
      * @param threadId The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
      * @return <tt>EntryView</tt> of the specified key.
      */
@@ -450,8 +454,8 @@ public interface MapCodecTemplate {
      * Evicts the specified key from this map. If a MapStore is defined for this map, then the entry is not deleted
      * from the underlying MapStore, evict only removes the entry from the memory.
      *
-     * @param name name of map
-     * @param key the specified key to evict from this map.
+     * @param name     name of map
+     * @param key      the specified key to evict from this map.
      * @param threadId The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
      * @return <tt>true</tt> if the key is evicted, <tt>false</tt> otherwise.
      */
@@ -471,7 +475,7 @@ public interface MapCodecTemplate {
     /**
      * Loads all keys into the store. This is a batch load operation so that an implementation can optimize the multiple loads.
      *
-     * @param name name of map
+     * @param name                  name of map
      * @param replaceExistingValues when <code>true</code>, existing values in the Map will
      *                              be replaced by those loaded from the MapLoader
      */
@@ -481,8 +485,8 @@ public interface MapCodecTemplate {
     /**
      * Loads the given keys. This is a batch load operation so that an implementation can optimize the multiple loads.
      *
-     * @param name name of map
-     * @param keys keys to load
+     * @param name                  name of map
+     * @param keys                  keys to load
      * @param replaceExistingValues when <code>true</code>, existing values in the Map will be replaced by those loaded from the MapLoader
      */
     @Request(id = 37, retryable = false, response = ResponseMessageConst.VOID)
@@ -540,7 +544,7 @@ public interface MapCodecTemplate {
      * set, and vice-versa This method is always executed by a distributed query so it may throw a
      * QUERY_RESULT_SIZE_EXCEEDED if GroupProperties#PROP_QUERY_RESULT_SIZE_LIMIT is configured.
      *
-     * @param name name of map.
+     * @param name      name of map.
      * @param predicate specified query criteria.
      * @return result key set for the query.
      */
@@ -553,7 +557,7 @@ public interface MapCodecTemplate {
      * in the collection, and vice-versa.This method is always executed by a distributed query so it may throw a
      * QUERY_RESULT_SIZE_EXCEEDED if GroupProperties#PROP_QUERY_RESULT_SIZE_LIMIT is configured.
      *
-     * @param name name of map
+     * @param name      name of map
      * @param predicate specified query criteria.
      * @return result value collection of the query.
      */
@@ -566,7 +570,7 @@ public interface MapCodecTemplate {
      * in the collection, and vice-versa.This method is always executed by a distributed query so it may throw a
      * QUERY_RESULT_SIZE_EXCEEDED if GroupProperties#PROP_QUERY_RESULT_SIZE_LIMIT is configured.
      *
-     * @param name name of map
+     * @param name      name of map
      * @param predicate specified query criteria.
      * @return result key-value entry collection of the query.
      */
@@ -583,7 +587,7 @@ public interface MapCodecTemplate {
      * Until the index finishes being created, any searches for the attribute will use a full Map scan, thus avoiding
      * using a partially built index and returning incorrect results.
      *
-     * @param name name of map
+     * @param name      name of map
      * @param attribute index attribute of value
      * @param ordered   <tt>true</tt> if index should be ordered, <tt>false</tt> otherwise.
      */
@@ -615,9 +619,8 @@ public interface MapCodecTemplate {
      * v in the specified map.The behavior of this operation is undefined if the specified map is modified while the
      * operation is in progress.
      *
-     * @param name name of map
+     * @param name    name of map
      * @param entries mappings to be stored in this map
-     *
      */
     @Request(id = 48, retryable = false, response = ResponseMessageConst.VOID)
     void putAll(String name, Map<Data, Data> entries);
@@ -636,9 +639,9 @@ public interface MapCodecTemplate {
      * Applies the user defined EntryProcessor to the entry mapped by the key. Returns the the object which is result of
      * the process() method of EntryProcessor.
      *
-     * @param name name of map
+     * @param name           name of map
      * @param entryProcessor processor to execute on the map entry
-     * @param key the key of the map entry.
+     * @param key            the key of the map entry.
      * @return result of entry process.
      */
     @Request(id = 50, retryable = false, response = ResponseMessageConst.DATA)
@@ -649,9 +652,9 @@ public interface MapCodecTemplate {
      * representing that task.EntryProcessor is not cancellable, so calling Future.cancel() method won't cancel the
      * operation of EntryProcessor.
      *
-     * @param name name of map
+     * @param name           name of map
      * @param entryProcessor entry processor to be executed on the entry.
-     * @param key the key of the map entry.
+     * @param key            the key of the map entry.
      * @return result of entry process.
      */
     @Request(id = 51, retryable = false, response = ResponseMessageConst.DATA)
@@ -660,7 +663,7 @@ public interface MapCodecTemplate {
     /**
      * Applies the user defined EntryProcessor to the all entries in the map.Returns the results mapped by each key in the map.
      *
-     * @param name name of map
+     * @param name           name of map
      * @param entryProcessor entry processor to be executed.
      * @return results of entry process on the entries
      */
@@ -671,9 +674,9 @@ public interface MapCodecTemplate {
      * Applies the user defined EntryProcessor to the entries in the map which satisfies provided predicate.
      * Returns the results mapped by each key in the map.
      *
-     * @param name name of map
+     * @param name           name of map
      * @param entryProcessor entry processor to be executed.
-     * @param predicate specified query criteria.
+     * @param predicate      specified query criteria.
      * @return results of entry process on the entries matching the query criteria
      */
     @Request(id = 53, retryable = false, response = ResponseMessageConst.SET_ENTRY)
@@ -683,11 +686,10 @@ public interface MapCodecTemplate {
      * Applies the user defined EntryProcessor to the entries mapped by the collection of keys.The results mapped by
      * each key in the collection.
      *
-     * @param name name of map
+     * @param name           name of map
      * @param entryProcessor entry processor to be executed.
-     * @param keys The keys for the entries for which the entry processor shall be executed on.
+     * @param keys           The keys for the entries for which the entry processor shall be executed on.
      * @return results of entry process on the entries with the provided keys
-     *
      */
     @Request(id = 54, retryable = false, response = ResponseMessageConst.SET_ENTRY)
     Object executeOnKeys(String name, Data entryProcessor, Set<Data> keys);
@@ -697,18 +699,15 @@ public interface MapCodecTemplate {
      * never blocks,and returns immediately.
      *
      * @param name name of map
-     * @param key the key of the map entry.
-     *
+     * @param key  the key of the map entry.
      */
     @Request(id = 55, retryable = false, response = ResponseMessageConst.VOID)
     void forceUnlock(String name, Data key);
 
     /**
-     *
-     * @param name name of map
+     * @param name      name of map
      * @param predicate specified query criteria.
      * @return result keys for the query.
-     *
      */
     @Request(id = 56, retryable = false, response = ResponseMessageConst.SET_DATA)
     Object keySetWithPagingPredicate(String name, Data predicate);
@@ -719,7 +718,7 @@ public interface MapCodecTemplate {
      * in the collection, and vice-versa. This method is always executed by a distributed query so it may throw a
      * QUERY_RESULT_SIZE_EXCEEDED if GroupProperties#PROP_QUERY_RESULT_SIZE_LIMIT is configured.
      *
-     * @param name name of map
+     * @param name      name of map
      * @param predicate specified query criteria.
      * @return values for the query.
      */
@@ -727,11 +726,9 @@ public interface MapCodecTemplate {
     Object valuesWithPagingPredicate(String name, Data predicate);
 
     /**
-     *
-     * @param name name of map
+     * @param name      name of map
      * @param predicate specified query criteria.
      * @return key-value pairs for the query.
-     *
      */
     @Request(id = 58, retryable = false, response = ResponseMessageConst.SET_ENTRY)
     Object entriesWithPagingPredicate(String name, Data predicate);

--- a/hazelcast/src/main/java/com/hazelcast/core/EntryEventType.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/EntryEventType.java
@@ -21,14 +21,14 @@ package com.hazelcast.core;
  */
 public enum EntryEventType {
 
-    ADDED(1),
-    REMOVED(2),
-    UPDATED(3),
-    EVICTED(4),
-    EVICT_ALL(5),
-    CLEAR_ALL(6),
-    MERGED(7),
-    EXPIRED(8);
+    ADDED(Type.ADDED),
+    REMOVED(Type.REMOVED),
+    UPDATED(Type.UPDATED),
+    EVICTED(Type.EVICTED),
+    EVICT_ALL(Type.EVICT_ALL),
+    CLEAR_ALL(Type.CLEAR_ALL),
+    MERGED(Type.MERGED),
+    EXPIRED(Type.EXPIRED);
 
     private int type;
 
@@ -58,4 +58,22 @@ public enum EntryEventType {
         }
         return null;
     }
+
+    /**
+     * These constants represent type-id and bit-mask of events.
+     *
+     * @see com.hazelcast.map.impl.MapListenerFlagOperator
+     */
+    //CHECKSTYLE:OFF
+    private static class Type {
+        private static final int ADDED = 1;
+        private static final int REMOVED = 1 << 1;
+        private static final int UPDATED = 1 << 2;
+        private static final int EVICTED = 1 << 3;
+        private static final int EVICT_ALL = 1 << 4;
+        private static final int CLEAR_ALL = 1 << 5;
+        private static final int MERGED = 1 << 6;
+        private static final int EXPIRED = 1 << 7;
+    }
+    //CHECKSTYLE:ON
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/EventListenerFilter.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/EventListenerFilter.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl;
+
+import com.hazelcast.core.EntryEventType;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.DataSerializable;
+import com.hazelcast.spi.EventFilter;
+import com.hazelcast.spi.impl.eventservice.impl.TrueEventFilter;
+
+import java.io.IOException;
+
+import static com.hazelcast.map.impl.MapListenerFlagOperator.ALL_LISTENER_FLAGS;
+
+/**
+ * Prevents sending of not requested events to a {@link com.hazelcast.map.listener.MapListener MapListener}
+ * by filtering events according the implemented {@link com.hazelcast.map.listener.MapListener MapListener} sub-interfaces.
+ * <p/>
+ * Specifically, for example, if a listener is registered via an implementation like this:
+ * <p/>
+ * {@code}
+ * public class MyMapListener implements EntryAddedListener, EntryRemovedListener {
+ * ...
+ * }
+ * {@code}
+ * <p/>
+ * That listener will only be notified for {@link EntryEventType#ADDED} and {@link EntryEventType#REMOVED} events.
+ * Other events, like {@link EntryEventType#EVICTED} or {@link EntryEventType#EXPIRED}, will not be sent over wire.
+ * This may help to reduce load on eventing system and network.
+ *
+ * @see MapListenerFlagOperator#setAndGetListenerFlags(ListenerAdapter)
+ * @see com.hazelcast.map.listener.MapListener
+ * @since 3.6
+ */
+public class EventListenerFilter implements EventFilter, DataSerializable {
+
+    /**
+     * Flags of implemented listeners.
+     */
+    private int listenerFlags;
+    private EventFilter eventFilter;
+
+    public EventListenerFilter() {
+        this(ALL_LISTENER_FLAGS, TrueEventFilter.INSTANCE);
+    }
+
+    public EventListenerFilter(int listenerFlags, EventFilter eventFilter) {
+        this.listenerFlags = listenerFlags;
+        this.eventFilter = eventFilter == null ? TrueEventFilter.INSTANCE : eventFilter;
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
+        out.writeObject(eventFilter);
+        out.writeInt(listenerFlags);
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) throws IOException {
+        eventFilter = in.readObject();
+        listenerFlags = in.readInt();
+    }
+
+    @Override
+    public boolean eval(Object object) {
+        Integer eventType = (Integer) object;
+        return (listenerFlags & eventType) != 0;
+    }
+
+    public EventFilter getEventFilter() {
+        return eventFilter;
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/InternalMapListenerAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/InternalMapListenerAdapter.java
@@ -31,7 +31,7 @@ import static com.hazelcast.util.Preconditions.isNotNull;
  * And also to provide an abstraction over all {@link MapListener} sub-interfaces to make a smooth usage when passing
  * fired events to listeners e.g. only calling {@link ListenerAdapter#onEvent} is sufficient to fire any event.
  */
-class InternalMapListenerAdapter implements ListenerAdapter {
+public class InternalMapListenerAdapter implements ListenerAdapter {
 
     private final ListenerAdapter[] listenerAdapters;
 
@@ -43,12 +43,20 @@ class InternalMapListenerAdapter implements ListenerAdapter {
 
     @Override
     public void onEvent(IMapEvent event) {
-        final EntryEventType eventType = event.getEventType();
-        final ListenerAdapter listenerAdapter = listenerAdapters[eventType.ordinal()];
+        EntryEventType eventType = event.getEventType();
+        if (eventType == null) {
+            return;
+        }
+
+        ListenerAdapter listenerAdapter = listenerAdapters[eventType.ordinal()];
         if (listenerAdapter == null) {
             return;
         }
         listenerAdapter.onEvent(event);
+    }
+
+    public ListenerAdapter[] getListenerAdapters() {
+        return listenerAdapters;
     }
 }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapListenerFlagOperator.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapListenerFlagOperator.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl;
+
+import com.hazelcast.core.EntryEventType;
+
+/**
+ * Contains helper methods to set bit flags of implemented listener interfaces
+ * of a {@link com.hazelcast.map.listener.MapListener MapListener}.
+ */
+public final class MapListenerFlagOperator {
+
+    /**
+     * Sets all listener flags. Used to be notified for all events. No filtering.
+     */
+    public static final int ALL_LISTENER_FLAGS = setAndGetAllListenerFlags();
+
+    private MapListenerFlagOperator() {
+    }
+
+    /**
+     * Sets and gets flags of implemented listener interfaces of a {@link com.hazelcast.map.listener.MapListener MapListener}.
+     */
+    public static int setAndGetListenerFlags(ListenerAdapter listenerAdapter) {
+        InternalMapListenerAdapter internalMapListenerAdapter = (InternalMapListenerAdapter) listenerAdapter;
+        ListenerAdapter[] listenerAdapters = internalMapListenerAdapter.getListenerAdapters();
+        EntryEventType[] values = EntryEventType.values();
+
+        int listenerFlags = 0;
+
+        for (EntryEventType eventType : values) {
+            ListenerAdapter definedAdapter = listenerAdapters[eventType.ordinal()];
+            if (definedAdapter != null) {
+                listenerFlags = listenerFlags | eventType.getType();
+            }
+        }
+        return listenerFlags;
+    }
+
+    /**
+     * Sets and gets all listener flags.
+     */
+    private static int setAndGetAllListenerFlags() {
+        int listenerFlags = 0;
+        EntryEventType[] values = EntryEventType.values();
+        for (EntryEventType eventType : values) {
+            listenerFlags = listenerFlags | eventType.getType();
+        }
+        return listenerFlags;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/client/MapAddEntryListenerRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/client/MapAddEntryListenerRequest.java
@@ -23,6 +23,7 @@ import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.PortableReader;
 import com.hazelcast.nio.serialization.PortableWriter;
 import com.hazelcast.query.Predicate;
+
 import java.io.IOException;
 
 public class MapAddEntryListenerRequest extends AbstractMapAddEntryListenerRequest {
@@ -32,16 +33,12 @@ public class MapAddEntryListenerRequest extends AbstractMapAddEntryListenerReque
     public MapAddEntryListenerRequest() {
     }
 
-    public MapAddEntryListenerRequest(String name, boolean includeValue) {
-        super(name, includeValue);
+    public MapAddEntryListenerRequest(String name, boolean includeValue, int listenerFlags) {
+        super(name, includeValue, listenerFlags);
     }
 
-    public MapAddEntryListenerRequest(String name, Data key, boolean includeValue) {
-        super(name, key, includeValue);
-    }
-
-    public MapAddEntryListenerRequest(String name, Data key, boolean includeValue, Predicate predicate) {
-        super(name, key, includeValue);
+    public MapAddEntryListenerRequest(String name, Data key, boolean includeValue, Predicate predicate, int listenerFlags) {
+        super(name, key, includeValue, listenerFlags);
         this.predicate = predicate;
     }
 
@@ -59,6 +56,7 @@ public class MapAddEntryListenerRequest extends AbstractMapAddEntryListenerReque
     public void write(PortableWriter writer) throws IOException {
         writer.writeUTF("name", name);
         writer.writeBoolean("i", includeValue);
+        writer.writeInt("lf", listenerFlags);
 
         final boolean hasKey = key != null;
         writer.writeBoolean("key", hasKey);
@@ -83,6 +81,7 @@ public class MapAddEntryListenerRequest extends AbstractMapAddEntryListenerReque
     public void read(PortableReader reader) throws IOException {
         name = reader.readUTF("name");
         includeValue = reader.readBoolean("i");
+        listenerFlags = reader.readInt("lf");
 
         boolean hasKey = reader.readBoolean("key");
         if (reader.readBoolean("pre")) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/client/MapAddEntryListenerSqlRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/client/MapAddEntryListenerSqlRequest.java
@@ -24,6 +24,7 @@ import com.hazelcast.nio.serialization.PortableReader;
 import com.hazelcast.nio.serialization.PortableWriter;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.SqlPredicate;
+
 import java.io.IOException;
 
 public class MapAddEntryListenerSqlRequest extends AbstractMapAddEntryListenerRequest {
@@ -34,16 +35,16 @@ public class MapAddEntryListenerSqlRequest extends AbstractMapAddEntryListenerRe
     public MapAddEntryListenerSqlRequest() {
     }
 
-    public MapAddEntryListenerSqlRequest(String name, boolean includeValue) {
-        super(name, includeValue);
+    public MapAddEntryListenerSqlRequest(String name, boolean includeValue, int listenerFlags) {
+        super(name, includeValue, listenerFlags);
     }
 
-    public MapAddEntryListenerSqlRequest(String name, Data key, boolean includeValue) {
-        super(name, key, includeValue);
+    public MapAddEntryListenerSqlRequest(String name, Data key, boolean includeValue, int listenerFlags) {
+        super(name, key, includeValue, listenerFlags);
     }
 
-    public MapAddEntryListenerSqlRequest(String name, Data key, boolean includeValue, String predicate) {
-        super(name, key, includeValue);
+    public MapAddEntryListenerSqlRequest(String name, Data key, boolean includeValue, String predicate, int listenerFlags) {
+        super(name, key, includeValue, listenerFlags);
         this.predicate = predicate;
     }
 
@@ -63,7 +64,11 @@ public class MapAddEntryListenerSqlRequest extends AbstractMapAddEntryListenerRe
     @Override
     public void write(PortableWriter writer) throws IOException {
         final boolean hasKey = key != null;
+        writer.writeUTF("name", name);
+        writer.writeBoolean("i", includeValue);
         writer.writeBoolean("key", hasKey);
+        writer.writeInt("lf", listenerFlags);
+
         if (predicate == null) {
             writer.writeBoolean("pre", false);
             if (hasKey) {
@@ -79,6 +84,7 @@ public class MapAddEntryListenerSqlRequest extends AbstractMapAddEntryListenerRe
             }
         }
 
+
     }
 
     @Override
@@ -86,6 +92,8 @@ public class MapAddEntryListenerSqlRequest extends AbstractMapAddEntryListenerRe
         name = reader.readUTF("name");
         includeValue = reader.readBoolean("i");
         boolean hasKey = reader.readBoolean("key");
+        listenerFlags = reader.readInt("lf");
+
         if (reader.readBoolean("pre")) {
             predicate = reader.readUTF("p");
             final ObjectDataInput in = reader.getRawDataInput();
@@ -96,6 +104,7 @@ public class MapAddEntryListenerSqlRequest extends AbstractMapAddEntryListenerRe
             final ObjectDataInput in = reader.getRawDataInput();
             key = in.readData();
         }
+
     }
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/client/MapAddNearCacheEntryListenerRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/client/MapAddNearCacheEntryListenerRequest.java
@@ -20,6 +20,9 @@ import com.hazelcast.map.impl.MapPortableHook;
 import com.hazelcast.map.impl.SyntheticEventFilter;
 import com.hazelcast.spi.EventFilter;
 
+import static com.hazelcast.map.impl.MapListenerFlagOperator.ALL_LISTENER_FLAGS;
+
+
 /**
  * Request for adding {@link com.hazelcast.core.EntryListener} for near cache operations.
  */
@@ -29,7 +32,7 @@ public class MapAddNearCacheEntryListenerRequest extends MapAddEntryListenerRequ
     }
 
     public MapAddNearCacheEntryListenerRequest(String name, boolean includeValue) {
-        super(name, includeValue);
+        super(name, includeValue, ALL_LISTENER_FLAGS);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/event/EntryEventData.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/event/EntryEventData.java
@@ -86,10 +86,6 @@ public class EntryEventData extends AbstractEventData {
         dataMergingValue = in.readData();
     }
 
-    public Object cloneWithoutValues() {
-        return new EntryEventData(getSource(), getMapName(), getCaller(), dataKey, null, null, null, getEventType());
-    }
-
     @Override
     public String toString() {
         return "EntryEventData{"

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/event/MapEventPublisherImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/event/MapEventPublisherImpl.java
@@ -20,6 +20,7 @@ import com.hazelcast.core.EntryEventType;
 import com.hazelcast.core.EntryView;
 import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.map.impl.EntryEventFilter;
+import com.hazelcast.map.impl.EventListenerFilter;
 import com.hazelcast.map.impl.MapContainer;
 import com.hazelcast.map.impl.MapPartitionLostEventFilter;
 import com.hazelcast.map.impl.MapServiceContext;
@@ -34,7 +35,7 @@ import com.hazelcast.spi.EventFilter;
 import com.hazelcast.spi.EventRegistration;
 import com.hazelcast.spi.EventService;
 import com.hazelcast.spi.NodeEngine;
-import com.hazelcast.spi.impl.eventservice.impl.EmptyFilter;
+import com.hazelcast.spi.impl.eventservice.impl.TrueEventFilter;
 import com.hazelcast.wan.ReplicationEventObject;
 import com.hazelcast.wan.WanReplicationPublisher;
 
@@ -43,49 +44,72 @@ import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
 
+import static com.hazelcast.core.EntryEventType.EVICTED;
+import static com.hazelcast.core.EntryEventType.EXPIRED;
+import static com.hazelcast.core.EntryEventType.REMOVED;
 import static com.hazelcast.map.impl.MapService.SERVICE_NAME;
+import static com.hazelcast.util.CollectionUtil.isEmpty;
 
 public class MapEventPublisherImpl implements MapEventPublisher {
 
     protected final MapServiceContext mapServiceContext;
+    protected final NodeEngine nodeEngine;
+    protected final SerializationService serializationService;
+    protected final EventService eventService;
 
     public MapEventPublisherImpl(MapServiceContext mapServiceContext) {
         this.mapServiceContext = mapServiceContext;
+        this.nodeEngine = mapServiceContext.getNodeEngine();
+        this.serializationService = nodeEngine.getSerializationService();
+        this.eventService = nodeEngine.getEventService();
     }
 
     @Override
     public void publishWanReplicationUpdate(String mapName, EntryView entryView) {
         MapContainer mapContainer = mapServiceContext.getMapContainer(mapName);
-        MapReplicationUpdate replicationEvent = new MapReplicationUpdate(mapName, mapContainer.getWanMergePolicy(),
-                entryView);
+        MapReplicationUpdate replicationEvent
+                = new MapReplicationUpdate(mapName, mapContainer.getWanMergePolicy(), entryView);
         mapContainer.getWanReplicationPublisher().publishReplicationEvent(SERVICE_NAME, replicationEvent);
     }
 
     @Override
     public void publishWanReplicationRemove(String mapName, Data key, long removeTime) {
-        final MapReplicationRemove event = new MapReplicationRemove(mapName, key, removeTime);
-
+        MapReplicationRemove event = new MapReplicationRemove(mapName, key, removeTime);
         publishWanReplicationEventInternal(mapName, event);
     }
 
     @Override
     public void publishMapEvent(Address caller, String mapName, EntryEventType eventType,
                                 int numberOfEntriesAffected) {
-        final Collection<EventRegistration> registrations = new LinkedList<EventRegistration>();
-        for (EventRegistration registration : getRegistrations(mapName)) {
-            if (!(registration.getFilter() instanceof MapPartitionLostEventFilter)) {
+        Collection<EventRegistration> mapsListenerRegistrations = getRegistrations(mapName);
+        if (isEmpty(mapsListenerRegistrations)) {
+            return;
+        }
+
+        Collection<EventRegistration> registrations = null;
+        for (EventRegistration registration : mapsListenerRegistrations) {
+            EventFilter filter = registration.getFilter();
+
+            if (filter instanceof EventListenerFilter) {
+                if (!filter.eval(eventType.getType())) {
+                    continue;
+                }
+            }
+
+            if (!(filter instanceof MapPartitionLostEventFilter)) {
+                if (registrations == null) {
+                    registrations = new ArrayList<EventRegistration>();
+                }
                 registrations.add(registration);
             }
         }
 
-        if (registrations.isEmpty()) {
+        if (isEmpty(registrations)) {
             return;
         }
 
-        final String source = getThisNodesAddress();
-        final MapEventData mapEventData = new MapEventData(source, mapName, caller,
-                eventType.getType(), numberOfEntriesAffected);
-
+        String source = getThisNodesAddress();
+        MapEventData mapEventData = new MapEventData(source, mapName, caller, eventType.getType(), numberOfEntriesAffected);
         publishEventInternal(registrations, mapEventData, mapName.hashCode());
     }
 
@@ -97,53 +121,132 @@ public class MapEventPublisherImpl implements MapEventPublisher {
 
     @Override
     public void publishEvent(Address caller, String mapName, EntryEventType eventType, boolean syntheticEvent,
-                             final Data dataKey, Data dataOldValue, Data dataValue) {
+                             Data dataKey, Data dataOldValue, Data dataValue) {
         publishEvent(caller, mapName, eventType, syntheticEvent, dataKey, dataOldValue, dataValue, null);
     }
 
     @Override
     public void publishEvent(Address caller, String mapName, EntryEventType eventType, boolean syntheticEvent,
-                             final Data dataKey, Data dataOldValue, Data dataValue, Data dataMergingValue) {
-        final Collection<EventRegistration> registrations = getRegistrations(mapName);
-        if (registrations.isEmpty()) {
+                             Data dataKey, Data dataOldValue, Data dataValue, Data dataMergingValue) {
+        Collection<EventRegistration> registrations = getRegistrations(mapName);
+        if (isEmpty(registrations)) {
             return;
         }
 
-        List<EventRegistration> registrationsWithValue = null;
-        List<EventRegistration> registrationsWithoutValue = null;
+        List<EventRegistration> includeValueRegistrations = null;
+        List<EventRegistration> nullValueRegistrations = null;
 
-        for (final EventRegistration candidate : registrations) {
-            final EventFilter filter = candidate.getFilter();
-            final Result result = applyEventFilter(filter, syntheticEvent, dataKey, dataOldValue, dataValue, eventType);
+        for (EventRegistration registration : registrations) {
+            EventFilter filter = registration.getFilter();
 
-            registrationsWithValue = initRegistrationsWithValue(registrationsWithValue, result);
-            registrationsWithoutValue = initRegistrationsWithoutValue(registrationsWithoutValue, result);
+            if (!doFilter(filter, syntheticEvent, dataKey, dataOldValue, dataValue, eventType)) {
+                continue;
+            }
 
-            registerCandidate(result, candidate, registrationsWithValue, registrationsWithoutValue);
+            if (isIncludeValue(filter)) {
+                includeValueRegistrations = getOrCreateList(includeValueRegistrations);
+                includeValueRegistrations.add(registration);
+            } else {
+                nullValueRegistrations = getOrCreateList(nullValueRegistrations);
+                nullValueRegistrations.add(registration);
+            }
         }
 
-        final boolean withValueRegistrationExists = isNotEmpty(registrationsWithValue);
-        final boolean withoutValueRegistrationExists = isNotEmpty(registrationsWithoutValue);
-
-        if (!withValueRegistrationExists && !withoutValueRegistrationExists) {
-            return;
+        if (!isEmpty(includeValueRegistrations)) {
+            EntryEventData eventData = createEntryEventData(mapName, caller, dataKey,
+                    dataValue, dataOldValue, dataMergingValue, eventType.getType());
+            int orderKey = pickOrderKey(dataKey);
+            publishEventInternal(includeValueRegistrations, eventData, orderKey);
         }
 
-        final EntryEventData eventData = createEntryEventData(mapName, caller,
-                dataKey, dataValue, dataOldValue, dataMergingValue, eventType.getType());
-        final int orderKey = pickOrderKey(dataKey);
+        if (!isEmpty(nullValueRegistrations)) {
+            EntryEventData eventData = createEntryEventData(mapName, caller, dataKey,
+                    null, null, null, eventType.getType());
+            int orderKey = pickOrderKey(dataKey);
+            publishEventInternal(nullValueRegistrations, eventData, orderKey);
+        }
+    }
 
-        if (withValueRegistrationExists) {
-            publishEventInternal(registrationsWithValue, eventData, orderKey);
+    protected List<EventRegistration> getOrCreateList(List<EventRegistration> registrations) {
+        if (registrations == null) {
+            registrations = new ArrayList<EventRegistration>();
         }
-        if (withoutValueRegistrationExists) {
-            publishEventInternal(registrationsWithoutValue, eventData.cloneWithoutValues(), orderKey);
+        return registrations;
+    }
+
+    //CHECKSTYLE:OFF
+    protected boolean doFilter(EventFilter filter, boolean syntheticEvent, Data dataKey,
+                               Data dataOldValue, Data dataValue, EntryEventType eventType) {
+
+        if (filter instanceof MapPartitionLostEventFilter) {
+            return false;
         }
+
+        // below, order of ifs are important.
+        // QueryEventFilter is instance of EntryEventFilter.
+        // SyntheticEventFilter wraps an event filter.
+        if (filter instanceof EventListenerFilter) {
+            if (!filter.eval(eventType.getType())) {
+                return false;
+            } else {
+                filter = ((EventListenerFilter) filter).getEventFilter();
+            }
+        }
+
+        if (filter instanceof SyntheticEventFilter) {
+            if (syntheticEvent) {
+                return false;
+            } else {
+                filter = ((SyntheticEventFilter) filter).getFilter();
+            }
+        }
+
+        if (filter instanceof TrueEventFilter) {
+            return true;
+        }
+
+        if (filter instanceof QueryEventFilter) {
+            return processQueryEventFilter(filter, eventType, dataKey, dataOldValue, dataValue);
+        }
+
+        if (filter instanceof EntryEventFilter) {
+            return processEntryEventFilter(filter, dataKey);
+        }
+
+        throw new IllegalArgumentException("Unknown EventFilter type = [" + filter.getClass().getCanonicalName() + "]");
+    }
+    //CHECKSTYLE:ON
+
+    protected boolean isIncludeValue(EventFilter filter) {
+        // below, order of ifs are important.
+        // QueryEventFilter is instance of EntryEventFilter.
+        // SyntheticEventFilter wraps an event filter.
+        if (filter instanceof EventListenerFilter) {
+            filter = ((EventListenerFilter) filter).getEventFilter();
+        }
+
+        if (filter instanceof SyntheticEventFilter) {
+            filter = ((SyntheticEventFilter) filter).getFilter();
+        }
+
+        if (filter instanceof TrueEventFilter) {
+            return true;
+        }
+
+        if (filter instanceof QueryEventFilter) {
+            return ((QueryEventFilter) filter).isIncludeValue();
+        }
+
+        if (filter instanceof EntryEventFilter) {
+            return ((EntryEventFilter) filter).isIncludeValue();
+        }
+
+        throw new IllegalArgumentException("Unknown EventFilter type = [" + filter.getClass().getCanonicalName() + "]");
     }
 
     @Override
     public void publishMapPartitionLostEvent(Address caller, String mapName, int partitionId) {
-        final Collection<EventRegistration> registrations = new LinkedList<EventRegistration>();
+        Collection<EventRegistration> registrations = new LinkedList<EventRegistration>();
         for (EventRegistration registration : getRegistrations(mapName)) {
             if (registration.getFilter() instanceof MapPartitionLostEventFilter) {
                 registrations.add(registration);
@@ -154,8 +257,8 @@ public class MapEventPublisherImpl implements MapEventPublisher {
             return;
         }
 
-        final String thisNodesAddress = getThisNodesAddress();
-        final MapPartitionEventData eventData = new MapPartitionEventData(thisNodesAddress, mapName, caller, partitionId);
+        String thisNodesAddress = getThisNodesAddress();
+        MapPartitionEventData eventData = new MapPartitionEventData(thisNodesAddress, mapName, caller, partitionId);
         publishEventInternal(registrations, eventData, partitionId);
     }
 
@@ -165,75 +268,7 @@ public class MapEventPublisherImpl implements MapEventPublisher {
         // NOP
     }
 
-    private List<EventRegistration> initRegistrationsWithoutValue(List<EventRegistration> registrationsWithoutValue,
-                                                                  Result result) {
-        if (registrationsWithoutValue != null) {
-            return registrationsWithoutValue;
-        }
-
-        if (Result.NO_VALUE_INCLUDED.equals(result)) {
-            registrationsWithoutValue = new ArrayList<EventRegistration>();
-        }
-        return registrationsWithoutValue;
-    }
-
-    private List<EventRegistration> initRegistrationsWithValue(List<EventRegistration> registrationsWithValue,
-                                                               Result result) {
-        if (registrationsWithValue != null) {
-            return registrationsWithValue;
-        }
-
-        if (Result.VALUE_INCLUDED.equals(result)) {
-            registrationsWithValue = new ArrayList<EventRegistration>();
-        }
-
-        return registrationsWithValue;
-    }
-
-    private static <T> boolean isNotEmpty(Collection<T> collection) {
-        return !(collection == null || collection.isEmpty());
-    }
-
-    protected Result applyEventFilter(EventFilter filter, boolean syntheticEvent, Data dataKey,
-                                      Data dataOldValue, Data dataValue, EntryEventType eventType) {
-
-        if (filter instanceof MapPartitionLostEventFilter) {
-            return Result.NONE;
-        }
-
-        // below, order of ifs are important.
-        // QueryEventFilter is instance of EntryEventFilter.
-        // SyntheticEventFilter wraps an event filter.
-        if (filter instanceof SyntheticEventFilter) {
-            if (syntheticEvent) {
-                return Result.NONE;
-            }
-            final SyntheticEventFilter syntheticEventFilter = (SyntheticEventFilter) filter;
-            filter = syntheticEventFilter.getFilter();
-        }
-
-        if (filter instanceof EmptyFilter) {
-            return Result.VALUE_INCLUDED;
-        }
-
-
-        if (filter instanceof QueryEventFilter) {
-            return processQueryEventFilter(filter, eventType, dataKey, dataOldValue, dataValue);
-        }
-
-        if (filter instanceof EntryEventFilter) {
-            return processEntryEventFilter(filter, dataKey);
-        }
-
-
-        throw new IllegalArgumentException("Unknown EventFilter type = [" + filter.getClass().getCanonicalName() + "]");
-    }
-
-    Collection<EventRegistration> getRegistrations(String mapName) {
-        final MapServiceContext mapServiceContext = this.mapServiceContext;
-        final NodeEngine nodeEngine = mapServiceContext.getNodeEngine();
-        final EventService eventService = nodeEngine.getEventService();
-
+    protected Collection<EventRegistration> getRegistrations(String mapName) {
         return eventService.getRegistrations(SERVICE_NAME, mapName);
     }
 
@@ -241,87 +276,46 @@ public class MapEventPublisherImpl implements MapEventPublisher {
         return key == null ? -1 : key.hashCode();
     }
 
-    private void registerCandidate(Result result, EventRegistration candidate,
-                                   Collection<EventRegistration> registrationsWithValue,
-                                   Collection<EventRegistration> registrationsWithoutValue) {
-        switch (result) {
-            case VALUE_INCLUDED:
-                registrationsWithValue.add(candidate);
-                break;
-            case NO_VALUE_INCLUDED:
-                registrationsWithoutValue.add(candidate);
-                break;
-            case NONE:
-                break;
-            default:
-                throw new IllegalArgumentException("Not a known result type [" + result + "]");
-        }
-    }
-
-    void publishEventInternal(Collection<EventRegistration> registrations, Object eventData, int orderKey) {
-        final MapServiceContext mapServiceContext = this.mapServiceContext;
-        final NodeEngine nodeEngine = mapServiceContext.getNodeEngine();
-        final EventService eventService = nodeEngine.getEventService();
-
+    protected void publishEventInternal(Collection<EventRegistration> registrations, Object eventData, int orderKey) {
         eventService.publishEvent(SERVICE_NAME, registrations, eventData, orderKey);
     }
 
     private String getThisNodesAddress() {
-        final NodeEngine nodeEngine = mapServiceContext.getNodeEngine();
-        final Address thisAddress = nodeEngine.getThisAddress();
+        Address thisAddress = nodeEngine.getThisAddress();
         return thisAddress.toString();
     }
 
-    private Result processEntryEventFilter(EventFilter filter, Data dataKey) {
-        final EntryEventFilter eventFilter = (EntryEventFilter) filter;
-
-        if (!eventFilter.eval(dataKey)) {
-            return Result.NONE;
-        }
-
-        if (eventFilter.isIncludeValue()) {
-            return Result.VALUE_INCLUDED;
-        }
-
-        return Result.NO_VALUE_INCLUDED;
+    private boolean processEntryEventFilter(EventFilter filter, Data dataKey) {
+        EntryEventFilter eventFilter = (EntryEventFilter) filter;
+        return eventFilter.eval(dataKey);
     }
 
-    private Result processQueryEventFilter(EventFilter filter, EntryEventType eventType,
-                                           final Data dataKey, Data dataOldValue, Data dataValue) {
-        final NodeEngine nodeEngine = mapServiceContext.getNodeEngine();
-        final SerializationService serializationService = nodeEngine.getSerializationService();
+    private boolean processQueryEventFilter(EventFilter filter, EntryEventType eventType,
+                                            Data dataKey, Data dataOldValue, Data dataValue) {
         Data testValue;
-        if (eventType == EntryEventType.REMOVED || eventType == EntryEventType.EVICTED || eventType == EntryEventType.EXPIRED) {
+        if (eventType == REMOVED || eventType == EVICTED || eventType == EXPIRED) {
             testValue = dataOldValue;
         } else {
             testValue = dataValue;
         }
-        final QueryEventFilter queryEventFilter = (QueryEventFilter) filter;
-        final QueryEntry entry = new QueryEntry(serializationService, dataKey, dataKey, testValue);
-        if (queryEventFilter.eval(entry)) {
-            return queryEventFilter.isIncludeValue() ? Result.VALUE_INCLUDED : Result.NO_VALUE_INCLUDED;
-        }
-        return Result.NONE;
+
+        QueryEventFilter queryEventFilter = (QueryEventFilter) filter;
+        QueryEntry entry = new QueryEntry(serializationService, dataKey, dataKey, testValue);
+        return queryEventFilter.eval(entry);
     }
 
-    void publishWanReplicationEventInternal(String mapName, ReplicationEventObject event) {
-        final MapServiceContext mapServiceContext = this.mapServiceContext;
-        final MapContainer mapContainer = mapServiceContext.getMapContainer(mapName);
-        final WanReplicationPublisher wanReplicationPublisher = mapContainer.getWanReplicationPublisher();
+    protected void publishWanReplicationEventInternal(String mapName, ReplicationEventObject event) {
+        MapContainer mapContainer = mapServiceContext.getMapContainer(mapName);
+        WanReplicationPublisher wanReplicationPublisher = mapContainer.getWanReplicationPublisher();
         wanReplicationPublisher.publishReplicationEvent(SERVICE_NAME, event);
     }
 
     private EntryEventData createEntryEventData(String mapName, Address caller,
                                                 Data dataKey, Data dataNewValue, Data dataOldValue,
                                                 Data dataMergingValue, int eventType) {
-        final String thisNodesAddress = getThisNodesAddress();
+        String thisNodesAddress = getThisNodesAddress();
         return new EntryEventData(thisNodesAddress, mapName, caller,
                 dataKey, dataNewValue, dataOldValue, dataMergingValue, eventType);
     }
 
-    protected enum Result {
-        VALUE_INCLUDED,
-        NO_VALUE_INCLUDED,
-        NONE
-    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/EventServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/EventServiceImpl.java
@@ -151,7 +151,7 @@ public class EventServiceImpl implements InternalEventService {
 
     @Override
     public EventRegistration registerLocalListener(String serviceName, String topic, Object listener) {
-        return registerListenerInternal(serviceName, topic, new EmptyFilter(), listener, true);
+        return registerListenerInternal(serviceName, topic, TrueEventFilter.INSTANCE, listener, true);
     }
 
     @Override
@@ -161,7 +161,7 @@ public class EventServiceImpl implements InternalEventService {
 
     @Override
     public EventRegistration registerListener(String serviceName, String topic, Object listener) {
-        return registerListenerInternal(serviceName, topic, new EmptyFilter(), listener, false);
+        return registerListenerInternal(serviceName, topic, TrueEventFilter.INSTANCE, listener, false);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/TrueEventFilter.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/TrueEventFilter.java
@@ -23,7 +23,12 @@ import com.hazelcast.spi.EventFilter;
 
 import java.io.IOException;
 
-public final class EmptyFilter implements EventFilter, DataSerializable {
+/**
+ * An event filter which does not filter any event and always evaluates {@code true} results.
+ */
+public final class TrueEventFilter implements EventFilter, DataSerializable {
+
+    public static final TrueEventFilter INSTANCE = new TrueEventFilter();
 
     @Override
     public boolean eval(Object arg) {
@@ -40,7 +45,7 @@ public final class EmptyFilter implements EventFilter, DataSerializable {
 
     @Override
     public boolean equals(Object obj) {
-        return obj instanceof EmptyFilter;
+        return obj instanceof TrueEventFilter;
     }
 
     @Override


### PR DESCRIPTION
Filters events according the implemented MapListener sub-interfaces.

Specifically, for example, if a listener is registered via an implementation like this :

```
 public class MyMapListener implements EntryAddedListener, EntryRemovedListener {
  ...
  }
``` 
That listener will only be notified for `EntryEventType#ADDED` and `EntryEventType#REMOVED` events.
  Other events, like `EntryEventType#EVICTED` or `EntryEventType#EXPIRED`, will not be sent over wire.
 This may help to reduce load on eventing system and network.