### PR TITLE
Fixed JavaDoc of SERVICE_NAME constants.

### DIFF
--- a/hazelcast-client-new/src/test/java/com/hazelcast/client/spi/ProxyFactoryTest.java
+++ b/hazelcast-client-new/src/test/java/com/hazelcast/client/spi/ProxyFactoryTest.java
@@ -6,7 +6,6 @@ import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.ServiceConfig;
 import com.hazelcast.core.DistributedObject;
-import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.spi.RemoteService;
 import com.hazelcast.test.HazelcastParallelClassRunner;
@@ -19,12 +18,12 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class ProxyFactoryTest {
 
-    static final String SERVICE_NAME = "CustomService";
+    private static final String SERVICE_NAME = "CustomService";
+
     private final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
 
     @After

--- a/hazelcast-client/src/test/java/com/hazelcast/client/spi/ProxyFactoryTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/spi/ProxyFactoryTest.java
@@ -6,7 +6,6 @@ import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.ServiceConfig;
 import com.hazelcast.core.DistributedObject;
-import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.spi.RemoteService;
 import com.hazelcast.test.HazelcastParallelClassRunner;
@@ -19,12 +18,12 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class ProxyFactoryTest {
 
-    static final String SERVICE_NAME = "CustomService";
+    private static final String SERVICE_NAME = "CustomService";
+
     private final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
 
     @After

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/ICacheService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/ICacheService.java
@@ -34,9 +34,6 @@ import java.util.Collection;
 public interface ICacheService extends ManagedService, RemoteService, MigrationAwareService,
             EventPublishingService<Object, CacheEventListener> {
 
-    /**
-     * Service name
-     */
     String SERVICE_NAME = "hz:impl:cacheService";
 
     ICacheRecordStore getOrCreateRecordStore(String name, int partitionId);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngineImpl.java
@@ -98,9 +98,10 @@ public class ClientEngineImpl implements ClientEngine, CoreService, PostJoinAwar
         ManagedService, MembershipAwareService, EventPublishingService<ClientEndpointImpl, ClientListener> {
 
     /**
-     * Service Name of clientEngine to be used in requests
+     * Service name to be used in requests.
      */
     public static final String SERVICE_NAME = "hz:core:clientEngine";
+
     private static final int ENDPOINT_REMOVE_DELAY_SECONDS = 10;
     private static final int EXECUTOR_QUEUE_CAPACITY_PER_CORE = 100000;
     private static final int THREADS_PER_CORE = 20;

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueService.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueService.java
@@ -72,10 +72,9 @@ import java.util.logging.Level;
  */
 public class QueueService implements ManagedService, MigrationAwareService, TransactionalService,
         RemoteService, EventPublishingService<QueueEvent, ItemListener>, StatisticsAwareService {
-    /**
-     * Service name.
-     */
+
     public static final String SERVICE_NAME = "hz:impl:queueService";
+
     private final EntryTaskScheduler queueEvictionScheduler;
     private final NodeEngine nodeEngine;
     private final ConcurrentMap<String, QueueContainer> containerMap

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/AtomicLongService.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/AtomicLongService.java
@@ -40,9 +40,6 @@ import static com.hazelcast.util.ConcurrencyUtil.getOrPutIfAbsent;
 
 public class AtomicLongService implements ManagedService, RemoteService, MigrationAwareService {
 
-    /**
-     * The name of this service.s
-     */
     public static final String SERVICE_NAME = "hz:impl:atomicLongService";
 
     private NodeEngine nodeEngine;

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/AtomicReferenceService.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/AtomicReferenceService.java
@@ -41,9 +41,6 @@ import static com.hazelcast.util.ConcurrencyUtil.getOrPutIfAbsent;
 
 public class AtomicReferenceService implements ManagedService, RemoteService, MigrationAwareService {
 
-    /**
-     * The name of the AtomicReferenceService.
-     */
     public static final String SERVICE_NAME = "hz:impl:atomicReferenceService";
 
     private NodeEngine nodeEngine;

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/countdownlatch/CountDownLatchService.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/countdownlatch/CountDownLatchService.java
@@ -37,9 +37,6 @@ import java.util.concurrent.ConcurrentMap;
 
 public class CountDownLatchService implements ManagedService, RemoteService, MigrationAwareService {
 
-    /**
-     * The service name of this CountDownLatchService.
-     */
     public static final String SERVICE_NAME = "hz:impl:countDownLatchService";
 
     private final ConcurrentMap<String, CountDownLatchContainer> containers

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/idgen/IdGeneratorService.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/idgen/IdGeneratorService.java
@@ -28,6 +28,7 @@ import java.util.Properties;
 public class IdGeneratorService implements ManagedService, RemoteService {
 
     public static final String SERVICE_NAME = "hz:impl:idGeneratorService";
+
     public static final String ATOMIC_LONG_NAME = "hz:atomic:idGenerator:";
 
     private NodeEngine nodeEngine;

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/SemaphoreService.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/SemaphoreService.java
@@ -47,8 +47,8 @@ import static com.hazelcast.partition.strategy.StringPartitioningStrategy.getPar
 import static com.hazelcast.spi.impl.OperationResponseHandlerFactory.createEmptyResponseHandler;
 import static com.hazelcast.util.ConcurrencyUtil.getOrPutIfAbsent;
 
-public class SemaphoreService implements ManagedService, MigrationAwareService, MembershipAwareService,
-        RemoteService, ClientAwareService {
+public class SemaphoreService implements ManagedService, MigrationAwareService, MembershipAwareService, RemoteService,
+        ClientAwareService {
 
     public static final String SERVICE_NAME = "hz:impl:semaphoreService";
 
@@ -74,7 +74,7 @@ public class SemaphoreService implements ManagedService, MigrationAwareService, 
         return getOrPutIfAbsent(containers, name, containerConstructor);
     }
 
-    // need for testing..
+    // just for testing
     public boolean containsSemaphore(String name) {
         return containers.containsKey(name);
     }

--- a/hazelcast/src/main/java/com/hazelcast/executor/impl/DistributedExecutorService.java
+++ b/hazelcast/src/main/java/com/hazelcast/executor/impl/DistributedExecutorService.java
@@ -49,8 +49,8 @@ public class DistributedExecutorService implements ManagedService, RemoteService
 
     public static final String SERVICE_NAME = "hz:impl:executorService";
 
-    //Updates the CallableProcessor.responseFlag field. An AtomicBoolean is simpler, but creates another unwanted
-    //object. Using this approach, you don't create that object.
+    // Updates the CallableProcessor.responseFlag field. An AtomicBoolean is simpler, but creates another unwanted
+    // object. Using this approach, you don't create that object.
     private static final AtomicReferenceFieldUpdater<CallableProcessor, Boolean> RESPONSE_FLAG =
             AtomicReferenceFieldUpdater.newUpdater(CallableProcessor.class, Boolean.class, "responseFlag");
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapService.java
@@ -65,10 +65,6 @@ public class MapService implements ManagedService, MigrationAwareService,
         PostJoinAwareService, SplitBrainHandlerService, ReplicationSupportingService, StatisticsAwareService,
         PartitionAwareService, ClientAwareService, QuorumAwareService {
 
-    /**
-     * Service name of map service used
-     * to register {@link com.hazelcast.spi.impl.ServiceManager#registerService}
-     */
     public static final String SERVICE_NAME = "hz:impl:mapService";
 
     protected ManagedService managedService;

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/MapReduceService.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/MapReduceService.java
@@ -58,9 +58,6 @@ import java.util.concurrent.Future;
 public class MapReduceService
         implements ManagedService, RemoteService {
 
-    /**
-     * The service name to retrieve an instance of the MapReduceService
-     */
     public static final String SERVICE_NAME = "hz:impl:mapReduceService";
 
     private static final ILogger LOGGER = Logger.getLogger(MapReduceService.class);

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/MapReduceUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/MapReduceUtil.java
@@ -57,6 +57,7 @@ public final class MapReduceUtil {
 
     private static final String EXECUTOR_NAME_PREFIX = "mapreduce::hz::";
     private static final String SERVICE_NAME = MapReduceService.SERVICE_NAME;
+
     private static final float DEFAULT_MAP_GROWTH_FACTOR = 0.75f;
     private static final int RETRY_PARTITION_TABLE_MILLIS = 100;
     private static final long PARTITION_READY_TIMEOUT = 10000;

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapService.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapService.java
@@ -66,6 +66,7 @@ public class MultiMapService implements ManagedService, RemoteService, Migration
         EventPublishingService<EventData, EntryListener>, TransactionalService, StatisticsAwareService {
 
     public static final String SERVICE_NAME = "hz:impl:multiMapService";
+
     private static final int STATS_MAP_INITIAL_CAPACITY = 1000;
     private static final int REPLICA_ADDRESS_TRY_COUNT = 3;
     private static final int REPLICA_ADDRESS_SLEEP_WAIT_MILLIS = 1000;

--- a/hazelcast/src/main/java/com/hazelcast/quorum/impl/QuorumServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/quorum/impl/QuorumServiceImpl.java
@@ -44,24 +44,18 @@ import java.util.Map;
 import static com.hazelcast.cluster.memberselector.MemberSelectors.DATA_MEMBER_SELECTOR;
 import static com.hazelcast.util.Preconditions.checkNotNull;
 
-
 /**
  * Service containing logic for cluster quorum.
  */
 public class QuorumServiceImpl implements EventPublishingService<QuorumEvent, QuorumListener>, MembershipAwareService,
         QuorumService {
 
-    /**
-     * Service name of map service used
-     * to register {@link com.hazelcast.spi.impl.ServiceManager#registerService}
-     */
     public static final String SERVICE_NAME = "hz:impl:quorumService";
 
     private final NodeEngineImpl nodeEngine;
     private final EventService eventService;
     private boolean inactive;
     private final Map<String, QuorumImpl> quorums = new HashMap<String, QuorumImpl>();
-
 
     public QuorumServiceImpl(NodeEngineImpl nodeEngine) {
         this.nodeEngine = nodeEngine;
@@ -108,7 +102,6 @@ public class QuorumServiceImpl implements EventPublishingService<QuorumEvent, Qu
     public void addQuorumListener(String name, QuorumListener listener) {
         eventService.registerLocalListener(SERVICE_NAME, name, listener);
     }
-
 
     public void ensureQuorumPresent(Operation op) {
         if (inactive) {

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/ReplicatedMapService.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/ReplicatedMapService.java
@@ -75,9 +75,6 @@ import static com.hazelcast.cluster.memberselector.MemberSelectors.DATA_MEMBER_S
 public class ReplicatedMapService implements ManagedService, RemoteService, EventPublishingService<Object, Object>,
         MigrationAwareService, SplitBrainHandlerService, StatisticsAwareService {
 
-    /**
-     * Public constant for the internal service name of the ReplicatedMapService
-     */
     public static final String SERVICE_NAME = "hz:impl:replicatedMapService";
 
     private static final int SYNC_INTERVAL_SECONDS = 10;

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/RingbufferService.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/RingbufferService.java
@@ -52,9 +52,6 @@ public class RingbufferService implements ManagedService, RemoteService, Migrati
      */
     public static final String TOPIC_RB_PREFIX = "_hz_rb_";
 
-    /**
-     * The name of the {@link RingbufferService}.
-     */
     public static final String SERVICE_NAME = "hz:impl:ringbufferService";
 
     private NodeEngine nodeEngine;

--- a/hazelcast/src/main/java/com/hazelcast/topic/impl/TopicService.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/impl/TopicService.java
@@ -50,6 +50,7 @@ import static com.hazelcast.util.ConcurrencyUtil.getOrPutSynchronized;
 public class TopicService implements ManagedService, RemoteService, EventPublishingService, StatisticsAwareService {
 
     public static final String SERVICE_NAME = "hz:impl:topicService";
+
     public static final int ORDERING_LOCKS_LENGTH = 1000;
 
     private final ConcurrentMap<String, LocalTopicStatsImpl> statsMap = new ConcurrentHashMap<String, LocalTopicStatsImpl>();

--- a/hazelcast/src/main/java/com/hazelcast/wan/WanReplicationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/wan/WanReplicationService.java
@@ -26,11 +26,10 @@ import com.hazelcast.spi.impl.PacketHandler;
  * to replicate values to other clusters over the wide area network, so it has to deal with long
  * delays, slow uploads and higher latencies.
  */
-public interface WanReplicationService
-        extends CoreService, PacketHandler {
+public interface WanReplicationService extends CoreService, PacketHandler {
 
     /**
-     * The service identifier
+     * Service name.
      */
     String SERVICE_NAME = "hz:core:wanReplicationService";
 

--- a/hazelcast/src/test/java/com/hazelcast/spi/MigrationAwareServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/MigrationAwareServiceTest.java
@@ -68,7 +68,7 @@ public class MigrationAwareServiceTest extends HazelcastTestSupport {
 
     @Test
     public void testPartitionDataSize_whenNodesStartedSequentially_withSingleBackup() throws InterruptedException {
-       testPartitionDataSize_whenNodesStartedSequentially(1);
+        testPartitionDataSize_whenNodesStartedSequentially(1);
     }
 
     @Test
@@ -244,17 +244,14 @@ public class MigrationAwareServiceTest extends HazelcastTestSupport {
 
     private static class SampleMigrationAwareService implements ManagedService, MigrationAwareService {
 
-        static final String SERVICE_NAME = "SampleMigrationAwareService";
+        private static final String SERVICE_NAME = "SampleMigrationAwareService";
 
-        private final ConcurrentMap<Integer, Object> data
-                = new ConcurrentHashMap<Integer, Object>();
+        private final ConcurrentMap<Integer, Object> data = new ConcurrentHashMap<Integer, Object>();
 
         private volatile int backupCount;
-        private volatile NodeEngine nodeEngine;
 
         @Override
         public void init(NodeEngine nodeEngine, Properties properties) {
-            this.nodeEngine = nodeEngine;
             backupCount = Integer.parseInt(properties.getProperty(BACKUP_COUNT_PROP, "1"));
         }
 
@@ -390,6 +387,7 @@ public class MigrationAwareServiceTest extends HazelcastTestSupport {
 
         final AssertTask assertTask = new AssertTask() {
             final InternalPartitionService partitionService = getNode(hz).getPartitionService();
+
             @Override
             public void run() throws Exception {
                 assertEquals(0, partitionService.getMigrationQueueSize());


### PR DESCRIPTION
Just a very minor change, but due to the number of files worthy for a PR.

Motivation for this PR was a broken JavaDoc reference to this outdated method name: `Service name of map service used to register {@link com.hazelcast.spi.impl.ServiceManager#registerService}`