### PR TITLE
Do not retry InitializeDistributedObjectOperation on server

### DIFF
--- a/hazelcast-client-new/src/test/java/com/hazelcast/client/mapreduce/MapReduceLiteMemberTest.java
+++ b/hazelcast-client-new/src/test/java/com/hazelcast/client/mapreduce/MapReduceLiteMemberTest.java
@@ -1,12 +1,9 @@
 package com.hazelcast.client.mapreduce;
 
-import com.hazelcast.client.spi.ClientClusterService;
 import com.hazelcast.client.test.TestHazelcastFactory;
-import com.hazelcast.cluster.memberselector.MemberSelectors;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.ICompletableFuture;
-import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -21,10 +18,7 @@ import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
-import static com.hazelcast.client.impl.ClientTestUtil.getHazelcastClientInstanceImpl;
 import static com.hazelcast.test.HazelcastTestSupport.assertClusterSizeEventually;
-import static com.hazelcast.test.HazelcastTestSupport.assertTrueEventually;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -102,14 +96,6 @@ public class MapReduceLiteMemberTest {
         assertClusterSizeEventually(2, lite);
         assertClusterSizeEventually(2, lite2);
 
-        final ClientClusterService clientClusterService = getHazelcastClientInstanceImpl(client).getClientClusterService();
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run()
-                    throws Exception {
-                assertEquals(0, clientClusterService.getSize(MemberSelectors.DATA_MEMBER_SELECTOR));
-            }
-        });
         ICompletableFuture<Map<String, List<Integer>>> future = com.hazelcast.mapreduce.MapReduceLiteMemberTest
                 .testMapReduceJobSubmissionWithNoDataNode(client);
 
@@ -117,7 +103,6 @@ public class MapReduceLiteMemberTest {
             future.get(30, TimeUnit.SECONDS);
             fail("Map-reduce job should not be submitted when there is no data member");
         } catch (ExecutionException e) {
-            System.out.println(e.getCause());
             assertTrue(e.getCause() instanceof IllegalStateException);
         }
     }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/mapreduce/MapReduceLiteMemberTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/mapreduce/MapReduceLiteMemberTest.java
@@ -1,12 +1,9 @@
 package com.hazelcast.client.mapreduce;
 
-import com.hazelcast.client.spi.ClientClusterService;
 import com.hazelcast.client.test.TestHazelcastFactory;
-import com.hazelcast.cluster.memberselector.MemberSelectors;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.ICompletableFuture;
-import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -22,10 +19,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import static com.hazelcast.client.impl.ClientTestUtil.getHazelcastClientInstanceImpl;
 import static com.hazelcast.test.HazelcastTestSupport.assertClusterSizeEventually;
-import static com.hazelcast.test.HazelcastTestSupport.assertTrueEventually;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -103,15 +97,6 @@ public class MapReduceLiteMemberTest {
         instance2.shutdown();
         assertClusterSizeEventually(2, lite);
         assertClusterSizeEventually(2, lite2);
-
-        final ClientClusterService clientClusterService = getHazelcastClientInstanceImpl(client).getClientClusterService();
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run()
-                    throws Exception {
-                assertEquals(0, clientClusterService.getSize(MemberSelectors.DATA_MEMBER_SELECTOR));
-            }
-        });
 
         ICompletableFuture<Map<String, List<Integer>>> future = com.hazelcast.mapreduce.MapReduceLiteMemberTest
                 .testMapReduceJobSubmissionWithNoDataNode(client);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/client/ClientCreateRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/client/ClientCreateRequest.java
@@ -64,7 +64,7 @@ public class ClientCreateRequest extends TargetClientRequest implements Portable
 
     @Override
     protected InvocationBuilder getInvocationBuilder(Operation op) {
-        return operationService.createInvocationBuilder(getServiceName(), op, target);
+        return operationService.createInvocationBuilder(getServiceName(), op, target).setTryCount(1);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/CreateProxyMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/CreateProxyMessageTask.java
@@ -39,7 +39,7 @@ public class CreateProxyMessageTask extends AbstractInvocationMessageTask<Client
     @Override
     protected InvocationBuilder getInvocationBuilder(Operation op) {
         final InternalOperationService operationService = nodeEngine.getOperationService();
-        return operationService.createInvocationBuilder(getServiceName(), op, parameters.target);
+        return operationService.createInvocationBuilder(getServiceName(), op, parameters.target).setTryCount(1);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/partition/impl/InternalPartitionServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/impl/InternalPartitionServiceImpl.java
@@ -1705,6 +1705,13 @@ public class InternalPartitionServiceImpl implements InternalPartitionService, M
                 Collection<MemberGroup> memberGroups = createMemberGroups();
                 Address[][] newState = psg.reArrange(memberGroups, partitions);
 
+                if (newState == null) {
+                    if (logger.isFinestEnabled()) {
+                        logger.finest("partition rearrangement couldn't be done. size of member groups: " + memberGroups.size());
+                    }
+                    return;
+                }
+
                 if (!isMigrationAllowed()) {
                     return;
                 }


### PR DESCRIPTION
* It is not necessary since client will pick another node
* Do not continue partition re-assignment if there is no data member

Fixes #6371