### PR TITLE
Remove dependency on (Map) Record in the indexing module

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapMigrationAwareService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapMigrationAwareService.java
@@ -21,6 +21,7 @@ import com.hazelcast.map.impl.operation.MapReplicationOperation;
 import com.hazelcast.map.impl.record.Record;
 import com.hazelcast.map.impl.record.Records;
 import com.hazelcast.map.impl.recordstore.RecordStore;
+import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.partition.MigrationEndpoint;
 import com.hazelcast.query.impl.Indexes;
 import com.hazelcast.query.impl.QueryableEntry;
@@ -95,8 +96,9 @@ class MapMigrationAwareService implements MigrationAwareService {
                 while (iterator.hasNext()) {
                     final Record record = iterator.next();
                     if (event.getMigrationEndpoint() == MigrationEndpoint.SOURCE) {
-                        // was no old value
-                        indexes.removeEntryIndex(record);
+                        Data key = record.getKey();
+                        Object value = Records.getValueOrCachedValue(record, serializationService);
+                        indexes.removeEntryIndex(key, value);
                     } else {
                         Object value = Records.getValueOrCachedValue(record, serializationService);
                         if (value != null) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/AbstractRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/AbstractRecordStore.java
@@ -164,7 +164,9 @@ abstract class AbstractRecordStore implements RecordStore {
     protected void removeIndex(Record record) {
         Indexes indexes = mapContainer.getIndexes();
         if (indexes.hasIndex()) {
-            indexes.removeEntryIndex(record);
+            Data key = record.getKey();
+            Object value = Records.getValueOrCachedValue(record, serializationService);
+            indexes.removeEntryIndex(key, value);
         }
     }
 
@@ -179,8 +181,10 @@ abstract class AbstractRecordStore implements RecordStore {
         Indexes indexes = mapContainer.getIndexes();
         if (indexes.hasIndex()) {
             for (Record record : keysToRemove) {
-                if (!keysToPreserve.contains(record.getKey())) {
-                    indexes.removeEntryIndex(record);
+                Data key = record.getKey();
+                if (!keysToPreserve.contains(key)) {
+                    Object value = Records.getValueOrCachedValue(record, serializationService);
+                    indexes.removeEntryIndex(key, value);
                 }
             }
         }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
@@ -33,6 +33,7 @@ import com.hazelcast.map.impl.mapstore.MapDataStore;
 import com.hazelcast.map.impl.mapstore.MapStoreContext;
 import com.hazelcast.map.impl.mapstore.MapStoreManager;
 import com.hazelcast.map.impl.record.Record;
+import com.hazelcast.map.impl.record.Records;
 import com.hazelcast.map.merge.MapMergePolicy;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.query.impl.Indexes;
@@ -243,7 +244,9 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore implements 
 
         if (indexes.hasIndex()) {
             for (Record record : records.values()) {
-                indexes.removeEntryIndex(record);
+                Data key = record.getKey();
+                Object value = Records.getValueOrCachedValue(record, serializationService);
+                indexes.removeEntryIndex(key, value);
             }
         }
         clearRecordsMap(Collections.<Data, Record>emptyMap());

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/Index.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/Index.java
@@ -17,7 +17,7 @@
 package com.hazelcast.query.impl;
 
 import com.hazelcast.core.TypeConverter;
-import com.hazelcast.map.impl.record.Record;
+import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.query.QueryException;
 
 import java.util.Set;
@@ -45,7 +45,7 @@ public interface Index {
      */
     TypeConverter getConverter();
 
-    void removeEntryIndex(Record record);
+    void removeEntryIndex(Data key, Object value);
 
     Set<QueryableEntry> getRecords(Comparable[] values);
 

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/IndexImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/IndexImpl.java
@@ -18,7 +18,6 @@ package com.hazelcast.query.impl;
 
 import com.hazelcast.core.TypeConverter;
 import com.hazelcast.internal.serialization.SerializationService;
-import com.hazelcast.map.impl.record.Record;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -64,15 +63,15 @@ public class IndexImpl implements Index {
     }
 
     @Override
-    public void removeEntryIndex(Record record) {
-        Comparable value = QueryEntryUtils.extractAttribute(attribute, record.getKey(), record.getValue(), ss);
+    public void removeEntryIndex(Data key, Object value) {
+        Comparable attributeValue = QueryEntryUtils.extractAttribute(this.attribute, key, value, ss);
 
-        if (value.getClass().isEnum()) {
-            value = TypeConverters.ENUM_CONVERTER.convert(value);
+        if (attributeValue.getClass().isEnum()) {
+            attributeValue = TypeConverters.ENUM_CONVERTER.convert(attributeValue);
         }
 
-        if (value != null) {
-            indexStore.removeIndex(value, record.getKey());
+        if (attributeValue != null) {
+            indexStore.removeIndex(attributeValue, key);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/Indexes.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/Indexes.java
@@ -17,7 +17,7 @@
 package com.hazelcast.query.impl;
 
 import com.hazelcast.internal.serialization.SerializationService;
-import com.hazelcast.map.impl.record.Record;
+import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.query.IndexAwarePredicate;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.QueryException;
@@ -72,10 +72,10 @@ public class Indexes {
         hasIndex = false;
     }
 
-    public void removeEntryIndex(Record record) throws QueryException {
+    public void removeEntryIndex(Data key, Object value) throws QueryException {
         Index[] indexes = getIndexes();
         for (Index index : indexes) {
-            index.removeEntryIndex(record);
+            index.removeEntryIndex(key, value);
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/IndexTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/IndexTest.java
@@ -25,6 +25,7 @@ import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
 import com.hazelcast.map.impl.record.DataRecordFactory;
 import com.hazelcast.map.impl.record.Record;
+import com.hazelcast.map.impl.record.Records;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -87,7 +88,7 @@ public class IndexTest {
         is.saveEntryIndex(new QueryEntry(ss, key, value), null);
         assertNotNull(is.getIndex("favoriteCity"));
         Record record = recordFactory.newRecord(key, value);
-        is.removeEntryIndex(record);
+        is.removeEntryIndex(key, Records.getValueOrCachedValue(record, ss));
         assertEquals(0,is.getIndex("favoriteCity").getRecords(SerializableWithEnum.City.Istanbul).size());
     }
 
@@ -462,7 +463,8 @@ public class IndexTest {
         assertEquals(3, index.getRecords(new Comparable[]{66L, 555L, 34234L}).size());
         assertEquals(2, index.getRecords(new Comparable[]{555L, 34234L}).size());
 
-        index.removeEntryIndex(record5.toRecord());
+        Record recordToRemove = record5.toRecord();
+        index.removeEntryIndex(recordToRemove.getKey(), Records.getValueOrCachedValue(recordToRemove, ss));
 
         assertEquals(Collections.<QueryableEntry>singleton(record50), index.getRecords(555L));
 
@@ -480,7 +482,9 @@ public class IndexTest {
         assertEquals(1, index.getSubRecords(ComparisonType.GREATER, 66L).size());
         assertEquals(2, index.getSubRecords(ComparisonType.GREATER_EQUAL, 66L).size());
         assertEquals(2, index.getSubRecords(ComparisonType.GREATER_EQUAL, 61L).size());
-        index.removeEntryIndex(record50.toRecord());
+
+        recordToRemove = record50.toRecord();
+        index.removeEntryIndex(recordToRemove.getKey(), Records.getValueOrCachedValue(recordToRemove, ss));
 
         assertEquals(0, index.getRecords(555L).size());
 
@@ -490,7 +494,9 @@ public class IndexTest {
         assertEquals(1, index.getSubRecordsBetween(55L, 555L).size());
         assertEquals(1, index.getSubRecordsBetween(66L, 555L).size());
         assertEquals(0, index.getSubRecordsBetween(555L, 555L).size());
-        index.removeEntryIndex(record6.toRecord());
+
+        recordToRemove = record6.toRecord();
+        index.removeEntryIndex(recordToRemove.getKey(), Records.getValueOrCachedValue(recordToRemove, ss));
 
         assertEquals(0, index.getRecords(66L).size());
 


### PR DESCRIPTION
The dependency was introduced by mistake at #6391
Indexing is used by the QueryCache as well -> it can't
depends on map-specific classes.