### PR TITLE
Fix duplicate events on migration listeners

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/partition/impl/PromoteFromBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/impl/PromoteFromBackupOperation.java
@@ -95,6 +95,9 @@ final class PromoteFromBackupOperation
     }
 
     private void sendMigrationEvent(final MigrationStatus status) {
+        if (reason != MEMBER_REMOVED) {
+            return;
+        }
         final int partitionId = getPartitionId();
         final NodeEngine nodeEngine = getNodeEngine();
         final Member localMember = nodeEngine.getLocalMember();

--- a/hazelcast/src/test/java/com/hazelcast/partition/PartitionMigrationListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/partition/PartitionMigrationListenerTest.java
@@ -1,14 +1,18 @@
 package com.hazelcast.partition;
 
+import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
 import com.hazelcast.core.MigrationEvent;
 import com.hazelcast.core.MigrationListener;
 import com.hazelcast.core.PartitionService;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -24,6 +28,23 @@ import static org.mockito.Mockito.verify;
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class PartitionMigrationListenerTest extends HazelcastTestSupport {
+
+
+    @Test
+    public void testMigrationListenerCalledOnlyOnceWhenMigrationHappens() throws Exception {
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+        Config config = new Config();
+        int partitionCount = 10;
+        config.setProperty(GroupProperty.PARTITION_COUNT, String.valueOf(partitionCount));
+        HazelcastInstance instance = factory.newHazelcastInstance(config);
+        CountingMigrationListener migrationListener = new CountingMigrationListener(partitionCount);
+        instance.getPartitionService().addMigrationListener(migrationListener);
+        IMap<Object, Object> aDefault = instance.getMap(randomName());
+        aDefault.put(1, 1);
+        factory.newHazelcastInstance(config);
+        assertAllLesserOrEquals(migrationListener.migrationStarted, 1);
+        assertAllLesserOrEquals(migrationListener.migrationCompleted, 1);
+    }
 
     @Test(expected = NullPointerException.class)
     public void testAddMigrationListener_whenNullListener() {
@@ -85,5 +106,45 @@ public class PartitionMigrationListenerTest extends HazelcastTestSupport {
 
         // and verify that the listener isn't called.
         verify(listener, never()).migrationStarted(any(MigrationEvent.class));
+    }
+
+
+    private void assertAllLesserOrEquals(AtomicInteger[] integers, int expected) {
+        for (AtomicInteger integer : integers) {
+            assertTrue(integer.get() <= expected);
+        }
+    }
+
+    class CountingMigrationListener implements MigrationListener {
+
+        AtomicInteger[] migrationStarted;
+        AtomicInteger[] migrationCompleted;
+        AtomicInteger[] migrationFailed;
+
+        public CountingMigrationListener(int partitionCount) {
+            migrationStarted = new AtomicInteger[partitionCount];
+            migrationCompleted = new AtomicInteger[partitionCount];
+            migrationFailed = new AtomicInteger[partitionCount];
+            for (int i = 0; i < partitionCount; i++) {
+                migrationStarted[i] = new AtomicInteger();
+                migrationCompleted[i] = new AtomicInteger();
+                migrationFailed[i] = new AtomicInteger();
+            }
+        }
+
+        @Override
+        public void migrationStarted(MigrationEvent migrationEvent) {
+            migrationStarted[migrationEvent.getPartitionId()].incrementAndGet();
+        }
+
+        @Override
+        public void migrationCompleted(MigrationEvent migrationEvent) {
+            migrationCompleted[migrationEvent.getPartitionId()].incrementAndGet();
+        }
+
+        @Override
+        public void migrationFailed(MigrationEvent migrationEvent) {
+            migrationFailed[migrationEvent.getPartitionId()].incrementAndGet();
+        }
     }
 }


### PR DESCRIPTION
Added check to PromoteFromBackupOperation for not sending events except MEMBER_REMOVED.
Fixes #6396 