### PR TITLE
Fix cluster state transaction's partition & migration handling

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/ClusterServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/ClusterServiceImpl.java
@@ -816,23 +816,30 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
 
     @Override
     public void changeClusterState(ClusterState newState) {
-        clusterStateManager.changeClusterState(newState);
+        int partitionStateVersion = node.getPartitionService().getPartitionStateVersion();
+        clusterStateManager.changeClusterState(newState, partitionStateVersion);
     }
 
     @Override
     public void changeClusterState(ClusterState newState, TransactionOptions options) {
-        clusterStateManager.changeClusterState(newState, options);
+        int partitionStateVersion = node.getPartitionService().getPartitionStateVersion();
+        clusterStateManager.changeClusterState(newState, options, partitionStateVersion);
+    }
+
+    // for testing
+    public void changeClusterState(ClusterState newState, int partitionStateVersion) {
+        clusterStateManager.changeClusterState(newState, partitionStateVersion);
     }
 
     @Override
     public void shutdown() {
-        clusterStateManager.changeClusterState(ClusterState.PASSIVE);
+        changeClusterState(ClusterState.PASSIVE);
         shutdownNodes();
     }
 
     @Override
     public void shutdown(TransactionOptions options) {
-        clusterStateManager.changeClusterState(ClusterState.PASSIVE, options);
+        changeClusterState(ClusterState.PASSIVE, options);
         shutdownNodes();
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <maven.shade.plugin.version>2.2</maven.shade.plugin.version>
         <junit.version>4.12</junit.version>
         <h2.version>1.3.160</h2.version>
-        <mockito.all.version>1.9.5</mockito.all.version>
+        <mockito.all.version>1.10.19</mockito.all.version>
         <log4j.version>1.2.12</log4j.version>
         <log4j2.version>2.0.1</log4j2.version>
         <slf4j.api.version>1.6.0</slf4j.api.version>


### PR DESCRIPTION
- Initial partition assignment must be rejected & fail when cluster state
is not ACTIVE. Partition specific/related invocations must fail immediately
if cluster state is not ACTIVE and initial partition assignments are empty.

- Fixed race issue between cluster state transaction and initial partition
assignment (and also partition rebalancing).