### PR TITLE
Cleanup of GroupPropery usage

### DIFF
--- a/hazelcast-client-new/src/test/java/com/hazelcast/client/SimpleMapTestFromClient.java
+++ b/hazelcast-client-new/src/test/java/com/hazelcast/client/SimpleMapTestFromClient.java
@@ -35,8 +35,8 @@ public class SimpleMapTestFromClient {
         GroupProperty.WAIT_SECONDS_BEFORE_JOIN.setSystemProperty("0");
         System.setProperty("java.net.preferIPv4Stack", "true");
         System.setProperty("hazelcast.local.localAddress", "127.0.0.1");
-        System.setProperty("hazelcast.version.check.enabled", "false");
-        System.setProperty("hazelcast.socket.bind.any", "false");
+        GroupProperty.VERSION_CHECK_ENABLED.setSystemProperty("false");
+        GroupProperty.SOCKET_BIND_ANY.setSystemProperty("false");
 
         Random rand = new Random();
         int g1 = rand.nextInt(255);

--- a/hazelcast-client/src/test/java/com/hazelcast/client/SimpleMapTestFromClient.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/SimpleMapTestFromClient.java
@@ -35,8 +35,8 @@ public class SimpleMapTestFromClient {
         GroupProperty.WAIT_SECONDS_BEFORE_JOIN.setSystemProperty("0");
         System.setProperty("java.net.preferIPv4Stack", "true");
         System.setProperty("hazelcast.local.localAddress", "127.0.0.1");
-        System.setProperty("hazelcast.version.check.enabled", "false");
-        System.setProperty("hazelcast.socket.bind.any", "false");
+        GroupProperty.VERSION_CHECK_ENABLED.setSystemProperty("false");
+        GroupProperty.SOCKET_BIND_ANY.setSystemProperty("false");
 
         Random rand = new Random();
         int g1 = rand.nextInt(255);

--- a/hazelcast/src/main/java/com/hazelcast/internal/monitors/HealthMonitor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/monitors/HealthMonitor.java
@@ -38,15 +38,15 @@ import static java.util.concurrent.TimeUnit.SECONDS;
  * Health monitor periodically prints logs about related internal metrics using the {@link MetricsRegistry} to provides some clues
  * about the internal Hazelcast state.
  * <p/>
- * Health monitor can be configured with system properties
+ * Health monitor can be configured with system properties.
  * <p/>
- * "hazelcast.health.monitoring.level"
- * This property can be one of the following
- * NOISY           => does not check threshold , always prints.
- * SILENT(default) => prints only if metrics are above threshold.
- * OFF             => Does not print anything.
+ * {@link com.hazelcast.instance.GroupProperty#HEALTH_MONITORING_LEVEL}
+ * This property can be one of the following:
+ * {@link HealthMonitorLevel#NOISY}  => does not check threshold, always prints.
+ * {@link HealthMonitorLevel#SILENT} => prints only if metrics are above threshold (default).
+ * {@link HealthMonitorLevel#OFF}    => does not print anything.
  * <p/>
- * "hazelcast.health.monitoring.delay.seconds"
+ * {@link com.hazelcast.instance.GroupProperty#HEALTH_MONITORING_DELAY_SECONDS}
  * Time between printing two logs of health monitor. Default values is 30 seconds.
  */
 public class HealthMonitor {

--- a/hazelcast/src/main/java/com/hazelcast/internal/monitors/HealthMonitorLevel.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/monitors/HealthMonitorLevel.java
@@ -17,19 +17,22 @@
 package com.hazelcast.internal.monitors;
 
 /**
- *  Health monitor can be configured with system properties
+ * Health monitor can be configured with system properties.
  *
- * "hazelcast.health.monitoring.level"
+ * {@link com.hazelcast.instance.GroupProperty#HEALTH_MONITORING_LEVEL}
  */
 public enum HealthMonitorLevel {
+
     /**
      * Does not print anything.
      */
     OFF,
+
     /**
      * (default) Prints only if metrics are above threshold.
      */
     SILENT,
+
     /**
      * Does not check threshold , always prints.
      */


### PR DESCRIPTION
Made usage of `GroupyProperty` constants where string literals where used in code.