### PR TITLE
Fixed Operation.toString

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheGetAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheGetAllOperation.java
@@ -71,8 +71,11 @@ public class CacheGetAllOperation
     }
 
     @Override
-    public String toString() {
-        return "CacheGetAllOperation{" + "keys:" + keys.toString() + "expiryPolicy:" + expiryPolicy + '}';
+    protected void toString(StringBuilder sb) {
+        super.toString(sb);
+
+        sb.append(", keys=").append(keys.toString());
+        sb.append(", expiryPolicy=").append(expiryPolicy);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/operations/FinalizeJoinOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/operations/FinalizeJoinOperation.java
@@ -128,11 +128,10 @@ public class FinalizeJoinOperation extends MemberInfoUpdateOperation implements 
     }
 
     @Override
-    public String toString() {
-        return "FinalizeJoinOperation{"
-                + "postJoinOp=" + postJoinOp
-                + "} "
-                + super.toString();
+    protected void toString(StringBuilder sb) {
+        super.toString(sb);
+
+        sb.append(", postJoinOp=").append(postJoinOp);
     }
 }
 

--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/operations/JoinRequestOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/operations/JoinRequestOperation.java
@@ -56,11 +56,9 @@ public class JoinRequestOperation extends AbstractClusterOperation implements Jo
     }
 
     @Override
-    public String toString() {
-        final StringBuilder sb = new StringBuilder();
-        sb.append("JoinRequestOperation");
-        sb.append("{message=").append(request);
-        sb.append('}');
-        return sb.toString();
+    protected void toString(StringBuilder sb) {
+        super.toString(sb);
+
+        sb.append(", message=").append(request);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/operations/MasterDiscoveryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/operations/MasterDiscoveryOperation.java
@@ -52,11 +52,9 @@ public class MasterDiscoveryOperation extends AbstractClusterOperation implement
     }
 
     @Override
-    public String toString() {
-        final StringBuilder sb = new StringBuilder();
-        sb.append("MasterDiscoveryOperation");
-        sb.append("{message=").append(joinMessage);
-        sb.append('}');
-        return sb.toString();
+    protected void toString(StringBuilder sb) {
+        super.toString(sb);
+
+        sb.append(", message=").append(joinMessage);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/operations/MemberInfoUpdateOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/operations/MemberInfoUpdateOperation.java
@@ -95,13 +95,13 @@ public class MemberInfoUpdateOperation extends AbstractClusterOperation implemen
     }
 
     @Override
-    public String toString() {
-        StringBuilder sb = new StringBuilder("MemberInfoUpdateOperation {\n");
+    protected void toString(StringBuilder sb) {
+        super.toString(sb);
+
+        sb.append(", members=");
         for (MemberInfo address : memberInfos) {
-            sb.append(address).append('\n');
+            sb.append(address).append(' ');
         }
-        sb.append('}');
-        return sb.toString();
     }
 }
 

--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/operations/PostJoinOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/operations/PostJoinOperation.java
@@ -121,10 +121,9 @@ public class PostJoinOperation extends AbstractOperation implements UrgentSystem
     }
 
     @Override
-    public String toString() {
-        final StringBuilder sb = new StringBuilder("PostJoinOperation{");
-        sb.append("operations=").append(Arrays.toString(operations));
-        sb.append('}');
-        return sb.toString();
+    protected void toString(StringBuilder sb) {
+        super.toString(sb);
+
+        sb.append(", operations=").append(Arrays.toString(operations));
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/operations/SetMasterOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/operations/SetMasterOperation.java
@@ -56,7 +56,9 @@ public class SetMasterOperation extends AbstractClusterOperation implements Join
     }
 
     @Override
-    public String toString() {
-        return "Master " + masterAddress;
+    protected void toString(StringBuilder sb) {
+        super.toString(sb);
+
+        sb.append(", master=").append(masterAddress);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/operations/CollectionOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/operations/CollectionOperation.java
@@ -126,4 +126,11 @@ public abstract class CollectionOperation extends Operation
     protected void readInternal(ObjectDataInput in) throws IOException {
         name = in.readUTF();
     }
+
+    @Override
+    protected void toString(StringBuilder sb) {
+        super.toString(sb);
+
+        sb.append(", name=").append(name);
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/AtomicLongBaseOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/AtomicLongBaseOperation.java
@@ -82,4 +82,10 @@ public abstract class AtomicLongBaseOperation extends Operation
         name = in.readUTF();
     }
 
+    @Override
+    protected void toString(StringBuilder sb) {
+        super.toString(sb);
+
+        sb.append(", name=").append(name);
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/AtomicReferenceBaseOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/AtomicReferenceBaseOperation.java
@@ -81,4 +81,11 @@ public abstract class AtomicReferenceBaseOperation extends Operation
     protected void readInternal(ObjectDataInput in) throws IOException {
         name = in.readUTF();
     }
+
+    @Override
+    protected void toString(StringBuilder sb) {
+        super.toString(sb);
+
+        sb.append(", name=").append(name);
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/BaseLockOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/BaseLockOperation.java
@@ -145,4 +145,11 @@ public abstract class BaseLockOperation extends AbstractOperation
         leaseTime = in.readLong();
         referenceCallId = in.readLong();
     }
+
+    @Override
+    protected void toString(StringBuilder sb) {
+        super.toString(sb);
+
+        sb.append(", namespace=").append(namespace);
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/executor/impl/operations/BaseCallableTaskOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/executor/impl/operations/BaseCallableTaskOperation.java
@@ -135,4 +135,12 @@ abstract class BaseCallableTaskOperation extends Operation implements TraceableO
         uuid = in.readUTF();
         callableData = in.readData();
     }
+
+
+    @Override
+    protected void toString(StringBuilder sb) {
+        super.toString(sb);
+
+        sb.append(", name=").append(name);
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/AddInterceptorOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/AddInterceptorOperation.java
@@ -76,8 +76,10 @@ public class AddInterceptorOperation extends AbstractOperation implements Mutati
     }
 
     @Override
-    public String toString() {
-        return "AddInterceptorOperation{}";
+    protected void toString(StringBuilder sb) {
+        super.toString(sb);
+
+        sb.append(", name=").append(mapName);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/BasePutOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/BasePutOperation.java
@@ -113,9 +113,4 @@ public abstract class BasePutOperation extends LockAwareOperation implements Bac
     public void onWaitExpire() {
         sendResponse(null);
     }
-
-    @Override
-    public String toString() {
-        return "BasePutOperation{" + name + "}";
-    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/BaseRemoveOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/BaseRemoveOperation.java
@@ -79,9 +79,4 @@ public abstract class BaseRemoveOperation extends LockAwareOperation implements 
     public void onWaitExpire() {
         sendResponse(null);
     }
-
-    @Override
-    public String toString() {
-        return "BaseRemoveOperation{" + name + "}";
-    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ClearBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ClearBackupOperation.java
@@ -50,9 +50,4 @@ public class ClearBackupOperation extends AbstractNamedOperation implements Back
     public void run() {
         recordStore.clear();
     }
-
-    @Override
-    public String toString() {
-        return "ClearBackupOperation{}";
-    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ClearExpiredOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ClearExpiredOperation.java
@@ -92,7 +92,9 @@ public class ClearExpiredOperation extends AbstractOperation implements Partitio
     }
 
     @Override
-    public String toString() {
-        return "ClearExpiredOperation{}";
+    protected void toString(StringBuilder sb) {
+        super.toString(sb);
+
+        sb.append(", expirationPercentage=").append(expirationPercentage);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ClearNearCacheOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ClearNearCacheOperation.java
@@ -48,10 +48,4 @@ public class ClearNearCacheOperation extends AbstractNamedOperation
     public Object getResponse() {
         return Boolean.TRUE;
     }
-
-    @Override
-    public String toString() {
-        return "ClearNearCacheOperation{}";
-    }
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ClearOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ClearOperation.java
@@ -98,9 +98,4 @@ public class ClearOperation extends AbstractMapOperation implements BackupAwareO
         clearBackupOperation.setServiceName(SERVICE_NAME);
         return clearBackupOperation;
     }
-
-    @Override
-    public String toString() {
-        return "ClearOperation{}";
-    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ContainsKeyOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ContainsKeyOperation.java
@@ -63,9 +63,4 @@ public class ContainsKeyOperation extends KeyBasedMapOperation implements Readon
     public void onWaitExpire() {
         sendResponse(new OperationTimeoutException("Cannot read transactionally locked entry!"));
     }
-
-    @Override
-    public String toString() {
-        return "ContainsKeyOperation{}";
-    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/DeleteOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/DeleteOperation.java
@@ -54,9 +54,4 @@ public class DeleteOperation extends BaseRemoveOperation {
     public void onWaitExpire() {
         sendResponse(false);
     }
-
-    @Override
-    public String toString() {
-        return "DeleteOperation{" + name + "}";
-    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryBackupOperation.java
@@ -108,11 +108,6 @@ public class EntryBackupOperation extends KeyBasedMapOperation implements Backup
         return true;
     }
 
-    @Override
-    public String toString() {
-        return "EntryBackupOperation{}";
-    }
-
     private void processBackup(Map.Entry entry) {
         entryProcessor.processBackup(entry);
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOperation.java
@@ -115,11 +115,6 @@ public class EntryOperation extends LockAwareOperation implements BackupAwareOpe
     }
 
     @Override
-    public String toString() {
-        return "EntryOperation{}";
-    }
-
-    @Override
     public Operation getBackupOperation() {
         EntryBackupProcessor backupProcessor = entryProcessor.getBackupProcessor();
         return backupProcessor != null ? new EntryBackupOperation(name, dataKey, backupProcessor) : null;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EvictAllBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EvictAllBackupOperation.java
@@ -45,9 +45,4 @@ public class EvictAllBackupOperation extends AbstractMapOperation implements Bac
         }
         recordStore.evictAll(true);
     }
-
-    @Override
-    public String toString() {
-        return "EvictAllBackupOperation{}";
-    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EvictAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EvictAllOperation.java
@@ -114,10 +114,10 @@ public class EvictAllOperation extends AbstractMapOperation implements BackupAwa
     }
 
     @Override
-    public String toString() {
-        return "EvictAllOperation{"
-                + "shouldRunOnBackup=" + shouldRunOnBackup
-                + ", numberOfEvictedEntries=" + numberOfEvictedEntries
-                + '}';
+    protected void toString(StringBuilder sb) {
+        super.toString(sb);
+
+        sb.append(", shouldRunOnBackup=").append(shouldRunOnBackup);
+        sb.append(", numberOfEvictedEntries=").append(numberOfEvictedEntries);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EvictOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EvictOperation.java
@@ -82,6 +82,7 @@ public class EvictOperation extends LockAwareOperation implements MutatingOperat
         return mapContainer.getBackupCount();
     }
 
+    @Override
     public boolean shouldBackup() {
         return evicted;
     }
@@ -108,10 +109,5 @@ public class EvictOperation extends LockAwareOperation implements MutatingOperat
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
         asyncBackup = in.readBoolean();
-    }
-
-    @Override
-    public String toString() {
-        return "EvictOperation{" + name + "}";
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/GetAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/GetAllOperation.java
@@ -80,11 +80,6 @@ public class GetAllOperation extends AbstractMapOperation implements ReadonlyOpe
     }
 
     @Override
-    public String toString() {
-        return "GetAllOperation{}";
-    }
-
-    @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
         if (keys == null) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/GetEntryViewOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/GetEntryViewOperation.java
@@ -72,9 +72,4 @@ public class GetEntryViewOperation extends KeyBasedMapOperation implements Reado
     public Object getResponse() {
         return result;
     }
-
-    @Override
-    public String toString() {
-        return "GetEntryViewOperation{}";
-    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/GetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/GetOperation.java
@@ -76,11 +76,6 @@ public final class GetOperation extends KeyBasedMapOperation
     }
 
     @Override
-    public String toString() {
-        return "GetOperation{" + name + "}";
-    }
-
-    @Override
     public int getFactoryId() {
         return MapDataSerializerHook.F_ID;
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/InvalidateNearCacheOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/InvalidateNearCacheOperation.java
@@ -74,7 +74,9 @@ public class InvalidateNearCacheOperation extends AbstractOperation implements M
     }
 
     @Override
-    public String toString() {
-        return "InvalidateNearCacheOperation{}";
+    protected void toString(StringBuilder sb) {
+        super.toString(sb);
+
+        sb.append(", name=").append(mapName);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/KeyBasedMapOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/KeyBasedMapOperation.java
@@ -151,4 +151,12 @@ public abstract class KeyBasedMapOperation extends Operation implements Partitio
         dataValue = in.readData();
         ttl = in.readLong();
     }
+
+
+    @Override
+    protected void toString(StringBuilder sb) {
+        super.toString(sb);
+
+        sb.append(", name=").append(name);
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MergeOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MergeOperation.java
@@ -111,10 +111,4 @@ public class MergeOperation extends BasePutOperation {
         mergingEntry = in.readObject();
         mergePolicy = in.readObject();
     }
-
-    @Override
-    public String toString() {
-        return "MergeOperation{" + name + "}";
-    }
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MultipleEntryBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MultipleEntryBackupOperation.java
@@ -92,9 +92,4 @@ public class MultipleEntryBackupOperation extends AbstractMultipleEntryBackupOpe
     public Object getResponse() {
         return true;
     }
-
-    @Override
-    public String toString() {
-        return "MultipleEntryBackupOperation{}";
-    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MultipleEntryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MultipleEntryOperation.java
@@ -87,11 +87,6 @@ public class MultipleEntryOperation extends AbstractMultipleEntryOperation imple
     }
 
     @Override
-    public String toString() {
-        return "MultipleEntryOperation{}";
-    }
-
-    @Override
     public boolean shouldBackup() {
         return entryProcessor.getBackupProcessor() != null;
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/NearCacheKeySetInvalidationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/NearCacheKeySetInvalidationOperation.java
@@ -80,7 +80,9 @@ public class NearCacheKeySetInvalidationOperation extends AbstractOperation impl
     }
 
     @Override
-    public String toString() {
-        return "NearCacheKeySetInvalidationOperation{}";
+    protected void toString(StringBuilder sb) {
+        super.toString(sb);
+
+        sb.append(", name=").append(mapName);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryBackupOperation.java
@@ -87,11 +87,6 @@ public class PartitionWideEntryBackupOperation extends AbstractMultipleEntryBack
     }
 
     @Override
-    public String toString() {
-        return "PartitionWideEntryBackupOperation{}";
-    }
-
-    @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
         backupProcessor = in.readObject();

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryOperation.java
@@ -134,11 +134,6 @@ public class PartitionWideEntryOperation extends AbstractMultipleEntryOperation 
     }
 
     @Override
-    public String toString() {
-        return "PartitionWideEntryOperation{}";
-    }
-
-    @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
         entryProcessor = in.readObject();

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryWithPredicateBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryWithPredicateBackupOperation.java
@@ -40,11 +40,6 @@ public class PartitionWideEntryWithPredicateBackupOperation extends PartitionWid
     }
 
     @Override
-    public String toString() {
-        return "PartitionWideEntryWithPredicateBackupOperation{}";
-    }
-
-    @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
         predicate = in.readObject();

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryWithPredicateOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryWithPredicateOperation.java
@@ -51,12 +51,9 @@ public class PartitionWideEntryWithPredicateOperation extends PartitionWideEntry
     }
 
     @Override
-    public String toString() {
-        return "PartitionWideEntryWithPredicateOperation{"
-                + "name='" + name
-                + "', entryProcessor='" + entryProcessor.toString()
-                + "', predicate='" + predicate.toString()
-                + "'}";
+    protected void toString(StringBuilder sb) {
+        sb.append(", entryProcessor=").append(entryProcessor);
+        sb.append(", predicate=").append(predicate);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutAllBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutAllBackupOperation.java
@@ -78,11 +78,6 @@ public class PutAllBackupOperation extends AbstractMapOperation implements Parti
     }
 
     @Override
-    public String toString() {
-        return "PutAllBackupOperation{}";
-    }
-
-    @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
         final int size = entries.size();

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutAllOperation.java
@@ -156,11 +156,6 @@ public class PutAllOperation extends AbstractMapOperation implements PartitionAw
     }
 
     @Override
-    public String toString() {
-        return "PutAllOperation{}";
-    }
-
-    @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
         out.writeObject(mapEntries);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutBackupOperation.java
@@ -151,9 +151,4 @@ public final class PutBackupOperation extends KeyBasedMapOperation implements Ba
         putTransient = in.readBoolean();
         wanOriginated = in.readBoolean();
     }
-
-    @Override
-    public String toString() {
-        return "PutBackupOperation{" + name + "}";
-    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutFromLoadAllBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutFromLoadAllBackupOperation.java
@@ -86,11 +86,6 @@ public class PutFromLoadAllBackupOperation extends AbstractMapOperation implemen
     }
 
     @Override
-    public String toString() {
-        return "PutFromLoadAllBackupOperation{}";
-    }
-
-    @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
         final List<Data> keyValueSequence = this.keyValueSequence;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutFromLoadAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutFromLoadAllOperation.java
@@ -143,11 +143,6 @@ public class PutFromLoadAllOperation extends AbstractMapOperation implements Par
     }
 
     @Override
-    public String toString() {
-        return "PutFromLoadAllOperation{}";
-    }
-
-    @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
         final List<Data> keyValueSequence = this.keyValueSequence;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutIfAbsentOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutIfAbsentOperation.java
@@ -52,9 +52,4 @@ public class PutIfAbsentOperation extends BasePutOperation {
     public boolean shouldBackup() {
         return successful && recordStore.getRecord(dataKey) != null;
     }
-
-    @Override
-    public String toString() {
-        return "PutIfAbsentOperation{" + name + "}";
-    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutOperation.java
@@ -40,11 +40,6 @@ public final class PutOperation extends BasePutOperation implements IdentifiedDa
     }
 
     @Override
-    public String toString() {
-        return "PutOperation{" + name + "}";
-    }
-
-    @Override
     public int getFactoryId() {
         return MapDataSerializerHook.F_ID;
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutTransientOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutTransientOperation.java
@@ -42,10 +42,4 @@ public class PutTransientOperation extends BasePutOperation {
     public void onWaitExpire() {
         sendResponse(null);
     }
-
-    @Override
-    public String toString() {
-        return "PutTransientOperation{" + name + "}";
-    }
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/RemoveIfSameOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/RemoveIfSameOperation.java
@@ -63,11 +63,6 @@ public class RemoveIfSameOperation extends BaseRemoveOperation {
     }
 
     @Override
-    public String toString() {
-        return "RemoveIfSameOperation{" + name + "}";
-    }
-
-    @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
         out.writeData(testValue);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/RemoveInterceptorOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/RemoveInterceptorOperation.java
@@ -73,7 +73,10 @@ public class RemoveInterceptorOperation extends AbstractOperation implements Mut
     }
 
     @Override
-    public String toString() {
-        return "RemoveInterceptorOperation{}";
+    protected void toString(StringBuilder sb) {
+        super.toString(sb);
+
+        sb.append(", mapName=").append(mapName);
+        sb.append(", id=").append(id);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/RemoveOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/RemoveOperation.java
@@ -52,11 +52,6 @@ public final class RemoveOperation extends BaseRemoveOperation implements Identi
     }
 
     @Override
-    public String toString() {
-        return "RemoveOperation{" + name + "}";
-    }
-
-    @Override
     public int getFactoryId() {
         return MapDataSerializerHook.F_ID;
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ReplaceIfSameOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ReplaceIfSameOperation.java
@@ -75,9 +75,4 @@ public class ReplaceIfSameOperation extends BasePutOperation {
         super.readInternal(in);
         expect = in.readData();
     }
-
-    @Override
-    public String toString() {
-        return "ReplaceIfSameOperation{" + name + "}";
-    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ReplaceOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ReplaceOperation.java
@@ -53,10 +53,4 @@ public class ReplaceOperation extends BasePutOperation {
     public Object getResponse() {
         return dataOldValue;
     }
-
-    @Override
-    public String toString() {
-        return "ReplaceOperation{" + name + "}";
-    }
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/SetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/SetOperation.java
@@ -45,9 +45,4 @@ public class SetOperation extends BasePutOperation {
     public Object getResponse() {
         return newRecord;
     }
-
-    @Override
-    public String toString() {
-        return "SetOperation{" + name + "}";
-    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/TryPutOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/TryPutOperation.java
@@ -56,9 +56,4 @@ public class TryPutOperation extends BasePutOperation {
     public Object getResponse() {
         return successful;
     }
-
-    @Override
-    public String toString() {
-        return "TryPutOperation{" + name + "}";
-    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/TryRemoveOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/TryRemoveOperation.java
@@ -64,11 +64,6 @@ public class TryRemoveOperation extends BaseRemoveOperation {
     }
 
     @Override
-    public String toString() {
-        return "TryRemoveOperation{" + name + "}";
-    }
-
-    @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/WanOriginatedDeleteOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/WanOriginatedDeleteOperation.java
@@ -70,10 +70,4 @@ public class WanOriginatedDeleteOperation extends BaseRemoveOperation {
     public void onWaitExpire() {
         sendResponse(false);
     }
-
-    @Override
-    public String toString() {
-        return "DeleteOperation{" + name + "}";
-    }
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnLockAndGetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnLockAndGetOperation.java
@@ -79,13 +79,11 @@ public class TxnLockAndGetOperation extends LockAwareOperation implements Mutati
         ownerUuid = in.readUTF();
     }
 
-
     @Override
-    public String toString() {
-        return "TxnLockAndGetOperation{"
-                + "timeout=" + getWaitTimeout()
-                + ", thread=" + getThreadId()
-                + '}';
-    }
+    protected void toString(StringBuilder sb) {
+        super.toString(sb);
 
+        sb.append(", timeout=").append(getWaitTimeout());
+        sb.append(", thread=").append(getThreadId());
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnPrepareOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnPrepareOperation.java
@@ -18,13 +18,14 @@ package com.hazelcast.map.impl.tx;
 
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.map.impl.operation.KeyBasedMapOperation;
-import com.hazelcast.spi.impl.MutatingOperation;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.BackupAwareOperation;
 import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.impl.MutatingOperation;
 import com.hazelcast.transaction.TransactionException;
+
 import java.io.IOException;
 
 /**
@@ -93,9 +94,9 @@ public class TxnPrepareOperation extends KeyBasedMapOperation implements BackupA
     }
 
     @Override
-    public String toString() {
-        return "TxnPrepareOperation{"
-                + "ownerUuid='" + ownerUuid + '\''
-                + '}';
+    protected void toString(StringBuilder sb) {
+        super.toString(sb);
+
+        sb.append(", ownerUuid=").append(ownerUuid);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/operation/KeyValueJobOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/operation/KeyValueJobOperation.java
@@ -178,4 +178,12 @@ public class KeyValueJobOperation<K, V>
     public int getId() {
         return MapReduceDataSerializerHook.TRACKED_JOB_OPERATION;
     }
+
+
+    @Override
+    protected void toString(StringBuilder sb) {
+        super.toString(sb);
+
+        sb.append(", name=").append(name);
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/operation/ProcessingOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/operation/ProcessingOperation.java
@@ -72,4 +72,11 @@ public abstract class ProcessingOperation
         jobId = in.readUTF();
     }
 
+
+    @Override
+    protected void toString(StringBuilder sb) {
+        super.toString(sb);
+
+        sb.append(", name=").append(name);
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/MultiMapOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/MultiMapOperation.java
@@ -133,4 +133,11 @@ public abstract class MultiMapOperation extends Operation
     public int getFactoryId() {
         return MultiMapDataSerializerHook.F_ID;
     }
+
+    @Override
+    protected void toString(StringBuilder sb) {
+        super.toString(sb);
+
+        sb.append(", name=").append(name);
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/partition/impl/BaseMigrationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/impl/BaseMigrationOperation.java
@@ -94,7 +94,9 @@ public abstract class BaseMigrationOperation extends AbstractOperation
     }
 
     @Override
-    public String toString() {
-        return getClass().getSimpleName() + "{partitionId=" + getPartitionId() + ", migration=" + migrationInfo + '}';
+    protected void toString(StringBuilder sb) {
+        super.toString(sb);
+
+        sb.append(", migration=").append(migrationInfo);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/partition/impl/CheckReplicaVersion.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/impl/CheckReplicaVersion.java
@@ -114,8 +114,9 @@ public final class CheckReplicaVersion extends Operation implements PartitionAwa
     }
 
     @Override
-    public String toString() {
-        return getClass().getSimpleName() + "{partitionId=" + getPartitionId() + ", replicaIndex=" + getReplicaIndex()
-                + ", version=" + version + '}';
+    protected void toString(StringBuilder sb) {
+        super.toString(sb);
+
+        sb.append(", version=").append(version);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/partition/impl/MigrationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/impl/MigrationOperation.java
@@ -236,9 +236,10 @@ public final class MigrationOperation extends BaseMigrationOperation {
     }
 
     @Override
-    public String toString() {
-        final int numberOfTasks = tasks != null ? tasks.size() : 0;
-        return getClass().getSimpleName() + "{partitionId=" + getPartitionId() + ", migration=" + migrationInfo
-                + ", replicaVersions=" + Arrays.toString(replicaVersions) + ", numberOfTasks=" + numberOfTasks + '}';
+    protected void toString(StringBuilder sb) {
+        int numberOfTasks = tasks == null ? 0 : tasks.size();
+        sb.append(", migration=").append(migrationInfo);
+        sb.append(", replicaVersions=").append(Arrays.toString(replicaVersions));
+        sb.append(", numberOfTasks=").append(numberOfTasks);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/partition/impl/ReplicaSyncRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/impl/ReplicaSyncRequest.java
@@ -225,9 +225,4 @@ public final class ReplicaSyncRequest extends Operation implements PartitionAwar
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
     }
-
-    @Override
-    public String toString() {
-        return getClass().getSimpleName() + "{partitionId=" + getPartitionId() + ", replicaIndex=" + getReplicaIndex() + '}';
-    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/partition/impl/ReplicaSyncResponse.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/impl/ReplicaSyncResponse.java
@@ -252,8 +252,9 @@ public class ReplicaSyncResponse extends Operation
     }
 
     @Override
-    public String toString() {
-        return getClass().getSimpleName() + "{partitionId=" + getPartitionId() + ", replicaIndex=" + getReplicaIndex()
-                + ", replicaVersions=" + Arrays.toString(replicaVersions) + '}';
+    protected void toString(StringBuilder sb) {
+        super.toString(sb);
+
+        sb.append(", replicaVersions=").append(Arrays.toString(replicaVersions));
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/partition/impl/ReplicaSyncRetryResponse.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/impl/ReplicaSyncRetryResponse.java
@@ -102,9 +102,4 @@ public class ReplicaSyncRetryResponse extends Operation
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
     }
-
-    @Override
-    public String toString() {
-        return getClass().getSimpleName() + "{partitionId=" + getPartitionId() + ", replicaIndex=" + getReplicaIndex() + '}';
-    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/partition/impl/SyncReplicaVersion.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/impl/SyncReplicaVersion.java
@@ -147,7 +147,10 @@ final class SyncReplicaVersion extends Operation implements PartitionAwareOperat
     }
 
     @Override
-    public String toString() {
-        return getClass().getSimpleName() + "{" + "partitionId=" + getPartitionId() + ", replicaIndex=" + syncReplicaIndex + '}';
+    protected void toString(StringBuilder sb) {
+        super.toString(sb);
+
+        sb.append(", syncReplicaIndex=").append(syncReplicaIndex);
+        sb.append(", sync=").append(sync);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/AbstractReplicatedMapOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/AbstractReplicatedMapOperation.java
@@ -95,4 +95,11 @@ public abstract class AbstractReplicatedMapOperation extends AbstractOperation {
             return resp;
         }
     }
+
+    @Override
+    protected void toString(StringBuilder sb) {
+        super.toString(sb);
+
+        sb.append(", name=").append(name);
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/AbstractRingBufferOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/AbstractRingBufferOperation.java
@@ -75,4 +75,11 @@ public abstract class AbstractRingBufferOperation extends AbstractOperation
         super.readInternal(in);
         name = in.readUTF();
     }
+
+    @Override
+    protected void toString(StringBuilder sb) {
+        super.toString(sb);
+
+        sb.append(", name=").append(name);
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/Operation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/Operation.java
@@ -571,15 +571,30 @@ public abstract class Operation implements DataSerializable {
 
     protected abstract void readInternal(ObjectDataInput in) throws IOException;
 
+    /**
+     * A template method allows for additional information to be passed into the {@link #toString()} method. So an Operation
+     * subclass can override this method and add additional debugging content. The default implementation does nothing so
+     * one is not forced to provide an empty implementation.
+     *
+     * It is a good practice always to call the super.toString(stringBuffer) when implementing this method to make sure
+     * that the super class can inject content if needed.
+     *
+     * @param sb the StringBuilder to add the debug info to.
+     */
+    protected void toString(StringBuilder sb) {
+    }
+
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder(getClass().getName()).append('{');
+        StringBuilder sb = new StringBuilder(getClass().getName()).append('{');
         sb.append("serviceName='").append(getServiceName()).append('\'');
         sb.append(", partitionId=").append(partitionId);
+        sb.append(", replicaIndex=").append(replicaIndex);
         sb.append(", callId=").append(callId);
         sb.append(", invocationTime=").append(invocationTime);
         sb.append(", waitTimeout=").append(waitTimeout);
         sb.append(", callTimeout=").append(callTimeout);
+        toString(sb);
         sb.append('}');
         return sb.toString();
     }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/AbstractNamedOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/AbstractNamedOperation.java
@@ -33,6 +33,7 @@ public abstract class AbstractNamedOperation extends AbstractOperation implement
     public AbstractNamedOperation() {
     }
 
+    @Override
     public final String getName() {
         return name;
     }
@@ -45,5 +46,12 @@ public abstract class AbstractNamedOperation extends AbstractOperation implement
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
         name = in.readUTF();
+    }
+
+    @Override
+    protected void toString(StringBuilder sb) {
+        super.toString(sb);
+
+        sb.append(", name=").append(name);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/operations/Backup.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/operations/Backup.java
@@ -239,15 +239,13 @@ public final class Backup extends Operation implements BackupOperation, Identifi
     }
 
     @Override
-    public String toString() {
-        final StringBuilder sb = new StringBuilder();
-        sb.append("Backup");
-        sb.append("{backupOp=").append(backupOp);
+    protected void toString(StringBuilder sb) {
+        super.toString(sb);
+
+        sb.append(", backupOp=").append(backupOp);
         sb.append(", backupOpData=").append(backupOpData);
         sb.append(", originalCaller=").append(originalCaller);
         sb.append(", version=").append(Arrays.toString(replicaVersions));
         sb.append(", sync=").append(sync);
-        sb.append('}');
-        return sb.toString();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/waitnotifyservice/impl/WaitingOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/waitnotifyservice/impl/WaitingOperation.java
@@ -23,9 +23,9 @@ import com.hazelcast.spi.OperationResponseHandler;
 import com.hazelcast.spi.PartitionAwareOperation;
 import com.hazelcast.spi.WaitSupport;
 import com.hazelcast.spi.exception.RetryableException;
-import com.hazelcast.spi.impl.operationservice.impl.responses.CallTimeoutResponse;
-import com.hazelcast.spi.impl.operationservice.InternalOperationService;
 import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.spi.impl.operationservice.InternalOperationService;
+import com.hazelcast.spi.impl.operationservice.impl.responses.CallTimeoutResponse;
 import com.hazelcast.util.Clock;
 
 import java.util.Queue;
@@ -192,13 +192,11 @@ class WaitingOperation extends AbstractOperation implements Delayed, PartitionAw
     }
 
     @Override
-    public String toString() {
-        final StringBuilder sb = new StringBuilder();
-        sb.append("WaitingOp");
-        sb.append("{op=").append(op);
+    protected void toString(StringBuilder sb) {
+        super.toString(sb);
+
+        sb.append(", op=").append(op);
         sb.append(", expirationTime=").append(expirationTime);
         sb.append(", valid=").append(valid);
-        sb.append('}');
-        return sb.toString();
     }
 }


### PR DESCRIPTION
The Operation has a nice toString method which is quite informative, unfortunately it was
overridden on quite a few places by one that doesn't include all this information.

This pr fixes that by replacing all Operation.toString methods by a better one that
can be glued into the one of the  operation