### PR TITLE
Improved replicated map stability and added basic performance test

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/core/ReplicatedMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/ReplicatedMap.java
@@ -56,15 +56,8 @@ public interface ReplicatedMap<K, V> extends Map<K, V>, DistributedObject {
 
     /**
      * <p>The clear operation wipes data out of the replicated maps.
-     * It is the only synchronous remote operation in this implementation, so
-     * be aware that this might be a slow operation.</p>
      * <p>If some node fails on executing the operation, it is retried for at most
-     * 3 times (on the failing nodes only). If it does not work after the third time, this
-     * method throws a {@link com.hazelcast.core.OperationTimeoutException} back
-     * to the caller.</p>
-     *
-     * @throws com.hazelcast.core.OperationTimeoutException thrown if clear could not
-     *                                           be executed on remote nodes.
+     * 5 times (on the failing nodes only).
      */
     void clear();
 

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/ReplicatedMapProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/ReplicatedMapProxy.java
@@ -29,6 +29,7 @@ import com.hazelcast.replicatedmap.impl.client.ReplicatedMapEntries;
 import com.hazelcast.replicatedmap.impl.operation.PutAllOperation;
 import com.hazelcast.replicatedmap.impl.operation.PutOperation;
 import com.hazelcast.replicatedmap.impl.operation.RemoveOperation;
+import com.hazelcast.replicatedmap.impl.operation.RequestMapDataOperation;
 import com.hazelcast.replicatedmap.impl.operation.VersionResponsePair;
 import com.hazelcast.replicatedmap.impl.record.ReplicatedEntryEventFilter;
 import com.hazelcast.replicatedmap.impl.record.ReplicatedQueryEventFilter;
@@ -133,7 +134,10 @@ public class ReplicatedMapProxy<K, V> extends AbstractDistributedObject
     private void requestDataForPartition(int partitionId) {
         RequestMapDataOperation requestMapDataOperation = new RequestMapDataOperation(name);
         OperationService operationService = nodeEngine.getOperationService();
-        operationService.invokeOnPartition(SERVICE_NAME, requestMapDataOperation, partitionId);
+        operationService
+                .createInvocationBuilder(SERVICE_NAME, requestMapDataOperation, partitionId)
+                .setTryCount(ReplicatedMapService.INVOCATION_TRY_COUNT)
+                .invoke();
     }
 
 

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/AbstractReplicatedMapOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/AbstractReplicatedMapOperation.java
@@ -63,7 +63,7 @@ public abstract class AbstractReplicatedMapOperation extends AbstractOperation {
     private void invoke(boolean isRemove, OperationService operationService, Address address, String name, Data key,
                         Data value, long ttl, VersionResponsePair response) {
         ReplicateUpdateOperation updateOperation = new ReplicateUpdateOperation(name, key, value, ttl, response,
-                isRemove);
+                isRemove, getCallerAddress());
         updateOperation.setPartitionId(getPartitionId());
         updateOperation.setValidateTarget(false);
         operationService

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/AbstractReplicatedMapOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/AbstractReplicatedMapOperation.java
@@ -18,8 +18,6 @@ package com.hazelcast.replicatedmap.impl.operation;
 
 import com.hazelcast.cluster.memberselector.MemberSelectors;
 import com.hazelcast.core.Member;
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.AbstractOperation;
@@ -28,10 +26,10 @@ import com.hazelcast.spi.impl.operationservice.impl.responses.NormalResponse;
 import java.util.ArrayList;
 import java.util.Collection;
 
+import static com.hazelcast.replicatedmap.impl.ReplicatedMapService.INVOCATION_TRY_COUNT;
+
 
 public abstract class AbstractReplicatedMapOperation extends AbstractOperation {
-
-    private static ILogger logger = Logger.getLogger(AbstractReplicatedMapOperation.class.getName());
 
     protected String name;
     protected Data key;
@@ -68,7 +66,10 @@ public abstract class AbstractReplicatedMapOperation extends AbstractOperation {
                 isRemove);
         updateOperation.setPartitionId(getPartitionId());
         updateOperation.setValidateTarget(false);
-        operationService.invokeOnTarget(getServiceName(), updateOperation, address);
+        operationService
+                .createInvocationBuilder(getServiceName(), updateOperation, address)
+                .setTryCount(INVOCATION_TRY_COUNT)
+                .invoke();
     }
 
     protected void sendUpdateCallerOperation(boolean isRemove) {
@@ -78,7 +79,10 @@ public abstract class AbstractReplicatedMapOperation extends AbstractOperation {
         updateCallerOperation.setPartitionId(getPartitionId());
         updateCallerOperation.setValidateTarget(false);
         updateCallerOperation.setServiceName(getServiceName());
-        operationService.invokeOnTarget(getServiceName(), updateCallerOperation, getCallerAddress());
+        operationService
+                .createInvocationBuilder(getServiceName(), updateCallerOperation, getCallerAddress())
+                .setTryCount(INVOCATION_TRY_COUNT)
+                .invoke();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/CheckReplicaVersion.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/CheckReplicaVersion.java
@@ -22,7 +22,6 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.replicatedmap.impl.PartitionContainer;
 import com.hazelcast.replicatedmap.impl.ReplicatedMapService;
-import com.hazelcast.replicatedmap.impl.RequestMapDataOperation;
 import com.hazelcast.replicatedmap.impl.record.ReplicatedRecordStore;
 import com.hazelcast.spi.AbstractOperation;
 import com.hazelcast.spi.OperationService;
@@ -32,6 +31,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
+import static com.hazelcast.replicatedmap.impl.ReplicatedMapService.INVOCATION_TRY_COUNT;
 import static com.hazelcast.replicatedmap.impl.ReplicatedMapService.SERVICE_NAME;
 
 /**
@@ -82,12 +82,15 @@ public class CheckReplicaVersion extends AbstractOperation implements PartitionA
     private void requestDataFromOwner(String name) {
         OperationService operationService = getNodeEngine().getOperationService();
         RequestMapDataOperation requestMapDataOperation = new RequestMapDataOperation(name);
-        operationService.invokeOnPartition(SERVICE_NAME, requestMapDataOperation, getPartitionId());
+        operationService
+                .createInvocationBuilder(SERVICE_NAME, requestMapDataOperation, getPartitionId())
+                .setTryCount(INVOCATION_TRY_COUNT)
+                .invoke();
     }
 
     @Override
-    public boolean returnsResponse() {
-        return false;
+    public Object getResponse() {
+        return true;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/CheckReplicaVersion.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/CheckReplicaVersion.java
@@ -89,11 +89,6 @@ public class CheckReplicaVersion extends AbstractOperation implements PartitionA
     }
 
     @Override
-    public Object getResponse() {
-        return true;
-    }
-
-    @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         out.writeInt(versions.size());
         for (Map.Entry<String, Long> entry : versions.entrySet()) {

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/ClearLocalAndRemoteOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/ClearLocalAndRemoteOperation.java
@@ -40,11 +40,6 @@ public class ClearLocalAndRemoteOperation extends AbstractOperation {
     }
 
     @Override
-    public Object getResponse() {
-        return true;
-    }
-
-    @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         out.writeUTF(name);
     }

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/ClearLocalAndRemoteOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/ClearLocalAndRemoteOperation.java
@@ -40,6 +40,11 @@ public class ClearLocalAndRemoteOperation extends AbstractOperation {
     }
 
     @Override
+    public Object getResponse() {
+        return true;
+    }
+
+    @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         out.writeUTF(name);
     }

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/MergeOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/MergeOperation.java
@@ -53,11 +53,6 @@ public class MergeOperation extends AbstractReplicatedMapOperation {
     }
 
     @Override
-    public Object getResponse() {
-        return true;
-    }
-
-    @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         out.writeUTF(name);
         IOUtil.writeObject(out, key);

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/MergeOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/MergeOperation.java
@@ -52,6 +52,10 @@ public class MergeOperation extends AbstractReplicatedMapOperation {
         store.merge(key, entryView, policy);
     }
 
+    @Override
+    public Object getResponse() {
+        return true;
+    }
 
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/PutAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/PutAllOperation.java
@@ -81,6 +81,12 @@ public class PutAllOperation extends AbstractOperation {
         }
     }
 
+
+    @Override
+    public Object getResponse() {
+        return true;
+    }
+
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         out.writeUTF(name);

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/PutAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/PutAllOperation.java
@@ -83,11 +83,6 @@ public class PutAllOperation extends AbstractOperation {
 
 
     @Override
-    public Object getResponse() {
-        return true;
-    }
-
-    @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         out.writeUTF(name);
         out.writeObject(entries);

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/RemoveOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/RemoveOperation.java
@@ -25,8 +25,6 @@ import com.hazelcast.replicatedmap.impl.record.ReplicatedRecordStore;
 import com.hazelcast.spi.PartitionAwareOperation;
 import java.io.IOException;
 
-import static com.hazelcast.replicatedmap.impl.record.AbstractReplicatedRecordStore.TOMBSTONE_REMOVAL_PERIOD_MS;
-
 /**
  * Removes the key from replicated map.
  */
@@ -44,10 +42,6 @@ public class RemoveOperation extends AbstractReplicatedMapOperation implements P
         this.key = key;
     }
 
-    @Override
-    public void beforeRun() throws Exception {
-        this.ttl = TOMBSTONE_REMOVAL_PERIOD_MS;
-    }
 
     @Override
     public void run() throws Exception {

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/ReplicateUpdateOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/ReplicateUpdateOperation.java
@@ -81,11 +81,6 @@ public class ReplicateUpdateOperation extends AbstractOperation implements Parti
     }
 
     @Override
-    public Object getResponse() {
-        return true;
-    }
-
-    @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         response.writeData(out);
         out.writeUTF(name);

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/ReplicateUpdateOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/ReplicateUpdateOperation.java
@@ -81,6 +81,11 @@ public class ReplicateUpdateOperation extends AbstractOperation implements Parti
     }
 
     @Override
+    public Object getResponse() {
+        return true;
+    }
+
+    @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         response.writeData(out);
         out.writeUTF(name);

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/ReplicateUpdateToCallerOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/ReplicateUpdateToCallerOperation.java
@@ -89,8 +89,8 @@ public class ReplicateUpdateToCallerOperation extends AbstractOperation implemen
     }
 
     @Override
-    public boolean returnsResponse() {
-        return false;
+    public Object getResponse() {
+        return true;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/ReplicateUpdateToCallerOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/ReplicateUpdateToCallerOperation.java
@@ -89,11 +89,6 @@ public class ReplicateUpdateToCallerOperation extends AbstractOperation implemen
     }
 
     @Override
-    public Object getResponse() {
-        return true;
-    }
-
-    @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         out.writeUTF(name);
         out.writeLong(callId);

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/RequestMapDataOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/RequestMapDataOperation.java
@@ -82,11 +82,6 @@ public class RequestMapDataOperation extends AbstractOperation {
     }
 
 
-    @Override
-    public Object getResponse() {
-        return true;
-    }
-
     private Set<RecordMigrationInfo> getRecordSet(ReplicatedRecordStore store) {
         Set<RecordMigrationInfo> recordSet = new HashSet<RecordMigrationInfo>(store.size());
         Iterator<ReplicatedRecord> iterator = store.recordIterator();

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/SyncReplicatedMapDataOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/SyncReplicatedMapDataOperation.java
@@ -21,17 +21,20 @@ import com.hazelcast.logging.Logger;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.replicatedmap.impl.ReplicatedMapService;
+import com.hazelcast.replicatedmap.impl.record.AbstractReplicatedRecordStore;
+import com.hazelcast.replicatedmap.impl.record.InternalReplicatedMapStorage;
 import com.hazelcast.replicatedmap.impl.record.RecordMigrationInfo;
-import com.hazelcast.replicatedmap.impl.record.ReplicatedRecordStore;
+import com.hazelcast.replicatedmap.impl.record.ReplicatedRecord;
 import com.hazelcast.spi.AbstractOperation;
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Carries set of replicated map records for a partition from one node to another
  */
-public class SyncReplicatedMapDataOperation extends AbstractOperation {
+public class SyncReplicatedMapDataOperation<K, V> extends AbstractOperation {
 
     private static ILogger logger = Logger.getLogger(SyncReplicatedMapDataOperation.class.getName());
 
@@ -53,18 +56,23 @@ public class SyncReplicatedMapDataOperation extends AbstractOperation {
         logger.finest("Carrying " + recordSet.size() + " records for partition -> " + getPartitionId()
                 + " from -> " + getCallerAddress() + ", to -> " + getNodeEngine().getThisAddress());
         ReplicatedMapService service = getService();
-        ReplicatedRecordStore store = service.getReplicatedRecordStore(name, true, getPartitionId());
-        store.clear();
+        AbstractReplicatedRecordStore store = (AbstractReplicatedRecordStore) service
+                .getReplicatedRecordStore(name, true, getPartitionId());
+        InternalReplicatedMapStorage<K, V> newStorage = new InternalReplicatedMapStorage<K, V>();
         for (RecordMigrationInfo record : recordSet) {
-            store.putRecord(record);
+            K key = (K) store.marshall(record.getKey());
+            V value = (V) store.marshall(record.getValue());
+            newStorage.putInternal(key, buildReplicatedRecord(key, value, record.getTtl()));
         }
-        store.setVersion(version);
+        newStorage.setVersion(version);
+        AtomicReference<InternalReplicatedMapStorage<K, V>> storageRef = store.getStorageRef();
+        storageRef.set(newStorage);
         store.setLoaded(true);
     }
 
-    @Override
-    public Object getResponse() {
-        return true;
+    private ReplicatedRecord<K, V> buildReplicatedRecord(K key, V value, long ttlMillis) {
+        int partitionId = getNodeEngine().getPartitionService().getPartitionId(key);
+        return new ReplicatedRecord<K, V>(key, value, ttlMillis, partitionId);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/SyncReplicatedMapDataOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/SyncReplicatedMapDataOperation.java
@@ -62,7 +62,12 @@ public class SyncReplicatedMapDataOperation<K, V> extends AbstractOperation {
         for (RecordMigrationInfo record : recordSet) {
             K key = (K) store.marshall(record.getKey());
             V value = (V) store.marshall(record.getValue());
-            newStorage.putInternal(key, buildReplicatedRecord(key, value, record.getTtl()));
+            ReplicatedRecord<K, V> replicatedRecord = buildReplicatedRecord(key, value, record.getTtl());
+            ReplicatedRecord oldRecord = store.getReplicatedRecord(key);
+            if (oldRecord != null) {
+                replicatedRecord.setHits(oldRecord.getHits());
+            }
+            newStorage.putInternal(key, replicatedRecord);
         }
         newStorage.setVersion(version);
         AtomicReference<InternalReplicatedMapStorage<K, V>> storageRef = store.getStorageRef();

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/SyncReplicatedMapDataOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/SyncReplicatedMapDataOperation.java
@@ -49,11 +49,6 @@ public class SyncReplicatedMapDataOperation extends AbstractOperation {
     }
 
     @Override
-    public boolean returnsResponse() {
-        return false;
-    }
-
-    @Override
     public void run() throws Exception {
         logger.finest("Carrying " + recordSet.size() + " records for partition -> " + getPartitionId()
                 + " from -> " + getCallerAddress() + ", to -> " + getNodeEngine().getThisAddress());
@@ -65,6 +60,11 @@ public class SyncReplicatedMapDataOperation extends AbstractOperation {
         }
         store.setVersion(version);
         store.setLoaded(true);
+    }
+
+    @Override
+    public Object getResponse() {
+        return true;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/ReplicatedRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/ReplicatedRecord.java
@@ -105,6 +105,10 @@ public class ReplicatedRecord<K, V> implements IdentifiedDataSerializable {
         return hits;
     }
 
+    public void setHits(long hits) {
+        this.hits = hits;
+    }
+
     public long getLastAccessTime() {
         return lastAccessTime;
     }
@@ -139,6 +143,7 @@ public class ReplicatedRecord<K, V> implements IdentifiedDataSerializable {
         out.writeLong(ttlMillis);
         out.writeLong(updateTime);
         out.writeLong(creationTime);
+        out.writeLong(hits);
         out.writeInt(partitionId);
     }
 
@@ -149,6 +154,7 @@ public class ReplicatedRecord<K, V> implements IdentifiedDataSerializable {
         ttlMillis = in.readLong();
         updateTime = in.readLong();
         creationTime = in.readLong();
+        HITS.set(this, in.readLong());
         partitionId = in.readInt();
     }
 
@@ -193,6 +199,10 @@ public class ReplicatedRecord<K, V> implements IdentifiedDataSerializable {
         sb.append("key=").append(key);
         sb.append(", value=").append(value);
         sb.append(", ttlMillis=").append(ttlMillis);
+        sb.append(", hits=").append(HITS.get(this));
+        sb.append(", creationTime=").append(creationTime);
+        sb.append(", lastAccessTime=").append(lastAccessTime);
+        sb.append(", updateTime=").append(updateTime);
         sb.append('}');
         return sb.toString();
     }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/operations/PostJoinProxyOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/operations/PostJoinProxyOperation.java
@@ -60,13 +60,6 @@ public class PostJoinProxyOperation extends AbstractOperation {
                         registry.createProxy(proxy.getObjectName(), false, true);
                     }
                 });
-//                DistributedObjectFuture future = registry.createProxy(proxy.getObjectName(), false, false);
-//                if (future != null) {
-//                    final DistributedObject object = future.get();
-//                    if (object instanceof InitializingObject) {
-//                        executionService.execute(ExecutionService.SYSTEM_EXECUTOR, new InitializeRunnable(object));
-//                    }
-//                }
             } catch (Throwable t) {
                 getLogger().warning("Cannot create proxy [" + proxy.getServiceName() + ":"
                         + proxy.getObjectName() + "]!", t);

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapHitsAndLastAccessTimeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapHitsAndLastAccessTimeTest.java
@@ -21,7 +21,6 @@ import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.core.EntryEventType;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.ReplicatedMap;
-import com.hazelcast.replicatedmap.impl.ReplicatedMapProxy;
 import com.hazelcast.replicatedmap.impl.record.ReplicatedRecord;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
@@ -207,7 +206,7 @@ public class ReplicatedMapHitsAndLastAccessTimeTest extends ReplicatedMapBaseTes
     }
 
     private void execute(final Runnable runnable, final EntryEventType type, final int operations,
-                         final double minExpectation, ReplicatedMap... maps)  throws TimeoutException {
+                         final double minExpectation, ReplicatedMap... maps) throws TimeoutException {
         final WatchedOperationExecutor executor = new WatchedOperationExecutor();
         executor.execute(runnable, 60, type, operations, minExpectation, maps);
     }

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapWriteOrderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapWriteOrderTest.java
@@ -20,12 +20,10 @@ import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.ReplicatedMap;
 import com.hazelcast.instance.HazelcastInstanceFactory;
-import com.hazelcast.internal.metrics.LongGauge;
 import com.hazelcast.replicatedmap.impl.ReplicatedMapProxy;
 import com.hazelcast.replicatedmap.impl.ReplicatedMapService;
 import com.hazelcast.replicatedmap.impl.record.ReplicatedRecord;
 import com.hazelcast.replicatedmap.impl.record.ReplicatedRecordStore;
-import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
@@ -120,17 +118,6 @@ public class ReplicatedMapWriteOrderTest extends HazelcastTestSupport {
                 public void run() throws Exception {
                     System.out.println("---------------------");
                     System.out.println("key = " + key);
-                    for (HazelcastInstance instance : instances) {
-                        NodeEngineImpl nodeEngine = getNodeEngineImpl(instance);
-                        int partitionId = nodeEngine.getPartitionService().getPartitionId(key);
-                        LongGauge version= nodeEngine.getMetricsRegistry().newLongGauge("test." + partitionId + ".version.version");
-                        LongGauge increments = nodeEngine.getMetricsRegistry().newLongGauge("test."+partitionId+ ".incrementVersion.incrementVersion");
-                        LongGauge setVersion = nodeEngine.getMetricsRegistry().newLongGauge("test."+partitionId+ ".setVersion.setVersion");
-                        System.out.println("version= " + version.read());
-                        System.out.println("increments= " + increments.read());
-                        System.out.println("setVersion= " + setVersion.read());
-                    }
-
                     printValues();
                     assertValuesAreEqual();
                 }
@@ -138,7 +125,7 @@ public class ReplicatedMapWriteOrderTest extends HazelcastTestSupport {
                 private void printValues() throws Exception {
                     for (int j = 0; j < maps.size(); j++) {
                         ReplicatedMap map = maps.get(j);
-                        System.out.println("value[" + j + "] = " + map.get(key)+" , store version : " + getStore(map, key).getVersion());
+                        System.out.println("value[" + j + "] = " + map.get(key) + " , store version : " + getStore(map, key).getVersion());
                     }
                 }
 
@@ -211,12 +198,11 @@ public class ReplicatedMapWriteOrderTest extends HazelcastTestSupport {
     }
 
     @SuppressWarnings("unchecked")
-    protected <K, V>  ReplicatedRecordStore getStore(ReplicatedMap<K, V> map, K key) throws Exception {
+    protected <K, V> ReplicatedRecordStore getStore(ReplicatedMap<K, V> map, K key) throws Exception {
         ReplicatedMapProxy<K, V> proxy = (ReplicatedMapProxy<K, V>) map;
         ReplicatedMapService service = (ReplicatedMapService) REPLICATED_MAP_SERVICE.get(proxy);
         return service.getReplicatedRecordStore(map.getName(), false, key);
     }
-
 
 
 }

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/standalone/SimpleReplicatedMapTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/standalone/SimpleReplicatedMapTest.java
@@ -1,0 +1,237 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.replicatedmap.standalone;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.XmlConfigBuilder;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.HazelcastInstanceNotActiveException;
+import com.hazelcast.core.Member;
+import com.hazelcast.core.Partition;
+import com.hazelcast.core.ReplicatedMap;
+import com.hazelcast.instance.GroupProperty;
+import com.hazelcast.logging.ILogger;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicLong;
+
+public class SimpleReplicatedMapTest {
+
+    private static final String NAMESPACE = "default";
+    private static final long STATS_SECONDS = 10;
+
+    private final HazelcastInstance instance;
+    private final ILogger logger;
+    private final Stats stats = new Stats();
+    private final Random random;
+
+    private final int threadCount;
+    private final int entryCount;
+    private final int valueSize;
+    private final int getPercentage;
+    private final int putPercentage;
+    private final boolean load;
+
+    static {
+        System.setProperty("hazelcast.version.check.enabled", "false");
+        System.setProperty("java.net.preferIPv4Stack", "true");
+    }
+
+    private SimpleReplicatedMapTest(final int threadCount, final int entryCount, final int valueSize,
+                                    final int getPercentage, final int putPercentage, final boolean load) {
+        this.threadCount = threadCount;
+        this.entryCount = entryCount;
+        this.valueSize = valueSize;
+        this.getPercentage = getPercentage;
+        this.putPercentage = putPercentage;
+        this.load = load;
+        Config cfg = new XmlConfigBuilder().build();
+        cfg.setProperty(GroupProperty.HEALTH_MONITORING_LEVEL, "NOISY");
+        cfg.setProperty(GroupProperty.HEALTH_MONITORING_DELAY_SECONDS, "5");
+        instance = Hazelcast.newHazelcastInstance(cfg);
+        logger = instance.getLoggingService().getLogger("SimpleReplicatedMapTest");
+        random = new Random();
+    }
+
+    /**
+     * Expects the Management Center to be running.
+     *
+     * @param input
+     * @throws InterruptedException
+     */
+    public static void main(String[] input) throws InterruptedException {
+        int threadCount = 40;
+        int entryCount = 300;
+        int valueSize = 100;
+        int getPercentage = 10;
+        int putPercentage = 40;
+        boolean load = false;
+
+        if (input != null && input.length > 0) {
+            for (String arg : input) {
+                arg = arg.trim();
+                if (arg.startsWith("t")) {
+                    threadCount = Integer.parseInt(arg.substring(1));
+                } else if (arg.startsWith("c")) {
+                    entryCount = Integer.parseInt(arg.substring(1));
+                } else if (arg.startsWith("v")) {
+                    valueSize = Integer.parseInt(arg.substring(1));
+                } else if (arg.startsWith("g")) {
+                    getPercentage = Integer.parseInt(arg.substring(1));
+                } else if (arg.startsWith("p")) {
+                    putPercentage = Integer.parseInt(arg.substring(1));
+                } else if (arg.startsWith("load")) {
+                    load = true;
+                }
+            }
+        } else {
+            System.out.println("Help: sh test.sh t200 v130 p10 g85 ");
+            System.out.println("means 200 threads, value-size 130 bytes, 10% put, 85% get");
+            System.out.println();
+        }
+
+        SimpleReplicatedMapTest test = new SimpleReplicatedMapTest(threadCount, entryCount, valueSize, getPercentage, putPercentage, load);
+        test.start();
+    }
+
+    private void start() throws InterruptedException {
+        printVariables();
+        ExecutorService es = Executors.newFixedThreadPool(threadCount);
+        startPrintStats();
+        load(es);
+        run(es);
+    }
+
+    private void run(ExecutorService es) {
+        final ReplicatedMap<String, Object> map = instance.getReplicatedMap(NAMESPACE);
+        for (int i = 0; i < threadCount; i++) {
+            es.execute(new Runnable() {
+                public void run() {
+                    try {
+                        while (true) {
+                            int key = (int) (random.nextFloat() * entryCount);
+                            int operation = ((int) (random.nextFloat() * 100));
+                            if (operation < getPercentage) {
+                                map.get(String.valueOf(key));
+                                stats.gets.incrementAndGet();
+                            } else if (operation < getPercentage + putPercentage) {
+                                map.put(String.valueOf(key), createValue());
+                                stats.puts.incrementAndGet();
+                            } else {
+                                map.remove(String.valueOf(key));
+                                stats.removes.incrementAndGet();
+                            }
+                        }
+                    } catch (HazelcastInstanceNotActiveException e) {
+                        e.printStackTrace();
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                    }
+                }
+            });
+        }
+    }
+
+    private Object createValue() {
+        return new byte[valueSize];
+    }
+
+    private void load(ExecutorService es) throws InterruptedException {
+        if (!load) {
+            return;
+        }
+
+        final ReplicatedMap<String, Object> map = instance.getReplicatedMap(NAMESPACE);
+        final Member thisMember = instance.getCluster().getLocalMember();
+        List<String> lsOwnedEntries = new LinkedList<String>();
+        for (int i = 0; i < entryCount; i++) {
+            final String key = String.valueOf(i);
+            Partition partition = instance.getPartitionService().getPartition(key);
+            if (thisMember.equals(partition.getOwner())) {
+                lsOwnedEntries.add(key);
+            }
+        }
+        final CountDownLatch latch = new CountDownLatch(lsOwnedEntries.size());
+        for (final String ownedKey : lsOwnedEntries) {
+            es.execute(new Runnable() {
+                public void run() {
+                    map.put(ownedKey, createValue());
+                    latch.countDown();
+                }
+            });
+        }
+        latch.await();
+    }
+
+    private void startPrintStats() {
+        Thread t = new Thread() {
+            {
+                setDaemon(true);
+                setName("PrintStats." + instance.getName());
+            }
+
+            public void run() {
+                while (true) {
+                    try {
+                        Thread.sleep(STATS_SECONDS * 1000);
+                        stats.printAndReset();
+                    } catch (InterruptedException ignored) {
+                        return;
+                    }
+                }
+            }
+        };
+        t.start();
+    }
+
+    /**
+     * A basic statistics class
+     */
+    private class Stats {
+
+        private AtomicLong gets = new AtomicLong();
+        private AtomicLong puts = new AtomicLong();
+        private AtomicLong removes = new AtomicLong();
+
+        public void printAndReset() {
+            long getsNow = gets.getAndSet(0);
+            long putsNow = puts.getAndSet(0);
+            long removesNow = removes.getAndSet(0);
+            long total = getsNow + putsNow + removesNow;
+
+            logger.info("total= " + total + ", gets:" + getsNow
+                    + ", puts:" + putsNow + ", removes:" + removesNow);
+            logger.info("Operations per Second : " + total / STATS_SECONDS);
+        }
+    }
+
+    private void printVariables() {
+        logger.info("Starting Test with ");
+        logger.info("Thread Count: " + threadCount);
+        logger.info("Entry Count: " + entryCount);
+        logger.info("Value Size: " + valueSize);
+        logger.info("Get Percentage: " + getPercentage);
+        logger.info("Put Percentage: " + putPercentage);
+        logger.info("Remove Percentage: " + (100 - (putPercentage + getPercentage)));
+        logger.info("Load: " + load);
+    }
+}

--- a/hazelcast/src/test/resources/log4j.properties
+++ b/hazelcast/src/test/resources/log4j.properties
@@ -21,7 +21,7 @@ log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=%d{ABSOLUTE} %5p [%c{1}] %t - %m%n
 
 #log4j.logger.com.hazelcast=debug
-log4j.logger.com.hazelcast.replicatedmap=debug
+#log4j.logger.com.hazelcast.replicatedmap=debug
 #log4j.logger.com.hazelcast.cluster=debug
 #log4j.logger.com.hazelcast.partition=debug
 #log4j.logger.com.hazelcast.partition.InternalPartitionService=debug


### PR DESCRIPTION
Changes made on this PR : 

- Default invocation try count (250) lowered to 3 on data sync/anti-entropy operations,
 since the process is periodic if we fail to do it right now, we can try it later in order to not put a pressure to the system. The new default invocation count of 3 for replication operations will be sufficient for intermittent connection/network problems. 
- Operations changed to return null responses since they are executed in an invocation context and they have to return a response in order to prevent invocations piling up at the caller side. 
- Event publishing refactored and uses correct caller/source address (which is the node where user initiates the operation).
- Added simple performance test
- Cleaned up some logging left-overs.
