### PR TITLE
Refactorings for IMap eviction

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -298,7 +298,8 @@
     <suppress checks="BooleanExpressionComplexityCheck" files="com/hazelcast/security/permission/QueuePermission"/>
     <suppress checks="BooleanExpressionComplexityCheck" files="com/hazelcast/security/permission/RingBufferPermission"/>
     <suppress checks="BooleanExpressionComplexityCheck" files="com/hazelcast/security/permission/CachePermission"/>
-    <suppress checks="BooleanExpressionComplexityCheck" files="com/hazelcast/security/permission/ReplicatedMapPermission"/>
+    <suppress checks="BooleanExpressionComplexityCheck"
+              files="com/hazelcast/security/permission/ReplicatedMapPermission"/>
     <suppress checks="BooleanExpressionComplexityCheck" files="com/hazelcast/security/permission/MapPermission"/>
     <suppress checks="BooleanExpressionComplexityCheck" files="com/hazelcast/security/permission/ListPermission"/>
     <suppress checks="NPathComplexity" files="com/hazelcast/security/permission/InstancePermission"/>
@@ -380,9 +381,12 @@
     <suppress checks="ExecutableStatementCount|ClassDataAbstractionCoupling|ClassFanOutComplexity"
               files="com/hazelcast/nio/tcp/TcpIpConnectionManager"/>
     <suppress checks="NPathComplexity" files="com/hazelcast/nio/tcp/spinning/SpinningSocketReader"/>
-    <suppress checks="MethodCount|MagicNumber" files="com/hazelcast/internal/serialization/impl/ByteArrayObjectDataInput"/>
-    <suppress checks="MethodCount|MagicNumber" files="com/hazelcast/internal/serialization/impl/ByteArrayObjectDataOutput"/>
-    <suppress checks="MethodCount|MagicNumber" files="com/hazelcast/internal/serialization/impl/ByteBufferObjectDataInput"/>
+    <suppress checks="MethodCount|MagicNumber"
+              files="com/hazelcast/internal/serialization/impl/ByteArrayObjectDataInput"/>
+    <suppress checks="MethodCount|MagicNumber"
+              files="com/hazelcast/internal/serialization/impl/ByteArrayObjectDataOutput"/>
+    <suppress checks="MethodCount|MagicNumber"
+              files="com/hazelcast/internal/serialization/impl/ByteBufferObjectDataInput"/>
     <suppress checks="MethodCount" files="com/hazelcast/internal/serialization/ObjectDataInputStream"/>
     <suppress checks="MethodCount" files="com/hazelcast/internal/serialization/impl/ByteBufferObjectDataOutput"/>
     <suppress checks="MagicNumber" files="com/hazelcast/nio/CipherHelper"/>
@@ -395,7 +399,8 @@
     <suppress checks="MethodCount" files="com/hazelcast/nio/NodeIOService"/>
     <suppress checks="MagicNumber|MethodCount|NPathComplexity" files="com/hazelcast/nio/Packet"/>
     <suppress checks="NPathComplexity" files="com/hazelcast/nio/tcp/nonblocking/NonBlockingSocketReader"/>
-    <suppress checks="MagicNumber|EmptyBlock|MethodCount" files="com/hazelcast/nio/tcp/nonblocking/NonBlockingWriteHandler"/>
+    <suppress checks="MagicNumber|EmptyBlock|MethodCount"
+              files="com/hazelcast/nio/tcp/nonblocking/NonBlockingWriteHandler"/>
     <suppress checks="ClassFanOutComplexity|ClassDataAbstractionCoupling|MethodCount|ParameterNumber"
               files="com/hazelcast/internal/serialization/impl/SerializationServiceImpl"/>
     <suppress checks="MethodCount" files="com/hazelcast/nio/tcp/TcpIpConnectionManager"/>
@@ -428,7 +433,8 @@
     <!-- Spring -->
     <suppress checks="MethodCount" files="com/hazelcast/spring/HazelcastConfigBeanDefinitionParser"/>
     <suppress checks="MethodLength" files="com/hazelcast/spring/HazelcastConfigBeanDefinitionParser"/>
-    <suppress checks="CyclomaticComplexity|NPathComplexity" files="com/hazelcast/spring/HazelcastConfigBeanDefinitionParser"/>
+    <suppress checks="CyclomaticComplexity|NPathComplexity"
+              files="com/hazelcast/spring/HazelcastConfigBeanDefinitionParser"/>
 
     <!-- Spring framework breaks the IllegalType check in its own implementation -->
     <suppress checks="IllegalType" files="com/hazelcast/spring/HazelcastClientBeanDefinitionParser"/>
@@ -456,10 +462,12 @@
     <suppress checks="MethodCountCheck" files="com/hazelcast/map/impl/proxy/MapProxySupport"/>
     <suppress checks="MethodCountCheck" files="com/hazelcast/map/impl/operation/MapOperationProvider"/>
     <suppress checks="MethodCountCheck" files="com/hazelcast/map/impl/operation/DefaultMapOperationProvider"/>
+    <suppress checks="MethodCountCheck" files="com/hazelcast/map/impl/MapContainer"/>
     <suppress checks="ClassFanOutComplexityCheck" files="com/hazelcast/map/impl/proxy/MapProxySupport"/>
     <suppress checks="ClassFanOutComplexityCheck" files="com/hazelcast/map/impl/MapServiceContextImpl"/>
     <suppress checks="ClassDataAbstractionCoupling" files="com/hazelcast/map/impl/proxy/MapProxySupport"/>
-    <suppress checks="ClassDataAbstractionCoupling" files="com/hazelcast/map/impl/operation/DefaultMapOperationProvider"/>
+    <suppress checks="ClassDataAbstractionCoupling"
+              files="com/hazelcast/map/impl/operation/DefaultMapOperationProvider"/>
     <suppress checks="CyclomaticComplexity" files="com/hazelcast/map/impl/client/AbstractTxnMapRequest"/>
     <suppress checks="MethodCount|ClassDataAbstractionCoupling" files="com/hazelcast/map/impl/MapServiceContextImpl"/>
     <suppress checks="MethodCount" files="com/hazelcast/map/impl/MapServiceContext"/>

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapKeyLoaderUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapKeyLoaderUtil.java
@@ -31,7 +31,8 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.NoSuchElementException;
 
-import static com.hazelcast.map.impl.eviction.MaxSizeChecker.getApproximateMaxSize;
+import static com.hazelcast.map.impl.eviction.EvictionCheckerImpl.getApproximateMaxSize;
+
 
 public final class MapKeyLoaderUtil {
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContext.java
@@ -18,7 +18,6 @@ package com.hazelcast.map.impl;
 
 import com.hazelcast.core.PartitioningStrategy;
 import com.hazelcast.map.impl.event.MapEventPublisher;
-import com.hazelcast.map.impl.eviction.EvictionOperator;
 import com.hazelcast.map.impl.eviction.ExpirationManager;
 import com.hazelcast.map.impl.nearcache.NearCacheProvider;
 import com.hazelcast.map.impl.operation.MapOperationProvider;
@@ -95,8 +94,6 @@ public interface MapServiceContext extends MapServiceContextInterceptorSupport, 
 
     ExpirationManager getExpirationManager();
 
-    EvictionOperator getEvictionOperator();
-
     void setService(MapService mapService);
 
     NodeEngine getNodeEngine();
@@ -110,14 +107,6 @@ public interface MapServiceContext extends MapServiceContextInterceptorSupport, 
     LocalMapStatsProvider getLocalMapStatsProvider();
 
     MapOperationProvider getMapOperationProvider(String name);
-
-    /**
-     * Sets an {@link EvictionOperator} to this {@link MapServiceContext}.
-     * Used for testing purposes.
-     *
-     * @param evictionOperator {@link EvictionOperator} to be set.
-     */
-    void setEvictionOperator(EvictionOperator evictionOperator);
 
     void incrementOperationStats(long startTime, LocalMapStatsImpl localMapStats, String mapName, Operation operation);
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/eviction/EvictionChecker.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/eviction/EvictionChecker.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.eviction;
+
+import com.hazelcast.map.impl.recordstore.RecordStore;
+
+/**
+ * Checks whether a specific threshold is exceeded or not to start eviction process
+ * for a {@link RecordStore}.
+ */
+public interface EvictionChecker {
+
+    /**
+     * Check whether the supplied record-store needs eviction.
+     *
+     * @param recordStore the recordStore
+     * @return {@code true} if eviction is required, {@code false} otherwise.
+     */
+    boolean checkEvictionPossible(RecordStore recordStore);
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/eviction/Evictor.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/eviction/Evictor.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.eviction;
+
+import com.hazelcast.map.impl.recordstore.RecordStore;
+
+/**
+ * Evicts a {@link RecordStore}.
+ *
+ * When the {@link RecordStore} needs to be evicted according to {@link EvictionChecker#checkEvictionPossible},
+ * {@link Evictor} removes records from {@link RecordStore}.
+ */
+public interface Evictor {
+
+    /**
+     * Find size to evict from a record-store.
+     *
+     * @param recordStore the recordStore
+     * @return removal size.
+     */
+    int findRemovalSize(RecordStore recordStore);
+
+    /**
+     * Remove supplied number of elements from record-store.
+     *
+     * @param removalSize supplied size to remove.
+     * @param recordStore the recordStore
+     */
+    void removeSize(int removalSize, RecordStore recordStore);
+
+    /**
+     * Get eviction checker for this {@link Evictor}
+     *
+     * @return the {@link EvictionChecker}
+     */
+    EvictionChecker getEvictionChecker();
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/AbstractMultipleEntryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/AbstractMultipleEntryOperation.java
@@ -288,9 +288,9 @@ abstract class AbstractMultipleEntryOperation extends MapOperation implements Mu
         return partitionService.getPartitionId(key) != getPartitionId();
     }
 
-    protected void evict(boolean backup) {
+    protected void evict() {
         final long now = Clock.currentTimeMillis();
-        recordStore.evictEntries(now, backup);
+        recordStore.evictEntries(now);
     }
 
     protected static class WanEventWrapper {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/BasePutOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/BasePutOperation.java
@@ -19,8 +19,8 @@ package com.hazelcast.map.impl.operation;
 import com.hazelcast.core.EntryEventType;
 import com.hazelcast.core.EntryView;
 import com.hazelcast.map.impl.EntryViews;
-import com.hazelcast.map.impl.event.MapEventPublisher;
 import com.hazelcast.map.impl.MapServiceContext;
+import com.hazelcast.map.impl.event.MapEventPublisher;
 import com.hazelcast.map.impl.mapstore.MapDataStore;
 import com.hazelcast.map.impl.record.Record;
 import com.hazelcast.map.impl.record.RecordInfo;
@@ -57,7 +57,7 @@ public abstract class BasePutOperation extends LockAwareOperation implements Bac
         mapEventPublisher.publishEvent(getCallerAddress(), name, eventType, dataKey, dataOldValue, dataValue);
         invalidateNearCaches();
         publishWANReplicationEvent(mapServiceContext, mapEventPublisher);
-        evict(false);
+        evict();
     }
 
     private void publishWANReplicationEvent(MapServiceContext mapServiceContext, MapEventPublisher mapEventPublisher) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/BaseRemoveOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/BaseRemoveOperation.java
@@ -17,12 +17,12 @@
 package com.hazelcast.map.impl.operation;
 
 import com.hazelcast.core.EntryEventType;
-import com.hazelcast.map.impl.event.MapEventPublisher;
 import com.hazelcast.map.impl.MapServiceContext;
+import com.hazelcast.map.impl.event.MapEventPublisher;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.BackupAwareOperation;
-import com.hazelcast.spi.impl.MutatingOperation;
 import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.impl.MutatingOperation;
 import com.hazelcast.util.Clock;
 
 public abstract class BaseRemoveOperation extends LockAwareOperation implements BackupAwareOperation, MutatingOperation {
@@ -47,7 +47,7 @@ public abstract class BaseRemoveOperation extends LockAwareOperation implements 
             // todo should evict operation replicated??
             mapEventPublisher.publishWanReplicationRemove(name, dataKey, Clock.currentTimeMillis());
         }
-        evict(false);
+        evict();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryBackupOperation.java
@@ -102,7 +102,7 @@ public class EntryBackupOperation extends KeyBasedMapOperation implements Backup
 
     @Override
     public void afterRun() throws Exception {
-        evict(true);
+        evict();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOperation.java
@@ -103,7 +103,7 @@ public class EntryOperation extends LockAwareOperation implements BackupAwareOpe
         invalidateNearCaches();
         publishEntryEvent();
         publishWanReplicationEvent();
-        evict(false);
+        evict();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/GetAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/GetAllOperation.java
@@ -62,16 +62,16 @@ public class GetAllOperation extends MapOperation implements ReadonlyOperation, 
     public void afterRun() throws Exception {
         super.afterRun();
         if (!entries.isEmpty()) {
-            evict(false);
+            evict();
         }
     }
 
-    protected void evict(boolean backup) {
+    protected void evict() {
         if (recordStore == null) {
             return;
         }
         final long now = Clock.currentTimeMillis();
-        recordStore.evictEntries(now, backup);
+        recordStore.evictEntries(now);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/KeyBasedMapOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/KeyBasedMapOperation.java
@@ -119,9 +119,9 @@ public abstract class KeyBasedMapOperation extends MapOperation implements Parti
         }
     }
 
-    protected void evict(boolean backup) {
+    protected void evict() {
         final long now = Clock.currentTimeMillis();
-        recordStore.evictEntries(now, backup);
+        recordStore.evictEntries(now);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MergeOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MergeOperation.java
@@ -83,7 +83,7 @@ public class MergeOperation extends BasePutOperation {
             mapEventPublisher.publishEvent(getCallerAddress(), name, EntryEventType.MERGED, false, dataKey, dataOldValue,
                     dataValue, mergingValue);
             invalidateNearCaches();
-            evict(false);
+            evict();
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MultipleEntryBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MultipleEntryBackupOperation.java
@@ -62,7 +62,7 @@ public class MultipleEntryBackupOperation extends AbstractMultipleEntryBackupOpe
             }
             entryAddedOrUpdatedBackup(entry, dataKey);
 
-            evict(true);
+            evict();
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MultipleEntryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MultipleEntryOperation.java
@@ -77,7 +77,7 @@ public class MultipleEntryOperation extends AbstractMultipleEntryOperation imple
 
             entryAddedOrUpdated(entry, dataKey, oldValue, now);
 
-            evict(false);
+            evict();
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryBackupOperation.java
@@ -63,7 +63,7 @@ public class PartitionWideEntryBackupOperation extends AbstractMultipleEntryBack
             }
             entryAddedOrUpdatedBackup(entry, dataKey);
 
-            evict(true);
+            evict();
         }
 
         publishWanReplicationEventBackups();

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryOperation.java
@@ -83,7 +83,7 @@ public class PartitionWideEntryOperation extends AbstractMultipleEntryOperation 
             }
             entryAddedOrUpdated(entry, dataKey, oldValue, now);
 
-            evict(false);
+            evict();
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutAllOperation.java
@@ -20,22 +20,23 @@ import com.hazelcast.core.EntryEventType;
 import com.hazelcast.core.EntryView;
 import com.hazelcast.map.impl.EntryViews;
 import com.hazelcast.map.impl.MapEntries;
-import com.hazelcast.map.impl.event.MapEventPublisher;
 import com.hazelcast.map.impl.MapServiceContext;
+import com.hazelcast.map.impl.event.MapEventPublisher;
 import com.hazelcast.map.impl.nearcache.NearCacheProvider;
-import com.hazelcast.map.impl.recordstore.RecordStore;
 import com.hazelcast.map.impl.record.Record;
 import com.hazelcast.map.impl.record.RecordInfo;
 import com.hazelcast.map.impl.record.Records;
+import com.hazelcast.map.impl.recordstore.RecordStore;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.partition.InternalPartitionService;
 import com.hazelcast.spi.BackupAwareOperation;
-import com.hazelcast.spi.impl.MutatingOperation;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.PartitionAwareOperation;
+import com.hazelcast.spi.impl.MutatingOperation;
 import com.hazelcast.util.Clock;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -115,7 +116,7 @@ public class PutAllOperation extends MapOperation implements PartitionAwareOpera
         backupEntrySet.add(entry);
         RecordInfo replicationInfo = Records.buildRecordInfo(recordStore.getRecord(dataKey));
         backupRecordInfos.add(replicationInfo);
-        evict(false);
+        evict();
     }
 
     protected final void invalidateNearCaches(Set<Data> keys) {
@@ -125,9 +126,9 @@ public class PutAllOperation extends MapOperation implements PartitionAwareOpera
         }
     }
 
-    protected void evict(boolean backup) {
+    protected void evict() {
         final long now = Clock.currentTimeMillis();
-        recordStore.evictEntries(now, backup);
+        recordStore.evictEntries(now);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutBackupOperation.java
@@ -84,7 +84,7 @@ public final class PutBackupOperation extends KeyBasedMapOperation implements Ba
     @Override
     public void afterRun() throws Exception {
         if (recordInfo != null) {
-            evict(true);
+            evict();
         }
         final MapServiceContext mapServiceContext = mapService.getMapServiceContext();
         final MapEventPublisher mapEventPublisher = mapServiceContext.getMapEventPublisher();

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/RemoveBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/RemoveBackupOperation.java
@@ -68,7 +68,7 @@ public class RemoveBackupOperation extends KeyBasedMapOperation implements Backu
 
     @Override
     public void afterRun() throws Exception {
-        evict(true);
+        evict();
         if (!wanOriginated
                 && !mapContainer.isWanReplicationEnabled()) {
             mapService.getMapServiceContext()

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/WanOriginatedDeleteOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/WanOriginatedDeleteOperation.java
@@ -53,7 +53,7 @@ public class WanOriginatedDeleteOperation extends BaseRemoveOperation {
         mapServiceContext.getMapEventPublisher()
                 .publishEvent(getCallerAddress(), name, EntryEventType.REMOVED, dataKey, dataOldValue, null);
         invalidateNearCaches();
-        evict(false);
+        evict();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/AbstractEvictableRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/AbstractEvictableRecordStore.java
@@ -22,11 +22,13 @@ import com.hazelcast.core.EntryView;
 import com.hazelcast.instance.GroupProperties;
 import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.map.impl.MapContainer;
-import com.hazelcast.map.impl.MapServiceContext;
-import com.hazelcast.map.impl.eviction.EvictionOperator;
-import com.hazelcast.map.impl.eviction.MaxSizeChecker;
+import com.hazelcast.map.impl.event.MapEventPublisher;
+import com.hazelcast.map.impl.eviction.EvictionChecker;
+import com.hazelcast.map.impl.eviction.Evictor;
 import com.hazelcast.map.impl.record.Record;
+import com.hazelcast.nio.Address;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.spi.EventService;
 import com.hazelcast.spi.NodeEngine;
 
 import java.util.Collection;
@@ -38,6 +40,7 @@ import static com.hazelcast.core.EntryEventType.EXPIRED;
 import static com.hazelcast.map.impl.ExpirationTimeSetter.calculateExpirationWithDelay;
 import static com.hazelcast.map.impl.ExpirationTimeSetter.calculateMaxIdleMillis;
 import static com.hazelcast.map.impl.ExpirationTimeSetter.setExpirationTime;
+import static com.hazelcast.map.impl.MapService.SERVICE_NAME;
 
 /**
  * Contains eviction specific functionality.
@@ -74,17 +77,20 @@ abstract class AbstractEvictableRecordStore extends AbstractRecordStore {
 
     private volatile boolean hasEntryWithCustomTTL;
     private final long expiryDelayMillis;
-    private final EvictionOperator evictionOperator;
+    private final Evictor evictor;
 
     protected AbstractEvictableRecordStore(MapContainer mapContainer, int partitionId) {
         super(mapContainer, partitionId);
         NodeEngine nodeEngine = mapServiceContext.getNodeEngine();
         GroupProperties groupProperties = nodeEngine.getGroupProperties();
         expiryDelayMillis = groupProperties.getMillis(GroupProperty.MAP_EXPIRY_DELAY_SECONDS);
-        evictionOperator = mapServiceContext.getEvictionOperator();
+        evictor = mapContainer.getEvictor();
     }
 
+    @Override
     public boolean isEvictionEnabled() {
+        // this can be updated dynamically by UpdateMapConfigOperation.
+        // that is why this check was put in a method instead of a class final field.
         EvictionPolicy evictionPolicy = getEvictionPolicy();
         return !EvictionPolicy.NONE.equals(evictionPolicy);
     }
@@ -175,7 +181,7 @@ abstract class AbstractEvictableRecordStore extends AbstractRecordStore {
     }
 
     /**
-     * TODO make checkEvictable fast by carrying threshold logic to partition.
+     * TODO make checkEvictionPossible fast by carrying threshold logic to partition.
      * This cleanup adds some latency to write operations.
      * But it sweeps records much better under high write loads.
      * <p/>
@@ -183,9 +189,9 @@ abstract class AbstractEvictableRecordStore extends AbstractRecordStore {
      * @param now now in time.
      */
     @Override
-    public void evictEntries(long now, boolean backup) {
+    public void evictEntries(long now) {
         if (isEvictionEnabled()) {
-            cleanUp(now, backup);
+            cleanUp(now);
         }
     }
 
@@ -195,11 +201,11 @@ abstract class AbstractEvictableRecordStore extends AbstractRecordStore {
      *
      * @param now now.
      */
-    protected void postReadCleanUp(long now, boolean backup) {
+    protected void postReadCleanUp(long now) {
         if (isEvictionEnabled()) {
             readCountBeforeCleanUp++;
             if ((readCountBeforeCleanUp & POST_READ_CHECK_POINT) == 0) {
-                cleanUp(now, backup);
+                cleanUp(now);
             }
         }
 
@@ -208,45 +214,47 @@ abstract class AbstractEvictableRecordStore extends AbstractRecordStore {
     /**
      * Makes eviction clean-up logic.
      *
-     * @param now    now in millis.
-     * @param backup <code>true</code> if running on a backup partition, otherwise <code>false</code>
+     * @param now now in millis.
      */
-    private void cleanUp(long now, boolean backup) {
+    private void cleanUp(long now) {
         if (size() == 0) {
             return;
         }
         if (shouldEvict(now)) {
-            removeEvictableRecords(backup);
+            evict();
             lastEvictionTime = now;
             readCountBeforeCleanUp = 0;
         }
     }
 
     protected boolean shouldEvict(long now) {
-        return isEvictionEnabled() && inEvictableTimeWindow(now) && isEvictable();
+        return isEvictionEnabled() && inEvictableTimeWindow(now) && checkEvictionPossible();
     }
 
-    private void removeEvictableRecords(boolean backup) {
-        final int evictableSize = getEvictableSize();
-        if (evictableSize < 1) {
+    private void evict() {
+        int removalSize = getRemovalSize();
+        if (removalSize < 1) {
             return;
         }
-        final MapConfig mapConfig = mapContainer.getMapConfig();
-        evictionOperator.removeEvictableRecords(this, evictableSize, mapConfig, backup);
+        evictor.removeSize(removalSize, this);
     }
 
-    private int getEvictableSize() {
+    private int getRemovalSize() {
         final int size = size();
         if (size < 1) {
             return 0;
         }
-        final int evictableSize = evictionOperator.evictableSize(size, mapContainer.getMapConfig());
-        if (evictableSize < 1) {
+        int removalSize = evictor.findRemovalSize(this);
+        if (removalSize < 1) {
             return 0;
         }
-        return evictableSize;
+        return removalSize;
     }
 
+
+    private Evictor getEvictor() {
+        return mapContainer.getEvictor();
+    }
 
     /**
      * Eviction waits at least {@link MapConfig#minEvictionCheckMillis} milliseconds to run.
@@ -265,9 +273,10 @@ abstract class AbstractEvictableRecordStore extends AbstractRecordStore {
         return mapConfig.getMinEvictionCheckMillis();
     }
 
-    private boolean isEvictable() {
-        final MaxSizeChecker maxSizeChecker = evictionOperator.getMaxSizeChecker();
-        return maxSizeChecker.checkEvictable(mapContainer, partitionId);
+    private boolean checkEvictionPossible() {
+        Evictor evictor = getEvictor();
+        EvictionChecker evictionChecker = evictor.getEvictionChecker();
+        return evictionChecker.checkEvictionPossible(this);
     }
 
     protected void markRecordStoreExpirable(long ttl) {
@@ -302,7 +311,7 @@ abstract class AbstractEvictableRecordStore extends AbstractRecordStore {
         final Object value = record.getValue();
         evictInternal(key, backup);
         if (!backup) {
-            doPostExpirationOperations(key, value);
+            doPostEvictionOperations(key, value, true);
         }
         return null;
     }
@@ -347,15 +356,32 @@ abstract class AbstractEvictableRecordStore extends AbstractRecordStore {
      * @param key   the key to be processed.
      * @param value the value to be processed.
      */
-    private void doPostExpirationOperations(Data key, Object value) {
-        final String mapName = this.name;
-        final MapServiceContext mapServiceContext = this.mapServiceContext;
+    @Override
+    public void doPostEvictionOperations(Data key, Object value, boolean isExpired) {
+        MapEventPublisher mapEventPublisher = mapServiceContext.getMapEventPublisher();
+        NodeEngine nodeEngine = mapServiceContext.getNodeEngine();
+        EventService eventService = nodeEngine.getEventService();
+
+        if (!eventService.hasEventRegistration(SERVICE_NAME, name)) {
+            return;
+        }
+
+        Address thisAddress = nodeEngine.getThisAddress();
+        Data dataValue = mapServiceContext.toData(value);
 
         // Fire EVICTED event also in case of expiration because historically eviction-listener
         // listens all kind of eviction and expiration events and by firing EVICTED event we are preserving
         // this behavior.
-        evictionOperator.fireEvent(key, value, mapName, EVICTED, mapServiceContext);
-        evictionOperator.fireEvent(key, value, mapName, EXPIRED, mapServiceContext);
+        mapEventPublisher.publishEvent(thisAddress, name, EVICTED, true, key, dataValue, null);
+
+        if (isExpired) {
+            // We will be in this if in two cases:
+            // 1. In case of TTL or max-idle-seconds expiration.
+            // 2. When evicting due to the size-based eviction, we are also firing an EXPIRED event
+            //    because there is a possibility that evicted entry may be also an expired one. Trying to catch
+            //    as much as possible expired entries.
+            mapEventPublisher.publishEvent(thisAddress, name, EXPIRED, true, key, dataValue, null);
+        }
     }
 
     void increaseRecordEvictionCriteriaNumber(Record record, EvictionPolicy evictionPolicy) {
@@ -398,7 +424,6 @@ abstract class AbstractEvictableRecordStore extends AbstractRecordStore {
 
         markRecordStoreExpirable(record.getTtl());
     }
-
 
     /**
      * Read only iterator. Iterates by checking whether a record expired or not.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
@@ -17,8 +17,6 @@
 package com.hazelcast.map.impl.recordstore;
 
 
-import static com.hazelcast.map.impl.ExpirationTimeSetter.updateExpiryTime;
-
 import com.hazelcast.concurrent.lock.LockService;
 import com.hazelcast.concurrent.lock.LockStore;
 import com.hazelcast.core.EntryView;
@@ -57,6 +55,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Future;
 
+import static com.hazelcast.map.impl.ExpirationTimeSetter.updateExpiryTime;
 import static com.hazelcast.map.impl.mapstore.MapDataStores.EMPTY_MAP_DATA_STORE;
 
 /**
@@ -285,7 +284,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore implements 
                 return true;
             }
         }
-        postReadCleanUp(now, false);
+        postReadCleanUp(now);
         return false;
     }
 
@@ -457,7 +456,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore implements 
         mapDataStore.removeAll(keysToDelete);
 
         final int numOfClearedEntries = keysToDelete.size();
-        for (Data key: keysToDelete) {
+        for (Data key : keysToDelete) {
             Record record = records.get(key);
             removeIndex(record);
         }
@@ -650,7 +649,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore implements 
         Object value = record == null ? null : record.getValue();
         value = mapServiceContext.interceptGet(name, value);
 
-        postReadCleanUp(now, false);
+        postReadCleanUp(now);
         return value;
     }
 
@@ -752,7 +751,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore implements 
             accessRecord(record, now);
         }
 
-        postReadCleanUp(now, false);
+        postReadCleanUp(now);
         return contains;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStore.java
@@ -275,6 +275,8 @@ public interface RecordStore {
      */
     boolean isExpired(Record record, long now, boolean backup);
 
+    void doPostEvictionOperations(Data key, Object value, boolean isExpired);
+
     /**
      * Loads all given keys from defined map store.
      *
@@ -298,7 +300,7 @@ public interface RecordStore {
      */
     Record getRecordOrNull(Data key);
 
-    void evictEntries(long now, boolean backup);
+    void evictEntries(long now);
 
     /**
      * Loads all keys and values
@@ -311,4 +313,6 @@ public interface RecordStore {
      * Performs initial loading from a MapLoader if it has not been done before
      **/
     void maybeDoInitialLoad();
+
+    boolean isEvictionEnabled();
 }


### PR DESCRIPTION
- Renamed old EvictionOperator as Evictor and made some distillation
- Removed boolean parameter backup from evict methods.
- Some tiny changes to provide extensibility.