### PR TITLE
Introduced InvocationMonitor

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -269,7 +269,8 @@
     <suppress checks="ClassFanOutComplexity" files="com/hazelcast/spi/impl/NodeEngineImpl"/>
     <!-- since this class needs to manage services, it knows about them, so it is fine to have lots of dependencies on these classes -->
     <suppress checks="ClassDataAbstractionCoupling" files="com/hazelcast/spi/impl/servicemanager/impl/ServiceManager"/>
-    <suppress checks="MethodCount|ExecutableStatementCount|ClassFanOutComplexity"
+
+    <suppress checks="MethodCount|ExecutableStatementCount|ClassFanOutComplexity|ClassDataAbstractionCoupling"
               files="com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl"/>
     <!-- the invocation just has many parameters because there are a lot of things to tune/ -->
     <suppress checks="ParameterNumber" files="com/hazelcast/spi/impl/operationservice/impl/InvocationImpl"/>

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationMonitor.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationMonitor.java
@@ -1,0 +1,237 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi.impl.operationservice.impl;
+
+import com.hazelcast.core.MemberLeftException;
+import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.instance.GroupProperty;
+import com.hazelcast.instance.HazelcastThreadGroup;
+import com.hazelcast.instance.MemberImpl;
+import com.hazelcast.internal.metrics.MetricsRegistry;
+import com.hazelcast.internal.metrics.Probe;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.nio.Address;
+import com.hazelcast.spi.ExecutionService;
+import com.hazelcast.spi.impl.operationexecutor.OperationHostileThread;
+import com.hazelcast.util.Clock;
+import com.hazelcast.util.EmptyStatement;
+import com.hazelcast.util.counters.SwCounter;
+
+import java.util.concurrent.TimeUnit;
+
+import static com.hazelcast.instance.OutOfMemoryErrorDispatcher.inspectOutputMemoryError;
+import static com.hazelcast.internal.metrics.ProbeLevel.MANDATORY;
+import static com.hazelcast.util.counters.SwCounter.newSwCounter;
+
+/**
+ * The InvocationMonitor monitors all pending invocations and determines if there are any problems like timeouts. It uses the
+ * {@link InvocationRegistry} to access the pending invocations.
+ *
+ * An experimental feature to support debugging is the slow invocation detector. So it can log any invocation that takes
+ * more than x seconds. See {@link GroupProperty#SLOW_INVOCATION_DETECTOR_THRESHOLD_MILLIS} for more information.
+ */
+public class InvocationMonitor {
+
+    private static final long ON_MEMBER_LEFT_DELAY_MS = 1111;
+    private static final int DELAY_MILLIS = 1000;
+
+    private final long backupTimeoutMillis;
+    private final long slowInvocationThresholdMs;
+    private final InvocationRegistry invocationRegistry;
+    private final ExecutionService executionService;
+    private final MonitorThread monitorThread;
+    private final ILogger logger;
+    @Probe(name = "invocations.backupTimeouts", level = MANDATORY)
+    private final SwCounter backupTimeoutsCount = newSwCounter();
+    @Probe(name = "invocations.normalTimeouts", level = MANDATORY)
+    private final SwCounter normalTimeoutsCount = newSwCounter();
+
+    public InvocationMonitor(InvocationRegistry invocationRegistry, ILogger logger, GroupProperties props,
+                             HazelcastThreadGroup hzThreadGroup, ExecutionService executionService,
+                             MetricsRegistry metricsRegistry) {
+        this.invocationRegistry = invocationRegistry;
+        this.logger = logger;
+        this.monitorThread = new MonitorThread(hzThreadGroup);
+        this.executionService = executionService;
+        monitorThread.start();
+        this.backupTimeoutMillis = props.getMillis(GroupProperty.OPERATION_BACKUP_TIMEOUT_MILLIS);
+        this.slowInvocationThresholdMs = initSlowInvocationThresholdMs(props);
+
+        metricsRegistry.scanAndRegister(this, "operation");
+    }
+
+    private long initSlowInvocationThresholdMs(GroupProperties props) {
+        long thresholdMs = props.getMillis(GroupProperty.SLOW_INVOCATION_DETECTOR_THRESHOLD_MILLIS);
+        if (thresholdMs > -1) {
+            logger.info("Slow invocation detector enabled, using threshold: " + thresholdMs + " ms");
+        }
+        return thresholdMs;
+    }
+
+    public void shutdown() {
+        monitorThread.shutdown();
+    }
+
+    public void awaitTermination(long timeoutMillis) throws InterruptedException {
+        monitorThread.join(timeoutMillis);
+    }
+
+    public void onMemberLeft(MemberImpl member) {
+        // postpone notifying invocations since real response may arrive in the mean time.
+        Runnable task = new OnMemberLeftTask(member);
+        executionService.schedule(task, ON_MEMBER_LEFT_DELAY_MS, TimeUnit.MILLISECONDS);
+    }
+
+    /**
+     * The MonitorThread iterates over all pending invocations and sees what needs to be done
+     *
+     * But it should also check if a 'is still running' check needs to be done. This removed complexity from
+     * the invocation.waitForResponse which is too complicated too understand.
+     *
+     * This class needs to implement the {@link OperationHostileThread} interface to make sure that the OperationExecutor
+     * is not going to schedule any operations on this task due to retry.
+     */
+    private final class MonitorThread extends Thread implements OperationHostileThread {
+
+        private volatile boolean shutdown;
+
+        private MonitorThread(HazelcastThreadGroup hzThreadGroup) {
+            super(hzThreadGroup.getInternalThreadGroup(), hzThreadGroup.getThreadNamePrefix("InvocationMonitorThread"));
+        }
+
+        public void shutdown() {
+            shutdown = true;
+            interrupt();
+        }
+
+        @Override
+        public void run() {
+            try {
+                while (!shutdown) {
+                    scan();
+                    if (!shutdown) {
+                        sleep();
+                    }
+                }
+            } catch (Throwable t) {
+                inspectOutputMemoryError(t);
+                logger.severe("Failed to run", t);
+            }
+        }
+
+        private void sleep() {
+            try {
+                Thread.sleep(DELAY_MILLIS);
+            } catch (InterruptedException ignore) {
+                // can safely be ignored. If this thread wants to shut down, it will read the shutdown variable.
+                EmptyStatement.ignore(ignore);
+            }
+        }
+
+        private void scan() {
+            if (invocationRegistry.size() == 0) {
+                return;
+            }
+
+            long now = Clock.currentTimeMillis();
+            int backupTimeouts = 0;
+            int invocationTimeouts = 0;
+            for (Invocation invocation : invocationRegistry.invocations()) {
+                if (shutdown) {
+                    return;
+                }
+
+                detectSlowInvocation(now, invocation);
+
+                if (checkInvocationTimeout(invocation)) {
+                    invocationTimeouts++;
+                }
+
+                if (checkBackupTimeout(invocation)) {
+                    backupTimeouts++;
+                }
+            }
+
+            backupTimeoutsCount.inc(backupTimeouts);
+            normalTimeoutsCount.inc(invocationTimeouts);
+            log(backupTimeouts, invocationTimeouts);
+        }
+
+        private void detectSlowInvocation(long now, Invocation invocation) {
+            if (slowInvocationThresholdMs > 0) {
+                long durationMs = now - invocation.op.getInvocationTime();
+                if (durationMs > slowInvocationThresholdMs) {
+                    logger.info("Slow invocation: duration=" + durationMs + " ms, operation="
+                            + invocation.op.getClass().getName() + " inv:" + invocation);
+                }
+            }
+        }
+
+        private boolean checkInvocationTimeout(Invocation invocation) {
+            try {
+                return invocation.checkInvocationTimeout();
+            } catch (Throwable t) {
+                inspectOutputMemoryError(t);
+                logger.severe("Failed to handle operation timeout of invocation:" + invocation, t);
+                return false;
+            }
+        }
+
+        private boolean checkBackupTimeout(Invocation invocation) {
+            try {
+                return invocation.checkBackupTimeout(backupTimeoutMillis);
+            } catch (Throwable t) {
+                inspectOutputMemoryError(t);
+                logger.severe("Failed to handle backup timeout of invocation:" + invocation, t);
+                return false;
+            }
+        }
+
+        private void log(int backupTimeouts, int invocationTimeouts) {
+            if (backupTimeouts > 0 || invocationTimeouts > 0) {
+                logger.info("Handled " + invocationTimeouts + " invocation timeouts and " + backupTimeouts + " backupTimeouts");
+            }
+        }
+    }
+
+    private final class OnMemberLeftTask implements Runnable {
+        private final MemberImpl leftMember;
+
+        public OnMemberLeftTask(MemberImpl leftMember) {
+            this.leftMember = leftMember;
+        }
+
+        @Override
+        public void run() {
+            for (Invocation invocation : invocationRegistry.invocations()) {
+                if (hasMemberLeft(invocation)) {
+                    invocation.notifyError(new MemberLeftException(leftMember));
+                }
+            }
+        }
+
+        private boolean hasMemberLeft(Invocation invocation) {
+            MemberImpl targetMember = invocation.targetMember;
+            if (targetMember == null) {
+                Address invTarget = invocation.invTarget;
+                return leftMember.getAddress().equals(invTarget);
+            } else {
+                return leftMember.getUuid().equals(targetMember.getUuid());
+            }
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationRegistry.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationRegistry.java
@@ -18,31 +18,23 @@ package com.hazelcast.spi.impl.operationservice.impl;
 
 import com.hazelcast.core.HazelcastInstanceNotActiveException;
 import com.hazelcast.core.MemberLeftException;
-import com.hazelcast.instance.GroupProperties;
-import com.hazelcast.instance.GroupProperty;
-import com.hazelcast.instance.MemberImpl;
 import com.hazelcast.internal.metrics.Probe;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Address;
 import com.hazelcast.partition.ReplicaErrorLogger;
 import com.hazelcast.spi.impl.NodeEngineImpl;
-import com.hazelcast.spi.impl.executionservice.InternalExecutionService;
-import com.hazelcast.spi.impl.operationexecutor.OperationHostileThread;
 import com.hazelcast.spi.impl.operationservice.impl.responses.BackupResponse;
 import com.hazelcast.spi.impl.operationservice.impl.responses.CallTimeoutResponse;
 import com.hazelcast.spi.impl.operationservice.impl.responses.ErrorResponse;
 import com.hazelcast.spi.impl.operationservice.impl.responses.NormalResponse;
 import com.hazelcast.spi.impl.operationservice.impl.responses.Response;
-import com.hazelcast.util.Clock;
-import com.hazelcast.util.EmptyStatement;
 import com.hazelcast.util.counters.MwCounter;
 import com.hazelcast.util.counters.SwCounter;
 
+import java.util.Collection;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.TimeUnit;
 
-import static com.hazelcast.instance.OutOfMemoryErrorDispatcher.inspectOutputMemoryError;
 import static com.hazelcast.internal.metrics.ProbeLevel.MANDATORY;
 import static com.hazelcast.spi.Operation.CALL_ID_LOCAL_SKIPPED;
 import static com.hazelcast.spi.OperationAccessor.setCallId;
@@ -50,7 +42,8 @@ import static com.hazelcast.util.counters.MwCounter.newMwCounter;
 import static com.hazelcast.util.counters.SwCounter.newSwCounter;
 
 /**
- * The InvocationsRegistry is responsible for the registration of all pending invocations.
+ * The InvocationsRegistry is responsible for the registration of all pending invocations. Using the InvocationRegistry the
+ * Invocation and its response(s) can be linked to each other.
  * <p/>
  * When an invocation is registered, a callId is determined. Based on this call-id, when a
  * {@link com.hazelcast.spi.impl.operationservice.impl.responses.Response} comes in, the
@@ -65,21 +58,16 @@ import static com.hazelcast.util.counters.SwCounter.newSwCounter;
  */
 public class InvocationRegistry {
 
-    private static final long SCHEDULE_DELAY = 1111;
     private static final int INITIAL_CAPACITY = 1000;
     private static final float LOAD_FACTOR = 0.75f;
-    private static final int DELAY_MILLIS = 1000;
     private static final double HUNDRED_PERCENT = 100d;
-
-    private final long backupTimeoutMillis;
 
     @Probe(name = "invocations.pending", level = MANDATORY)
     private final ConcurrentMap<Long, Invocation> invocations;
+    //todo: this dependency on nodeEngineImpl sucks.
     private final NodeEngineImpl nodeEngine;
     private final ILogger logger;
-    private final InspectionThread inspectionThread;
     private final CallIdSequence callIdSequence;
-    private final long slowInvocationThresholdMs;
 
     @Probe(name = "response.normal.count", level = MANDATORY)
     private final SwCounter responseNormalCounter = newSwCounter();
@@ -89,25 +77,15 @@ public class InvocationRegistry {
     private final MwCounter responseBackupCounter = newMwCounter();
     @Probe(name = "response.error.count", level = MANDATORY)
     private final SwCounter responseErrorCounter = newSwCounter();
-    @Probe(name = "invocations.backupTimeouts", level = MANDATORY)
-    private final SwCounter backupTimeoutsCount = newSwCounter();
-    @Probe(name = "invocations.normalTimeouts", level = MANDATORY)
-    private final SwCounter normalTimeoutsCount = newSwCounter();
 
     public InvocationRegistry(NodeEngineImpl nodeEngine, ILogger logger, BackpressureRegulator backpressureRegulator,
                               int concurrencyLevel) {
         this.nodeEngine = nodeEngine;
         this.logger = logger;
         this.callIdSequence = backpressureRegulator.newCallIdSequence();
-        GroupProperties props = nodeEngine.getGroupProperties();
-        this.slowInvocationThresholdMs = initSlowInvocationThresholdMs(props);
-        this.backupTimeoutMillis = props.getMillis(GroupProperty.OPERATION_BACKUP_TIMEOUT_MILLIS);
         this.invocations = new ConcurrentHashMap<Long, Invocation>(INITIAL_CAPACITY, LOAD_FACTOR, concurrencyLevel);
 
         nodeEngine.getMetricsRegistry().scanAndRegister(this, "operation");
-
-        this.inspectionThread = new InspectionThread();
-        inspectionThread.start();
     }
 
     @Probe(name = "invocations.usedPercentage")
@@ -118,14 +96,6 @@ public class InvocationRegistry {
         }
 
         return (HUNDRED_PERCENT * invocations.size()) / maxConcurrentInvocations;
-    }
-
-    private long initSlowInvocationThresholdMs(GroupProperties props) {
-        long thresholdMs = props.getMillis(GroupProperty.SLOW_INVOCATION_DETECTOR_THRESHOLD_MILLIS);
-        if (thresholdMs > -1) {
-            logger.info("Slow invocation detector enabled, using threshold: " + thresholdMs + " ms");
-        }
-        return thresholdMs;
     }
 
     @Probe(name = "invocations.lastCallId")
@@ -182,6 +152,10 @@ public class InvocationRegistry {
      */
     public int size() {
         return invocations.size();
+    }
+
+    public Collection<Invocation> invocations() {
+        return invocations.values();
     }
 
     /**
@@ -276,13 +250,6 @@ public class InvocationRegistry {
         invocation.notifyCallTimeout();
     }
 
-    public void onMemberLeft(MemberImpl member) {
-        // postpone notifying calls since real response may arrive in the mean time.
-        InternalExecutionService executionService = nodeEngine.getExecutionService();
-        Runnable task = new OnMemberLeftTask(member);
-        executionService.schedule(task, SCHEDULE_DELAY, TimeUnit.MILLISECONDS);
-    }
-
     public void reset() {
         for (Invocation invocation : invocations.values()) {
             try {
@@ -294,8 +261,6 @@ public class InvocationRegistry {
     }
 
     public void shutdown() {
-        inspectionThread.shutdown();
-
         for (Invocation invocation : invocations.values()) {
             try {
                 invocation.notifyError(new HazelcastInstanceNotActiveException());
@@ -305,147 +270,4 @@ public class InvocationRegistry {
         }
     }
 
-    public void awaitTermination(long timeoutMillis) throws InterruptedException {
-        inspectionThread.join(timeoutMillis);
-    }
-
-    /**
-     * The InspectionThread iterates over all pending invocations and sees what needs to be done:
-     * - currently it only checks for timeouts
-     * <p/>
-     * But it should also check if a 'is still running' check needs to be done. This removed complexity from
-     * the invocation.waitForResponse which is too complicated too understand.
-     *
-     * This class needs to implement the OperationHostileThread interface to make sure that the OperationExecutor
-     * is not going to schedule any operations on this task due to retry.
-     */
-    class InspectionThread extends Thread implements OperationHostileThread {
-
-        private volatile boolean shutdown;
-
-        InspectionThread() {
-            super(nodeEngine.getNode().getHazelcastThreadGroup().getThreadNamePrefix("InspectInvocationsThread"));
-        }
-
-        public void shutdown() {
-            shutdown = true;
-            interrupt();
-        }
-
-        @Override
-        public void run() {
-            try {
-                while (!shutdown) {
-                    scanHandleOperationTimeout();
-                    if (!shutdown) {
-                        sleep();
-                    }
-                }
-            } catch (Throwable t) {
-                inspectOutputMemoryError(t);
-                logger.severe("Failed to run", t);
-            }
-        }
-
-        private void sleep() {
-            try {
-                Thread.sleep(DELAY_MILLIS);
-            } catch (InterruptedException ignore) {
-                // can safely be ignored. If this thread wants to shut down, it will read the shutdown variable.
-                EmptyStatement.ignore(ignore);
-            }
-        }
-
-        private void scanHandleOperationTimeout() {
-            if (invocations.isEmpty()) {
-                return;
-            }
-
-            long now = Clock.currentTimeMillis();
-            int backupTimeouts = 0;
-            int invocationTimeouts = 0;
-            for (Invocation invocation : invocations.values()) {
-                if (shutdown) {
-                    return;
-                }
-
-                detectSlowInvocation(now, invocation);
-
-                if (checkInvocationTimeout(invocation)) {
-                    invocationTimeouts++;
-                }
-
-                if (checkBackupTimeout(invocation)) {
-                    backupTimeouts++;
-                }
-            }
-
-            backupTimeoutsCount.inc(backupTimeouts);
-            normalTimeoutsCount.inc(invocationTimeouts);
-            log(backupTimeouts, invocationTimeouts);
-        }
-
-        private void detectSlowInvocation(long now, Invocation invocation) {
-            if (slowInvocationThresholdMs > 0) {
-                long durationMs = now - invocation.op.getInvocationTime();
-                if (durationMs > slowInvocationThresholdMs) {
-                    logger.info("Slow invocation: duration=" + durationMs + " ms, operation="
-                            + invocation.op.getClass().getName() + " inv:" + invocation);
-                }
-            }
-        }
-
-        private boolean checkInvocationTimeout(Invocation invocation) {
-            try {
-                return invocation.checkInvocationTimeout();
-            } catch (Throwable t) {
-                inspectOutputMemoryError(t);
-                logger.severe("Failed to handle operation timeout of invocation:" + invocation, t);
-                return false;
-            }
-        }
-
-        private boolean checkBackupTimeout(Invocation invocation) {
-            try {
-                return invocation.checkBackupTimeout(backupTimeoutMillis);
-            } catch (Throwable t) {
-                inspectOutputMemoryError(t);
-                logger.severe("Failed to handle backup timeout of invocation:" + invocation, t);
-                return false;
-            }
-        }
-
-        private void log(int backupTimeouts, int invocationTimeouts) {
-            if (backupTimeouts > 0 || invocationTimeouts > 0) {
-                logger.info("Handled " + invocationTimeouts + " invocation timeouts and " + backupTimeouts + " backupTimeouts");
-            }
-        }
-    }
-
-    private class OnMemberLeftTask implements Runnable {
-        private final MemberImpl leftMember;
-
-        public OnMemberLeftTask(MemberImpl leftMember) {
-            this.leftMember = leftMember;
-        }
-
-        @Override
-        public void run() {
-            for (Invocation invocation : invocations.values()) {
-                if (hasMemberLeft(invocation)) {
-                    invocation.notifyError(new MemberLeftException(leftMember));
-                }
-            }
-        }
-
-        private boolean hasMemberLeft(Invocation invocation) {
-            MemberImpl targetMember = invocation.targetMember;
-            if (targetMember == null) {
-                Address invTarget = invocation.invTarget;
-                return leftMember.getAddress().equals(invTarget);
-            } else {
-                return leftMember.getUuid().equals(targetMember.getUuid());
-            }
-        }
-    }
 }


### PR DESCRIPTION
The InvocationMonitor logic was pulled out from the InvocationRegistry. The InvocationRegistry is now a dumb container for invocations. And the monitoring (checking for timeouts, member leaving the cluster) and responding to it is a responsibility of the InvocationMonitor.

So it is a seperation of concerns.

One of the reasons, apart from having cleaner code, to have this seperation, is that in 3.7 I want to
experiment with different types of invocation-storage. Currently we use a CHM for it but it generates
quite a lot of waste.