### PR TITLE
Add async management center request handling

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/management/ManagementCenterService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/ManagementCenterService.java
@@ -33,6 +33,7 @@ import com.hazelcast.instance.MemberImpl;
 import com.hazelcast.internal.ascii.rest.HttpCommand;
 import com.hazelcast.internal.management.operation.UpdateManagementCenterUrlOperation;
 import com.hazelcast.internal.management.request.ChangeWanStateRequest;
+import com.hazelcast.internal.management.request.AsyncConsoleRequest;
 import com.hazelcast.internal.management.request.ClusterPropsRequest;
 import com.hazelcast.internal.management.request.ConsoleCommandRequest;
 import com.hazelcast.internal.management.request.ConsoleRequest;
@@ -51,6 +52,7 @@ import com.hazelcast.map.impl.MapService;
 import com.hazelcast.monitor.TimedMemberState;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.IOUtil;
+import com.hazelcast.spi.ExecutionService;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.OperationService;
 import com.hazelcast.util.Clock;
@@ -76,6 +78,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static com.hazelcast.instance.OutOfMemoryErrorDispatcher.inspectOutputMemoryError;
 import static com.hazelcast.nio.IOUtil.closeResource;
+import static com.hazelcast.spi.ExecutionService.ASYNC_EXECUTOR;
 import static com.hazelcast.util.EmptyStatement.ignore;
 import static com.hazelcast.util.JsonUtil.getInt;
 import static com.hazelcast.util.JsonUtil.getObject;
@@ -423,6 +426,9 @@ public class ManagementCenterService {
         private final Map<Integer, Class<? extends ConsoleRequest>> consoleRequests
                 = new HashMap<Integer, Class<? extends ConsoleRequest>>();
 
+        private final ExecutionService executionService = instance.node.getNodeEngine()
+                .getExecutionService();
+
         TaskPollThread() {
             super(threadGroup.getInternalThreadGroup(), threadGroup.getThreadNamePrefix("MC.Task.Poller"));
             register(new ThreadDumpRequest());
@@ -498,9 +504,15 @@ public class ManagementCenterService {
                     }
                     ConsoleRequest task = requestClass.newInstance();
                     task.fromJson(getObject(innerRequest, "request"));
-                    boolean success = processTaskAndSendResponse(taskId, task);
+                    boolean success;
+                    if (task instanceof AsyncConsoleRequest) {
+                        executionService.execute(ASYNC_EXECUTOR, new AsyncConsoleRequestTask(taskId, task));
+                        success = true;
+                    } else {
+                        success = processTaskAndSendResponse(taskId, task);
+                    }
                     if (taskPollFailed && success) {
-                        logger.info("Management center task polling successfull.");
+                        logger.info("Management center task polling successful.");
                         taskPollFailed = false;
                     }
                 }
@@ -558,6 +570,25 @@ public class ManagementCenterService {
             String urlString = cleanupUrl(managementCenterUrl) + "getTask.do?member=" + localAddress.getHost()
                     + ":" + localAddress.getPort() + "&cluster=" + groupConfig.getName();
             return new URL(urlString);
+        }
+
+        private class AsyncConsoleRequestTask implements Runnable {
+            private final int taskId;
+            private final ConsoleRequest task;
+
+            public AsyncConsoleRequestTask(int taskId, ConsoleRequest task) {
+                this.taskId = taskId;
+                this.task = task;
+            }
+
+            @Override
+            public void run() {
+                try {
+                    processTaskAndSendResponse(taskId, task);
+                } catch (Exception e) {
+                    logger.warning("Problem while handling task: " + task, e);
+                }
+            }
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/request/AsyncConsoleRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/request/AsyncConsoleRequest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.management.request;
+
+/**
+ * Represents async requests sent from Management Center.
+ * <p/>
+ * Normally, ManagementCenterService handles {@code ConsoleRequest}s synchronously
+ * on its {@code TaskPollThread}, a single thread polls tasks from Management Center,
+ * executes them and writes back the response directly. This is fine for short running tasks
+ * but for long running tasks or blocking invocations, it's required to offload request
+ * handling to an async thread pool. Otherwise, {@code TaskPollThread} will be blocked
+ * for a long time without handling any request from Management Center.
+ *
+ * @see ConsoleRequest
+ * @since 3.6
+ */
+public interface AsyncConsoleRequest extends ConsoleRequest {
+}


### PR DESCRIPTION
Added AsyncConsoleRequest marker interface to denote management
center requests which should be offloaded to a separate thread,
because they are long running or blocking.

PS: This is to change cluster state and shutdown cluster from 
management center UI. Both are blocking operations.