### PR TITLE
DiscoverySPI 2nd/final batch

### DIFF
--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/config/ClientNetworkConfig.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/config/ClientNetworkConfig.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.client.config;
 
-import com.hazelcast.config.DiscoveryStrategiesConfig;
+import com.hazelcast.config.DiscoveryConfig;
 import com.hazelcast.config.SSLConfig;
 import com.hazelcast.config.SocketInterceptorConfig;
 
@@ -41,27 +41,27 @@ public class ClientNetworkConfig {
     private SocketOptions socketOptions = new SocketOptions();
     private SSLConfig sslConfig;
     private ClientAwsConfig clientAwsConfig;
-    private DiscoveryStrategiesConfig discoveryStrategiesConfig;
+    private DiscoveryConfig discoveryConfig;
 
     /**
      * Returns the configuration of the Hazelcast Discovery SPI and configured discovery providers
      *
      * @return Discovery Provider SPI configuration
      */
-    public DiscoveryStrategiesConfig getDiscoveryStrategiesConfig() {
-        if (discoveryStrategiesConfig == null) {
-            discoveryStrategiesConfig = new DiscoveryStrategiesConfig();
+    public DiscoveryConfig getDiscoveryConfig() {
+        if (discoveryConfig == null) {
+            discoveryConfig = new DiscoveryConfig();
         }
-        return discoveryStrategiesConfig;
+        return discoveryConfig;
     }
 
     /**
      * Defines the Discovery Provider SPI configuration
      *
-     * @param discoveryStrategiesConfig the Discovery Provider SPI configuration
+     * @param discoveryConfig the Discovery Provider SPI configuration
      */
-    public void setDiscoveryStrategiesConfig(DiscoveryStrategiesConfig discoveryStrategiesConfig) {
-        this.discoveryStrategiesConfig = discoveryStrategiesConfig;
+    public void setDiscoveryConfig(DiscoveryConfig discoveryConfig) {
+        this.discoveryConfig = discoveryConfig;
     }
 
     /**

--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/config/XmlClientConfigBuilder.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/config/XmlClientConfigBuilder.java
@@ -21,7 +21,7 @@ import com.hazelcast.client.util.RoundRobinLB;
 import com.hazelcast.config.AbstractConfigBuilder;
 import com.hazelcast.config.ConfigLoader;
 import com.hazelcast.config.DiscoveryStrategyConfig;
-import com.hazelcast.config.DiscoveryStrategiesConfig;
+import com.hazelcast.config.DiscoveryConfig;
 import com.hazelcast.config.EvictionConfig;
 import com.hazelcast.config.EvictionPolicy;
 import com.hazelcast.config.InMemoryFormat;
@@ -337,27 +337,27 @@ public class XmlClientConfigBuilder extends AbstractConfigBuilder {
     }
 
     private void handleDiscoveryStrategies(Node node, ClientNetworkConfig clientNetworkConfig) {
-        final DiscoveryStrategiesConfig discoveryStrategiesConfig = clientNetworkConfig.getDiscoveryStrategiesConfig();
+        final DiscoveryConfig discoveryConfig = clientNetworkConfig.getDiscoveryConfig();
         for (Node child : new IterableNodeList(node.getChildNodes())) {
             final String name = cleanNodeName(child.getNodeName());
             if ("discovery-strategy".equals(name)) {
-                handleDiscoveryStrategy(child, discoveryStrategiesConfig);
+                handleDiscoveryStrategy(child, discoveryConfig);
             } else if ("node-filter".equals(name)) {
-                handleDiscoveryNodeFilter(child, discoveryStrategiesConfig);
+                handleDiscoveryNodeFilter(child, discoveryConfig);
             }
         }
     }
 
-    private void handleDiscoveryNodeFilter(Node node, DiscoveryStrategiesConfig discoveryStrategiesConfig) {
+    private void handleDiscoveryNodeFilter(Node node, DiscoveryConfig discoveryConfig) {
         final NamedNodeMap atts = node.getAttributes();
 
         final Node att = atts.getNamedItem("class");
         if (att != null) {
-            discoveryStrategiesConfig.setNodeFilterClass(getTextContent(att).trim());
+            discoveryConfig.setNodeFilterClass(getTextContent(att).trim());
         }
     }
 
-    private void handleDiscoveryStrategy(Node node, DiscoveryStrategiesConfig discoveryStrategiesConfig) {
+    private void handleDiscoveryStrategy(Node node, DiscoveryConfig discoveryConfig) {
         final NamedNodeMap atts = node.getAttributes();
 
         boolean enabled = false;
@@ -385,7 +385,7 @@ public class XmlClientConfigBuilder extends AbstractConfigBuilder {
             }
         }
 
-        discoveryStrategiesConfig.addDiscoveryProviderConfig(new DiscoveryStrategyConfig(clazz, properties));
+        discoveryConfig.addDiscoveryProviderConfig(new DiscoveryStrategyConfig(clazz, properties));
     }
 
     private void handleAWS(Node node, ClientNetworkConfig clientNetworkConfig) {

--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
@@ -46,7 +46,7 @@ import com.hazelcast.concurrent.idgen.IdGeneratorService;
 import com.hazelcast.concurrent.lock.LockServiceImpl;
 import com.hazelcast.concurrent.semaphore.SemaphoreService;
 import com.hazelcast.config.Config;
-import com.hazelcast.config.DiscoveryStrategiesConfig;
+import com.hazelcast.config.DiscoveryConfig;
 import com.hazelcast.config.GroupConfig;
 import com.hazelcast.core.Client;
 import com.hazelcast.core.ClientService;
@@ -86,10 +86,11 @@ import com.hazelcast.ringbuffer.Ringbuffer;
 import com.hazelcast.ringbuffer.impl.RingbufferService;
 import com.hazelcast.security.Credentials;
 import com.hazelcast.security.UsernamePasswordCredentials;
-import com.hazelcast.spi.discovery.DiscoveryMode;
 import com.hazelcast.spi.discovery.impl.DefaultDiscoveryServiceProvider;
+import com.hazelcast.spi.discovery.integration.DiscoveryMode;
 import com.hazelcast.spi.discovery.integration.DiscoveryService;
 import com.hazelcast.spi.discovery.integration.DiscoveryServiceProvider;
+import com.hazelcast.spi.discovery.integration.DiscoveryServiceSettings;
 import com.hazelcast.spi.impl.SerializationServiceSupport;
 import com.hazelcast.topic.impl.TopicService;
 import com.hazelcast.topic.impl.reliable.ReliableTopicService;
@@ -203,15 +204,20 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
 
     private DiscoveryService initDiscoveryService(ClientConfig config) {
         ClientNetworkConfig networkConfig = config.getNetworkConfig();
-        DiscoveryStrategiesConfig discoveryStrategiesConfig = networkConfig.getDiscoveryStrategiesConfig().getAsReadOnly();
-        if (discoveryStrategiesConfig == null || !discoveryStrategiesConfig.isEnabled()) {
+        DiscoveryConfig discoveryConfig = networkConfig.getDiscoveryConfig().getAsReadOnly();
+        if (discoveryConfig == null || !discoveryConfig.isEnabled()) {
             return null;
         }
-        DiscoveryServiceProvider factory = discoveryStrategiesConfig.getDiscoveryServiceProvider();
+        DiscoveryServiceProvider factory = discoveryConfig.getDiscoveryServiceProvider();
         if (factory == null) {
             factory = new DefaultDiscoveryServiceProvider();
         }
-        return factory.newDiscoveryService(DiscoveryMode.Client, discoveryStrategiesConfig, config.getClassLoader());
+        ILogger logger = Logger.getLogger(DiscoveryService.class);
+
+        DiscoveryServiceSettings settings = new DiscoveryServiceSettings().setConfigClassLoader(config.getClassLoader())
+                .setLogger(logger).setDiscoveryMode(DiscoveryMode.Client).setDiscoveryConfig(discoveryConfig);
+
+        return factory.newDiscoveryService(settings);
     }
 
     private LoadBalancer initLoadBalancer(ClientConfig config) {

--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/spi/impl/discovery/DiscoveryAddressProvider.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/spi/impl/discovery/DiscoveryAddressProvider.java
@@ -20,7 +20,7 @@ import com.hazelcast.client.connection.AddressProvider;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.nio.Address;
-import com.hazelcast.spi.discovery.DiscoveredNode;
+import com.hazelcast.spi.discovery.DiscoveryNode;
 import com.hazelcast.spi.discovery.integration.DiscoveryService;
 
 import java.net.InetSocketAddress;
@@ -41,11 +41,11 @@ public class DiscoveryAddressProvider
 
     @Override
     public Collection<InetSocketAddress> loadAddresses() {
-        Iterable<DiscoveredNode> discoveredNodes = discoveryService.discoverNodes();
+        Iterable<DiscoveryNode> discoveredNodes = discoveryService.discoverNodes();
 
         Collection<InetSocketAddress> possibleMembers = new ArrayList<InetSocketAddress>();
-        for (DiscoveredNode discoveredNode : discoveredNodes) {
-            Address discoveredAddress = discoveredNode.getPrivateAddress();
+        for (DiscoveryNode discoveryNode : discoveredNodes) {
+            Address discoveredAddress = discoveryNode.getPrivateAddress();
             try {
                 possibleMembers.add(discoveredAddress.getInetSocketAddress());
             } catch (UnknownHostException e) {

--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/spi/impl/discovery/DiscoveryAddressTranslator.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/spi/impl/discovery/DiscoveryAddressTranslator.java
@@ -18,7 +18,7 @@ package com.hazelcast.client.spi.impl.discovery;
 
 import com.hazelcast.client.connection.AddressTranslator;
 import com.hazelcast.nio.Address;
-import com.hazelcast.spi.discovery.DiscoveredNode;
+import com.hazelcast.spi.discovery.DiscoveryNode;
 import com.hazelcast.spi.discovery.integration.DiscoveryService;
 
 import java.util.HashMap;
@@ -64,11 +64,11 @@ public class DiscoveryAddressTranslator
 
     @Override
     public void refresh() {
-        Iterable<DiscoveredNode> discoveredNodes = discoveryService.discoverNodes();
+        Iterable<DiscoveryNode> discoveredNodes = discoveryService.discoverNodes();
 
         Map<Address, Address> privateToPublic = new HashMap<Address, Address>();
-        for (DiscoveredNode discoveredNode : discoveredNodes) {
-            privateToPublic.put(discoveredNode.getPrivateAddress(), discoveredNode.getPublicAddress());
+        for (DiscoveryNode discoveryNode : discoveredNodes) {
+            privateToPublic.put(discoveryNode.getPrivateAddress(), discoveryNode.getPublicAddress());
         }
         this.privateToPublic = privateToPublic;
     }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientNetworkConfig.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientNetworkConfig.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.client.config;
 
-import com.hazelcast.config.DiscoveryStrategiesConfig;
+import com.hazelcast.config.DiscoveryConfig;
 import com.hazelcast.config.SSLConfig;
 import com.hazelcast.config.SocketInterceptorConfig;
 
@@ -41,28 +41,28 @@ public class ClientNetworkConfig {
     private SocketOptions socketOptions = new SocketOptions();
     private SSLConfig sslConfig;
     private ClientAwsConfig clientAwsConfig;
-    private DiscoveryStrategiesConfig discoveryStrategiesConfig;
+    private DiscoveryConfig discoveryConfig;
 
     /**
      * Returns the configuration of the Hazelcast Discovery SPI and configured discovery providers
      *
      * @return Discovery Provider SPI configuration
      */
-    public DiscoveryStrategiesConfig getDiscoveryStrategiesConfig() {
-        if (discoveryStrategiesConfig == null) {
-            discoveryStrategiesConfig = new DiscoveryStrategiesConfig();
+    public DiscoveryConfig getDiscoveryConfig() {
+        if (discoveryConfig == null) {
+            discoveryConfig = new DiscoveryConfig();
         }
-        return discoveryStrategiesConfig;
+        return discoveryConfig;
     }
 
     /**
      * Defines the Discovery Provider SPI configuration. If <tt>null</tt> is given as the argument it will
      * reset the discovery strategies to defaults.
      *
-     * @param discoveryStrategiesConfig the Discovery Provider SPI configuration
+     * @param discoveryConfig the Discovery Provider SPI configuration
      */
-    public void setDiscoveryStrategiesConfig(DiscoveryStrategiesConfig discoveryStrategiesConfig) {
-        this.discoveryStrategiesConfig = discoveryStrategiesConfig;
+    public void setDiscoveryConfig(DiscoveryConfig discoveryConfig) {
+        this.discoveryConfig = discoveryConfig;
     }
 
     /**

--- a/hazelcast-client/src/main/java/com/hazelcast/client/config/XmlClientConfigBuilder.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/config/XmlClientConfigBuilder.java
@@ -21,7 +21,7 @@ import com.hazelcast.client.util.RoundRobinLB;
 import com.hazelcast.config.AbstractConfigBuilder;
 import com.hazelcast.config.ConfigLoader;
 import com.hazelcast.config.DiscoveryStrategyConfig;
-import com.hazelcast.config.DiscoveryStrategiesConfig;
+import com.hazelcast.config.DiscoveryConfig;
 import com.hazelcast.config.EvictionConfig;
 import com.hazelcast.config.EvictionPolicy;
 import com.hazelcast.config.InMemoryFormat;
@@ -338,27 +338,27 @@ public class XmlClientConfigBuilder extends AbstractConfigBuilder {
     }
 
     private void handleDiscoveryStrategies(Node node, ClientNetworkConfig clientNetworkConfig) {
-        DiscoveryStrategiesConfig discoveryStrategiesConfig = clientNetworkConfig.getDiscoveryStrategiesConfig();
+        DiscoveryConfig discoveryConfig = clientNetworkConfig.getDiscoveryConfig();
         for (Node child : new IterableNodeList(node.getChildNodes())) {
             String name = cleanNodeName(child.getNodeName());
             if ("discovery-strategy".equals(name)) {
-                handleDiscoveryStrategy(child, discoveryStrategiesConfig);
+                handleDiscoveryStrategy(child, discoveryConfig);
             } else if ("node-filter".equals(name)) {
-                handleDiscoveryNodeFilter(child, discoveryStrategiesConfig);
+                handleDiscoveryNodeFilter(child, discoveryConfig);
             }
         }
     }
 
-    private void handleDiscoveryNodeFilter(Node node, DiscoveryStrategiesConfig discoveryStrategiesConfig) {
+    private void handleDiscoveryNodeFilter(Node node, DiscoveryConfig discoveryConfig) {
         NamedNodeMap atts = node.getAttributes();
 
         Node att = atts.getNamedItem("class");
         if (att != null) {
-            discoveryStrategiesConfig.setNodeFilterClass(getTextContent(att).trim());
+            discoveryConfig.setNodeFilterClass(getTextContent(att).trim());
         }
     }
 
-    private void handleDiscoveryStrategy(Node node, DiscoveryStrategiesConfig discoveryStrategiesConfig) {
+    private void handleDiscoveryStrategy(Node node, DiscoveryConfig discoveryConfig) {
         NamedNodeMap atts = node.getAttributes();
 
         boolean enabled = false;
@@ -386,7 +386,7 @@ public class XmlClientConfigBuilder extends AbstractConfigBuilder {
             }
         }
 
-        discoveryStrategiesConfig.addDiscoveryProviderConfig(new DiscoveryStrategyConfig(clazz, properties));
+        discoveryConfig.addDiscoveryProviderConfig(new DiscoveryStrategyConfig(clazz, properties));
     }
 
     private void handleAWS(Node node, ClientNetworkConfig clientNetworkConfig) {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
@@ -45,7 +45,7 @@ import com.hazelcast.concurrent.idgen.IdGeneratorService;
 import com.hazelcast.concurrent.lock.LockServiceImpl;
 import com.hazelcast.concurrent.semaphore.SemaphoreService;
 import com.hazelcast.config.Config;
-import com.hazelcast.config.DiscoveryStrategiesConfig;
+import com.hazelcast.config.DiscoveryConfig;
 import com.hazelcast.config.GroupConfig;
 import com.hazelcast.core.Client;
 import com.hazelcast.core.ClientService;
@@ -86,10 +86,11 @@ import com.hazelcast.ringbuffer.Ringbuffer;
 import com.hazelcast.ringbuffer.impl.RingbufferService;
 import com.hazelcast.security.Credentials;
 import com.hazelcast.security.UsernamePasswordCredentials;
-import com.hazelcast.spi.discovery.DiscoveryMode;
 import com.hazelcast.spi.discovery.impl.DefaultDiscoveryServiceProvider;
+import com.hazelcast.spi.discovery.integration.DiscoveryMode;
 import com.hazelcast.spi.discovery.integration.DiscoveryService;
 import com.hazelcast.spi.discovery.integration.DiscoveryServiceProvider;
+import com.hazelcast.spi.discovery.integration.DiscoveryServiceSettings;
 import com.hazelcast.spi.impl.SerializableList;
 import com.hazelcast.spi.impl.SerializationServiceSupport;
 import com.hazelcast.topic.impl.TopicService;
@@ -203,15 +204,20 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
 
     private DiscoveryService initDiscoveryService(ClientConfig config) {
         ClientNetworkConfig networkConfig = config.getNetworkConfig();
-        DiscoveryStrategiesConfig discoveryStrategiesConfig = networkConfig.getDiscoveryStrategiesConfig().getAsReadOnly();
-        if (discoveryStrategiesConfig == null || !discoveryStrategiesConfig.isEnabled()) {
+        DiscoveryConfig discoveryConfig = networkConfig.getDiscoveryConfig().getAsReadOnly();
+        if (discoveryConfig == null || !discoveryConfig.isEnabled()) {
             return null;
         }
-        DiscoveryServiceProvider factory = discoveryStrategiesConfig.getDiscoveryServiceProvider();
+        DiscoveryServiceProvider factory = discoveryConfig.getDiscoveryServiceProvider();
         if (factory == null) {
             factory = new DefaultDiscoveryServiceProvider();
         }
-        return factory.newDiscoveryService(DiscoveryMode.Client, discoveryStrategiesConfig, config.getClassLoader());
+        ILogger logger = Logger.getLogger(DiscoveryService.class);
+
+        DiscoveryServiceSettings settings = new DiscoveryServiceSettings().setConfigClassLoader(config.getClassLoader())
+                .setLogger(logger).setDiscoveryMode(DiscoveryMode.Client).setDiscoveryConfig(discoveryConfig);
+
+        return factory.newDiscoveryService(settings);
     }
 
     private LoadBalancer initLoadBalancer(ClientConfig config) {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/discovery/DiscoveryAddressProvider.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/discovery/DiscoveryAddressProvider.java
@@ -20,7 +20,7 @@ import com.hazelcast.client.connection.AddressProvider;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.nio.Address;
-import com.hazelcast.spi.discovery.DiscoveredNode;
+import com.hazelcast.spi.discovery.DiscoveryNode;
 import com.hazelcast.spi.discovery.integration.DiscoveryService;
 
 import java.net.InetSocketAddress;
@@ -43,8 +43,8 @@ public class DiscoveryAddressProvider
     @Override
     public Collection<InetSocketAddress> loadAddresses() {
         Collection<InetSocketAddress> possibleMembers = new ArrayList<InetSocketAddress>();
-        for (DiscoveredNode discoveredNode : discoveryService.discoverNodes()) {
-            Address discoveredAddress = discoveredNode.getPrivateAddress();
+        for (DiscoveryNode discoveryNode : discoveryService.discoverNodes()) {
+            Address discoveredAddress = discoveryNode.getPrivateAddress();
             try {
                 possibleMembers.add(discoveredAddress.getInetSocketAddress());
             } catch (UnknownHostException e) {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/discovery/DiscoveryAddressTranslator.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/discovery/DiscoveryAddressTranslator.java
@@ -18,7 +18,7 @@ package com.hazelcast.client.spi.impl.discovery;
 
 import com.hazelcast.client.connection.AddressTranslator;
 import com.hazelcast.nio.Address;
-import com.hazelcast.spi.discovery.DiscoveredNode;
+import com.hazelcast.spi.discovery.DiscoveryNode;
 import com.hazelcast.spi.discovery.integration.DiscoveryService;
 
 import java.util.HashMap;
@@ -64,11 +64,11 @@ public class DiscoveryAddressTranslator
 
     @Override
     public void refresh() {
-        Iterable<DiscoveredNode> discoveredNodes = discoveryService.discoverNodes();
+        Iterable<DiscoveryNode> discoveredNodes = discoveryService.discoverNodes();
 
         Map<Address, Address> privateToPublic = new HashMap<Address, Address>();
-        for (DiscoveredNode discoveredNode : discoveredNodes) {
-            privateToPublic.put(discoveredNode.getPrivateAddress(), discoveredNode.getPublicAddress());
+        for (DiscoveryNode discoveryNode : discoveredNodes) {
+            privateToPublic.put(discoveryNode.getPrivateAddress(), discoveryNode.getPublicAddress());
         }
         this.privateToPublic = privateToPublic;
     }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/spi/impl/discovery/ClientDiscoverySpiTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/spi/impl/discovery/ClientDiscoverySpiTest.java
@@ -16,30 +16,37 @@
 
 package com.hazelcast.client.spi.impl.discovery;
 
+import com.hazelcast.client.HazelcastClient;
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.config.ClientNetworkConfig;
 import com.hazelcast.client.config.XmlClientConfigBuilder;
-import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.client.connection.AddressTranslator;
 import com.hazelcast.config.AwsConfig;
 import com.hazelcast.config.Config;
-import com.hazelcast.config.DiscoveryStrategiesConfig;
+import com.hazelcast.config.DiscoveryConfig;
 import com.hazelcast.config.DiscoveryStrategyConfig;
 import com.hazelcast.config.InterfacesConfig;
+import com.hazelcast.config.JoinConfig;
 import com.hazelcast.config.properties.PropertyDefinition;
 import com.hazelcast.config.properties.PropertyTypeConverter;
 import com.hazelcast.config.properties.SimplePropertyDefinition;
+import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
 import com.hazelcast.nio.Address;
-import com.hazelcast.spi.discovery.DiscoveredNode;
-import com.hazelcast.spi.discovery.DiscoveryMode;
-import com.hazelcast.spi.discovery.integration.DiscoveryService;
-import com.hazelcast.spi.discovery.integration.DiscoveryServiceProvider;
+import com.hazelcast.spi.discovery.AbstractDiscoveryStrategy;
+import com.hazelcast.spi.discovery.DiscoveryNode;
 import com.hazelcast.spi.discovery.DiscoveryStrategy;
 import com.hazelcast.spi.discovery.DiscoveryStrategyFactory;
 import com.hazelcast.spi.discovery.NodeFilter;
-import com.hazelcast.spi.discovery.SimpleDiscoveredNode;
+import com.hazelcast.spi.discovery.SimpleDiscoveryNode;
 import com.hazelcast.spi.discovery.impl.DefaultDiscoveryService;
 import com.hazelcast.spi.discovery.impl.DefaultDiscoveryServiceProvider;
+import com.hazelcast.spi.discovery.integration.DiscoveryMode;
+import com.hazelcast.spi.discovery.integration.DiscoveryService;
+import com.hazelcast.spi.discovery.integration.DiscoveryServiceProvider;
+import com.hazelcast.spi.discovery.integration.DiscoveryServiceSettings;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
@@ -47,7 +54,6 @@ import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
-import org.xml.sax.SAXException;
 
 import javax.xml.XMLConstants;
 import javax.xml.transform.Source;
@@ -63,12 +69,18 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
 public class ClientDiscoverySpiTest extends HazelcastTestSupport {
+
+    private static final ILogger LOGGER = Logger.getLogger(ClientDiscoverySpiTest.class);
 
     @Test
     public void testSchema() throws Exception {
@@ -95,12 +107,12 @@ public class ClientDiscoverySpiTest extends HazelcastTestSupport {
         AwsConfig awsConfig = networkConfig.getAwsConfig();
         assertNull(awsConfig);
 
-        DiscoveryStrategiesConfig discoveryStrategiesConfig = networkConfig.getDiscoveryStrategiesConfig();
-        assertTrue(discoveryStrategiesConfig.isEnabled());
+        DiscoveryConfig discoveryConfig = networkConfig.getDiscoveryConfig();
+        assertTrue(discoveryConfig.isEnabled());
 
-        assertEquals(1, discoveryStrategiesConfig.getDiscoveryStrategyConfigs().size());
+        assertEquals(1, discoveryConfig.getDiscoveryStrategyConfigs().size());
 
-        DiscoveryStrategyConfig providerConfig = discoveryStrategiesConfig.getDiscoveryStrategyConfigs().iterator().next();
+        DiscoveryStrategyConfig providerConfig = discoveryConfig.getDiscoveryStrategyConfigs().iterator().next();
 
         assertEquals(3, providerConfig.getProperties().size());
         assertEquals("foo", providerConfig.getProperties().get("key-string"));
@@ -110,25 +122,40 @@ public class ClientDiscoverySpiTest extends HazelcastTestSupport {
 
     @Test
     public void testNodeStartup() {
-        TestHazelcastFactory factory = new TestHazelcastFactory();
-
         Config config = new Config();
+        config.setProperty("hazelcast.discovery.enabled", "true");
+
         config.getNetworkConfig().setPort(50001);
         InterfacesConfig interfaces = config.getNetworkConfig().getInterfaces();
         interfaces.clear();
         interfaces.setEnabled(true);
         interfaces.addInterface("127.0.0.1");
 
-        final HazelcastInstance hazelcastInstance1 = factory.newHazelcastInstance(config);
-        final HazelcastInstance hazelcastInstance2 = factory.newHazelcastInstance(config);
-        final HazelcastInstance hazelcastInstance3 = factory.newHazelcastInstance(config);
+        List<DiscoveryNode> discoveryNodes = new CopyOnWriteArrayList<DiscoveryNode>();
+        DiscoveryStrategyFactory factory = new CollectingDiscoveryStrategyFactory(discoveryNodes);
+
+        JoinConfig join = config.getNetworkConfig().getJoin();
+        join.getTcpIpConfig().setEnabled(false);
+        join.getMulticastConfig().setEnabled(false);
+        DiscoveryConfig discoveryConfig = join.getDiscoveryConfig();
+        discoveryConfig.getDiscoveryStrategyConfigs().clear();
+
+        DiscoveryStrategyConfig strategyConfig = new DiscoveryStrategyConfig(factory, Collections.<String, Comparable>emptyMap());
+        discoveryConfig.addDiscoveryProviderConfig(strategyConfig);
+
+        final HazelcastInstance hazelcastInstance1 = Hazelcast.newHazelcastInstance(config);
+        final HazelcastInstance hazelcastInstance2 = Hazelcast.newHazelcastInstance(config);
+        final HazelcastInstance hazelcastInstance3 = Hazelcast.newHazelcastInstance(config);
 
         try {
-            String xmlFileName = "hazelcast-client-discovery-spi-test.xml";
-            InputStream xmlResource = ClientDiscoverySpiTest.class.getClassLoader().getResourceAsStream(xmlFileName);
+            ClientConfig clientConfig = new ClientConfig();
+            discoveryConfig = clientConfig.getNetworkConfig().getDiscoveryConfig();
+            discoveryConfig.getDiscoveryStrategyConfigs().clear();
 
-            ClientConfig clientConfig = new XmlClientConfigBuilder(xmlResource).build();
-            final HazelcastInstance client = factory.newHazelcastClient(clientConfig);
+            strategyConfig = new DiscoveryStrategyConfig(factory, Collections.<String, Comparable>emptyMap());
+            discoveryConfig.addDiscoveryProviderConfig(strategyConfig);
+
+            final HazelcastInstance client = HazelcastClient.newHazelcastClient(clientConfig);
 
             assertNotNull(hazelcastInstance1);
             assertNotNull(hazelcastInstance2);
@@ -147,7 +174,8 @@ public class ClientDiscoverySpiTest extends HazelcastTestSupport {
                 }
             });
         } finally {
-            factory.shutdownAll();
+            HazelcastClient.shutdownAll();
+            Hazelcast.shutdownAll();
         }
     }
 
@@ -159,13 +187,10 @@ public class ClientDiscoverySpiTest extends HazelcastTestSupport {
 
         ClientNetworkConfig networkConfig = clientConfig.getNetworkConfig();
 
-        DiscoveryStrategiesConfig discoveryStrategiesConfig = networkConfig.getDiscoveryStrategiesConfig();
-        assertNotNull(discoveryStrategiesConfig);
-        assertNotNull(discoveryStrategiesConfig.getNodeFilterClass());
+        DiscoveryConfig discoveryConfig = networkConfig.getDiscoveryConfig();
 
         DiscoveryServiceProvider provider = new DefaultDiscoveryServiceProvider();
-        DiscoveryService discoveryService = provider.newDiscoveryService(DiscoveryMode.Client,
-                discoveryStrategiesConfig, ClientDiscoverySpiTest.class.getClassLoader());
+        DiscoveryService discoveryService = provider.newDiscoveryService(buildDiscoveryServiceSettings(discoveryConfig));
 
         discoveryService.start();
         discoveryService.discoverNodes();
@@ -179,27 +204,56 @@ public class ClientDiscoverySpiTest extends HazelcastTestSupport {
         assertEquals(4, nodeFilter.getNodes().size());
     }
 
+    @Test
+    public void test_discovery_address_translator() throws Exception {
+        String xmlFileName = "hazelcast-client-discovery-spi-test.xml";
+        InputStream xmlResource = ClientDiscoverySpiTest.class.getClassLoader().getResourceAsStream(xmlFileName);
+        ClientConfig clientConfig = new XmlClientConfigBuilder(xmlResource).build();
+
+        ClientNetworkConfig networkConfig = clientConfig.getNetworkConfig();
+
+        DiscoveryConfig discoveryConfig = networkConfig.getDiscoveryConfig();
+
+        DiscoveryServiceProvider provider = new DefaultDiscoveryServiceProvider();
+        DiscoveryService discoveryService = provider.newDiscoveryService(buildDiscoveryServiceSettings(discoveryConfig));
+
+        AddressTranslator translator = new DiscoveryAddressTranslator(discoveryService);
+
+        Address address = new Address("127.0.0.1", 50001);
+
+        assertNull(translator.translate(null));
+        assertEquals(address, translator.translate(address));
+
+        // Enforce refresh of the internal mapping
+        assertEquals(address, translator.translate(address));
+    }
+
+    private DiscoveryServiceSettings buildDiscoveryServiceSettings(DiscoveryConfig config) {
+        return new DiscoveryServiceSettings().setConfigClassLoader(ClientDiscoverySpiTest.class.getClassLoader())
+                                             .setDiscoveryConfig(config).setDiscoveryMode(DiscoveryMode.Client).setLogger(LOGGER);
+    }
+
     private static class TestDiscoveryStrategy implements DiscoveryStrategy {
 
         @Override
-        public void start(DiscoveryMode discoveryMode) {
+        public void start() {
         }
 
         @Override
-        public Collection<DiscoveredNode> discoverNodes() {
+        public Collection<DiscoveryNode> discoverNodes() {
             try {
-                List<DiscoveredNode> discoveredNodes = new ArrayList<DiscoveredNode>(4);
+                List<DiscoveryNode> discoveryNodes = new ArrayList<DiscoveryNode>(4);
                 Address privateAddress = new Address("127.0.0.1", 1);
                 Address publicAddress = new Address("127.0.0.1", 50001);
-                discoveredNodes.add(new SimpleDiscoveredNode(privateAddress, publicAddress));
+                discoveryNodes.add(new SimpleDiscoveryNode(privateAddress, publicAddress));
                 publicAddress = new Address("127.0.0.1", 50002);
-                discoveredNodes.add(new SimpleDiscoveredNode(privateAddress, publicAddress));
+                discoveryNodes.add(new SimpleDiscoveryNode(privateAddress, publicAddress));
                 publicAddress = new Address("127.0.0.1", 50003);
-                discoveredNodes.add(new SimpleDiscoveredNode(privateAddress, publicAddress));
+                discoveryNodes.add(new SimpleDiscoveryNode(privateAddress, publicAddress));
                 publicAddress = new Address("127.0.0.1", 50004);
-                discoveredNodes.add(new SimpleDiscoveredNode(privateAddress, publicAddress));
+                discoveryNodes.add(new SimpleDiscoveryNode(privateAddress, publicAddress));
 
-                return discoveredNodes;
+                return discoveryNodes;
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }
@@ -229,7 +283,8 @@ public class ClientDiscoverySpiTest extends HazelcastTestSupport {
         }
 
         @Override
-        public DiscoveryStrategy newDiscoveryStrategy(Map<String, Comparable> properties) {
+        public DiscoveryStrategy newDiscoveryStrategy(DiscoveryNode discoveryNode, ILogger logger,
+                                                      Map<String, Comparable> properties) {
             return new TestDiscoveryStrategy();
         }
 
@@ -239,17 +294,74 @@ public class ClientDiscoverySpiTest extends HazelcastTestSupport {
         }
     }
 
-    public static class TestNodeFilter implements NodeFilter {
+    public static class CollectingDiscoveryStrategyFactory implements DiscoveryStrategyFactory {
 
-        private final List<DiscoveredNode> nodes = new ArrayList<DiscoveredNode>();
+        private final List<DiscoveryNode> discoveryNodes;
+
+        private CollectingDiscoveryStrategyFactory(List<DiscoveryNode> discoveryNodes) {
+            this.discoveryNodes = discoveryNodes;
+        }
 
         @Override
-        public boolean test(DiscoveredNode candidate) {
+        public Class<? extends DiscoveryStrategy> getDiscoveryStrategyType() {
+            return CollectingDiscoveryStrategy.class;
+        }
+
+        @Override
+        public DiscoveryStrategy newDiscoveryStrategy(DiscoveryNode discoveryNode, ILogger logger,
+                                                      Map<String, Comparable> properties) {
+            return new CollectingDiscoveryStrategy(discoveryNode, discoveryNodes, logger, properties);
+        }
+
+        @Override
+        public Collection<PropertyDefinition> getConfigurationProperties() {
+            return null;
+        }
+    }
+
+    private static class CollectingDiscoveryStrategy extends AbstractDiscoveryStrategy {
+
+        private final List<DiscoveryNode> discoveryNodes;
+        private final DiscoveryNode discoveryNode;
+
+        public CollectingDiscoveryStrategy(DiscoveryNode discoveryNode, List<DiscoveryNode> discoveryNodes, ILogger logger,
+                                           Map<String, Comparable> properties) {
+            super(logger, properties);
+            this.discoveryNodes = discoveryNodes;
+            this.discoveryNode = discoveryNode;
+        }
+
+        @Override
+        public void start() {
+            super.start();
+            discoveryNodes.add(discoveryNode);
+            getLogger();
+            getProperties();
+        }
+
+        @Override
+        public Iterable<DiscoveryNode> discoverNodes() {
+            return new ArrayList<DiscoveryNode>(discoveryNodes);
+        }
+
+        @Override
+        public void destroy() {
+            super.destroy();
+            discoveryNodes.remove(discoveryNode);
+        }
+    }
+
+    public static class TestNodeFilter implements NodeFilter {
+
+        private final List<DiscoveryNode> nodes = new ArrayList<DiscoveryNode>();
+
+        @Override
+        public boolean test(DiscoveryNode candidate) {
             nodes.add(candidate);
             return true;
         }
 
-        private List<DiscoveredNode> getNodes() {
+        private List<DiscoveryNode> getNodes() {
             return nodes;
         }
     }

--- a/hazelcast-jclouds/src/main/java/com/hazelcast/jclouds/JCloudsDiscoveryStrategy.java
+++ b/hazelcast-jclouds/src/main/java/com/hazelcast/jclouds/JCloudsDiscoveryStrategy.java
@@ -19,10 +19,9 @@ package com.hazelcast.jclouds;
 import com.hazelcast.config.InvalidConfigurationException;
 import com.hazelcast.core.HazelcastException;
 import com.hazelcast.nio.Address;
-import com.hazelcast.spi.discovery.DiscoveredNode;
-import com.hazelcast.spi.discovery.DiscoveryMode;
+import com.hazelcast.spi.discovery.DiscoveryNode;
 import com.hazelcast.spi.discovery.DiscoveryStrategy;
-import com.hazelcast.spi.discovery.SimpleDiscoveredNode;
+import com.hazelcast.spi.discovery.SimpleDiscoveryNode;
 import org.jclouds.compute.domain.NodeMetadata;
 
 import java.net.InetAddress;
@@ -48,25 +47,25 @@ public class JCloudsDiscoveryStrategy implements DiscoveryStrategy {
     }
 
     @Override
-    public void start(DiscoveryMode discoveryMode) {
+    public void start() {
         this.computeServiceBuilder.build();
     }
 
     @Override
-    public Iterable<DiscoveredNode> discoverNodes() {
-        List<DiscoveredNode> discoveredNodes = new ArrayList<DiscoveredNode>();
+    public Iterable<DiscoveryNode> discoverNodes() {
+        List<DiscoveryNode> discoveryNodes = new ArrayList<DiscoveryNode>();
         try {
             Iterable<? extends NodeMetadata> nodes =  computeServiceBuilder.getFilteredNodes();
             for (NodeMetadata metadata : nodes) {
                 if (metadata.getStatus() != NodeMetadata.Status.RUNNING) {
                     continue;
                 }
-                discoveredNodes.add(buildDiscoveredNode(metadata));
+                discoveryNodes.add(buildDiscoveredNode(metadata));
             }
         } catch (Exception e) {
             throw new HazelcastException("Failed to get registered addresses", e);
         }
-        return discoveredNodes;
+        return discoveryNodes;
     }
 
     @Override
@@ -74,7 +73,7 @@ public class JCloudsDiscoveryStrategy implements DiscoveryStrategy {
         computeServiceBuilder.destroy();
     }
 
-    private DiscoveredNode buildDiscoveredNode(NodeMetadata metadata) {
+    private DiscoveryNode buildDiscoveredNode(NodeMetadata metadata) {
         Address privateAddressInstance = null;
         if (!metadata.getPrivateAddresses().isEmpty()) {
             InetAddress privateAddress = mapAddress(metadata.getPrivateAddresses().iterator().next());
@@ -87,7 +86,7 @@ public class JCloudsDiscoveryStrategy implements DiscoveryStrategy {
             publicAddressInstance =  new Address(publicAddress, computeServiceBuilder.getServicePort());
         }
 
-        return new SimpleDiscoveredNode(privateAddressInstance, publicAddressInstance);
+        return new SimpleDiscoveryNode(privateAddressInstance, publicAddressInstance);
     }
 
     private InetAddress mapAddress(String address) {

--- a/hazelcast-jclouds/src/main/java/com/hazelcast/jclouds/JCloudsDiscoveryStrategyFactory.java
+++ b/hazelcast-jclouds/src/main/java/com/hazelcast/jclouds/JCloudsDiscoveryStrategyFactory.java
@@ -17,6 +17,8 @@
 package com.hazelcast.jclouds;
 
 import com.hazelcast.config.properties.PropertyDefinition;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.spi.discovery.DiscoveryNode;
 import com.hazelcast.spi.discovery.DiscoveryStrategy;
 import com.hazelcast.spi.discovery.DiscoveryStrategyFactory;
 
@@ -55,7 +57,7 @@ public class JCloudsDiscoveryStrategyFactory implements DiscoveryStrategyFactory
     }
 
     @Override
-    public DiscoveryStrategy newDiscoveryStrategy(Map<String, Comparable> properties) {
+    public DiscoveryStrategy newDiscoveryStrategy(DiscoveryNode node, ILogger logger, Map<String, Comparable> properties) {
         return new JCloudsDiscoveryStrategy(properties);
     }
 

--- a/hazelcast-jclouds/src/test/java/com/hazelcast/JCloudsDiscoveryFactoryTest.java
+++ b/hazelcast-jclouds/src/test/java/com/hazelcast/JCloudsDiscoveryFactoryTest.java
@@ -1,20 +1,15 @@
 package com.hazelcast;
 
-
 import com.hazelcast.config.AwsConfig;
 import com.hazelcast.config.Config;
-import com.hazelcast.config.DiscoveryStrategiesConfig;
+import com.hazelcast.config.DiscoveryConfig;
 import com.hazelcast.config.DiscoveryStrategyConfig;
-import com.hazelcast.config.InterfacesConfig;
 import com.hazelcast.config.JoinConfig;
 import com.hazelcast.config.MulticastConfig;
 import com.hazelcast.config.TcpIpConfig;
 import com.hazelcast.config.XmlConfigBuilder;
-import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
-import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -24,7 +19,6 @@ import java.io.InputStream;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
@@ -48,12 +42,12 @@ public class JCloudsDiscoveryFactoryTest extends HazelcastTestSupport {
         MulticastConfig multicastConfig = joinConfig.getMulticastConfig();
         assertFalse(multicastConfig.isEnabled());
 
-        DiscoveryStrategiesConfig discoveryStrategiesConfig = joinConfig.getDiscoveryStrategiesConfig();
-        assertTrue(discoveryStrategiesConfig.isEnabled());
+        DiscoveryConfig discoveryConfig = joinConfig.getDiscoveryConfig();
+        assertTrue(discoveryConfig.isEnabled());
 
-        assertEquals(1, discoveryStrategiesConfig.getDiscoveryStrategyConfigs().size());
+        assertEquals(1, discoveryConfig.getDiscoveryStrategyConfigs().size());
 
-        DiscoveryStrategyConfig providerConfig = discoveryStrategiesConfig.getDiscoveryStrategyConfigs().iterator().next();
+        DiscoveryStrategyConfig providerConfig = discoveryConfig.getDiscoveryStrategyConfigs().iterator().next();
 
         assertEquals(11, providerConfig.getProperties().size());
         assertEquals("aws-ec2", providerConfig.getProperties().get("provider"));
@@ -68,40 +62,5 @@ public class JCloudsDiscoveryFactoryTest extends HazelcastTestSupport {
         assertEquals("5702", providerConfig.getProperties().get("hz-port"));
         assertEquals("myfile.json", providerConfig.getProperties().get("credentialPath"));
         assertEquals("myRole", providerConfig.getProperties().get("role-name"));
-    }
-
-
-    @Test
-    public void testNodeStartup() {
-        String xmlFileName = "test-jclouds-config.xml";
-        InputStream xmlResource = JCloudsDiscoveryFactoryTest.class.getClassLoader().getResourceAsStream(xmlFileName);
-        Config config = new XmlConfigBuilder(xmlResource).build();
-        config.getNetworkConfig().setPort(50001);
-        InterfacesConfig interfaces = config.getNetworkConfig().getInterfaces();
-        interfaces.clear();
-        interfaces.setEnabled(true);
-        interfaces.addInterface("127.0.0.1");
-
-        String[] addresses = {"127.0.0.1", "127.0.0.1", "127.0.0.1"};
-        final TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(50001, addresses);
-
-        final HazelcastInstance hazelcastInstance1 = factory.newHazelcastInstance(config);
-        final HazelcastInstance hazelcastInstance2 = factory.newHazelcastInstance(config);
-        final HazelcastInstance hazelcastInstance3 = factory.newHazelcastInstance(config);
-
-        assertNotNull(hazelcastInstance1);
-        assertNotNull(hazelcastInstance2);
-        assertNotNull(hazelcastInstance3);
-
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run()
-                    throws Exception {
-
-                assertEquals(3, hazelcastInstance1.getCluster().getMembers().size());
-                assertEquals(3, hazelcastInstance2.getCluster().getMembers().size());
-                assertEquals(3, hazelcastInstance3.getCluster().getMembers().size());
-            }
-        });
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/cluster/ClusterService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/ClusterService.java
@@ -87,6 +87,13 @@ public interface ClusterService extends CoreService, Cluster {
     Address getThisAddress();
 
     /**
+     * Gets the local member instance.
+     *
+     * @return the local member instance. The returned value will never be null.
+     */
+    Member getLocalMember();
+
+    /**
      * Gets the current number of members.
      *
      * @return the current number of members.

--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/DiscoveryJoiner.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/DiscoveryJoiner.java
@@ -19,7 +19,7 @@ package com.hazelcast.cluster.impl;
 import com.hazelcast.instance.MemberImpl;
 import com.hazelcast.instance.Node;
 import com.hazelcast.nio.Address;
-import com.hazelcast.spi.discovery.DiscoveredNode;
+import com.hazelcast.spi.discovery.DiscoveryNode;
 import com.hazelcast.spi.discovery.integration.DiscoveryService;
 
 import java.util.ArrayList;
@@ -37,14 +37,14 @@ public class DiscoveryJoiner
 
     @Override
     protected Collection<Address> getPossibleAddresses() {
-        Iterable<DiscoveredNode> discoveredNodes = discoveryService.discoverNodes();
+        Iterable<DiscoveryNode> discoveredNodes = discoveryService.discoverNodes();
 
         MemberImpl localMember = node.nodeEngine.getLocalMember();
         Address localAddress = localMember.getAddress();
 
         Collection<Address> possibleMembers = new ArrayList<Address>();
-        for (DiscoveredNode discoveredNode : discoveredNodes) {
-            Address discoveredAddress = discoveredNode.getPrivateAddress();
+        for (DiscoveryNode discoveryNode : discoveredNodes) {
+            Address discoveredAddress = discoveryNode.getPrivateAddress();
             if (localAddress.equals(discoveredAddress)) {
                 continue;
             }

--- a/hazelcast/src/main/java/com/hazelcast/config/DiscoveryConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/DiscoveryConfig.java
@@ -16,44 +16,43 @@
 
 package com.hazelcast.config;
 
-import com.hazelcast.spi.discovery.integration.DiscoveryServiceProvider;
 import com.hazelcast.spi.discovery.DiscoveryStrategy;
 import com.hazelcast.spi.discovery.NodeFilter;
+import com.hazelcast.spi.discovery.integration.DiscoveryServiceProvider;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 
 /**
  * This configuration class describes the top-level config of the discovery
  * SPI and its discovery strategies.
  */
-public class DiscoveryStrategiesConfig {
+public class DiscoveryConfig {
 
     private final List<DiscoveryStrategyConfig> discoveryStrategyConfigs = new ArrayList<DiscoveryStrategyConfig>();
     private DiscoveryServiceProvider discoveryServiceProvider;
     private NodeFilter nodeFilter;
     private String nodeFilterClass;
 
-    private DiscoveryStrategiesConfig readonly;
+    private DiscoveryConfig readonly;
 
-    public DiscoveryStrategiesConfig() {
+    public DiscoveryConfig() {
     }
 
-    protected DiscoveryStrategiesConfig(DiscoveryServiceProvider discoveryServiceProvider, NodeFilter nodeFilter,
-                                        String nodeFilterClass, Collection<DiscoveryStrategyConfig> discoveryStrategyConfigs) {
+    protected DiscoveryConfig(DiscoveryServiceProvider discoveryServiceProvider, NodeFilter nodeFilter, String nodeFilterClass,
+                              Collection<DiscoveryStrategyConfig> discoveryStrategyConfigs) {
         this.discoveryServiceProvider = discoveryServiceProvider;
         this.nodeFilter = nodeFilter;
         this.nodeFilterClass = nodeFilterClass;
         this.discoveryStrategyConfigs.addAll(discoveryStrategyConfigs);
     }
 
-    public DiscoveryStrategiesConfig getAsReadOnly() {
+    public DiscoveryConfig getAsReadOnly() {
         if (readonly != null) {
             return readonly;
         }
-        readonly = new DiscoveryStrategiesConfigReadOnly(this);
+        readonly = new DiscoveryConfigReadOnly(this);
         return readonly;
     }
 
@@ -96,7 +95,7 @@ public class DiscoveryStrategiesConfig {
      * @return all enabled {@link DiscoveryStrategy} configurations
      */
     public Collection<DiscoveryStrategyConfig> getDiscoveryStrategyConfigs() {
-        return Collections.unmodifiableCollection(discoveryStrategyConfigs);
+        return discoveryStrategyConfigs;
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/config/DiscoveryConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/DiscoveryConfigReadOnly.java
@@ -20,14 +20,14 @@ import com.hazelcast.spi.discovery.integration.DiscoveryServiceProvider;
 import com.hazelcast.spi.discovery.NodeFilter;
 
 /**
- * Readonly version of {@link DiscoveryStrategiesConfig}
+ * Readonly version of {@link DiscoveryConfig}
  */
-public class DiscoveryStrategiesConfigReadOnly
-        extends DiscoveryStrategiesConfig {
+public class DiscoveryConfigReadOnly
+        extends DiscoveryConfig {
 
-    DiscoveryStrategiesConfigReadOnly(DiscoveryStrategiesConfig discoveryStrategiesConfig) {
-        super(discoveryStrategiesConfig.getDiscoveryServiceProvider(), discoveryStrategiesConfig.getNodeFilter(),
-                discoveryStrategiesConfig.getNodeFilterClass(), discoveryStrategiesConfig.getDiscoveryStrategyConfigs());
+    DiscoveryConfigReadOnly(DiscoveryConfig discoveryConfig) {
+        super(discoveryConfig.getDiscoveryServiceProvider(), discoveryConfig.getNodeFilter(),
+                discoveryConfig.getNodeFilterClass(), discoveryConfig.getDiscoveryStrategyConfigs());
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/config/DiscoveryStrategyConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/DiscoveryStrategyConfig.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.config;
 
+import com.hazelcast.spi.discovery.DiscoveryStrategyFactory;
+
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -29,6 +31,7 @@ public class DiscoveryStrategyConfig {
     private final Map<String, Comparable> properties = new HashMap<String, Comparable>();
 
     private final String className;
+    private final DiscoveryStrategyFactory discoveryStrategyFactory;
 
     public DiscoveryStrategyConfig(String className) {
         this(className, Collections.<String, Comparable>emptyMap());
@@ -37,10 +40,26 @@ public class DiscoveryStrategyConfig {
     public DiscoveryStrategyConfig(String className, Map<String, Comparable> properties) {
         this.className = className;
         this.properties.putAll(properties);
+        this.discoveryStrategyFactory = null;
+    }
+
+
+    public DiscoveryStrategyConfig(DiscoveryStrategyFactory discoveryStrategyFactory) {
+        this(discoveryStrategyFactory, Collections.<String, Comparable>emptyMap());
+    }
+
+    public DiscoveryStrategyConfig(DiscoveryStrategyFactory discoveryStrategyFactory, Map<String, Comparable> properties) {
+        this.className = null;
+        this.properties.putAll(properties);
+        this.discoveryStrategyFactory = discoveryStrategyFactory;
     }
 
     public String getClassName() {
         return className;
+    }
+
+    public DiscoveryStrategyFactory getDiscoveryStrategyFactory() {
+        return discoveryStrategyFactory;
     }
 
     public void addProperty(String key, Comparable value) {

--- a/hazelcast/src/main/java/com/hazelcast/config/JoinConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/JoinConfig.java
@@ -31,7 +31,7 @@ public class JoinConfig {
 
     private AwsConfig awsConfig = new AwsConfig();
 
-    private DiscoveryStrategiesConfig discoveryStrategiesConfig = new DiscoveryStrategiesConfig();
+    private DiscoveryConfig discoveryConfig = new DiscoveryConfig();
 
     /**
      * @return the multicastConfig join configuration
@@ -82,22 +82,22 @@ public class JoinConfig {
     }
 
     /**
-     * Returns the currently defined {@link DiscoveryStrategiesConfig}
+     * Returns the currently defined {@link DiscoveryConfig}
      *
      * @return current DiscoveryProvidersConfig instance
      */
-    public DiscoveryStrategiesConfig getDiscoveryStrategiesConfig() {
-        return discoveryStrategiesConfig;
+    public DiscoveryConfig getDiscoveryConfig() {
+        return discoveryConfig;
     }
 
     /**
-     * Sets a custom defined {@link DiscoveryStrategiesConfig}
+     * Sets a custom defined {@link DiscoveryConfig}
      *
-     * @param discoveryStrategiesConfig configuration to set
+     * @param discoveryConfig configuration to set
      * @throws java.lang.IllegalArgumentException if discoveryProvidersConfig is null
      */
-    public JoinConfig setDiscoveryStrategiesConfig(DiscoveryStrategiesConfig discoveryStrategiesConfig) {
-        this.discoveryStrategiesConfig = isNotNull(discoveryStrategiesConfig, "discoveryProvidersConfig");
+    public JoinConfig setDiscoveryConfig(DiscoveryConfig discoveryConfig) {
+        this.discoveryConfig = isNotNull(discoveryConfig, "discoveryProvidersConfig");
         return this;
     }
 
@@ -119,7 +119,7 @@ public class JoinConfig {
             throw new InvalidConfigurationException("Multicast and AWS join can't be enabled at the same time");
         }
 
-        Collection<DiscoveryStrategyConfig> discoveryStrategyConfigs = discoveryStrategiesConfig.getDiscoveryStrategyConfigs();
+        Collection<DiscoveryStrategyConfig> discoveryStrategyConfigs = discoveryConfig.getDiscoveryStrategyConfigs();
         if (getMulticastConfig().isEnabled() && discoveryStrategyConfigs.size() > 0) {
             throw new InvalidConfigurationException(
                     "Multicast and DiscoveryProviders join can't be enabled at the same time");
@@ -137,7 +137,7 @@ public class JoinConfig {
         sb.append("multicastConfig=").append(multicastConfig);
         sb.append(", tcpIpConfig=").append(tcpIpConfig);
         sb.append(", awsConfig=").append(awsConfig);
-        sb.append(", discoveryProvidersConfig=").append(discoveryStrategiesConfig);
+        sb.append(", discoveryProvidersConfig=").append(discoveryConfig);
         sb.append('}');
         return sb.toString();
     }

--- a/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
@@ -636,27 +636,27 @@ public class XmlConfigBuilder extends AbstractConfigBuilder implements ConfigBui
 
     private void handleDiscoveryStrategies(Node node) {
         final JoinConfig join = config.getNetworkConfig().getJoin();
-        final DiscoveryStrategiesConfig discoveryStrategiesConfig = join.getDiscoveryStrategiesConfig();
+        final DiscoveryConfig discoveryConfig = join.getDiscoveryConfig();
         for (Node child : new IterableNodeList(node.getChildNodes())) {
             final String name = cleanNodeName(child.getNodeName());
             if ("discovery-strategy".equals(name)) {
-                handleDiscoveryStrategy(child, discoveryStrategiesConfig);
+                handleDiscoveryStrategy(child, discoveryConfig);
             } else if ("node-filter".equals(name)) {
-                handleDiscoveryNodeFilter(child, discoveryStrategiesConfig);
+                handleDiscoveryNodeFilter(child, discoveryConfig);
             }
         }
     }
 
-    private void handleDiscoveryNodeFilter(Node node, DiscoveryStrategiesConfig discoveryStrategiesConfig) {
+    private void handleDiscoveryNodeFilter(Node node, DiscoveryConfig discoveryConfig) {
         final NamedNodeMap atts = node.getAttributes();
 
         final Node att = atts.getNamedItem("class");
         if (att != null) {
-            discoveryStrategiesConfig.setNodeFilterClass(getTextContent(att).trim());
+            discoveryConfig.setNodeFilterClass(getTextContent(att).trim());
         }
     }
 
-    private void handleDiscoveryStrategy(Node node, DiscoveryStrategiesConfig discoveryStrategiesConfig) {
+    private void handleDiscoveryStrategy(Node node, DiscoveryConfig discoveryConfig) {
         final NamedNodeMap atts = node.getAttributes();
 
         boolean enabled = false;
@@ -684,7 +684,7 @@ public class XmlConfigBuilder extends AbstractConfigBuilder implements ConfigBui
             }
         }
 
-        discoveryStrategiesConfig.addDiscoveryProviderConfig(new DiscoveryStrategyConfig(clazz, properties));
+        discoveryConfig.addDiscoveryProviderConfig(new DiscoveryStrategyConfig(clazz, properties));
     }
 
     private void handleAWS(Node node) {

--- a/hazelcast/src/main/java/com/hazelcast/config/properties/PropertyTypeConverter.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/properties/PropertyTypeConverter.java
@@ -17,6 +17,7 @@
 package com.hazelcast.config.properties;
 
 import com.hazelcast.core.TypeConverter;
+import com.hazelcast.util.Preconditions;
 
 /**
  * This enum class contains basic {@link TypeConverter} implementations to
@@ -29,6 +30,7 @@ public enum PropertyTypeConverter implements TypeConverter {
     STRING {
         @Override
         public Comparable convert(Comparable value) {
+            Preconditions.checkNotNull(value, "The value to convert cannot be null");
             return value.toString();
         }
     },
@@ -110,5 +112,4 @@ public enum PropertyTypeConverter implements TypeConverter {
             throw new IllegalArgumentException("Cannot convert to boolean");
         }
     }
-    ;
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/AbstractDiscoveryStrategy.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/AbstractDiscoveryStrategy.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi.discovery;
+
+import com.hazelcast.config.properties.PropertyDefinition;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.spi.annotation.Beta;
+import com.hazelcast.util.StringUtil;
+
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * An common abstract superclass for {@link DiscoveryStrategy} implementations,
+ * offering convenient access to configuration properties (which may be overridden
+ * on the system's environment or JVM properties), as well as a {@link ILogger} instance.
+ *
+ * @since 3.6
+ */
+@Beta
+public abstract class AbstractDiscoveryStrategy implements DiscoveryStrategy {
+
+    private final ILogger logger;
+    private final Map<String, Comparable> properties;
+
+    public AbstractDiscoveryStrategy(ILogger logger, Map<String, Comparable> properties) {
+        this.logger = logger;
+        this.properties = Collections.unmodifiableMap(properties);
+    }
+
+    @Override
+    public void destroy() {
+    }
+
+    @Override
+    public void start() {
+    }
+
+    /**
+     * Returns an immutable copy of the configuration properties.
+     *
+     * @return the configuration properties
+     */
+    protected Map<String, Comparable> getProperties() {
+        return properties;
+    }
+
+    /**
+     * Returns a {@link ILogger} instance bound to the current class.
+     *
+     * @return a ILogger instance
+     */
+    protected ILogger getLogger() {
+        return logger;
+    }
+
+    /**
+     * Returns the value of the requested {@link PropertyDefinition} if available in the
+     * declarative or programmatic configuration (XML or Config API), otherwise it will
+     * return <tt>null</tt>.
+     * <p/>
+     * <b>This method overload won't do environment or JVM property lookup.</b> A call to
+     * this overload is equivalent to {@link #getOrNull(String, PropertyDefinition)}
+     * with <tt>null</tt> passed as the first parameter.
+     *
+     * @param property the PropertyDefinition to lookup
+     * @param <T>      the type of the property, must be compatible with the conversion
+     *                 result of {@link PropertyDefinition#typeConverter()}
+     * @return the value of the given property if available in the configuration, otherwise null
+     */
+    protected <T extends Comparable> T getOrNull(PropertyDefinition property) {
+        return getOrDefault(property, null);
+    }
+
+    /**
+     * Returns the value of the requested {@link PropertyDefinition} if available in the
+     * declarative or programmatic configuration (XML or Config API), can be found in the
+     * system's environment, or passed as a JVM property. Otherwise it will return <tt>null</tt>.
+     * <p/>
+     * This overload will resolve the requested property in the following order, whereas the
+     * higher priority is from top to bottom:
+     * <ul>
+     * <li>{@link System#getProperty(String)}: JVM properties</li>
+     * <li>{@link System#getenv(String)}: System environment</li>
+     * <li>Configuration properties of this {@link DiscoveryStrategy}</li>
+     * </ul>
+     * To resolve JVM properties or the system environment the property's key is prefixed with
+     * given <tt>prefix</tt>, therefore a prefix of <i>com.hazelcast.discovery</i> and a property
+     * key of <i>hostname</i> will result in a property lookup of <i>com.hazelcast.discovery.hostname</i>
+     * in the system environment and JVM properties.
+     *
+     * @param prefix   the property key prefix for environment and JVM properties lookup
+     * @param property the PropertyDefinition to lookup
+     * @param <T>      the type of the property, must be compatible with the conversion
+     *                 result of {@link PropertyDefinition#typeConverter()}
+     * @return the value of the given property if available in the configuration, system environment
+     * or JVM properties, otherwise null
+     */
+    protected <T extends Comparable> T getOrNull(String prefix, PropertyDefinition property) {
+        return getOrDefault(prefix, property, null);
+    }
+
+    /**
+     * Returns the value of the requested {@link PropertyDefinition} if available in the
+     * declarative or programmatic configuration (XML or Config API), otherwise it will
+     * return the given <tt>defaultValue</tt>.
+     * <p/>
+     * <b>This method overload won't do environment or JVM property lookup.</b> A call to
+     * this overload is equivalent to {@link #getOrDefault(String, PropertyDefinition, Comparable)}
+     * with <tt>null</tt> passed as the first parameter.
+     *
+     * @param property the PropertyDefinition to lookup
+     * @param <T>      the type of the property, must be compatible with the conversion
+     *                 result of {@link PropertyDefinition#typeConverter()}
+     * @return the value of the given property if available in the configuration, otherwise the
+     * given default value
+     */
+    protected <T extends Comparable> T getOrDefault(PropertyDefinition property, T defaultValue) {
+        return getOrDefault(null, property, defaultValue);
+    }
+
+    /**
+     * Returns the value of the requested {@link PropertyDefinition} if available in the
+     * declarative or programmatic configuration (XML or Config API), can be found in the
+     * system's environment, or passed as a JVM property. otherwise it will return the given
+     * <tt>defaultValue</tt>.
+     * <p/>
+     * This overload will resolve the requested property in the following order, whereas the
+     * higher priority is from top to bottom:
+     * <ul>
+     * <li>{@link System#getProperty(String)}: JVM properties</li>
+     * <li>{@link System#getenv(String)}: System environment</li>
+     * <li>Configuration properties of this {@link DiscoveryStrategy}</li>
+     * </ul>
+     * To resolve JVM properties or the system environment the property's key is prefixed with
+     * given <tt>prefix</tt>, therefore a prefix of <i>com.hazelcast.discovery</i> and a property
+     * key of <i>hostname</i> will result in a property lookup of <i>com.hazelcast.discovery.hostname</i>
+     * in the system environment and JVM properties.
+     *
+     * @param prefix   the property key prefix for environment and JVM properties lookup
+     * @param property the PropertyDefinition to lookup
+     * @param <T>      the type of the property, must be compatible with the conversion
+     *                 result of {@link PropertyDefinition#typeConverter()}
+     * @return the value of the given property if available in the configuration, system environment
+     * or JVM properties, otherwise the given default value
+     */
+    protected <T extends Comparable> T getOrDefault(String prefix, PropertyDefinition property, T defaultValue) {
+        if (properties == null || property == null) {
+            return defaultValue;
+        }
+
+        Comparable value = readProperty(prefix, property);
+        if (value == null) {
+            value = properties.get(property.key());
+        }
+
+        if (value == null) {
+            return defaultValue;
+        }
+
+        return (T) value;
+    }
+
+    private Comparable readProperty(String prefix, PropertyDefinition property) {
+        if (prefix != null) {
+            String p = getProperty(prefix, property);
+            String v = System.getProperty(p);
+            if (StringUtil.isNullOrEmpty(v)) {
+                v = System.getenv(p);
+            }
+
+            if (!StringUtil.isNullOrEmpty(v)) {
+                return property.typeConverter().convert(v);
+            }
+        }
+        return null;
+    }
+
+    private String getProperty(String prefix, PropertyDefinition property) {
+        StringBuilder sb = new StringBuilder(prefix);
+        if (prefix.charAt(prefix.length() - 1) != '.') {
+            sb.append('.');
+        }
+        return sb.append(property.key()).toString();
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/DiscoveryNode.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/DiscoveryNode.java
@@ -17,11 +17,12 @@
 package com.hazelcast.spi.discovery;
 
 import com.hazelcast.nio.Address;
+import com.hazelcast.spi.annotation.Beta;
 
 import java.util.Map;
 
 /**
- * A <tt>DiscoveredNode</tt> describes a nodes addresses (private and if
+ * A <tt>DiscoveryNode</tt> describes a nodes addresses (private and if
  * necessary a public one) as well as attributes assigned to this node.
  * Private address defines the typical internal communication port, all
  * cluster communication and also client communication inside the same
@@ -40,8 +41,15 @@ import java.util.Map;
  * {@link com.hazelcast.spi.discovery.NodeFilter} is configured, these
  * properties might be used for further refinement of the discovered nodes
  * based on whatever the filter decides.
+ * <p/>
+ * This class is implemented as an abstract class to offer easy extensibility
+ * in later versions of the SPI. Since Java only offers forward evolution of
+ * interfaces starting with Java 8, this is the best option.
+ *
+ * @since 3.6
  */
-public interface DiscoveredNode {
+@Beta
+public abstract class DiscoveryNode {
 
     /**
      * Returns the private address of the discovered node. The private address
@@ -49,7 +57,7 @@ public interface DiscoveredNode {
      *
      * @return the private address of the discovered node
      */
-    Address getPrivateAddress();
+    public abstract Address getPrivateAddress();
 
     /**
      * Returns the public address of the discovered node if available. Public addresses
@@ -57,7 +65,7 @@ public interface DiscoveredNode {
      *
      * @return the public address of the discovered node if available otherwise null or {@link #getPrivateAddress()}
      */
-    Address getPublicAddress();
+    public abstract Address getPublicAddress();
 
     /**
      * Returns a set of unmodifiable properties that are assigned to the discovered node. These properties
@@ -65,5 +73,5 @@ public interface DiscoveredNode {
      *
      * @return assigned properties of that node
      */
-    Map<String, Object> getProperties();
+    public abstract Map<String, Object> getProperties();
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/DiscoveryStrategy.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/DiscoveryStrategy.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.spi.discovery;
 
+import com.hazelcast.spi.annotation.Beta;
+
 /**
  * The <tt>DiscoveryStrategy</tt> itself is the actual implementation to discover
  * nodes based on whatever environment is used to run the Hazelcast cloud. The
@@ -29,17 +31,18 @@ package com.hazelcast.spi.discovery;
  * Using the simple lifecycle management strategies like multicast discovery is able to
  * register and destroy sockets based on Hazelcast’s lifecycle. Deactivated services will
  * also never be started.
+ *
+ * @since 3.6
  */
+@Beta
 public interface DiscoveryStrategy {
 
     /**
      * The <tt>start</tt> method is used to initialize internal state and perform any kind of
      * startup procedure like multicast socket creation. The behavior of this method might
-     * change based on the passed {@link DiscoveredNode}.
-     *
-     * @param discoveryMode the provided discovery mode
+     * change based on the {@link DiscoveryNode} instance passed to the {@link DiscoveryStrategyFactory}.
      */
-    void start(DiscoveryMode discoveryMode);
+    void start();
 
     /**
      * Returns a set of all discovered nodes based on the defined properties that were used
@@ -47,7 +50,7 @@ public interface DiscoveryStrategy {
      *
      * @return a set of all discovered nodes
      */
-    Iterable<DiscoveredNode> discoverNodes();
+    Iterable<DiscoveryNode> discoverNodes();
 
     /**
      * The <tt>stop</tt> method is used to stop internal services, sockets or to destroy any

--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/DiscoveryStrategyFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/DiscoveryStrategyFactory.java
@@ -17,6 +17,9 @@
 package com.hazelcast.spi.discovery;
 
 import com.hazelcast.config.properties.PropertyDefinition;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.spi.annotation.Beta;
 
 import java.util.Collection;
 import java.util.Map;
@@ -37,7 +40,10 @@ import java.util.Map;
  * provider plugins. Any kind of violation while verification of any type conversion error
  * as well as missing non-optional properties will throw an exception and prevent the node
  * from starting up.
+ *
+ * @since 3.6
  */
+@Beta
 public interface DiscoveryStrategyFactory {
 
     /**
@@ -49,12 +55,17 @@ public interface DiscoveryStrategyFactory {
 
     /**
      * Instantiates a new instance of the {@link DiscoveryStrategy} with the given configuration
-     * properties.
+     * properties. The provided {@link HazelcastInstance} can be used to register instances in
+     * a service registry whenever the discovery strategy is started.
      *
-     * @param properties the properties parsed from the configuration
+     * @param discoveryNode the current local <tt>DiscoveryNode</tt>, representing the local
+     *                      connection information if running on a Hazelcast member, otherwise on
+     *                      Hazelcast clients always <tt>null</tt>
+     * @param logger        the logger instance
+     * @param properties    the properties parsed from the configuration
      * @return a new instance of the discovery strategy
      */
-    DiscoveryStrategy newDiscoveryStrategy(Map<String, Comparable> properties);
+    DiscoveryStrategy newDiscoveryStrategy(DiscoveryNode discoveryNode, ILogger logger, Map<String, Comparable> properties);
 
     /**
      * Returns a set of the expected configuration properties. These properties contain

--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/NodeFilter.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/NodeFilter.java
@@ -16,27 +16,32 @@
 
 package com.hazelcast.spi.discovery;
 
+import com.hazelcast.spi.annotation.Beta;
+
 /**
  * The NodeFilter, if supplied, will retrieve all discovered nodes and might
  * apply additional filtering based on vendor provided metadata. These metadata
- * are expected to be provided using the {@link DiscoveredNode#getProperties()}
+ * are expected to be provided using the {@link DiscoveryNode#getProperties()}
  * method and may contain additional information initially setup by the user.
  * <p/>
  * This is useful for additional security settings, to apply a certain type of
  * policy or to work around insufficient query languages of cloud providers.
  * <p/>
- * Denied {@link com.hazelcast.spi.discovery.DiscoveredNode}s will not be
+ * Denied {@link DiscoveryNode}s will not be
  * handed over to the Hazelcast connection framework and therefore are not
  * known to the discovered.
+ *
+ * @since 3.6
  */
+@Beta
 public interface NodeFilter {
 
     /**
-     * Accepts or denies a {@link com.hazelcast.spi.discovery.DiscoveredNode}
+     * Accepts or denies a {@link DiscoveryNode}
      * based on the implemented rules.
      *
      * @param candidate the candidate to be tested
-     * @return true if the DiscoveredNode is selected to be discovered, otherwise false.
+     * @return true if the DiscoveryNode is selected to be discovered, otherwise false.
      */
-    boolean test(DiscoveredNode candidate);
+    boolean test(DiscoveryNode candidate);
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/SimpleDiscoveryNode.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/SimpleDiscoveryNode.java
@@ -17,17 +17,21 @@
 package com.hazelcast.spi.discovery;
 
 import com.hazelcast.nio.Address;
+import com.hazelcast.spi.annotation.Beta;
 import com.hazelcast.util.Preconditions;
 
 import java.util.Collections;
 import java.util.Map;
 
 /**
- * Simple immutable implementation of the {@link DiscoveredNode} interface for convenience
+ * Simple immutable implementation of the {@link DiscoveryNode} interface for convenience
  * when implementing a {@link DiscoveryStrategy}.
+ *
+ * @since 3.6
  */
-public class SimpleDiscoveredNode
-        implements DiscoveredNode {
+@Beta
+public final class SimpleDiscoveryNode
+        extends DiscoveryNode {
 
     private final Address privateAddress;
     private final Address publicAddress;
@@ -39,7 +43,7 @@ public class SimpleDiscoveredNode
      *
      * @param privateAddress the discovered node's private address
      */
-    public SimpleDiscoveredNode(Address privateAddress) {
+    public SimpleDiscoveryNode(Address privateAddress) {
         this(privateAddress, privateAddress, Collections.<String, Object>emptyMap());
     }
 
@@ -49,7 +53,7 @@ public class SimpleDiscoveredNode
      * @param privateAddress the discovered node's private address
      * @param properties     the discovered node's additional properties
      */
-    public SimpleDiscoveredNode(Address privateAddress, Map<String, Object> properties) {
+    public SimpleDiscoveryNode(Address privateAddress, Map<String, Object> properties) {
         this(privateAddress, privateAddress, properties);
     }
 
@@ -62,7 +66,7 @@ public class SimpleDiscoveredNode
      * @param privateAddress the discovered node's private address
      * @param publicAddress  the discovered node's public address
      */
-    public SimpleDiscoveredNode(Address privateAddress, Address publicAddress) {
+    public SimpleDiscoveryNode(Address privateAddress, Address publicAddress) {
         this(privateAddress, publicAddress, Collections.<String, Object>emptyMap());
     }
 
@@ -75,12 +79,12 @@ public class SimpleDiscoveredNode
      * @param publicAddress  the discovered node's public address
      * @param properties     the discovered node's additional properties
      */
-    public SimpleDiscoveredNode(Address privateAddress, Address publicAddress, Map<String, Object> properties) {
+    public SimpleDiscoveryNode(Address privateAddress, Address publicAddress, Map<String, Object> properties) {
         Preconditions.checkNotNull(privateAddress, "The private address cannot be null");
         Preconditions.checkNotNull(properties, "The properties cannot be null");
         this.privateAddress = privateAddress;
         this.publicAddress = publicAddress;
-        this.properties = Collections.unmodifiableMap(properties);
+        this.properties = properties == null ? Collections.<String, Object>emptyMap() : Collections.unmodifiableMap(properties);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/impl/DefaultDiscoveryService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/impl/DefaultDiscoveryService.java
@@ -16,18 +16,21 @@
 
 package com.hazelcast.spi.discovery.impl;
 
-import com.hazelcast.config.DiscoveryStrategiesConfig;
+import com.hazelcast.config.DiscoveryConfig;
 import com.hazelcast.config.DiscoveryStrategyConfig;
 import com.hazelcast.config.properties.PropertyDefinition;
 import com.hazelcast.config.properties.ValueValidator;
 import com.hazelcast.core.HazelcastException;
+import com.hazelcast.core.Member;
 import com.hazelcast.core.TypeConverter;
-import com.hazelcast.spi.discovery.DiscoveredNode;
-import com.hazelcast.spi.discovery.DiscoveryMode;
-import com.hazelcast.spi.discovery.integration.DiscoveryService;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.spi.discovery.DiscoveryNode;
 import com.hazelcast.spi.discovery.DiscoveryStrategy;
 import com.hazelcast.spi.discovery.DiscoveryStrategyFactory;
 import com.hazelcast.spi.discovery.NodeFilter;
+import com.hazelcast.spi.discovery.SimpleDiscoveryNode;
+import com.hazelcast.spi.discovery.integration.DiscoveryService;
+import com.hazelcast.spi.discovery.integration.DiscoveryServiceSettings;
 import com.hazelcast.util.ServiceLoader;
 
 import java.util.ArrayList;
@@ -45,40 +48,40 @@ public class DefaultDiscoveryService
 
     private static final String SERVICE_LOADER_TAG = DiscoveryStrategyFactory.class.getCanonicalName();
 
+    private final DiscoveryNode discoveryNode;
+    private final ILogger logger;
     private final Iterable<DiscoveryStrategy> discoveryProviders;
-    private final DiscoveryMode discoveryMode;
     private final NodeFilter nodeFilter;
 
-    public DefaultDiscoveryService(DiscoveryMode discoveryMode, DiscoveryStrategiesConfig discoveryStrategiesConfig,
-                                   ClassLoader configClassLoader) {
-
-        this.discoveryMode = discoveryMode;
-        this.nodeFilter = getNodeFilter(discoveryStrategiesConfig, configClassLoader);
-        this.discoveryProviders = loadDiscoveryProviders(discoveryStrategiesConfig, configClassLoader);
+    public DefaultDiscoveryService(DiscoveryServiceSettings settings) {
+        this.discoveryNode = settings.getDiscoveryNode();
+        this.logger = settings.getLogger();
+        this.nodeFilter = getNodeFilter(settings);
+        this.discoveryProviders = loadDiscoveryProviders(settings);
     }
 
     @Override
     public void start() {
         for (DiscoveryStrategy discoveryStrategy : discoveryProviders) {
-            discoveryStrategy.start(discoveryMode);
+            discoveryStrategy.start();
         }
     }
 
     @Override
-    public Iterable<DiscoveredNode> discoverNodes() {
-        Set<DiscoveredNode> discoveredNodes = new HashSet<DiscoveredNode>();
+    public Iterable<DiscoveryNode> discoverNodes() {
+        Set<DiscoveryNode> discoveryNodes = new HashSet<DiscoveryNode>();
         for (DiscoveryStrategy discoveryStrategy : discoveryProviders) {
-            Iterable<DiscoveredNode> candidates = discoveryStrategy.discoverNodes();
+            Iterable<DiscoveryNode> candidates = discoveryStrategy.discoverNodes();
 
             if (candidates != null) {
-                for (DiscoveredNode candidate : candidates) {
+                for (DiscoveryNode candidate : candidates) {
                     if (validateCandidate(candidate)) {
-                        discoveredNodes.add(candidate);
+                        discoveryNodes.add(candidate);
                     }
                 }
             }
         }
-        return discoveredNodes;
+        return discoveryNodes;
     }
 
     @Override
@@ -88,18 +91,20 @@ public class DefaultDiscoveryService
         }
     }
 
-    private NodeFilter getNodeFilter(DiscoveryStrategiesConfig discoveryStrategiesConfig, ClassLoader configClassLoader) {
-        if (discoveryStrategiesConfig.getNodeFilter() != null) {
-            return discoveryStrategiesConfig.getNodeFilter();
+    private NodeFilter getNodeFilter(DiscoveryServiceSettings settings) {
+        DiscoveryConfig discoveryConfig = settings.getDiscoveryConfig();
+        ClassLoader configClassLoader = settings.getConfigClassLoader();
+        if (discoveryConfig.getNodeFilter() != null) {
+            return discoveryConfig.getNodeFilter();
         }
-        if (discoveryStrategiesConfig.getNodeFilterClass() != null) {
+        if (discoveryConfig.getNodeFilterClass() != null) {
             try {
                 ClassLoader cl = configClassLoader;
                 if (cl == null) {
                     cl = DefaultDiscoveryService.class.getClassLoader();
                 }
 
-                String className = discoveryStrategiesConfig.getNodeFilterClass();
+                String className = discoveryConfig.getNodeFilterClass();
                 return (NodeFilter) cl.loadClass(className).newInstance();
             } catch (Exception e) {
                 throw new RuntimeException("Failed to configure discovery node filter", e);
@@ -108,21 +113,35 @@ public class DefaultDiscoveryService
         return null;
     }
 
-    private boolean validateCandidate(DiscoveredNode candidate) {
+    private boolean validateCandidate(DiscoveryNode candidate) {
         return nodeFilter == null || nodeFilter.test(candidate);
     }
 
-    private Iterable<DiscoveryStrategy> loadDiscoveryProviders(DiscoveryStrategiesConfig providersConfig,
-                                                               ClassLoader configClassLoader) {
+    private Iterable<DiscoveryStrategy> loadDiscoveryProviders(DiscoveryServiceSettings settings) {
+        DiscoveryConfig discoveryConfig = settings.getDiscoveryConfig();
+        ClassLoader configClassLoader = settings.getConfigClassLoader();
+
         try {
-            Collection<DiscoveryStrategyConfig> discoveryStrategyConfigs = providersConfig.getDiscoveryStrategyConfigs();
+            Collection<DiscoveryStrategyConfig> discoveryStrategyConfigs = new ArrayList<DiscoveryStrategyConfig>(
+                    discoveryConfig.getDiscoveryStrategyConfigs());
 
             Iterator<DiscoveryStrategyFactory> iterator = ServiceLoader
                     .iterator(DiscoveryStrategyFactory.class, SERVICE_LOADER_TAG, configClassLoader);
 
-            List<DiscoveryStrategy> discoveryStrategies = new ArrayList<DiscoveryStrategy>();
+            // Collect possible factories
+            List<DiscoveryStrategyFactory> factories = new ArrayList<DiscoveryStrategyFactory>();
             while (iterator.hasNext()) {
-                DiscoveryStrategyFactory factory = iterator.next();
+                factories.add(iterator.next());
+            }
+            for (DiscoveryStrategyConfig config : discoveryStrategyConfigs) {
+                DiscoveryStrategyFactory factory = config.getDiscoveryStrategyFactory();
+                if (factory != null) {
+                    factories.add(factory);
+                }
+            }
+
+            List<DiscoveryStrategy> discoveryStrategies = new ArrayList<DiscoveryStrategy>();
+            for (DiscoveryStrategyFactory factory : factories) {
                 DiscoveryStrategy discoveryStrategy = buildDiscoveryProvider(factory, discoveryStrategyConfigs);
                 if (discoveryStrategy != null) {
                     discoveryStrategies.add(discoveryStrategy);
@@ -175,12 +194,24 @@ public class DefaultDiscoveryService
         String className = discoveryProviderType.getName();
 
         for (DiscoveryStrategyConfig config : discoveryStrategyConfigs) {
-            if (config.getClassName().equals(className)) {
+            String factoryClassName = getFactoryClassName(config);
+            if (className.equals(factoryClassName)) {
                 Map<String, Comparable> properties = buildProperties(factory, config, className);
-                return factory.newDiscoveryStrategy(properties);
+                return factory.newDiscoveryStrategy(discoveryNode, logger, properties);
             }
         }
         return null;
     }
 
+    private String getFactoryClassName(DiscoveryStrategyConfig config) {
+        if (config.getDiscoveryStrategyFactory() != null) {
+            DiscoveryStrategyFactory factory = config.getDiscoveryStrategyFactory();
+            return factory.getDiscoveryStrategyType().getName();
+        }
+        return config.getClassName();
+    }
+
+    private DiscoveryNode buildDiscoveryNode(Member member) {
+        return member == null ? null : new SimpleDiscoveryNode(member.getAddress(), member.getAttributes());
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/impl/DefaultDiscoveryServiceProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/impl/DefaultDiscoveryServiceProvider.java
@@ -16,18 +16,16 @@
 
 package com.hazelcast.spi.discovery.impl;
 
-import com.hazelcast.config.DiscoveryStrategiesConfig;
-import com.hazelcast.spi.discovery.DiscoveryMode;
 import com.hazelcast.spi.discovery.integration.DiscoveryService;
 import com.hazelcast.spi.discovery.integration.DiscoveryServiceProvider;
+import com.hazelcast.spi.discovery.integration.DiscoveryServiceSettings;
 
 public class DefaultDiscoveryServiceProvider
         implements DiscoveryServiceProvider {
 
     @Override
-    public DiscoveryService newDiscoveryService(DiscoveryMode discoveryMode, DiscoveryStrategiesConfig discoveryStrategiesConfig,
-                                                ClassLoader configClassLoader) {
+    public DiscoveryService newDiscoveryService(DiscoveryServiceSettings settings) {
 
-        return new DefaultDiscoveryService(discoveryMode, discoveryStrategiesConfig, configClassLoader);
+        return new DefaultDiscoveryService(settings);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/integration/DiscoveryMode.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/integration/DiscoveryMode.java
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
-package com.hazelcast.spi.discovery;
+package com.hazelcast.spi.discovery.integration;
+
+import com.hazelcast.spi.annotation.Beta;
+import com.hazelcast.spi.discovery.DiscoveryStrategy;
 
 /**
  * <p>The <tt>DiscoveryMode</tt> describes how the {@link DiscoveryStrategy} is going
@@ -23,7 +26,10 @@ package com.hazelcast.spi.discovery;
  * <p>Implementors of {@link DiscoveryStrategy}s are free to change behavior as necessary.
  * One possible use case is to prevent to start a multicast service on clients when only
  * discovery is necessary.</p>
+ *
+ * @since 3.6
  */
+@Beta
 public enum DiscoveryMode {
     /**
      * The current runtime environment is a Hazelcast member node

--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/integration/DiscoveryService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/integration/DiscoveryService.java
@@ -16,7 +16,8 @@
 
 package com.hazelcast.spi.discovery.integration;
 
-import com.hazelcast.spi.discovery.DiscoveredNode;
+import com.hazelcast.spi.annotation.Beta;
+import com.hazelcast.spi.discovery.DiscoveryNode;
 import com.hazelcast.spi.discovery.DiscoveryStrategy;
 import com.hazelcast.spi.discovery.NodeFilter;
 
@@ -36,14 +37,16 @@ import com.hazelcast.spi.discovery.NodeFilter;
  * <tt>DiscoveryService</tt> implementation, multiple {@link DiscoveryStrategy}s
  * might be enabled at the same time (e.g. TCP-IP Joiner with well known addresses
  * and Cloud discovery).
+ *
+ * @since 3.6
  */
+@Beta
 public interface DiscoveryService {
 
     /**
      * The <tt>start</tt> method is called on system startup to implement simple
      * lifecycle management. This method is expected to call
-     * {@link DiscoveryStrategy#start(com.hazelcast.spi.discovery.DiscoveryMode)} on all
-     * discovered and activated strategies.
+     * {@link DiscoveryStrategy#start()} on all discovered and start up strategies.
      */
     void start();
 
@@ -53,13 +56,13 @@ public interface DiscoveryService {
      *
      * @return a set of discovered and filtered nodes
      */
-    Iterable<DiscoveredNode> discoverNodes();
+    Iterable<DiscoveryNode> discoverNodes();
 
     /**
      * The <tt>start</tt> method is called on system startup to implement simple
      * lifecycle management. This method is expected to call
-     * {@link DiscoveryStrategy#destroy()} on all discovered and activated strategies
-     * before the service itself will shutdown.
+     * {@link DiscoveryStrategy#destroy()} on all discovered and destroy strategies
+     * before the service itself will be destroyed.
      */
     void destroy();
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/integration/DiscoveryServiceProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/integration/DiscoveryServiceProvider.java
@@ -16,8 +16,7 @@
 
 package com.hazelcast.spi.discovery.integration;
 
-import com.hazelcast.config.DiscoveryStrategiesConfig;
-import com.hazelcast.spi.discovery.DiscoveryMode;
+import com.hazelcast.spi.annotation.Beta;
 
 /**
  * The <tt>DiscoveryServiceProvider</tt> interface provides the possibility to build {@link DiscoveryService}s.
@@ -25,18 +24,18 @@ import com.hazelcast.spi.discovery.DiscoveryMode;
  * provide this ability. Every service should have its own provider, however in rare cases a single provider might
  * create different <tt>DiscoveryService</tt> implementations based on the provided {@link DiscoveryMode} or other
  * configuration details.
+ *
+ * @since 3.6
  */
+@Beta
 public interface DiscoveryServiceProvider {
 
     /**
      * Instantiates a new instance of the {@link DiscoveryService}.
      *
-     * @param discoveryMode            the current discovery mode
-     * @param discoveryStrategiesConfig the configuration parsed from the XML or provided using the programmatic API
-     * @param configClassLoader        the classloader set in the configuration
+     * @param settings The settings to pass to creation of the <tt>DiscoveryService</tt>
      * @return a new instance of the discovery service
      */
-    DiscoveryService newDiscoveryService(DiscoveryMode discoveryMode, DiscoveryStrategiesConfig discoveryStrategiesConfig,
-                                         ClassLoader configClassLoader);
+    DiscoveryService newDiscoveryService(DiscoveryServiceSettings settings);
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/integration/DiscoveryServiceSettings.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/integration/DiscoveryServiceSettings.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi.discovery.integration;
+
+import com.hazelcast.config.DiscoveryConfig;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.spi.discovery.DiscoveryNode;
+
+/**
+ * The <tt>DiscoveryServiceSettings</tt> class is used to pass the necessary
+ * configuration to create a {@link DiscoveryService} to the
+ * {@link DiscoveryServiceProvider}. This approach is chosen to have an easily
+ * extensible way to provide new configuration properties over time.
+ */
+public final class DiscoveryServiceSettings {
+    private DiscoveryNode discoveryNode;
+    private ILogger logger;
+    private ClassLoader configClassLoader;
+    private DiscoveryConfig discoveryConfig;
+    private DiscoveryMode discoveryMode;
+
+    public DiscoveryNode getDiscoveryNode() {
+        return discoveryNode;
+    }
+
+    public DiscoveryServiceSettings setDiscoveryNode(DiscoveryNode discoveryNode) {
+        this.discoveryNode = discoveryNode;
+        return this;
+    }
+
+    public ILogger getLogger() {
+        return logger;
+    }
+
+    public DiscoveryServiceSettings setLogger(ILogger logger) {
+        this.logger = logger;
+        return this;
+    }
+
+    public ClassLoader getConfigClassLoader() {
+        return configClassLoader;
+    }
+
+    public DiscoveryServiceSettings setConfigClassLoader(ClassLoader configClassLoader) {
+        this.configClassLoader = configClassLoader;
+        return this;
+    }
+
+    public DiscoveryConfig getDiscoveryConfig() {
+        return discoveryConfig;
+    }
+
+    public DiscoveryServiceSettings setDiscoveryConfig(DiscoveryConfig discoveryConfig) {
+        this.discoveryConfig = discoveryConfig;
+        return this;
+    }
+
+    public DiscoveryMode getDiscoveryMode() {
+        return discoveryMode;
+    }
+
+    public DiscoveryServiceSettings setDiscoveryMode(DiscoveryMode discoveryMode) {
+        this.discoveryMode = discoveryMode;
+        return this;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/integration/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/integration/package-info.java
@@ -19,5 +19,10 @@
  * people that integrate Hazelcast into their own systems or frameworks and cannot
  * use the default discovery service implementation (for example using a different
  * {@link com.hazelcast.spi.discovery.DiscoveryStrategy} lookup strategy like OSGi).
+ *
+ * @since 3.6
  */
+@Beta
 package com.hazelcast.spi.discovery.integration;
+
+import com.hazelcast.spi.annotation.Beta;

--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/package-info.java
@@ -17,5 +17,10 @@
 /**
  * This package contains the public SPI for vendors and users to implement their
  * custom node / IP discovery strategy.
+ *
+ * @since 3.6
  */
+@Beta
 package com.hazelcast.spi.discovery;
+
+import com.hazelcast.spi.annotation.Beta;

--- a/hazelcast/src/test/java/com/hazelcast/config/properties/PropertyTypeConverterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/properties/PropertyTypeConverterTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2008-2014, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config.properties;
+
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category(QuickTest.class)
+public class PropertyTypeConverterTest {
+
+    @Test(expected = NullPointerException.class)
+    public void test_string_converter_thenNullPointerException() throws Exception {
+        PropertyTypeConverter.STRING.convert(null);
+    }
+
+    @Test
+    public void test_string_converter() throws Exception {
+        assertEquals("test", PropertyTypeConverter.STRING.convert("test"));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void test_short_converter_thenIllegalArgumentException() throws Exception {
+        PropertyTypeConverter.SHORT.convert(null);
+    }
+
+    @Test(expected = NumberFormatException.class)
+    public void test_short_converter_thenNumberFormatException() throws Exception {
+        PropertyTypeConverter.SHORT.convert("test");
+    }
+
+    @Test
+    public void test_short_converter() throws Exception {
+        assertEquals(Short.MAX_VALUE, PropertyTypeConverter.SHORT.convert(String.valueOf(Short.MAX_VALUE)));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void test_int_converter_thenIllegalArgumentException() throws Exception {
+        PropertyTypeConverter.INTEGER.convert(null);
+    }
+
+    @Test(expected = NumberFormatException.class)
+    public void test_int_converter_thenNumberFormatException() throws Exception {
+        PropertyTypeConverter.INTEGER.convert("test");
+    }
+
+    @Test
+    public void test_int_converter() throws Exception {
+        assertEquals(Integer.MAX_VALUE, PropertyTypeConverter.INTEGER.convert(String.valueOf(Integer.MAX_VALUE)));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void test_long_converter_thenIllegalArgumentException() throws Exception {
+        PropertyTypeConverter.LONG.convert(null);
+    }
+
+    @Test(expected = NumberFormatException.class)
+    public void test_long_converter_thenNumberFormatException() throws Exception {
+        PropertyTypeConverter.LONG.convert("test");
+    }
+
+    @Test
+    public void test_long_converter() throws Exception {
+        assertEquals(Long.MAX_VALUE, PropertyTypeConverter.LONG.convert(String.valueOf(Long.MAX_VALUE)));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void test_float_converter_thenIllegalArgumentException() throws Exception {
+        PropertyTypeConverter.FLOAT.convert(null);
+    }
+
+    @Test(expected = NumberFormatException.class)
+    public void test_float_converter_thenNumberFormatException() throws Exception {
+        PropertyTypeConverter.FLOAT.convert("test");
+    }
+
+    @Test
+    public void test_float_converter() throws Exception {
+        assertEquals(Float.MAX_VALUE, PropertyTypeConverter.FLOAT.convert(String.valueOf(Float.MAX_VALUE)));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void test_double_converter_thenIllegalArgumentException() throws Exception {
+        PropertyTypeConverter.DOUBLE.convert(null);
+    }
+
+    @Test(expected = NumberFormatException.class)
+    public void test_double_converter_thenNumberFormatException() throws Exception {
+        PropertyTypeConverter.DOUBLE.convert("test");
+    }
+
+    @Test
+    public void test_double_converter() throws Exception {
+        assertEquals(Double.MAX_VALUE, PropertyTypeConverter.DOUBLE.convert(String.valueOf(Double.MAX_VALUE)));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void test_boolean_converter_thenIllegalArgumentException() throws Exception {
+        PropertyTypeConverter.BOOLEAN.convert(null);
+    }
+
+    @Test
+    public void test_boolean_converter_false() throws Exception {
+        assertFalse((Boolean) PropertyTypeConverter.BOOLEAN.convert("test"));
+    }
+
+    @Test
+    public void test_boolean_converter_true() throws Exception {
+        assertTrue((Boolean) PropertyTypeConverter.BOOLEAN.convert("true"));
+    }
+}


### PR DESCRIPTION
1. Added tests to higher the code coverage
2. Added Member parameter to DiscoveryStrategy::start and DiscoveryStrategy::destroy to offer the possibility for strategies to register themselves as services (or for multicast to offer themselves ;-))
3. Slightly changed DiscoveryServiceFactory interface to meet the new requirements
4. Added @Beta annotations and @since Javadoc tags
5. Added AbstractDiscoveryStrategy to offer convenience and common methods to implement strategies in even less code

**PS: To test the Discovery SPI we cannot use the test factories since those use a hardcoded version of the Joiner and ignore all configuration!**

**PPS: I expect the Member to, eventually, have public and private addresses, isn't that the plan?**