### PR TITLE
Extend cluster state transition capabilities

### DIFF
--- a/hazelcast-client-new/src/test/java/com/hazelcast/client/cluster/ClientClusterStateTest.java
+++ b/hazelcast-client-new/src/test/java/com/hazelcast/client/cluster/ClientClusterStateTest.java
@@ -1,0 +1,120 @@
+package com.hazelcast.client.cluster;
+
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.config.ClientProperties;
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.cluster.ClusterState;
+import com.hazelcast.config.Config;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static com.hazelcast.cluster.AdvancedClusterStateTest.changeClusterStateEventually;
+import static com.hazelcast.test.HazelcastTestSupport.assertClusterSizeEventually;
+import static com.hazelcast.test.HazelcastTestSupport.randomMapName;
+import static com.hazelcast.test.HazelcastTestSupport.warmUpPartitions;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ClientClusterStateTest {
+
+    private TestHazelcastFactory factory;
+
+    private HazelcastInstance[] instances;
+
+    private HazelcastInstance instance;
+
+    @Before
+    public void before() {
+        factory = new TestHazelcastFactory();
+        instances = factory.newInstances(new Config(), 3);
+        for (HazelcastInstance instance : instances) {
+            assertClusterSizeEventually(3, instance);
+        }
+        instance = instances[instances.length - 1];
+    }
+
+    @After
+    public void after() {
+        factory.shutdownAll();
+    }
+
+    @Test
+    public void testClient_canConnect_whenClusterState_frozen() {
+        instance.getCluster().changeClusterState(ClusterState.FROZEN);
+        factory.newHazelcastClient();
+    }
+
+    @Test
+    public void testClient_canExecuteWriteOperations_whenClusterState_frozen() {
+        warmUpPartitions(instances);
+
+        changeClusterStateEventually(instance, ClusterState.FROZEN);
+        final HazelcastInstance client = factory.newHazelcastClient();
+        final IMap<Object, Object> map = client.getMap(randomMapName());
+        map.put(1, 1);
+    }
+
+    @Test
+    public void testClient_canExecuteReadOperations_whenClusterState_frozen() {
+        warmUpPartitions(instances);
+
+        changeClusterStateEventually(instance, ClusterState.FROZEN);
+        final HazelcastInstance client = factory.newHazelcastClient();
+        final IMap<Object, Object> map = client.getMap(randomMapName());
+        map.get(1);
+    }
+
+    @Test
+    public void testClient_canConnect_whenClusterState_passive() {
+        instance.getCluster().changeClusterState(ClusterState.PASSIVE);
+        factory.newHazelcastClient();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testClient_canNotExecuteWriteOperations_whenClusterState_passive() {
+        warmUpPartitions(instances);
+
+        final ClientConfig clientConfig = new ClientConfig().setProperty(ClientProperties.PROP_INVOCATION_TIMEOUT_SECONDS, "3");
+        final HazelcastInstance client = factory.newHazelcastClient(clientConfig);
+        final IMap<Object, Object> map = client.getMap(randomMapName());
+        changeClusterStateEventually(instance, ClusterState.PASSIVE);
+        map.put(1, 1);
+    }
+
+    @Test
+    public void testClient_canExecuteReadOperations_whenClusterState_passive() {
+        warmUpPartitions(instances);
+
+        final HazelcastInstance client = factory.newHazelcastClient();
+        final IMap<Object, Object> map = client.getMap(randomMapName());
+        changeClusterStateEventually(instance, ClusterState.PASSIVE);
+        map.get(1);
+    }
+
+    @Test
+    public void testClient_canConnect_whenClusterState_goesBackToActive_fromPassive() {
+        instance.getCluster().changeClusterState(ClusterState.PASSIVE);
+        instance.getCluster().changeClusterState(ClusterState.ACTIVE);
+        factory.newHazelcastClient();
+    }
+
+    @Test
+    public void testClient_canExecuteOperations_whenClusterState_goesBackToActive_fromPassive() {
+        warmUpPartitions(instances);
+
+        changeClusterStateEventually(instance, ClusterState.PASSIVE);
+        instance.getCluster().changeClusterState(ClusterState.ACTIVE);
+        final HazelcastInstance client = factory.newHazelcastClient();
+        final IMap<Object, Object> map = client.getMap(randomMapName());
+        map.put(1, 1);
+    }
+
+}

--- a/hazelcast-client-new/src/test/java/com/hazelcast/client/test/TestClientRegistry.java
+++ b/hazelcast-client-new/src/test/java/com/hazelcast/client/test/TestClientRegistry.java
@@ -250,7 +250,7 @@ public class TestClientRegistry {
         @Override
         public boolean write(OutboundFrame frame) {
             final ClientMessage packet = (ClientMessage) frame;
-            if (nodeEngine.isActive()) {
+            if (nodeEngine.isRunning()) {
                 ClientMessage newPacket = readFromPacket(packet);
                 responseConnection.handleClientMessage(newPacket);
                 return true;

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cluster/ClientClusterStateTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cluster/ClientClusterStateTest.java
@@ -1,0 +1,124 @@
+package com.hazelcast.client.cluster;
+
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.config.ClientProperties;
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.cluster.ClusterState;
+import com.hazelcast.config.Config;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static com.hazelcast.cluster.AdvancedClusterStateTest.changeClusterStateEventually;
+import static com.hazelcast.test.HazelcastTestSupport.assertClusterSizeEventually;
+import static com.hazelcast.test.HazelcastTestSupport.randomMapName;
+import static com.hazelcast.test.HazelcastTestSupport.warmUpPartitions;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ClientClusterStateTest {
+
+    private TestHazelcastFactory factory;
+
+    private HazelcastInstance[] instances;
+
+    private HazelcastInstance instance;
+
+    @Before
+    public void before() {
+        factory = new TestHazelcastFactory();
+        instances = factory.newInstances(new Config(), 3);
+        for (HazelcastInstance instance : instances) {
+            assertClusterSizeEventually(3, instance);
+        }
+        instance = instances[instances.length - 1];
+    }
+
+    @After
+    public void after() {
+        factory.terminateAll();
+    }
+
+    @Test
+    public void testClient_canConnect_whenClusterState_frozen() {
+        instance.getCluster().changeClusterState(ClusterState.FROZEN);
+        factory.newHazelcastClient();
+    }
+
+    @Test
+    public void testClient_canExecuteWriteOperations_whenClusterState_frozen() {
+        warmUpPartitions(instances);
+
+        final HazelcastInstance client = factory.newHazelcastClient();
+        changeClusterStateEventually(instance, ClusterState.FROZEN);
+        assertEquals(ClusterState.FROZEN, instance.getCluster().getClusterState());
+        final IMap<Object, Object> map = client.getMap(randomMapName());
+        map.put(1, 1);
+    }
+
+    @Test
+    public void testClient_canExecuteReadOperations_whenClusterState_frozen() {
+        warmUpPartitions(instances);
+
+        changeClusterStateEventually(instance, ClusterState.FROZEN);
+        final HazelcastInstance client = factory.newHazelcastClient();
+        final IMap<Object, Object> map = client.getMap(randomMapName());
+        map.get(1);
+    }
+
+    @Test
+    public void testClient_canConnect_whenClusterState_passive() {
+        instance.getCluster().changeClusterState(ClusterState.PASSIVE);
+        factory.newHazelcastClient();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testClient_canNotExecuteWriteOperations_whenClusterState_passive() {
+        warmUpPartitions(instances);
+
+        final ClientConfig clientConfig = new ClientConfig().setProperty(ClientProperties.PROP_INVOCATION_TIMEOUT_SECONDS, "3");
+        final HazelcastInstance client = factory.newHazelcastClient(
+                clientConfig);
+        final IMap<Object, Object> map = client.getMap(randomMapName());
+        changeClusterStateEventually(instance, ClusterState.PASSIVE);
+        map.put(1, 1);
+    }
+
+    @Test
+    public void testClient_canExecuteReadOperations_whenClusterState_passive() {
+        warmUpPartitions(instances);
+
+        final HazelcastInstance client = factory.newHazelcastClient();
+        final IMap<Object, Object> map = client.getMap(randomMapName());
+
+        changeClusterStateEventually(instance, ClusterState.PASSIVE);
+        map.get(1);
+    }
+
+    @Test
+    public void testClient_canConnect_whenClusterState_goesBackToActive_fromPassive() {
+        instance.getCluster().changeClusterState(ClusterState.PASSIVE);
+        instance.getCluster().changeClusterState(ClusterState.ACTIVE);
+        factory.newHazelcastClient();
+    }
+
+    @Test
+    public void testClient_canExecuteOperations_whenClusterState_goesBackToActive_fromPassive() {
+        warmUpPartitions(instances);
+
+        changeClusterStateEventually(instance, ClusterState.PASSIVE);
+        instance.getCluster().changeClusterState(ClusterState.ACTIVE);
+        final HazelcastInstance client = factory.newHazelcastClient();
+        final IMap<Object, Object> map = client.getMap(randomMapName());
+        map.put(1, 1);
+    }
+
+}

--- a/hazelcast-client/src/test/java/com/hazelcast/client/test/TestClientRegistry.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/test/TestClientRegistry.java
@@ -37,8 +37,8 @@ import com.hazelcast.logging.Logger;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.ConnectionType;
-import com.hazelcast.nio.Packet;
 import com.hazelcast.nio.OutboundFrame;
+import com.hazelcast.nio.Packet;
 import com.hazelcast.spi.discovery.integration.DiscoveryService;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.test.TestNodeRegistry;
@@ -271,7 +271,7 @@ public class TestClientRegistry {
         @Override
         public boolean write(OutboundFrame frame) {
             final Packet packet = (Packet) frame;
-            if (nodeEngine.isActive()) {
+            if (nodeEngine.isRunning()) {
                 Packet newPacket = readFromPacket(packet);
                 responseConnection.handlePacket(newPacket);
                 return true;

--- a/hazelcast-wm/src/test/java/com/hazelcast/wm/test/AbstractWebFilterTest.java
+++ b/hazelcast-wm/src/test/java/com/hazelcast/wm/test/AbstractWebFilterTest.java
@@ -21,7 +21,6 @@ import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.instance.Node;
-import com.hazelcast.instance.NodeState;
 import com.hazelcast.instance.TestUtil;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestEnvironment;
@@ -178,7 +177,7 @@ public abstract class AbstractWebFilterTest extends HazelcastTestSupport {
             return true;
         }
         Node node = TestUtil.getNode(hz);
-        return node == null || node.getState() != NodeState.ACTIVE;
+        return node == null || !node.isRunning();
     }
 
     @AfterClass

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheProxyBase.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheProxyBase.java
@@ -20,10 +20,10 @@ import com.hazelcast.cache.impl.operation.CacheDestroyOperation;
 import com.hazelcast.config.CacheConfig;
 import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.core.HazelcastInstanceNotActiveException;
+import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.IOUtil;
 import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.partition.InternalPartitionService;
 import com.hazelcast.spi.ExecutionService;
 import com.hazelcast.spi.InternalCompletableFuture;
@@ -33,6 +33,10 @@ import com.hazelcast.spi.OperationFactory;
 import com.hazelcast.spi.OperationService;
 import com.hazelcast.util.executor.CompletableFutureTask;
 
+import javax.cache.CacheException;
+import javax.cache.configuration.Factory;
+import javax.cache.integration.CacheLoader;
+import javax.cache.integration.CompletionListener;
 import java.io.Closeable;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -44,11 +48,6 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-
-import javax.cache.CacheException;
-import javax.cache.configuration.Factory;
-import javax.cache.integration.CacheLoader;
-import javax.cache.integration.CompletionListener;
 
 import static com.hazelcast.cache.impl.CacheProxyUtil.validateResults;
 
@@ -181,7 +180,7 @@ abstract class AbstractCacheProxyBase<K, V> {
     }
 
     protected NodeEngine getNodeEngine() {
-        if (nodeEngine == null || !nodeEngine.isActive()) {
+        if (nodeEngine == null || !nodeEngine.isRunning()) {
             throw new HazelcastInstanceNotActiveException();
         }
         return nodeEngine;

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractInternalCacheProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractInternalCacheProxy.java
@@ -379,7 +379,7 @@ abstract class AbstractInternalCacheProxy<K, V>
             while (currentTimeoutMs > 0
                     && !countDownLatch.await(COMPLETION_LATCH_WAIT_TIME_STEP, TimeUnit.MILLISECONDS)) {
                 currentTimeoutMs -= COMPLETION_LATCH_WAIT_TIME_STEP;
-                if (!getNodeEngine().isActive()) {
+                if (!getNodeEngine().isRunning()) {
                     throw new HazelcastInstanceNotActiveException();
                 } else if (isClosed()) {
                     throw new IllegalStateException("Cache (" + nameWithPrefix + ") is closed !");

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngineImpl.java
@@ -40,6 +40,7 @@ import com.hazelcast.core.Member;
 import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.instance.MemberImpl;
 import com.hazelcast.instance.Node;
+import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ClassLoaderUtil;
@@ -48,7 +49,6 @@ import com.hazelcast.nio.ConnectionListener;
 import com.hazelcast.nio.Packet;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.PortableReader;
-import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.nio.tcp.TcpIpConnection;
 import com.hazelcast.partition.InternalPartitionService;
 import com.hazelcast.security.Credentials;
@@ -430,7 +430,7 @@ public class ClientEngineImpl implements ClientEngine, CoreService, PostJoinAwar
         }
 
         private void logProcessingFailure(ClientRequest request, Throwable e) {
-            Level level = nodeEngine.isActive() ? Level.SEVERE : Level.FINEST;
+            Level level = nodeEngine.isRunning() ? Level.SEVERE : Level.FINEST;
             if (logger.isLoggable(level)) {
                 if (request == null) {
                     logger.log(level, e.getMessage(), e);
@@ -458,7 +458,7 @@ public class ClientEngineImpl implements ClientEngine, CoreService, PostJoinAwar
                 return portableReader.readInt("cId");
 
             } catch (Throwable e) {
-                Level level = nodeEngine.isActive() ? Level.SEVERE : Level.FINEST;
+                Level level = nodeEngine.isRunning() ? Level.SEVERE : Level.FINEST;
                 if (logger.isLoggable(level)) {
                     logger.log(level, e.getMessage(), e);
                 }
@@ -521,7 +521,7 @@ public class ClientEngineImpl implements ClientEngine, CoreService, PostJoinAwar
 
             Object service = nodeEngine.getService(serviceName);
             if (service == null) {
-                if (nodeEngine.isActive()) {
+                if (nodeEngine.isRunning()) {
                     throw new IllegalArgumentException("No service registered with name: " + serviceName);
                 }
                 throw new HazelcastInstanceNotActiveException();
@@ -531,7 +531,7 @@ public class ClientEngineImpl implements ClientEngine, CoreService, PostJoinAwar
 
         private void handleAuthenticationFailure(ClientEndpointImpl endpoint, ClientRequest request) {
             Exception exception;
-            if (nodeEngine.isActive()) {
+            if (nodeEngine.isRunning()) {
                 String message = "Client " + endpoint + " must authenticate before any operation.";
                 logger.severe(message);
                 exception = new AuthenticationException(message);
@@ -554,7 +554,7 @@ public class ClientEngineImpl implements ClientEngine, CoreService, PostJoinAwar
 
         @Override
         public void connectionRemoved(Connection connection) {
-            if (connection.isClient() && nodeEngine.isActive()) {
+            if (connection.isClient() && nodeEngine.isRunning()) {
                 ClientEndpointImpl endpoint = (ClientEndpointImpl) endpointManager.getEndpoint(connection);
                 if (endpoint == null) {
                     return;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractMessageTask.java
@@ -27,9 +27,9 @@ import com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes;
 import com.hazelcast.client.impl.protocol.parameters.ErrorCodec;
 import com.hazelcast.core.HazelcastInstanceNotActiveException;
 import com.hazelcast.instance.Node;
+import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Connection;
-import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.security.Credentials;
 import com.hazelcast.security.SecurityContext;
 import com.hazelcast.spi.impl.NodeEngineImpl;
@@ -123,7 +123,7 @@ public abstract class AbstractMessageTask<P>
 
     private void handleAuthenticationFailure() {
         Exception exception;
-        if (nodeEngine.isActive()) {
+        if (nodeEngine.isRunning()) {
             String message = "Client " + endpoint + " must authenticate before any operation.";
             logger.severe(message);
             exception = new AuthenticationException(message);
@@ -145,7 +145,7 @@ public abstract class AbstractMessageTask<P>
     }
 
     private void logProcessingFailure(Throwable throwable) {
-        Level level = nodeEngine.isActive() ? Level.SEVERE : Level.FINEST;
+        Level level = nodeEngine.isRunning() ? Level.SEVERE : Level.FINEST;
         if (logger.isLoggable(level)) {
             if (parameters == null) {
                 logger.log(level, throwable.getMessage(), throwable);

--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/ClusterMergeTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/ClusterMergeTask.java
@@ -20,7 +20,6 @@ import com.hazelcast.core.HazelcastInstanceNotActiveException;
 import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.instance.LifecycleServiceImpl;
 import com.hazelcast.instance.Node;
-import com.hazelcast.instance.NodeState;
 import com.hazelcast.spi.ManagedService;
 import com.hazelcast.spi.SplitBrainHandlerService;
 import com.hazelcast.util.Clock;
@@ -68,7 +67,7 @@ class ClusterMergeTask implements Runnable {
 
         executeMergeTasks(tasks);
 
-        if (node.getState() == NodeState.ACTIVE && node.joined()) {
+        if (node.isRunning() && node.joined()) {
             lifecycleService.fireLifecycleEvent(MERGED);
         }
     }
@@ -148,7 +147,7 @@ class ClusterMergeTask implements Runnable {
                 if (deadline <= 0) {
                     throw t;
                 }
-                if (node.getState() != NodeState.ACTIVE) {
+                if (!node.isRunning()) {
                     future.cancel(true);
                     throw new HazelcastInstanceNotActiveException();
                 }

--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/ClusterStateTransactionLogRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/ClusterStateTransactionLogRecord.java
@@ -42,12 +42,13 @@ public class ClusterStateTransactionLogRecord implements TargetAwareTransactionL
     private Address target;
     private String txnId;
     private long leaseTime;
+    private int partitionStateVersion;
 
     public ClusterStateTransactionLogRecord() {
     }
 
     public ClusterStateTransactionLogRecord(ClusterState newState, Address initiator, Address target,
-            String txnId, long leaseTime) {
+            String txnId, long leaseTime, int partitionStateVersion) {
         Preconditions.checkNotNull(newState);
         Preconditions.checkNotNull(initiator);
         Preconditions.checkNotNull(target);
@@ -59,6 +60,7 @@ public class ClusterStateTransactionLogRecord implements TargetAwareTransactionL
         this.target = target;
         this.txnId = txnId;
         this.leaseTime = leaseTime;
+        this.partitionStateVersion = partitionStateVersion;
     }
 
     @Override
@@ -68,7 +70,7 @@ public class ClusterStateTransactionLogRecord implements TargetAwareTransactionL
 
     @Override
     public Operation newPrepareOperation() {
-        return new LockClusterStateOperation(newState, initiator, txnId, leaseTime);
+        return new LockClusterStateOperation(newState, initiator, txnId, leaseTime, partitionStateVersion);
     }
 
     @Override
@@ -93,6 +95,7 @@ public class ClusterStateTransactionLogRecord implements TargetAwareTransactionL
         target.writeData(out);
         out.writeUTF(txnId);
         out.writeLong(leaseTime);
+        out.writeInt(partitionStateVersion);
     }
 
     @Override
@@ -105,5 +108,6 @@ public class ClusterStateTransactionLogRecord implements TargetAwareTransactionL
         target.readData(in);
         txnId = in.readUTF();
         leaseTime = in.readLong();
+        partitionStateVersion = in.readInt();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/MulticastJoiner.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/MulticastJoiner.java
@@ -19,7 +19,6 @@ package com.hazelcast.cluster.impl;
 import com.hazelcast.config.NetworkConfig;
 import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.instance.Node;
-import com.hazelcast.instance.NodeState;
 import com.hazelcast.nio.Address;
 import com.hazelcast.util.Clock;
 import com.hazelcast.util.EmptyStatement;
@@ -49,7 +48,7 @@ public class MulticastJoiner extends AbstractJoiner {
         long maxJoinMillis = getMaxJoinMillis();
         Address thisAddress = node.getThisAddress();
 
-        while (node.getState() == NodeState.ACTIVE && !node.joined()
+        while (node.isRunning() && !node.joined()
                 && (Clock.currentTimeMillis() - joinStartTime < maxJoinMillis)) {
 
             // clear master node
@@ -75,7 +74,7 @@ public class MulticastJoiner extends AbstractJoiner {
         long maxMasterJoinTime = getMaxJoinTimeToMasterNode();
         long start = Clock.currentTimeMillis();
 
-        while (node.getState() == NodeState.ACTIVE  && !node.joined()
+        while (node.isRunning() && !node.joined()
                 && Clock.currentTimeMillis() - start < maxMasterJoinTime) {
 
             Address master = node.getMasterAddress();
@@ -160,7 +159,7 @@ public class MulticastJoiner extends AbstractJoiner {
                 logger.finest("Searching for master node. Max tries: " + maxTryCount.get());
             }
             JoinRequest joinRequest = node.createJoinRequest(false);
-            while (node.getState() == NodeState.ACTIVE  && currentTryCount.incrementAndGet() <= maxTryCount.get()) {
+            while (node.isRunning() && currentTryCount.incrementAndGet() <= maxTryCount.get()) {
                 joinRequest.setTryCount(currentTryCount.get());
                 node.multicastService.send(joinRequest);
                 if (node.getMasterAddress() == null) {

--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/NodeMulticastListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/NodeMulticastListener.java
@@ -19,7 +19,6 @@ package com.hazelcast.cluster.impl;
 import com.hazelcast.cluster.Joiner;
 import com.hazelcast.core.Member;
 import com.hazelcast.instance.Node;
-import com.hazelcast.instance.NodeState;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.Packet;
@@ -52,7 +51,7 @@ public class NodeMulticastListener implements MulticastListener {
         }
 
         JoinMessage joinMessage = (JoinMessage) msg;
-        if (node.getState() == NodeState.ACTIVE && node.joined()) {
+        if (node.isRunning() && node.joined()) {
             handleActiveAndJoined(joinMessage);
         } else {
             handleNotActiveOrNotJoined(joinMessage);

--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/SplitBrainHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/SplitBrainHandler.java
@@ -18,7 +18,6 @@ package com.hazelcast.cluster.impl;
 
 import com.hazelcast.cluster.Joiner;
 import com.hazelcast.instance.Node;
-import com.hazelcast.instance.NodeState;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -55,7 +54,7 @@ final class SplitBrainHandler implements Runnable {
             return false;
         }
 
-        if (node.getState() != NodeState.ACTIVE) {
+        if (!node.isRunning()) {
             return false;
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/TcpIpJoiner.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/TcpIpJoiner.java
@@ -23,7 +23,6 @@ import com.hazelcast.config.NetworkConfig;
 import com.hazelcast.config.TcpIpConfig;
 import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.instance.Node;
-import com.hazelcast.instance.NodeState;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.util.AddressUtil;
@@ -100,7 +99,7 @@ public class TcpIpJoiner extends AbstractJoiner {
             }
             long joinStartTime = Clock.currentTimeMillis();
             Connection connection;
-            while (node.getState() == NodeState.ACTIVE && !node.joined()
+            while (node.isRunning() && !node.joined()
                     && (Clock.currentTimeMillis() - joinStartTime < maxJoinMillis)) {
 
                 connection = node.connectionManager.getOrConnect(targetAddress);
@@ -136,7 +135,7 @@ public class TcpIpJoiner extends AbstractJoiner {
             long maxJoinMillis = getMaxJoinMillis();
             long startTime = Clock.currentTimeMillis();
 
-            while (node.getState() == NodeState.ACTIVE && !node.joined()
+            while (node.isRunning() && !node.joined()
                     && (Clock.currentTimeMillis() - startTime < maxJoinMillis)) {
 
                 tryToJoinPossibleAddresses(possibleAddresses);
@@ -313,7 +312,7 @@ public class TcpIpJoiner extends AbstractJoiner {
         long maxMasterJoinTime = getMaxJoinTimeToMasterNode();
         long start = Clock.currentTimeMillis();
 
-        while (node.getState() == NodeState.ACTIVE && !node.joined()
+        while (node.isRunning() && !node.joined()
                 && Clock.currentTimeMillis() - start < maxMasterJoinTime) {
 
             Address master = node.getMasterAddress();

--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/operations/ChangeClusterStateOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/operations/ChangeClusterStateOperation.java
@@ -23,12 +23,13 @@ import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.spi.AbstractOperation;
+import com.hazelcast.spi.impl.AllowedDuringPassiveState;
 import com.hazelcast.transaction.TransactionException;
 import com.hazelcast.util.EmptyStatement;
 
 import java.io.IOException;
 
-public class ChangeClusterStateOperation extends AbstractOperation {
+public class ChangeClusterStateOperation extends AbstractOperation implements AllowedDuringPassiveState {
 
     private ClusterState newState;
     private Address initiator;

--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/operations/FinalizeJoinOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/operations/FinalizeJoinOperation.java
@@ -80,6 +80,12 @@ public class FinalizeJoinOperation extends MemberInfoUpdateOperation implements 
         final Operation[] postJoinOperations = nodeEngine.getPostJoinOperations();
         final OperationService operationService = nodeEngine.getOperationService();
 
+        if (clusterState == ClusterState.PASSIVE) {
+            nodeEngine.getNode().changeNodeStateToPassive();
+        } else {
+            nodeEngine.getNode().changeNodeStateToActive();
+        }
+
         if (postJoinOperations != null && postJoinOperations.length > 0) {
             final Collection<Member> members = clusterService.getMembers();
             for (Member member : members) {

--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/operations/HeartbeatOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/operations/HeartbeatOperation.java
@@ -23,12 +23,11 @@ import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.spi.impl.AllowedDuringShutdown;
 
 import java.io.IOException;
 
 public final class HeartbeatOperation extends AbstractClusterOperation
-        implements JoinOperation, IdentifiedDataSerializable, AllowedDuringShutdown {
+        implements JoinOperation, IdentifiedDataSerializable {
 
     private long timestamp;
 

--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/operations/JoinCheckOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/operations/JoinCheckOperation.java
@@ -19,7 +19,6 @@ package com.hazelcast.cluster.impl.operations;
 import com.hazelcast.cluster.impl.ClusterServiceImpl;
 import com.hazelcast.cluster.impl.JoinMessage;
 import com.hazelcast.instance.Node;
-import com.hazelcast.instance.NodeState;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
@@ -112,7 +111,7 @@ public class JoinCheckOperation extends AbstractOperation implements JoinOperati
             return false;
         }
 
-        if (node.getState() != NodeState.ACTIVE) {
+        if (!node.isRunning()) {
             logger.info("Ignoring join check from " + getCallerAddress() + ", because this node is not active...");
             return false;
         }

--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/operations/MasterConfirmationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/operations/MasterConfirmationOperation.java
@@ -23,11 +23,11 @@ import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.spi.OperationService;
-import com.hazelcast.spi.impl.AllowedDuringShutdown;
+import com.hazelcast.spi.impl.AllowedDuringPassiveState;
 
 import java.io.IOException;
 
-public class MasterConfirmationOperation extends AbstractClusterOperation implements AllowedDuringShutdown {
+public class MasterConfirmationOperation extends AbstractClusterOperation implements AllowedDuringPassiveState {
 
     private long timestamp;
 

--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/operations/MemberRemoveOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/operations/MemberRemoveOperation.java
@@ -21,11 +21,11 @@ import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.spi.impl.AllowedDuringShutdown;
+import com.hazelcast.spi.impl.AllowedDuringPassiveState;
 
 import java.io.IOException;
 
-public class MemberRemoveOperation extends AbstractClusterOperation implements AllowedDuringShutdown {
+public class MemberRemoveOperation extends AbstractClusterOperation implements AllowedDuringPassiveState {
 
     private Address deadAddress;
 

--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/operations/RollbackClusterStateOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/operations/RollbackClusterStateOperation.java
@@ -22,10 +22,11 @@ import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.spi.AbstractOperation;
+import com.hazelcast.spi.impl.AllowedDuringPassiveState;
 
 import java.io.IOException;
 
-public class RollbackClusterStateOperation extends AbstractOperation {
+public class RollbackClusterStateOperation extends AbstractOperation implements AllowedDuringPassiveState {
 
     private Address initiator;
     private String txnId;

--- a/hazelcast/src/main/java/com/hazelcast/core/Cluster.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/Cluster.java
@@ -118,15 +118,14 @@ public interface Cluster {
      * <p/>
      * If there are ongoing/pending migration/replication operations, because of re-balancing due to
      * member join or leave, then trying to change from {@code ACTIVE} to {@code FROZEN}
-     * or {@code SHUTTING_DOWN} will fail with an {@code IllegalStateException}.
+     * or {@code PASSIVE} will fail with an {@code IllegalStateException}.
      * <p/>
      * If transaction timeouts during state change, then this method will fail with a {@code TransactionException}.
      *
      * @param newState new state of the cluster
      * @throws NullPointerException     if newState is null
      * @throws IllegalArgumentException if newState is {@link ClusterState#IN_TRANSITION}
-     * @throws IllegalStateException    if current cluster state is {@link ClusterState#SHUTTING_DOWN}
-     *                                  or member-list changes during the transaction
+     * @throws IllegalStateException    if member-list changes during the transaction
      *                                  or there are ongoing/pending migration operations
      * @throws TransactionException     if there's already an ongoing transaction
      *                                  or this transaction fails
@@ -150,7 +149,7 @@ public interface Cluster {
      * <p/>
      * If there are ongoing/pending migration/replication operations, because of re-balancing due to
      * member join or leave, then trying to change from {@code ACTIVE} to {@code FROZEN}
-     * or {@code SHUTTING_DOWN} will fail with an {@code IllegalStateException}.
+     * or {@code PASSIVE} will fail with an {@code IllegalStateException}.
      * <p/>
      * If transaction timeouts during state change, then this method will fail with a {@code TransactionException}.
      *
@@ -159,8 +158,7 @@ public interface Cluster {
      * @throws NullPointerException     if newState is null
      * @throws IllegalArgumentException if newState is {@link ClusterState#IN_TRANSITION}
      *                                  or transaction type is not {@code TWO_PHASE}
-     * @throws IllegalStateException    if current cluster state is {@link ClusterState#SHUTTING_DOWN}
-     *                                  or member-list changes during the transaction
+     * @throws IllegalStateException    if member-list changes during the transaction
      *                                  or there are ongoing/pending migration operations
      * @throws TransactionException     if there's already an ongoing transaction
      *                                  or this transaction fails

--- a/hazelcast/src/main/java/com/hazelcast/instance/HazelcastInstanceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/HazelcastInstanceImpl.java
@@ -129,7 +129,7 @@ public class HazelcastInstanceImpl implements HazelcastInstance {
             lifecycleService.fireLifecycleEvent(STARTING);
 
             node.start();
-            if (node.getState() != NodeState.ACTIVE) {
+            if (!node.isRunning()) {
                 throw new IllegalStateException("Node failed to start!");
             }
 

--- a/hazelcast/src/main/java/com/hazelcast/instance/LifecycleServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/LifecycleServiceImpl.java
@@ -74,7 +74,7 @@ public class LifecycleServiceImpl implements LifecycleService {
     @Override
     public boolean isRunning() {
         //no synchronization needed since getState() is atomic.
-        return instance.node.getState() == NodeState.ACTIVE;
+        return instance.node.isRunning();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/instance/NodeShutdownLatch.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/NodeShutdownLatch.java
@@ -50,7 +50,7 @@ final class NodeShutdownLatch {
                 final MemberImpl member = entry.getKey();
                 if (members.contains(member)) {
                     HazelcastInstanceImpl instance = entry.getValue();
-                    if (instance.node.getState() == NodeState.ACTIVE) {
+                    if (instance.node.isRunning()) {
                         try {
                             ClusterServiceImpl clusterService = instance.node.clusterService;
                             final String id = clusterService.addMembershipListener(new ShutdownMembershipListener());
@@ -71,7 +71,7 @@ final class NodeShutdownLatch {
 
         int permits = registrations.size();
         for (HazelcastInstanceImpl instance : registrations.values()) {
-            if (instance.node.getState() == NodeState.ACTIVE) {
+            if (instance.node.isRunning()) {
                 permits--;
             }
         }

--- a/hazelcast/src/main/java/com/hazelcast/partition/MigrationCycleOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/MigrationCycleOperation.java
@@ -17,7 +17,7 @@
 package com.hazelcast.partition;
 
 import com.hazelcast.spi.UrgentSystemOperation;
-import com.hazelcast.spi.impl.AllowedDuringShutdown;
+import com.hazelcast.spi.impl.AllowedDuringPassiveState;
 
-public interface MigrationCycleOperation extends UrgentSystemOperation, AllowedDuringShutdown {
+public interface MigrationCycleOperation extends UrgentSystemOperation, AllowedDuringPassiveState {
 }

--- a/hazelcast/src/main/java/com/hazelcast/partition/PartitionServiceProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/PartitionServiceProxy.java
@@ -22,7 +22,6 @@ import com.hazelcast.core.Partition;
 import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.instance.MemberImpl;
 import com.hazelcast.instance.Node;
-import com.hazelcast.instance.NodeState;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Address;
 import com.hazelcast.partition.impl.InternalPartitionServiceImpl;
@@ -177,7 +176,7 @@ public class PartitionServiceProxy implements com.hazelcast.core.PartitionServic
 
     private boolean nodeActive() {
         final Node node = getNode();
-        return node.getState() == NodeState.ACTIVE ;
+        return node.isRunning();
     }
 
     private Node getNode() {

--- a/hazelcast/src/main/java/com/hazelcast/partition/impl/CheckReplicaVersion.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/impl/CheckReplicaVersion.java
@@ -21,14 +21,14 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.partition.InternalPartitionService;
 import com.hazelcast.partition.ReplicaErrorLogger;
-import com.hazelcast.spi.impl.AllowedDuringShutdown;
+import com.hazelcast.spi.impl.AllowedDuringPassiveState;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.PartitionAwareOperation;
 
 import java.io.IOException;
 
 // should not be an urgent operation. required to be in order with backup operations on target node
-public final class CheckReplicaVersion extends Operation implements PartitionAwareOperation, AllowedDuringShutdown {
+public final class CheckReplicaVersion extends Operation implements PartitionAwareOperation, AllowedDuringPassiveState {
 
     private long version;
     private boolean returnResponse;

--- a/hazelcast/src/main/java/com/hazelcast/partition/impl/HasOngoingMigration.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/impl/HasOngoingMigration.java
@@ -18,12 +18,12 @@ package com.hazelcast.partition.impl;
 
 import com.hazelcast.core.MemberLeftException;
 import com.hazelcast.partition.InternalPartitionService;
-import com.hazelcast.spi.impl.AllowedDuringShutdown;
+import com.hazelcast.spi.impl.AllowedDuringPassiveState;
 import com.hazelcast.spi.AbstractOperation;
 import com.hazelcast.spi.ExceptionAction;
 import com.hazelcast.spi.exception.TargetNotMemberException;
 
-public final class HasOngoingMigration extends AbstractOperation implements AllowedDuringShutdown {
+public final class HasOngoingMigration extends AbstractOperation implements AllowedDuringPassiveState {
 
     private Object response;
 

--- a/hazelcast/src/main/java/com/hazelcast/partition/impl/MigrationRequestOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/impl/MigrationRequestOperation.java
@@ -109,7 +109,7 @@ public final class MigrationRequestOperation extends BaseMigrationOperation {
 
     private Level getLogLevel(Throwable e) {
         return (e instanceof MemberLeftException || e instanceof InterruptedException)
-                || !getNodeEngine().isActive() ? Level.INFO : Level.WARNING;
+                || !getNodeEngine().isRunning() ? Level.INFO : Level.WARNING;
     }
 
     private void verifyNotThisNode(NodeEngine nodeEngine, Address source) {

--- a/hazelcast/src/main/java/com/hazelcast/partition/impl/ReplicaSyncRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/impl/ReplicaSyncRequest.java
@@ -65,7 +65,7 @@ public final class ReplicaSyncRequest extends Operation implements PartitionAwar
         int partitionId = getPartitionId();
         int replicaIndex = getReplicaIndex();
 
-        if (!partitionService.isMigrationActive()) {
+        if (!partitionService.isReplicaSyncAllowed()) {
             ILogger logger = getLogger();
             if (logger.isFinestEnabled()) {
                 logger.finest("Migration is paused! Cannot run replica sync -> " + toString());

--- a/hazelcast/src/main/java/com/hazelcast/partition/impl/ReplicaSyncResponse.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/impl/ReplicaSyncResponse.java
@@ -22,7 +22,7 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.partition.InternalPartitionService;
 import com.hazelcast.partition.ReplicaErrorLogger;
-import com.hazelcast.spi.impl.AllowedDuringShutdown;
+import com.hazelcast.spi.impl.AllowedDuringPassiveState;
 import com.hazelcast.spi.BackupOperation;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.Operation;
@@ -42,7 +42,7 @@ import static com.hazelcast.spi.impl.OperationResponseHandlerFactory.createError
 
 @SuppressFBWarnings("EI_EXPOSE_REP")
 public class ReplicaSyncResponse extends Operation
-        implements PartitionAwareOperation, BackupOperation, UrgentSystemOperation, AllowedDuringShutdown {
+        implements PartitionAwareOperation, BackupOperation, UrgentSystemOperation, AllowedDuringPassiveState {
 
     private List<Operation> tasks;
     private long[] replicaVersions;
@@ -165,7 +165,7 @@ public class ReplicaSyncResponse extends Operation
     private void logException(Operation op, Throwable e) {
         ILogger logger = getLogger();
         NodeEngine nodeEngine = getNodeEngine();
-        Level level = nodeEngine.isActive() ? Level.WARNING : Level.FINEST;
+        Level level = nodeEngine.isRunning() ? Level.WARNING : Level.FINEST;
         if (logger.isLoggable(level)) {
             logger.log(level, "While executing " + op, e);
         }

--- a/hazelcast/src/main/java/com/hazelcast/partition/impl/SafeStateCheckOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/impl/SafeStateCheckOperation.java
@@ -17,6 +17,7 @@
 package com.hazelcast.partition.impl;
 
 import com.hazelcast.spi.AbstractOperation;
+import com.hazelcast.spi.impl.AllowedDuringPassiveState;
 
 /**
  * Checks whether a node is safe or not.
@@ -25,7 +26,7 @@ import com.hazelcast.spi.AbstractOperation;
  * @see com.hazelcast.core.PartitionService#isClusterSafe
  * @see com.hazelcast.core.PartitionService#isMemberSafe
  */
-public class SafeStateCheckOperation extends AbstractOperation {
+public class SafeStateCheckOperation extends AbstractOperation implements AllowedDuringPassiveState {
 
     private transient boolean safe;
 

--- a/hazelcast/src/main/java/com/hazelcast/partition/impl/SyncReplicaVersion.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/impl/SyncReplicaVersion.java
@@ -23,7 +23,7 @@ import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.partition.InternalPartition;
 import com.hazelcast.partition.InternalPartitionService;
 import com.hazelcast.partition.ReplicaErrorLogger;
-import com.hazelcast.spi.impl.AllowedDuringShutdown;
+import com.hazelcast.spi.impl.AllowedDuringPassiveState;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.OperationService;
@@ -34,7 +34,7 @@ import java.io.IOException;
 
 // runs locally
 final class SyncReplicaVersion extends Operation implements PartitionAwareOperation,
-        UrgentSystemOperation, AllowedDuringShutdown {
+        UrgentSystemOperation, AllowedDuringPassiveState {
 
     public static final int OPERATION_TRY_COUNT = 10;
     public static final int OPERATION_TRY_PAUSE_MILLIS = 250;

--- a/hazelcast/src/main/java/com/hazelcast/spi/AbstractDistributedObject.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/AbstractDistributedObject.java
@@ -76,7 +76,7 @@ public abstract class AbstractDistributedObject<S extends RemoteService> impleme
     }
 
     private void lifecycleCheck(final NodeEngine engine) {
-        if (engine == null || !engine.isActive()) {
+        if (engine == null || !engine.isRunning()) {
             throwNotActiveException();
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/spi/NodeEngine.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/NodeEngine.java
@@ -21,12 +21,12 @@ import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.Member;
 import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.internal.storage.DataRef;
 import com.hazelcast.internal.storage.Storage;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.partition.InternalPartitionService;
 import com.hazelcast.quorum.QuorumService;
 import com.hazelcast.transaction.TransactionManagerService;
@@ -225,11 +225,19 @@ public interface NodeEngine {
     /**
      * Checks if the HazelcastInstance that this {@link NodeEngine} belongs to is still active.
      * <p/>
-     * A HazelcastInstance is not active when it is shut down.
+     * A HazelcastInstance is not active when it is shutting down or already shut down.
+     * * Also see {@link NodeEngine#isRunning()}
      *
      * @return true if active, false otherwise.
      */
+    @Deprecated
     boolean isActive();
+
+    /**
+     * Indicates that node is not shutting down or it has not already shut down
+     * @return true if node is not shutting down or it has not already shut down
+     */
+    boolean isRunning();
 
     /**
      * Returns the HazelcastInstance that this {@link NodeEngine} belongs to.

--- a/hazelcast/src/main/java/com/hazelcast/spi/Operation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/Operation.java
@@ -226,7 +226,7 @@ public abstract class Operation implements DataSerializable {
             final String name = serviceName != null ? serviceName : getServiceName();
             service = ((NodeEngineImpl) nodeEngine).getService(name);
             if (service == null) {
-                if (nodeEngine.isActive()) {
+                if (nodeEngine.isRunning()) {
                     throw new HazelcastException("Service with name '" + name + "' not found!");
                 } else {
                     throw new RetryableHazelcastException("HazelcastInstance[" + nodeEngine.getThisAddress()
@@ -477,7 +477,7 @@ public abstract class Operation implements DataSerializable {
         } else if (e instanceof QuorumException) {
             logger.log(Level.WARNING, e.getMessage());
         } else {
-            final Level level = nodeEngine != null && nodeEngine.isActive() ? Level.SEVERE : Level.FINEST;
+            final Level level = nodeEngine != null && nodeEngine.isRunning() ? Level.SEVERE : Level.FINEST;
             if (logger.isLoggable(level)) {
                 logger.log(level, e.getMessage(), e);
             }

--- a/hazelcast/src/main/java/com/hazelcast/spi/ReadonlyOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/ReadonlyOperation.java
@@ -16,11 +16,13 @@
 
 package com.hazelcast.spi;
 
+import com.hazelcast.spi.impl.AllowedDuringPassiveState;
+
 /**
  * Read-only operations are not retried during migration.
  *
  * @author mdogan 7/17/13
  */
-public interface ReadonlyOperation {
+public interface ReadonlyOperation extends AllowedDuringPassiveState {
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/AllowedDuringPassiveState.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/AllowedDuringPassiveState.java
@@ -16,14 +16,17 @@
 
 package com.hazelcast.spi.impl;
 
+import com.hazelcast.instance.Node;
+import com.hazelcast.instance.NodeState;
+
 /**
  * Marker interface for operations those are allowed to be executed or invoked during
- * {@link com.hazelcast.instance.Node}'s {@link com.hazelcast.instance.NodeState#SHUTTING_DOWN} state.
+ * {@link Node}'s {@link NodeState#PASSIVE} state.
  * <p/>
- * By default, only replication/migration and cluster heartbeat operations are allowed during shutdown.
+ * By default, only join, replication and cluster heartbeat operations are allowed during shutdown.
  *
- * @see com.hazelcast.instance.NodeState
+ * @see NodeState
  * @since 3.6
  */
-public interface AllowedDuringShutdown {
+public interface AllowedDuringPassiveState {
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
@@ -22,7 +22,6 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.instance.GroupProperties;
 import com.hazelcast.instance.MemberImpl;
 import com.hazelcast.instance.Node;
-import com.hazelcast.instance.NodeState;
 import com.hazelcast.internal.management.ManagementCenterService;
 import com.hazelcast.internal.metrics.MetricsRegistry;
 import com.hazelcast.internal.metrics.ProbeLevel;
@@ -235,7 +234,12 @@ public class NodeEngineImpl implements NodeEngine {
 
     @Override
     public boolean isActive() {
-        return node.getState() == NodeState.ACTIVE;
+        return isRunning();
+    }
+
+    @Override
+    public boolean isRunning() {
+        return node.isRunning();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/EventProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/EventProcessor.java
@@ -56,7 +56,7 @@ public class EventProcessor implements StripedRunnable {
     private EventPublishingService<Object, Object> getPublishingService(String serviceName) {
         EventPublishingService<Object, Object> service = eventService.nodeEngine.getService(serviceName);
         if (service == null) {
-            if (eventService.nodeEngine.isActive()) {
+            if (eventService.nodeEngine.isRunning()) {
                 eventService.logger.warning("There is no service named: " + serviceName);
             }
             return null;
@@ -67,7 +67,7 @@ public class EventProcessor implements StripedRunnable {
     private Registration getRegistration(EventEnvelope eventEnvelope, String serviceName) {
         EventServiceSegment segment = eventService.getSegment(serviceName, false);
         if (segment == null) {
-            if (eventService.nodeEngine.isActive()) {
+            if (eventService.nodeEngine.isRunning()) {
                 eventService.logger.warning("No service registration found for " + serviceName);
             }
             return null;
@@ -76,7 +76,7 @@ public class EventProcessor implements StripedRunnable {
         String id = eventEnvelope.getEventId();
         Registration registration = (Registration) segment.getRegistrationIdMap().get(id);
         if (registration == null) {
-            if (eventService.nodeEngine.isActive()) {
+            if (eventService.nodeEngine.isRunning()) {
                 if (eventService.logger.isFinestEnabled()) {
                     eventService.logger.finest("No registration found for " + serviceName + " / " + id);
                 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/EventServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/EventServiceImpl.java
@@ -345,7 +345,7 @@ public class EventServiceImpl implements InternalEventService {
     }
 
     private void executeLocal(String serviceName, Object event, EventRegistration registration, int orderKey) {
-        if (nodeEngine.isActive()) {
+        if (nodeEngine.isRunning()) {
             Registration reg = (Registration) registration;
             try {
                 if (reg.getListener() != null) {
@@ -385,7 +385,7 @@ public class EventServiceImpl implements InternalEventService {
             packet.setHeader(Packet.HEADER_EVENT);
 
             if (!nodeEngine.getNode().getConnectionManager().transmit(packet, subscriber)) {
-                if (nodeEngine.isActive()) {
+                if (nodeEngine.isRunning()) {
                     logFailure("IO Queue overloaded! Failed to send event packet to: %s", subscriber);
                 }
             }
@@ -414,7 +414,7 @@ public class EventServiceImpl implements InternalEventService {
 
     @Override
     public void executeEventCallback(Runnable callback) {
-        if (nodeEngine.isActive()) {
+        if (nodeEngine.isRunning()) {
             try {
                 eventExecutor.execute(callback);
             } catch (RejectedExecutionException e) {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/LocalEventDispatcher.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/LocalEventDispatcher.java
@@ -54,7 +54,7 @@ public final class LocalEventDispatcher implements StripedRunnable, TimeoutRunna
     public void run() {
         final EventPublishingService<Object, Object> service = eventService.nodeEngine.getService(serviceName);
         if (service == null) {
-            if (eventService.nodeEngine.isActive()) {
+            if (eventService.nodeEngine.isRunning()) {
                 throw new IllegalArgumentException("Service[" + serviceName + "] could not be found!");
             }
             return;

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationRegistry.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationRegistry.java
@@ -241,7 +241,7 @@ public class InvocationRegistry {
         Invocation invocation = invocations.get(response.getCallId());
 
         if (invocation == null) {
-            if (nodeEngine.isActive()) {
+            if (nodeEngine.isRunning()) {
                 logger.warning("No Invocation found for response: " + response + " sent from " + sender);
             }
             return;
@@ -255,7 +255,7 @@ public class InvocationRegistry {
         Invocation invocation = invocations.get(response.getCallId());
 
         if (invocation == null) {
-            if (nodeEngine.isActive()) {
+            if (nodeEngine.isRunning()) {
                 logger.warning("No Invocation found for response: " + response + " sent from " + sender);
             }
             return;
@@ -268,7 +268,7 @@ public class InvocationRegistry {
         Invocation invocation = invocations.get(response.getCallId());
 
         if (invocation == null) {
-            if (nodeEngine.isActive()) {
+            if (nodeEngine.isRunning()) {
                 logger.warning("No Invocation found for response: " + response + " sent from " + sender);
             }
             return;

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/ProxyRegistry.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/ProxyRegistry.java
@@ -58,7 +58,7 @@ public final class ProxyRegistry {
             return service;
         }
 
-        if (proxyService.nodeEngine.isActive()) {
+        if (proxyService.nodeEngine.isRunning()) {
             throw new IllegalArgumentException("Unknown service: " + serviceName);
         } else {
             throw new HazelcastInstanceNotActiveException();
@@ -146,7 +146,7 @@ public final class ProxyRegistry {
     DistributedObject getOrCreateProxy(String name, boolean publishEvent, boolean initialize) {
         DistributedObjectFuture proxyFuture = proxies.get(name);
         if (proxyFuture == null) {
-            if (!proxyService.nodeEngine.isActive()) {
+            if (!proxyService.nodeEngine.isRunning()) {
                 throw new HazelcastInstanceNotActiveException();
             }
             proxyFuture = createProxy(name, publishEvent, initialize);
@@ -171,7 +171,7 @@ public final class ProxyRegistry {
             return null;
         }
 
-        if (!proxyService.nodeEngine.isActive()) {
+        if (!proxyService.nodeEngine.isRunning()) {
             throw new HazelcastInstanceNotActiveException();
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/AllowedDuringPassiveStateTransactionImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/AllowedDuringPassiveStateTransactionImpl.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.transaction.impl;
+
+import com.hazelcast.spi.NodeEngine;
+import com.hazelcast.transaction.TransactionOptions;
+import com.hazelcast.transaction.impl.operations.CreateAllowedDuringPassiveStateTxBackupLogOperation;
+import com.hazelcast.transaction.impl.operations.CreateTxBackupLogOperation;
+import com.hazelcast.transaction.impl.operations.PurgeAllowedDuringPassiveStateTxBackupLogOperation;
+import com.hazelcast.transaction.impl.operations.PurgeTxBackupLogOperation;
+import com.hazelcast.transaction.impl.operations.ReplicateAllowedDuringPassiveStateTxBackupLogOperation;
+import com.hazelcast.transaction.impl.operations.ReplicateTxBackupLogOperation;
+import com.hazelcast.transaction.impl.operations.RollbackAllowedDuringPassiveStateTxBackupLogOperation;
+import com.hazelcast.transaction.impl.operations.RollbackTxBackupLogOperation;
+
+import java.util.List;
+
+public class AllowedDuringPassiveStateTransactionImpl
+        extends TransactionImpl {
+
+    public AllowedDuringPassiveStateTransactionImpl(TransactionManagerServiceImpl transactionManagerService,
+                                                    NodeEngine nodeEngine, TransactionOptions options, String txOwnerUuid) {
+        super(transactionManagerService, nodeEngine, options, txOwnerUuid);
+    }
+
+    // used by tx backups
+    AllowedDuringPassiveStateTransactionImpl(TransactionManagerServiceImpl transactionManagerService, NodeEngine nodeEngine,
+                                             String txnId, List<TransactionLogRecord> transactionLog, long timeoutMillis,
+                                             long startTime, String txOwnerUuid) {
+        super(transactionManagerService, nodeEngine, txnId, transactionLog, timeoutMillis, startTime, txOwnerUuid);
+    }
+
+    protected CreateTxBackupLogOperation createCreateTxBackupLogOperation() {
+        return new CreateAllowedDuringPassiveStateTxBackupLogOperation(getOwnerUuid(), getTxnId());
+    }
+
+    protected ReplicateTxBackupLogOperation createReplicateTxBackupLogOperation() {
+        return new ReplicateAllowedDuringPassiveStateTxBackupLogOperation(
+                getTransactionLog().getRecordList(), getOwnerUuid(), getTxnId(), getTimeoutMillis(), getStartTime());
+    }
+
+    protected RollbackTxBackupLogOperation createRollbackTxBackupLogOperation() {
+        return new RollbackAllowedDuringPassiveStateTxBackupLogOperation(getTxnId());
+    }
+
+    protected PurgeTxBackupLogOperation createPurgeTxBackupLogOperation() {
+        return new PurgeAllowedDuringPassiveStateTxBackupLogOperation(getTxnId());
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionContextImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionContextImpl.java
@@ -148,7 +148,7 @@ final class TransactionContextImpl implements TransactionContext {
         final Object service = nodeEngine.getService(serviceName);
 
         if (service == null) {
-            if (!nodeEngine.isActive()) {
+            if (!nodeEngine.isRunning()) {
                 throw new HazelcastInstanceNotActiveException();
             }
             throw new IllegalArgumentException("Unknown Service[" + serviceName + "]!");

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionDataSerializerHook.java
@@ -20,10 +20,14 @@ import com.hazelcast.nio.serialization.DataSerializableFactory;
 import com.hazelcast.internal.serialization.DataSerializerHook;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.internal.serialization.impl.FactoryIdHelper;
+import com.hazelcast.transaction.impl.operations.CreateAllowedDuringPassiveStateTxBackupLogOperation;
 import com.hazelcast.transaction.impl.operations.CreateTxBackupLogOperation;
 import com.hazelcast.transaction.impl.operations.BroadcastTxRollbackOperation;
+import com.hazelcast.transaction.impl.operations.PurgeAllowedDuringPassiveStateTxBackupLogOperation;
 import com.hazelcast.transaction.impl.operations.PurgeTxBackupLogOperation;
+import com.hazelcast.transaction.impl.operations.ReplicateAllowedDuringPassiveStateTxBackupLogOperation;
 import com.hazelcast.transaction.impl.operations.ReplicateTxBackupLogOperation;
+import com.hazelcast.transaction.impl.operations.RollbackAllowedDuringPassiveStateTxBackupLogOperation;
 import com.hazelcast.transaction.impl.operations.RollbackTxBackupLogOperation;
 
 import static com.hazelcast.internal.serialization.impl.FactoryIdHelper.TRANSACTION_DS_FACTORY;
@@ -38,6 +42,10 @@ public final class TransactionDataSerializerHook implements DataSerializerHook {
     public static final int PURGE_TX_BACKUP_LOG = 2;
     public static final int REPLICATE_TX_BACKUP_LOG = 3;
     public static final int ROLLBACK_TX_BACKUP_LOG = 4;
+    public static final int CREATE_ALLOWED_DURING_PASSIVE_STATE_TX_BACKUP_LOG = 5;
+    public static final int PURGE_ALLOWED_DURING_PASSIVE_STATE_TX_BACKUP_LOG = 6;
+    public static final int REPLICATE_ALLOWED_DURING_PASSIVE_STATE_TX_BACKUP_LOG = 7;
+    public static final int ROLLBACK_ALLOWED_DURING_PASSIVE_STATE_TX_BACKUP_LOG = 8;
 
     @Override
     public int getFactoryId() {
@@ -60,6 +68,14 @@ public final class TransactionDataSerializerHook implements DataSerializerHook {
                         return new ReplicateTxBackupLogOperation();
                     case ROLLBACK_TX_BACKUP_LOG:
                         return new RollbackTxBackupLogOperation();
+                    case CREATE_ALLOWED_DURING_PASSIVE_STATE_TX_BACKUP_LOG:
+                        return new CreateAllowedDuringPassiveStateTxBackupLogOperation();
+                    case PURGE_ALLOWED_DURING_PASSIVE_STATE_TX_BACKUP_LOG:
+                        return new PurgeAllowedDuringPassiveStateTxBackupLogOperation();
+                    case REPLICATE_ALLOWED_DURING_PASSIVE_STATE_TX_BACKUP_LOG:
+                        return new ReplicateAllowedDuringPassiveStateTxBackupLogOperation();
+                    case ROLLBACK_ALLOWED_DURING_PASSIVE_STATE_TX_BACKUP_LOG:
+                        return new RollbackAllowedDuringPassiveStateTxBackupLogOperation();
                     default:
                         return null;
                 }

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/operations/CreateAllowedDuringPassiveStateTxBackupLogOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/operations/CreateAllowedDuringPassiveStateTxBackupLogOperation.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.transaction.impl.operations;
+
+import com.hazelcast.spi.impl.AllowedDuringPassiveState;
+import com.hazelcast.transaction.impl.TransactionManagerServiceImpl;
+
+import static com.hazelcast.transaction.impl.TransactionDataSerializerHook.CREATE_ALLOWED_DURING_PASSIVE_STATE_TX_BACKUP_LOG;
+
+public final class CreateAllowedDuringPassiveStateTxBackupLogOperation
+        extends CreateTxBackupLogOperation
+        implements AllowedDuringPassiveState {
+
+    public CreateAllowedDuringPassiveStateTxBackupLogOperation() {
+    }
+
+    public CreateAllowedDuringPassiveStateTxBackupLogOperation(String callerUuid, String txnId) {
+        super(callerUuid, txnId);
+    }
+
+    @Override
+    public void run()
+            throws Exception {
+        TransactionManagerServiceImpl txManagerService = getService();
+        txManagerService.createAllowedDuringPassiveStateBackupLog(getCallerUuid(), getTxnId());
+    }
+
+    @Override
+    public int getId() {
+        return CREATE_ALLOWED_DURING_PASSIVE_STATE_TX_BACKUP_LOG;
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/operations/CreateTxBackupLogOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/operations/CreateTxBackupLogOperation.java
@@ -28,7 +28,7 @@ import java.io.IOException;
 import static com.hazelcast.spi.ExceptionAction.THROW_EXCEPTION;
 import static com.hazelcast.transaction.impl.TransactionDataSerializerHook.CREATE_TX_BACKUP_LOG;
 
-public final class CreateTxBackupLogOperation extends TxBaseOperation {
+public class CreateTxBackupLogOperation extends TxBaseOperation {
 
     private String callerUuid;
     private String txnId;
@@ -63,6 +63,15 @@ public final class CreateTxBackupLogOperation extends TxBaseOperation {
     @Override
     public int getId() {
         return CREATE_TX_BACKUP_LOG;
+    }
+
+    @Override
+    public String getCallerUuid() {
+        return callerUuid;
+    }
+
+    public String getTxnId() {
+        return txnId;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/operations/PurgeAllowedDuringPassiveStateTxBackupLogOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/operations/PurgeAllowedDuringPassiveStateTxBackupLogOperation.java
@@ -14,14 +14,25 @@
  * limitations under the License.
  */
 
-package com.hazelcast.cluster.impl.operations;
+package com.hazelcast.transaction.impl.operations;
 
-import com.hazelcast.spi.UrgentSystemOperation;
 import com.hazelcast.spi.impl.AllowedDuringPassiveState;
 
-/**
- * Marker interface for join and post-join operations.
- */
-public interface JoinOperation extends UrgentSystemOperation, AllowedDuringPassiveState {
+import static com.hazelcast.transaction.impl.TransactionDataSerializerHook.PURGE_ALLOWED_DURING_PASSIVE_STATE_TX_BACKUP_LOG;
 
+public final class PurgeAllowedDuringPassiveStateTxBackupLogOperation
+        extends PurgeTxBackupLogOperation
+        implements AllowedDuringPassiveState {
+
+    public PurgeAllowedDuringPassiveStateTxBackupLogOperation() {
+    }
+
+    public PurgeAllowedDuringPassiveStateTxBackupLogOperation(String txnId) {
+        super(txnId);
+    }
+
+    @Override
+    public int getId() {
+        return PURGE_ALLOWED_DURING_PASSIVE_STATE_TX_BACKUP_LOG;
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/operations/PurgeTxBackupLogOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/operations/PurgeTxBackupLogOperation.java
@@ -28,7 +28,7 @@ import java.io.IOException;
 import static com.hazelcast.spi.ExceptionAction.THROW_EXCEPTION;
 import static com.hazelcast.transaction.impl.TransactionDataSerializerHook.PURGE_TX_BACKUP_LOG;
 
-public final class PurgeTxBackupLogOperation extends TxBaseOperation {
+public class PurgeTxBackupLogOperation extends TxBaseOperation {
 
     private String txnId;
 

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/operations/ReplicateAllowedDuringPassiveStateTxBackupLogOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/operations/ReplicateAllowedDuringPassiveStateTxBackupLogOperation.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.transaction.impl.operations;
+
+import com.hazelcast.spi.impl.AllowedDuringPassiveState;
+import com.hazelcast.transaction.impl.TransactionLogRecord;
+
+import java.util.List;
+
+import static com.hazelcast.transaction.impl.TransactionDataSerializerHook.REPLICATE_ALLOWED_DURING_PASSIVE_STATE_TX_BACKUP_LOG;
+
+public final class ReplicateAllowedDuringPassiveStateTxBackupLogOperation
+        extends ReplicateTxBackupLogOperation
+        implements AllowedDuringPassiveState {
+
+    public ReplicateAllowedDuringPassiveStateTxBackupLogOperation() {
+    }
+
+    public ReplicateAllowedDuringPassiveStateTxBackupLogOperation(List<TransactionLogRecord> logs, String callerUuid,
+                                                                  String txnId, long timeoutMillis, long startTime) {
+        super(logs, callerUuid, txnId, timeoutMillis, startTime);
+    }
+
+    @Override
+    public int getId() {
+        return REPLICATE_ALLOWED_DURING_PASSIVE_STATE_TX_BACKUP_LOG;
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/operations/ReplicateTxBackupLogOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/operations/ReplicateTxBackupLogOperation.java
@@ -36,7 +36,7 @@ import static com.hazelcast.transaction.impl.TransactionDataSerializerHook.REPLI
  *
  * This operation is only executed when durability > 0
  */
-public final class ReplicateTxBackupLogOperation extends TxBaseOperation {
+public class ReplicateTxBackupLogOperation extends TxBaseOperation {
 
     // todo: probably we don't want to use linked list.
     private final List<TransactionLogRecord> records = new LinkedList<TransactionLogRecord>();

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/operations/RollbackAllowedDuringPassiveStateTxBackupLogOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/operations/RollbackAllowedDuringPassiveStateTxBackupLogOperation.java
@@ -14,14 +14,26 @@
  * limitations under the License.
  */
 
-package com.hazelcast.cluster.impl.operations;
+package com.hazelcast.transaction.impl.operations;
 
-import com.hazelcast.spi.UrgentSystemOperation;
 import com.hazelcast.spi.impl.AllowedDuringPassiveState;
 
-/**
- * Marker interface for join and post-join operations.
- */
-public interface JoinOperation extends UrgentSystemOperation, AllowedDuringPassiveState {
+import static com.hazelcast.transaction.impl.TransactionDataSerializerHook.ROLLBACK_ALLOWED_DURING_PASSIVE_STATE_TX_BACKUP_LOG;
+
+public class RollbackAllowedDuringPassiveStateTxBackupLogOperation
+        extends RollbackTxBackupLogOperation
+        implements AllowedDuringPassiveState {
+
+    public RollbackAllowedDuringPassiveStateTxBackupLogOperation() {
+    }
+
+    public RollbackAllowedDuringPassiveStateTxBackupLogOperation(String txnId) {
+        super(txnId);
+    }
+
+    @Override
+    public int getId() {
+        return ROLLBACK_ALLOWED_DURING_PASSIVE_STATE_TX_BACKUP_LOG;
+    }
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/operations/RollbackTxBackupLogOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/operations/RollbackTxBackupLogOperation.java
@@ -28,7 +28,7 @@ import java.io.IOException;
 import static com.hazelcast.spi.ExceptionAction.THROW_EXCEPTION;
 import static com.hazelcast.transaction.impl.TransactionDataSerializerHook.ROLLBACK_TX_BACKUP_LOG;
 
-public final class RollbackTxBackupLogOperation extends TxBaseOperation {
+public class RollbackTxBackupLogOperation extends TxBaseOperation {
 
     private String txnId;
 

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/XATransactionContextImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/XATransactionContextImpl.java
@@ -123,7 +123,7 @@ public class XATransactionContextImpl implements TransactionContext {
             txnObjectMap.put(key, obj);
         } else {
             if (service == null) {
-                if (!nodeEngine.isActive()) {
+                if (!nodeEngine.isRunning()) {
                     throw new HazelcastInstanceNotActiveException();
                 }
                 throw new IllegalArgumentException("Unknown Service[" + serviceName + "]!");

--- a/hazelcast/src/test/java/com/hazelcast/client/ClientTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/ClientTestSupport.java
@@ -20,7 +20,6 @@ import com.hazelcast.client.impl.ClientEngineImpl;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.instance.Node;
-import com.hazelcast.instance.NodeState;
 import com.hazelcast.instance.TestUtil;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
@@ -78,7 +77,7 @@ public abstract class ClientTestSupport extends HazelcastTestSupport {
     }
 
     public static SimpleClient newClient(Node node) throws IOException {
-        if (node.getState() == NodeState.ACTIVE) {
+        if (node.nodeEngine.isRunning()) {
             if (TestEnvironment.isMockNetwork()) {
                 ClientEngineImpl engine = node.clientEngine;
                 return new MockSimpleClient(engine, node.getSerializationService());

--- a/hazelcast/src/test/java/com/hazelcast/cluster/BasicClusterStateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/BasicClusterStateTest.java
@@ -33,6 +33,9 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import java.util.Map;
+
+import static com.hazelcast.cluster.AdvancedClusterStateTest.changeClusterStateEventually;
 import static com.hazelcast.instance.TestUtil.terminateInstance;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
@@ -60,14 +63,14 @@ public class BasicClusterStateTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void changeClusterState_from_Active_to_ShuttingDown() {
+    public void changeClusterState_from_Active_to_Passive() {
         TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(3);
         HazelcastInstance[] instances = factory.newInstances();
 
         HazelcastInstance hz = instances[instances.length - 1];
-        hz.getCluster().changeClusterState(ClusterState.SHUTTING_DOWN);
+        hz.getCluster().changeClusterState(ClusterState.PASSIVE);
 
-        assertClusterState(ClusterState.SHUTTING_DOWN, instances);
+        assertClusterState(ClusterState.PASSIVE, instances);
     }
 
     @Test
@@ -77,54 +80,49 @@ public class BasicClusterStateTest extends HazelcastTestSupport {
 
         HazelcastInstance hz = instances[instances.length - 1];
         hz.getCluster().changeClusterState(ClusterState.FROZEN);
-        hz.getCluster().changeClusterState(ClusterState.ACTIVE);
+        assertClusterState(ClusterState.FROZEN, instances);
 
+        hz.getCluster().changeClusterState(ClusterState.ACTIVE);
         assertClusterState(ClusterState.ACTIVE, instances);
     }
 
     @Test
-    public void changeClusterState_from_Frozen_to_ShuttingDown() {
+    public void changeClusterState_from_Frozen_to_Passive() {
         TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(3);
         HazelcastInstance[] instances = factory.newInstances();
 
         HazelcastInstance hz = instances[instances.length - 1];
         hz.getCluster().changeClusterState(ClusterState.FROZEN);
-        hz.getCluster().changeClusterState(ClusterState.SHUTTING_DOWN);
+        assertClusterState(ClusterState.FROZEN, instances);
 
-        assertClusterState(ClusterState.SHUTTING_DOWN, instances);
-    }
-
-    @Test(expected = IllegalStateException.class)
-    public void changeClusterState_from_ShuttingDown_to_Active() {
-        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(3);
-        HazelcastInstance[] instances = factory.newInstances();
-
-        HazelcastInstance hz = instances[instances.length - 1];
-        hz.getCluster().changeClusterState(ClusterState.SHUTTING_DOWN);
-
-        hz.getCluster().changeClusterState(ClusterState.ACTIVE);
-    }
-
-    @Test(expected = IllegalStateException.class)
-    public void changeClusterState_from_ShuttingDown_to_Frozen() {
-        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(3);
-        HazelcastInstance[] instances = factory.newInstances();
-
-        HazelcastInstance hz = instances[instances.length - 1];
-        hz.getCluster().changeClusterState(ClusterState.SHUTTING_DOWN);
-
-        hz.getCluster().changeClusterState(ClusterState.FROZEN);
+        hz.getCluster().changeClusterState(ClusterState.PASSIVE);
+        assertClusterState(ClusterState.PASSIVE, instances);
     }
 
     @Test
-    public void nodeState_shouldBe_ShuttingDown_whenClusterState_isShuttingDown() {
+    public void changeClusterState_from_Passive_to_Active() {
         TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(3);
         HazelcastInstance[] instances = factory.newInstances();
 
         HazelcastInstance hz = instances[instances.length - 1];
-        hz.getCluster().changeClusterState(ClusterState.SHUTTING_DOWN);
+        hz.getCluster().changeClusterState(ClusterState.PASSIVE);
+        assertClusterState(ClusterState.PASSIVE, instances);
 
-        assertNodeState(instances, NodeState.SHUTTING_DOWN);
+        hz.getCluster().changeClusterState(ClusterState.ACTIVE);
+        assertClusterState(ClusterState.ACTIVE, instances);
+    }
+
+    @Test
+    public void changeClusterState_from_Passive_to_Frozen() {
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(3);
+        HazelcastInstance[] instances = factory.newInstances();
+
+        HazelcastInstance hz = instances[instances.length - 1];
+        hz.getCluster().changeClusterState(ClusterState.PASSIVE);
+        assertClusterState(ClusterState.PASSIVE, instances);
+
+        hz.getCluster().changeClusterState(ClusterState.FROZEN);
+        assertClusterState(ClusterState.FROZEN, instances);
     }
 
     @Test(expected = IllegalStateException.class)
@@ -140,6 +138,21 @@ public class BasicClusterStateTest extends HazelcastTestSupport {
 
         factory.newHazelcastInstance();
         fail("New node should not start when cluster state is: " + ClusterState.FROZEN);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void joinNotAllowed_whenClusterState_isPassive() {
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(4);
+        HazelcastInstance[] instances = new HazelcastInstance[3];
+        for (int i = 0; i < 3; i++) {
+            instances[i] = factory.newHazelcastInstance();
+        }
+
+        HazelcastInstance hz = instances[instances.length - 1];
+        hz.getCluster().changeClusterState(ClusterState.PASSIVE);
+
+        factory.newHazelcastInstance();
+        fail("New node should not start when cluster state is: " + ClusterState.PASSIVE);
     }
 
     @Test
@@ -161,25 +174,29 @@ public class BasicClusterStateTest extends HazelcastTestSupport {
 
         assertClusterSizeEventually(3, hz1);
         assertClusterSizeEventually(3, hz2);
+        assertEquals(NodeState.ACTIVE, getNode(hz2).getState());
     }
 
     @Test
-    public void joinNotAllowed_whenClusterState_isShuttingDown() {
+    public void joinAllowed_whenKnownMemberReJoins_whenClusterState_isPassive() {
         TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(4);
         HazelcastInstance[] instances = new HazelcastInstance[3];
         for (int i = 0; i < 3; i++) {
             instances[i] = factory.newHazelcastInstance();
         }
 
-        HazelcastInstance hz = instances[instances.length - 1];
-        hz.getCluster().changeClusterState(ClusterState.SHUTTING_DOWN);
+        HazelcastInstance hz1 = instances[instances.length - 1];
+        hz1.getCluster().changeClusterState(ClusterState.PASSIVE);
 
-        HazelcastInstance newInstance = factory.newHazelcastInstance();
-        assertClusterSize(1, newInstance);
+        HazelcastInstance hz2 = instances[0];
+        Address address = getNode(hz2).getThisAddress();
+        hz2.getLifecycleService().terminate();
 
-        for (HazelcastInstance instance : instances) {
-            assertClusterSize(3, instance);
-        }
+        hz2 = factory.newHazelcastInstance(address);
+
+        assertClusterSizeEventually(3, hz1);
+        assertClusterSizeEventually(3, hz2);
+        assertEquals(NodeState.PASSIVE, getNode(hz2).getState());
     }
 
     @Test(expected = IllegalStateException.class)
@@ -196,7 +213,7 @@ public class BasicClusterStateTest extends HazelcastTestSupport {
     }
 
     @Test(expected = IllegalStateException.class)
-    public void changeClusterState_toShuttingDown_shouldFail_whilePartitionsMigrating() {
+    public void changeClusterState_toPassive_shouldFail_whilePartitionsMigrating() {
         Config config = new Config();
         config.setProperty(GroupProperties.PROP_PARTITION_MIGRATION_INTERVAL, "10");
 
@@ -205,7 +222,7 @@ public class BasicClusterStateTest extends HazelcastTestSupport {
         warmUpPartitions(hz);
 
         HazelcastInstance hz2 = factory.newHazelcastInstance(config);
-        hz2.getCluster().changeClusterState(ClusterState.SHUTTING_DOWN);
+        hz2.getCluster().changeClusterState(ClusterState.PASSIVE);
     }
 
     @Test
@@ -220,9 +237,8 @@ public class BasicClusterStateTest extends HazelcastTestSupport {
         HazelcastInstance hz2 = instances[1];
         HazelcastInstance hz3 = instances[2];
         warmUpPartitions(instances);
-        waitAllForSafeState(instances);
 
-        hz2.getCluster().changeClusterState(ClusterState.FROZEN);
+        changeClusterStateEventually(hz2, ClusterState.FROZEN);
         terminateInstance(hz1);
 
         hz3.getCluster().changeClusterState(ClusterState.ACTIVE);
@@ -230,11 +246,86 @@ public class BasicClusterStateTest extends HazelcastTestSupport {
         assertClusterState(ClusterState.ACTIVE, hz2, hz3);
     }
 
+    @Test
+    public void changeClusterState_toPassive_isAllowed_whileReplicationInProgress() {
+        Config config = new Config();
+        config.setProperty(GroupProperties.PROP_PARTITION_MIGRATION_INTERVAL, "10");
+        config.setProperty(GroupProperties.PROP_PARTITION_MAX_PARALLEL_REPLICATIONS, "1");
+
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(3);
+        HazelcastInstance[] instances = factory.newInstances(config);
+        HazelcastInstance hz1 = instances[0];
+        HazelcastInstance hz2 = instances[1];
+        HazelcastInstance hz3 = instances[2];
+        warmUpPartitions(instances);
+
+        changeClusterStateEventually(hz2, ClusterState.FROZEN);
+        terminateInstance(hz1);
+
+        hz3.getCluster().changeClusterState(ClusterState.PASSIVE);
+
+        assertClusterState(ClusterState.PASSIVE, hz2, hz3);
+    }
+
+    @Test
+    public void changeClusterState_toFrozen_makesNodeStates_Active() {
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(3);
+        HazelcastInstance[] instances = factory.newInstances();
+
+        HazelcastInstance hz = instances[instances.length - 1];
+        hz.getCluster().changeClusterState(ClusterState.FROZEN);
+        assertNodeState(instances, NodeState.ACTIVE);
+    }
+
+    @Test
+    public void changeClusterState_toPassive_makesNodeStates_Passive() {
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(3);
+        HazelcastInstance[] instances = factory.newInstances();
+
+        HazelcastInstance hz = instances[instances.length - 1];
+        hz.getCluster().changeClusterState(ClusterState.PASSIVE);
+        assertNodeState(instances, NodeState.PASSIVE);
+    }
+
+    @Test
+    public void changeClusterState_fromPassiveToActive_makesNodeStates_Active() {
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(3);
+        HazelcastInstance[] instances = factory.newInstances();
+
+        HazelcastInstance hz = instances[instances.length - 1];
+        hz.getCluster().changeClusterState(ClusterState.PASSIVE);
+        hz.getCluster().changeClusterState(ClusterState.ACTIVE);
+        assertNodeState(instances, NodeState.ACTIVE);
+    }
+
+    @Test
+    public void changeClusterState_fromPassiveToFrozen_makesNodeStates_Active() {
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(3);
+        HazelcastInstance[] instances = factory.newInstances();
+
+        HazelcastInstance hz = instances[instances.length - 1];
+        hz.getCluster().changeClusterState(ClusterState.PASSIVE);
+        hz.getCluster().changeClusterState(ClusterState.ACTIVE);
+        assertNodeState(instances, NodeState.ACTIVE);
+    }
+
     @Test(expected = IllegalArgumentException.class)
     public void changeClusterState_transaction_mustBe_TWO_PHASE() {
         HazelcastInstance hz = createHazelcastInstance();
         hz.getCluster().changeClusterState(ClusterState.FROZEN,
                 new TransactionOptions().setTransactionType(TransactionType.LOCAL));
+    }
+
+    @Test
+    public void readOperations_succeed_whenClusterState_passive() {
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(3);
+        HazelcastInstance[] instances = factory.newInstances();
+        warmUpPartitions(instances);
+
+        HazelcastInstance hz = instances[instances.length - 1];
+        Map map = hz.getMap(randomMapName());
+        changeClusterStateEventually(hz, ClusterState.PASSIVE);
+        map.get(1);
     }
 
     private static void assertClusterState(ClusterState expectedState, HazelcastInstance... instances) {

--- a/hazelcast/src/test/java/com/hazelcast/partition/impl/FrozenPartitionTableTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/partition/impl/FrozenPartitionTableTest.java
@@ -1,0 +1,169 @@
+package com.hazelcast.partition.impl;
+
+import com.hazelcast.cluster.ClusterState;
+import com.hazelcast.config.Config;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.nio.Address;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static com.hazelcast.cluster.AdvancedClusterStateTest.changeClusterStateEventually;
+import static com.hazelcast.instance.TestUtil.terminateInstance;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class FrozenPartitionTableTest  extends HazelcastTestSupport {
+
+    @Test
+    public void partitionTable_isFrozen_whenNodesLeave_duringClusterStateIsFrozen() {
+        testPartitionTableIsFrozenDuring(ClusterState.FROZEN);
+    }
+
+    @Test
+    public void partitionTable_isFrozen_whenNodesLeave_duringClusterStateIsPassive() {
+        testPartitionTableIsFrozenDuring(ClusterState.PASSIVE);
+    }
+
+    @Test
+    public void partitionTable_isFrozen_whenMemberReJoins_duringClusterStateIsFrozen() {
+        Config config = new Config();
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(4);
+        HazelcastInstance[] instances = factory.newInstances(config, 3);
+        HazelcastInstance hz1 = instances[0];
+        HazelcastInstance hz2 = instances[1];
+        HazelcastInstance hz3 = instances[2];
+        Address hz3Address = getNode(hz3).getThisAddress();
+        warmUpPartitions(instances);
+
+        final Map<Integer, List<Address>> partitionTable = getPartitionTable(hz1);
+
+        changeClusterStateEventually(hz2, ClusterState.FROZEN);
+
+        terminateInstance(hz3);
+        hz3 = factory.newHazelcastInstance(hz3Address);
+
+        assertClusterSizeEventually(3, hz1);
+        assertClusterSizeEventually(3, hz2);
+        assertClusterSizeEventually(3, hz3);
+
+        for (HazelcastInstance instance : Arrays.asList(hz1, hz2, hz3)) {
+            assertPartitionTablesSame(partitionTable, getPartitionTable(instance));
+        }
+    }
+
+    @Test
+    public void partitionTable_shouldBeFixed_whenMemberLeaves_inFrozenState_thenStateChangesToActive() {
+        testPartitionTableIsHealedWhenClusterStateIsActiveAfter(ClusterState.FROZEN);
+    }
+
+    @Test
+    public void partitionTable_shouldBeFixed_whenMemberLeaves_inPassiveState_thenStateChangesToActive() {
+        testPartitionTableIsHealedWhenClusterStateIsActiveAfter(ClusterState.PASSIVE);
+    }
+
+    private void testPartitionTableIsFrozenDuring(final ClusterState clusterState) {
+        final TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(3);
+        HazelcastInstance[] instances = factory.newInstances();
+        warmUpPartitions(instances);
+
+        changeClusterStateEventually(instances[0], clusterState);
+        List<HazelcastInstance> instancesList = new ArrayList<HazelcastInstance>(Arrays.asList(instances));
+        Collections.shuffle(instancesList);
+
+        final Map<Integer, List<Address>> partitionTable = getPartitionTable(instances[0]);
+
+        while (instancesList.size() > 1) {
+            final HazelcastInstance instanceToShutdown = instancesList.remove(0);
+            instanceToShutdown.shutdown();
+            for (HazelcastInstance instance : instancesList) {
+                assertClusterSizeEventually(instancesList.size(), instance);
+                assertPartitionTablesSame(partitionTable, getPartitionTable(instance));
+            }
+        }
+    }
+
+    private Map<Integer, List<Address>> getPartitionTable(final HazelcastInstance instance) {
+        final InternalPartitionServiceImpl partitionService = getNode(instance).partitionService;
+        final Map<Integer, List<Address>> partitionTable = new HashMap<Integer, List<Address>>();
+        for (int partitionId = 0; partitionId < partitionService.getPartitionCount(); partitionId++) {
+            final InternalPartitionImpl partition = partitionService.getPartition(partitionId);
+            for (int replicaIndex = 0; replicaIndex < InternalPartitionImpl.MAX_REPLICA_COUNT; replicaIndex++) {
+                Address replicaAddress = partition.getReplicaAddress(replicaIndex);
+                if (replicaAddress == null) {
+                    break;
+                }
+
+                List<Address> replicaAddresses = partitionTable.get(partitionId);
+                if (replicaAddresses == null) {
+                    replicaAddresses = new ArrayList<Address>();
+                    partitionTable.put(partitionId, replicaAddresses);
+                }
+
+                replicaAddresses.add(replicaAddress);
+            }
+        }
+
+        return partitionTable;
+    }
+
+    private void testPartitionTableIsHealedWhenClusterStateIsActiveAfter(final ClusterState clusterState) {
+        final TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(3);
+        HazelcastInstance[] instances = factory.newInstances();
+        warmUpPartitions(instances);
+
+        changeClusterStateEventually(instances[0], clusterState);
+
+        List<HazelcastInstance> instancesList = new ArrayList<HazelcastInstance>(Arrays.asList(instances));
+        Collections.shuffle(instancesList);
+        final HazelcastInstance instanceToShutdown = instancesList.remove(0);
+        final Address addressToShutdown = getNode(instanceToShutdown).getThisAddress();
+        instanceToShutdown.shutdown();
+
+        for (HazelcastInstance instance : instancesList) {
+            assertClusterSizeEventually(2, instance);
+        }
+
+        instancesList.get(0).getCluster().changeClusterState(ClusterState.ACTIVE);
+        waitAllForSafeState(instancesList);
+
+        for (HazelcastInstance instance : instancesList) {
+            final Map<Integer, List<Address>> partitionTable = getPartitionTable(instance);
+            for (List<Address> addresses : partitionTable.values()) {
+                for (Address address : addresses) {
+                    assertNotEquals(addressToShutdown, address);
+                }
+            }
+        }
+    }
+
+    private void assertPartitionTablesSame(Map<Integer, List<Address>> partitionTable1,
+                                           Map<Integer, List<Address>> partitionTable2) {
+        for (Map.Entry<Integer, List<Address>> partition : partitionTable1.entrySet()) {
+            int partitionId = partition.getKey();
+            List<Address> replicaAddresses1 = partition.getValue();
+            List<Address> replicaAddresses2 = partitionTable2.get(partitionId);
+            assertNotNull(replicaAddresses2);
+            assertEquals(replicaAddresses1.size(), replicaAddresses2.size());
+            for (int replicaIndex = 0; replicaIndex < replicaAddresses1.size(); replicaIndex++) {
+                assertEquals(replicaAddresses1.get(replicaIndex), replicaAddresses2.get(replicaIndex));
+            }
+        }
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/TestNodeRegistry.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/TestNodeRegistry.java
@@ -73,7 +73,7 @@ public final class TestNodeRegistry {
     public NodeContext createNodeContext(Address address) {
         NodeEngineImpl nodeEngine;
         if ((nodeEngine = nodes.get(address)) != null) {
-            if (nodeEngine.isActive()) {
+            if (nodeEngine.isRunning()) {
                 throw new IllegalArgumentException("This address already in registry! " + address);
             }
             nodes.remove(address);
@@ -83,13 +83,13 @@ public final class TestNodeRegistry {
 
     public HazelcastInstance getInstance(Address address) {
         NodeEngineImpl nodeEngine = nodes.get(address);
-        return nodeEngine != null && nodeEngine.isActive() ? nodeEngine.getHazelcastInstance() : null;
+        return nodeEngine != null && nodeEngine.isRunning() ? nodeEngine.getHazelcastInstance() : null;
     }
 
     Collection<HazelcastInstance> getAllHazelcastInstances() {
         Collection<HazelcastInstance> all = new LinkedList<HazelcastInstance>();
         for (NodeEngineImpl nodeEngine : nodes.values()) {
-            if (nodeEngine.isActive()) {
+            if (nodeEngine.isRunning()) {
                 all.add(nodeEngine.getHazelcastInstance());
             }
         }
@@ -185,7 +185,7 @@ public final class TestNodeRegistry {
             synchronized (joinerLock) {
                 for (Address address : joinAddresses) {
                     NodeEngineImpl ne = nodes.get(address);
-                    if (ne != null && ne.isActive() && ne.getNode().joined()) {
+                    if (ne != null && ne.isRunning() && ne.getNode().joined()) {
                         nodeEngine = ne;
                         break;
                     }
@@ -207,7 +207,8 @@ public final class TestNodeRegistry {
                     node.setAsMaster();
                 } else {
                     final ClusterJoinManager clusterJoinManager = node.clusterService.getClusterJoinManager();
-                    for (int i = 0; !node.joined() && node.getState() == NodeState.ACTIVE && i < 2000; i++) {
+
+                    for (int i = 0; !node.joined() && node.isRunning() && i < 2000; i++) {
                         try {
                             clusterJoinManager.sendJoinRequest(node.getMasterAddress(), true);
                             Thread.sleep(50);
@@ -311,7 +312,7 @@ public final class TestNodeRegistry {
                 }
 
                 final NodeEngineImpl nodeEngine = nodes.get(address);
-                if (nodeEngine != null && nodeEngine.isActive()) {
+                if (nodeEngine != null && nodeEngine.isRunning()) {
                     nodeEngine.getExecutionService().execute(ExecutionService.SYSTEM_EXECUTOR, new Runnable() {
                         public void run() {
                             ClusterServiceImpl clusterService = (ClusterServiceImpl) nodeEngine.getClusterService();


### PR DESCRIPTION
* Enable the transition from PASSIVE cluster state to others
* Introduce a new transaction impl for making transactional operations while cluster state is passive
* Rename SHUT_DOWN state name to PASSIVE for both node state and cluster state
* Allow join operations while cluster state is passive
* Deprecate NodeEngine.isActive() and use NodeEngine.isRunning() instead
* Add more tests for cluster state transitions
