### PR TITLE
Cleaned up toString on a lot of places

### DIFF
--- a/hazelcast-client-legacy/src/main/java/com/hazelcast/client/cache/impl/HazelcastClientCachingProvider.java
+++ b/hazelcast-client-legacy/src/main/java/com/hazelcast/client/cache/impl/HazelcastClientCachingProvider.java
@@ -121,9 +121,6 @@ public final class HazelcastClientCachingProvider extends AbstractHazelcastCachi
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder("HazelcastClientCachingProvider{");
-        sb.append("hazelcastInstance=").append(hazelcastInstance);
-        sb.append('}');
-        return sb.toString();
+        return "HazelcastClientCachingProvider{hazelcastInstance=" + hazelcastInstance + '}';
     }
 }

--- a/hazelcast-client-legacy/src/main/java/com/hazelcast/client/connection/nio/AbstractClientSelectionHandler.java
+++ b/hazelcast-client-legacy/src/main/java/com/hazelcast/client/connection/nio/AbstractClientSelectionHandler.java
@@ -51,12 +51,8 @@ public abstract class AbstractClientSelectionHandler implements SelectionHandler
             sk.cancel();
         }
         connectionManager.destroyConnection(connection);
-        StringBuilder sb = new StringBuilder();
-        sb.append(Thread.currentThread().getName());
-        sb.append(" Closing socket to endpoint ");
-        sb.append(connection.getEndPoint());
-        sb.append(", Cause:").append(e);
-        logger.warning(sb.toString());
+        logger.warning(Thread.currentThread().getName() + " Closing socket to endpoint " + connection.getEndPoint()
+                + ", Cause:" + e);
     }
 
     final void registerOp(final int operation) {

--- a/hazelcast-client-legacy/src/main/java/com/hazelcast/client/connection/nio/ClientConnection.java
+++ b/hazelcast-client-legacy/src/main/java/com/hazelcast/client/connection/nio/ClientConnection.java
@@ -213,7 +213,7 @@ public class ClientConnection implements Connection, Closeable {
         }
         String message = "Connection [" + getRemoteSocketAddress() + "] lost. Reason: ";
         if (t != null) {
-            message += t.getClass().getName() + "[" + t.getMessage() + "]";
+            message += t.getClass().getName() + '[' + t.getMessage() + ']';
         } else {
             message += "Socket explicitly closed";
         }
@@ -277,14 +277,13 @@ public class ClientConnection implements Connection, Closeable {
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder("ClientConnection{");
-        sb.append("live=").append(live);
-        sb.append(", writeHandler=").append(writeHandler);
-        sb.append(", readHandler=").append(readHandler);
-        sb.append(", connectionId=").append(connectionId);
-        sb.append(", socketChannel=").append(socketChannelWrapper);
-        sb.append(", remoteEndpoint=").append(remoteEndpoint);
-        sb.append('}');
-        return sb.toString();
+        return "ClientConnection{"
+                + "live=" + live
+                + ", writeHandler=" + writeHandler
+                + ", readHandler=" + readHandler
+                + ", connectionId=" + connectionId
+                + ", socketChannel=" + socketChannelWrapper
+                + ", remoteEndpoint=" + remoteEndpoint
+                + '}';
     }
 }

--- a/hazelcast-client-legacy/src/main/java/com/hazelcast/client/console/ClientConsoleApp.java
+++ b/hazelcast-client-legacy/src/main/java/com/hazelcast/client/console/ClientConsoleApp.java
@@ -462,7 +462,7 @@ public class ClientConsoleApp implements EntryListener, ItemListener, MessageLis
 
         long startMs = System.currentTimeMillis();
 
-        IExecutorService executor = hazelcast.getExecutorService(executorNamespace + " " + threadCount);
+        IExecutorService executor = hazelcast.getExecutorService(executorNamespace + ' ' + threadCount);
         List<Future> futures = new LinkedList<Future>();
         List<Member> members = new LinkedList<Member>(hazelcast.getCluster().getMembers());
 
@@ -546,21 +546,17 @@ public class ClientConsoleApp implements EntryListener, ItemListener, MessageLis
     @SuppressFBWarnings("DM_GC")
     private void handleJvm() {
         System.gc();
-        println("Memory max: " + Runtime.getRuntime().maxMemory() / ONE_KB / ONE_KB
-                + "M");
-        println("Memory free: "
-                + Runtime.getRuntime().freeMemory()
-                / ONE_KB
-                / ONE_KB
-                + "M "
-                + (int) (Runtime.getRuntime().freeMemory() * HUNDRED_CONSTANT / Runtime.getRuntime()
-                .maxMemory()) + "%");
-        long total = Runtime.getRuntime().totalMemory();
-        long free = Runtime.getRuntime().freeMemory();
+        Runtime runtime = Runtime.getRuntime();
+        println("Memory max: " + runtime.maxMemory() / ONE_KB / ONE_KB + 'M');
+        long freeMemory = runtime.freeMemory() / ONE_KB / ONE_KB;
+        int freeMemoryPercentage = (int) (runtime.freeMemory() * HUNDRED_CONSTANT / runtime.maxMemory());
+        println("Memory free: " + freeMemory + "M " + freeMemoryPercentage + '%');
+        long total = runtime.totalMemory();
+        long free = runtime.freeMemory();
         println("Used Memory:" + ((total - free) / ONE_KB / ONE_KB) + "MB");
-        println("# procs: " + Runtime.getRuntime().availableProcessors());
+        println("# procs: " + runtime.availableProcessors());
         println("OS info: " + ManagementFactory.getOperatingSystemMXBean().getArch()
-                + " " + ManagementFactory.getOperatingSystemMXBean().getName() + " "
+                + ' ' + ManagementFactory.getOperatingSystemMXBean().getName() + ' '
                 + ManagementFactory.getOperatingSystemMXBean().getVersion());
         println("JVM: " + ManagementFactory.getRuntimeMXBean().getVmVendor() + " "
                 + ManagementFactory.getRuntimeMXBean().getVmName() + " "

--- a/hazelcast-client-legacy/src/main/java/com/hazelcast/client/spi/impl/ClientPartitionServiceImpl.java
+++ b/hazelcast-client-legacy/src/main/java/com/hazelcast/client/spi/impl/ClientPartitionServiceImpl.java
@@ -207,10 +207,7 @@ public final class ClientPartitionServiceImpl implements ClientPartitionService 
 
         @Override
         public String toString() {
-            final StringBuilder sb = new StringBuilder("PartitionImpl{");
-            sb.append("partitionId=").append(partitionId);
-            sb.append('}');
-            return sb.toString();
+            return "PartitionImpl{partitionId=" + partitionId + '}';
         }
     }
 

--- a/hazelcast-client-legacy/src/main/java/com/hazelcast/client/txn/proxy/xa/XAResourceProxy.java
+++ b/hazelcast-client-legacy/src/main/java/com/hazelcast/client/txn/proxy/xa/XAResourceProxy.java
@@ -245,9 +245,7 @@ public class XAResourceProxy extends ClientProxy implements HazelcastXAResource 
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder();
-        sb.append("HazelcastXaResource {").append(getGroupName()).append('}');
-        return sb.toString();
+        return "HazelcastXaResource {" + getGroupName() + '}';
     }
 
 }

--- a/hazelcast-client-legacy/src/main/java/com/hazelcast/client/util/AddressHelper.java
+++ b/hazelcast-client-legacy/src/main/java/com/hazelcast/client/util/AddressHelper.java
@@ -44,7 +44,7 @@ public final class AddressHelper {
     public static Collection<InetSocketAddress> getSocketAddresses(String address) {
         final AddressHolder addressHolder = AddressUtil.getAddressHolder(address, -1);
         final String scopedAddress = addressHolder.getScopeId() != null
-                ? addressHolder.getAddress() + "%" + addressHolder.getScopeId()
+                ? addressHolder.getAddress() + '%' + addressHolder.getScopeId()
                 : addressHolder.getAddress();
 
         int port = addressHolder.getPort();

--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/HazelcastClientCachingProvider.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/HazelcastClientCachingProvider.java
@@ -121,9 +121,6 @@ public final class HazelcastClientCachingProvider extends AbstractHazelcastCachi
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder("HazelcastClientCachingProvider{");
-        sb.append("hazelcastInstance=").append(hazelcastInstance);
-        sb.append('}');
-        return sb.toString();
+        return "HazelcastClientCachingProvider{hazelcastInstance=" + hazelcastInstance + '}';
     }
 }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/AbstractClientSelectionHandler.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/AbstractClientSelectionHandler.java
@@ -51,12 +51,8 @@ public abstract class AbstractClientSelectionHandler implements SelectionHandler
             sk.cancel();
         }
         connectionManager.destroyConnection(connection);
-        StringBuilder sb = new StringBuilder();
-        sb.append(Thread.currentThread().getName());
-        sb.append(" Closing socket to endpoint ");
-        sb.append(connection.getEndPoint());
-        sb.append(", Cause:").append(e);
-        logger.warning(sb.toString());
+        logger.warning(Thread.currentThread().getName() + " Closing socket to endpoint "
+                + connection.getEndPoint() + ", Cause:" + e);
     }
 
     final void registerOp(final int operation) {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnection.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnection.java
@@ -211,7 +211,7 @@ public class ClientConnection implements Connection, Closeable {
         }
         String message = "Connection [" + getRemoteSocketAddress() + "] lost. Reason: ";
         if (t != null) {
-            message += t.getClass().getName() + "[" + t.getMessage() + "]";
+            message += t.getClass().getName() + '[' + t.getMessage() + ']';
         } else {
             message += "Socket explicitly closed";
         }
@@ -275,14 +275,13 @@ public class ClientConnection implements Connection, Closeable {
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder("ClientConnection{");
-        sb.append("live=").append(live);
-        sb.append(", writeHandler=").append(writeHandler);
-        sb.append(", readHandler=").append(readHandler);
-        sb.append(", connectionId=").append(connectionId);
-        sb.append(", socketChannel=").append(socketChannelWrapper);
-        sb.append(", remoteEndpoint=").append(remoteEndpoint);
-        sb.append('}');
-        return sb.toString();
+        return "ClientConnection{"
+                + "live=" + live
+                + ", writeHandler=" + writeHandler
+                + ", readHandler=" + readHandler
+                + ", connectionId=" + connectionId
+                + ", socketChannel=" + socketChannelWrapper
+                + ", remoteEndpoint=" + remoteEndpoint
+                + '}';
     }
 }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/console/ClientConsoleApp.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/console/ClientConsoleApp.java
@@ -462,7 +462,7 @@ public class ClientConsoleApp implements EntryListener, ItemListener, MessageLis
 
         long startMs = System.currentTimeMillis();
 
-        IExecutorService executor = hazelcast.getExecutorService(executorNamespace + " " + threadCount);
+        IExecutorService executor = hazelcast.getExecutorService(executorNamespace + ' ' + threadCount);
         List<Future> futures = new LinkedList<Future>();
         List<Member> members = new LinkedList<Member>(hazelcast.getCluster().getMembers());
 
@@ -546,21 +546,17 @@ public class ClientConsoleApp implements EntryListener, ItemListener, MessageLis
     @SuppressFBWarnings("DM_GC")
     private void handleJvm() {
         System.gc();
-        println("Memory max: " + Runtime.getRuntime().maxMemory() / ONE_KB / ONE_KB
-                + "M");
-        println("Memory free: "
-                + Runtime.getRuntime().freeMemory()
-                / ONE_KB
-                / ONE_KB
-                + "M "
-                + (int) (Runtime.getRuntime().freeMemory() * HUNDRED_CONSTANT / Runtime.getRuntime()
-                .maxMemory()) + "%");
-        long total = Runtime.getRuntime().totalMemory();
-        long free = Runtime.getRuntime().freeMemory();
+        Runtime runtime = Runtime.getRuntime();
+        println("Memory max: " + runtime.maxMemory() / ONE_KB / ONE_KB + 'M');
+        long freeMemory = runtime.freeMemory() / ONE_KB / ONE_KB;
+        int freeMemoryPercentage = (int) (runtime.freeMemory() * HUNDRED_CONSTANT / runtime.maxMemory());
+        println("Memory free: " + freeMemory + "M " + freeMemoryPercentage + '%');
+        long total = runtime.totalMemory();
+        long free = runtime.freeMemory();
         println("Used Memory:" + ((total - free) / ONE_KB / ONE_KB) + "MB");
-        println("# procs: " + Runtime.getRuntime().availableProcessors());
+        println("# procs: " + runtime.availableProcessors());
         println("OS info: " + ManagementFactory.getOperatingSystemMXBean().getArch()
-                + " " + ManagementFactory.getOperatingSystemMXBean().getName() + " "
+                + ' ' + ManagementFactory.getOperatingSystemMXBean().getName() + ' '
                 + ManagementFactory.getOperatingSystemMXBean().getVersion());
         println("JVM: " + ManagementFactory.getRuntimeMXBean().getVmVendor() + " "
                 + ManagementFactory.getRuntimeMXBean().getVmName() + " "

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/txn/xa/XAResourceProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/txn/xa/XAResourceProxy.java
@@ -248,9 +248,6 @@ public class XAResourceProxy extends ClientProxy implements HazelcastXAResource 
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder();
-        sb.append("HazelcastXaResource {").append(getGroupName()).append('}');
-        return sb.toString();
+        return "HazelcastXaResource{" + getGroupName() + '}';
     }
-
 }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientPartitionServiceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientPartitionServiceImpl.java
@@ -208,10 +208,7 @@ public final class ClientPartitionServiceImpl
 
         @Override
         public String toString() {
-            final StringBuilder sb = new StringBuilder("PartitionImpl{");
-            sb.append("partitionId=").append(partitionId);
-            sb.append('}');
-            return sb.toString();
+            return "PartitionImpl{partitionId=" + partitionId + '}';
         }
     }
 

--- a/hazelcast-client/src/main/java/com/hazelcast/client/util/AddressHelper.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/util/AddressHelper.java
@@ -44,7 +44,7 @@ public final class AddressHelper {
     public static Collection<InetSocketAddress> getSocketAddresses(String address) {
         final AddressHolder addressHolder = AddressUtil.getAddressHolder(address, -1);
         final String scopedAddress = addressHolder.getScopeId() != null
-                ? addressHolder.getAddress() + "%" + addressHolder.getScopeId()
+                ? addressHolder.getAddress() + '%' + addressHolder.getScopeId()
                 : addressHolder.getAddress();
 
         int port = addressHolder.getPort();

--- a/hazelcast-hibernate/hazelcast-hibernate3/src/main/java/com/hazelcast/hibernate/local/Invalidation.java
+++ b/hazelcast-hibernate/hazelcast-hibernate3/src/main/java/com/hazelcast/hibernate/local/Invalidation.java
@@ -72,11 +72,6 @@ public class Invalidation implements IdentifiedDataSerializable {
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder();
-        sb.append("Invalidation");
-        sb.append("{key=").append(key);
-        sb.append(", version=").append(version);
-        sb.append('}');
-        return sb.toString();
+        return "Invalidation{key=" + key + ", version=" + version + '}';
     }
 }

--- a/hazelcast-hibernate/hazelcast-hibernate3/src/main/java/com/hazelcast/hibernate/local/Timestamp.java
+++ b/hazelcast-hibernate/hazelcast-hibernate3/src/main/java/com/hazelcast/hibernate/local/Timestamp.java
@@ -71,11 +71,6 @@ public class Timestamp implements IdentifiedDataSerializable {
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder();
-        sb.append("Timestamp");
-        sb.append("{key=").append(key);
-        sb.append(", timestamp=").append(timestamp);
-        sb.append('}');
-        return sb.toString();
+        return "Timestamp" + "{key=" + key + ", timestamp=" + timestamp + '}';
     }
 }

--- a/hazelcast-hibernate/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/local/Invalidation.java
+++ b/hazelcast-hibernate/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/local/Invalidation.java
@@ -70,11 +70,6 @@ public class Invalidation implements IdentifiedDataSerializable {
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder();
-        sb.append("Invalidation");
-        sb.append("{key=").append(key);
-        sb.append(", version=").append(version);
-        sb.append('}');
-        return sb.toString();
+        return "Invalidation{key=" + key + ", version=" + version + '}';
     }
 }

--- a/hazelcast-hibernate/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/local/Timestamp.java
+++ b/hazelcast-hibernate/hazelcast-hibernate4/src/main/java/com/hazelcast/hibernate/local/Timestamp.java
@@ -71,11 +71,6 @@ public class Timestamp implements IdentifiedDataSerializable {
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder();
-        sb.append("Timestamp");
-        sb.append("{key=").append(key);
-        sb.append(", timestamp=").append(timestamp);
-        sb.append('}');
-        return sb.toString();
+        return "Timestamp" + "{key=" + key + ", timestamp=" + timestamp + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/HazelcastCachingProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/HazelcastCachingProvider.java
@@ -178,9 +178,6 @@ public final class HazelcastCachingProvider
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder("HazelcastCachingProvider{");
-        sb.append("delegate=").append(delegate);
-        sb.append('}');
-        return sb.toString();
+        return "HazelcastCachingProvider{delegate=" + delegate + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractHazelcastCacheManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractHazelcastCacheManager.java
@@ -370,13 +370,13 @@ public abstract class AbstractHazelcastCacheManager
     protected String cacheNamePrefix() {
         StringBuilder sb = new StringBuilder("/hz");
         if (!isDefaultURI) {
-            sb.append("/").append(uri.toASCIIString());
+            sb.append('/').append(uri.toASCIIString());
         }
         ClassLoader classLoader = getClassLoader();
         if (!isDefaultClassLoader && classLoader != null) {
-            sb.append("/").append(classLoader.toString());
+            sb.append('/').append(classLoader.toString());
         }
-        sb.append("/");
+        sb.append('/');
         return sb.toString();
     }
 
@@ -414,11 +414,7 @@ public abstract class AbstractHazelcastCacheManager
 
     @Override
     public String toString() {
-        StringBuilder sb = new StringBuilder("HazelcastCacheManager{");
-        sb.append("hazelcastInstance=").append(hazelcastInstance);
-        sb.append(", cachingProvider=").append(cachingProvider);
-        sb.append('}');
-        return sb.toString();
+        return "HazelcastCacheManager{hazelcastInstance=" + hazelcastInstance + ", cachingProvider=" + cachingProvider + '}';
     }
 
     protected abstract <K, V> void addCacheConfigIfAbsent(CacheConfig<K, V> cacheConfig);

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractHazelcastCachingProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractHazelcastCachingProvider.java
@@ -94,7 +94,7 @@ public abstract class AbstractHazelcastCachingProvider
                     cacheManager = createHazelcastCacheManager(uri, classLoader, managerProperties);
                     cacheManagersByURI.put(managerURI, cacheManager);
                 } catch (Exception e) {
-                    throw new CacheException("Error opening URI [" + managerURI.toString() + "]", e);
+                    throw new CacheException("Error opening URI [" + managerURI.toString() + ']', e);
                 }
             }
             return cacheManager;

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheKeyIteratorResult.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheKeyIteratorResult.java
@@ -91,10 +91,7 @@ public class CacheKeyIteratorResult
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder("CacheKeyIteratorResult{");
-        sb.append(", tableIndex=").append(tableIndex);
-        sb.append('}');
-        return sb.toString();
+        return "CacheKeyIteratorResult{tableIndex=" + tableIndex + '}';
     }
 
     public int getCount() {

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheRecordStore.java
@@ -80,7 +80,7 @@ public class CacheRecordStore
 
         if (maxSizePolicy != EvictionConfig.MaxSizePolicy.ENTRY_COUNT) {
             throw new IllegalArgumentException("Invalid max-size policy "
-                    + "(" + maxSizePolicy + ") for " + getClass().getName() + " ! Only "
+                    + '(' + maxSizePolicy + ") for " + getClass().getName() + "! Only "
                     + EvictionConfig.MaxSizePolicy.ENTRY_COUNT + " is supported.");
         } else {
             return super.createCacheMaxSizeChecker(size, maxSizePolicy);

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheService.java
@@ -66,7 +66,7 @@ public class CacheService extends AbstractCacheService {
 
     @Override
     public String toString() {
-        return "CacheService[" + SERVICE_NAME + "]";
+        return "CacheService[" + SERVICE_NAME + ']';
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/HazelcastServerCachingProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/HazelcastServerCachingProvider.java
@@ -126,9 +126,6 @@ public final class HazelcastServerCachingProvider
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder("HazelcastServerCachingProvider{");
-        sb.append("hazelcastInstance=").append(hazelcastInstance);
-        sb.append('}');
-        return sb.toString();
+        return "HazelcastServerCachingProvider{hazelcastInstance=" + hazelcastInstance + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/client/CacheBatchInvalidationMessage.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/client/CacheBatchInvalidationMessage.java
@@ -93,11 +93,10 @@ public class CacheBatchInvalidationMessage extends CacheInvalidationMessage {
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder("CacheBatchInvalidationMessage{");
-        sb.append("name='").append(name).append('\'');
-        sb.append(", invalidationMessages=").append(invalidationMessages);
-        sb.append('}');
-        return sb.toString();
+        return "CacheBatchInvalidationMessage{"
+                + "name='" + name + '\''
+                + ", invalidationMessages=" + invalidationMessages
+                + '}';
     }
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/client/CacheSingleInvalidationMessage.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/client/CacheSingleInvalidationMessage.java
@@ -78,12 +78,11 @@ public class CacheSingleInvalidationMessage extends CacheInvalidationMessage {
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder("CacheSingleInvalidationMessage{");
-        sb.append("name='").append(name).append('\'');
-        sb.append(", key=").append(key);
-        sb.append(", sourceUuid='").append(sourceUuid).append('\'');
-        sb.append('}');
-        return sb.toString();
+        return "CacheSingleInvalidationMessage{"
+                + "name='" + name + '\''
+                + ", key=" + key
+                + ", sourceUuid='" + sourceUuid + '\''
+                + '}';
     }
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/event/CachePartitionLostEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/event/CachePartitionLostEvent.java
@@ -46,7 +46,7 @@ public class CachePartitionLostEvent extends AbstractICacheEvent {
 
     @Override
     public String toString() {
-        return getClass().getSimpleName() + "{"
+        return getClass().getSimpleName() + '{'
                 + super.toString()
                 + ", partitionId=" + partitionId
                 + '}';

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/nearcache/impl/store/BaseHeapNearCacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/nearcache/impl/store/BaseHeapNearCacheRecordStore.java
@@ -45,7 +45,7 @@ public abstract class BaseHeapNearCacheRecordStore<K, V, R extends NearCacheReco
             return new EntryCountNearCacheMaxSizeChecker(evictionConfig.getSize(), records);
         }
         throw new IllegalArgumentException("Invalid max-size policy "
-                + "(" + maxSizePolicy + ") for " + getClass().getName() + " ! Only "
+                + '(' + maxSizePolicy + ") for " + getClass().getName() + "! Only "
                 + EvictionConfig.MaxSizePolicy.ENTRY_COUNT + " is supported.");
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEndpointImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEndpointImpl.java
@@ -267,12 +267,11 @@ public final class ClientEndpointImpl implements Client, ClientEndpoint {
 
     @Override
     public String toString() {
-        StringBuilder sb = new StringBuilder("ClientEndpoint{");
-        sb.append("conn=").append(conn);
-        sb.append(", principal='").append(principal).append('\'');
-        sb.append(", firstConnection=").append(firstConnection);
-        sb.append(", authenticated=").append(authenticated);
-        sb.append('}');
-        return sb.toString();
+        return "ClientEndpoint{"
+                + "conn=" + conn
+                + ", principal='" + principal + '\''
+                + ", firstConnection=" + firstConnection
+                + ", authenticated=" + authenticated
+                + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/client/ClientPrincipal.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/client/ClientPrincipal.java
@@ -95,10 +95,6 @@ public final class ClientPrincipal implements Portable {
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder("ClientPrincipal{");
-        sb.append("uuid='").append(uuid).append('\'');
-        sb.append(", ownerUuid='").append(ownerUuid).append('\'');
-        sb.append('}');
-        return sb.toString();
+        return "ClientPrincipal{uuid='" + uuid + '\'' + ", ownerUuid='" + ownerUuid + '\'' + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/client/ClientResponse.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/client/ClientResponse.java
@@ -77,10 +77,6 @@ public class ClientResponse implements IdentifiedDataSerializable {
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder("ClientResponse{");
-        sb.append("callId=").append(callId);
-        sb.append(", isError=").append(isError);
-        sb.append('}');
-        return sb.toString();
+        return "ClientResponse{callId=" + callId + ", isError=" + isError + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/client/GenericError.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/client/GenericError.java
@@ -87,10 +87,6 @@ public final class GenericError implements Portable {
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder("GenericError{");
-        sb.append("message='").append(message).append('\'');
-        sb.append(", type=").append(type);
-        sb.append('}');
-        return sb.toString();
+        return "GenericError{message='" + message + '\'' + ", type=" + type + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapLoadGivenKeysMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapLoadGivenKeysMessageTask.java
@@ -40,7 +40,7 @@ public class MapLoadGivenKeysMessageTask
 
     @Override
     protected OperationFactory createOperationFactory() {
-        Data[] keys = parameters.keys.toArray(new Data[0]);
+        Data[] keys = parameters.keys.toArray(new Data[parameters.keys.size()]);
         MapOperationProvider operationProvider = getOperationProvider(parameters.name);
         return operationProvider.createLoadAllOperationFactory(parameters.name,
                 Arrays.asList(keys), parameters.replaceExistingValues);

--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/AbstractJoiner.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/AbstractJoiner.java
@@ -122,9 +122,7 @@ public abstract class AbstractJoiner implements Joiner {
             }
 
             if (clusterService.getSize() == 1) {
-                final StringBuilder sb = new StringBuilder("\n");
-                sb.append(node.clusterService.membersString());
-                logger.info(sb.toString());
+                logger.info('\n' + node.clusterService.membersString());
             }
         }
     }
@@ -217,7 +215,7 @@ public abstract class AbstractJoiner implements Joiner {
                 // I should join the other cluster
                 logger.info(node.getThisAddress() + " is merging to " + joinMessage.getAddress()
                         + ", because : joinMessage.getMemberCount() > currentMemberCount ["
-                        + (joinMessage.getMemberCount() + " > " + currentMemberCount) + "]");
+                        + (joinMessage.getMemberCount() + " > " + currentMemberCount) + ']');
                 if (logger.isFinestEnabled()) {
                     logger.finest(joinMessage.toString());
                 }
@@ -240,7 +238,7 @@ public abstract class AbstractJoiner implements Joiner {
             } else {
                 logger.info(joinMessage.getAddress() + " should merge to this node "
                         + ", because : currentMemberCount > joinMessage.getMemberCount() ["
-                        + (currentMemberCount + " > " + joinMessage.getMemberCount()) + "]");
+                        + (currentMemberCount + " > " + joinMessage.getMemberCount()) + ']');
             }
         } catch (Throwable e) {
             logger.severe(e);

--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/ClusterStateLock.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/ClusterStateLock.java
@@ -109,11 +109,10 @@ class ClusterStateLock {
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder("ClusterStateLock{");
-        sb.append("lockOwner=").append(lockOwner);
-        sb.append(", transactionId='").append(transactionId).append('\'');
-        sb.append(", lockExpiryTime=").append(lockExpiryTime);
-        sb.append('}');
-        return sb.toString();
+        return "ClusterStateLock{"
+                + "lockOwner=" + lockOwner
+                + ", transactionId='" + transactionId + '\''
+                + ", lockExpiryTime=" + lockExpiryTime
+                + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/ClusterStateManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/ClusterStateManager.java
@@ -291,20 +291,12 @@ public class ClusterStateManager {
     }
 
     String stateToString() {
-        final StringBuilder sb = new StringBuilder("ClusterState{");
-        sb.append("state=").append(state);
-        sb.append(", lock=").append(stateLockRef.get());
-        sb.append('}');
-        return sb.toString();
+        return "ClusterState{state=" + state + ", lock=" + stateLockRef.get() + '}';
     }
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder("ClusterStateManager{");
-        sb.append("stateLockRef=").append(stateLockRef);
-        sb.append(", state=").append(state);
-        sb.append('}');
-        return sb.toString();
+        return "ClusterStateManager{stateLockRef=" + stateLockRef + ", state=" + state + '}';
     }
 
     private static final class StateManagerExceptionHandler implements FutureUtil.ExceptionHandler {

--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/JoinMessage.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/JoinMessage.java
@@ -40,12 +40,12 @@ public class JoinMessage implements DataSerializable {
     }
 
     public JoinMessage(byte packetVersion, int buildNumber, Address address,
-            String uuid, boolean liteMember, ConfigCheck configCheck) {
+                       String uuid, boolean liteMember, ConfigCheck configCheck) {
         this(packetVersion, buildNumber, address, uuid, liteMember, configCheck, Collections.<Address>emptySet());
     }
 
     public JoinMessage(byte packetVersion, int buildNumber, Address address,
-            String uuid, boolean liteMember, ConfigCheck configCheck, Collection<Address> memberAddresses) {
+                       String uuid, boolean liteMember, ConfigCheck configCheck, Collection<Address> memberAddresses) {
         this.packetVersion = packetVersion;
         this.buildNumber = buildNumber;
         this.address = address;
@@ -127,16 +127,14 @@ public class JoinMessage implements DataSerializable {
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder();
-        sb.append("JoinMessage");
-        sb.append("{packetVersion=").append(packetVersion);
-        sb.append(", buildNumber=").append(buildNumber);
-        sb.append(", address=").append(address);
-        sb.append(", uuid='").append(uuid).append('\'');
-        sb.append(", liteMember=").append(liteMember);
-        sb.append(", memberCount=").append(getMemberCount());
-        sb.append('}');
-        return sb.toString();
+        return "JoinMessage{"
+                + "packetVersion=" + packetVersion
+                + ", buildNumber=" + buildNumber
+                + ", address=" + address
+                + ", uuid='" + uuid + '\''
+                + ", liteMember=" + liteMember
+                + ", memberCount=" + getMemberCount()
+                + '}';
     }
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueProxyImpl.java
@@ -233,10 +233,6 @@ public class QueueProxyImpl<E> extends QueueProxySupport implements IQueue<E>, I
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder();
-        sb.append("IQueue");
-        sb.append("{name='").append(name).append('\'');
-        sb.append('}');
-        return sb.toString();
+        return "IQueue{name='" + name + '\'' + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/TransactionalQueueProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/TransactionalQueueProxy.java
@@ -105,9 +105,6 @@ public class TransactionalQueueProxy<E> extends TransactionalQueueProxySupport i
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder("TransactionalQueue{");
-        sb.append("name=").append(name);
-        sb.append('}');
-        return sb.toString();
+        return "TransactionalQueue{name=" + name + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/countdownlatch/CountDownLatchContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/countdownlatch/CountDownLatchContainer.java
@@ -75,11 +75,6 @@ public class CountDownLatchContainer implements DataSerializable {
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder();
-        sb.append("LocalCountDownLatch");
-        sb.append("{name='").append(name).append('\'');
-        sb.append(", count=").append(count);
-        sb.append('}');
-        return sb.toString();
+        return "LocalCountDownLatch{name='" + name + '\'' + ", count=" + count + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/countdownlatch/CountDownLatchProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/countdownlatch/CountDownLatchProxy.java
@@ -102,9 +102,6 @@ public class CountDownLatchProxy extends AbstractDistributedObject<CountDownLatc
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder("ICountDownLatch{");
-        sb.append("name='").append(name).append('\'');
-        sb.append('}');
-        return sb.toString();
+        return "ICountDownLatch{name='" + name + '\'' + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockProxy.java
@@ -151,9 +151,6 @@ public class LockProxy extends AbstractDistributedObject<LockServiceImpl> implem
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder("ILock{");
-        sb.append("name='").append(name).append('\'');
-        sb.append('}');
-        return sb.toString();
+        return "ILock{name='" + name + '\'' + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockResourceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockResourceImpl.java
@@ -435,15 +435,13 @@ final class LockResourceImpl implements DataSerializable, LockResource {
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder();
-        sb.append("LockResource");
-        sb.append("{owner='").append(owner).append('\'');
-        sb.append(", threadId=").append(threadId);
-        sb.append(", lockCount=").append(lockCount);
-        sb.append(", acquireTime=").append(acquireTime);
-        sb.append(", expirationTime=").append(expirationTime);
-        sb.append('}');
-        return sb.toString();
+        return "LockResource{"
+                + "owner='" + owner + '\''
+                + ", threadId=" + threadId
+                + ", lockCount=" + lockCount
+                + ", acquireTime=" + acquireTime
+                + ", expirationTime=" + expirationTime
+                + '}';
     }
 
     private static boolean isNullOrEmpty(Collection c) {

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockStoreImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockStoreImpl.java
@@ -338,12 +338,10 @@ public final class LockStoreImpl implements DataSerializable, LockStore {
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder();
-        sb.append("LockStoreImpl");
-        sb.append("{namespace=").append(namespace);
-        sb.append(", backupCount=").append(backupCount);
-        sb.append(", asyncBackupCount=").append(asyncBackupCount);
-        sb.append('}');
-        return sb.toString();
+        return "LockStoreImpl{"
+                + "namespace=" + namespace
+                + ", backupCount=" + backupCount
+                + ", asyncBackupCount=" + asyncBackupCount
+                + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/SemaphoreProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/SemaphoreProxy.java
@@ -166,9 +166,6 @@ public class SemaphoreProxy extends AbstractDistributedObject<SemaphoreService> 
 
     @Override
     public String toString() {
-        StringBuilder sb = new StringBuilder("ISemaphore{");
-        sb.append("name='").append(name).append('\'');
-        sb.append('}');
-        return sb.toString();
+        return "ISemaphore{name='" + name + '\'' + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/AbstractConfigBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/AbstractConfigBuilder.java
@@ -127,7 +127,7 @@ public abstract class AbstractConfigBuilder extends AbstractXmlConfigHelper {
         NodeList misplacedHazelcastTag = (NodeList) xpath.evaluate("//" + this.getXmlType().name, root.getOwnerDocument(),
                 XPathConstants.NODESET);
         if (misplacedHazelcastTag.getLength() > 1) {
-            throw new InvalidConfigurationException("<" + this.getXmlType().name + "> element can appear only once in the XML");
+            throw new InvalidConfigurationException('<' + this.getXmlType().name + "> element can appear only once in the XML");
         }
         NamedNodeMap attributes = root.getAttributes();
         if (attributes != null) {

--- a/hazelcast/src/main/java/com/hazelcast/config/AbstractXmlConfigHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/AbstractXmlConfigHelper.java
@@ -154,8 +154,8 @@ public abstract class AbstractXmlConfigHelper {
             if (xsdLocation.isEmpty()) {
                 continue;
             }
-            String namespace = xsdLocation.split("[" + lineSeperator + " ]+")[0];
-            String uri = xsdLocation.split("[" + lineSeperator + " ]+")[1];
+            String namespace = xsdLocation.split('[' + lineSeperator + " ]+")[0];
+            String uri = xsdLocation.split('[' + lineSeperator + " ]+")[1];
 
             // if this is hazelcast namespace but location is different log only warning
             if (namespace.equals(xmlns) && !uri.endsWith(hazelcastSchemaLocation)) {

--- a/hazelcast/src/main/java/com/hazelcast/config/AwsConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/AwsConfig.java
@@ -277,16 +277,14 @@ public class AwsConfig {
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder("AwsConfig{");
-        sb.append("enabled=").append(enabled);
-        sb.append(", region='").append(region).append('\'');
-        sb.append(", securityGroupName='").append(securityGroupName).append('\'');
-        sb.append(", tagKey='").append(tagKey).append('\'');
-        sb.append(", tagValue='").append(tagValue).append('\'');
-        sb.append(", hostHeader='").append(hostHeader).append('\'');
-        sb.append(", iamRole='").append(iamRole).append('\'');
-        sb.append(", connectionTimeoutSeconds=").append(connectionTimeoutSeconds);
-        sb.append('}');
-        return sb.toString();
+        return "AwsConfig{"
+                + "enabled=" + enabled
+                + ", region='" + region + '\''
+                + ", securityGroupName='" + securityGroupName + '\''
+                + ", tagKey='" + tagKey + '\''
+                + ", tagValue='" + tagValue + '\''
+                + ", hostHeader='" + hostHeader + '\''
+                + ", iamRole='" + iamRole + '\''
+                + ", connectionTimeoutSeconds=" + connectionTimeoutSeconds + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/Config.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/Config.java
@@ -1131,26 +1131,24 @@ public class Config {
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder();
-        sb.append("Config");
-        sb.append("{groupConfig=").append(groupConfig);
-        sb.append(", properties=").append(properties);
-        sb.append(", networkConfig=").append(networkConfig);
-        sb.append(", mapConfigs=").append(mapConfigs);
-        sb.append(", topicConfigs=").append(topicConfigs);
-        sb.append(", reliableTopicConfigs=").append(reliableTopicConfigs);
-        sb.append(", queueConfigs=").append(queueConfigs);
-        sb.append(", multiMapConfigs=").append(multiMapConfigs);
-        sb.append(", executorConfigs=").append(executorConfigs);
-        sb.append(", semaphoreConfigs=").append(semaphoreConfigs);
-        sb.append(", ringbufferConfigs=").append(ringbufferConfigs);
-        sb.append(", wanReplicationConfigs=").append(wanReplicationConfigs);
-        sb.append(", listenerConfigs=").append(listenerConfigs);
-        sb.append(", partitionGroupConfig=").append(partitionGroupConfig);
-        sb.append(", managementCenterConfig=").append(managementCenterConfig);
-        sb.append(", securityConfig=").append(securityConfig);
-        sb.append(", liteMember=").append(liteMember);
-        sb.append('}');
-        return sb.toString();
+        return "Config{"
+                + "groupConfig=" + groupConfig
+                + ", properties=" + properties
+                + ", networkConfig=" + networkConfig
+                + ", mapConfigs=" + mapConfigs
+                + ", topicConfigs=" + topicConfigs
+                + ", reliableTopicConfigs=" + reliableTopicConfigs
+                + ", queueConfigs=" + queueConfigs
+                + ", multiMapConfigs=" + multiMapConfigs
+                + ", executorConfigs=" + executorConfigs
+                + ", semaphoreConfigs=" + semaphoreConfigs
+                + ", ringbufferConfigs=" + ringbufferConfigs
+                + ", wanReplicationConfigs=" + wanReplicationConfigs
+                + ", listenerConfigs=" + listenerConfigs
+                + ", partitionGroupConfig=" + partitionGroupConfig
+                + ", managementCenterConfig=" + managementCenterConfig
+                + ", securityConfig=" + securityConfig
+                + ", liteMember=" + liteMember
+                + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/CredentialsFactoryConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CredentialsFactoryConfig.java
@@ -67,12 +67,10 @@ public class CredentialsFactoryConfig {
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder();
-        sb.append("CredentialsFactoryConfig");
-        sb.append("{className='").append(className).append('\'');
-        sb.append(", implementation=").append(implementation);
-        sb.append(", properties=").append(properties);
-        sb.append('}');
-        return sb.toString();
+        return "CredentialsFactoryConfig{"
+                + "className='" + className + '\''
+                + ", implementation=" + implementation
+                + ", properties=" + properties
+                + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/EntryListenerConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/EntryListenerConfig.java
@@ -87,12 +87,7 @@ public class EntryListenerConfig extends ListenerConfig {
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder();
-        sb.append("EntryListenerConfig");
-        sb.append("{local=").append(local);
-        sb.append(", includeValue=").append(includeValue);
-        sb.append('}');
-        return sb.toString();
+        return "EntryListenerConfig{local=" + local + ", includeValue=" + includeValue + '}';
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/config/ExecutorConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ExecutorConfig.java
@@ -152,12 +152,10 @@ public class ExecutorConfig {
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder();
-        sb.append("ExecutorConfig");
-        sb.append("{name='").append(name).append('\'');
-        sb.append(", poolSize=").append(poolSize);
-        sb.append(", queueCapacity=").append(queueCapacity);
-        sb.append('}');
-        return sb.toString();
+        return "ExecutorConfig{"
+                + "name='" + name + '\''
+                + ", poolSize=" + poolSize
+                + ", queueCapacity=" + queueCapacity
+                + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/GlobalSerializerConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/GlobalSerializerConfig.java
@@ -49,10 +49,9 @@ public class GlobalSerializerConfig {
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder("GlobalSerializerConfig{");
-        sb.append("className='").append(className).append('\'');
-        sb.append(", implementation=").append(implementation);
-        sb.append('}');
-        return sb.toString();
+        return "GlobalSerializerConfig{"
+                + "className='" + className + '\''
+                + ", implementation=" + implementation
+                + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/InterfacesConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/InterfacesConfig.java
@@ -83,11 +83,6 @@ public class InterfacesConfig {
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder();
-        sb.append("InterfacesConfig");
-        sb.append("{enabled=").append(enabled);
-        sb.append(", interfaces=").append(interfaceSet);
-        sb.append('}');
-        return sb.toString();
+        return "InterfacesConfig{enabled=" + enabled + ", interfaces=" + interfaceSet + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/ItemListenerConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ItemListenerConfig.java
@@ -73,11 +73,7 @@ public class ItemListenerConfig extends ListenerConfig {
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder();
-        sb.append("ItemListenerConfig");
-        sb.append("{includeValue=").append(includeValue);
-        sb.append('}');
-        return sb.toString();
+        return "ItemListenerConfig{includeValue=" + includeValue + '}';
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/config/JoinConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/JoinConfig.java
@@ -133,12 +133,11 @@ public class JoinConfig {
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder("JoinConfig{");
-        sb.append("multicastConfig=").append(multicastConfig);
-        sb.append(", tcpIpConfig=").append(tcpIpConfig);
-        sb.append(", awsConfig=").append(awsConfig);
-        sb.append(", discoveryProvidersConfig=").append(discoveryConfig);
-        sb.append('}');
-        return sb.toString();
+        return "JoinConfig{"
+                + "multicastConfig=" + multicastConfig
+                + ", tcpIpConfig=" + tcpIpConfig
+                + ", awsConfig=" + awsConfig
+                + ", discoveryProvidersConfig=" + discoveryConfig
+                + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/LoginModuleConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/LoginModuleConfig.java
@@ -97,12 +97,6 @@ public class LoginModuleConfig {
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder();
-        sb.append("LoginModuleConfig");
-        sb.append("{className='").append(className).append('\'');
-        sb.append(", usage=").append(usage);
-        sb.append(", properties=").append(properties);
-        sb.append('}');
-        return sb.toString();
+        return "LoginModuleConfig{className='" + className + "', usage=" + usage + ", properties=" + properties + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/ManagementCenterConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ManagementCenterConfig.java
@@ -103,12 +103,6 @@ public class ManagementCenterConfig {
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder();
-        sb.append("ManagementCenterConfig");
-        sb.append("{enabled=").append(enabled);
-        sb.append(", url='").append(url).append('\'');
-        sb.append(", updateInterval=").append(updateInterval);
-        sb.append('}');
-        return sb.toString();
+        return "ManagementCenterConfig{enabled=" + enabled + ", url='" + url + "', updateInterval=" + updateInterval + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/MapConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MapConfig.java
@@ -761,29 +761,27 @@ public class MapConfig {
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder();
-        sb.append("MapConfig");
-        sb.append("{name='").append(name).append('\'');
-        sb.append(", inMemoryFormat=").append(inMemoryFormat).append('\'');
-        sb.append(", backupCount=").append(backupCount);
-        sb.append(", asyncBackupCount=").append(asyncBackupCount);
-        sb.append(", timeToLiveSeconds=").append(timeToLiveSeconds);
-        sb.append(", maxIdleSeconds=").append(maxIdleSeconds);
-        sb.append(", evictionPolicy='").append(evictionPolicy).append('\'');
-        sb.append(", evictionPercentage=").append(evictionPercentage);
-        sb.append(", minEvictionCheckMillis=").append(minEvictionCheckMillis);
-        sb.append(", maxSizeConfig=").append(maxSizeConfig);
-        sb.append(", readBackupData=").append(readBackupData);
-        sb.append(", nearCacheConfig=").append(nearCacheConfig);
-        sb.append(", mapStoreConfig=").append(mapStoreConfig);
-        sb.append(", mergePolicyConfig='").append(mergePolicy).append('\'');
-        sb.append(", wanReplicationRef=").append(wanReplicationRef);
-        sb.append(", entryListenerConfigs=").append(entryListenerConfigs);
-        sb.append(", mapIndexConfigs=").append(mapIndexConfigs);
-        sb.append(", mapAttributeConfigs=").append(mapAttributeConfigs);
-        sb.append(", quorumName=").append(quorumName);
-        sb.append(", queryCacheConfigs=").append(queryCacheConfigs);
-        sb.append('}');
-        return sb.toString();
+        return "MapConfig{"
+                + "name='" + name + '\''
+                + "', inMemoryFormat=" + inMemoryFormat + '\''
+                + ", backupCount=" + backupCount
+                + ", asyncBackupCount=" + asyncBackupCount
+                + ", timeToLiveSeconds=" + timeToLiveSeconds
+                + ", maxIdleSeconds=" + maxIdleSeconds
+                + ", evictionPolicy='" + evictionPolicy + '\''
+                + ", evictionPercentage=" + evictionPercentage
+                + ", minEvictionCheckMillis=" + minEvictionCheckMillis
+                + ", maxSizeConfig=" + maxSizeConfig
+                + ", readBackupData=" + readBackupData
+                + ", nearCacheConfig=" + nearCacheConfig
+                + ", mapStoreConfig=" + mapStoreConfig
+                + ", mergePolicyConfig='" + mergePolicy + '\''
+                + ", wanReplicationRef=" + wanReplicationRef
+                + ", entryListenerConfigs=" + entryListenerConfigs
+                + ", mapIndexConfigs=" + mapIndexConfigs
+                + ", mapAttributeConfigs=" + mapAttributeConfigs
+                + ", quorumName=" + quorumName
+                + ", queryCacheConfigs=" + queryCacheConfigs
+                + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/MapIndexConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MapIndexConfig.java
@@ -107,10 +107,6 @@ public class MapIndexConfig {
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder("MapIndexConfig{");
-        sb.append("attribute='").append(attribute).append('\'');
-        sb.append(", ordered=").append(ordered);
-        sb.append('}');
-        return sb.toString();
+        return "MapIndexConfig{attribute='" + attribute + "', ordered=" + ordered + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/MemberGroupConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MemberGroupConfig.java
@@ -89,9 +89,6 @@ public class MemberGroupConfig {
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder("MemberGroupConfig{");
-        sb.append("interfaces=").append(interfaces);
-        sb.append('}');
-        return sb.toString();
+        return "MemberGroupConfig{interfaces=" + interfaces + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/MultiMapConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MultiMapConfig.java
@@ -300,15 +300,13 @@ public class MultiMapConfig {
 //    }
 
     public String toString() {
-        final StringBuilder sb = new StringBuilder();
-        sb.append("MultiMapConfig");
-        sb.append("{name='").append(name).append('\'');
-        sb.append(", valueCollectionType='").append(valueCollectionType).append('\'');
-        sb.append(", listenerConfigs=").append(listenerConfigs);
-        sb.append(", binary=").append(binary);
-        sb.append(", backupCount=").append(backupCount);
-        sb.append(", asyncBackupCount=").append(asyncBackupCount);
-        sb.append('}');
-        return sb.toString();
+        return "MultiMapConfig{"
+                + "name='" + name + '\''
+                + ", valueCollectionType='" + valueCollectionType + '\''
+                + ", listenerConfigs=" + listenerConfigs
+                + ", binary=" + binary
+                + ", backupCount=" + backupCount
+                + ", asyncBackupCount=" + asyncBackupCount
+                + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/NearCacheConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/NearCacheConfig.java
@@ -414,17 +414,16 @@ public class NearCacheConfig
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder("NearCacheConfig{");
-        sb.append("timeToLiveSeconds=").append(timeToLiveSeconds);
-        sb.append(", maxSize=").append(maxSize);
-        sb.append(", evictionPolicy='").append(evictionPolicy).append('\'');
-        sb.append(", maxIdleSeconds=").append(maxIdleSeconds);
-        sb.append(", invalidateOnChange=").append(invalidateOnChange);
-        sb.append(", inMemoryFormat=").append(inMemoryFormat);
-        sb.append(", cacheLocalEntries=").append(cacheLocalEntries);
-        sb.append(", localUpdatePolicy=").append(localUpdatePolicy);
-        sb.append(", evictionConfig=").append(evictionConfig);
-        sb.append('}');
-        return sb.toString();
+        return "NearCacheConfig{"
+                + "timeToLiveSeconds=" + timeToLiveSeconds
+                + ", maxSize=" + maxSize
+                + ", evictionPolicy='" + evictionPolicy + '\''
+                + ", maxIdleSeconds=" + maxIdleSeconds
+                + ", invalidateOnChange=" + invalidateOnChange
+                + ", inMemoryFormat=" + inMemoryFormat
+                + ", cacheLocalEntries=" + cacheLocalEntries
+                + ", localUpdatePolicy=" + localUpdatePolicy
+                + ", evictionConfig=" + evictionConfig
+                + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/NetworkConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/NetworkConfig.java
@@ -318,18 +318,16 @@ public class NetworkConfig {
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder();
-        sb.append("NetworkConfig {");
-        sb.append("publicAddress='").append(publicAddress).append('\'');
-        sb.append(", port=").append(port);
-        sb.append(", portCount=").append(portCount);
-        sb.append(", portAutoIncrement=").append(portAutoIncrement);
-        sb.append(", join=").append(join);
-        sb.append(", interfaces=").append(interfaces);
-        sb.append(", sslConfig=").append(sslConfig);
-        sb.append(", socketInterceptorConfig=").append(socketInterceptorConfig);
-        sb.append(", symmetricEncryptionConfig=").append(symmetricEncryptionConfig);
-        sb.append('}');
-        return sb.toString();
+        return "NetworkConfig{"
+                + "publicAddress='" + publicAddress + '\''
+                + ", port=" + port
+                + ", portCount=" + portCount
+                + ", portAutoIncrement=" + portAutoIncrement
+                + ", join=" + join
+                + ", interfaces=" + interfaces
+                + ", sslConfig=" + sslConfig
+                + ", socketInterceptorConfig=" + socketInterceptorConfig
+                + ", symmetricEncryptionConfig=" + symmetricEncryptionConfig
+                + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/PartitionGroupConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/PartitionGroupConfig.java
@@ -226,12 +226,10 @@ public class PartitionGroupConfig {
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder();
-        sb.append("PartitionGroupConfig");
-        sb.append("{enabled=").append(enabled);
-        sb.append(", groupType=").append(groupType);
-        sb.append(", memberGroupConfigs=").append(memberGroupConfigs);
-        sb.append('}');
-        return sb.toString();
+        return "PartitionGroupConfig{"
+                + "enabled=" + enabled
+                + ", groupType=" + groupType
+                + ", memberGroupConfigs=" + memberGroupConfigs
+                + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/PartitioningStrategyConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/PartitioningStrategyConfig.java
@@ -72,10 +72,9 @@ public class PartitioningStrategyConfig {
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder("PartitioningStrategyConfig{");
-        sb.append("partitioningStrategyClass='").append(partitioningStrategyClass).append('\'');
-        sb.append(", partitionStrategy=").append(partitionStrategy);
-        sb.append('}');
-        return sb.toString();
+        return "PartitioningStrategyConfig{"
+                + "partitioningStrategyClass='" + partitioningStrategyClass + '\''
+                + ", partitionStrategy=" + partitionStrategy
+                + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/PermissionConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/PermissionConfig.java
@@ -188,14 +188,12 @@ public class PermissionConfig {
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder();
-        sb.append("PermissionConfig");
-        sb.append("{type=").append(type);
-        sb.append(", name='").append(name).append('\'');
-        sb.append(", principal='").append(principal).append('\'');
-        sb.append(", endpoints=").append(endpoints);
-        sb.append(", actions=").append(actions);
-        sb.append('}');
-        return sb.toString();
+        return "PermissionConfig{"
+                + "type=" + type
+                + ", name='" + name + '\''
+                + ", principal='" + principal + '\''
+                + ", endpoints=" + endpoints
+                + ", actions=" + actions
+                + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/PermissionPolicyConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/PermissionPolicyConfig.java
@@ -66,12 +66,10 @@ public class PermissionPolicyConfig {
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder();
-        sb.append("PermissionPolicyConfig");
-        sb.append("{className='").append(className).append('\'');
-        sb.append(", implementation=").append(implementation);
-        sb.append(", properties=").append(properties);
-        sb.append('}');
-        return sb.toString();
+        return "PermissionPolicyConfig{"
+                + "className='" + className + '\''
+                + ", implementation=" + implementation
+                + ", properties=" + properties
+                + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/QueueConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/QueueConfig.java
@@ -155,8 +155,8 @@ public class QueueConfig {
      * @param backupCount the number of synchronous backups to set
      * @return the current QueueConfig
      * @throws IllegalArgumentException if backupCount is smaller than 0,
-     *             or larger than the maximum number of backups,
-     *             or the sum of the backups and async backups is larger than the maximum number of backups
+     *                                  or larger than the maximum number of backups,
+     *                                  or the sum of the backups and async backups is larger than the maximum number of backups
      * @see #setAsyncBackupCount(int)
      */
     public QueueConfig setBackupCount(int backupCount) {
@@ -179,8 +179,8 @@ public class QueueConfig {
      * @param asyncBackupCount the number of asynchronous synchronous backups to set
      * @return the updated QueueConfig
      * @throws IllegalArgumentException if asyncBackupCount smaller than 0,
-     *             or larger than the maximum number of backup
-     *             or the sum of the backups and async backups is larger than the maximum number of backups
+     *                                  or larger than the maximum number of backup
+     *                                  or the sum of the backups and async backups is larger than the maximum number of backups
      * @see #setBackupCount(int)
      * @see #getAsyncBackupCount()
      */
@@ -224,7 +224,7 @@ public class QueueConfig {
      * @param statisticsEnabled True to enable statistics for this queue, false to disable.
      * @return the updated QueueConfig
      */
-   public QueueConfig setStatisticsEnabled(boolean statisticsEnabled) {
+    public QueueConfig setStatisticsEnabled(boolean statisticsEnabled) {
         this.statisticsEnabled = statisticsEnabled;
         return this;
     }
@@ -281,19 +281,17 @@ public class QueueConfig {
         return this;
     }
 
-
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder("QueueConfig{");
-        sb.append("name='").append(name).append('\'');
-        sb.append(", listenerConfigs=").append(listenerConfigs);
-        sb.append(", backupCount=").append(backupCount);
-        sb.append(", asyncBackupCount=").append(asyncBackupCount);
-        sb.append(", maxSize=").append(maxSize);
-        sb.append(", emptyQueueTtl=").append(emptyQueueTtl);
-        sb.append(", queueStoreConfig=").append(queueStoreConfig);
-        sb.append(", statisticsEnabled=").append(statisticsEnabled);
-        sb.append('}');
-        return sb.toString();
+        return "QueueConfig{"
+                + "name='" + name + '\''
+                + ", listenerConfigs=" + listenerConfigs
+                + ", backupCount=" + backupCount
+                + ", asyncBackupCount=" + asyncBackupCount
+                + ", maxSize=" + maxSize
+                + ", emptyQueueTtl=" + emptyQueueTtl
+                + ", queueStoreConfig=" + queueStoreConfig
+                + ", statisticsEnabled=" + statisticsEnabled
+                + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/QueueStoreConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/QueueStoreConfig.java
@@ -119,12 +119,10 @@ public class QueueStoreConfig {
     }
 
     public String toString() {
-        final StringBuilder sb = new StringBuilder();
-        sb.append("QueueStoreConfig");
-        sb.append("{enabled=").append(enabled);
-        sb.append(", className='").append(className).append('\'');
-        sb.append(", properties=").append(properties);
-        sb.append('}');
-        return sb.toString();
+        return "QueueStoreConfig{"
+                + "enabled=" + enabled
+                + ", className='" + className + '\''
+                + ", properties=" + properties
+                + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/SecurityConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/SecurityConfig.java
@@ -124,15 +124,13 @@ public class SecurityConfig {
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder();
-        sb.append("SecurityConfig");
-        sb.append("{enabled=").append(enabled);
-        sb.append(", memberCredentialsConfig=").append(memberCredentialsConfig);
-        sb.append(", memberLoginModuleConfigs=").append(memberLoginModuleConfigs);
-        sb.append(", clientLoginModuleConfigs=").append(clientLoginModuleConfigs);
-        sb.append(", clientPolicyConfig=").append(clientPolicyConfig);
-        sb.append(", clientPermissionConfigs=").append(clientPermissionConfigs);
-        sb.append('}');
-        return sb.toString();
+        return "SecurityConfig{"
+                + "enabled=" + enabled
+                + ", memberCredentialsConfig=" + memberCredentialsConfig
+                + ", memberLoginModuleConfigs=" + memberLoginModuleConfigs
+                + ", clientLoginModuleConfigs=" + clientLoginModuleConfigs
+                + ", clientPolicyConfig=" + clientPolicyConfig
+                + ", clientPermissionConfigs=" + clientPermissionConfigs
+                + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/SemaphoreConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/SemaphoreConfig.java
@@ -175,12 +175,11 @@ public class SemaphoreConfig {
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder("SemaphoreConfig{");
-        sb.append("name='").append(name).append('\'');
-        sb.append(", initialPermits=").append(initialPermits);
-        sb.append(", backupCount=").append(backupCount);
-        sb.append(", asyncBackupCount=").append(asyncBackupCount);
-        sb.append('}');
-        return sb.toString();
+        return "SemaphoreConfig{"
+                + "name='" + name + '\''
+                + ", initialPermits=" + initialPermits
+                + ", backupCount=" + backupCount
+                + ", asyncBackupCount=" + asyncBackupCount
+                + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/SerializationConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/SerializationConfig.java
@@ -442,19 +442,18 @@ public class SerializationConfig {
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder("SerializationConfig{");
-        sb.append("portableVersion=").append(portableVersion);
-        sb.append(", dataSerializableFactoryClasses=").append(dataSerializableFactoryClasses);
-        sb.append(", dataSerializableFactories=").append(dataSerializableFactories);
-        sb.append(", portableFactoryClasses=").append(portableFactoryClasses);
-        sb.append(", portableFactories=").append(portableFactories);
-        sb.append(", globalSerializerConfig=").append(globalSerializerConfig);
-        sb.append(", serializerConfigs=").append(serializerConfigs);
-        sb.append(", checkClassDefErrors=").append(checkClassDefErrors);
-        sb.append(", classDefinitions=").append(classDefinitions);
-        sb.append(", byteOrder=").append(byteOrder);
-        sb.append(", useNativeByteOrder=").append(useNativeByteOrder);
-        sb.append('}');
-        return sb.toString();
+        return "SerializationConfig{"
+                + "portableVersion=" + portableVersion
+                + ", dataSerializableFactoryClasses=" + dataSerializableFactoryClasses
+                + ", dataSerializableFactories=" + dataSerializableFactories
+                + ", portableFactoryClasses=" + portableFactoryClasses
+                + ", portableFactories=" + portableFactories
+                + ", globalSerializerConfig=" + globalSerializerConfig
+                + ", serializerConfigs=" + serializerConfigs
+                + ", checkClassDefErrors=" + checkClassDefErrors
+                + ", classDefinitions=" + classDefinitions
+                + ", byteOrder=" + byteOrder
+                + ", useNativeByteOrder=" + useNativeByteOrder
+                + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/SerializerConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/SerializerConfig.java
@@ -134,12 +134,11 @@ public class SerializerConfig {
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder("SerializerConfig{");
-        sb.append("className='").append(className).append('\'');
-        sb.append(", implementation=").append(implementation);
-        sb.append(", typeClass=").append(typeClass);
-        sb.append(", typeClassName='").append(typeClassName).append('\'');
-        sb.append('}');
-        return sb.toString();
+        return "SerializerConfig{"
+                + "className='" + className + '\''
+                + ", implementation=" + implementation
+                + ", typeClass=" + typeClass
+                + ", typeClassName='" + typeClassName + '\''
+                + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/ServiceConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ServiceConfig.java
@@ -100,13 +100,12 @@ public class ServiceConfig {
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder("ServiceConfig{");
-        sb.append("enabled=").append(enabled);
-        sb.append(", name='").append(name).append('\'');
-        sb.append(", className='").append(className).append('\'');
-        sb.append(", serviceImpl=").append(serviceImpl);
-        sb.append(", properties=").append(properties);
-        sb.append('}');
-        return sb.toString();
+        return "ServiceConfig{"
+                + "enabled=" + enabled
+                + ", name='" + name + '\''
+                + ", className='" + className + '\''
+                + ", serviceImpl=" + serviceImpl
+                + ", properties=" + properties
+                + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/ServicesConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ServicesConfig.java
@@ -70,10 +70,6 @@ public class ServicesConfig {
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder("ServicesConfig{");
-        sb.append("enableDefaults=").append(enableDefaults);
-        sb.append(", services=").append(services);
-        sb.append('}');
-        return sb.toString();
+        return "ServicesConfig{enableDefaults=" + enableDefaults + ", services=" + services + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/SocketInterceptorConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/SocketInterceptorConfig.java
@@ -137,13 +137,11 @@ public class SocketInterceptorConfig {
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder();
-        sb.append("SocketInterceptorConfig");
-        sb.append("{className='").append(className).append('\'');
-        sb.append(", enabled=").append(enabled);
-        sb.append(", implementation=").append(implementation);
-        sb.append(", properties=").append(properties);
-        sb.append('}');
-        return sb.toString();
+        return "SocketInterceptorConfig{"
+                + "className='" + className + '\''
+                + ", enabled=" + enabled
+                + ", implementation=" + implementation
+                + ", properties=" + properties
+                + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/SymmetricEncryptionConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/SymmetricEncryptionConfig.java
@@ -88,13 +88,12 @@ public class SymmetricEncryptionConfig {
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder("SymmetricEncryptionConfig{");
-        sb.append("enabled=").append(enabled);
-        sb.append(", iterationCount=").append(iterationCount);
-        sb.append(", algorithm='").append(algorithm).append('\'');
-        sb.append(", key=").append(Arrays.toString(key));
-        sb.append('}');
-        return sb.toString();
+        return "SymmetricEncryptionConfig{"
+                + "enabled=" + enabled
+                + ", iterationCount=" + iterationCount
+                + ", algorithm='" + algorithm + '\''
+                + ", key=" + Arrays.toString(key)
+                + '}';
     }
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/WanReplicationConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/WanReplicationConfig.java
@@ -68,12 +68,10 @@ public class WanReplicationConfig {
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder();
-        sb.append("WanReplicationConfig");
-        sb.append("{name='").append(name).append('\'');
-        sb.append(", snapshotEnabled=").append(snapshotEnabled);
-        sb.append(", targetClusterConfigs=").append(targetClusterConfigs);
-        sb.append('}');
-        return sb.toString();
+        return "WanReplicationConfig"
+                + "{name='" + name + '\''
+                + ", snapshotEnabled=" + snapshotEnabled
+                + ", targetClusterConfigs=" + targetClusterConfigs
+                + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/WanTargetClusterConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/WanTargetClusterConfig.java
@@ -96,14 +96,12 @@ public class WanTargetClusterConfig {
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder();
-        sb.append("WanTargetClusterConfig");
-        sb.append("{groupName='").append(groupName).append('\'');
-        sb.append(", replicationImpl='").append(replicationImpl).append('\'');
-        sb.append(", replicationImplObject=").append(replicationImplObject);
-        sb.append(", endpoints=").append(endpoints);
-        sb.append(", acknowledgeType=").append(acknowledgeType);
-        sb.append('}');
-        return sb.toString();
+        return "WanTargetClusterConfig{"
+                + "groupName='" + groupName + '\''
+                + ", replicationImpl='" + replicationImpl + '\''
+                + ", replicationImplObject=" + replicationImplObject
+                + ", endpoints=" + endpoints
+                + ", acknowledgeType=" + acknowledgeType
+                + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/core/DistributedObjectEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/DistributedObjectEvent.java
@@ -100,11 +100,10 @@ public class DistributedObjectEvent {
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder("DistributedObjectEvent{");
-        sb.append("eventType=").append(eventType);
-        sb.append(", serviceName='").append(serviceName).append('\'');
-        sb.append(", distributedObject=").append(distributedObject);
-        sb.append('}');
-        return sb.toString();
+        return "DistributedObjectEvent{"
+                + "eventType=" + eventType
+                + ", serviceName='" + serviceName + '\''
+                + ", distributedObject=" + distributedObject
+                + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/core/MigrationEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/MigrationEvent.java
@@ -145,12 +145,11 @@ public class MigrationEvent implements DataSerializable, PartitionEvent {
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder("MigrationEvent{");
-        sb.append("partitionId=").append(partitionId);
-        sb.append(", status=").append(status);
-        sb.append(", oldOwner=").append(oldOwner);
-        sb.append(", newOwner=").append(newOwner);
-        sb.append('}');
-        return sb.toString();
+        return "MigrationEvent{"
+                + "partitionId=" + partitionId
+                + ", status=" + status
+                + ", oldOwner=" + oldOwner
+                + ", newOwner=" + newOwner
+                + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/instance/BuildInfo.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/BuildInfo.java
@@ -61,14 +61,13 @@ public class BuildInfo {
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder("BuildInfo{");
-        sb.append("version='").append(version).append('\'');
-        sb.append(", build='").append(build).append('\'');
-        sb.append(", buildNumber=").append(buildNumber);
-        sb.append(", revision=").append(revision);
-        sb.append(", enterprise=").append(enterprise);
-        sb.append(", serializationVersion=").append(serializationVersion);
-        sb.append('}');
-        return sb.toString();
+        return "BuildInfo{"
+                + "version='" + version + '\''
+                + ", build='" + build + '\''
+                + ", buildNumber=" + buildNumber
+                + ", revision=" + revision
+                + ", enterprise=" + enterprise
+                + ", serializationVersion=" + serializationVersion
+                + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/instance/HazelcastInstanceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/HazelcastInstanceImpl.java
@@ -400,11 +400,6 @@ public class HazelcastInstanceImpl implements HazelcastInstance {
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder();
-        sb.append("HazelcastInstance");
-        sb.append("{name='").append(name).append('\'');
-        sb.append(", node=").append(node.getThisAddress());
-        sb.append('}');
-        return sb.toString();
+        return "HazelcastInstance{name='" + name + "', node=" + node.getThisAddress() + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/instance/Node.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/Node.java
@@ -329,12 +329,8 @@ public class Node {
         int clusterSize = clusterService.getSize();
         if (config.getNetworkConfig().isPortAutoIncrement()
                 && address.getPort() >= config.getNetworkConfig().getPort() + clusterSize) {
-            StringBuilder sb = new StringBuilder("Config seed port is ");
-            sb.append(config.getNetworkConfig().getPort());
-            sb.append(" and cluster size is ");
-            sb.append(clusterSize);
-            sb.append(". Some of the ports seem occupied!");
-            logger.warning(sb.toString());
+            logger.warning("Config seed port is " + config.getNetworkConfig().getPort()
+                    + " and cluster size is " + clusterSize + ". Some of the ports seem occupied!");
         }
         try {
             managementCenterService = new ManagementCenterService(hazelcastInstance);

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/ThreadDumpGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/ThreadDumpGenerator.java
@@ -51,7 +51,7 @@ public final class ThreadDumpGenerator {
         header(s);
         appendThreadInfos(infos, s);
         if (LOGGER.isFinestEnabled()) {
-            LOGGER.finest("\n" + s.toString());
+            LOGGER.finest("\n" + s);
         }
         return s.toString();
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ByteArrayObjectDataInput.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ByteArrayObjectDataInput.java
@@ -694,12 +694,10 @@ class ByteArrayObjectDataInput extends InputStream implements BufferObjectDataIn
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder();
-        sb.append("ByteArrayObjectDataInput");
-        sb.append("{size=").append(size);
-        sb.append(", pos=").append(pos);
-        sb.append(", mark=").append(mark);
-        sb.append('}');
-        return sb.toString();
+        return "ByteArrayObjectDataInput{"
+                + "size=" + size
+                + ", pos=" + pos
+                + ", mark=" + mark
+                + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ByteArrayObjectDataOutput.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ByteArrayObjectDataOutput.java
@@ -429,11 +429,9 @@ class ByteArrayObjectDataOutput extends OutputStream implements BufferObjectData
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder();
-        sb.append("ByteArrayObjectDataOutput");
-        sb.append("{size=").append(buffer != null ? buffer.length : 0);
-        sb.append(", pos=").append(pos);
-        sb.append('}');
-        return sb.toString();
+        return "ByteArrayObjectDataOutput{"
+                + "size=" + (buffer != null ? buffer.length : 0)
+                + ", pos=" + pos
+                + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ByteArraySerializerAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ByteArraySerializerAdapter.java
@@ -65,10 +65,7 @@ class ByteArraySerializerAdapter implements SerializerAdapter {
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder("SerializerAdapter{");
-        sb.append("serializer=").append(serializer);
-        sb.append('}');
-        return sb.toString();
+        return "SerializerAdapter{serializer=" + serializer + '}';
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ClassDefinitionImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ClassDefinitionImpl.java
@@ -147,13 +147,11 @@ public class ClassDefinitionImpl implements ClassDefinition {
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder();
-        sb.append("ClassDefinition");
-        sb.append("{factoryId=").append(factoryId);
-        sb.append(", classId=").append(classId);
-        sb.append(", version=").append(version);
-        sb.append(", fieldDefinitions=").append(fieldDefinitionsMap.values());
-        sb.append('}');
-        return sb.toString();
+        return "ClassDefinition{"
+                + "factoryId=" + factoryId
+                + ", classId=" + classId
+                + ", version=" + version
+                + ", fieldDefinitions=" + fieldDefinitionsMap.values()
+                + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/FieldDefinitionImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/FieldDefinitionImpl.java
@@ -105,13 +105,12 @@ public class FieldDefinitionImpl implements FieldDefinition {
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder("FieldDefinitionImpl{");
-        sb.append("index=").append(index);
-        sb.append(", fieldName='").append(fieldName).append('\'');
-        sb.append(", type=").append(type);
-        sb.append(", classId=").append(classId);
-        sb.append(", factoryId=").append(factoryId);
-        sb.append('}');
-        return sb.toString();
+        return "FieldDefinitionImpl{"
+                + "index=" + index
+                + ", fieldName='" + fieldName + '\''
+                + ", type=" + type
+                + ", classId=" + classId
+                + ", factoryId=" + factoryId
+                + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/HeapData.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/HeapData.java
@@ -160,14 +160,13 @@ public class HeapData implements Data {
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder("DefaultData{");
-        sb.append("type=").append(getType());
-        sb.append(", hashCode=").append(hashCode());
-        sb.append(", partitionHash=").append(getPartitionHash());
-        sb.append(", totalSize=").append(totalSize());
-        sb.append(", dataSize=").append(dataSize());
-        sb.append(", heapCost=").append(getHeapCost());
-        sb.append('}');
-        return sb.toString();
+        return "HeapData{"
+                + "type=" + getType()
+                + ", hashCode=" + hashCode()
+                + ", partitionHash=" + getPartitionHash()
+                + ", totalSize=" + totalSize()
+                + ", dataSize=" + dataSize()
+                + ", heapCost=" + getHeapCost()
+                + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/StreamSerializerAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/StreamSerializerAdapter.java
@@ -63,10 +63,7 @@ class StreamSerializerAdapter implements SerializerAdapter {
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder("SerializerAdapter{");
-        sb.append("serializer=").append(serializer);
-        sb.append('}');
-        return sb.toString();
+        return "StreamSerializerAdapter{serializer=" + serializer + '}';
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/UnsafeObjectDataInput.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/UnsafeObjectDataInput.java
@@ -265,13 +265,11 @@ class UnsafeObjectDataInput extends ByteArrayObjectDataInput {
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder();
-        sb.append("UnsafeObjectDataInput");
-        sb.append("{size=").append(size);
-        sb.append(", pos=").append(pos);
-        sb.append(", mark=").append(mark);
-        sb.append(", byteOrder=").append(getByteOrder());
-        sb.append('}');
-        return sb.toString();
+        return "UnsafeObjectDataInput{"
+                + "size=" + size
+                + ", pos=" + pos
+                + ", mark=" + mark
+                + ", byteOrder=" + getByteOrder()
+                + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/UnsafeObjectDataOutput.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/UnsafeObjectDataOutput.java
@@ -277,12 +277,10 @@ class UnsafeObjectDataOutput extends ByteArrayObjectDataOutput {
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder();
-        sb.append("UnsafeObjectDataOutput");
-        sb.append("{size=").append(buffer != null ? buffer.length : 0);
-        sb.append(", pos=").append(pos);
-        sb.append(", byteOrder=").append(getByteOrder());
-        sb.append('}');
-        return sb.toString();
+        return "UnsafeObjectDataOutput{"
+                + "size=" + (buffer != null ? buffer.length : 0)
+                + ", pos=" + pos
+                + ", byteOrder=" + getByteOrder()
+                + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/client/AbstractTxnMapRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/client/AbstractTxnMapRequest.java
@@ -141,7 +141,7 @@ public abstract class AbstractTxnMapRequest extends BaseTransactionRequest {
                 result = getMapValueCollection(map.values(getPredicate()));
                 break;
             default:
-                throw new IllegalArgumentException("Not a known TxnMapRequestType [" + requestType + "]");
+                throw new IllegalArgumentException("Not a known TxnMapRequestType [" + requestType + ']');
         }
         return result;
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
@@ -769,11 +769,7 @@ public class MapProxyImpl<K, V> extends MapProxySupport implements IMap<K, V>, I
 
     @Override
     public String toString() {
-        StringBuilder sb = new StringBuilder();
-        sb.append("IMap");
-        sb.append("{name='").append(name).append('\'');
-        sb.append('}');
-        return sb.toString();
+        return "IMap{name='" + name + '\'' + '}';
     }
 }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/record/RecordInfo.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/record/RecordInfo.java
@@ -138,23 +138,14 @@ public class RecordInfo implements DataSerializable {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder();
-        builder.append("RecordInfo{");
-        builder.append("statistics=");
-        builder.append(statistics);
-        builder.append(", version=");
-        builder.append(version);
-        builder.append(", evictionCriteriaNumber=");
-        builder.append(evictionCriteriaNumber);
-        builder.append(", ttl=");
-        builder.append(ttl);
-        builder.append(", creationTime=");
-        builder.append(creationTime);
-        builder.append(", lastAccessTime=");
-        builder.append(lastAccessTime);
-        builder.append(", lastUpdateTime=");
-        builder.append(lastUpdateTime);
-        builder.append('}');
-        return builder.toString();
+        return "RecordInfo{"
+                + "statistics=" + statistics
+                + ", version=" + version
+                + ", evictionCriteriaNumber=" + evictionCriteriaNumber
+                + ", ttl=" + ttl
+                + ", creationTime=" + creationTime
+                + ", lastAccessTime=" + lastAccessTime
+                + ", lastUpdateTime=" + lastUpdateTime
+                + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/memory/DefaultMemoryStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/memory/DefaultMemoryStats.java
@@ -84,17 +84,14 @@ public class DefaultMemoryStats implements MemoryStats {
 
     @Override
     public String toString() {
-        StringBuilder sb = new StringBuilder();
-        sb.append("MemoryStats {");
-        sb.append("Total Physical: ").append(MemorySize.toPrettyString(getTotalPhysical()));
-        sb.append(", Free Physical: ").append(MemorySize.toPrettyString(getFreePhysical()));
-        sb.append(", Max Heap: ").append(MemorySize.toPrettyString(getMaxHeap()));
-        sb.append(", Committed Heap: ").append(MemorySize.toPrettyString(getCommittedHeap()));
-        sb.append(", Used Heap: ").append(MemorySize.toPrettyString(getUsedHeap()));
-        sb.append(", Free Heap: ").append(MemorySize.toPrettyString(getFreeHeap()));
-        sb.append(", ");
-        sb.append(getGCStats());
-        sb.append('}');
-        return sb.toString();
+        return "MemoryStats{"
+                + "Total Physical: " + MemorySize.toPrettyString(getTotalPhysical())
+                + ", Free Physical: " + MemorySize.toPrettyString(getFreePhysical())
+                + ", Max Heap: " + MemorySize.toPrettyString(getMaxHeap())
+                + ", Committed Heap: " + MemorySize.toPrettyString(getCommittedHeap())
+                + ", Used Heap: " + MemorySize.toPrettyString(getUsedHeap())
+                + ", Free Heap: " + MemorySize.toPrettyString(getFreeHeap())
+                + ", " + getGCStats()
+                + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapProxySupport.java
@@ -275,10 +275,7 @@ public abstract class MultiMapProxySupport extends AbstractDistributedObject<Mul
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder("MultiMap{");
-        sb.append("name=").append(name);
-        sb.append('}');
-        return sb.toString();
+        return "MultiMap{name=" + name + '}';
     }
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TransactionalMultiMapProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TransactionalMultiMapProxy.java
@@ -90,9 +90,6 @@ public class TransactionalMultiMapProxy<K, V> extends TransactionalMultiMapProxy
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder("TransactionalMultiMap{");
-        sb.append("name=").append(getName());
-        sb.append('}');
-        return sb.toString();
+        return "TransactionalMultiMap{name=" + getName() + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/nio/Address.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/Address.java
@@ -127,7 +127,7 @@ public final class Address implements IdentifiedDataSerializable {
 
     public String getScopedHost() {
         return (isIPv4() || hostSet || scopeId == null) ? getHost()
-                : getHost() + "%" + scopeId;
+                : getHost() + '%' + scopeId;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/nio/Packet.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/Packet.java
@@ -407,14 +407,13 @@ public final class Packet extends HeapData implements OutboundFrame {
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder("Packet{");
-        sb.append("header=").append(header);
-        sb.append(", isResponse=").append(isHeaderSet(Packet.HEADER_RESPONSE));
-        sb.append(", isOperation=").append(isHeaderSet(Packet.HEADER_OP));
-        sb.append(", isEvent=").append(isHeaderSet(Packet.HEADER_EVENT));
-        sb.append(", partitionId=").append(partitionId);
-        sb.append(", conn=").append(conn);
-        sb.append('}');
-        return sb.toString();
+        return "Packet{"
+                + "header=" + header
+                + ", isResponse=" + isHeaderSet(Packet.HEADER_RESPONSE)
+                + ", isOperation=" + isHeaderSet(Packet.HEADER_OP)
+                + ", isEvent=" + isHeaderSet(Packet.HEADER_EVENT)
+                + ", partitionId=" + partitionId
+                + ", conn=" + conn
+                + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/DefaultSocketChannelWrapper.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/DefaultSocketChannelWrapper.java
@@ -99,9 +99,6 @@ public class DefaultSocketChannelWrapper implements SocketChannelWrapper {
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder("DefaultSocketChannelWrapper{");
-        sb.append("socketChannel=").append(socketChannel);
-        sb.append('}');
-        return sb.toString();
+        return "DefaultSocketChannelWrapper{socketChannel=" + socketChannel + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/partition/impl/InternalPartitionServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/impl/InternalPartitionServiceImpl.java
@@ -1677,11 +1677,7 @@ public class InternalPartitionServiceImpl implements InternalPartitionService, M
 
     @Override
     public String toString() {
-        StringBuilder sb = new StringBuilder("PartitionManager[" + stateVersion + "] {\n");
-        sb.append("\n");
-        sb.append("migrationQ: ").append(migrationQueue.size());
-        sb.append("\n}");
-        return sb.toString();
+        return "PartitionManager[" + stateVersion + "] {\n\n" + "migrationQ: " + migrationQueue.size() + "\n}";
     }
 
     public Node getNode() {

--- a/hazelcast/src/main/java/com/hazelcast/partition/membergroup/DefaultMemberGroup.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/membergroup/DefaultMemberGroup.java
@@ -93,10 +93,6 @@ public class DefaultMemberGroup implements MemberGroup {
 
     @Override
     public String toString() {
-        StringBuilder sb = new StringBuilder();
-        sb.append("DefaultMemberGroup");
-        sb.append("{members=").append(members);
-        sb.append('}');
-        return sb.toString();
+        return "DefaultMemberGroup{members=" + members + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/partition/membergroup/SingleMemberGroup.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/membergroup/SingleMemberGroup.java
@@ -124,10 +124,6 @@ public class SingleMemberGroup implements MemberGroup {
 
     @Override
     public String toString() {
-        StringBuilder sb = new StringBuilder();
-        sb.append("SingleMemberGroup");
-        sb.append("{member=").append(member);
-        sb.append('}');
-        return sb.toString();
+        return "SingleMemberGroup{member=" + member + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/query/PredicateBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/PredicateBuilder.java
@@ -118,11 +118,6 @@ public class PredicateBuilder implements IndexAwarePredicate, DataSerializable {
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder();
-        sb.append("PredicateBuilder");
-        sb.append("{\n");
-        sb.append(lsPredicates.size() == 0 ? "" : lsPredicates.get(0));
-        sb.append("\n}");
-        return sb.toString();
+        return "PredicateBuilder{\n" + (lsPredicates.size() == 0 ? "" : lsPredicates.get(0)) + "\n}";
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/AndPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/AndPredicate.java
@@ -119,7 +119,7 @@ public final class AndPredicate implements IndexAwarePredicate, DataSerializable
     @Override
     public String toString() {
         final StringBuilder sb = new StringBuilder();
-        sb.append("(");
+        sb.append('(');
         int size = predicates.length;
         for (int i = 0; i < size; i++) {
             if (i > 0) {
@@ -127,7 +127,7 @@ public final class AndPredicate implements IndexAwarePredicate, DataSerializable
             }
             sb.append(predicates[i]);
         }
-        sb.append(")");
+        sb.append(')');
         return sb.toString();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/ILikePredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/ILikePredicate.java
@@ -32,13 +32,8 @@ public class ILikePredicate extends LikePredicate {
 
     @Override
     public String toString() {
-        StringBuilder builder = new StringBuilder(attributeName)
-                .append(" ILIKE '")
-                .append(expression)
-                .append("'");
-        return builder.toString();
+        return attributeName + " ILIKE '" + expression + "'";
     }
-
 
     @Override
     protected int getFlags() {

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/LikePredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/LikePredicate.java
@@ -89,10 +89,6 @@ public class LikePredicate extends AbstractPredicate {
 
     @Override
     public String toString() {
-        StringBuilder builder = new StringBuilder(attributeName)
-                .append(" LIKE '")
-                .append(expression)
-                .append("'");
-        return builder.toString();
+        return attributeName + " LIKE '" + expression + "'";
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/ReplicatedRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/ReplicatedRecord.java
@@ -195,16 +195,15 @@ public class ReplicatedRecord<K, V> implements IdentifiedDataSerializable {
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder("ReplicatedRecord{");
-        sb.append("key=").append(key);
-        sb.append(", value=").append(value);
-        sb.append(", ttlMillis=").append(ttlMillis);
-        sb.append(", hits=").append(HITS.get(this));
-        sb.append(", creationTime=").append(creationTime);
-        sb.append(", lastAccessTime=").append(lastAccessTime);
-        sb.append(", updateTime=").append(updateTime);
-        sb.append('}');
-        return sb.toString();
+        return "ReplicatedRecord{"
+                + "key=" + key
+                + ", value=" + value
+                + ", ttlMillis=" + ttlMillis
+                + ", hits=" + HITS.get(this)
+                + ", creationTime=" + creationTime
+                + ", lastAccessTime=" + lastAccessTime
+                + ", updateTime=" + updateTime
+                + '}';
     }
 }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/DefaultObjectNamespace.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/DefaultObjectNamespace.java
@@ -91,11 +91,6 @@ public final class DefaultObjectNamespace implements ObjectNamespace {
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder();
-        sb.append("DefaultObjectNamespace");
-        sb.append("{service='").append(service).append('\'');
-        sb.append(", objectName=").append(objectName);
-        sb.append('}');
-        return sb.toString();
+        return "DefaultObjectNamespace{service='" + service + '\'' + ", objectName=" + objectName + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/PartitionMigrationEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/PartitionMigrationEvent.java
@@ -56,11 +56,6 @@ public class PartitionMigrationEvent extends EventObject {
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder();
-        sb.append("PartitionMigrationEvent");
-        sb.append("{migrationEndpoint=").append(migrationEndpoint);
-        sb.append(", partitionId=").append(partitionId);
-        sb.append('}');
-        return sb.toString();
+        return "PartitionMigrationEvent{migrationEndpoint=" + migrationEndpoint + ", partitionId=" + partitionId + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/PartitionReplicationEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/PartitionReplicationEvent.java
@@ -59,10 +59,6 @@ public class PartitionReplicationEvent extends EventObject {
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder("PartitionReplicationEvent{");
-        sb.append("partitionId=").append(partitionId);
-        sb.append(", replicaIndex=").append(replicaIndex);
-        sb.append('}');
-        return sb.toString();
+        return "PartitionReplicationEvent{partitionId=" + partitionId + ", replicaIndex=" + replicaIndex + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/EventEnvelope.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/EventEnvelope.java
@@ -91,11 +91,6 @@ public final class EventEnvelope implements IdentifiedDataSerializable {
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder("EventEnvelope{");
-        sb.append("id='").append(id).append('\'');
-        sb.append(", serviceName='").append(serviceName).append('\'');
-        sb.append(", event=").append(event);
-        sb.append('}');
-        return sb.toString();
+        return "EventEnvelope{id='" + id + "', serviceName='" + serviceName + "', event=" + event + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/EventProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/EventProcessor.java
@@ -113,9 +113,6 @@ public class EventProcessor implements StripedRunnable {
 
     @Override
     public String toString() {
-        StringBuilder sb = new StringBuilder("EventProcessor{");
-        sb.append("envelope=").append(envelope);
-        sb.append('}');
-        return sb.toString();
+        return "EventProcessor{envelope=" + envelope + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/Registration.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/Registration.java
@@ -143,14 +143,12 @@ public class Registration implements EventRegistration {
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder();
-        sb.append("Registration");
-        sb.append("{filter=").append(filter);
-        sb.append(", id='").append(id).append('\'');
-        sb.append(", serviceName='").append(serviceName).append('\'');
-        sb.append(", subscriber=").append(subscriber);
-        sb.append(", listener=").append(listener);
-        sb.append('}');
-        return sb.toString();
+        return "Registration{"
+                + "filter=" + filter
+                + ", id='" + id + '\''
+                + ", serviceName='" + serviceName + '\''
+                + ", subscriber=" + subscriber
+                + ", listener=" + listener
+                + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/Invocation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/Invocation.java
@@ -631,21 +631,19 @@ abstract class Invocation implements OperationResponseHandler, Runnable {
             connectionStr = connection == null ? null : connection.toString();
         }
 
-        StringBuilder sb = new StringBuilder();
-        sb.append("Invocation");
-        sb.append("{ serviceName='").append(serviceName).append('\'');
-        sb.append(", op=").append(op);
-        sb.append(", partitionId=").append(partitionId);
-        sb.append(", replicaIndex=").append(replicaIndex);
-        sb.append(", tryCount=").append(tryCount);
-        sb.append(", tryPauseMillis=").append(tryPauseMillis);
-        sb.append(", invokeCount=").append(invokeCount);
-        sb.append(", callTimeout=").append(callTimeout);
-        sb.append(", target=").append(invTarget);
-        sb.append(", backupsExpected=").append(backupsExpected);
-        sb.append(", backupsCompleted=").append(backupsCompleted);
-        sb.append(", connection=").append(connectionStr);
-        sb.append('}');
-        return sb.toString();
+        return "Invocation{"
+                + "serviceName='" + serviceName + '\''
+                + ", op=" + op
+                + ", partitionId=" + partitionId
+                + ", replicaIndex=" + replicaIndex
+                + ", tryCount=" + tryCount
+                + ", tryPauseMillis=" + tryPauseMillis
+                + ", invokeCount=" + invokeCount
+                + ", callTimeout=" + callTimeout
+                + ", target=" + invTarget
+                + ", backupsExpected=" + backupsExpected
+                + ", backupsCompleted=" + backupsCompleted
+                + ", connection=" + connectionStr
+                + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationFuture.java
@@ -407,12 +407,7 @@ final class InvocationFuture<E> implements InternalCompletableFuture<E> {
 
     @Override
     public String toString() {
-        StringBuilder sb = new StringBuilder("InvocationFuture{");
-        sb.append("invocation=").append(invocation.toString());
-        sb.append(", response=").append(response);
-        sb.append(", done=").append(isDone());
-        sb.append('}');
-        return sb.toString();
+        return "InvocationFuture{invocation=" + invocation.toString() + ", response=" + response + ", done=" + isDone() + '}';
     }
 
     private static final class ExecutionCallbackNode<E> {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/responses/BackupResponse.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/responses/BackupResponse.java
@@ -41,11 +41,6 @@ public final class BackupResponse extends Response {
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder();
-        sb.append("BackupResponse");
-        sb.append("{callId=").append(callId);
-        sb.append(", urgent=").append(urgent);
-        sb.append('}');
-        return sb.toString();
+        return "BackupResponse{callId=" + callId + ", urgent=" + urgent + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/responses/CallTimeoutResponse.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/responses/CallTimeoutResponse.java
@@ -43,12 +43,7 @@ public class CallTimeoutResponse extends Response implements IdentifiedDataSeria
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder();
-        sb.append("CallTimeoutResponse");
-        sb.append("{callId=").append(callId);
-        sb.append(", urgent=").append(urgent);
-        sb.append('}');
-        return sb.toString();
+        return "CallTimeoutResponse{callId=" + callId + ", urgent=" + urgent + '}';
     }
 }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/responses/ErrorResponse.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/responses/ErrorResponse.java
@@ -56,12 +56,6 @@ public class ErrorResponse extends Response {
 
     @Override
     public String toString() {
-        StringBuilder sb = new StringBuilder();
-        sb.append("ErrorResponse");
-        sb.append("{callId=").append(callId);
-        sb.append(", urgent=").append(urgent);
-        sb.append(", cause=").append(cause);
-        sb.append('}');
-        return sb.toString();
+        return "ErrorResponse{callId=" + callId + ", urgent=" + urgent + ", cause=" + cause + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/responses/NormalResponse.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/responses/NormalResponse.java
@@ -105,13 +105,11 @@ public class NormalResponse extends Response {
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder();
-        sb.append("NormalResponse");
-        sb.append("{callId=").append(callId);
-        sb.append(", urgent=").append(urgent);
-        sb.append(", value=").append(value);
-        sb.append(", backupCount=").append(backupCount);
-        sb.append('}');
-        return sb.toString();
+        return "NormalResponse{"
+                + "callId=" + callId
+                + ", urgent=" + urgent
+                + ", value=" + value
+                + ", backupCount=" + backupCount
+                + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/DistributedObjectEventPacket.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/DistributedObjectEventPacket.java
@@ -68,12 +68,10 @@ public final class DistributedObjectEventPacket implements DataSerializable {
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder();
-        sb.append("DistributedObjectEvent");
-        sb.append("{eventType=").append(eventType);
-        sb.append(", serviceName='").append(serviceName).append('\'');
-        sb.append(", name=").append(name);
-        sb.append('}');
-        return sb.toString();
+        return "DistributedObjectEvent{"
+                + "eventType=" + eventType
+                + ", serviceName='" + serviceName + '\''
+                + ", name=" + name
+                + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/ProxyInfo.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/ProxyInfo.java
@@ -35,10 +35,6 @@ public final class ProxyInfo {
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder("ProxyInfo{");
-        sb.append("serviceName='").append(serviceName).append('\'');
-        sb.append(", objectName='").append(objectName).append('\'');
-        sb.append('}');
-        return sb.toString();
+        return "ProxyInfo{serviceName='" + serviceName + "', objectName='" + objectName + "'}";
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/servicemanager/ServiceInfo.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/servicemanager/ServiceInfo.java
@@ -85,10 +85,6 @@ public final class ServiceInfo {
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder("ServiceInfo{");
-        sb.append("name='").append(name).append('\'');
-        sb.append(", service=").append(service);
-        sb.append('}');
-        return sb.toString();
+        return "ServiceInfo{name='" + name + "', service=" + service + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/transaction/TransactionOptions.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/TransactionOptions.java
@@ -174,13 +174,11 @@ public final class TransactionOptions implements DataSerializable {
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder();
-        sb.append("TransactionOptions");
-        sb.append("{timeoutMillis=").append(timeoutMillis);
-        sb.append(", durability=").append(durability);
-        sb.append(", txType=").append(transactionType);
-        sb.append('}');
-        return sb.toString();
+        return "TransactionOptions{"
+                + "timeoutMillis=" + timeoutMillis
+                + ", durability=" + durability
+                + ", txType=" + transactionType
+                + '}';
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionImpl.java
@@ -450,13 +450,11 @@ public class TransactionImpl implements Transaction {
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder();
-        sb.append("Transaction");
-        sb.append("{txnId='").append(txnId).append('\'');
-        sb.append(", state=").append(state);
-        sb.append(", txType=").append(transactionType);
-        sb.append(", timeoutMillis=").append(timeoutMillis);
-        sb.append('}');
-        return sb.toString();
+        return "Transaction{"
+                + "txnId='" + txnId + '\''
+                + ", state=" + state
+                + ", txType=" + transactionType
+                + ", timeoutMillis=" + timeoutMillis
+                + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/SerializableXID.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/SerializableXID.java
@@ -108,11 +108,10 @@ public class SerializableXID implements Xid, DataSerializable {
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder("SerializableXid{");
-        sb.append("formatId=").append(formatId);
-        sb.append(", globalTransactionId=").append(Arrays.toString(globalTransactionId));
-        sb.append(", branchQualifier=").append(Arrays.toString(branchQualifier));
-        sb.append('}');
-        return sb.toString();
+        return "SerializableXid{"
+                + "formatId=" + formatId
+                + ", globalTransactionId=" + Arrays.toString(globalTransactionId)
+                + ", branchQualifier=" + Arrays.toString(branchQualifier)
+                + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/XAResourceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/XAResourceImpl.java
@@ -301,8 +301,6 @@ public final class XAResourceImpl extends AbstractDistributedObject<XAService> i
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder();
-        sb.append("HazelcastXaResource {").append(groupName).append('}');
-        return sb.toString();
+        return "HazelcastXaResource {" + groupName + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/util/AddressUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/AddressUtil.java
@@ -272,22 +272,22 @@ public final class AddressUtil {
                     + addressMatcher);
         }
         final Collection<String> addresses = new HashSet<String>();
-        final String first3 = addressMatcher.address[0] + "."
+        final String first3 = addressMatcher.address[0] + '.'
                 + addressMatcher.address[1]
-                + "."
+                + '.'
                 + addressMatcher.address[2];
         final String lastPart = addressMatcher.address[3];
         final int dashPos;
         if ("*".equals(lastPart)) {
             for (int j = 0; j <= NUMBER_OF_ADDRESSES; j++) {
-                addresses.add(first3 + "." + j);
+                addresses.add(first3 + '.' + j);
             }
         } else if (lastPart.indexOf('-') > 0) {
             dashPos = lastPart.indexOf('-');
             final int start = Integer.parseInt(lastPart.substring(0, dashPos));
             final int end = Integer.parseInt(lastPart.substring(dashPos + 1));
             for (int j = start; j <= end; j++) {
-                addresses.add(first3 + "." + j);
+                addresses.add(first3 + '.' + j);
             }
         } else {
             addresses.add(addressMatcher.getAddress());
@@ -457,10 +457,7 @@ public final class AddressUtil {
 
         @Override
         public String toString() {
-            final StringBuilder sb = new StringBuilder();
-            sb.append("AddressHolder ");
-            sb.append('[').append(address).append("]:").append(port);
-            return sb.toString();
+            return "AddressHolder [" + address + "]:" + port;
         }
 
         public String getAddress() {
@@ -539,12 +536,7 @@ public final class AddressUtil {
 
         @Override
         public String toString() {
-            final StringBuilder sb = new StringBuilder();
-            sb.append(getClass().getSimpleName());
-            sb.append('{');
-            sb.append(getAddress());
-            sb.append('}');
-            return sb.toString();
+            return getClass().getSimpleName() + '{' + getAddress() + '}';
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/util/Clock.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/Clock.java
@@ -115,13 +115,7 @@ public final class Clock {
 
         @Override
         public String toString() {
-            final StringBuilder sb = new StringBuilder();
-            sb.append("SystemOffsetClock");
-            sb.append("{offset=").append(offset);
-            sb.append('}');
-            return sb.toString();
+            return "SystemOffsetClock{offset=" + offset + '}';
         }
     }
-
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/util/scheduler/TimeKey.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/scheduler/TimeKey.java
@@ -65,10 +65,6 @@ final class TimeKey {
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder("TimeKey{");
-        sb.append("key=").append(key);
-        sb.append(",time=").append(time);
-        sb.append('}');
-        return sb.toString();
+        return "TimeKey{" + "key=" + key + ",time=" + time + '}';
     }
 }


### PR DESCRIPTION
Instead of explicitly using a stringbuilder, use string concatination. The JVM will take care of
transforming it to StringBuilder calls.

A lot of verbose code has been replaced with easier to digest code. 