### PR TITLE
Fix spuriously failing cluster state tests

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/ClusterStateManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/ClusterStateManager.java
@@ -128,7 +128,7 @@ public class ClusterStateManager {
 
             final ClusterStateLock currentLock = getStateLock();
             if (!currentLock.allowsLock(txnId)) {
-                throw new TransactionException("Locking failed for " + initiator
+                throw new TransactionException("Locking failed for " + initiator + ", tx: " + txnId
                         + ", current state: " + toString());
             }
             stateLockRef.set(new ClusterStateLock(initiator, txnId, leaseTime));


### PR DESCRIPTION
Fixed (hopefully) spuriously failing cluster state tests:
- Some with increasing transaction timeout
- Some with making cluster change in an eventual way

Fixes #6383