### PR TITLE
compile fix for java 1.6

### DIFF
--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/cache/impl/AbstractClientCacheProxy.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/cache/impl/AbstractClientCacheProxy.java
@@ -346,7 +346,7 @@ abstract class AbstractClientCacheProxy<K, V>
         final long start = System.nanoTime();
         final Future<Boolean> f = putIfAbsentAsyncInternal(key, value, expiryPolicy, true, false);
         try {
-            boolean saved = toObject(f.get());
+            boolean saved = f.get();
             if (statisticsEnabled) {
                 handleStatisticsOnPutIfAbsent(start, saved);
             }
@@ -361,7 +361,7 @@ abstract class AbstractClientCacheProxy<K, V>
         final long start = System.nanoTime();
         final Future<Boolean> f = replaceAsyncInternal(key, oldValue, newValue, expiryPolicy, true, true, false);
         try {
-            boolean replaced = toObject(f.get());
+            boolean replaced = f.get();
             if (statisticsEnabled) {
                 handleStatisticsOnReplace(false, start, replaced);
             }
@@ -376,7 +376,7 @@ abstract class AbstractClientCacheProxy<K, V>
         final long start = System.nanoTime();
         final Future<Boolean> f = replaceAsyncInternal(key, null, value, expiryPolicy, false, true, false);
         try {
-            boolean replaced = toObject(f.get());
+            boolean replaced = f.get();
             if (statisticsEnabled) {
                 handleStatisticsOnReplace(false, start, replaced);
             }
@@ -391,7 +391,7 @@ abstract class AbstractClientCacheProxy<K, V>
         final long start = System.nanoTime();
         final Future<V> f = replaceAndGetAsyncInternal(key, null, value, expiryPolicy, false, true, false);
         try {
-            V oldValue = toObject(f.get());
+            V oldValue = f.get();
             if (statisticsEnabled) {
                 handleStatisticsOnReplace(true, start, oldValue);
             }

--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/cache/impl/AbstractClientInternalCacheProxy.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/cache/impl/AbstractClientInternalCacheProxy.java
@@ -439,7 +439,7 @@ abstract class AbstractClientInternalCacheProxy<K, V>
         }
 
         ClientDelegatingFuture delegatingFuture =
-                new ClientDelegatingFuture<T>(future, clientContext.getSerializationService(),
+                new ClientDelegatingFuture<Data>(future, clientContext.getSerializationService(),
                                               getAndReplaceResponseDecoder);
         if (async && statisticsEnabled) {
             delegatingFuture.andThen(new ExecutionCallback<Object>() {


### PR DESCRIPTION
Error caused by toObject method generics:
type parameters of T cannot be determined; no unique maximal instance exists for type variable T with upper bounds boolean,java.lang.Object

toObject methods are removed since they are not needed anyway. Response is already deserialized.

backport of https://github.com/hazelcast/hazelcast/pull/6381