### PR TITLE
Add IAM Role support for jclouds integration.

### DIFF
--- a/hazelcast-jclouds/src/main/java/com/hazelcast/jclouds/IAMRoleCredentialSupplierBuilder.java
+++ b/hazelcast-jclouds/src/main/java/com/hazelcast/jclouds/IAMRoleCredentialSupplierBuilder.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jclouds;
+
+
+import com.hazelcast.config.InvalidConfigurationException;
+import org.jclouds.aws.domain.SessionCredentials;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Build SessionCredentials for JClouds Compute Service API
+ * with IAM Role.
+ */
+
+public class IAMRoleCredentialSupplierBuilder {
+
+    private static final String IAM_ROLE_ENDPOINT = "169.254.169.254";
+
+    private String roleName;
+    private SessionCredentials credentials;
+
+    public IAMRoleCredentialSupplierBuilder() {
+    }
+
+    public IAMRoleCredentialSupplierBuilder withRoleName(String roleName) {
+        this.roleName = roleName;
+        return this;
+    }
+
+    private  Map<String, String> getKeysFromIamRole() {
+        try {
+            String query = "latest/meta-data/iam/security-credentials/" + roleName;
+            URL url = new URL("http", IAM_ROLE_ENDPOINT, query);
+            InputStreamReader is = new InputStreamReader(url.openStream(), "UTF-8");
+            BufferedReader reader = new BufferedReader(is);
+            Map<String, String> map = parseIamRole(reader);
+            return map;
+        } catch (IOException io) {
+            throw new InvalidConfigurationException("Invalid Aws Configuration");
+        }
+    }
+
+    private Map<String, String> parseIamRole(BufferedReader reader) throws IOException {
+        Map map = new HashMap();
+        Pattern keyPattern = Pattern.compile("\"(.*?)\" : ");
+        Pattern valuePattern = Pattern.compile(" : \"(.*?)\",");
+        String line;
+        for (line = reader.readLine(); line != null; line = reader.readLine()) {
+            if (line.contains(":")) {
+                Matcher keyMatcher = keyPattern.matcher(line);
+                Matcher valueMatcher = valuePattern.matcher(line);
+                if (keyMatcher.find() && valueMatcher.find()) {
+                    String key = keyMatcher.group(1);
+                    String value = valueMatcher.group(1);
+                    map.put(key, value);
+                }
+            }
+        }
+        return map;
+    }
+
+    public SessionCredentials build() {
+        Map<String, String> keyMaps = getKeysFromIamRole();
+        credentials = new SessionCredentials.Builder()
+                .accessKeyId(keyMaps.get("AccessKeyId"))
+                .secretAccessKey(keyMaps.get("SecretAccessKey"))
+                .sessionToken(keyMaps.get("Token")).build();
+        return  credentials;
+    }
+}


### PR DESCRIPTION
This pr makes call AWS API defined here http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html#instance-metadata-security-credentials and parses and builds `Credentials` for JClouds API. Parser code is copied from `hazelcast-clouds` module.