### PR TITLE
Fixed wrong method tested in ClientMapBasicTest

### DIFF
--- a/hazelcast-client-new/src/test/java/com/hazelcast/client/map/ClientMapBasicTest.java
+++ b/hazelcast-client-new/src/test/java/com/hazelcast/client/map/ClientMapBasicTest.java
@@ -1030,11 +1030,12 @@ public class ClientMapBasicTest {
             Object value = key+"value";
             map.put(key, value);
         }
-        expected.add(4);
+        expected.add("4value");
 
-        final Set keySet = map.keySet(new SqlPredicate("this == 4value"));
+        final Collection collection = map.values(new SqlPredicate("this == 4value"));
+        final Set resultSet = new TreeSet(collection);
 
-        assertEquals(expected, keySet);
+        assertEquals(expected, resultSet);
     }
 
     @Test

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapBasicTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapBasicTest.java
@@ -1030,11 +1030,12 @@ public class ClientMapBasicTest {
             Object value = key+"value";
             map.put(key, value);
         }
-        expected.add(4);
+        expected.add("4value");
 
-        final Set keySet = map.keySet(new SqlPredicate("this == 4value"));
+        final Collection collection = map.values(new SqlPredicate("this == 4value"));
+        final Set resultSet = new TreeSet(collection);
 
-        assertEquals(expected, keySet);
+        assertEquals(expected, resultSet);
     }
 
     @Test


### PR DESCRIPTION
Fixed copy&paste error in `ClientMapBasicTest.testValues_withPredicate()` (`keySet()` was used instead of `values()` in values test).