### PR TITLE
Reduce index memory usage

### DIFF
--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/cache/impl/AbstractClientCacheProxy.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/cache/impl/AbstractClientCacheProxy.java
@@ -334,7 +334,7 @@ abstract class AbstractClientCacheProxy<K, V>
         final long start = System.nanoTime();
         final Future<Boolean> f = putIfAbsentAsyncInternal(key, value, expiryPolicy, true, false);
         try {
-            boolean saved = toObject(f.get());
+            boolean saved = f.get();
             if (statisticsEnabled) {
                 handleStatisticsOnPutIfAbsent(start, saved);
             }
@@ -349,7 +349,7 @@ abstract class AbstractClientCacheProxy<K, V>
         final long start = System.nanoTime();
         final Future<Boolean> f = replaceAsyncInternal(key, oldValue, newValue, expiryPolicy, true, true, false);
         try {
-            boolean replaced = toObject(f.get());
+            boolean replaced = f.get();
             if (statisticsEnabled) {
                 handleStatisticsOnReplace(false, start, replaced);
             }
@@ -364,7 +364,7 @@ abstract class AbstractClientCacheProxy<K, V>
         final long start = System.nanoTime();
         final Future<Boolean> f = replaceAsyncInternal(key, null, value, expiryPolicy, false, true, false);
         try {
-            boolean replaced = toObject(f.get());
+            boolean replaced = f.get();
             if (statisticsEnabled) {
                 handleStatisticsOnReplace(false, start, replaced);
             }
@@ -379,7 +379,7 @@ abstract class AbstractClientCacheProxy<K, V>
         final long start = System.nanoTime();
         final Future<V> f = replaceAndGetAsyncInternal(key, null, value, expiryPolicy, false, true, false);
         try {
-            V oldValue = toObject(f.get());
+            V oldValue = f.get();
             if (statisticsEnabled) {
                 handleStatisticsOnReplace(true, start, oldValue);
             }

--- a/hazelcast-client-new/src/test/java/com/hazelcast/client/map/ClientSortLimitTest.java
+++ b/hazelcast-client-new/src/test/java/com/hazelcast/client/map/ClientSortLimitTest.java
@@ -340,7 +340,7 @@ public class ClientSortLimitTest extends HazelcastTestSupport {
             set = map.entrySet(pagingPredicate);
             for (Map.Entry<Integer, Employee> entry : set) {
                 Employee e = entry.getValue();
-                QueryEntry qe = new QueryEntry(null, ss.toData(e.getId()), e.getId(), e);
+                QueryEntry qe = new QueryEntry(ss, ss.toData(e.getId()), e.getId(), e);
                 assertTrue(predicate.apply(qe));
                 results.add(e);
             }

--- a/hazelcast-client-new/src/test/java/com/hazelcast/client/map/ClientSortLimitTest.java
+++ b/hazelcast-client-new/src/test/java/com/hazelcast/client/map/ClientSortLimitTest.java
@@ -340,7 +340,7 @@ public class ClientSortLimitTest extends HazelcastTestSupport {
             set = map.entrySet(pagingPredicate);
             for (Map.Entry<Integer, Employee> entry : set) {
                 Employee e = entry.getValue();
-                QueryEntry qe = new QueryEntry(ss, ss.toData(e.getId()), e.getId(), e);
+                QueryEntry qe = new QueryEntry(ss, ss.toData(e.getId()), e);
                 assertTrue(predicate.apply(qe));
                 results.add(e);
             }

--- a/hazelcast-client-new/src/test/java/com/hazelcast/client/map/ClientSortLimitTest.java
+++ b/hazelcast-client-new/src/test/java/com/hazelcast/client/map/ClientSortLimitTest.java
@@ -58,7 +58,7 @@ import static org.junit.Assert.assertTrue;
 public class ClientSortLimitTest extends HazelcastTestSupport {
 
     private final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
-    private final SerializationService ss = new DefaultSerializationServiceBuilder().build();
+    private final SerializationService serializationService = new DefaultSerializationServiceBuilder().build();
     private HazelcastInstance client;
     private HazelcastInstance server;
     private IMap map;
@@ -340,7 +340,7 @@ public class ClientSortLimitTest extends HazelcastTestSupport {
             set = map.entrySet(pagingPredicate);
             for (Map.Entry<Integer, Employee> entry : set) {
                 Employee e = entry.getValue();
-                QueryEntry qe = new QueryEntry(ss, ss.toData(e.getId()), e);
+                QueryEntry qe = new QueryEntry(serializationService, serializationService.toData(e.getId()), e);
                 assertTrue(predicate.apply(qe));
                 results.add(e);
             }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientSortLimitTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientSortLimitTest.java
@@ -340,7 +340,7 @@ public class ClientSortLimitTest extends HazelcastTestSupport {
             set = map.entrySet(pagingPredicate);
             for (Map.Entry<Integer, Employee> entry : set) {
                 Employee e = entry.getValue();
-                QueryEntry qe = new QueryEntry(null, ss.toData(e.getId()), e.getId(), e);
+                QueryEntry qe = new QueryEntry(ss, ss.toData(e.getId()), e.getId(), e);
                 assertTrue(predicate.apply(qe));
                 results.add(e);
             }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientSortLimitTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientSortLimitTest.java
@@ -340,7 +340,7 @@ public class ClientSortLimitTest extends HazelcastTestSupport {
             set = map.entrySet(pagingPredicate);
             for (Map.Entry<Integer, Employee> entry : set) {
                 Employee e = entry.getValue();
-                QueryEntry qe = new QueryEntry(ss, ss.toData(e.getId()), e.getId(), e);
+                QueryEntry qe = new QueryEntry(ss, ss.toData(e.getId()), e);
                 assertTrue(predicate.apply(qe));
                 results.add(e);
             }

--- a/hazelcast/src/main/java/com/hazelcast/instance/GroupProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/GroupProperty.java
@@ -548,6 +548,18 @@ public enum GroupProperty implements HazelcastProperty {
      */
     QUERY_OPTIMIZER_TYPE("hazelcast.query.optimizer.type", QueryOptimizerFactory.Type.RULES.toString()),
 
+
+    /**
+     * Cache de-serialized entries. Decreases number of de-serializations needed to evaluate a query when true.
+     * It allows to trade some memory for CPU cycles.
+     *
+     * Default: true
+     *
+     * TODO: What should be default here?
+     *
+     */
+    QUERY_CACHE_ENTRIES("hazelcast.query.cache.entries", true),
+
     /**
      * Forces the JCache provider, which can have values client or server, to force the provider type.
      * If not provided, the provider will be client or server, whichever is found on the classpath first respectively.

--- a/hazelcast/src/main/java/com/hazelcast/instance/GroupProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/GroupProperty.java
@@ -550,17 +550,6 @@ public enum GroupProperty implements HazelcastProperty {
 
 
     /**
-     * Cache de-serialized entries. Decreases number of de-serializations needed to evaluate a query when true.
-     * It allows to trade some memory for CPU cycles.
-     *
-     * Default: true
-     *
-     * TODO: What should be default here?
-     *
-     */
-    QUERY_CACHE_ENTRIES("hazelcast.query.cache.entries", true),
-
-    /**
      * Forces the JCache provider, which can have values client or server, to force the provider type.
      * If not provided, the provider will be client or server, whichever is found on the classpath first respectively.
      */

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapContainer.java
@@ -31,6 +31,7 @@ import com.hazelcast.core.PartitioningStrategy;
 import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.map.MapInterceptor;
 import com.hazelcast.map.impl.mapstore.MapStoreContext;
+import com.hazelcast.map.impl.query.QueryEntryFactory;
 import com.hazelcast.map.impl.record.DataRecordFactory;
 import com.hazelcast.map.impl.record.NativeRecordFactory;
 import com.hazelcast.map.impl.record.ObjectRecordFactory;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapContainer.java
@@ -16,11 +16,19 @@
 
 package com.hazelcast.map.impl;
 
+import static com.hazelcast.map.impl.ExpirationTimeSetter.calculateMaxIdleMillis;
+import static com.hazelcast.map.impl.ExpirationTimeSetter.calculateTTLMillis;
+import static com.hazelcast.map.impl.ExpirationTimeSetter.pickTTL;
+import static com.hazelcast.map.impl.ExpirationTimeSetter.setExpirationTime;
+import static com.hazelcast.map.impl.SizeEstimators.createNearCacheSizeEstimator;
+import static com.hazelcast.map.impl.mapstore.MapStoreContextFactory.createMapStoreContext;
+
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.config.PartitioningStrategyConfig;
 import com.hazelcast.config.WanReplicationRef;
 import com.hazelcast.core.IFunction;
 import com.hazelcast.core.PartitioningStrategy;
+import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.map.MapInterceptor;
 import com.hazelcast.map.impl.mapstore.MapStoreContext;
 import com.hazelcast.map.impl.record.DataRecordFactory;
@@ -31,7 +39,6 @@ import com.hazelcast.map.impl.record.RecordFactory;
 import com.hazelcast.map.merge.MapMergePolicy;
 import com.hazelcast.nio.ClassLoaderUtil;
 import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.query.impl.Indexes;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.util.ExceptionUtil;
@@ -42,13 +49,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
-
-import static com.hazelcast.map.impl.ExpirationTimeSetter.calculateMaxIdleMillis;
-import static com.hazelcast.map.impl.ExpirationTimeSetter.calculateTTLMillis;
-import static com.hazelcast.map.impl.ExpirationTimeSetter.pickTTL;
-import static com.hazelcast.map.impl.ExpirationTimeSetter.setExpirationTime;
-import static com.hazelcast.map.impl.SizeEstimators.createNearCacheSizeEstimator;
-import static com.hazelcast.map.impl.mapstore.MapStoreContextFactory.createMapStoreContext;
 
 /**
  * Map container.
@@ -63,7 +63,7 @@ public class MapContainer {
 
     private final Map<String, MapInterceptor> interceptorMap;
 
-    private final Indexes indexes = new Indexes();
+    private final Indexes indexes;
 
     private final SizeEstimator nearCacheSizeEstimator;
 
@@ -108,6 +108,7 @@ public class MapContainer {
         nearCacheSizeEstimator = createNearCacheSizeEstimator();
         mapStoreContext = createMapStoreContext(this);
         mapStoreContext.start();
+        indexes = new Indexes(nodeEngine.getSerializationService());
     }
 
     private RecordFactory createRecordFactory(NodeEngine nodeEngine) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapMigrationAwareService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapMigrationAwareService.java
@@ -16,10 +16,10 @@
 
 package com.hazelcast.map.impl;
 
+import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.map.impl.operation.MapReplicationOperation;
 import com.hazelcast.map.impl.record.Record;
 import com.hazelcast.map.impl.recordstore.RecordStore;
-import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.partition.MigrationEndpoint;
 import com.hazelcast.query.impl.Indexes;
 import com.hazelcast.query.impl.QueryEntry;
@@ -94,12 +94,13 @@ class MapMigrationAwareService implements MigrationAwareService {
                 while (iterator.hasNext()) {
                     final Record record = iterator.next();
                     if (event.getMigrationEndpoint() == MigrationEndpoint.SOURCE) {
-                        indexes.removeEntryIndex(record.getKey());
+                        // was no old value
+                        indexes.removeEntryIndex(record);
                     } else {
                         Object value = record.getValue();
                         if (value != null) {
                             indexes.saveEntryIndex(new QueryEntry(serializationService, record.getKey(),
-                                    record.getKey(), value));
+                                    record.getKey(), value), null);
                         }
                     }
                 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapMigrationAwareService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapMigrationAwareService.java
@@ -99,7 +99,7 @@ class MapMigrationAwareService implements MigrationAwareService {
                     } else {
                         Object value = record.getValue();
                         if (value != null) {
-                            QueryableEntry queryEntry = mapServiceContext.newQueryEntry(record.getKey(), record.getKey(), value);
+                            QueryableEntry queryEntry = mapServiceContext.newQueryEntry(record.getKey(), value);
                             indexes.saveEntryIndex(queryEntry, null);
                         }
                     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapMigrationAwareService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapMigrationAwareService.java
@@ -19,6 +19,7 @@ package com.hazelcast.map.impl;
 import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.map.impl.operation.MapReplicationOperation;
 import com.hazelcast.map.impl.record.Record;
+import com.hazelcast.map.impl.record.Records;
 import com.hazelcast.map.impl.recordstore.RecordStore;
 import com.hazelcast.partition.MigrationEndpoint;
 import com.hazelcast.query.impl.Indexes;
@@ -97,9 +98,9 @@ class MapMigrationAwareService implements MigrationAwareService {
                         // was no old value
                         indexes.removeEntryIndex(record);
                     } else {
-                        Object value = record.getValue();
+                        Object value = Records.getValueOrCachedValue(record, serializationService);
                         if (value != null) {
-                            QueryableEntry queryEntry = mapServiceContext.newQueryEntry(record.getKey(), value);
+                            QueryableEntry queryEntry = mapContainer.newQueryEntry(record.getKey(), value);
                             indexes.saveEntryIndex(queryEntry, null);
                         }
                     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapMigrationAwareService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapMigrationAwareService.java
@@ -22,7 +22,7 @@ import com.hazelcast.map.impl.record.Record;
 import com.hazelcast.map.impl.recordstore.RecordStore;
 import com.hazelcast.partition.MigrationEndpoint;
 import com.hazelcast.query.impl.Indexes;
-import com.hazelcast.query.impl.QueryEntry;
+import com.hazelcast.query.impl.QueryableEntry;
 import com.hazelcast.spi.MigrationAwareService;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.PartitionMigrationEvent;
@@ -99,8 +99,8 @@ class MapMigrationAwareService implements MigrationAwareService {
                     } else {
                         Object value = record.getValue();
                         if (value != null) {
-                            indexes.saveEntryIndex(new QueryEntry(serializationService, record.getKey(),
-                                    record.getKey(), value), null);
+                            QueryableEntry queryEntry = mapServiceContext.newQueryEntry(record.getKey(), record.getKey(), value);
+                            indexes.saveEntryIndex(queryEntry, null);
                         }
                     }
                 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContext.java
@@ -115,5 +115,5 @@ public interface MapServiceContext extends MapServiceContextInterceptorSupport, 
      */
     void setEvictionOperator(EvictionOperator evictionOperator);
 
-    QueryableEntry newQueryEntry(Data indexKey, Object key, Object value);
+    QueryableEntry newQueryEntry(Data key, Object value);
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContext.java
@@ -25,7 +25,6 @@ import com.hazelcast.map.impl.query.MapQueryEngine;
 import com.hazelcast.map.impl.recordstore.RecordStore;
 import com.hazelcast.map.merge.MergePolicyProvider;
 import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.query.impl.QueryableEntry;
 import com.hazelcast.spi.NodeEngine;
 
 import java.util.Collection;
@@ -115,5 +114,4 @@ public interface MapServiceContext extends MapServiceContextInterceptorSupport, 
      */
     void setEvictionOperator(EvictionOperator evictionOperator);
 
-    QueryableEntry newQueryEntry(Data key, Object value);
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContext.java
@@ -25,6 +25,7 @@ import com.hazelcast.map.impl.query.MapQueryEngine;
 import com.hazelcast.map.impl.recordstore.RecordStore;
 import com.hazelcast.map.merge.MergePolicyProvider;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.query.impl.QueryableEntry;
 import com.hazelcast.spi.NodeEngine;
 
 import java.util.Collection;
@@ -113,4 +114,6 @@ public interface MapServiceContext extends MapServiceContextInterceptorSupport, 
      * @param evictionOperator {@link EvictionOperator} to be set.
      */
     void setEvictionOperator(EvictionOperator evictionOperator);
+
+    QueryableEntry newQueryEntry(Data indexKey, Object key, Object value);
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
@@ -315,8 +315,8 @@ class MapServiceContextImpl implements MapServiceContext {
     }
 
     @Override
-    public QueryableEntry newQueryEntry(Data indexKey, Object key, Object value) {
-        return queryEntryFactory.newEntry(getNodeEngine().getSerializationService(), indexKey, key, value);
+    public QueryableEntry newQueryEntry(Data key, Object value) {
+        return queryEntryFactory.newEntry(getNodeEngine().getSerializationService(), key, value);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
@@ -34,7 +34,6 @@ import com.hazelcast.map.merge.MergePolicyProvider;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.partition.InternalPartition;
 import com.hazelcast.partition.InternalPartitionService;
-import com.hazelcast.query.impl.QueryableEntry;
 import com.hazelcast.spi.EventFilter;
 import com.hazelcast.spi.EventRegistration;
 import com.hazelcast.spi.EventService;
@@ -74,7 +73,6 @@ class MapServiceContextImpl implements MapServiceContext {
     private final PartitionContainer[] partitionContainers;
     private final ConcurrentMap<String, MapContainer> mapContainers;
     private final AtomicReference<Collection<Integer>> ownedPartitions;
-    private final QueryEntryFactory queryEntryFactory;
     private final ConstructorFunction<String, MapContainer> mapConstructor = new ConstructorFunction<String, MapContainer>() {
         public MapContainer createNew(String mapName) {
             final MapServiceContext mapServiceContext = getService().getMapServiceContext();
@@ -114,7 +112,6 @@ class MapServiceContextImpl implements MapServiceContext {
         this.mapEventPublisher = createMapEventPublisherSupport();
         this.mapQueryEngine = new MapQueryEngineImpl(this, newOptimizer(nodeEngine.getGroupProperties()));
         this.eventService = nodeEngine.getEventService();
-        this.queryEntryFactory = new QueryEntryFactory(nodeEngine.getGroupProperties());
     }
 
     MapEventPublisherImpl createMapEventPublisherSupport() {
@@ -312,11 +309,6 @@ class MapServiceContextImpl implements MapServiceContext {
     @Override
     public void setEvictionOperator(EvictionOperator evictionOperator) {
         this.evictionOperator = evictionOperator;
-    }
-
-    @Override
-    public QueryableEntry newQueryEntry(Data key, Object value) {
-        return queryEntryFactory.newEntry(getNodeEngine().getSerializationService(), key, value);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
@@ -34,6 +34,7 @@ import com.hazelcast.map.merge.MergePolicyProvider;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.partition.InternalPartition;
 import com.hazelcast.partition.InternalPartitionService;
+import com.hazelcast.query.impl.QueryableEntry;
 import com.hazelcast.spi.EventFilter;
 import com.hazelcast.spi.EventRegistration;
 import com.hazelcast.spi.EventService;
@@ -73,6 +74,7 @@ class MapServiceContextImpl implements MapServiceContext {
     private final PartitionContainer[] partitionContainers;
     private final ConcurrentMap<String, MapContainer> mapContainers;
     private final AtomicReference<Collection<Integer>> ownedPartitions;
+    private final QueryEntryFactory queryEntryFactory;
     private final ConstructorFunction<String, MapContainer> mapConstructor = new ConstructorFunction<String, MapContainer>() {
         public MapContainer createNew(String mapName) {
             final MapServiceContext mapServiceContext = getService().getMapServiceContext();
@@ -112,6 +114,7 @@ class MapServiceContextImpl implements MapServiceContext {
         this.mapEventPublisher = createMapEventPublisherSupport();
         this.mapQueryEngine = new MapQueryEngineImpl(this, newOptimizer(nodeEngine.getGroupProperties()));
         this.eventService = nodeEngine.getEventService();
+        this.queryEntryFactory = new QueryEntryFactory(nodeEngine.getGroupProperties());
     }
 
     MapEventPublisherImpl createMapEventPublisherSupport() {
@@ -309,6 +312,11 @@ class MapServiceContextImpl implements MapServiceContext {
     @Override
     public void setEvictionOperator(EvictionOperator evictionOperator) {
         this.evictionOperator = evictionOperator;
+    }
+
+    @Override
+    public QueryableEntry newQueryEntry(Data indexKey, Object key, Object value) {
+        return queryEntryFactory.newEntry(getNodeEngine().getSerializationService(), indexKey, key, value);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/event/MapEventPublisherImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/event/MapEventPublisherImpl.java
@@ -30,6 +30,7 @@ import com.hazelcast.map.impl.wan.MapReplicationRemove;
 import com.hazelcast.map.impl.wan.MapReplicationUpdate;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.query.impl.CachedQueryEntry;
 import com.hazelcast.query.impl.QueryableEntry;
 import com.hazelcast.spi.EventFilter;
 import com.hazelcast.spi.EventRegistration;
@@ -300,7 +301,7 @@ public class MapEventPublisherImpl implements MapEventPublisher {
         }
 
         QueryEventFilter queryEventFilter = (QueryEventFilter) filter;
-        QueryableEntry entry = mapServiceContext.newQueryEntry(dataKey, testValue);
+        QueryableEntry entry = new CachedQueryEntry(serializationService, dataKey, testValue);
         return queryEventFilter.eval(entry);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/event/MapEventPublisherImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/event/MapEventPublisherImpl.java
@@ -300,7 +300,7 @@ public class MapEventPublisherImpl implements MapEventPublisher {
         }
 
         QueryEventFilter queryEventFilter = (QueryEventFilter) filter;
-        QueryableEntry entry = mapServiceContext.newQueryEntry(dataKey, dataKey, testValue);
+        QueryableEntry entry = mapServiceContext.newQueryEntry(dataKey, testValue);
         return queryEventFilter.eval(entry);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/event/MapEventPublisherImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/event/MapEventPublisherImpl.java
@@ -30,7 +30,7 @@ import com.hazelcast.map.impl.wan.MapReplicationRemove;
 import com.hazelcast.map.impl.wan.MapReplicationUpdate;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.query.impl.QueryEntry;
+import com.hazelcast.query.impl.QueryableEntry;
 import com.hazelcast.spi.EventFilter;
 import com.hazelcast.spi.EventRegistration;
 import com.hazelcast.spi.EventService;
@@ -300,7 +300,7 @@ public class MapEventPublisherImpl implements MapEventPublisher {
         }
 
         QueryEventFilter queryEventFilter = (QueryEventFilter) filter;
-        QueryEntry entry = new QueryEntry(serializationService, dataKey, dataKey, testValue);
+        QueryableEntry entry = mapServiceContext.newQueryEntry(dataKey, dataKey, testValue);
         return queryEventFilter.eval(entry);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/AddIndexOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/AddIndexOperation.java
@@ -16,21 +16,22 @@
 
 package com.hazelcast.map.impl.operation;
 
+import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.map.impl.MapContainer;
 import com.hazelcast.map.impl.MapService;
-import com.hazelcast.map.impl.recordstore.RecordStore;
 import com.hazelcast.map.impl.record.Record;
+import com.hazelcast.map.impl.recordstore.RecordStore;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.query.impl.Index;
 import com.hazelcast.query.impl.Indexes;
 import com.hazelcast.query.impl.QueryEntry;
-import com.hazelcast.spi.impl.MutatingOperation;
 import com.hazelcast.spi.PartitionAwareOperation;
 import com.hazelcast.spi.impl.AbstractNamedOperation;
+import com.hazelcast.spi.impl.MutatingOperation;
 import com.hazelcast.util.Clock;
+
 import java.io.IOException;
 import java.util.Iterator;
 
@@ -62,13 +63,14 @@ public class AddIndexOperation extends AbstractNamedOperation implements Partiti
         Indexes indexes = mapContainer.getIndexes();
         SerializationService ss = getNodeEngine().getSerializationService();
         Index index = indexes.addOrGetIndex(attributeName, ordered);
+
         final long now = getNow();
         final Iterator<Record> iterator = recordStore.iterator(now, false);
         while (iterator.hasNext()) {
             final Record record = iterator.next();
             Data key = record.getKey();
             Object value = record.getValue();
-            index.saveEntryIndex(new QueryEntry(ss, key, key, value));
+            index.saveEntryIndex(new QueryEntry(ss, key, key, value), null);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/AddIndexOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/AddIndexOperation.java
@@ -70,7 +70,7 @@ public class AddIndexOperation extends AbstractNamedOperation implements Partiti
             final Record record = iterator.next();
             Data key = record.getKey();
             Object value = record.getValue();
-            QueryableEntry queryEntry = serviceContext.newQueryEntry(key, key, value);
+            QueryableEntry queryEntry = serviceContext.newQueryEntry(key, value);
             index.saveEntryIndex(queryEntry, null);
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/AddIndexOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/AddIndexOperation.java
@@ -16,10 +16,12 @@
 
 package com.hazelcast.map.impl.operation;
 
+import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.map.impl.MapContainer;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.map.impl.MapServiceContext;
 import com.hazelcast.map.impl.record.Record;
+import com.hazelcast.map.impl.record.Records;
 import com.hazelcast.map.impl.recordstore.RecordStore;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
@@ -66,11 +68,12 @@ public class AddIndexOperation extends AbstractNamedOperation implements Partiti
         MapServiceContext serviceContext = mapContainer.getMapServiceContext();
         final long now = getNow();
         final Iterator<Record> iterator = recordStore.iterator(now, false);
+        SerializationService serializationService = getNodeEngine().getSerializationService();
         while (iterator.hasNext()) {
             final Record record = iterator.next();
             Data key = record.getKey();
-            Object value = record.getValue();
-            QueryableEntry queryEntry = serviceContext.newQueryEntry(key, value);
+            Object value = Records.getValueOrCachedValue(record, serializationService);
+            QueryableEntry queryEntry = mapContainer.newQueryEntry(key, value);
             index.saveEntryIndex(queryEntry, null);
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryBackupOperation.java
@@ -48,7 +48,7 @@ public class PartitionWideEntryBackupOperation extends AbstractMultipleEntryOper
             final Data dataKey = record.getKey();
             final Object oldValue = record.getValue();
 
-            if (!applyPredicate(dataKey, dataKey, oldValue)) {
+            if (!applyPredicate(dataKey, oldValue)) {
                 continue;
             }
             final Map.Entry entry = createMapEntry(dataKey, oldValue);
@@ -76,11 +76,11 @@ public class PartitionWideEntryBackupOperation extends AbstractMultipleEntryOper
         return true;
     }
 
-    private boolean applyPredicate(Data dataKey, Object key, Object value) {
+    private boolean applyPredicate(Data key, Object value) {
         if (getPredicate() == null) {
             return true;
         }
-        QueryableEntry queryEntry = getMapServiceContext().newQueryEntry(dataKey, key, value);
+        QueryableEntry queryEntry = getMapServiceContext().newQueryEntry(key, value);
         return getPredicate().apply(queryEntry);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryBackupOperation.java
@@ -21,9 +21,8 @@ import com.hazelcast.map.impl.record.Record;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.query.Predicate;
-import com.hazelcast.query.impl.QueryEntry;
+import com.hazelcast.query.impl.QueryableEntry;
 import com.hazelcast.spi.BackupOperation;
 
 import java.io.IOException;
@@ -81,8 +80,7 @@ public class PartitionWideEntryBackupOperation extends AbstractMultipleEntryOper
         if (getPredicate() == null) {
             return true;
         }
-        final SerializationService ss = getNodeEngine().getSerializationService();
-        QueryEntry queryEntry = new QueryEntry(ss, dataKey, key, value);
+        QueryableEntry queryEntry = getMapServiceContext().newQueryEntry(dataKey, key, value);
         return getPredicate().apply(queryEntry);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryBackupOperation.java
@@ -80,7 +80,7 @@ public class PartitionWideEntryBackupOperation extends AbstractMultipleEntryOper
         if (getPredicate() == null) {
             return true;
         }
-        QueryableEntry queryEntry = getMapServiceContext().newQueryEntry(key, value);
+        QueryableEntry queryEntry = mapContainer.newQueryEntry(key, value);
         return getPredicate().apply(queryEntry);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryOperation.java
@@ -27,7 +27,7 @@ import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.TruePredicate;
 import com.hazelcast.query.impl.FalsePredicate;
-import com.hazelcast.query.impl.QueryEntry;
+import com.hazelcast.query.impl.QueryableEntry;
 import com.hazelcast.spi.BackupAwareOperation;
 import com.hazelcast.spi.Operation;
 
@@ -126,7 +126,7 @@ public class PartitionWideEntryOperation extends AbstractMultipleEntryOperation 
         }
 
         final SerializationService ss = getNodeEngine().getSerializationService();
-        QueryEntry queryEntry = new QueryEntry(ss, dataKey, key, value);
+        QueryableEntry queryEntry = getMapServiceContext().newQueryEntry(dataKey, key, value);
         return getPredicate().apply(queryEntry);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryOperation.java
@@ -125,7 +125,7 @@ public class PartitionWideEntryOperation extends AbstractMultipleEntryOperation 
             return false;
         }
 
-        QueryableEntry queryEntry = getMapServiceContext().newQueryEntry(key, value);
+        QueryableEntry queryEntry = mapContainer.newQueryEntry(key, value);
         return getPredicate().apply(queryEntry);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryOperation.java
@@ -65,7 +65,7 @@ public class PartitionWideEntryOperation extends AbstractMultipleEntryOperation 
             final Data dataKey = record.getKey();
             final Object oldValue = record.getValue();
 
-            if (!applyPredicate(dataKey, dataKey, oldValue)) {
+            if (!applyPredicate(dataKey, oldValue)) {
                 continue;
             }
 
@@ -114,7 +114,7 @@ public class PartitionWideEntryOperation extends AbstractMultipleEntryOperation 
         return backupProcessor != null ? new PartitionWideEntryBackupOperation(name, backupProcessor) : null;
     }
 
-    private boolean applyPredicate(Data dataKey, Object key, Object value) {
+    private boolean applyPredicate(Data key, Object value) {
         Predicate predicate = getPredicate();
 
         if (predicate == null || TruePredicate.INSTANCE == predicate) {
@@ -125,8 +125,7 @@ public class PartitionWideEntryOperation extends AbstractMultipleEntryOperation 
             return false;
         }
 
-        final SerializationService ss = getNodeEngine().getSerializationService();
-        QueryableEntry queryEntry = getMapServiceContext().newQueryEntry(dataKey, key, value);
+        QueryableEntry queryEntry = getMapServiceContext().newQueryEntry(key, value);
         return getPredicate().apply(queryEntry);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/MapQueryEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/MapQueryEngineImpl.java
@@ -16,6 +16,19 @@
 
 package com.hazelcast.map.impl.query;
 
+import static com.hazelcast.instance.GroupProperty.QUERY_PREDICATE_PARALLEL_EVALUATION;
+import static com.hazelcast.map.impl.record.Record.NOT_CACHED;
+import static com.hazelcast.query.PagingPredicateAccessor.getNearestAnchorEntry;
+import static com.hazelcast.spi.ExecutionService.QUERY_EXECUTOR;
+import static com.hazelcast.util.ExceptionUtil.rethrow;
+import static com.hazelcast.util.FutureUtil.RETHROW_EVERYTHING;
+import static com.hazelcast.util.FutureUtil.returnWithDeadline;
+import static com.hazelcast.util.SortingUtil.compareAnchor;
+import static com.hazelcast.util.SortingUtil.getSortedQueryResultSet;
+import static com.hazelcast.util.SortingUtil.getSortedSubList;
+import static java.util.Collections.singletonList;
+import static java.util.concurrent.TimeUnit.MINUTES;
+
 import com.hazelcast.cluster.ClusterService;
 import com.hazelcast.core.Member;
 import com.hazelcast.internal.serialization.SerializationService;
@@ -56,19 +69,6 @@ import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
-
-import static com.hazelcast.instance.GroupProperty.QUERY_PREDICATE_PARALLEL_EVALUATION;
-import static com.hazelcast.map.impl.record.Record.NOT_CACHED;
-import static com.hazelcast.query.PagingPredicateAccessor.getNearestAnchorEntry;
-import static com.hazelcast.spi.ExecutionService.QUERY_EXECUTOR;
-import static com.hazelcast.util.ExceptionUtil.rethrow;
-import static com.hazelcast.util.FutureUtil.RETHROW_EVERYTHING;
-import static com.hazelcast.util.FutureUtil.returnWithDeadline;
-import static com.hazelcast.util.SortingUtil.compareAnchor;
-import static com.hazelcast.util.SortingUtil.getSortedQueryResultSet;
-import static com.hazelcast.util.SortingUtil.getSortedSubList;
-import static java.util.Collections.singletonList;
-import static java.util.concurrent.TimeUnit.MINUTES;
 
 /**
  * The {@link MapQueryEngine} implementation.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/MapQueryEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/MapQueryEngineImpl.java
@@ -46,7 +46,6 @@ import com.hazelcast.partition.InternalPartitionService;
 import com.hazelcast.query.PagingPredicate;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.TruePredicate;
-import com.hazelcast.query.impl.QueryEntry;
 import com.hazelcast.query.impl.QueryableEntry;
 import com.hazelcast.query.impl.predicates.QueryOptimizer;
 import com.hazelcast.spi.NodeEngine;
@@ -273,7 +272,7 @@ public class MapQueryEngineImpl implements MapQueryEngine {
             if (value == null) {
                 continue;
             }
-            QueryEntry queryEntry = new QueryEntry(serializationService, key, key, value);
+            QueryableEntry queryEntry = mapServiceContext.newQueryEntry(key, key, value);
 
             if (predicate.apply(queryEntry) && compareAnchor(pagingPredicate, queryEntry, nearestAnchorEntry)) {
                 resultList.add(queryEntry);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/MapQueryEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/MapQueryEngineImpl.java
@@ -272,7 +272,7 @@ public class MapQueryEngineImpl implements MapQueryEngine {
             if (value == null) {
                 continue;
             }
-            QueryableEntry queryEntry = mapServiceContext.newQueryEntry(key, key, value);
+            QueryableEntry queryEntry = mapServiceContext.newQueryEntry(key, value);
 
             if (predicate.apply(queryEntry) && compareAnchor(pagingPredicate, queryEntry, nearestAnchorEntry)) {
                 resultList.add(queryEntry);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryEntryFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryEntryFactory.java
@@ -30,11 +30,11 @@ public final class QueryEntryFactory {
     }
 
 
-    public QueryableEntry newEntry(SerializationService serializationService, Data indexKey, Object key, Object value) {
+    public QueryableEntry newEntry(SerializationService serializationService, Data key, Object value) {
         if (useCache) {
-            return new CachedQueryEntry(serializationService, indexKey, key, value);
+            return new CachedQueryEntry(serializationService, key, value);
         } else {
-            return new QueryEntry(serializationService, indexKey, key, value);
+            return new QueryEntry(serializationService, key, value);
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryEntryFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryEntryFactory.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.query;
+
+import com.hazelcast.internal.serialization.SerializationService;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.query.impl.CachedQueryEntry;
+import com.hazelcast.query.impl.QueryEntry;
+import com.hazelcast.query.impl.QueryableEntry;
+
+public final class QueryEntryFactory {
+    private final boolean useCache;
+
+    public QueryEntryFactory(boolean optimizeQueries) {
+        useCache = optimizeQueries;
+    }
+
+
+    public QueryableEntry newEntry(SerializationService serializationService, Data indexKey, Object key, Object value) {
+        if (useCache) {
+            return new CachedQueryEntry(serializationService, indexKey, key, value);
+        } else {
+            return new QueryEntry(serializationService, indexKey, key, value);
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryEventFilter.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryEventFilter.java
@@ -21,7 +21,7 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.query.Predicate;
-import com.hazelcast.query.impl.QueryEntry;
+import com.hazelcast.query.impl.QueryableEntry;
 
 import java.io.IOException;
 import java.util.Map;
@@ -44,7 +44,7 @@ public class QueryEventFilter extends EntryEventFilter {
 
     @Override
     public boolean eval(Object arg) {
-        QueryEntry entry = (QueryEntry) arg;
+        QueryableEntry entry = (QueryableEntry) arg;
         Data keyData = entry.getKeyData();
         return (key == null || key.equals(keyData)) && predicate.apply((Map.Entry) arg);
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryResultSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryResultSet.java
@@ -16,6 +16,9 @@
 
 package com.hazelcast.map.impl.query;
 
+import static com.hazelcast.util.IterationType.ENTRY;
+import static java.util.Collections.newSetFromMap;
+
 import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
@@ -29,9 +32,6 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-
-import static com.hazelcast.util.IterationType.ENTRY;
-import static java.util.Collections.newSetFromMap;
 
 /**
  * Collection(Set) class for result of query operations.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/record/Records.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/record/Records.java
@@ -16,6 +16,11 @@
 
 package com.hazelcast.map.impl.record;
 
+import com.hazelcast.internal.serialization.SerializationService;
+import com.hazelcast.nio.serialization.Data;
+
+import static com.hazelcast.map.impl.record.Record.NOT_CACHED;
+
 /**
  * Contains various factory & helper methods for a {@link com.hazelcast.map.impl.record.Record} object.
  */
@@ -44,5 +49,18 @@ public final class Records {
         return info;
     }
 
+    public static Object getValueOrCachedValue(Record record, SerializationService serializationService) {
+        Object value = record.getCachedValue();
+        if (value == NOT_CACHED) {
+            value = record.getValue();
+        } else if (value == null) {
+            value = record.getValue();
+            if (record instanceof CachedDataRecord && value instanceof Data && !((Data) value).isPortable()) {
+                value = serializationService.toObject(value);
+                record.setCachedValue(value);
+            }
+        }
+        return value;
+    }
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/AbstractRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/AbstractRecordStore.java
@@ -162,9 +162,9 @@ abstract class AbstractRecordStore implements RecordStore {
     }
 
     protected void removeIndex(Record record) {
-        final Indexes indexService = mapContainer.getIndexes();
-        if (indexService.hasIndex()) {
-            indexService.removeEntryIndex(record);
+        Indexes indexes = mapContainer.getIndexes();
+        if (indexes.hasIndex()) {
+            indexes.removeEntryIndex(record);
         }
     }
 
@@ -176,7 +176,7 @@ abstract class AbstractRecordStore implements RecordStore {
      */
 
     protected void removeIndexByPreservingKeys(Collection<Record> keysToRemove, Set<Data> keysToPreserve) {
-        final Indexes indexes = mapContainer.getIndexes();
+        Indexes indexes = mapContainer.getIndexes();
         if (indexes.hasIndex()) {
             for (Record record : keysToRemove) {
                 if (!keysToPreserve.contains(record.getKey())) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/AbstractRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/AbstractRecordStore.java
@@ -29,6 +29,7 @@ import com.hazelcast.map.impl.SizeEstimator;
 import com.hazelcast.map.impl.mapstore.MapStoreContext;
 import com.hazelcast.map.impl.record.Record;
 import com.hazelcast.map.impl.record.RecordFactory;
+import com.hazelcast.map.impl.record.Records;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.query.impl.Indexes;
 import com.hazelcast.query.impl.QueryableEntry;
@@ -154,7 +155,8 @@ abstract class AbstractRecordStore implements RecordStore {
         Data dataKey = record.getKey();
         final Indexes indexes = mapContainer.getIndexes();
         if (indexes.hasIndex()) {
-            QueryableEntry queryableEntry = mapServiceContext.newQueryEntry(dataKey, record.getValue());
+            Object value = Records.getValueOrCachedValue(record, serializationService);
+            QueryableEntry queryableEntry = mapContainer.newQueryEntry(dataKey, value);
             indexes.saveEntryIndex(queryableEntry, oldValue);
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/AbstractRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/AbstractRecordStore.java
@@ -31,7 +31,6 @@ import com.hazelcast.map.impl.record.Record;
 import com.hazelcast.map.impl.record.RecordFactory;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.query.impl.Indexes;
-import com.hazelcast.query.impl.QueryEntry;
 import com.hazelcast.query.impl.QueryableEntry;
 import com.hazelcast.spi.DefaultObjectNamespace;
 import com.hazelcast.spi.NodeEngine;
@@ -156,7 +155,7 @@ abstract class AbstractRecordStore implements RecordStore {
         final Indexes indexes = mapContainer.getIndexes();
         if (indexes.hasIndex()) {
             SerializationService ss = mapServiceContext.getNodeEngine().getSerializationService();
-            QueryableEntry queryableEntry = new QueryEntry(ss, dataKey, dataKey, record.getValue());
+            QueryableEntry queryableEntry = mapServiceContext.newQueryEntry(dataKey, dataKey, record.getValue());
             indexes.saveEntryIndex(queryableEntry, oldValue);
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/AbstractRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/AbstractRecordStore.java
@@ -154,8 +154,7 @@ abstract class AbstractRecordStore implements RecordStore {
         Data dataKey = record.getKey();
         final Indexes indexes = mapContainer.getIndexes();
         if (indexes.hasIndex()) {
-            SerializationService ss = mapServiceContext.getNodeEngine().getSerializationService();
-            QueryableEntry queryableEntry = mapServiceContext.newQueryEntry(dataKey, dataKey, record.getValue());
+            QueryableEntry queryableEntry = mapServiceContext.newQueryEntry(dataKey, record.getValue());
             indexes.saveEntryIndex(queryableEntry, oldValue);
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
@@ -17,6 +17,8 @@
 package com.hazelcast.map.impl.recordstore;
 
 
+import static com.hazelcast.map.impl.ExpirationTimeSetter.updateExpiryTime;
+
 import com.hazelcast.concurrent.lock.LockService;
 import com.hazelcast.concurrent.lock.LockStore;
 import com.hazelcast.core.EntryView;
@@ -54,7 +56,6 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Future;
 
-import static com.hazelcast.map.impl.ExpirationTimeSetter.updateExpiryTime;
 import static com.hazelcast.map.impl.mapstore.MapDataStores.EMPTY_MAP_DATA_STORE;
 
 /**
@@ -237,10 +238,12 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore implements 
             final DefaultObjectNamespace namespace = new DefaultObjectNamespace(MapService.SERVICE_NAME, name);
             lockService.clearLockStore(partitionId, namespace);
         }
+
         final Indexes indexes = mapContainer.getIndexes();
+
         if (indexes.hasIndex()) {
-            for (Data key : records.keySet()) {
-                indexes.removeEntryIndex(key);
+            for (Record record : records.values()) {
+                indexes.removeEntryIndex(record);
             }
         }
         clearRecordsMap(Collections.<Data, Record>emptyMap());
@@ -373,7 +376,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore implements 
             record = createRecord(key, value, getNow());
             records.put(key, record);
             if (!backup) {
-                saveIndex(record);
+                saveIndex(record, null);
             }
             updateSizeEstimator(calculateRecordHeapCost(record));
         }
@@ -451,7 +454,10 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore implements 
         mapDataStore.removeAll(keysToDelete);
 
         final int numOfClearedEntries = keysToDelete.size();
-        removeIndex(keysToDelete);
+        for (Data key: keysToDelete) {
+            Record record = records.get(key);
+            removeIndex(record);
+        }
 
         clearRecordsMap(lockedRecords);
         resetAccessSequenceNumber();
@@ -487,8 +493,8 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore implements 
                 mapServiceContext.interceptRemove(name, value);
             }
             updateSizeEstimator(-calculateRecordHeapCost(record));
+            removeIndex(record);
             deleteRecord(key);
-            removeIndex(key);
         }
         return value;
     }
@@ -504,7 +510,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore implements 
         updateSizeEstimator(calculateRecordHeapCost(recordsToPreserve.values()));
 
         flush(recordsToPreserve, backup);
-        removeIndexByPreservingKeys(records.keySet(), recordsToPreserve.keySet());
+        removeIndexByPreservingKeys(records.values(), recordsToPreserve.keySet());
         clearRecordsMap(recordsToPreserve);
 
         return sizeBeforeEviction - recordsToPreserve.size();
@@ -576,7 +582,6 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore implements 
         if (record == null) {
             oldValue = mapDataStore.load(key);
             if (oldValue != null) {
-                removeIndex(key);
                 mapDataStore.remove(key, now);
             }
         } else {
@@ -603,7 +608,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore implements 
         }
         if (mapServiceContext.compare(name, testValue, oldValue)) {
             mapServiceContext.interceptRemove(name, oldValue);
-            removeIndex(key);
+            removeIndex(record);
             mapDataStore.remove(key, now);
             onStore(record);
             // reduce size
@@ -621,7 +626,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore implements 
 
         final Record record = getRecordOrNull(key, now, false);
         if (record == null) {
-            removeIndex(key);
+            removeIndex(record);
             mapDataStore.remove(key, now);
         } else {
             return removeRecord(key, record, now) != null;
@@ -776,7 +781,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore implements 
         }
 
         updateSizeEstimator(calculateRecordHeapCost(record));
-        saveIndex(record);
+        saveIndex(record, oldValue);
 
         return oldValue;
     }
@@ -789,6 +794,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore implements 
         Record record = getRecordOrNull(key, now, false);
         mergingEntry = EntryViews.convertToLazyEntryView(mergingEntry, serializationService, mergePolicy);
         Object newValue;
+        Object oldValue = null;
         if (record == null) {
             final Object notExistingKey = mapServiceContext.toObject(key);
             final EntryView nullEntryView = EntryViews.createNullEntryView(notExistingKey);
@@ -802,13 +808,13 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore implements 
             records.put(key, record);
             updateSizeEstimator(calculateRecordHeapCost(record));
         } else {
-            Object oldValue = record.getValue();
+            oldValue = record.getValue();
             EntryView existingEntry = EntryViews.createLazyEntryView(record.getKey(), record.getValue(),
                     record, serializationService, mergePolicy);
             newValue = mergePolicy.merge(name, mergingEntry, existingEntry);
             // existing entry will be removed
             if (newValue == null) {
-                removeIndex(key);
+                removeIndex(record);
                 mapDataStore.remove(key, now);
                 onStore(record);
                 // reduce size.
@@ -830,7 +836,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore implements 
             recordFactory.setValue(record, newValue);
             updateSizeEstimator(calculateRecordHeapCost(record));
         }
-        saveIndex(record);
+        saveIndex(record, oldValue);
         return newValue != null;
     }
 
@@ -851,7 +857,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore implements 
         updateSizeEstimator(-calculateRecordHeapCost(record));
         updateRecord(record, update, now);
         updateSizeEstimator(calculateRecordHeapCost(record));
-        saveIndex(record);
+        saveIndex(record, oldValue);
         return oldValue;
     }
 
@@ -876,7 +882,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore implements 
         updateSizeEstimator(-calculateRecordHeapCost(record));
         updateRecord(record, update, now);
         updateSizeEstimator(calculateRecordHeapCost(record));
-        saveIndex(record);
+        saveIndex(record, current);
         return true;
     }
 
@@ -887,19 +893,21 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore implements 
         markRecordStoreExpirable(ttl);
 
         Record record = getRecordOrNull(key, now, false);
+        Object oldValue = null;
         if (record == null) {
             value = mapServiceContext.interceptPut(name, null, value);
             record = createRecord(key, value, ttl, now);
             records.put(key, record);
             updateSizeEstimator(calculateRecordHeapCost(record));
         } else {
-            value = mapServiceContext.interceptPut(name, record.getValue(), value);
+            oldValue = record.getValue();
+            value = mapServiceContext.interceptPut(name, oldValue, value);
             updateSizeEstimator(-calculateRecordHeapCost(record));
             updateRecord(record, value, now);
             updateSizeEstimator(calculateRecordHeapCost(record));
             updateExpiryTime(record, ttl, mapContainer.getMapConfig());
         }
-        saveIndex(record);
+        saveIndex(record, oldValue);
         mapDataStore.addTransient(key, now);
     }
 
@@ -932,7 +940,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore implements 
             updateSizeEstimator(calculateRecordHeapCost(record));
             updateExpiryTime(record, ttl, mapContainer.getMapConfig());
         }
-        saveIndex(record);
+        saveIndex(record, oldValue);
 
         return oldValue;
     }
@@ -977,7 +985,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore implements 
             updateSizeEstimator(calculateRecordHeapCost(record));
             updateExpiryTime(record, ttl, mapContainer.getMapConfig());
         }
-        saveIndex(record);
+        saveIndex(record, oldValue);
         return oldValue;
     }
 
@@ -991,7 +999,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore implements 
         Object oldValue = record.getValue();
         oldValue = mapServiceContext.interceptRemove(name, oldValue);
         if (oldValue != null) {
-            removeIndex(key);
+            removeIndex(record);
             mapDataStore.remove(key, now);
             onStore(record);
         }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TransactionalMapProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TransactionalMapProxy.java
@@ -23,7 +23,7 @@ import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.query.PagingPredicate;
 import com.hazelcast.query.Predicate;
-import com.hazelcast.query.impl.QueryEntry;
+import com.hazelcast.query.impl.QueryableEntry;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.transaction.impl.Transaction;
 import com.hazelcast.util.IterationType;
@@ -335,7 +335,7 @@ public class TransactionalMapProxy extends TransactionalMapProxySupport implemen
                 Object value = entry.getValue().value instanceof Data
                         ? mapServiceContext.toObject(entry.getValue().value) : entry.getValue().value;
 
-                QueryEntry queryEntry = new QueryEntry(ss, entry.getKey(), key, value);
+                QueryableEntry queryEntry = mapServiceContext.newQueryEntry(entry.getKey(), key, value);
                 // apply predicate on txMap
                 if (predicate.apply(queryEntry)) {
                     keySet.add(key);
@@ -395,6 +395,7 @@ public class TransactionalMapProxy extends TransactionalMapProxySupport implemen
         // TODO: Can't we just use the original set?
         List<Object> valueSet = new ArrayList<Object>();
         Set<Object> keyWontBeIncluded = new HashSet<Object>();
+        MapServiceContext mapServiceContext = getService().getMapServiceContext();
 
         // iterate over the txMap and see if the values are updated or removed
         for (Map.Entry<Data, TxnValueWrapper> entry : txMap.entrySet()) {
@@ -409,8 +410,7 @@ public class TransactionalMapProxy extends TransactionalMapProxySupport implemen
                     keyWontBeIncluded.add(keyObject);
                 }
                 Object entryValue = entry.getValue().value;
-
-                QueryEntry queryEntry = new QueryEntry(serializationService, entry.getKey(), keyObject, entryValue);
+                QueryableEntry queryEntry = mapServiceContext.newQueryEntry(entry.getKey(), keyObject, entryValue);
                 if (predicate.apply(queryEntry)) {
                     valueSet.add(queryEntry.getValue());
                 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TransactionalMapProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TransactionalMapProxy.java
@@ -330,19 +330,21 @@ public class TransactionalMapProxy extends TransactionalMapProxySupport implemen
         // TODO: Can't we just use the original set?
         Set<Object> keySet = new HashSet<Object>(queryResultSet);
         for (Map.Entry<Data, TxnValueWrapper> entry : txMap.entrySet()) {
-            Object key = ss.toObject(entry.getKey());
+            Data keyData = entry.getKey();
             if (!TxnValueWrapper.Type.REMOVED.equals(entry.getValue().type)) {
                 Object value = entry.getValue().value instanceof Data
                         ? mapServiceContext.toObject(entry.getValue().value) : entry.getValue().value;
 
-                QueryableEntry queryEntry = mapServiceContext.newQueryEntry(entry.getKey(), key, value);
+                QueryableEntry queryEntry = mapServiceContext.newQueryEntry(keyData, value);
                 // apply predicate on txMap
                 if (predicate.apply(queryEntry)) {
-                    keySet.add(key);
+                    Object keyObject = ss.toObject(keyData);
+                    keySet.add(keyObject);
                 }
             } else {
                 // meanwhile remove keys which are not in txMap
-                keySet.remove(key);
+                Object keyObject = ss.toObject(keyData);
+                keySet.remove(keyObject);
             }
         }
         return keySet;
@@ -410,7 +412,7 @@ public class TransactionalMapProxy extends TransactionalMapProxySupport implemen
                     keyWontBeIncluded.add(keyObject);
                 }
                 Object entryValue = entry.getValue().value;
-                QueryableEntry queryEntry = mapServiceContext.newQueryEntry(entry.getKey(), keyObject, entryValue);
+                QueryableEntry queryEntry = mapServiceContext.newQueryEntry(entry.getKey(), entryValue);
                 if (predicate.apply(queryEntry)) {
                     valueSet.add(queryEntry.getValue());
                 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TransactionalMapProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TransactionalMapProxy.java
@@ -23,6 +23,7 @@ import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.query.PagingPredicate;
 import com.hazelcast.query.Predicate;
+import com.hazelcast.query.impl.CachedQueryEntry;
 import com.hazelcast.query.impl.QueryableEntry;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.transaction.impl.Transaction;
@@ -335,7 +336,7 @@ public class TransactionalMapProxy extends TransactionalMapProxySupport implemen
                 Object value = entry.getValue().value instanceof Data
                         ? mapServiceContext.toObject(entry.getValue().value) : entry.getValue().value;
 
-                QueryableEntry queryEntry = mapServiceContext.newQueryEntry(keyData, value);
+                QueryableEntry queryEntry = new CachedQueryEntry(ss, keyData, value);
                 // apply predicate on txMap
                 if (predicate.apply(queryEntry)) {
                     Object keyObject = ss.toObject(keyData);
@@ -412,7 +413,7 @@ public class TransactionalMapProxy extends TransactionalMapProxySupport implemen
                     keyWontBeIncluded.add(keyObject);
                 }
                 Object entryValue = entry.getValue().value;
-                QueryableEntry queryEntry = mapServiceContext.newQueryEntry(entry.getKey(), entryValue);
+                QueryableEntry queryEntry = new CachedQueryEntry(serializationService, entry.getKey(), entryValue);
                 if (predicate.apply(queryEntry)) {
                     valueSet.add(queryEntry.getValue());
                 }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/CachedQueryEntry.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/CachedQueryEntry.java
@@ -31,7 +31,6 @@ import static com.hazelcast.query.QueryConstants.THIS_ATTRIBUTE_NAME;
  */
 public class CachedQueryEntry implements QueryableEntry {
 
-    private Data indexKey;
     private Data keyData;
     private Object keyObject;
     private Data valueData;
@@ -41,54 +40,24 @@ public class CachedQueryEntry implements QueryableEntry {
     public CachedQueryEntry() {
     }
 
-    public CachedQueryEntry(SerializationService serializationService, Data indexKey, Object key, Object value) {
-        init(serializationService, indexKey, key, value);
+    public CachedQueryEntry(SerializationService serializationService, Data key, Object value) {
+        init(serializationService, key, value);
     }
 
-    /**
-     * It may be useful to use this {@code init} method in some cases that same instance of this class can be used
-     * instead of creating a new one for every iteration when scanning large data sets, for example:
-     * <pre>
-     * <code>Predicate predicate = ...
-     * QueryEntry entry = new QueryEntry()
-     * for(i == 0; i < HUGE_NUMBER; i++) {
-     *       entry.init(...)
-     *       boolean valid = predicate.apply(queryEntry);
-     *
-     *       if(valid) {
-     *          ....
-     *       }
-     *  }
-     * </code>
-     * </pre>
-     */
-    public void init(SerializationService serializationService, Data indexKey, Object key, Object value) {
-        if (indexKey == null) {
-            throw new IllegalArgumentException("index keyData cannot be null");
-        }
+    public void init(SerializationService serializationService, Data key, Object value) {
         if (key == null) {
             throw new IllegalArgumentException("keyData cannot be null");
         }
-
         this.serializationService = serializationService;
-        this.indexKey = indexKey;
-
-        keyData = null;
-        keyObject = null;
-
-        if (key instanceof Data) {
-            this.keyData = (Data) key;
-        } else {
-            this.keyObject = key;
-        }
-
-        valueData = null;
-        valueObject = null;
+        this.keyData = key;
+        this.keyObject = null;
 
         if (value instanceof Data) {
             this.valueData = (Data) value;
+            this.valueObject = null;
         } else {
             this.valueObject = value;
+            this.valueData = null;
         }
     }
 
@@ -199,11 +168,6 @@ public class CachedQueryEntry implements QueryableEntry {
     }
 
     @Override
-    public Data getIndexKey() {
-        return indexKey;
-    }
-
-    @Override
     public Object setValue(Object value) {
         throw new UnsupportedOperationException();
     }
@@ -217,7 +181,7 @@ public class CachedQueryEntry implements QueryableEntry {
             return false;
         }
         CachedQueryEntry that = (CachedQueryEntry) o;
-        if (!indexKey.equals(that.indexKey)) {
+        if (!keyData.equals(that.keyData)) {
             return false;
         }
         return true;
@@ -225,7 +189,7 @@ public class CachedQueryEntry implements QueryableEntry {
 
     @Override
     public int hashCode() {
-        return indexKey.hashCode();
+        return keyData.hashCode();
     }
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/Index.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/Index.java
@@ -27,6 +27,8 @@ import java.util.Set;
  */
 public interface Index {
 
+    void clear();
+
     /**
      * Add entry to this index.
      * @param e entry
@@ -34,8 +36,6 @@ public interface Index {
      * @throws QueryException
      */
     void saveEntryIndex(QueryableEntry e, Object oldValue) throws QueryException;
-
-    void clear();
 
     /**
      * Return converter associated with this Index.

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/Index.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/Index.java
@@ -17,16 +17,23 @@
 package com.hazelcast.query.impl;
 
 import com.hazelcast.core.TypeConverter;
-import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.map.impl.record.Record;
 import com.hazelcast.query.QueryException;
 
 import java.util.Set;
+
 /**
  * This interface contains the methods related to index of Query.
  */
 public interface Index {
 
-    void saveEntryIndex(QueryableEntry e) throws QueryException;
+    /**
+     * Add entry to this index.
+     * @param e entry
+     * @param oldValue or null if there is no old value
+     * @throws QueryException
+     */
+    void saveEntryIndex(QueryableEntry e, Object oldValue) throws QueryException;
 
     void clear();
 
@@ -38,7 +45,7 @@ public interface Index {
      */
     TypeConverter getConverter();
 
-    void removeEntryIndex(Data indexKey);
+    void removeEntryIndex(Record record);
 
     Set<QueryableEntry> getRecords(Comparable[] values);
 

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/IndexImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/IndexImpl.java
@@ -63,14 +63,14 @@ public class IndexImpl implements Index {
 
     @Override
     public void removeEntryIndex(Record record) {
-        Comparable value = QueryEntry.extractAttribute(attribute, record.getKey(), record.getValue(), ss);
+        Comparable value = QueryEntryUtils.extractAttribute(attribute, record.getKey(), record.getValue(), ss);
 
         if (value.getClass().isEnum()) {
             value = TypeConverters.ENUM_CONVERTER.convert(value);
         }
 
         if (value != null) {
-            indexStore.removeIndex(value, (Data) record.getKey());
+            indexStore.removeIndex(value, record.getKey());
         }
     }
 
@@ -102,11 +102,11 @@ public class IndexImpl implements Index {
 
         Comparable oldValue = null;
         if (oldRecordValue != null) {
-            oldValue = QueryEntry.extractAttribute(attribute, e.getKey(), oldRecordValue, ss);
+            oldValue = QueryEntryUtils.extractAttribute(attribute, e.getKey(), oldRecordValue, ss);
             oldValue = sanitizeValue(oldValue);
         }
 
-        Comparable newValue = QueryEntry.extractAttribute(attribute, e.getKey(), e.getValue(), ss);
+        Comparable newValue = QueryEntryUtils.extractAttribute(attribute, e.getKey(), e.getValue(), ss);
         newValue = sanitizeValue(newValue);
 
         if (oldValue == null) {

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/IndexImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/IndexImpl.java
@@ -30,6 +30,8 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.ConcurrentMap;
 
+import static com.hazelcast.query.impl.TypeConverters.IDENTITY_CONVERTER;
+
 /**
  * Implementation for {@link com.hazelcast.query.impl.Index}
  */
@@ -53,7 +55,7 @@ public class IndexImpl implements Index {
         this.attribute = attribute;
         this.ordered = ordered;
         this.ss = ss;
-        indexStore = (ordered) ? new SortedIndexStore() : new UnsortedIndexStore();
+        this.indexStore = ordered ? new SortedIndexStore() : new UnsortedIndexStore();
     }
 
     @Override
@@ -97,7 +99,7 @@ public class IndexImpl implements Index {
         if (converter == null) {
             // Initialize attribute type by using entry index
             AttributeType attributeType = e.getAttributeType(attribute);
-            converter = attributeType == null ? TypeConverters.IDENTITY_CONVERTER : attributeType.getConverter();
+            converter = attributeType == null ? IDENTITY_CONVERTER : attributeType.getConverter();
         }
 
         Comparable oldValue = null;

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/Indexes.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/Indexes.java
@@ -35,10 +35,10 @@ public class Indexes {
     private final ConcurrentMap<String, Index> mapIndexes = new ConcurrentHashMap<String, Index>(3);
     private final AtomicReference<Index[]> indexes = new AtomicReference<Index[]>(EMPTY_INDEX);
     private volatile boolean hasIndex;
-    private final SerializationService ss;
+    private final SerializationService serializationService;
 
-    public Indexes(SerializationService ss) {
-        this.ss = ss;
+    public Indexes(SerializationService serializationService) {
+        this.serializationService = serializationService;
     }
 
     public synchronized Index destroyIndex(String attribute) {
@@ -50,7 +50,7 @@ public class Indexes {
         if (index != null) {
             return index;
         }
-        index = new IndexImpl(attribute, ordered, ss);
+        index = new IndexImpl(attribute, ordered, serializationService);
         mapIndexes.put(attribute, index);
         Object[] indexObjects = mapIndexes.values().toArray();
         Index[] newIndexes = new Index[indexObjects.length];

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/MultiResultSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/MultiResultSet.java
@@ -53,13 +53,13 @@ public class MultiResultSet extends AbstractSet<QueryableEntry> {
                 index = new HashSet<Object>();
                 for (ConcurrentMap<Data, QueryableEntry> result : resultSets) {
                     for (QueryableEntry queryableEntry : result.values()) {
-                        index.add(queryableEntry.getIndexKey());
+                        index.add(queryableEntry.getKeyData());
                     }
                 }
                 return checkFromIndex(entry);
             } else {
                 for (ConcurrentMap<Data, QueryableEntry> resultSet : resultSets) {
-                    if (resultSet.containsKey(entry.getIndexKey())) {
+                    if (resultSet.containsKey(entry.getKeyData())) {
                         return true;
                     }
                 }
@@ -69,7 +69,7 @@ public class MultiResultSet extends AbstractSet<QueryableEntry> {
     }
 
     private boolean checkFromIndex(QueryableEntry entry) {
-        return index.contains(entry.getIndexKey());
+        return index.contains(entry.getKeyData());
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/QueryEntry.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/QueryEntry.java
@@ -31,16 +31,15 @@ import com.hazelcast.query.impl.getters.ReflectionHelper;
  */
 public class QueryEntry implements QueryableEntry {
 
-    private Data indexKey;
-    private Object key;
+    private Data key;
     private Object value;
     private SerializationService serializationService;
 
     public QueryEntry() {
     }
 
-    public QueryEntry(SerializationService serializationService, Data indexKey, Object key, Object value) {
-        init(serializationService, indexKey, key, value);
+    public QueryEntry(SerializationService serializationService, Data key, Object value) {
+        init(serializationService, key, value);
     }
 
     /**
@@ -60,15 +59,11 @@ public class QueryEntry implements QueryableEntry {
      * </code>
      * </pre>
      */
-    public void init(SerializationService serializationService, Data indexKey, Object key, Object value) {
-        if (indexKey == null) {
-            throw new IllegalArgumentException("index keyData cannot be null");
-        }
+    public void init(SerializationService serializationService, Data key, Object value) {
         if (key == null) {
             throw new IllegalArgumentException("keyData cannot be null");
         }
 
-        this.indexKey = indexKey;
         this.serializationService = serializationService;
 
         this.key = key;
@@ -87,7 +82,7 @@ public class QueryEntry implements QueryableEntry {
 
     @Override
     public Data getKeyData() {
-        return indexKey;
+        return key;
     }
 
     @Override
@@ -127,11 +122,6 @@ public class QueryEntry implements QueryableEntry {
 
 
     @Override
-    public Data getIndexKey() {
-        return indexKey;
-    }
-
-    @Override
     public Object setValue(Object value) {
         throw new UnsupportedOperationException();
     }
@@ -145,7 +135,7 @@ public class QueryEntry implements QueryableEntry {
             return false;
         }
         QueryEntry that = (QueryEntry) o;
-        if (!indexKey.equals(that.indexKey)) {
+        if (!key.equals(that.key)) {
             return false;
         }
         return true;
@@ -153,7 +143,7 @@ public class QueryEntry implements QueryableEntry {
 
     @Override
     public int hashCode() {
-        return indexKey.hashCode();
+        return key.hashCode();
     }
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/QueryEntryUtils.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/QueryEntryUtils.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.query.impl;
+
+import com.hazelcast.internal.serialization.SerializationService;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.nio.serialization.Portable;
+import com.hazelcast.query.QueryException;
+import com.hazelcast.query.impl.getters.ReflectionHelper;
+
+import static com.hazelcast.query.QueryConstants.KEY_ATTRIBUTE_NAME;
+import static com.hazelcast.query.QueryConstants.THIS_ATTRIBUTE_NAME;
+
+final class QueryEntryUtils {
+
+    private QueryEntryUtils() {
+
+    }
+
+    public static boolean isKey(String attributeName) {
+        return attributeName.startsWith(KEY_ATTRIBUTE_NAME);
+    }
+
+    static String getAttributeName(boolean isKey, String attributeName) {
+        if (isKey) {
+            return attributeName.substring(KEY_ATTRIBUTE_NAME.length() + 1);
+        } else {
+            return attributeName;
+        }
+    }
+
+    static Comparable extractViaPortable(String attributeName, Data data, SerializationService ss) {
+        try {
+            return PortableExtractor.extractValue(ss, data, attributeName);
+        } catch (QueryException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new QueryException(e);
+        }
+    }
+
+
+    public static Comparable extractAttribute(String attributeName, Object key, Object value, SerializationService ss) {
+        if (KEY_ATTRIBUTE_NAME.equals(attributeName)) {
+            return (Comparable) ss.toObject(key);
+        } else if (THIS_ATTRIBUTE_NAME.equals(attributeName)) {
+            return (Comparable) ss.toObject(value);
+        }
+
+        boolean isKey = isKey(attributeName);
+        attributeName = getAttributeName(isKey, attributeName);
+        Object target = isKey ? key : value;
+
+        return extractAttribute(attributeName, target, ss);
+    }
+
+    public static Comparable extractAttribute(String attributeName, Object target, SerializationService ss) {
+        if (target instanceof Portable || target instanceof Data) {
+            Data targetData = ss.toData(target);
+            if (targetData.isPortable()) {
+                return extractViaPortable(attributeName, targetData, ss);
+            }
+        }
+
+        Object targetObject = ss.toObject(target);
+        return QueryEntryUtils.extractViaReflection(attributeName, targetObject);
+    }
+
+    // This method is very inefficient because:
+    // lot of time is spend on retrieving field/method and it isn't cached
+    // the actual invocation on the Field, Method is also is quite expensive.
+    static Comparable extractViaReflection(String attributeName, Object obj) {
+        try {
+            return ReflectionHelper.extractValue(obj, attributeName);
+        } catch (QueryException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new QueryException(e);
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/QueryableEntry.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/QueryableEntry.java
@@ -30,8 +30,6 @@ public interface QueryableEntry extends Map.Entry {
 
     Object getKey();
 
-    Data getIndexKey();
-
     Data getKeyData();
 
     Data getValueData();

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/SortedIndexStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/SortedIndexStore.java
@@ -41,14 +41,14 @@ public class SortedIndexStore extends BaseIndexStore {
         takeWriteLock();
         try {
             if (newValue instanceof IndexImpl.NullObject) {
-                recordsWithNullValue.put(record.getIndexKey(), record);
+                recordsWithNullValue.put(record.getKeyData(), record);
             } else {
                 ConcurrentMap<Data, QueryableEntry> records = recordMap.get(newValue);
                 if (records == null) {
                     records = new ConcurrentHashMap<Data, QueryableEntry>(1, LOAD_FACTOR, 1);
                     recordMap.put(newValue, records);
                 }
-                records.put(record.getIndexKey(), record);
+                records.put(record.getKeyData(), record);
             }
         } finally {
             releaseWriteLock();
@@ -59,7 +59,7 @@ public class SortedIndexStore extends BaseIndexStore {
     public void updateIndex(Comparable oldValue, Comparable newValue, QueryableEntry entry) {
         takeWriteLock();
         try {
-            removeIndex(oldValue, entry.getIndexKey());
+            removeIndex(oldValue, entry.getKeyData());
             newIndex(newValue, entry);
         } finally {
             releaseWriteLock();

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/UnsortedIndexStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/UnsortedIndexStore.java
@@ -38,14 +38,14 @@ public class UnsortedIndexStore extends BaseIndexStore {
         takeWriteLock();
         try {
             if (newValue instanceof IndexImpl.NullObject) {
-                recordsWithNullValue.put(record.getIndexKey(), record);
+                recordsWithNullValue.put(record.getKeyData(), record);
             } else {
                 ConcurrentMap<Data, QueryableEntry> records = recordMap.get(newValue);
                 if (records == null) {
                     records = new ConcurrentHashMap<Data, QueryableEntry>(1, LOAD_FACTOR, 1);
                     recordMap.put(newValue, records);
                 }
-                records.put(record.getIndexKey(), record);
+                records.put(record.getKeyData(), record);
             }
         } finally {
             releaseWriteLock();
@@ -56,7 +56,7 @@ public class UnsortedIndexStore extends BaseIndexStore {
     public void updateIndex(Comparable oldValue, Comparable newValue, QueryableEntry entry) {
         takeWriteLock();
         try {
-            removeIndex(oldValue, entry.getIndexKey());
+            removeIndex(oldValue, entry.getKeyData());
             newIndex(newValue, entry);
         } finally {
             releaseWriteLock();

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/ReplicatedQueryEventFilter.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/ReplicatedQueryEventFilter.java
@@ -18,7 +18,7 @@ package com.hazelcast.replicatedmap.impl.record;
 
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.query.Predicate;
-import com.hazelcast.query.impl.QueryEntry;
+import com.hazelcast.query.impl.QueryableEntry;
 
 import java.util.Map;
 
@@ -40,7 +40,7 @@ public class ReplicatedQueryEventFilter
     }
 
     public boolean eval(Object arg) {
-        final QueryEntry entry = (QueryEntry) arg;
+        final QueryableEntry entry = (QueryableEntry) arg;
         final Data keyData = entry.getKeyData();
         return (key == null || key.equals(keyData)) && predicate.apply((Map.Entry) arg);
     }

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryIndexMigrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryIndexMigrationTest.java
@@ -16,6 +16,12 @@
 
 package com.hazelcast.map.impl.query;
 
+import static com.hazelcast.query.Predicates.equal;
+import static com.hazelcast.test.TimeConstants.MINUTE;
+import static java.lang.Thread.interrupted;
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
 import com.hazelcast.config.Config;
 import com.hazelcast.config.MapIndexConfig;
 import com.hazelcast.core.HazelcastInstance;
@@ -33,12 +39,6 @@ import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.util.Clock;
 import com.hazelcast.util.IterableUtil;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -51,13 +51,14 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
-import static com.hazelcast.query.Predicates.equal;
-import static com.hazelcast.test.TimeConstants.MINUTE;
-import static java.lang.Thread.interrupted;
-import static java.util.concurrent.TimeUnit.MINUTES;
-import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
@@ -135,7 +136,6 @@ public class QueryIndexMigrationTest extends HazelcastTestSupport {
         }, 3);
     }
 
-    @Ignore
     @Test
     public void testQueryWithIndexesWhileMigrating() throws Exception {
         HazelcastInstance instance = nodeFactory.newHazelcastInstance();
@@ -162,7 +162,6 @@ public class QueryIndexMigrationTest extends HazelcastTestSupport {
     /**
      * test for issue #359
      */
-    @Ignore
     @Test(timeout = MINUTE)
     public void testIndexCleanupOnMigration() throws Exception {
         int nodeCount = 6;

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryIndexTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryIndexTest.java
@@ -128,6 +128,19 @@ public class QueryIndexTest extends HazelcastTestSupport {
     }
 
     @Test(timeout = 1000 * 60)
+    public void testQueryDoesntMatchOldResults_whenEntriesAreUpdated() {
+        HazelcastInstance instance = createHazelcastInstance();
+        IMap<String, SampleObjects.Value> map = instance.getMap("default");
+        map.addIndex("name", true);
+
+        map.put("0", new Value("name"));
+        map.put("0", new Value("newName"));
+
+        Collection<SampleObjects.Value> values = map.values(new SqlPredicate("name='name'"));
+        assertEquals(0, values.size());
+    }
+
+    @Test(timeout = 1000 * 60)
         public void testOneIndexedFieldsWithTwoCriteriaField() throws Exception {
             HazelcastInstance h1 = createHazelcastInstance();
             IMap imap = h1.getMap("employees");

--- a/hazelcast/src/test/java/com/hazelcast/query/PortablePredicatesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/PortablePredicatesTest.java
@@ -69,7 +69,7 @@ public class PortablePredicatesTest {
     }
 
     private QueryEntry toQueryEntry(Object key, Object value) {
-        return new QueryEntry(ss, ss.toData(key), key, value);
+        return new QueryEntry(ss, ss.toData(key), value);
     }
 
     class TestPortableFactory implements PortableFactory {

--- a/hazelcast/src/test/java/com/hazelcast/query/SqlPredicateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/SqlPredicateTest.java
@@ -367,7 +367,7 @@ public class SqlPredicateTest {
     }
 
     private Map.Entry createEntry(final Object key, final Object value) {
-        return new QueryEntry(ss, toData(key), key, value);
+        return new QueryEntry(ss, toData(key), value);
     }
 
     private void assertSqlTrue(String s, Object value) {

--- a/hazelcast/src/test/java/com/hazelcast/query/SqlPredicateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/SqlPredicateTest.java
@@ -16,6 +16,10 @@
 
 package com.hazelcast.query;
 
+import static com.hazelcast.instance.TestUtil.toData;
+
+import com.hazelcast.internal.serialization.SerializationService;
+import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
 import com.hazelcast.query.SampleObjects.Employee;
 import com.hazelcast.query.SampleObjects.ObjectWithBigDecimal;
 import com.hazelcast.query.SampleObjects.ObjectWithBoolean;
@@ -34,9 +38,6 @@ import com.hazelcast.query.impl.DateHelperTest;
 import com.hazelcast.query.impl.QueryEntry;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -48,15 +49,21 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
-import static com.hazelcast.instance.TestUtil.toData;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
 public class SqlPredicateTest {
+
+    final SerializationService ss = new DefaultSerializationServiceBuilder().build();
+
     @Test
     public void testEqualsWhenSqlMatches() throws Exception {
         SqlPredicate sql1 = new SqlPredicate("foo='bar'");
@@ -359,8 +366,8 @@ public class SqlPredicateTest {
         return new SqlPredicate(sql).toString();
     }
 
-    private static Map.Entry createEntry(final Object key, final Object value) {
-        return new QueryEntry(null, toData(key), key, value);
+    private Map.Entry createEntry(final Object key, final Object value) {
+        return new QueryEntry(ss, toData(key), key, value);
     }
 
     private void assertSqlTrue(String s, Object value) {

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/AndResultSetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/AndResultSetTest.java
@@ -88,10 +88,5 @@ public class AndResultSetTest extends HazelcastTestSupport {
         public Data getValueData() {
             return null;
         }
-
-        @Override
-        public Data getIndexKey() {
-            return null;
-        }
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/IndexTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/IndexTest.java
@@ -84,7 +84,7 @@ public class IndexTest {
         is.addOrGetIndex("favoriteCity", false);
         Data key = ss.toData(1);
         Data value = ss.toData(new SerializableWithEnum(SerializableWithEnum.City.Istanbul));
-        is.saveEntryIndex(new QueryEntry(ss, key, key, value), null);
+        is.saveEntryIndex(new QueryEntry(ss, key, value), null);
         assertNotNull(is.getIndex("favoriteCity"));
         Record record = recordFactory.newRecord(key, value);
         is.removeEntryIndex(record);
@@ -97,10 +97,10 @@ public class IndexTest {
         is.addOrGetIndex("favoriteCity", false);
         Data key = ss.toData(1);
         Data value = ss.toData(new SerializableWithEnum(SerializableWithEnum.City.Istanbul));
-        is.saveEntryIndex(new QueryEntry(ss, key, key, value), null);
+        is.saveEntryIndex(new QueryEntry(ss, key, value), null);
 
         Data newValue = ss.toData(new SerializableWithEnum(SerializableWithEnum.City.Krakow));
-        is.saveEntryIndex(new QueryEntry(ss, key, key, newValue), value);
+        is.saveEntryIndex(new QueryEntry(ss, key, newValue), value);
 
         assertEquals(0, is.getIndex("favoriteCity").getRecords(SerializableWithEnum.City.Istanbul).size());
         assertEquals(1, is.getIndex("favoriteCity").getRecords(SerializableWithEnum.City.Krakow).size());
@@ -115,7 +115,7 @@ public class IndexTest {
         for (int i = 0; i < 1000; i++) {
             Data key = ss.toData(i);
             Data value = ss.toData(new MainPortable(i % 2 == 0, -10.34d, "joe" + i));
-            is.saveEntryIndex(new QueryEntry(ss, key, key, value), null);
+            is.saveEntryIndex(new QueryEntry(ss, key, value), null);
         }
         assertEquals(1000, dIndex.getRecords(-10.34d).size());
         assertEquals(1, strIndex.getRecords("joe23").size());
@@ -126,7 +126,7 @@ public class IndexTest {
         for (int i = 0; i < 1000; i++) {
             Data key = ss.toData(i);
             Data value = ss.toData(new MainPortable(false, 11.34d, "joe"));
-            is.saveEntryIndex(new QueryEntry(ss, key, key, value), null);
+            is.saveEntryIndex(new QueryEntry(ss, key, value), null);
         }
 
         assertEquals(0, dIndex.getRecords(-10.34d).size());
@@ -140,7 +140,7 @@ public class IndexTest {
         for (int i = 0; i < 1000; i++) {
             Data key = ss.toData(i);
             Data value = ss.toData(new MainPortable(false, -1 * (i + 1), "joe" + i));
-            is.saveEntryIndex(new QueryEntry(ss, key, key, value), null);
+            is.saveEntryIndex(new QueryEntry(ss, key, value), null);
         }
         assertEquals(0, dIndex.getSubRecordsBetween(1d, 1001d).size());
         assertEquals(1000, dIndex.getSubRecordsBetween(-1d, -1001d).size());
@@ -149,7 +149,7 @@ public class IndexTest {
         for (int i = 0; i < 1000; i++) {
             Data key = ss.toData(i);
             Data value = ss.toData(new MainPortable(false, 1 * (i + 1), "joe" + i));
-            is.saveEntryIndex(new QueryEntry(ss, key, key, value), null);
+            is.saveEntryIndex(new QueryEntry(ss, key, value), null);
         }
         assertEquals(1000, dIndex.getSubRecordsBetween(1d, 1001d).size());
         assertEquals(0, dIndex.getSubRecordsBetween(-1d, -1001d).size());
@@ -175,17 +175,17 @@ public class IndexTest {
 
         Data value = ss.toData(new MainPortable(false, 1, null));
         Data key1 = ss.toData(0);
-        is.saveEntryIndex(new QueryEntry(ss, key1, key1, value), null);
+        is.saveEntryIndex(new QueryEntry(ss, key1, value), null);
 
         value = ss.toData(new MainPortable(false, 2, null));
         Data key2 = ss.toData(1);
-        is.saveEntryIndex(new QueryEntry(ss, key2, key2, value), null);
+        is.saveEntryIndex(new QueryEntry(ss, key2, value), null);
 
 
         for (int i = 2; i < 1000; i++) {
             Data key = ss.toData(i);
             value = ss.toData(new MainPortable(false, 1 * (i + 1), "joe" + i));
-            is.saveEntryIndex(new QueryEntry(ss, key, key, value), null);
+            is.saveEntryIndex(new QueryEntry(ss, key, value), null);
         }
 
         Comparable c = null;
@@ -378,10 +378,6 @@ public class IndexTest {
             return null;
         }
 
-        public Data getIndexKey() {
-            return key;
-        }
-
         public long getCreationTime() {
             return 0;
         }
@@ -448,8 +444,8 @@ public class IndexTest {
         ConcurrentMap<Data, QueryableEntry> records = index.getRecordMap(555L);
         assertNotNull(records);
         assertEquals(2, records.size());
-        assertEquals(record5, records.get(record5.getIndexKey()));
-        assertEquals(record50, records.get(record50.getIndexKey()));
+        assertEquals(record5, records.get(record5.getKeyData()));
+        assertEquals(record50, records.get(record50.getKeyData()));
         assertEquals(2, index.getRecords(555L).size());
         assertEquals(3, index.getSubRecordsBetween(55L, 555L).size());
         assertEquals(3, index.getSubRecordsBetween(66L, 555L).size());

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/IndexTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/IndexTest.java
@@ -16,33 +16,44 @@
 
 package com.hazelcast.query.impl;
 
+import static com.hazelcast.instance.TestUtil.toData;
+import static java.util.Arrays.asList;
+
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.core.PartitioningStrategy;
+import com.hazelcast.internal.serialization.SerializationService;
+import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
+import com.hazelcast.map.impl.record.DataRecordFactory;
+import com.hazelcast.map.impl.record.Record;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.DataSerializable;
-import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
 import com.hazelcast.nio.serialization.Portable;
 import com.hazelcast.nio.serialization.PortableFactory;
 import com.hazelcast.nio.serialization.PortableReader;
 import com.hazelcast.nio.serialization.PortableWriter;
-import com.hazelcast.internal.serialization.SerializationService;
-import com.hazelcast.query.impl.predicates.AndPredicate;
-import com.hazelcast.query.impl.predicates.EqualPredicate;
+import com.hazelcast.partition.strategy.DefaultPartitioningStrategy;
+import com.hazelcast.query.QueryConstants;
 import com.hazelcast.query.QueryException;
 import com.hazelcast.query.impl.getters.ReflectionHelper;
+import com.hazelcast.query.impl.predicates.AndPredicate;
+import com.hazelcast.query.impl.predicates.EqualPredicate;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
 
 import java.io.IOException;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.concurrent.ConcurrentMap;
 
-import static com.hazelcast.instance.TestUtil.toData;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
@@ -52,6 +63,10 @@ public class IndexTest {
 
     final SerializationService ss = new DefaultSerializationServiceBuilder()
             .addPortableFactory(FACTORY_ID, new TestPortableFactory()).build();
+
+    private PartitioningStrategy partitionStrategy = new DefaultPartitioningStrategy();
+
+    final DataRecordFactory recordFactory = new DataRecordFactory(new MapConfig(), ss, partitionStrategy);
 
     @Test
     public void testBasics() {
@@ -65,51 +80,76 @@ public class IndexTest {
 
     @Test
     public void testRemoveEnumIndex() {
-        Indexes is = new Indexes();
+        Indexes is = new Indexes(ss);
         is.addOrGetIndex("favoriteCity", false);
         Data key = ss.toData(1);
         Data value = ss.toData(new SerializableWithEnum(SerializableWithEnum.City.Istanbul));
-        is.saveEntryIndex(new QueryEntry(ss, key, key, value));
+        is.saveEntryIndex(new QueryEntry(ss, key, key, value), null);
         assertNotNull(is.getIndex("favoriteCity"));
-        is.removeEntryIndex(key);
+        Record record = recordFactory.newRecord(key, value);
+        is.removeEntryIndex(record);
         assertEquals(0,is.getIndex("favoriteCity").getRecords(SerializableWithEnum.City.Istanbul).size());
     }
 
     @Test
+    public void testUpdateEnumIndex() {
+        Indexes is = new Indexes(ss);
+        is.addOrGetIndex("favoriteCity", false);
+        Data key = ss.toData(1);
+        Data value = ss.toData(new SerializableWithEnum(SerializableWithEnum.City.Istanbul));
+        is.saveEntryIndex(new QueryEntry(ss, key, key, value), null);
+
+        Data newValue = ss.toData(new SerializableWithEnum(SerializableWithEnum.City.Krakow));
+        is.saveEntryIndex(new QueryEntry(ss, key, key, newValue), value);
+
+        assertEquals(0, is.getIndex("favoriteCity").getRecords(SerializableWithEnum.City.Istanbul).size());
+        assertEquals(1, is.getIndex("favoriteCity").getRecords(SerializableWithEnum.City.Krakow).size());
+    }
+
+    @Test
     public void testIndex() throws QueryException {
-        Indexes is = new Indexes();
+        Indexes is = new Indexes(ss);
         Index dIndex = is.addOrGetIndex("d", false);
         Index boolIndex = is.addOrGetIndex("bool", false);
         Index strIndex = is.addOrGetIndex("str", false);
         for (int i = 0; i < 1000; i++) {
             Data key = ss.toData(i);
             Data value = ss.toData(new MainPortable(i % 2 == 0, -10.34d, "joe" + i));
-            is.saveEntryIndex(new QueryEntry(ss, key, key, value));
+            is.saveEntryIndex(new QueryEntry(ss, key, key, value), null);
         }
         assertEquals(1000, dIndex.getRecords(-10.34d).size());
         assertEquals(1, strIndex.getRecords("joe23").size());
         assertEquals(500, boolIndex.getRecords(true).size());
+
+        clearIndexes(dIndex, boolIndex, strIndex);
+
         for (int i = 0; i < 1000; i++) {
             Data key = ss.toData(i);
             Data value = ss.toData(new MainPortable(false, 11.34d, "joe"));
-            is.saveEntryIndex(new QueryEntry(ss, key, key, value));
+            is.saveEntryIndex(new QueryEntry(ss, key, key, value), null);
         }
+
         assertEquals(0, dIndex.getRecords(-10.34d).size());
         assertEquals(0, strIndex.getRecords("joe23").size());
         assertEquals(1000, strIndex.getRecords("joe").size());
         assertEquals(1000, boolIndex.getRecords(false).size());
         assertEquals(0, boolIndex.getRecords(true).size());
+
+        clearIndexes(dIndex, boolIndex, strIndex);
+
         for (int i = 0; i < 1000; i++) {
             Data key = ss.toData(i);
             Data value = ss.toData(new MainPortable(false, -1 * (i + 1), "joe" + i));
-            is.saveEntryIndex(new QueryEntry(ss, key, key, value));
+            is.saveEntryIndex(new QueryEntry(ss, key, key, value), null);
         }
         assertEquals(0, dIndex.getSubRecordsBetween(1d, 1001d).size());
         assertEquals(1000, dIndex.getSubRecordsBetween(-1d, -1001d).size());
+        clearIndexes(dIndex, boolIndex, strIndex);
+
         for (int i = 0; i < 1000; i++) {
             Data key = ss.toData(i);
             Data value = ss.toData(new MainPortable(false, 1 * (i + 1), "joe" + i));
-            is.saveEntryIndex(new QueryEntry(ss, key, key, value));
+            is.saveEntryIndex(new QueryEntry(ss, key, key, value), null);
         }
         assertEquals(1000, dIndex.getSubRecordsBetween(1d, 1001d).size());
         assertEquals(0, dIndex.getSubRecordsBetween(-1d, -1001d).size());
@@ -122,24 +162,30 @@ public class IndexTest {
         assertEquals(1, is.query(new AndPredicate(new EqualPredicate("d", "1"), new EqualPredicate("bool", false))).size());
     }
 
+    private void clearIndexes(Index ... indexes) {
+        for(Index index: indexes) {
+            index.clear();
+        }
+    }
+
     @Test
     public void testIndexWithNull() throws QueryException {
-        Indexes is = new Indexes();
+        Indexes is = new Indexes(ss);
         Index strIndex = is.addOrGetIndex("str", true);
 
         Data value = ss.toData(new MainPortable(false, 1, null));
         Data key1 = ss.toData(0);
-        is.saveEntryIndex(new QueryEntry(ss, key1, key1, value));
+        is.saveEntryIndex(new QueryEntry(ss, key1, key1, value), null);
 
         value = ss.toData(new MainPortable(false, 2, null));
         Data key2 = ss.toData(1);
-        is.saveEntryIndex(new QueryEntry(ss, key2, key2, value));
+        is.saveEntryIndex(new QueryEntry(ss, key2, key2, value), null);
 
 
         for (int i = 2; i < 1000; i++) {
             Data key = ss.toData(i);
             value = ss.toData(new MainPortable(false, 1 * (i + 1), "joe" + i));
-            is.saveEntryIndex(new QueryEntry(ss, key, key, value));
+            is.saveEntryIndex(new QueryEntry(ss, key, key, value), null);
         }
 
         Comparable c = null;
@@ -349,7 +395,7 @@ public class IndexTest {
         }
 
         public Object getValue() {
-            return null;
+            return attributeValue;
         }
 
         public Object setValue(Object value) {
@@ -365,33 +411,40 @@ public class IndexTest {
 
         public void readData(ObjectDataInput in) throws IOException {
         }
+
+        public Record toRecord() {
+            return recordFactory.newRecord(key, attributeValue);
+        }
     }
 
     private void testIt(boolean ordered) {
-        IndexImpl index = new IndexImpl(null, ordered);
+        IndexImpl index = new IndexImpl(QueryConstants.THIS_ATTRIBUTE_NAME, ordered, ss);
         assertEquals(0, index.getRecords(0L).size());
         assertEquals(0, index.getSubRecordsBetween(0L, 1000L).size());
         QueryRecord record5 = newRecord(5L, 55L);
-        index.saveEntryIndex(record5);
-        assertEquals(1, index.getRecordValues().size());
-        assertEquals(55L, index.getRecordValues().get(record5.getIndexKey()));
+        index.saveEntryIndex(record5, null);
+        assertEquals(Collections.<QueryableEntry>singleton(record5), index.getRecords(55L));
+
         QueryRecord record6 = newRecord(6L, 66L);
-        index.saveEntryIndex(record6);
-        assertEquals(2, index.getRecordValues().size());
-        assertEquals(new Long(66L), index.getRecordValues().get(record6.getIndexKey()));
-        record5.changeAttribute(555L);
-        index.saveEntryIndex(record5);
-        assertEquals(2, index.getRecordValues().size());
-        assertEquals(new Long(555L), index.getRecordValues().get(record5.getIndexKey()));
+        index.saveEntryIndex(record6, null);
+
+        assertEquals(Collections.<QueryableEntry>singleton(record6), index.getRecords(66L));
+
+        QueryRecord newRecord5 = newRecord(5L, 555L);
+        index.saveEntryIndex(newRecord5, record5.getValue());
+        record5 = newRecord5;
+
+        assertEquals(0, index.getRecords(55L).size());
+        assertEquals(Collections.<QueryableEntry>singleton(record5), index.getRecords(555L));
+
         assertEquals(1, index.getRecords(555L).size());
         assertEquals(2, index.getSubRecordsBetween(55L, 555L).size());
         assertEquals(2, index.getSubRecordsBetween(66L, 555L).size());
         assertEquals(1, index.getSubRecordsBetween(555L, 555L).size());
         QueryRecord record50 = newRecord(50L, 555L);
-        index.saveEntryIndex(record50);
-        assertEquals(3, index.getRecordValues().size());
-        assertEquals(new Long(555L), index.getRecordValues().get(record5.getIndexKey()));
-        assertEquals(new Long(555L), index.getRecordValues().get(record50.getIndexKey()));
+        index.saveEntryIndex(record50, null);
+        assertEquals(new HashSet(asList(record5, record50)), index.getRecords(555L));
+
         ConcurrentMap<Data, QueryableEntry> records = index.getRecordMap(555L);
         assertNotNull(records);
         assertEquals(2, records.size());
@@ -412,10 +465,11 @@ public class IndexTest {
         assertEquals(1, index.getSubRecords(ComparisonType.NOT_EQUAL, 555L).size());
         assertEquals(3, index.getRecords(new Comparable[]{66L, 555L, 34234L}).size());
         assertEquals(2, index.getRecords(new Comparable[]{555L, 34234L}).size());
-        index.removeEntryIndex(record5.getIndexKey());
-        assertEquals(2, index.getRecordValues().size());
-        assertEquals(new Long(555L), index.getRecordValues().get(record50.getIndexKey()));
-        assertEquals(null, index.getRecordValues().get(record5.getIndexKey()));
+
+        index.removeEntryIndex(record5.toRecord());
+
+        assertEquals(Collections.<QueryableEntry>singleton(record50), index.getRecords(555L));
+
         records = index.getRecordMap(555L);
         assertNotNull(records);
         assertEquals(null, records.get(5L));
@@ -430,18 +484,20 @@ public class IndexTest {
         assertEquals(1, index.getSubRecords(ComparisonType.GREATER, 66L).size());
         assertEquals(2, index.getSubRecords(ComparisonType.GREATER_EQUAL, 66L).size());
         assertEquals(2, index.getSubRecords(ComparisonType.GREATER_EQUAL, 61L).size());
-        index.removeEntryIndex(record50.getIndexKey());
-        assertEquals(1, index.getRecordValues().size());
-        assertEquals(null, index.getRecordValues().get(50L));
+        index.removeEntryIndex(record50.toRecord());
+
+        assertEquals(0, index.getRecords(555L).size());
+
         records = index.getRecordMap(555L);
         assertNull(records);
         assertEquals(0, index.getRecords(555L).size());
         assertEquals(1, index.getSubRecordsBetween(55L, 555L).size());
         assertEquals(1, index.getSubRecordsBetween(66L, 555L).size());
         assertEquals(0, index.getSubRecordsBetween(555L, 555L).size());
-        index.removeEntryIndex(record6.getIndexKey());
-        assertEquals(0, index.getRecordValues().size());
-        assertEquals(null, index.getRecordValues().get(6L));
+        index.removeEntryIndex(record6.toRecord());
+
+        assertEquals(0, index.getRecords(66L).size());
+
         assertNull(index.getRecordMap(66L));
         assertEquals(0, index.getRecords(555L).size());
         assertEquals(0, index.getSubRecordsBetween(55L, 555L).size());

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/IndexesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/IndexesTest.java
@@ -53,7 +53,7 @@ public class IndexesTest {
         indexes.addOrGetIndex("salary", true);
         for (int i = 0; i < 20000; i++) {
             Employee employee = new Employee(i + "Name", i % 80, (i % 2 == 0), 100 + (i % 1000));
-            indexes.saveEntryIndex(new QueryEntry(ss, toData(i), i, employee), null);
+            indexes.saveEntryIndex(new QueryEntry(ss, toData(i), employee), null);
         }
         int count = 1000;
         Set<String> ages = new HashSet<String>(count);
@@ -79,7 +79,7 @@ public class IndexesTest {
         indexes.addOrGetIndex("salary", true);
         for (int i = 0; i < 2000; i++) {
             Employee employee = new Employee(i + "Name", i % 80, (i % 2 == 0), 100 + (i % 100));
-            indexes.saveEntryIndex(new QueryEntry(ss, toData(i), i, employee), null);
+            indexes.saveEntryIndex(new QueryEntry(ss, toData(i), employee), null);
         }
 
         for (int i = 0; i < 10; i++) {
@@ -93,15 +93,15 @@ public class IndexesTest {
     public void testIndex2() throws Exception {
         Indexes indexes = new Indexes(ss);
         indexes.addOrGetIndex("name", false);
-        indexes.saveEntryIndex(new QueryEntry(ss, toData(1), 1, new Value("abc")), null);
-        indexes.saveEntryIndex(new QueryEntry(ss, toData(2), 2, new Value("xyz")), null);
-        indexes.saveEntryIndex(new QueryEntry(ss, toData(3), 3, new Value("aaa")), null);
-        indexes.saveEntryIndex(new QueryEntry(ss, toData(4), 4, new Value("zzz")), null);
-        indexes.saveEntryIndex(new QueryEntry(ss, toData(5), 5, new Value("klm")), null);
-        indexes.saveEntryIndex(new QueryEntry(ss, toData(6), 6, new Value("prs")), null);
-        indexes.saveEntryIndex(new QueryEntry(ss, toData(7), 7, new Value("prs")), null);
-        indexes.saveEntryIndex(new QueryEntry(ss, toData(8), 8, new Value("def")), null);
-        indexes.saveEntryIndex(new QueryEntry(ss, toData(9), 9, new Value("qwx")), null);
+        indexes.saveEntryIndex(new QueryEntry(ss, toData(1), new Value("abc")), null);
+        indexes.saveEntryIndex(new QueryEntry(ss, toData(2), new Value("xyz")), null);
+        indexes.saveEntryIndex(new QueryEntry(ss, toData(3), new Value("aaa")), null);
+        indexes.saveEntryIndex(new QueryEntry(ss, toData(4), new Value("zzz")), null);
+        indexes.saveEntryIndex(new QueryEntry(ss, toData(5), new Value("klm")), null);
+        indexes.saveEntryIndex(new QueryEntry(ss, toData(6), new Value("prs")), null);
+        indexes.saveEntryIndex(new QueryEntry(ss, toData(7), new Value("prs")), null);
+        indexes.saveEntryIndex(new QueryEntry(ss, toData(8), new Value("def")), null);
+        indexes.saveEntryIndex(new QueryEntry(ss, toData(9), new Value("qwx")), null);
         assertEquals(8, new HashSet(indexes.query(new SqlPredicate("name > 'aac'"))).size());
     }
 
@@ -130,7 +130,7 @@ public class IndexesTest {
     private void shouldReturnNull_whenQueryingOnKeys(Indexes indexes) {
         for (int i = 0; i < 50; i++) {
             // passing null value to QueryEntry.
-            indexes.saveEntryIndex(new QueryEntry(ss, toData(i), i, null), null);
+            indexes.saveEntryIndex(new QueryEntry(ss, toData(i), null), null);
         }
 
         Set<QueryableEntry> query = indexes.query(new SqlPredicate("__key > 10 "));
@@ -145,7 +145,7 @@ public class IndexesTest {
 
         for (int i = 0; i < 100; i++) {
             // passing null value to QueryEntry.
-            indexes.saveEntryIndex(new QueryEntry(ss, toData(i), i, null), null);
+            indexes.saveEntryIndex(new QueryEntry(ss, toData(i), null), null);
         }
 
         Set<QueryableEntry> query = indexes.query(new SqlPredicate("__key > 10 "));

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/QueryEntryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/QueryEntryTest.java
@@ -45,11 +45,10 @@ public class QueryEntryTest extends HazelcastTestSupport {
 
     @Test
     public void getAttribute_whenValueIsPortableObject_thenConvertedToData() {
-        Data indexedKey = serializationService.toData("indexedKey");
+        Data key = serializationService.toData("indexedKey");
 
-        SerializableObject key = new SerializableObject();
         Portable value = new SampleObjects.PortableEmployee(30, "peter");
-        QueryEntry queryEntry = new QueryEntry(serializationService, indexedKey, key, value);
+        QueryEntry queryEntry = new QueryEntry(serializationService, key, value);
 
         // in the portable-data, the attribute 'name' is called 'n'. So if we can retrieve on n
         // correctly it shows that we have used the Portable data, not the actual Portable object
@@ -60,11 +59,10 @@ public class QueryEntryTest extends HazelcastTestSupport {
 
     @Test
     public void getAttribute_whenKeyIsPortableObject_thenConvertedToData() {
-        Data indexedKey = serializationService.toData("indexedKey");
+        Data key = serializationService.toData(new SampleObjects.PortableEmployee(30, "peter"));
 
-        Portable key = new SampleObjects.PortableEmployee(30, "peter");
         SerializableObject value = new SerializableObject();
-        QueryEntry queryEntry = new QueryEntry(serializationService, indexedKey, key, value);
+        QueryEntry queryEntry = new QueryEntry(serializationService, key, value);
 
         // in the portable-data, the attribute 'name' is called 'n'. So if we can retrieve on n
         // correctly it shows that we have used the Portable data, not the actual Portable object
@@ -75,11 +73,10 @@ public class QueryEntryTest extends HazelcastTestSupport {
 
     @Test
     public void getAttribute_whenKeyPortableObjectThenConvertedToData() {
-        Data indexedKey = serializationService.toData("indexedKey");
+        Data key = serializationService.toData(new SampleObjects.PortableEmployee(30, "peter"));
 
-        Portable key = new SampleObjects.PortableEmployee(30, "peter");
         SerializableObject value = new SerializableObject();
-        QueryEntry queryEntry = new QueryEntry(serializationService, indexedKey, key, value);
+        QueryEntry queryEntry = new QueryEntry(serializationService, key, value);
 
         Object result = queryEntry.getAttribute(QueryConstants.KEY_ATTRIBUTE_NAME + ".n");
 
@@ -88,54 +85,28 @@ public class QueryEntryTest extends HazelcastTestSupport {
 
     @Test
     public void getAttribute_whenValueInObjectFormatThenNoSerialization() {
-        Data indexedKey = serializationService.toData("indexedKey");
-
-        SerializableObject key = new SerializableObject();
+        Data key = serializationService.toData(new SerializableObject());
         SerializableObject value = new SerializableObject();
         value.name = "somename";
-        QueryEntry queryEntry = new QueryEntry(serializationService, indexedKey, key, value);
+        QueryEntry queryEntry = new QueryEntry(serializationService, key, value);
 
         Object result = queryEntry.getAttribute("name");
 
         assertEquals("somename", result);
         assertEquals(0, value.deserializationCount);
         assertEquals(0, value.serializationCount);
-        assertEquals(0, key.deserializationCount);
-        assertEquals(0, key.serializationCount);
     }
-
-    @Test
-    public void getAttribute_whenKeyInObjectFormatThenNoSerialization() {
-        Data indexedKey = serializationService.toData("indexedKey");
-
-        SerializableObject key = new SerializableObject();
-        SerializableObject value = new SerializableObject();
-        value.name = "somename";
-        key.name = "somekey";
-        QueryEntry queryEntry = new QueryEntry(serializationService, indexedKey, key, value);
-
-        Object result = queryEntry.getAttribute(QueryConstants.KEY_ATTRIBUTE_NAME + ".name");
-
-        assertEquals(result, "somekey");
-        assertEquals(0, value.deserializationCount);
-        assertEquals(0, value.serializationCount);
-        assertEquals(0, key.deserializationCount);
-        assertEquals(0, key.serializationCount);
-    }
-
 
     @Test
     public void test_init() throws Exception {
-        Data indexedKey = new HeapData();
-
         Data dataKey = serializationService.toData("dataKey");
         Data dataValue = serializationService.toData("dataValue");
-        QueryEntry queryEntry = new QueryEntry(serializationService, indexedKey, dataKey, dataValue);
+        QueryEntry queryEntry = new QueryEntry(serializationService, dataKey, dataValue);
 
         Object objectValue = queryEntry.getValue();
         Object objectKey = queryEntry.getKey();
 
-        queryEntry.init(serializationService, indexedKey, objectKey, objectValue);
+        queryEntry.init(serializationService, serializationService.toData(objectKey), objectValue);
 
         // compare references of objects since they should be cloned after QueryEntry#init call.
         assertTrue("Old dataKey should not be here", dataKey != queryEntry.getKeyData());

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/PredicatesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/PredicatesTest.java
@@ -16,35 +16,7 @@
 
 package com.hazelcast.query.impl.predicates;
 
-import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.IMap;
-import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.query.EntryObject;
-import com.hazelcast.query.IndexAwarePredicate;
-import com.hazelcast.query.Predicate;
-import com.hazelcast.query.PredicateBuilder;
-import com.hazelcast.query.Predicates;
-import com.hazelcast.query.QueryException;
-import com.hazelcast.query.impl.AttributeType;
-import com.hazelcast.query.impl.Index;
-import com.hazelcast.query.impl.IndexImpl;
-import com.hazelcast.query.impl.QueryContext;
-import com.hazelcast.query.impl.QueryEntry;
-import com.hazelcast.query.impl.QueryableEntry;
-import com.hazelcast.query.impl.getters.ReflectionHelper;
-import com.hazelcast.test.HazelcastSerialClassRunner;
-import com.hazelcast.test.HazelcastTestSupport;
-import com.hazelcast.test.annotation.QuickTest;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
-
-import java.math.BigDecimal;
-import java.util.Map;
-import java.util.Set;
-
 import static com.hazelcast.instance.TestUtil.toData;
-
 import static com.hazelcast.query.Predicates.and;
 import static com.hazelcast.query.Predicates.between;
 import static com.hazelcast.query.Predicates.equal;
@@ -59,20 +31,53 @@ import static com.hazelcast.query.Predicates.like;
 import static com.hazelcast.query.Predicates.notEqual;
 import static com.hazelcast.query.Predicates.or;
 import static com.hazelcast.query.Predicates.regex;
-import static com.hazelcast.query.SampleObjects.Employee;
-import static com.hazelcast.query.SampleObjects.Value;
 import static java.lang.Boolean.FALSE;
 import static java.lang.Boolean.TRUE;
-import static java.util.Map.Entry;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.internal.serialization.SerializationService;
+import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.query.EntryObject;
+import com.hazelcast.query.IndexAwarePredicate;
+import com.hazelcast.query.Predicate;
+import com.hazelcast.query.PredicateBuilder;
+import com.hazelcast.query.Predicates;
+import com.hazelcast.query.QueryException;
+import com.hazelcast.query.SampleObjects.Employee;
+import com.hazelcast.query.SampleObjects.Value;
+import com.hazelcast.query.impl.AttributeType;
+import com.hazelcast.query.impl.Index;
+import com.hazelcast.query.impl.IndexImpl;
+import com.hazelcast.query.impl.QueryContext;
+import com.hazelcast.query.impl.QueryEntry;
+import com.hazelcast.query.impl.QueryableEntry;
+import com.hazelcast.query.impl.getters.ReflectionHelper;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.QuickTest;
+
+import java.math.BigDecimal;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
 public class PredicatesTest extends HazelcastTestSupport {
+
+    final SerializationService ss = new DefaultSerializationServiceBuilder().build();
 
     @Test
     public void testAndPredicate_whenFirstIndexAwarePredicateIsNotIndexed() throws Exception {
@@ -295,7 +300,7 @@ public class PredicatesTest extends HazelcastTestSupport {
 
     @Test
     public void testNotEqualsPredicateDoesNotUseIndex() {
-        Index dummyIndex = new IndexImpl("foo", false);
+        Index dummyIndex = new IndexImpl("foo", false, ss);
         QueryContext mockQueryContext = mock(QueryContext.class);
         when(mockQueryContext.getIndex(anyString())).
                 thenReturn(dummyIndex);
@@ -310,7 +315,7 @@ public class PredicatesTest extends HazelcastTestSupport {
     private class DummyEntry extends QueryEntry {
 
         DummyEntry(Comparable attribute) {
-            super(null, toData("1"), "1", attribute);
+            super(ss, toData("1"), "1", attribute);
         }
 
         @Override
@@ -381,8 +386,8 @@ public class PredicatesTest extends HazelcastTestSupport {
 
     }
 
-    private static Entry createEntry(final Object key, final Object value) {
-        return new QueryEntry(null, toData(key), key, value);
+    private Entry createEntry(final Object key, final Object value) {
+        return new QueryEntry(ss, toData(key), key, value);
     }
 
     private void assertPredicateTrue(Predicate p, Comparable comparable) {

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/PredicatesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/PredicatesTest.java
@@ -315,7 +315,7 @@ public class PredicatesTest extends HazelcastTestSupport {
     private class DummyEntry extends QueryEntry {
 
         DummyEntry(Comparable attribute) {
-            super(ss, toData("1"), "1", attribute);
+            super(ss, toData("1"), attribute);
         }
 
         @Override
@@ -379,15 +379,10 @@ public class PredicatesTest extends HazelcastTestSupport {
             return null;
         }
 
-        @Override
-        public Data getIndexKey() {
-            return null;
-        }
-
     }
 
     private Entry createEntry(final Object key, final Object value) {
-        return new QueryEntry(ss, toData(key), key, value);
+        return new QueryEntry(ss, toData(key), value);
     }
 
     private void assertPredicateTrue(Predicate p, Comparable comparable) {

--- a/hazelcast/src/test/java/com/hazelcast/test/TestHazelcastInstanceFactory.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/TestHazelcastInstanceFactory.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.test;
 
+import static com.hazelcast.util.Preconditions.checkNotNull;
+
 import com.hazelcast.config.Config;
 import com.hazelcast.config.XmlConfigBuilder;
 import com.hazelcast.core.Hazelcast;
@@ -31,8 +33,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicInteger;
-
-import static com.hazelcast.util.Preconditions.checkNotNull;
 
 public class TestHazelcastInstanceFactory {
 


### PR DESCRIPTION
This includes changes made by @ajermakovics at #6304

I did 2 additional changes:
- Added a GroupProperty to re-introduce caching of de-serilized objects. It allows to trade memory for CPU as without this it could lead to serious performance regressions. I have a test where throughput is less then half when caching is disabled

- Removed getIndex from `QueryableEntry`. It serve no purpose as keys are always stored in a binary format.

See commit messages for details.

I'm sending this to allow preliminary review. There are 2 missing things:
- better description of the new `GroupProperty`
- explicit tests for CacheQueryEntry