### PR TITLE
Do not deserialize key when not needed

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/query/impl/IndexImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/IndexImpl.java
@@ -103,11 +103,11 @@ public class IndexImpl implements Index {
 
         Comparable oldValue = null;
         if (oldRecordValue != null) {
-            oldValue = QueryEntryUtils.extractAttribute(attribute, e.getKey(), oldRecordValue, ss);
+            oldValue = QueryEntryUtils.extractAttribute(attribute, e.getKeyData(), oldRecordValue, ss);
             oldValue = sanitizeValue(oldValue);
         }
 
-        Comparable newValue = QueryEntryUtils.extractAttribute(attribute, e.getKey(), e.getValue(), ss);
+        Comparable newValue = e.getAttribute(attribute);
         newValue = sanitizeValue(newValue);
 
         if (oldValue == null) {

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/QueryEntryUtils.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/QueryEntryUtils.java
@@ -54,7 +54,7 @@ final class QueryEntryUtils {
     }
 
 
-    public static Comparable extractAttribute(String attributeName, Object key, Object value, SerializationService ss) {
+    public static Comparable extractAttribute(String attributeName, Data key, Object value, SerializationService ss) {
         if (KEY_ATTRIBUTE_NAME.equals(attributeName)) {
             return (Comparable) ss.toObject(key);
         } else if (THIS_ATTRIBUTE_NAME.equals(attributeName)) {

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/IndexImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/IndexImplTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.query.impl;
+
+import com.hazelcast.internal.serialization.SerializationService;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class IndexImplTest {
+
+    private static final String ATTRIBUTE_NAME = "attribute";
+
+    private IndexImpl index;
+
+    @Before
+    public void setUp() {
+        SerializationService mockSerializationService = mock(SerializationService.class);
+        index = new IndexImpl(ATTRIBUTE_NAME, false, mockSerializationService);
+    }
+
+    @Test
+    public void saveEntryIndex_doNotDeserializeKey() {
+        QueryableEntry entry = createMockQueryableEntry();
+        index.saveEntryIndex(entry, null);
+        verify(entry, never()).getKey();
+    }
+
+    private QueryableEntry createMockQueryableEntry() {
+        QueryableEntry entry = mock(QueryableEntry.class);
+        Data keyData = mock(Data.class);
+        when(entry.getKeyData()).thenReturn(keyData);
+        return entry;
+    }
+}


### PR DESCRIPTION
Old implementation eagerly deserialized key. This is not needed as in most
cases desired attribute is extracted from value and not from key.

Moreover eager de-serialization means ClassNotFoundError when domain class is not
available on a classpath.