### PR TITLE
Treat <> as an alias for !=

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/query/Parser.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/Parser.java
@@ -57,6 +57,7 @@ class Parser {
         PRECEDENCE.put("<=", LESS_EQUAL_PRECEDENCE);
         PRECEDENCE.put("==", ASSIGN_PRECEDENCE);
         PRECEDENCE.put("!=", NOT_EQUAL_PRECEDENCE);
+        PRECEDENCE.put("<>", NOT_EQUAL_PRECEDENCE);
         PRECEDENCE.put("between", BETWEEN_PRECEDENCE);
         PRECEDENCE.put("in", IN_PRECEDENCE);
         PRECEDENCE.put("like", LIKE_PRECEDENCE);

--- a/hazelcast/src/main/java/com/hazelcast/query/SqlPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/SqlPredicate.java
@@ -161,7 +161,7 @@ public class SqlPredicate extends AbstractPredicate implements IndexAwarePredica
                         Object first = toValue(tokens.remove(position), mapPhrases);
                         Object second = toValue(tokens.remove(position), mapPhrases);
                         setOrAdd(tokens, position, equal((String) first, (Comparable) second));
-                    } else if ("!=".equals(token)) {
+                    } else if ("!=".equals(token) || "<>".equals(token)) {
                         int position = (i - 2);
                         validateOperandPosition(position);
                         Object first = toValue(tokens.remove(position), mapPhrases);

--- a/hazelcast/src/test/java/com/hazelcast/query/SqlPredicateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/SqlPredicateTest.java
@@ -158,6 +158,7 @@ public class SqlPredicateTest {
         assertSqlTrue("attribute = 123", value);
         assertSqlTrue("attribute = '123'", value);
         assertSqlTrue("attribute != 124", value);
+        assertSqlTrue("attribute <> 124", value);
         assertSqlFalse("attribute = 124", value);
         assertSqlTrue("attribute between 122 and 124", value);
         assertSqlTrue("attribute in (122, 123, 124)", value);
@@ -172,7 +173,9 @@ public class SqlPredicateTest {
         assertSqlTrue("name = null", nullNameValue);
         assertSqlTrue("name = NULL", nullNameValue);
         assertSqlTrue("name != null", value);
+        assertSqlTrue("name <> null", value);
         assertSqlTrue("name != NULL", value);
+        assertSqlTrue("name <> NULL", value);
         assertSqlTrue(" (name LIKE 'abc-%') AND (age <= " + 40 + ")", value);
         assertSqlTrue(" (name REGEX 'abc-.*') AND (age <= " + 40 + ")", value);
 


### PR DESCRIPTION
ANSI SQL defines <> only
Fixes #6195