### PR TITLE
Cleanup of ClientProperties

### DIFF
--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/config/ClientProperties.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/config/ClientProperties.java
@@ -16,175 +16,117 @@
 
 package com.hazelcast.client.config;
 
+import com.hazelcast.config.Config;
+import com.hazelcast.instance.HazelcastProperties;
+
+import static com.hazelcast.client.config.ClientProperty.EVENT_QUEUE_CAPACITY;
+import static com.hazelcast.client.config.ClientProperty.EVENT_THREAD_COUNT;
+import static com.hazelcast.client.config.ClientProperty.HEARTBEAT_INTERVAL;
+import static com.hazelcast.client.config.ClientProperty.HEARTBEAT_TIMEOUT;
+import static com.hazelcast.client.config.ClientProperty.INVOCATION_TIMEOUT_SECONDS;
+import static com.hazelcast.client.config.ClientProperty.SHUFFLE_MEMBER_LIST;
+
 /**
- * Client Properties
+ * Container for configured Hazelcast Client properties ({@see ClientProperty}).
+ * <p/>
+ * A {@link ClientProperty} can be set as:
+ * <p><ul>
+ * <li>an environmental variable using {@link System#setProperty(String, String)}</li>
+ * <li>the programmatic configuration using {@link Config#setProperty(String, String)}</li>
+ * <li>the XML configuration
+ * {@see http://docs.hazelcast.org/docs/latest-dev/manual/html-single/hazelcast-documentation.html#system-properties}</li>
+ * </ul></p>
+ * The old property definitions are deprecated since Hazelcast 3.6. Please use the new {@link ClientProperty} definitions instead.
  */
-public class ClientProperties {
+@SuppressWarnings("unused")
+public class ClientProperties extends HazelcastProperties {
 
     /**
-     * Client shuffles the given member list to prevent all clients to connect to the same node when
-     * this property is set to false. When it is set to true, the client tries to connect to the nodes
-     * in the given order.
+     * Deprecated since Hazelcast 3.6. Please use the new {@link ClientProperty#SHUFFLE_MEMBER_LIST} instead.
      */
-    public static final String PROP_SHUFFLE_MEMBER_LIST = "hazelcast.client.shuffle.member.list";
-    /**
-     * Default value of the shuffle member list is true unless the user specifies it explicitly.
-     */
-    public static final String PROP_SHUFFLE_INITIAL_MEMBER_LIST_DEFAULT = "true";
+    @Deprecated
+    public static final String PROP_SHUFFLE_MEMBER_LIST = SHUFFLE_MEMBER_LIST.getName();
 
     /**
-     * Client sends heartbeat messages to the members and this is the timeout for this sending operations. If there
-     * is not any message passing between the client and member within the given time via this property
-     * in milliseconds, the connection will be closed.
+     * Deprecated since Hazelcast 3.6. Please use the new {@link ClientProperty#SHUFFLE_MEMBER_LIST} instead.
      */
-    public static final String PROP_HEARTBEAT_TIMEOUT = "hazelcast.client.heartbeat.timeout";
-    /**
-     * Default value of the heartbeat timeout unless the user specifies it explicitly.
-     */
-    public static final String PROP_HEARTBEAT_TIMEOUT_DEFAULT = "60000";
+    @Deprecated
+    public static final String PROP_SHUFFLE_INITIAL_MEMBER_LIST_DEFAULT = SHUFFLE_MEMBER_LIST.getDefaultValue();
 
     /**
-     * Time interval between the heartbeats sent by the client to the nodes.
+     * Deprecated since Hazelcast 3.6. Please use the new {@link ClientProperty#HEARTBEAT_TIMEOUT} instead.
      */
-    public static final String PROP_HEARTBEAT_INTERVAL = "hazelcast.client.heartbeat.interval";
-    /**
-     * Default value of heartbeat interval unless the user specifies it explicitly.
-     */
-    public static final String PROP_HEARTBEAT_INTERVAL_DEFAULT = "5000";
+    @Deprecated
+    public static final String PROP_HEARTBEAT_TIMEOUT = HEARTBEAT_TIMEOUT.getName();
 
     /**
-     * Number of the threads to handle the incoming event packets.
+     * Deprecated since Hazelcast 3.6. Please use the new {@link ClientProperty#HEARTBEAT_TIMEOUT} instead.
      */
-    public static final String PROP_EVENT_THREAD_COUNT = "hazelcast.client.event.thread.count";
+    @Deprecated
+    public static final String PROP_HEARTBEAT_TIMEOUT_DEFAULT = HEARTBEAT_TIMEOUT.getDefaultValue();
 
     /**
-     * Default value of the number of threads to handle the incoming event packets.
+     * Deprecated since Hazelcast 3.6. Please use the new {@link ClientProperty#HEARTBEAT_INTERVAL} instead.
      */
-    public static final String PROP_EVENT_THREAD_COUNT_DEFAULT = "5";
+    @Deprecated
+    public static final String PROP_HEARTBEAT_INTERVAL = HEARTBEAT_INTERVAL.getName();
 
     /**
-     * Capacity of the executor that handles the incoming event packets.
+     * Deprecated since Hazelcast 3.6. Please use the new {@link ClientProperty#HEARTBEAT_INTERVAL} instead.
      */
-    public static final String PROP_EVENT_QUEUE_CAPACITY = "hazelcast.client.event.queue.capacity";
+    @Deprecated
+    public static final String PROP_HEARTBEAT_INTERVAL_DEFAULT = HEARTBEAT_INTERVAL.getDefaultValue();
 
     /**
-     * Default value of the capacity of the executor that handles the incoming event packets.
+     * Deprecated since Hazelcast 3.6. Please use the new {@link ClientProperty#EVENT_THREAD_COUNT} instead.
      */
-    public static final String PROP_EVENT_QUEUE_CAPACITY_DEFAULT = "1000000";
+    @Deprecated
+    public static final String PROP_EVENT_THREAD_COUNT = EVENT_THREAD_COUNT.getName();
 
     /**
-     * Time to give up on invocation when a member in the member list is not reachable.
+     * Deprecated since Hazelcast 3.6. Please use the new {@link ClientProperty#EVENT_THREAD_COUNT} instead.
      */
-    public static final String PROP_INVOCATION_TIMEOUT_SECONDS = "hazelcast.client.invocation.timeout.seconds";
+    @Deprecated
+    public static final String PROP_EVENT_THREAD_COUNT_DEFAULT = EVENT_THREAD_COUNT.getDefaultValue();
 
     /**
-     * Default value of invocation timeout seconds.
+     * Deprecated since Hazelcast 3.6. Please use the new {@link ClientProperty#EVENT_QUEUE_CAPACITY} instead.
      */
-    public static final String PROP_INVOCATION_TIMEOUT_SECONDS_DEFAULT = "120";
+    @Deprecated
+    public static final String PROP_EVENT_QUEUE_CAPACITY = EVENT_QUEUE_CAPACITY.getName();
 
+    /**
+     * Deprecated since Hazelcast 3.6. Please use the new {@link ClientProperty#EVENT_QUEUE_CAPACITY} instead.
+     */
+    @Deprecated
+    public static final String PROP_EVENT_QUEUE_CAPACITY_DEFAULT = EVENT_QUEUE_CAPACITY.getDefaultValue();
 
-    private final ClientProperty heartbeatTimeout;
-    private final ClientProperty heartbeatInterval;
-    private final ClientProperty eventThreadCount;
-    private final ClientProperty eventQueueCapacity;
-    private final ClientProperty invocationTimeout;
-    private final ClientProperty shuffleMemberList;
+    /**
+     * Deprecated since Hazelcast 3.6. Please use the new {@link ClientProperty#INVOCATION_TIMEOUT_SECONDS} instead.
+     */
+    @Deprecated
+    public static final String PROP_INVOCATION_TIMEOUT_SECONDS = INVOCATION_TIMEOUT_SECONDS.getName();
 
+    /**
+     * Deprecated since Hazelcast 3.6. Please use the new {@link ClientProperty#INVOCATION_TIMEOUT_SECONDS} instead.
+     */
+    @Deprecated
+    public static final String PROP_INVOCATION_TIMEOUT_SECONDS_DEFAULT = INVOCATION_TIMEOUT_SECONDS.getDefaultValue();
 
-    public ClientProperties(ClientConfig clientConfig) {
-        heartbeatTimeout = new ClientProperty(clientConfig, PROP_HEARTBEAT_TIMEOUT, PROP_HEARTBEAT_TIMEOUT_DEFAULT);
-        heartbeatInterval = new ClientProperty(clientConfig, PROP_HEARTBEAT_INTERVAL, PROP_HEARTBEAT_INTERVAL_DEFAULT);
-        eventThreadCount = new ClientProperty(clientConfig, PROP_EVENT_THREAD_COUNT, PROP_EVENT_THREAD_COUNT_DEFAULT);
-        eventQueueCapacity = new ClientProperty(clientConfig, PROP_EVENT_QUEUE_CAPACITY, PROP_EVENT_QUEUE_CAPACITY_DEFAULT);
-        invocationTimeout = new ClientProperty(clientConfig, PROP_INVOCATION_TIMEOUT_SECONDS,
-                PROP_INVOCATION_TIMEOUT_SECONDS_DEFAULT);
-        shuffleMemberList = new ClientProperty(clientConfig, PROP_SHUFFLE_MEMBER_LIST,
-                PROP_SHUFFLE_INITIAL_MEMBER_LIST_DEFAULT);
+    /**
+     * Creates a container with configured Hazelcast properties.
+     * <p/>
+     * Uses the environmental value if no value is defined in the configuration.
+     * Uses the default value if no environmental value is defined.
+     *
+     * @param config {@link Config} used to configure the {@link ClientProperty} values.
+     */
+    public ClientProperties(ClientConfig config) {
+        initProperties(config.getProperties(), ClientProperty.values());
     }
 
-    public ClientProperty getHeartbeatTimeout() {
-        return heartbeatTimeout;
-    }
-
-    public ClientProperty getHeartbeatInterval() {
-        return heartbeatInterval;
-    }
-
-    public ClientProperty getEventQueueCapacity() {
-        return eventQueueCapacity;
-    }
-
-    public ClientProperty getEventThreadCount() {
-        return eventThreadCount;
-    }
-
-    public ClientProperty getInvocationTimeoutSeconds() {
-        return invocationTimeout;
-    }
-
-    public ClientProperty getShuffleMemberList() {
-        return shuffleMemberList;
-    }
-
-    /**
-     * A single client property.
-     */
-    public static class ClientProperty {
-
-        private final String name;
-        private final String value;
-
-        ClientProperty(ClientConfig config, String name) {
-            this(config, name, (String) null);
-        }
-
-        ClientProperty(ClientConfig config, String name, ClientProperty defaultValue) {
-            this(config, name, defaultValue != null ? defaultValue.getString() : null);
-        }
-
-        ClientProperty(ClientConfig config, String name, String defaultValue) {
-            this.name = name;
-            String configValue = (config != null) ? config.getProperty(name) : null;
-            if (configValue != null) {
-                value = configValue;
-            } else if (System.getProperty(name) != null) {
-                value = System.getProperty(name);
-            } else {
-                value = defaultValue;
-            }
-        }
-
-        public String getName() {
-            return this.name;
-        }
-
-        public String getValue() {
-            return value;
-        }
-
-        public int getInteger() {
-            return Integer.parseInt(this.value);
-        }
-
-        public byte getByte() {
-            return Byte.parseByte(this.value);
-        }
-
-        public boolean getBoolean() {
-            return Boolean.valueOf(this.value);
-        }
-
-        public String getString() {
-            return value;
-        }
-
-        public long getLong() {
-            return Long.parseLong(this.value);
-        }
-
-        @Override
-        public String toString() {
-            return "ClientProperty [name=" + this.name + ", value=" + this.value + "]";
-        }
+    @Override
+    protected String[] createProperties() {
+        return new String[ClientProperty.values().length];
     }
 }

--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/config/ClientProperty.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/config/ClientProperty.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.config;
+
+import com.hazelcast.instance.GroupProperty;
+import com.hazelcast.instance.HazelcastProperty;
+import com.hazelcast.spi.annotation.PrivateApi;
+
+import java.util.concurrent.TimeUnit;
+
+import static com.hazelcast.util.Preconditions.checkHasText;
+import static java.lang.String.format;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+/**
+ * Defines the name and default value for Hazelcast Client properties.
+ */
+@PrivateApi
+public enum ClientProperty implements HazelcastProperty {
+
+    /**
+     * Client shuffles the given member list to prevent all clients to connect to the same node when
+     * this property is set to false. When it is set to true, the client tries to connect to the nodes
+     * in the given order.
+     */
+    SHUFFLE_MEMBER_LIST("hazelcast.client.shuffle.member.list", true),
+
+    /**
+     * Client sends heartbeat messages to the members and this is the timeout for this sending operations.
+     * If there is not any message passing between the client and member within the given time via this property
+     * in milliseconds, the connection will be closed.
+     */
+    HEARTBEAT_TIMEOUT("hazelcast.client.heartbeat.timeout", 60000, MILLISECONDS),
+
+    /**
+     * Time interval between the heartbeats sent by the client to the nodes.
+     */
+    HEARTBEAT_INTERVAL("hazelcast.client.heartbeat.interval", 5000, MILLISECONDS),
+
+    /**
+     * Number of the threads to handle the incoming event packets.
+     */
+    EVENT_THREAD_COUNT("hazelcast.client.event.thread.count", 5),
+
+    /**
+     * Capacity of the executor that handles the incoming event packets.
+     */
+    EVENT_QUEUE_CAPACITY("hazelcast.client.event.queue.capacity", 1000000),
+
+    /**
+     * Time to give up on invocation when a member in the member list is not reachable.
+     */
+    INVOCATION_TIMEOUT_SECONDS("hazelcast.client.invocation.timeout.seconds", 120, SECONDS);
+
+    private final String name;
+    private final String defaultValue;
+    private final TimeUnit timeUnit;
+
+    ClientProperty(String name, boolean defaultValue) {
+        this(name, defaultValue ? "true" : "false");
+    }
+
+    ClientProperty(String name, Integer defaultValue) {
+        this(name, String.valueOf(defaultValue));
+    }
+
+    ClientProperty(String name, String defaultValue) {
+        this(name, defaultValue, null);
+    }
+
+    ClientProperty(String name, Integer defaultValue, TimeUnit timeUnit) {
+        this(name, String.valueOf(defaultValue), timeUnit);
+    }
+
+    ClientProperty(String name, String defaultValue, TimeUnit timeUnit) {
+        checkHasText(name, "The property name cannot be null or empty!");
+
+        this.name = name;
+        this.defaultValue = defaultValue;
+        this.timeUnit = timeUnit;
+    }
+
+    @Override
+    public int getIndex() {
+        return ordinal();
+    }
+
+    @Override
+    public String getName() {
+        return this.name;
+    }
+
+    @Override
+    public String getDefaultValue() {
+        return defaultValue;
+    }
+
+    @Override
+    public TimeUnit getTimeUnit() {
+        if (timeUnit == null) {
+            throw new IllegalArgumentException(format("groupProperty %s has no TimeUnit defined!", this));
+        }
+        return timeUnit;
+    }
+
+    @Override
+    public GroupProperty getParent() {
+        return null;
+    }
+
+    @Override
+    public void setSystemProperty(String value) {
+        System.setProperty(name, value);
+    }
+
+    @Override
+    public String getSystemProperty() {
+        return System.getProperty(name);
+    }
+
+    @Override
+    public String clearSystemProperty() {
+        return System.clearProperty(name);
+    }
+
+    @Override
+    public String toString() {
+        return name;
+    }
+}

--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
@@ -40,10 +40,10 @@ import com.hazelcast.nio.Address;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.ConnectionListener;
 import com.hazelcast.nio.SocketInterceptor;
-import com.hazelcast.nio.tcp.nonblocking.NonBlockingIOThreadOutOfMemoryHandler;
-import com.hazelcast.nio.tcp.nonblocking.NonBlockingIOThread;
 import com.hazelcast.nio.tcp.SocketChannelWrapper;
 import com.hazelcast.nio.tcp.SocketChannelWrapperFactory;
+import com.hazelcast.nio.tcp.nonblocking.NonBlockingIOThread;
+import com.hazelcast.nio.tcp.nonblocking.NonBlockingIOThreadOutOfMemoryHandler;
 import com.hazelcast.util.Clock;
 import com.hazelcast.util.ExceptionUtil;
 
@@ -58,8 +58,8 @@ import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static com.hazelcast.client.config.ClientProperties.PROP_HEARTBEAT_INTERVAL_DEFAULT;
-import static com.hazelcast.client.config.ClientProperties.PROP_HEARTBEAT_TIMEOUT_DEFAULT;
+import static com.hazelcast.client.config.ClientProperty.HEARTBEAT_INTERVAL;
+import static com.hazelcast.client.config.ClientProperty.HEARTBEAT_TIMEOUT;
 import static com.hazelcast.client.config.SocketOptions.DEFAULT_BUFFER_SIZE_BYTE;
 import static com.hazelcast.client.config.SocketOptions.KILO_BYTE;
 
@@ -75,8 +75,8 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
     };
 
     private final int connectionTimeout;
-    private final int heartBeatInterval;
-    private final int heartBeatTimeout;
+    private final long heartBeatInterval;
+    private final long heartBeatTimeout;
 
     private final ConcurrentMap<Address, Object> connectionLockMap = new ConcurrentHashMap<Address, Object>();
 
@@ -99,8 +99,7 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
 
     protected volatile boolean alive;
 
-    public ClientConnectionManagerImpl(HazelcastClientInstanceImpl client,
-                                       AddressTranslator addressTranslator) {
+    public ClientConnectionManagerImpl(HazelcastClientInstanceImpl client, AddressTranslator addressTranslator) {
         this.client = client;
         this.addressTranslator = addressTranslator;
         final ClientConfig config = client.getClientConfig();
@@ -109,12 +108,12 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
         final int connTimeout = networkConfig.getConnectionTimeout();
         connectionTimeout = connTimeout == 0 ? Integer.MAX_VALUE : connTimeout;
 
-        final ClientProperties clientProperties = client.getClientProperties();
-        int timeout = clientProperties.getHeartbeatTimeout().getInteger();
-        this.heartBeatTimeout = timeout > 0 ? timeout : Integer.parseInt(PROP_HEARTBEAT_TIMEOUT_DEFAULT);
+        ClientProperties clientProperties = client.getClientProperties();
+        long timeout = clientProperties.getMillis(HEARTBEAT_TIMEOUT);
+        this.heartBeatTimeout = timeout > 0 ? timeout : Integer.parseInt(HEARTBEAT_TIMEOUT.getDefaultValue());
 
-        int interval = clientProperties.getHeartbeatInterval().getInteger();
-        heartBeatInterval = interval > 0 ? interval : Integer.parseInt(PROP_HEARTBEAT_INTERVAL_DEFAULT);
+        long interval = clientProperties.getMillis(HEARTBEAT_INTERVAL);
+        heartBeatInterval = interval > 0 ? interval : Integer.parseInt(HEARTBEAT_INTERVAL.getDefaultValue());
 
         executionService = (ClientExecutionServiceImpl) client.getClientExecutionService();
 

--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
@@ -8,6 +8,7 @@ import com.hazelcast.client.config.ClientAwsConfig;
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.config.ClientNetworkConfig;
 import com.hazelcast.client.config.ClientProperties;
+import com.hazelcast.client.config.ClientProperty;
 import com.hazelcast.client.config.ClientSecurityConfig;
 import com.hazelcast.client.connection.AddressProvider;
 import com.hazelcast.client.connection.ClientConnectionManager;
@@ -86,9 +87,9 @@ import com.hazelcast.ringbuffer.impl.RingbufferService;
 import com.hazelcast.security.Credentials;
 import com.hazelcast.security.UsernamePasswordCredentials;
 import com.hazelcast.spi.discovery.DiscoveryMode;
+import com.hazelcast.spi.discovery.impl.DefaultDiscoveryServiceProvider;
 import com.hazelcast.spi.discovery.integration.DiscoveryService;
 import com.hazelcast.spi.discovery.integration.DiscoveryServiceProvider;
-import com.hazelcast.spi.discovery.impl.DefaultDiscoveryServiceProvider;
 import com.hazelcast.spi.impl.SerializationServiceSupport;
 import com.hazelcast.topic.impl.TopicService;
 import com.hazelcast.topic.impl.reliable.ReliableTopicService;
@@ -272,16 +273,14 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
     }
 
     private ClientListenerServiceImpl initListenerService() {
-        int eventQueueCapacity = clientProperties.getEventQueueCapacity().getInteger();
-        int eventThreadCount = clientProperties.getEventThreadCount().getInteger();
+        int eventQueueCapacity = clientProperties.getInteger(ClientProperty.EVENT_QUEUE_CAPACITY);
+        int eventThreadCount = clientProperties.getInteger(ClientProperty.EVENT_THREAD_COUNT);
         return new ClientListenerServiceImpl(this, eventThreadCount, eventQueueCapacity);
     }
 
     private ClientExecutionServiceImpl initExecutionService() {
-        return new ClientExecutionServiceImpl(instanceName, threadGroup,
-                config.getClassLoader(), config.getExecutorPoolSize());
+        return new ClientExecutionServiceImpl(instanceName, threadGroup, config.getClassLoader(), config.getExecutorPoolSize());
     }
-
 
     public void start() {
         lifecycleService.setStarted();

--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/spi/ProxyManager.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/spi/ProxyManager.java
@@ -92,6 +92,8 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
+import static com.hazelcast.client.config.ClientProperty.INVOCATION_TIMEOUT_SECONDS;
+
 /**
  * The ProxyManager handles client proxy instantiation and retrieval at start- and runtime by registering
  * corresponding service manager names and their {@link com.hazelcast.client.spi.ClientProxyFactory}s.
@@ -247,10 +249,9 @@ public final class ProxyManager {
     }
 
     private long getRetryCountLimit() {
-        final ClientProperties clientProperties = client.getClientProperties();
-        int waitTime = clientProperties.getInvocationTimeoutSeconds().getInteger();
-        long retryTimeoutInSeconds = waitTime > 0 ? waitTime
-                : Integer.parseInt(ClientProperties.PROP_INVOCATION_TIMEOUT_SECONDS_DEFAULT);
+        ClientProperties clientProperties = client.getClientProperties();
+        int waitTime = clientProperties.getSeconds(INVOCATION_TIMEOUT_SECONDS);
+        long retryTimeoutInSeconds = waitTime > 0 ? waitTime : Integer.parseInt(INVOCATION_TIMEOUT_SECONDS.getDefaultValue());
         return retryTimeoutInSeconds / ClientInvocation.RETRY_WAIT_TIME_IN_SECONDS;
     }
 

--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/spi/impl/ClientInvocation.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/spi/impl/ClientInvocation.java
@@ -39,7 +39,8 @@ import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static com.hazelcast.client.config.ClientProperties.PROP_HEARTBEAT_INTERVAL_DEFAULT;
+import static com.hazelcast.client.config.ClientProperty.HEARTBEAT_INTERVAL;
+import static com.hazelcast.client.config.ClientProperty.INVOCATION_TIMEOUT_SECONDS;
 
 /**
  * ClientInvocation handles routing of a request from client
@@ -80,20 +81,18 @@ public class ClientInvocation implements Runnable {
         this.partitionId = partitionId;
         this.address = address;
         this.connection = connection;
-        final ClientProperties clientProperties = client.getClientProperties();
 
-        int waitTime = clientProperties.getInvocationTimeoutSeconds().getInteger();
-        long retryTimeoutInSeconds = waitTime > 0 ? waitTime
-                : Integer.parseInt(ClientProperties.PROP_INVOCATION_TIMEOUT_SECONDS_DEFAULT);
+        ClientProperties clientProperties = client.getClientProperties();
+        int waitTime = clientProperties.getSeconds(INVOCATION_TIMEOUT_SECONDS);
+        long retryTimeoutInSeconds = waitTime > 0 ? waitTime : Integer.parseInt(INVOCATION_TIMEOUT_SECONDS.getDefaultValue());
 
         clientInvocationFuture = new ClientInvocationFuture(this, client, clientMessage);
 
         this.retryCountLimit = retryTimeoutInSeconds / RETRY_WAIT_TIME_IN_SECONDS;
 
-        int interval = clientProperties.getHeartbeatInterval().getInteger();
-        this.heartBeatInterval = interval > 0 ? interval : Integer.parseInt(PROP_HEARTBEAT_INTERVAL_DEFAULT);
+        int interval = clientProperties.getInteger(HEARTBEAT_INTERVAL);
+        this.heartBeatInterval = interval > 0 ? interval : Integer.parseInt(HEARTBEAT_INTERVAL.getDefaultValue());
     }
-
 
     public ClientInvocation(HazelcastClientInstanceImpl client, ClientMessage clientMessage) {
         this(client, clientMessage, UNASSIGNED_PARTITION, null, null);
@@ -191,7 +190,6 @@ public class ClientInvocation implements Runnable {
         }
         clientInvocationFuture.setResponse(exception);
     }
-
 
     private boolean handleRetry() {
         if (isBindToSingleConnection()) {

--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/spi/impl/ClusterListenerSupport.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/spi/impl/ClusterListenerSupport.java
@@ -33,13 +33,13 @@ import com.hazelcast.client.spi.ClientClusterService;
 import com.hazelcast.client.spi.ClientExecutionService;
 import com.hazelcast.core.LifecycleEvent;
 import com.hazelcast.core.Member;
+import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.ConnectionListener;
 import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.security.Credentials;
 import com.hazelcast.security.UsernamePasswordCredentials;
 import com.hazelcast.util.Clock;
@@ -60,8 +60,9 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 
-public abstract class ClusterListenerSupport implements ConnectionListener, ConnectionHeartbeatListener,
-        ClientClusterService {
+import static com.hazelcast.client.config.ClientProperty.SHUFFLE_MEMBER_LIST;
+
+public abstract class ClusterListenerSupport implements ConnectionListener, ConnectionHeartbeatListener, ClientClusterService {
 
     private static final ILogger LOGGER = Logger.getLogger(ClusterListenerSupport.class);
     private static final long TERMINATE_TIMEOUT_SECONDS = 30;
@@ -82,7 +83,7 @@ public abstract class ClusterListenerSupport implements ConnectionListener, Conn
     public ClusterListenerSupport(HazelcastClientInstanceImpl client, Collection<AddressProvider> addressProviders) {
         this.client = client;
         this.addressProviders = addressProviders;
-        this.shuffleMemberList = client.getClientProperties().getShuffleMemberList().getBoolean();
+        this.shuffleMemberList = client.getClientProperties().getBoolean(SHUFFLE_MEMBER_LIST);
         this.clusterExecutor = createSingleThreadExecutorService(client);
     }
 
@@ -267,7 +268,6 @@ public abstract class ClusterListenerSupport implements ConnectionListener, Conn
 
     @Override
     public void connectionAdded(Connection connection) {
-
     }
 
     @Override
@@ -292,7 +292,6 @@ public abstract class ClusterListenerSupport implements ConnectionListener, Conn
 
     @Override
     public void heartBeatStarted(Connection connection) {
-
     }
 
     @Override
@@ -302,4 +301,3 @@ public abstract class ClusterListenerSupport implements ConnectionListener, Conn
         }
     }
 }
-

--- a/hazelcast-client-new/src/test/java/com/hazelcast/client/ClientConnectionTest.java
+++ b/hazelcast-client-new/src/test/java/com/hazelcast/client/ClientConnectionTest.java
@@ -17,7 +17,7 @@
 package com.hazelcast.client;
 
 import com.hazelcast.client.config.ClientConfig;
-import com.hazelcast.client.config.ClientProperties;
+import com.hazelcast.client.config.ClientProperty;
 import com.hazelcast.client.connection.ClientConnectionManager;
 import com.hazelcast.client.impl.ClientTestUtil;
 import com.hazelcast.client.impl.HazelcastClientInstanceImpl;
@@ -70,7 +70,7 @@ public class ClientConnectionTest extends HazelcastTestSupport {
 
         HazelcastInstance server = hazelcastFactory.newHazelcastInstance();
         ClientConfig config = new ClientConfig();
-        config.setProperty(ClientProperties.PROP_SHUFFLE_MEMBER_LIST, "false");
+        config.setProperty(ClientProperty.SHUFFLE_MEMBER_LIST, "false");
         config.getNetworkConfig().addAddress(illegalAddress).addAddress("localhost");
         HazelcastInstance client = hazelcastFactory.newHazelcastClient(config);
 
@@ -83,12 +83,11 @@ public class ClientConnectionTest extends HazelcastTestSupport {
 
     @Test
     public void testMemberConnectionOrder() {
-
         HazelcastInstance server1 = hazelcastFactory.newHazelcastInstance();
         HazelcastInstance server2 = hazelcastFactory.newHazelcastInstance();
 
         ClientConfig config = new ClientConfig();
-        config.setProperty(ClientProperties.PROP_SHUFFLE_MEMBER_LIST, "false");
+        config.setProperty(ClientProperty.SHUFFLE_MEMBER_LIST, "false");
         config.getNetworkConfig().setSmartRouting(false);
 
         InetSocketAddress socketAddress1 = server1.getCluster().getLocalMember().getSocketAddress();
@@ -141,5 +140,4 @@ public class ClientConnectionTest extends HazelcastTestSupport {
             count.incrementAndGet();
         }
     }
-
 }

--- a/hazelcast-client-new/src/test/java/com/hazelcast/client/ClientRegressionWithMockNetworkTest.java
+++ b/hazelcast-client-new/src/test/java/com/hazelcast/client/ClientRegressionWithMockNetworkTest.java
@@ -17,7 +17,7 @@
 package com.hazelcast.client;
 
 import com.hazelcast.client.config.ClientConfig;
-import com.hazelcast.client.config.ClientProperties;
+import com.hazelcast.client.config.ClientProperty;
 import com.hazelcast.client.config.ClientSecurityConfig;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.Config;
@@ -78,8 +78,7 @@ import static org.junit.Assert.fail;
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
 @Ignore //https://github.com/hazelcast/hazelcast/issues/6153
-public class ClientRegressionWithMockNetworkTest
-        extends HazelcastTestSupport {
+public class ClientRegressionWithMockNetworkTest extends HazelcastTestSupport {
 
     private final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
 
@@ -87,7 +86,6 @@ public class ClientRegressionWithMockNetworkTest
     public void cleanup() {
         hazelcastFactory.terminateAll();
     }
-
 
     @Test
     public void testInitialMemberListener() throws InterruptedException {
@@ -107,7 +105,7 @@ public class ClientRegressionWithMockNetworkTest
         assertTrue("After starting", latch2.await(5, TimeUnit.SECONDS));
     }
 
-    static class StaticMemberListener implements MembershipListener, InitialMembershipListener {
+    private static class StaticMemberListener implements MembershipListener, InitialMembershipListener {
 
         final CountDownLatch latch;
 
@@ -137,7 +135,6 @@ public class ClientRegressionWithMockNetworkTest
 
         final HazelcastInstance hz1 = hazelcastFactory.newHazelcastInstance();
         hazelcastFactory.newHazelcastInstance();
-
 
         ClientConfig clientConfig = new ClientConfig();
         clientConfig.getNetworkConfig().setRedoOperation(true);
@@ -293,7 +290,6 @@ public class ClientRegressionWithMockNetworkTest
         list.offer(LifecycleState.CLIENT_DISCONNECTED);
         list.offer(LifecycleState.CLIENT_CONNECTED);
 
-
         final HazelcastInstance instance = hazelcastFactory.newHazelcastInstance();
         final CountDownLatch latch = new CountDownLatch(list.size());
         LifecycleListener listener = new LifecycleListener() {
@@ -337,15 +333,12 @@ public class ClientRegressionWithMockNetworkTest
             }
 
             public void memberAdded(MembershipEvent membershipEvent) {
-
             }
 
             public void memberRemoved(MembershipEvent membershipEvent) {
-
             }
 
             public void memberAttributeChanged(MemberAttributeEvent memberAttributeEvent) {
-
             }
         }));
         hazelcastFactory.newHazelcastClient(clientConfig);
@@ -354,7 +347,6 @@ public class ClientRegressionWithMockNetworkTest
 
     @Test
     public void testInterceptor() throws InterruptedException {
-
         final HazelcastInstance instance = hazelcastFactory.newHazelcastInstance();
         final HazelcastInstance client = hazelcastFactory.newHazelcastClient();
 
@@ -375,7 +367,6 @@ public class ClientRegressionWithMockNetworkTest
 
         assertEquals("val", map.get("key1"));
 
-
         map.put("key2", "oldValue");
         assertEquals("oldValue", map.get("key2"));
         map.put("key2", "newValue");
@@ -384,12 +375,9 @@ public class ClientRegressionWithMockNetworkTest
         map.put("key3", "value2");
         assertEquals("value2", map.get("key3"));
         assertEquals("removeIntercepted", map.remove("key3"));
-
-
     }
 
-    static class MapInterceptorImpl implements MapInterceptor {
-
+    private static class MapInterceptorImpl implements MapInterceptor {
 
         MapInterceptorImpl() {
         }
@@ -402,7 +390,6 @@ public class ClientRegressionWithMockNetworkTest
         }
 
         public void afterGet(Object value) {
-
         }
 
         public Object interceptPut(Object oldValue, Object newValue) {
@@ -424,7 +411,6 @@ public class ClientRegressionWithMockNetworkTest
 
         public void afterRemove(Object value) {
         }
-
     }
 
     @Test
@@ -458,7 +444,6 @@ public class ClientRegressionWithMockNetworkTest
         securityConfig.setCredentialsClassname(MyCredentials.class.getName());
 
         final HazelcastInstance client = hazelcastFactory.newHazelcastClient(clientConfig);
-
     }
 
     public static class MyCredentials extends UsernamePasswordCredentials {
@@ -521,7 +506,6 @@ public class ClientRegressionWithMockNetworkTest
         }
 
         public SamplePortable() {
-
         }
 
         public int getFactoryId() {
@@ -543,7 +527,6 @@ public class ClientRegressionWithMockNetworkTest
 
     @Test
     public void testNearCache_WhenRegisteredNodeIsDead() {
-
         final HazelcastInstance instance = hazelcastFactory.newHazelcastInstance();
 
         final ClientConfig clientConfig = new ClientConfig();
@@ -572,7 +555,6 @@ public class ClientRegressionWithMockNetworkTest
                 assertEquals(null, map.get("a"));
             }
         });
-
     }
 
     @Category(NightlyTest.class)
@@ -588,7 +570,6 @@ public class ClientRegressionWithMockNetworkTest
     }
 
     private void testLock_WhenClientAndOwnerNodeDiesTogether(boolean smart) throws InterruptedException {
-
         hazelcastFactory.newHazelcastInstance();
         final ClientConfig clientConfig = new ClientConfig();
         clientConfig.getNetworkConfig().setSmartRouting(smart);
@@ -685,9 +666,7 @@ public class ClientRegressionWithMockNetworkTest
     }
 
     @Test(expected = ExecutionException.class, timeout = 120000)
-    public void testGithubIssue3557()
-            throws Exception {
-
+    public void testGithubIssue3557() throws Exception {
         HazelcastInstance hz = hazelcastFactory.newHazelcastInstance();
         HazelcastInstance client = hazelcastFactory.newHazelcastClient();
 
@@ -698,8 +677,7 @@ public class ClientRegressionWithMockNetworkTest
         future.get();
     }
 
-    public static class Issue2509Runnable
-            implements Callable<Integer>, DataSerializable {
+    public static class Issue2509Runnable implements Callable<Integer>, DataSerializable {
 
         private UnDeserializable unDeserializable;
 
@@ -711,16 +689,12 @@ public class ClientRegressionWithMockNetworkTest
         }
 
         @Override
-        public void writeData(ObjectDataOutput out)
-                throws IOException {
-
+        public void writeData(ObjectDataOutput out) throws IOException {
             out.writeObject(unDeserializable);
         }
 
         @Override
-        public void readData(ObjectDataInput in)
-                throws IOException {
-
+        public void readData(ObjectDataInput in) throws IOException {
             unDeserializable = in.readObject();
         }
 
@@ -730,8 +704,7 @@ public class ClientRegressionWithMockNetworkTest
         }
     }
 
-    public static class UnDeserializable
-            implements DataSerializable {
+    public static class UnDeserializable implements DataSerializable {
 
         private int foo;
 
@@ -740,16 +713,12 @@ public class ClientRegressionWithMockNetworkTest
         }
 
         @Override
-        public void writeData(ObjectDataOutput out)
-                throws IOException {
-
+        public void writeData(ObjectDataOutput out) throws IOException {
             out.writeInt(foo);
         }
 
         @Override
-        public void readData(ObjectDataInput in)
-                throws IOException {
-
+        public void readData(ObjectDataInput in) throws IOException {
             foo = in.readInt();
         }
     }
@@ -792,14 +761,13 @@ public class ClientRegressionWithMockNetworkTest
             }
         }).start();
 
-
         ClientConfig clientConfig = new ClientConfig();
         //Retry all requests
         clientConfig.getNetworkConfig().setRedoOperation(true);
         //retry to connect to cluster forever(never shutdown the client)
         clientConfig.getNetworkConfig().setConnectionAttemptLimit(Integer.MAX_VALUE);
         //Retry all requests forever(until client is shutdown)
-        clientConfig.setProperty(ClientProperties.PROP_INVOCATION_TIMEOUT_SECONDS, String.valueOf(Integer.MAX_VALUE));
+        clientConfig.setProperty(ClientProperty.INVOCATION_TIMEOUT_SECONDS, String.valueOf(Integer.MAX_VALUE));
         HazelcastInstance client = hazelcastFactory.newHazelcastClient(clientConfig);
 
         IMap<Object, Object> map = client.getMap(randomMapName());
@@ -825,7 +793,7 @@ public class ClientRegressionWithMockNetworkTest
         //Retry all requests
         clientConfig.getNetworkConfig().setRedoOperation(true);
         //Retry all requests forever(until client is shutdown)
-        clientConfig.setProperty(ClientProperties.PROP_INVOCATION_TIMEOUT_SECONDS, String.valueOf(Integer.MAX_VALUE));
+        clientConfig.setProperty(ClientProperty.INVOCATION_TIMEOUT_SECONDS, String.valueOf(Integer.MAX_VALUE));
         HazelcastInstance client = hazelcastFactory.newHazelcastClient(clientConfig);
 
         final IMap<Object, Object> map = client.getMap(randomMapName());
@@ -863,6 +831,5 @@ public class ClientRegressionWithMockNetworkTest
         hazelcastInstance.shutdown();
 
         assertOpenEventually("Put operations should not hang.", testFinishedLatch);
-
     }
 }

--- a/hazelcast-client-new/src/test/java/com/hazelcast/client/config/ClientPropertiesTest.java
+++ b/hazelcast-client-new/src/test/java/com/hazelcast/client/config/ClientPropertiesTest.java
@@ -1,0 +1,112 @@
+package com.hazelcast.client.config;
+
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for {@link ClientProperty} and {@link ClientProperties} classes.
+ * <p/>
+ * Need to run with {@link HazelcastSerialClassRunner} due to tests with System environment variables.
+ */
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+
+public class ClientPropertiesTest {
+
+    private final ClientConfig config = new ClientConfig();
+    private final ClientProperties defaultClientProperties = new ClientProperties(config);
+
+    @Test(expected = NullPointerException.class)
+    public void constructor_withNullConfig() {
+        new ClientProperties(null);
+    }
+
+    @Test
+    public void setProperty_ensureHighestPriorityOfConfig() {
+        config.setProperty(ClientProperty.EVENT_THREAD_COUNT, "1000");
+        ClientProperty.EVENT_THREAD_COUNT.setSystemProperty("5000");
+
+        ClientProperties ClientProperties = new ClientProperties(config);
+        int eventThreadCount = ClientProperties.getInteger(ClientProperty.EVENT_THREAD_COUNT);
+
+        ClientProperty.EVENT_THREAD_COUNT.clearSystemProperty();
+
+        assertEquals(1000, eventThreadCount);
+    }
+
+    @Test
+    public void setProperty_ensureUsageOfSystemProperty() {
+        ClientProperty.EVENT_THREAD_COUNT.setSystemProperty("2342");
+
+        ClientProperties ClientProperties = new ClientProperties(config);
+        int eventThreadCount = ClientProperties.getInteger(ClientProperty.EVENT_THREAD_COUNT);
+
+        ClientProperty.EVENT_THREAD_COUNT.clearSystemProperty();
+
+        assertEquals(2342, eventThreadCount);
+    }
+
+    @Test
+    public void setProperty_ensureUsageOfDefaultValue() {
+        int eventThreadCount = defaultClientProperties.getInteger(ClientProperty.EVENT_THREAD_COUNT);
+
+        assertEquals(5, eventThreadCount);
+    }
+
+    @Test
+    public void getSystemProperty() {
+        ClientProperty.EVENT_THREAD_COUNT.setSystemProperty("8000");
+
+        assertEquals("8000", ClientProperty.EVENT_THREAD_COUNT.getSystemProperty());
+
+        ClientProperty.EVENT_THREAD_COUNT.clearSystemProperty();
+    }
+
+    @Test
+    public void getBoolean() {
+        boolean shuffleMemberList = defaultClientProperties.getBoolean(ClientProperty.SHUFFLE_MEMBER_LIST);
+
+        assertTrue(shuffleMemberList);
+    }
+
+    @Test
+    public void getInteger() {
+        int eventThreadCount = defaultClientProperties.getInteger(ClientProperty.EVENT_THREAD_COUNT);
+
+        assertEquals(5, eventThreadCount);
+    }
+
+    @Test
+    public void getTimeUnit() {
+        config.setProperty(ClientProperty.INVOCATION_TIMEOUT_SECONDS, "300");
+        ClientProperties ClientProperties = new ClientProperties(config);
+
+        assertEquals(300, ClientProperties.getSeconds(ClientProperty.INVOCATION_TIMEOUT_SECONDS));
+    }
+
+    @Test
+    public void getTimeUnit_default() {
+        long expectedSeconds = 5;
+
+        long intervalNanos = defaultClientProperties.getNanos(ClientProperty.HEARTBEAT_INTERVAL);
+        long intervalMillis = defaultClientProperties.getMillis(ClientProperty.HEARTBEAT_INTERVAL);
+        long intervalSeconds = defaultClientProperties.getSeconds(ClientProperty.HEARTBEAT_INTERVAL);
+
+        assertEquals(TimeUnit.SECONDS.toNanos(expectedSeconds), intervalNanos);
+        assertEquals(TimeUnit.SECONDS.toMillis(expectedSeconds), intervalMillis);
+        assertEquals(expectedSeconds, intervalSeconds);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void getTimeUnit_noTimeUnitProperty() {
+        defaultClientProperties.getMillis(ClientProperty.EVENT_QUEUE_CAPACITY);
+    }
+}

--- a/hazelcast-client-new/src/test/java/com/hazelcast/client/map/ClientMapIssueTest.java
+++ b/hazelcast-client-new/src/test/java/com/hazelcast/client/map/ClientMapIssueTest.java
@@ -17,7 +17,7 @@
 package com.hazelcast.client.map;
 
 import com.hazelcast.client.config.ClientConfig;
-import com.hazelcast.client.config.ClientProperties;
+import com.hazelcast.client.config.ClientProperty;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.core.EntryAdapter;
 import com.hazelcast.core.HazelcastInstance;
@@ -94,7 +94,7 @@ public class ClientMapIssueTest extends HazelcastTestSupport {
         ClientConfig clientConfig = new ClientConfig();
         clientConfig.setExecutorPoolSize(1);
         clientConfig.getNetworkConfig().setConnectionAttemptLimit(Integer.MAX_VALUE);
-        clientConfig.setProperty(ClientProperties.PROP_INVOCATION_TIMEOUT_SECONDS, "10");
+        clientConfig.setProperty(ClientProperty.INVOCATION_TIMEOUT_SECONDS, "10");
 
         HazelcastInstance client = hazelcastFactory.newHazelcastClient(clientConfig);
         final IMap<String, String> map = client.getMap(randomMapName());
@@ -128,7 +128,7 @@ public class ClientMapIssueTest extends HazelcastTestSupport {
         ClientConfig clientConfig = new ClientConfig();
         clientConfig.setExecutorPoolSize(1);
         clientConfig.getNetworkConfig().setConnectionAttemptLimit(Integer.MAX_VALUE);
-        clientConfig.setProperty(ClientProperties.PROP_INVOCATION_TIMEOUT_SECONDS, "10");
+        clientConfig.setProperty(ClientProperty.INVOCATION_TIMEOUT_SECONDS, "10");
 
         HazelcastInstance client = hazelcastFactory.newHazelcastClient(clientConfig);
         final IMap<String, String> map = client.getMap(randomMapName());
@@ -221,5 +221,4 @@ public class ClientMapIssueTest extends HazelcastTestSupport {
         final Set<Integer> values = map.keySet(predicate);
         assertEquals(pageSize, values.size());
     }
-
 }

--- a/hazelcast-client-new/src/test/java/com/hazelcast/client/replicatedmap/ClientReplicatedMapLiteMemberTest.java
+++ b/hazelcast-client-new/src/test/java/com/hazelcast/client/replicatedmap/ClientReplicatedMapLiteMemberTest.java
@@ -2,7 +2,7 @@ package com.hazelcast.client.replicatedmap;
 
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.config.ClientNetworkConfig;
-import com.hazelcast.client.config.ClientProperties;
+import com.hazelcast.client.config.ClientProperty;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
@@ -11,15 +11,16 @@ import com.hazelcast.replicatedmap.ReplicatedMapCantBeCreatedOnLiteMemberExcepti
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
-import java.net.InetSocketAddress;
-import java.net.UnknownHostException;
-import java.util.ArrayList;
-import java.util.List;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+
+import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.List;
 
 import static com.hazelcast.test.HazelcastTestSupport.assertClusterSizeEventually;
 import static com.hazelcast.test.HazelcastTestSupport.getAddress;
@@ -81,8 +82,8 @@ public class ClientReplicatedMapLiteMemberTest {
     }
 
     private void testReplicatedMapCreated(final int numberOfLiteNodes,
-                                            final int numberOfDataNodes,
-                                            final ClientConfig clientConfig) {
+                                          final int numberOfDataNodes,
+                                          final ClientConfig clientConfig) {
         createNodes(numberOfLiteNodes, numberOfDataNodes);
 
         final HazelcastInstance client = factory.newHazelcastClient(clientConfig);
@@ -99,8 +100,7 @@ public class ClientReplicatedMapLiteMemberTest {
     }
 
     @Test
-    public void testReplicatedMapPutByDummyClient()
-            throws UnknownHostException {
+    public void testReplicatedMapPutByDummyClient() throws UnknownHostException {
         final List<HazelcastInstance> instances = createNodes(3, 1);
         configureDummyClientConnection(instances.get(0));
 
@@ -110,10 +110,9 @@ public class ClientReplicatedMapLiteMemberTest {
         map.put(1, 2);
     }
 
-    private void configureDummyClientConnection(final HazelcastInstance instance)
-            throws UnknownHostException {
+    private void configureDummyClientConnection(final HazelcastInstance instance) throws UnknownHostException {
         final InetSocketAddress socketAddress = getAddress(instance).getInetSocketAddress();
-        dummyClientConfig.setProperty(ClientProperties.PROP_SHUFFLE_MEMBER_LIST, "false");
+        dummyClientConfig.setProperty(ClientProperty.SHUFFLE_MEMBER_LIST, "false");
         final ClientNetworkConfig networkConfig = dummyClientConfig.getNetworkConfig();
         networkConfig.addAddress(socketAddress.getHostName() + ":" + socketAddress.getPort());
     }
@@ -137,5 +136,4 @@ public class ClientReplicatedMapLiteMemberTest {
 
         return instances;
     }
-
 }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientProperties.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientProperties.java
@@ -16,175 +16,117 @@
 
 package com.hazelcast.client.config;
 
+import com.hazelcast.config.Config;
+import com.hazelcast.instance.HazelcastProperties;
+
+import static com.hazelcast.client.config.ClientProperty.EVENT_QUEUE_CAPACITY;
+import static com.hazelcast.client.config.ClientProperty.EVENT_THREAD_COUNT;
+import static com.hazelcast.client.config.ClientProperty.HEARTBEAT_INTERVAL;
+import static com.hazelcast.client.config.ClientProperty.HEARTBEAT_TIMEOUT;
+import static com.hazelcast.client.config.ClientProperty.INVOCATION_TIMEOUT_SECONDS;
+import static com.hazelcast.client.config.ClientProperty.SHUFFLE_MEMBER_LIST;
+
 /**
- * Client Properties
+ * Container for configured Hazelcast Client properties ({@see ClientProperty}).
+ * <p/>
+ * A {@link ClientProperty} can be set as:
+ * <p><ul>
+ * <li>an environmental variable using {@link System#setProperty(String, String)}</li>
+ * <li>the programmatic configuration using {@link Config#setProperty(String, String)}</li>
+ * <li>the XML configuration
+ * {@see http://docs.hazelcast.org/docs/latest-dev/manual/html-single/hazelcast-documentation.html#system-properties}</li>
+ * </ul></p>
+ * The old property definitions are deprecated since Hazelcast 3.6. Please use the new {@link ClientProperty} definitions instead.
  */
-public class ClientProperties {
+@SuppressWarnings("unused")
+public class ClientProperties extends HazelcastProperties {
 
     /**
-     * Client shuffles the given member list to prevent all clients to connect to the same node when
-     * this property is set to false. When it is set to true, the client tries to connect to the nodes
-     * in the given order.
+     * Deprecated since Hazelcast 3.6. Please use the new {@link ClientProperty#SHUFFLE_MEMBER_LIST} instead.
      */
-    public static final String PROP_SHUFFLE_MEMBER_LIST = "hazelcast.client.shuffle.member.list";
-    /**
-     * Default value of the shuffle member list is true unless the user specifies it explicitly.
-     */
-    public static final String PROP_SHUFFLE_INITIAL_MEMBER_LIST_DEFAULT = "true";
+    @Deprecated
+    public static final String PROP_SHUFFLE_MEMBER_LIST = SHUFFLE_MEMBER_LIST.getName();
 
     /**
-     * Client sends heartbeat messages to the members and this is the timeout for this sending operations. If there
-     * is not any message passing between the client and member within the given time via this property
-     * in milliseconds, the connection will be closed.
+     * Deprecated since Hazelcast 3.6. Please use the new {@link ClientProperty#SHUFFLE_MEMBER_LIST} instead.
      */
-    public static final String PROP_HEARTBEAT_TIMEOUT = "hazelcast.client.heartbeat.timeout";
-    /**
-     * Default value of the heartbeat timeout unless the user specifies it explicitly.
-     */
-    public static final String PROP_HEARTBEAT_TIMEOUT_DEFAULT = "60000";
+    @Deprecated
+    public static final String PROP_SHUFFLE_INITIAL_MEMBER_LIST_DEFAULT = SHUFFLE_MEMBER_LIST.getDefaultValue();
 
     /**
-     * Time interval between the heartbeats sent by the client to the nodes.
+     * Deprecated since Hazelcast 3.6. Please use the new {@link ClientProperty#HEARTBEAT_TIMEOUT} instead.
      */
-    public static final String PROP_HEARTBEAT_INTERVAL = "hazelcast.client.heartbeat.interval";
-    /**
-     * Default value of heartbeat interval unless the user specifies it explicitly.
-     */
-    public static final String PROP_HEARTBEAT_INTERVAL_DEFAULT = "5000";
+    @Deprecated
+    public static final String PROP_HEARTBEAT_TIMEOUT = HEARTBEAT_TIMEOUT.getName();
 
     /**
-     * Number of the threads to handle the incoming event packets.
+     * Deprecated since Hazelcast 3.6. Please use the new {@link ClientProperty#HEARTBEAT_TIMEOUT} instead.
      */
-    public static final String PROP_EVENT_THREAD_COUNT = "hazelcast.client.event.thread.count";
+    @Deprecated
+    public static final String PROP_HEARTBEAT_TIMEOUT_DEFAULT = HEARTBEAT_TIMEOUT.getDefaultValue();
 
     /**
-     * Default value of the number of threads to handle the incoming event packets.
+     * Deprecated since Hazelcast 3.6. Please use the new {@link ClientProperty#HEARTBEAT_INTERVAL} instead.
      */
-    public static final String PROP_EVENT_THREAD_COUNT_DEFAULT = "5";
+    @Deprecated
+    public static final String PROP_HEARTBEAT_INTERVAL = HEARTBEAT_INTERVAL.getName();
 
     /**
-     * Capacity of the executor that handles the incoming event packets.
+     * Deprecated since Hazelcast 3.6. Please use the new {@link ClientProperty#HEARTBEAT_INTERVAL} instead.
      */
-    public static final String PROP_EVENT_QUEUE_CAPACITY = "hazelcast.client.event.queue.capacity";
+    @Deprecated
+    public static final String PROP_HEARTBEAT_INTERVAL_DEFAULT = HEARTBEAT_INTERVAL.getDefaultValue();
 
     /**
-     * Default value of the capacity of the executor that handles the incoming event packets.
+     * Deprecated since Hazelcast 3.6. Please use the new {@link ClientProperty#EVENT_THREAD_COUNT} instead.
      */
-    public static final String PROP_EVENT_QUEUE_CAPACITY_DEFAULT = "1000000";
+    @Deprecated
+    public static final String PROP_EVENT_THREAD_COUNT = EVENT_THREAD_COUNT.getName();
 
     /**
-     * Time to give up on invocation when a member in the member list is not reachable.
+     * Deprecated since Hazelcast 3.6. Please use the new {@link ClientProperty#EVENT_THREAD_COUNT} instead.
      */
-    public static final String PROP_INVOCATION_TIMEOUT_SECONDS = "hazelcast.client.invocation.timeout.seconds";
+    @Deprecated
+    public static final String PROP_EVENT_THREAD_COUNT_DEFAULT = EVENT_THREAD_COUNT.getDefaultValue();
 
     /**
-     * Default value of invocation timeout seconds.
+     * Deprecated since Hazelcast 3.6. Please use the new {@link ClientProperty#EVENT_QUEUE_CAPACITY} instead.
      */
-    public static final String PROP_INVOCATION_TIMEOUT_SECONDS_DEFAULT = "120";
+    @Deprecated
+    public static final String PROP_EVENT_QUEUE_CAPACITY = EVENT_QUEUE_CAPACITY.getName();
 
+    /**
+     * Deprecated since Hazelcast 3.6. Please use the new {@link ClientProperty#EVENT_QUEUE_CAPACITY} instead.
+     */
+    @Deprecated
+    public static final String PROP_EVENT_QUEUE_CAPACITY_DEFAULT = EVENT_QUEUE_CAPACITY.getDefaultValue();
 
-    private final ClientProperty heartbeatTimeout;
-    private final ClientProperty heartbeatInterval;
-    private final ClientProperty eventThreadCount;
-    private final ClientProperty eventQueueCapacity;
-    private final ClientProperty invocationTimeout;
-    private final ClientProperty shuffleMemberList;
+    /**
+     * Deprecated since Hazelcast 3.6. Please use the new {@link ClientProperty#INVOCATION_TIMEOUT_SECONDS} instead.
+     */
+    @Deprecated
+    public static final String PROP_INVOCATION_TIMEOUT_SECONDS = INVOCATION_TIMEOUT_SECONDS.getName();
 
+    /**
+     * Deprecated since Hazelcast 3.6. Please use the new {@link ClientProperty#INVOCATION_TIMEOUT_SECONDS} instead.
+     */
+    @Deprecated
+    public static final String PROP_INVOCATION_TIMEOUT_SECONDS_DEFAULT = INVOCATION_TIMEOUT_SECONDS.getDefaultValue();
 
-    public ClientProperties(ClientConfig clientConfig) {
-        heartbeatTimeout = new ClientProperty(clientConfig, PROP_HEARTBEAT_TIMEOUT, PROP_HEARTBEAT_TIMEOUT_DEFAULT);
-        heartbeatInterval = new ClientProperty(clientConfig, PROP_HEARTBEAT_INTERVAL, PROP_HEARTBEAT_INTERVAL_DEFAULT);
-        eventThreadCount = new ClientProperty(clientConfig, PROP_EVENT_THREAD_COUNT, PROP_EVENT_THREAD_COUNT_DEFAULT);
-        eventQueueCapacity = new ClientProperty(clientConfig, PROP_EVENT_QUEUE_CAPACITY, PROP_EVENT_QUEUE_CAPACITY_DEFAULT);
-        invocationTimeout = new ClientProperty(clientConfig, PROP_INVOCATION_TIMEOUT_SECONDS,
-                PROP_INVOCATION_TIMEOUT_SECONDS_DEFAULT);
-        shuffleMemberList = new ClientProperty(clientConfig, PROP_SHUFFLE_MEMBER_LIST,
-                PROP_SHUFFLE_INITIAL_MEMBER_LIST_DEFAULT);
+    /**
+     * Creates a container with configured Hazelcast properties.
+     * <p/>
+     * Uses the environmental value if no value is defined in the configuration.
+     * Uses the default value if no environmental value is defined.
+     *
+     * @param config {@link Config} used to configure the {@link ClientProperty} values.
+     */
+    public ClientProperties(ClientConfig config) {
+        initProperties(config.getProperties(), ClientProperty.values());
     }
 
-    public ClientProperty getHeartbeatTimeout() {
-        return heartbeatTimeout;
-    }
-
-    public ClientProperty getHeartbeatInterval() {
-        return heartbeatInterval;
-    }
-
-    public ClientProperty getEventQueueCapacity() {
-        return eventQueueCapacity;
-    }
-
-    public ClientProperty getEventThreadCount() {
-        return eventThreadCount;
-    }
-
-    public ClientProperty getInvocationTimeoutSeconds() {
-        return invocationTimeout;
-    }
-
-    public ClientProperty getShuffleMemberList() {
-        return shuffleMemberList;
-    }
-
-    /**
-     * A single client property.
-     */
-    public static class ClientProperty {
-
-        private final String name;
-        private final String value;
-
-        ClientProperty(ClientConfig config, String name) {
-            this(config, name, (String) null);
-        }
-
-        ClientProperty(ClientConfig config, String name, ClientProperty defaultValue) {
-            this(config, name, defaultValue != null ? defaultValue.getString() : null);
-        }
-
-        ClientProperty(ClientConfig config, String name, String defaultValue) {
-            this.name = name;
-            String configValue = (config != null) ? config.getProperty(name) : null;
-            if (configValue != null) {
-                value = configValue;
-            } else if (System.getProperty(name) != null) {
-                value = System.getProperty(name);
-            } else {
-                value = defaultValue;
-            }
-        }
-
-        public String getName() {
-            return this.name;
-        }
-
-        public String getValue() {
-            return value;
-        }
-
-        public int getInteger() {
-            return Integer.parseInt(this.value);
-        }
-
-        public byte getByte() {
-            return Byte.parseByte(this.value);
-        }
-
-        public boolean getBoolean() {
-            return Boolean.valueOf(this.value);
-        }
-
-        public String getString() {
-            return value;
-        }
-
-        public long getLong() {
-            return Long.parseLong(this.value);
-        }
-
-        @Override
-        public String toString() {
-            return "ClientProperty [name=" + this.name + ", value=" + this.value + "]";
-        }
+    @Override
+    protected String[] createProperties() {
+        return new String[ClientProperty.values().length];
     }
 }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientProperty.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientProperty.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.config;
+
+import com.hazelcast.instance.GroupProperty;
+import com.hazelcast.instance.HazelcastProperty;
+import com.hazelcast.spi.annotation.PrivateApi;
+
+import java.util.concurrent.TimeUnit;
+
+import static com.hazelcast.util.Preconditions.checkHasText;
+import static java.lang.String.format;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+/**
+ * Defines the name and default value for Hazelcast Client properties.
+ */
+@PrivateApi
+public enum ClientProperty implements HazelcastProperty {
+
+    /**
+     * Client shuffles the given member list to prevent all clients to connect to the same node when
+     * this property is set to false. When it is set to true, the client tries to connect to the nodes
+     * in the given order.
+     */
+    SHUFFLE_MEMBER_LIST("hazelcast.client.shuffle.member.list", true),
+
+    /**
+     * Client sends heartbeat messages to the members and this is the timeout for this sending operations.
+     * If there is not any message passing between the client and member within the given time via this property
+     * in milliseconds, the connection will be closed.
+     */
+    HEARTBEAT_TIMEOUT("hazelcast.client.heartbeat.timeout", 60000, MILLISECONDS),
+
+    /**
+     * Time interval between the heartbeats sent by the client to the nodes.
+     */
+    HEARTBEAT_INTERVAL("hazelcast.client.heartbeat.interval", 5000, MILLISECONDS),
+
+    /**
+     * Number of the threads to handle the incoming event packets.
+     */
+    EVENT_THREAD_COUNT("hazelcast.client.event.thread.count", 5),
+
+    /**
+     * Capacity of the executor that handles the incoming event packets.
+     */
+    EVENT_QUEUE_CAPACITY("hazelcast.client.event.queue.capacity", 1000000),
+
+    /**
+     * Time to give up on invocation when a member in the member list is not reachable.
+     */
+    INVOCATION_TIMEOUT_SECONDS("hazelcast.client.invocation.timeout.seconds", 120, SECONDS);
+
+    private final String name;
+    private final String defaultValue;
+    private final TimeUnit timeUnit;
+
+    ClientProperty(String name, boolean defaultValue) {
+        this(name, defaultValue ? "true" : "false");
+    }
+
+    ClientProperty(String name, Integer defaultValue) {
+        this(name, String.valueOf(defaultValue));
+    }
+
+    ClientProperty(String name, String defaultValue) {
+        this(name, defaultValue, null);
+    }
+
+    ClientProperty(String name, Integer defaultValue, TimeUnit timeUnit) {
+        this(name, String.valueOf(defaultValue), timeUnit);
+    }
+
+    ClientProperty(String name, String defaultValue, TimeUnit timeUnit) {
+        checkHasText(name, "The property name cannot be null or empty!");
+
+        this.name = name;
+        this.defaultValue = defaultValue;
+        this.timeUnit = timeUnit;
+    }
+
+    @Override
+    public int getIndex() {
+        return ordinal();
+    }
+
+    @Override
+    public String getName() {
+        return this.name;
+    }
+
+    @Override
+    public String getDefaultValue() {
+        return defaultValue;
+    }
+
+    @Override
+    public TimeUnit getTimeUnit() {
+        if (timeUnit == null) {
+            throw new IllegalArgumentException(format("groupProperty %s has no TimeUnit defined!", this));
+        }
+        return timeUnit;
+    }
+
+    @Override
+    public GroupProperty getParent() {
+        return null;
+    }
+
+    @Override
+    public void setSystemProperty(String value) {
+        System.setProperty(name, value);
+    }
+
+    @Override
+    public String getSystemProperty() {
+        return System.getProperty(name);
+    }
+
+    @Override
+    public String clearSystemProperty() {
+        return System.clearProperty(name);
+    }
+
+    @Override
+    public String toString() {
+        return name;
+    }
+}

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
@@ -8,6 +8,7 @@ import com.hazelcast.client.config.ClientAwsConfig;
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.config.ClientNetworkConfig;
 import com.hazelcast.client.config.ClientProperties;
+import com.hazelcast.client.config.ClientProperty;
 import com.hazelcast.client.config.ClientSecurityConfig;
 import com.hazelcast.client.connection.AddressProvider;
 import com.hazelcast.client.connection.ClientConnectionManager;
@@ -69,6 +70,7 @@ import com.hazelcast.core.MultiMap;
 import com.hazelcast.core.PartitionService;
 import com.hazelcast.core.ReplicatedMap;
 import com.hazelcast.executor.impl.DistributedExecutorService;
+import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.logging.LoggingService;
@@ -78,7 +80,6 @@ import com.hazelcast.mapreduce.impl.MapReduceService;
 import com.hazelcast.multimap.impl.MultiMapService;
 import com.hazelcast.nio.ClassLoaderUtil;
 import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.quorum.QuorumService;
 import com.hazelcast.replicatedmap.impl.ReplicatedMapService;
 import com.hazelcast.ringbuffer.Ringbuffer;
@@ -86,9 +87,9 @@ import com.hazelcast.ringbuffer.impl.RingbufferService;
 import com.hazelcast.security.Credentials;
 import com.hazelcast.security.UsernamePasswordCredentials;
 import com.hazelcast.spi.discovery.DiscoveryMode;
+import com.hazelcast.spi.discovery.impl.DefaultDiscoveryServiceProvider;
 import com.hazelcast.spi.discovery.integration.DiscoveryService;
 import com.hazelcast.spi.discovery.integration.DiscoveryServiceProvider;
-import com.hazelcast.spi.discovery.impl.DefaultDiscoveryServiceProvider;
 import com.hazelcast.spi.impl.SerializableList;
 import com.hazelcast.spi.impl.SerializationServiceSupport;
 import com.hazelcast.topic.impl.TopicService;
@@ -143,9 +144,9 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
                                        AddressProvider externalAddressProvider) {
         this.config = config;
         final GroupConfig groupConfig = config.getGroupConfig();
-        
-        if(config.getInstanceName() != null) {
-        	instanceName = config.getInstanceName();
+
+        if (config.getInstanceName() != null) {
+            instanceName = config.getInstanceName();
         } else {
             instanceName = "hz.client_" + id + (groupConfig != null ? "_" + groupConfig.getName() : "");
         }
@@ -272,14 +273,13 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
     }
 
     private ClientListenerServiceImpl initListenerService() {
-        int eventQueueCapacity = clientProperties.getEventQueueCapacity().getInteger();
-        int eventThreadCount = clientProperties.getEventThreadCount().getInteger();
+        int eventQueueCapacity = clientProperties.getInteger(ClientProperty.EVENT_QUEUE_CAPACITY);
+        int eventThreadCount = clientProperties.getInteger(ClientProperty.EVENT_THREAD_COUNT);
         return new ClientListenerServiceImpl(this, eventThreadCount, eventQueueCapacity);
     }
 
     private ClientExecutionServiceImpl initExecutionService() {
-        return new ClientExecutionServiceImpl(instanceName, threadGroup,
-                config.getClassLoader(), config.getExecutorPoolSize());
+        return new ClientExecutionServiceImpl(instanceName, threadGroup, config.getClassLoader(), config.getExecutorPoolSize());
     }
 
     public void start() {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/ProxyManager.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/ProxyManager.java
@@ -92,6 +92,8 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
+import static com.hazelcast.client.config.ClientProperty.INVOCATION_TIMEOUT_SECONDS;
+
 /**
  * The ProxyManager handles client proxy instantiation and retrieval at start- and runtime by registering
  * corresponding service manager names and their {@link com.hazelcast.client.spi.ClientProxyFactory}s.
@@ -138,7 +140,7 @@ public final class ProxyManager {
 
         register(ReliableTopicService.SERVICE_NAME, new ClientProxyFactory() {
             public ClientProxy create(String id) {
-                 return new ClientReliableTopicProxy(id, client);
+                return new ClientReliableTopicProxy(id, client);
             }
         });
 
@@ -252,10 +254,9 @@ public final class ProxyManager {
     }
 
     private long getRetryCountLimit() {
-        final ClientProperties clientProperties = client.getClientProperties();
-        int waitTime = clientProperties.getInvocationTimeoutSeconds().getInteger();
-        long retryTimeoutInSeconds = waitTime > 0 ? waitTime
-                : Integer.parseInt(ClientProperties.PROP_INVOCATION_TIMEOUT_SECONDS_DEFAULT);
+        ClientProperties clientProperties = client.getClientProperties();
+        int waitTime = clientProperties.getSeconds(INVOCATION_TIMEOUT_SECONDS);
+        long retryTimeoutInSeconds = waitTime > 0 ? waitTime : Integer.parseInt(INVOCATION_TIMEOUT_SECONDS.getDefaultValue());
         return retryTimeoutInSeconds / ClientInvocation.RETRY_WAIT_TIME_IN_SECONDS;
     }
 

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocation.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocation.java
@@ -41,7 +41,8 @@ import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static com.hazelcast.client.config.ClientProperties.PROP_HEARTBEAT_INTERVAL_DEFAULT;
+import static com.hazelcast.client.config.ClientProperty.HEARTBEAT_INTERVAL;
+import static com.hazelcast.client.config.ClientProperty.INVOCATION_TIMEOUT_SECONDS;
 
 public class ClientInvocation implements Runnable {
 
@@ -77,17 +78,16 @@ public class ClientInvocation implements Runnable {
         this.partitionId = partitionId;
         this.address = address;
         this.connection = connection;
-        final ClientProperties clientProperties = client.getClientProperties();
 
-        int waitTime = clientProperties.getInvocationTimeoutSeconds().getInteger();
-        long retryTimeoutInSeconds = waitTime > 0 ? waitTime
-                : Integer.parseInt(ClientProperties.PROP_INVOCATION_TIMEOUT_SECONDS_DEFAULT);
+        ClientProperties clientProperties = client.getClientProperties();
+        int waitTime = clientProperties.getSeconds(INVOCATION_TIMEOUT_SECONDS);
+        long retryTimeoutInSeconds = waitTime > 0 ? waitTime : Integer.parseInt(INVOCATION_TIMEOUT_SECONDS.getDefaultValue());
 
-        clientInvocationFuture = new ClientInvocationFuture(this, client, request, handler);
+        this.clientInvocationFuture = new ClientInvocationFuture(this, client, request, handler);
         this.retryCountLimit = retryTimeoutInSeconds / RETRY_WAIT_TIME_IN_SECONDS;
 
-        int interval = clientProperties.getHeartbeatInterval().getInteger();
-        this.heartBeatInterval = interval > 0 ? interval : Integer.parseInt(PROP_HEARTBEAT_INTERVAL_DEFAULT);
+        int interval = clientProperties.getInteger(HEARTBEAT_INTERVAL);
+        this.heartBeatInterval = interval > 0 ? interval : Integer.parseInt(HEARTBEAT_INTERVAL.getDefaultValue());
     }
 
     public ClientInvocation(HazelcastClientInstanceImpl client, EventHandler handler, ClientRequest request) {
@@ -294,5 +294,4 @@ public class ClientInvocation implements Runnable {
                 || t instanceof HazelcastInstanceNotActiveException
                 || t instanceof AuthenticationException;
     }
-
 }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClusterListenerSupport.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClusterListenerSupport.java
@@ -58,8 +58,9 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 
-public abstract class ClusterListenerSupport implements ConnectionListener, ConnectionHeartbeatListener,
-        ClientClusterService {
+import static com.hazelcast.client.config.ClientProperty.SHUFFLE_MEMBER_LIST;
+
+public abstract class ClusterListenerSupport implements ConnectionListener, ConnectionHeartbeatListener, ClientClusterService {
 
     private static final ILogger LOGGER = Logger.getLogger(ClusterListenerSupport.class);
     private static final long TERMINATE_TIMEOUT_SECONDS = 30;
@@ -80,7 +81,7 @@ public abstract class ClusterListenerSupport implements ConnectionListener, Conn
     public ClusterListenerSupport(HazelcastClientInstanceImpl client, Collection<AddressProvider> addressProviders) {
         this.client = client;
         this.addressProviders = addressProviders;
-        this.shuffleMemberList = client.getClientProperties().getShuffleMemberList().getBoolean();
+        this.shuffleMemberList = client.getClientProperties().getBoolean(SHUFFLE_MEMBER_LIST);
         this.clusterExecutor = createSingleThreadExecutorService(client);
     }
 
@@ -250,7 +251,6 @@ public abstract class ClusterListenerSupport implements ConnectionListener, Conn
 
     @Override
     public void connectionAdded(Connection connection) {
-
     }
 
     @Override
@@ -275,7 +275,6 @@ public abstract class ClusterListenerSupport implements ConnectionListener, Conn
 
     @Override
     public void heartBeatStarted(Connection connection) {
-
     }
 
     @Override
@@ -285,4 +284,3 @@ public abstract class ClusterListenerSupport implements ConnectionListener, Conn
         }
     }
 }
-

--- a/hazelcast-client/src/test/java/com/hazelcast/client/ClientConnectionTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ClientConnectionTest.java
@@ -17,7 +17,7 @@
 package com.hazelcast.client;
 
 import com.hazelcast.client.config.ClientConfig;
-import com.hazelcast.client.config.ClientProperties;
+import com.hazelcast.client.config.ClientProperty;
 import com.hazelcast.client.connection.ClientConnectionManager;
 import com.hazelcast.client.impl.ClientTestUtil;
 import com.hazelcast.client.impl.HazelcastClientInstanceImpl;
@@ -70,7 +70,7 @@ public class ClientConnectionTest extends HazelcastTestSupport {
 
         HazelcastInstance server = hazelcastFactory.newHazelcastInstance();
         ClientConfig config = new ClientConfig();
-        config.setProperty(ClientProperties.PROP_SHUFFLE_MEMBER_LIST, "false");
+        config.setProperty(ClientProperty.SHUFFLE_MEMBER_LIST, "false");
         config.getNetworkConfig().addAddress(illegalAddress).addAddress("localhost");
         HazelcastInstance client = hazelcastFactory.newHazelcastClient(config);
 
@@ -83,12 +83,11 @@ public class ClientConnectionTest extends HazelcastTestSupport {
 
     @Test
     public void testMemberConnectionOrder() {
-
         HazelcastInstance server1 = hazelcastFactory.newHazelcastInstance();
         HazelcastInstance server2 = hazelcastFactory.newHazelcastInstance();
 
         ClientConfig config = new ClientConfig();
-        config.setProperty(ClientProperties.PROP_SHUFFLE_MEMBER_LIST, "false");
+        config.setProperty(ClientProperty.SHUFFLE_MEMBER_LIST, "false");
         config.getNetworkConfig().setSmartRouting(false);
 
         InetSocketAddress socketAddress1 = server1.getCluster().getLocalMember().getSocketAddress();
@@ -141,5 +140,4 @@ public class ClientConnectionTest extends HazelcastTestSupport {
             count.incrementAndGet();
         }
     }
-
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/ClientRegressionWithMockNetworkTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ClientRegressionWithMockNetworkTest.java
@@ -17,7 +17,7 @@
 package com.hazelcast.client;
 
 import com.hazelcast.client.config.ClientConfig;
-import com.hazelcast.client.config.ClientProperties;
+import com.hazelcast.client.config.ClientProperty;
 import com.hazelcast.client.config.ClientSecurityConfig;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.Config;
@@ -78,8 +78,7 @@ import static org.junit.Assert.fail;
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
 @Ignore //https://github.com/hazelcast/hazelcast/issues/6153
-public class ClientRegressionWithMockNetworkTest
-        extends HazelcastTestSupport {
+public class ClientRegressionWithMockNetworkTest extends HazelcastTestSupport {
 
     private final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
 
@@ -87,7 +86,6 @@ public class ClientRegressionWithMockNetworkTest
     public void cleanup() {
         hazelcastFactory.terminateAll();
     }
-
 
     @Test
     public void testInitialMemberListener() throws InterruptedException {
@@ -107,7 +105,7 @@ public class ClientRegressionWithMockNetworkTest
         assertTrue("After starting", latch2.await(5, TimeUnit.SECONDS));
     }
 
-    static class StaticMemberListener implements MembershipListener, InitialMembershipListener {
+    private static class StaticMemberListener implements MembershipListener, InitialMembershipListener {
 
         final CountDownLatch latch;
 
@@ -137,7 +135,6 @@ public class ClientRegressionWithMockNetworkTest
 
         final HazelcastInstance hz1 = hazelcastFactory.newHazelcastInstance();
         hazelcastFactory.newHazelcastInstance();
-
 
         ClientConfig clientConfig = new ClientConfig();
         clientConfig.getNetworkConfig().setRedoOperation(true);
@@ -293,7 +290,6 @@ public class ClientRegressionWithMockNetworkTest
         list.offer(LifecycleState.CLIENT_DISCONNECTED);
         list.offer(LifecycleState.CLIENT_CONNECTED);
 
-
         final HazelcastInstance instance = hazelcastFactory.newHazelcastInstance();
         final CountDownLatch latch = new CountDownLatch(list.size());
         LifecycleListener listener = new LifecycleListener() {
@@ -337,15 +333,12 @@ public class ClientRegressionWithMockNetworkTest
             }
 
             public void memberAdded(MembershipEvent membershipEvent) {
-
             }
 
             public void memberRemoved(MembershipEvent membershipEvent) {
-
             }
 
             public void memberAttributeChanged(MemberAttributeEvent memberAttributeEvent) {
-
             }
         }));
         hazelcastFactory.newHazelcastClient(clientConfig);
@@ -364,7 +357,6 @@ public class ClientRegressionWithMockNetworkTest
         final String id = map.addInterceptor(interceptor);
         assertNotNull(id);
 
-
         map.put("key1", "value");
         assertEquals("value", map.get("key1"));
         map.put("key1", "value1");
@@ -375,7 +367,6 @@ public class ClientRegressionWithMockNetworkTest
 
         assertEquals("val", map.get("key1"));
 
-
         map.put("key2", "oldValue");
         assertEquals("oldValue", map.get("key2"));
         map.put("key2", "newValue");
@@ -384,12 +375,9 @@ public class ClientRegressionWithMockNetworkTest
         map.put("key3", "value2");
         assertEquals("value2", map.get("key3"));
         assertEquals("removeIntercepted", map.remove("key3"));
-
-
     }
 
-    static class MapInterceptorImpl implements MapInterceptor {
-
+    private static class MapInterceptorImpl implements MapInterceptor {
 
         MapInterceptorImpl() {
         }
@@ -402,7 +390,6 @@ public class ClientRegressionWithMockNetworkTest
         }
 
         public void afterGet(Object value) {
-
         }
 
         public Object interceptPut(Object oldValue, Object newValue) {
@@ -424,7 +411,6 @@ public class ClientRegressionWithMockNetworkTest
 
         public void afterRemove(Object value) {
         }
-
     }
 
     @Test
@@ -458,7 +444,6 @@ public class ClientRegressionWithMockNetworkTest
         securityConfig.setCredentialsClassname(MyCredentials.class.getName());
 
         final HazelcastInstance client = hazelcastFactory.newHazelcastClient(clientConfig);
-
     }
 
     public static class MyCredentials extends UsernamePasswordCredentials {
@@ -521,7 +506,6 @@ public class ClientRegressionWithMockNetworkTest
         }
 
         public SamplePortable() {
-
         }
 
         public int getFactoryId() {
@@ -572,7 +556,6 @@ public class ClientRegressionWithMockNetworkTest
                 assertEquals(null, map.get("a"));
             }
         });
-
     }
 
     @Category(NightlyTest.class)
@@ -588,13 +571,11 @@ public class ClientRegressionWithMockNetworkTest
     }
 
     private void testLock_WhenClientAndOwnerNodeDiesTogether(boolean smart) throws InterruptedException {
-
         hazelcastFactory.newHazelcastInstance();
         final ClientConfig clientConfig = new ClientConfig();
         clientConfig.getNetworkConfig().setSmartRouting(smart);
 
         final int tryCount = 5;
-
         for (int i = 0; i < tryCount; i++) {
             final HazelcastInstance instance = hazelcastFactory.newHazelcastInstance();
             final HazelcastInstance client = hazelcastFactory.newHazelcastClient(clientConfig);
@@ -685,9 +666,7 @@ public class ClientRegressionWithMockNetworkTest
     }
 
     @Test(expected = ExecutionException.class, timeout = 120000)
-    public void testGithubIssue3557()
-            throws Exception {
-
+    public void testGithubIssue3557() throws Exception {
         HazelcastInstance hz = hazelcastFactory.newHazelcastInstance();
         HazelcastInstance client = hazelcastFactory.newHazelcastClient();
 
@@ -698,8 +677,7 @@ public class ClientRegressionWithMockNetworkTest
         future.get();
     }
 
-    public static class Issue2509Runnable
-            implements Callable<Integer>, DataSerializable {
+    public static class Issue2509Runnable implements Callable<Integer>, DataSerializable {
 
         private UnDeserializable unDeserializable;
 
@@ -711,16 +689,12 @@ public class ClientRegressionWithMockNetworkTest
         }
 
         @Override
-        public void writeData(ObjectDataOutput out)
-                throws IOException {
-
+        public void writeData(ObjectDataOutput out) throws IOException {
             out.writeObject(unDeserializable);
         }
 
         @Override
-        public void readData(ObjectDataInput in)
-                throws IOException {
-
+        public void readData(ObjectDataInput in) throws IOException {
             unDeserializable = in.readObject();
         }
 
@@ -730,8 +704,7 @@ public class ClientRegressionWithMockNetworkTest
         }
     }
 
-    public static class UnDeserializable
-            implements DataSerializable {
+    public static class UnDeserializable implements DataSerializable {
 
         private int foo;
 
@@ -740,16 +713,12 @@ public class ClientRegressionWithMockNetworkTest
         }
 
         @Override
-        public void writeData(ObjectDataOutput out)
-                throws IOException {
-
+        public void writeData(ObjectDataOutput out) throws IOException {
             out.writeInt(foo);
         }
 
         @Override
-        public void readData(ObjectDataInput in)
-                throws IOException {
-
+        public void readData(ObjectDataInput in) throws IOException {
             foo = in.readInt();
         }
     }
@@ -792,14 +761,13 @@ public class ClientRegressionWithMockNetworkTest
             }
         }).start();
 
-
         ClientConfig clientConfig = new ClientConfig();
         //Retry all requests
         clientConfig.getNetworkConfig().setRedoOperation(true);
         //retry to connect to cluster forever(never shutdown the client)
         clientConfig.getNetworkConfig().setConnectionAttemptLimit(Integer.MAX_VALUE);
         //Retry all requests forever(until client is shutdown)
-        clientConfig.setProperty(ClientProperties.PROP_INVOCATION_TIMEOUT_SECONDS, String.valueOf(Integer.MAX_VALUE));
+        clientConfig.setProperty(ClientProperty.INVOCATION_TIMEOUT_SECONDS, String.valueOf(Integer.MAX_VALUE));
         HazelcastInstance client = hazelcastFactory.newHazelcastClient(clientConfig);
 
         IMap<Object, Object> map = client.getMap(randomMapName());
@@ -825,7 +793,7 @@ public class ClientRegressionWithMockNetworkTest
         //Retry all requests
         clientConfig.getNetworkConfig().setRedoOperation(true);
         //Retry all requests forever(until client is shutdown)
-        clientConfig.setProperty(ClientProperties.PROP_INVOCATION_TIMEOUT_SECONDS, String.valueOf(Integer.MAX_VALUE));
+        clientConfig.setProperty(ClientProperty.INVOCATION_TIMEOUT_SECONDS, String.valueOf(Integer.MAX_VALUE));
         HazelcastInstance client = hazelcastFactory.newHazelcastClient(clientConfig);
 
         final IMap<Object, Object> map = client.getMap(randomMapName());
@@ -863,6 +831,5 @@ public class ClientRegressionWithMockNetworkTest
         hazelcastInstance.shutdown();
 
         assertOpenEventually("Put operations should not hang.", testFinishedLatch);
-
     }
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/config/ClientPropertiesTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/config/ClientPropertiesTest.java
@@ -1,0 +1,112 @@
+package com.hazelcast.client.config;
+
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for {@link ClientProperty} and {@link ClientProperties} classes.
+ * <p/>
+ * Need to run with {@link HazelcastSerialClassRunner} due to tests with System environment variables.
+ */
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+
+public class ClientPropertiesTest {
+
+    private final ClientConfig config = new ClientConfig();
+    private final ClientProperties defaultClientProperties = new ClientProperties(config);
+
+    @Test(expected = NullPointerException.class)
+    public void constructor_withNullConfig() {
+        new ClientProperties(null);
+    }
+
+    @Test
+    public void setProperty_ensureHighestPriorityOfConfig() {
+        config.setProperty(ClientProperty.EVENT_THREAD_COUNT, "1000");
+        ClientProperty.EVENT_THREAD_COUNT.setSystemProperty("5000");
+
+        ClientProperties ClientProperties = new ClientProperties(config);
+        int eventThreadCount = ClientProperties.getInteger(ClientProperty.EVENT_THREAD_COUNT);
+
+        ClientProperty.EVENT_THREAD_COUNT.clearSystemProperty();
+
+        assertEquals(1000, eventThreadCount);
+    }
+
+    @Test
+    public void setProperty_ensureUsageOfSystemProperty() {
+        ClientProperty.EVENT_THREAD_COUNT.setSystemProperty("2342");
+
+        ClientProperties ClientProperties = new ClientProperties(config);
+        int eventThreadCount = ClientProperties.getInteger(ClientProperty.EVENT_THREAD_COUNT);
+
+        ClientProperty.EVENT_THREAD_COUNT.clearSystemProperty();
+
+        assertEquals(2342, eventThreadCount);
+    }
+
+    @Test
+    public void setProperty_ensureUsageOfDefaultValue() {
+        int eventThreadCount = defaultClientProperties.getInteger(ClientProperty.EVENT_THREAD_COUNT);
+
+        assertEquals(5, eventThreadCount);
+    }
+
+    @Test
+    public void getSystemProperty() {
+        ClientProperty.EVENT_THREAD_COUNT.setSystemProperty("8000");
+
+        assertEquals("8000", ClientProperty.EVENT_THREAD_COUNT.getSystemProperty());
+
+        ClientProperty.EVENT_THREAD_COUNT.clearSystemProperty();
+    }
+
+    @Test
+    public void getBoolean() {
+        boolean shuffleMemberList = defaultClientProperties.getBoolean(ClientProperty.SHUFFLE_MEMBER_LIST);
+
+        assertTrue(shuffleMemberList);
+    }
+
+    @Test
+    public void getInteger() {
+        int eventThreadCount = defaultClientProperties.getInteger(ClientProperty.EVENT_THREAD_COUNT);
+
+        assertEquals(5, eventThreadCount);
+    }
+
+    @Test
+    public void getTimeUnit() {
+        config.setProperty(ClientProperty.INVOCATION_TIMEOUT_SECONDS, "300");
+        ClientProperties ClientProperties = new ClientProperties(config);
+
+        assertEquals(300, ClientProperties.getSeconds(ClientProperty.INVOCATION_TIMEOUT_SECONDS));
+    }
+
+    @Test
+    public void getTimeUnit_default() {
+        long expectedSeconds = 5;
+
+        long intervalNanos = defaultClientProperties.getNanos(ClientProperty.HEARTBEAT_INTERVAL);
+        long intervalMillis = defaultClientProperties.getMillis(ClientProperty.HEARTBEAT_INTERVAL);
+        long intervalSeconds = defaultClientProperties.getSeconds(ClientProperty.HEARTBEAT_INTERVAL);
+
+        assertEquals(TimeUnit.SECONDS.toNanos(expectedSeconds), intervalNanos);
+        assertEquals(TimeUnit.SECONDS.toMillis(expectedSeconds), intervalMillis);
+        assertEquals(expectedSeconds, intervalSeconds);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void getTimeUnit_noTimeUnitProperty() {
+        defaultClientProperties.getMillis(ClientProperty.EVENT_QUEUE_CAPACITY);
+    }
+}

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapIssueTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapIssueTest.java
@@ -17,7 +17,7 @@
 package com.hazelcast.client.map;
 
 import com.hazelcast.client.config.ClientConfig;
-import com.hazelcast.client.config.ClientProperties;
+import com.hazelcast.client.config.ClientProperty;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.core.EntryAdapter;
 import com.hazelcast.core.HazelcastInstance;
@@ -94,7 +94,7 @@ public class ClientMapIssueTest extends HazelcastTestSupport {
         ClientConfig clientConfig = new ClientConfig();
         clientConfig.setExecutorPoolSize(1);
         clientConfig.getNetworkConfig().setConnectionAttemptLimit(Integer.MAX_VALUE);
-        clientConfig.setProperty(ClientProperties.PROP_INVOCATION_TIMEOUT_SECONDS, "10");
+        clientConfig.setProperty(ClientProperty.INVOCATION_TIMEOUT_SECONDS, "10");
 
         HazelcastInstance client = hazelcastFactory.newHazelcastClient(clientConfig);
         final IMap<String, String> map = client.getMap(randomMapName());
@@ -128,7 +128,7 @@ public class ClientMapIssueTest extends HazelcastTestSupport {
         ClientConfig clientConfig = new ClientConfig();
         clientConfig.setExecutorPoolSize(1);
         clientConfig.getNetworkConfig().setConnectionAttemptLimit(Integer.MAX_VALUE);
-        clientConfig.setProperty(ClientProperties.PROP_INVOCATION_TIMEOUT_SECONDS, "10");
+        clientConfig.setProperty(ClientProperty.INVOCATION_TIMEOUT_SECONDS, "10");
 
         HazelcastInstance client = hazelcastFactory.newHazelcastClient(clientConfig);
         final IMap<String, String> map = client.getMap(randomMapName());
@@ -221,5 +221,4 @@ public class ClientMapIssueTest extends HazelcastTestSupport {
         final Set<Integer> values = map.keySet(predicate);
         assertEquals(pageSize, values.size());
     }
-
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/replicatedmap/ClientReplicatedMapLiteMemberTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/replicatedmap/ClientReplicatedMapLiteMemberTest.java
@@ -2,7 +2,7 @@ package com.hazelcast.client.replicatedmap;
 
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.config.ClientNetworkConfig;
-import com.hazelcast.client.config.ClientProperties;
+import com.hazelcast.client.config.ClientProperty;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
@@ -11,15 +11,16 @@ import com.hazelcast.replicatedmap.ReplicatedMapCantBeCreatedOnLiteMemberExcepti
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
-import java.net.InetSocketAddress;
-import java.net.UnknownHostException;
-import java.util.ArrayList;
-import java.util.List;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+
+import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.List;
 
 import static com.hazelcast.test.HazelcastTestSupport.assertClusterSizeEventually;
 import static com.hazelcast.test.HazelcastTestSupport.getAddress;
@@ -81,8 +82,8 @@ public class ClientReplicatedMapLiteMemberTest {
     }
 
     private void testReplicatedMapCreated(final int numberOfLiteNodes,
-                                            final int numberOfDataNodes,
-                                            final ClientConfig clientConfig) {
+                                          final int numberOfDataNodes,
+                                          final ClientConfig clientConfig) {
         createNodes(numberOfLiteNodes, numberOfDataNodes);
 
         final HazelcastInstance client = factory.newHazelcastClient(clientConfig);
@@ -99,8 +100,7 @@ public class ClientReplicatedMapLiteMemberTest {
     }
 
     @Test
-    public void testReplicatedMapPutByDummyClient()
-            throws UnknownHostException {
+    public void testReplicatedMapPutByDummyClient() throws UnknownHostException {
         final List<HazelcastInstance> instances = createNodes(3, 1);
         configureDummyClientConnection(instances.get(0));
 
@@ -111,10 +111,9 @@ public class ClientReplicatedMapLiteMemberTest {
     }
 
 
-    private void configureDummyClientConnection(final HazelcastInstance instance)
-            throws UnknownHostException {
+    private void configureDummyClientConnection(final HazelcastInstance instance) throws UnknownHostException {
         final InetSocketAddress socketAddress = getAddress(instance).getInetSocketAddress();
-        dummyClientConfig.setProperty(ClientProperties.PROP_SHUFFLE_MEMBER_LIST, "false");
+        dummyClientConfig.setProperty(ClientProperty.SHUFFLE_MEMBER_LIST, "false");
         final ClientNetworkConfig networkConfig = dummyClientConfig.getNetworkConfig();
         networkConfig.addAddress(socketAddress.getHostName() + ":" + socketAddress.getPort());
     }
@@ -123,11 +122,11 @@ public class ClientReplicatedMapLiteMemberTest {
         final List<HazelcastInstance> instances = new ArrayList<HazelcastInstance>();
 
         final Config liteConfig = new Config().setLiteMember(true);
-        for (int i = 0;  i < numberOfLiteNodes; i++) {
+        for (int i = 0; i < numberOfLiteNodes; i++) {
             instances.add(factory.newHazelcastInstance(liteConfig));
         }
 
-        for (int i = 0;  i < numberOfDataNodes; i++) {
+        for (int i = 0; i < numberOfDataNodes; i++) {
             instances.add(factory.newHazelcastInstance());
         }
 
@@ -138,5 +137,4 @@ public class ClientReplicatedMapLiteMemberTest {
 
         return instances;
     }
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/instance/GroupProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/GroupProperty.java
@@ -23,6 +23,7 @@ import com.hazelcast.map.QueryResultSizeExceededException;
 import com.hazelcast.map.impl.query.QueryResultSizeLimiter;
 import com.hazelcast.query.TruePredicate;
 import com.hazelcast.query.impl.predicates.QueryOptimizerFactory;
+import com.hazelcast.spi.annotation.PrivateApi;
 
 import java.util.concurrent.TimeUnit;
 
@@ -34,6 +35,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 /**
  * Defines the name and default value for Hazelcast properties.
  */
+@PrivateApi
 public enum GroupProperty implements HazelcastProperty {
 
     /**
@@ -608,25 +610,21 @@ public enum GroupProperty implements HazelcastProperty {
         this.parent = parent;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
+    public int getIndex() {
+        return ordinal();
+    }
+
     @Override
     public String getName() {
         return name;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public String getDefaultValue() {
         return defaultValue;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public TimeUnit getTimeUnit() {
         if (timeUnit == null) {
@@ -635,35 +633,22 @@ public enum GroupProperty implements HazelcastProperty {
         return timeUnit;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public GroupProperty getParent() {
         return parent;
     }
 
-    /**
-     * Sets the environmental value of the property.
-     *
-     * @param value the value to set
-     */
+    @Override
     public void setSystemProperty(String value) {
         System.setProperty(name, value);
     }
 
-    /**
-     * Gets the environmental value of the property.
-     *
-     * @return the value of the property
-     */
+    @Override
     public String getSystemProperty() {
         return System.getProperty(name);
     }
 
-    /**
-     * Clears the environmental value of the property.
-     */
+    @Override
     public String clearSystemProperty() {
         return System.clearProperty(name);
     }

--- a/hazelcast/src/main/java/com/hazelcast/instance/HazelcastProperties.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/HazelcastProperties.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.instance;
+
+import com.hazelcast.config.Config;
+
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+
+import static java.lang.String.format;
+
+/**
+ * Container for configured Hazelcast properties ({@see HazelcastProperty}).
+ * <p/>
+ * A {@link HazelcastProperty} can be set as:
+ * <p><ul>
+ * <li>an environmental variable using {@link System#setProperty(String, String)}</li>
+ * <li>the programmatic configuration using {@link Config#setProperty(String, String)}</li>
+ * <li>the XML configuration
+ * {@see http://docs.hazelcast.org/docs/latest-dev/manual/html-single/hazelcast-documentation.html#system-properties}</li>
+ * </ul></p>
+ */
+public abstract class HazelcastProperties {
+
+    private final String[] properties = createProperties();
+
+    /**
+     * Created the properties array.
+     *
+     * @return a String array with the size of the properties.
+     */
+    protected abstract String[] createProperties();
+
+    /**
+     * Creates a container with configured Hazelcast properties.
+     * <p/>
+     * Uses the environmental value if no value is defined in the configuration.
+     * Uses the default value if no environmental value is defined.
+     *
+     * @param properties          {@link Properties} used to configure the {@link HazelcastProperty} values.
+     * @param hazelcastProperties array of {@link HazelcastProperty} to configure
+     */
+    protected void initProperties(Properties properties, HazelcastProperty[] hazelcastProperties) {
+        for (HazelcastProperty property : hazelcastProperties) {
+            String configValue = (properties != null) ? properties.getProperty(property.getName()) : null;
+            if (configValue != null) {
+                this.properties[property.getIndex()] = configValue;
+                continue;
+            }
+            String propertyValue = property.getSystemProperty();
+            if (propertyValue != null) {
+                this.properties[property.getIndex()] = propertyValue;
+                continue;
+            }
+            GroupProperty parent = property.getParent();
+            if (parent != null) {
+                this.properties[property.getIndex()] = this.properties[parent.ordinal()];
+                continue;
+            }
+            this.properties[property.getIndex()] = property.getDefaultValue();
+        }
+    }
+
+    /**
+     * Returns the configured value of a {@link HazelcastProperty} as String.
+     *
+     * @param groupProperty the {@link HazelcastProperty} to get the value from
+     * @return the value or <tt>null</tt> if nothing has been configured
+     */
+    public String getString(HazelcastProperty groupProperty) {
+        return properties[groupProperty.getIndex()];
+    }
+
+    /**
+     * Returns the configured boolean value of a {@link HazelcastProperty}.
+     *
+     * @param groupProperty the {@link HazelcastProperty} to get the value from
+     * @return the value as boolean
+     */
+    public boolean getBoolean(HazelcastProperty groupProperty) {
+        return Boolean.valueOf(properties[groupProperty.getIndex()]);
+    }
+
+    /**
+     * Returns the configured int value of a {@link HazelcastProperty}.
+     *
+     * @param groupProperty the {@link HazelcastProperty} to get the value from
+     * @return the value as int
+     * @throws NumberFormatException if the value cannot be parsed
+     */
+    public int getInteger(HazelcastProperty groupProperty) {
+        return Integer.parseInt(properties[groupProperty.getIndex()]);
+    }
+
+    /**
+     * Returns the configured long value of a {@link HazelcastProperty}.
+     *
+     * @param groupProperty the {@link HazelcastProperty} to get the value from
+     * @return the value as long
+     * @throws NumberFormatException if the value cannot be parsed
+     */
+    public long getLong(HazelcastProperty groupProperty) {
+        return Long.parseLong(properties[groupProperty.getIndex()]);
+    }
+
+    /**
+     * Returns the configured float value of a {@link HazelcastProperty}.
+     *
+     * @param groupProperty the {@link HazelcastProperty} to get the value from
+     * @return the value as float
+     * @throws NumberFormatException if the value cannot be parsed
+     */
+    public float getFloat(HazelcastProperty groupProperty) {
+        return Float.valueOf(properties[groupProperty.getIndex()]);
+    }
+
+    /**
+     * Returns the configured value of a {@link HazelcastProperty} converted to nanoseconds.
+     *
+     * @param groupProperty the {@link HazelcastProperty} to get the value from
+     * @return the value in nanoseconds
+     * @throws IllegalArgumentException if the {@link HazelcastProperty} has no {@link TimeUnit}
+     */
+    public long getNanos(HazelcastProperty groupProperty) {
+        TimeUnit timeUnit = groupProperty.getTimeUnit();
+        return timeUnit.toNanos(getLong(groupProperty));
+    }
+
+    /**
+     * Returns the configured value of a {@link HazelcastProperty} converted to milliseconds.
+     *
+     * @param groupProperty the {@link HazelcastProperty} to get the value from
+     * @return the value in milliseconds
+     * @throws IllegalArgumentException if the {@link HazelcastProperty} has no {@link TimeUnit}
+     */
+    public long getMillis(HazelcastProperty groupProperty) {
+        TimeUnit timeUnit = groupProperty.getTimeUnit();
+        return timeUnit.toMillis(getLong(groupProperty));
+    }
+
+    /**
+     * Returns the configured value of a {@link HazelcastProperty} converted to seconds.
+     *
+     * @param groupProperty the {@link HazelcastProperty} to get the value from
+     * @return the value in seconds
+     * @throws IllegalArgumentException if the {@link HazelcastProperty} has no {@link TimeUnit}
+     */
+    public int getSeconds(HazelcastProperty groupProperty) {
+        TimeUnit timeUnit = groupProperty.getTimeUnit();
+        return (int) timeUnit.toSeconds(getLong(groupProperty));
+    }
+
+    /**
+     * Returns the configured enum value of a {@link GroupProperty}.
+     * <p/>
+     * The case of the enum is ignored.
+     *
+     * @param groupProperty the {@link GroupProperty} to get the value from
+     * @return the enum
+     * @throws IllegalArgumentException if the enum value can't be found
+     */
+    public <E extends Enum> E getEnum(GroupProperty groupProperty, Class<E> enumClazz) {
+        String value = getString(groupProperty);
+
+        for (E enumConstant : enumClazz.getEnumConstants()) {
+            if (enumConstant.name().equalsIgnoreCase(value)) {
+                return enumConstant;
+            }
+        }
+
+        throw new IllegalArgumentException(format("value '%s' for property '%s' is not a valid %s value",
+                value, groupProperty.getName(), enumClazz.getName()));
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/instance/HazelcastProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/HazelcastProperty.java
@@ -16,12 +16,22 @@
 
 package com.hazelcast.instance;
 
+import com.hazelcast.spi.annotation.PrivateApi;
+
 import java.util.concurrent.TimeUnit;
 
 /**
  * Interface for Hazelcast Member and Client properties.
  */
+@PrivateApi
 public interface HazelcastProperty {
+
+    /**
+     * Gets the index of the property.
+     *
+     * @return index of the property
+     */
+    int getIndex();
 
     /**
      * Returns the property name.
@@ -51,4 +61,23 @@ public interface HazelcastProperty {
      * @return the parent {@link GroupProperty} or <tt>null</tt> if none is defined
      */
     GroupProperty getParent();
+
+    /**
+     * Sets the environmental value of the property.
+     *
+     * @param value the value to set
+     */
+    void setSystemProperty(String value);
+
+    /**
+     * Gets the environmental value of the property.
+     *
+     * @return the value of the property
+     */
+    String getSystemProperty();
+
+    /**
+     * Clears the environmental value of the property.
+     */
+    String clearSystemProperty();
 }

--- a/hazelcast/src/test/java/com/hazelcast/instance/GroupPropertiesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/GroupPropertiesTest.java
@@ -26,6 +26,11 @@ public class GroupPropertiesTest {
     private final Config config = new Config();
     private final GroupProperties defaultGroupProperties = new GroupProperties(config);
 
+    @Test(expected = NullPointerException.class)
+    public void constructor_withNullConfig() {
+        new GroupProperties(null);
+    }
+
     @Test
     public void setProperty_ensureHighestPriorityOfConfig() {
         config.setProperty(GroupProperty.ELASTIC_MEMORY_TOTAL_SIZE, "configValue");
@@ -52,28 +57,8 @@ public class GroupPropertiesTest {
     }
 
     @Test
-    public void setProperty_ensureUsageOfSystemProperty_withNullConfig() {
-        GroupProperty.ELASTIC_MEMORY_TOTAL_SIZE.setSystemProperty("systemValue");
-
-        GroupProperties groupProperties = new GroupProperties(null);
-        String loggingType = groupProperties.getString(GroupProperty.ELASTIC_MEMORY_TOTAL_SIZE);
-
-        GroupProperty.ELASTIC_MEMORY_TOTAL_SIZE.clearSystemProperty();
-
-        assertEquals("systemValue", loggingType);
-    }
-
-    @Test
     public void setProperty_ensureUsageOfDefaultValue() {
         String loggingType = defaultGroupProperties.getString(GroupProperty.ELASTIC_MEMORY_TOTAL_SIZE);
-
-        assertEquals("128M", loggingType);
-    }
-
-    @Test
-    public void setProperty_ensureUsageOfDefaultValue_withNullConfig() {
-        GroupProperties groupProperties = new GroupProperties(null);
-        String loggingType = groupProperties.getString(GroupProperty.ELASTIC_MEMORY_TOTAL_SIZE);
 
         assertEquals("128M", loggingType);
     }


### PR DESCRIPTION
* Cleanup of `ClientProperties` according to `GroupProperties`.
* Pulled out `HazelcastProperties` to reduce code duplication.
* Added `@PrivateApi` annotation to `GroupProperty`, `ClientProperty` and `HazelcastProperty` classes.