### PR TITLE
Fix cluster state transaction process

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/cluster/AdvancedClusterStateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/AdvancedClusterStateTest.java
@@ -422,7 +422,7 @@ public class AdvancedClusterStateTest extends HazelcastTestSupport {
         final Cluster cluster = hz.getCluster();
         long timeout = TimeUnit.SECONDS.toMillis(ASSERT_TRUE_EVENTUALLY_TIMEOUT);
         Throwable t = null;
-        while (timeout > 0 && cluster.getClusterState() != newState) {
+        while (timeout > 0) {
             long start = Clock.currentTimeMillis();
             try {
                 cluster.changeClusterState(newState);


### PR DESCRIPTION
Fixed cluster state transaction process. There were two issues:

- Transaction logs should be appended before acquiring initial locks,
not after. Otherwise during rollback, successfully acquired locks will
remain locked until expiration time.

- To provide initial lock and rollback/commit ordering, locking block
should wait for all futures. Throwing error on the first lock failure
will break order and may cause rollback executed before other lock operations.
That will cause again hanging locks (until expiration).

Fixes #6383