### PR TITLE
Server side cache batch putAll implementation

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -80,6 +80,8 @@
     <suppress checks="MethodCount" files="com/hazelcast/cache/impl/AbstractHazelcastCacheManager"/>
     <suppress checks="ClassFanOutComplexityCheck" files="com/hazelcast/cache/impl/AbstractCacheService"/>
     <suppress checks="MethodCount" files="com/hazelcast/cache/impl/CacheStatisticsImpl"/>
+    <suppress checks="ClassDataAbstractionCoupling"
+              files="com/hazelcast/cache/impl/DefaultOperationProvider"/>
 
     <!-- Core -->
     <suppress checks="JavadocMethod" files="com/hazelcast/core/"/>

--- a/hazelcast/src/main/java/com/hazelcast/cache/ICache.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/ICache.java
@@ -595,7 +595,6 @@ public interface ICache<K, V>
      */
     ICompletableFuture<Boolean> replaceAsync(K key, V oldValue, V newValue, ExpiryPolicy expiryPolicy);
 
-
     /**
      * Asynchronously replaces the assigned value of the given key by the specified value and returns
      * the previously assigned value.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheProxyBase.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheProxyBase.java
@@ -70,6 +70,7 @@ abstract class AbstractCacheProxyBase<K, V> {
     protected final ICacheService cacheService;
     protected final SerializationService serializationService;
     protected final CacheOperationProvider operationProvider;
+    protected final InternalPartitionService partitionService;
 
     private final NodeEngine nodeEngine;
     private final CopyOnWriteArrayList<Future> loadAllTasks = new CopyOnWriteArrayList<Future>();
@@ -83,6 +84,7 @@ abstract class AbstractCacheProxyBase<K, V> {
         this.nameWithPrefix = cacheConfig.getNameWithPrefix();
         this.cacheConfig = cacheConfig;
         this.nodeEngine = nodeEngine;
+        this.partitionService = nodeEngine.getPartitionService();
         this.cacheService = cacheService;
         this.serializationService = nodeEngine.getSerializationService();
         this.operationProvider =

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheDataSerializerHook.java
@@ -38,6 +38,7 @@ import com.hazelcast.cache.impl.operation.CacheLoadAllOperationFactory;
 import com.hazelcast.cache.impl.operation.CacheManagementConfigOperation;
 import com.hazelcast.cache.impl.operation.CacheMergeOperation;
 import com.hazelcast.cache.impl.operation.CachePutAllBackupOperation;
+import com.hazelcast.cache.impl.operation.CachePutAllOperation;
 import com.hazelcast.cache.impl.operation.CachePutBackupOperation;
 import com.hazelcast.cache.impl.operation.CachePutIfAbsentOperation;
 import com.hazelcast.cache.impl.operation.CachePutOperation;
@@ -105,9 +106,10 @@ public final class CacheDataSerializerHook
     public static final short REMOVE_ALL = 34;
     public static final short REMOVE_ALL_BACKUP = 35;
     public static final short REMOVE_ALL_FACTORY = 36;
-    public static final short MERGE = 37;
+    public static final short PUT_ALL = 37;
+    public static final short MERGE = 38;
 
-    private static final int LEN = 38;
+    private static final int LEN = 39;
 
     public int getFactoryId() {
         return F_ID;
@@ -296,6 +298,11 @@ public final class CacheDataSerializerHook
         constructors[REMOVE_ALL_FACTORY] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
             public IdentifiedDataSerializable createNew(Integer arg) {
                 return new CacheRemoveAllOperationFactory();
+            }
+        };
+        constructors[PUT_ALL] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new CachePutAllOperation();
             }
         };
         constructors[MERGE] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheOperationProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheOperationProvider.java
@@ -22,6 +22,8 @@ import com.hazelcast.spi.OperationFactory;
 
 import javax.cache.expiry.ExpiryPolicy;
 import javax.cache.processor.EntryProcessor;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -30,6 +32,8 @@ import java.util.Set;
 public interface CacheOperationProvider {
 
     Operation createPutOperation(Data key, Data value, ExpiryPolicy policy, boolean get, int completionId);
+
+    Operation createPutAllOperation(List<Map.Entry<Data, Data>> entries, ExpiryPolicy policy, int completionId);
 
     Operation createGetOperation(Data key, ExpiryPolicy policy);
 

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/DefaultOperationProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/DefaultOperationProvider.java
@@ -25,6 +25,7 @@ import com.hazelcast.cache.impl.operation.CacheGetAndReplaceOperation;
 import com.hazelcast.cache.impl.operation.CacheGetOperation;
 import com.hazelcast.cache.impl.operation.CacheKeyIteratorOperation;
 import com.hazelcast.cache.impl.operation.CacheLoadAllOperationFactory;
+import com.hazelcast.cache.impl.operation.CachePutAllOperation;
 import com.hazelcast.cache.impl.operation.CachePutIfAbsentOperation;
 import com.hazelcast.cache.impl.operation.CachePutOperation;
 import com.hazelcast.cache.impl.operation.CacheRemoveAllOperationFactory;
@@ -38,6 +39,8 @@ import com.hazelcast.spi.OperationFactory;
 
 import javax.cache.expiry.ExpiryPolicy;
 import javax.cache.processor.EntryProcessor;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -54,6 +57,11 @@ public class DefaultOperationProvider implements CacheOperationProvider {
     @Override
     public Operation createPutOperation(Data key, Data value, ExpiryPolicy policy, boolean get, int completionId) {
         return new CachePutOperation(nameWithPrefix, key, value, policy, get, completionId);
+    }
+
+    @Override
+    public Operation createPutAllOperation(List<Map.Entry<Data, Data>> entries, ExpiryPolicy policy, int completionId) {
+        return new CachePutAllOperation(nameWithPrefix, entries, policy, completionId);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CachePutAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CachePutAllOperation.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.cache.impl.operation;
+
+import com.hazelcast.cache.impl.CacheDataSerializerHook;
+import com.hazelcast.cache.impl.ICacheRecordStore;
+import com.hazelcast.cache.impl.ICacheService;
+import com.hazelcast.cache.impl.record.CacheRecord;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.spi.BackupAwareOperation;
+import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.PartitionAwareOperation;
+import com.hazelcast.spi.impl.AbstractNamedOperation;
+import com.hazelcast.spi.impl.MutatingOperation;
+
+import javax.cache.expiry.ExpiryPolicy;
+import java.io.IOException;
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class CachePutAllOperation
+        extends AbstractNamedOperation
+        implements PartitionAwareOperation, IdentifiedDataSerializable, BackupAwareOperation,
+                   MutableOperation, MutatingOperation {
+
+    private List<Map.Entry<Data, Data>> entries;
+    private ExpiryPolicy expiryPolicy;
+    private int completionId;
+
+    private transient ICacheRecordStore cache;
+    private transient Map<Data, CacheRecord> backupRecords;
+
+    public CachePutAllOperation() {
+    }
+
+    public CachePutAllOperation(String name, List<Map.Entry<Data, Data>> entries,
+                                ExpiryPolicy expiryPolicy, int completionId) {
+        super(name);
+        this.entries = entries;
+        this.expiryPolicy = expiryPolicy;
+        this.completionId = completionId;
+    }
+
+    @Override
+    public int getCompletionId() {
+        return completionId;
+    }
+
+    @Override
+    public void setCompletionId(int completionId) {
+        this.completionId = completionId;
+    }
+
+    @Override
+    public void run()
+            throws Exception {
+        int partitionId = getPartitionId();
+        String callerUuid = getCallerUuid();
+        ICacheService service = getService();
+        cache = service.getOrCreateRecordStore(name, partitionId);
+        backupRecords = new HashMap<Data, CacheRecord>(entries.size());
+        for (Map.Entry<Data, Data> entry : entries) {
+            Data key = entry.getKey();
+            Data value = entry.getValue();
+            CacheRecord backupRecord = cache.put(key, value, expiryPolicy, callerUuid, completionId);
+            backupRecords.put(key, backupRecord);
+        }
+    }
+
+    @Override
+    public boolean shouldBackup() {
+        return !backupRecords.isEmpty();
+    }
+
+    @Override
+    public Operation getBackupOperation() {
+        return new CachePutAllBackupOperation(name, backupRecords);
+    }
+
+    @Override
+    public int getId() {
+        return CacheDataSerializerHook.PUT_ALL;
+    }
+
+    @Override
+    public int getFactoryId() {
+        return CacheDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public final int getSyncBackupCount() {
+        return cache != null ? cache.getConfig().getBackupCount() : 0;
+    }
+
+    @Override
+    public final int getAsyncBackupCount() {
+        return cache != null ? cache.getConfig().getAsyncBackupCount() : 0;
+    }
+
+    @Override
+    protected void writeInternal(ObjectDataOutput out) throws IOException {
+        super.writeInternal(out);
+        out.writeObject(expiryPolicy);
+        out.writeInt(completionId);
+        out.writeInt(entries.size());
+        for (Map.Entry<Data, Data> entry : entries) {
+            out.writeData(entry.getKey());
+            out.writeData(entry.getValue());
+        }
+    }
+
+    @Override
+    protected void readInternal(ObjectDataInput in) throws IOException {
+        super.readInternal(in);
+        expiryPolicy = in.readObject();
+        completionId = in.readInt();
+        int size = in.readInt();
+        entries = new ArrayList<Map.Entry<Data, Data>>(size);
+        for (int i = 0; i < size; i++) {
+            Data key = in.readData();
+            Data value = in.readData();
+            entries.add(new AbstractMap.SimpleImmutableEntry<Data, Data>(key, value));
+        }
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/cache/CachePutAllTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CachePutAllTest.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.cache;
+
+import com.hazelcast.cache.impl.ICacheRecordStore;
+import com.hazelcast.cache.impl.ICacheService;
+import com.hazelcast.config.CacheConfig;
+import com.hazelcast.config.Config;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.instance.Node;
+import com.hazelcast.internal.serialization.SerializationService;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.partition.InternalPartitionService;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import javax.cache.expiry.ExpiryPolicy;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class CachePutAllTest extends CacheTestSupport {
+
+    private static final int INSTANCE_COUNT = 2;
+
+    private TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(INSTANCE_COUNT);
+    private HazelcastInstance[] hazelcastInstances;
+    private HazelcastInstance hazelcastInstance;
+
+    @Override
+    protected void onSetup() {
+    }
+
+    @Override
+    protected void onTearDown() {
+        factory.terminateAll();
+        hazelcastInstances = null;
+        hazelcastInstance = null;
+    }
+
+    @Override
+    protected <K, V> CacheConfig<K, V> createCacheConfig() {
+        CacheConfig cacheConfig = super.createCacheConfig();
+        cacheConfig.setBackupCount(INSTANCE_COUNT - 1);
+        return cacheConfig;
+    }
+
+    @Override
+    protected HazelcastInstance getHazelcastInstance() {
+        Config config = createConfig();
+        hazelcastInstances = new HazelcastInstance[INSTANCE_COUNT];
+        for (int i = 0; i < INSTANCE_COUNT; i++) {
+            hazelcastInstances[i] = factory.newHazelcastInstance(config);
+        }
+        warmUpPartitions(hazelcastInstances);
+        waitAllForSafeState(hazelcastInstances);
+        hazelcastInstance = hazelcastInstances[0];
+        return hazelcastInstance;
+    }
+
+    private Map<String, String> createAndFillEntries() {
+        final int ENTRY_COUNT_PER_PARTITION = 3;
+        Node node = getNode(hazelcastInstance);
+        int partitionCount = node.getPartitionService().getPartitionCount();
+        Map<String, String> entries = new HashMap<String, String>(partitionCount * ENTRY_COUNT_PER_PARTITION);
+
+        for (int partitionId = 0; partitionId < partitionCount; partitionId++) {
+            for (int i = 0; i < ENTRY_COUNT_PER_PARTITION; i++) {
+                String key = generateKeyForPartition(hazelcastInstance, partitionId);
+                String value = generateRandomString(16);
+                entries.put(key, value);
+            }
+        }
+
+        return entries;
+    }
+
+    @Test
+    public void testPutAll() {
+        ICache<String, String> cache = createCache();
+        String cacheName = cache.getName();
+        Map<String, String> entries = createAndFillEntries();
+
+        cache.putAll(entries);
+
+        // Verify that put-all works
+        for (Map.Entry<String, String> entry : entries.entrySet()) {
+            String key = entry.getKey();
+            String expectedValue = entries.get(key);
+            String actualValue = cache.get(key);
+            assertEquals(expectedValue, actualValue);
+        }
+
+        Node node = getNode(hazelcastInstance);
+        InternalPartitionService partitionService = node.getPartitionService();
+        SerializationService serializationService = node.getSerializationService();
+
+        // Verify that backup of put-all works
+        for (Map.Entry<String, String> entry : entries.entrySet()) {
+            String key = entry.getKey();
+            String expectedValue = entries.get(key);
+            Data keyData = serializationService.toData(key);
+            int keyPartitionId = partitionService.getPartitionId(keyData);
+            for (int i = 0; i < INSTANCE_COUNT; i++) {
+                Node n = getNode(hazelcastInstances[i]);
+                ICacheService cacheService = n.getNodeEngine().getService(ICacheService.SERVICE_NAME);
+                ICacheRecordStore recordStore = cacheService.getRecordStore("/hz/" + cacheName, keyPartitionId);
+                assertNotNull(recordStore);
+                String actualValue = serializationService.toObject(recordStore.get(keyData, null));
+                assertEquals(expectedValue, actualValue);
+            }
+        }
+    }
+
+    @Test
+    public void testPutAllWithExpiration() {
+        final long EXPIRATION_TIME_IN_MILLISECONDS = 5000;
+
+        ExpiryPolicy expiryPolicy = new HazelcastExpiryPolicy(EXPIRATION_TIME_IN_MILLISECONDS, 0, 0);
+        ICache<String, String> cache = createCache();
+        Map<String, String> entries = createAndFillEntries();
+
+        cache.putAll(entries, expiryPolicy);
+
+        sleepAtLeastMillis(EXPIRATION_TIME_IN_MILLISECONDS + 1000);
+
+        // Verify that expiration of put-all works
+        for (Map.Entry<String, String> entry : entries.entrySet()) {
+            String key = entry.getKey();
+            String actualValue = cache.get(key);
+            assertNull(actualValue);
+        }
+    }
+
+}


### PR DESCRIPTION
This PR implements batching support for cache's putAll operation.

The follow-up PRs are going to be:
* Batch putAll implementation for HD-JCache on server side
* Batch putAll implementation on client side

**P.S:** This doesn't break enterprise side. With this batch implementation HD-JCache also has improvements of batching but HD-JCache specific logic will be implemented for reading and writing operation data directly from/to native memory.