### PR TITLE
Cache changes to support hot restart

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheProxyBase.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheProxyBase.java
@@ -148,7 +148,7 @@ abstract class AbstractCacheProxyBase<K, V> {
         // TODO What happens in exception case? Cache doesn't get destroyed
         f.getSafely();
 
-        cacheService.destroyCache(getDistributedObjectName(), true, null);
+        cacheService.deleteCache(getDistributedObjectName(), true, null, true);
         f.getSafely();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheRecordStore.java
@@ -17,21 +17,23 @@
 package com.hazelcast.cache.impl;
 
 import com.hazelcast.cache.CacheNotExistsException;
+import com.hazelcast.cache.impl.maxsize.MaxSizeChecker;
+import com.hazelcast.cache.impl.maxsize.impl.EntryCountCacheMaxSizeChecker;
+import com.hazelcast.cache.impl.record.CacheRecord;
+import com.hazelcast.cache.impl.record.CacheRecordMap;
+import com.hazelcast.cache.impl.record.SampleableCacheRecordMap;
+import com.hazelcast.config.CacheConfig;
+import com.hazelcast.config.EvictionConfig;
+import com.hazelcast.config.EvictionPolicy;
+import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.internal.eviction.EvictionChecker;
 import com.hazelcast.internal.eviction.EvictionListener;
 import com.hazelcast.internal.eviction.EvictionPolicyEvaluator;
 import com.hazelcast.internal.eviction.EvictionPolicyEvaluatorProvider;
 import com.hazelcast.internal.eviction.EvictionStrategy;
 import com.hazelcast.internal.eviction.EvictionStrategyProvider;
-import com.hazelcast.cache.impl.maxsize.MaxSizeChecker;
-import com.hazelcast.cache.impl.maxsize.impl.EntryCountCacheMaxSizeChecker;
-import com.hazelcast.cache.impl.record.CacheRecord;
-import com.hazelcast.cache.impl.record.SampleableCacheRecordMap;
-import com.hazelcast.config.CacheConfig;
-import com.hazelcast.config.EvictionConfig;
-import com.hazelcast.config.EvictionPolicy;
-import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.map.impl.MapEntries;
+import com.hazelcast.nio.Disposable;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.partition.InternalPartitionService;
 import com.hazelcast.spi.EventRegistration;
@@ -42,10 +44,8 @@ import com.hazelcast.util.EmptyStatement;
 import com.hazelcast.util.ExceptionUtil;
 
 import javax.cache.configuration.Factory;
-import javax.cache.expiry.CreatedExpiryPolicy;
 import javax.cache.expiry.Duration;
 import javax.cache.expiry.ExpiryPolicy;
-import javax.cache.expiry.ModifiedExpiryPolicy;
 import javax.cache.integration.CacheLoader;
 import javax.cache.integration.CacheLoaderException;
 import javax.cache.integration.CacheWriter;
@@ -58,7 +58,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.cache.impl.CacheEventContextUtil.createBaseEventContext;
 import static com.hazelcast.cache.impl.CacheEventContextUtil.createCacheCompleteEvent;
@@ -222,7 +221,6 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
         if (isEvictionEnabled()) {
             evictedCount = evictionStrategy.evict(records, evictionPolicyEvaluator, evictionChecker, this);
             if (isStatisticsEnabled() && evictedCount > 0) {
-
                 statistics.increaseCacheEvictions(evictedCount);
             }
         }
@@ -293,14 +291,9 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
         onProcessExpiredEntry(key, removedRecord, removedRecord.getExpirationTime(), now, source, origin);
         if (isEventsEnabled()) {
             publishEvent(createCacheExpiredEvent(keyEventData, recordEventData,
-                                                 CacheRecord.EXPIRATION_TIME_NOT_AVAILABLE,
-                                                 origin, IGNORE_COMPLETION));
+                    CacheRecord.EXPIRATION_TIME_NOT_AVAILABLE, origin, IGNORE_COMPLETION));
         }
         return true;
-    }
-
-    protected R processExpiredEntry(Data key, R record, long expiryTime, long now) {
-        return processExpiredEntry(key, record, expiryTime, now, SOURCE_NOT_AVAILABLE);
     }
 
     protected R processExpiredEntry(Data key, R record, long expiryTime, long now, String source) {
@@ -457,31 +450,6 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
         return v1.equals(v2);
     }
 
-    protected long expiryPolicyToTTL(ExpiryPolicy expiryPolicy) {
-        if (expiryPolicy == null) {
-            return CacheRecord.EXPIRATION_TIME_NOT_AVAILABLE;
-        }
-        try {
-            Duration expiryDuration = expiryPolicy.getExpiryForCreation();
-            if (expiryDuration == null || expiryDuration.isEternal()) {
-                return CacheRecord.EXPIRATION_TIME_NOT_AVAILABLE;
-            }
-            long durationAmount = expiryDuration.getDurationAmount();
-            TimeUnit durationTimeUnit = expiryDuration.getTimeUnit();
-            return TimeUnit.MILLISECONDS.convert(durationAmount, durationTimeUnit);
-        } catch (Exception e) {
-            return CacheRecord.EXPIRATION_TIME_NOT_AVAILABLE;
-        }
-    }
-
-    protected ExpiryPolicy ttlToExpirePolicy(long ttl) {
-        if (ttl >= 0) {
-            return new ModifiedExpiryPolicy(new Duration(TimeUnit.MILLISECONDS, ttl));
-        } else {
-            return new CreatedExpiryPolicy(Duration.ETERNAL);
-        }
-    }
-
     protected R createRecord(long expiryTime) {
         return createRecord(null, Clock.currentTimeMillis(), expiryTime);
     }
@@ -559,14 +527,6 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
 
     protected void onUpdateRecordError(Data key, R record, Object value, Data newDataValue,
                                        Data oldDataValue, Throwable error) {
-    }
-
-    protected R updateRecord(Data key, R record, Object value, int completionId) {
-        return updateRecord(key, record, value, completionId, SOURCE_NOT_AVAILABLE);
-    }
-
-    protected R updateRecord(Data key, R record, Object value, int completionId, String source) {
-        return updateRecord(key, record, value, completionId, source, null);
     }
 
     protected R updateRecord(Data key, R record, Object value, int completionId, String source, String origin) {
@@ -841,11 +801,6 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
     @Override
     public CacheRecord getRecord(Data key) {
         return records.get(key);
-    }
-
-    @Override
-    public void setRecord(Data key, CacheRecord record) {
-        doPutRecord(key, (R) record);
     }
 
     @Override
@@ -1485,5 +1440,19 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
     @Override
     public boolean isWanReplicationEnabled() {
         return wanReplicationEnabled;
+    }
+
+    @Override
+    public void transferRecordsFrom(ICacheRecordStore src) {
+        if (!(src instanceof AbstractCacheRecordStore)) {
+            throw new IllegalArgumentException("Expecting AbstractCacheRecordStore!");
+        }
+
+        AbstractCacheRecordStore dest = this;
+        CacheRecordMap oldRecords = dest.records;
+        dest.records = ((AbstractCacheRecordStore) src).records;
+        if (oldRecords instanceof Disposable) {
+            ((Disposable) oldRecords).dispose();
+        }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheRecordStore.java
@@ -602,7 +602,7 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
             Data eventDataValue = toEventData(dataValue);
             Data eventDataOldValue = toEventData(dataOldValue);
 
-            record.setValue(recordValue);
+            updateRecordValue(record, recordValue);
             onUpdateRecord(key, record, value, dataOldValue);
             invalidateEntry(key, source);
 
@@ -618,6 +618,10 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
             onUpdateRecordError(key, record, value, dataValue, dataOldValue, error);
             throw ExceptionUtil.rethrow(error);
         }
+    }
+
+    protected void updateRecordValue(R record, Object recordValue) {
+        record.setValue(recordValue);
     }
 
     protected boolean updateRecordWithExpiry(Data key, Object value, R record, long expiryTime,
@@ -851,7 +855,7 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
         doPutRecord(key, (R) record);
     }
 
-    protected final R doPutRecord(Data key, R record) {
+    public final R doPutRecord(Data key, R record) {
         return doPutRecord(key, record, SOURCE_NOT_AVAILABLE);
     }
 
@@ -1445,6 +1449,12 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
 
     protected void onClear() {
         invalidateAllEntries();
+    }
+
+    @Override
+    public void close() {
+        clear();
+        closeListeners();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CachePartitionSegment.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CachePartitionSegment.java
@@ -110,14 +110,4 @@ public class CachePartitionSegment implements ConstructorFunction<String, ICache
         }
         recordStores.clear();
     }
-
-    protected static void transferRecordData(ICacheRecordStore src, ICacheRecordStore dest) {
-        if (!(src instanceof AbstractCacheRecordStore)) {
-            throw new IllegalArgumentException("Expecting AbstractCacheRecordStore!");
-        }
-        if (!(dest instanceof AbstractCacheRecordStore)) {
-            throw new IllegalArgumentException("Expecting AbstractCacheRecordStore!");
-        }
-        ((AbstractCacheRecordStore) dest).records = ((AbstractCacheRecordStore) src).records;
-    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheService.java
@@ -46,8 +46,11 @@ import com.hazelcast.spi.PartitionReplicationEvent;
  * using {@link AbstractHazelcastCacheManager#cacheNamePrefix()}.
  * </p>
  */
-public class CacheService
-        extends AbstractCacheService {
+public class CacheService extends AbstractCacheService {
+
+    @Override protected CachePartitionSegment newPartitionSegment(int partitionId) {
+        return new CachePartitionSegment(this, partitionId);
+    }
 
     @Override
     protected ICacheRecordStore createNewRecordStore(String name, int partitionId) {

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/ICacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/ICacheRecordStore.java
@@ -43,8 +43,7 @@ import java.util.Set;
  */
 public interface ICacheRecordStore {
 
-    // Defined as constant for check-style error
-    int ONE_HUNDRED_PERCENT = 100;
+    int UNIT_PERCENTAGE = 100;
 
     /**
      * Gets the value to which the specified key is mapped,
@@ -308,12 +307,27 @@ public interface ICacheRecordStore {
     void removeAll(Set<Data> keys, int completionId);
 
     /**
+     * Close is equivalent to below operations in the given order:
+     * <ul>
+     *     <li>close resources.</li>
+     *     <li>unregister all listeners.</li>
+     * </ul>
+     *
+     * @see #clear()
+     * @see #destroy()
+     */
+    void close();
+
+    /**
      * Destroy is equivalent to below operations in the given order:
      * <ul>
      *     <li>clear all.</li>
      *     <li>close resources.</li>
      *     <li>unregister all listeners.</li>
      * </ul>
+     *
+     * @see #clear()
+     * @see #close()
      */
     void destroy();
 

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/ICacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/ICacheRecordStore.java
@@ -359,17 +359,6 @@ public interface ICacheRecordStore {
     /**
      * Associates the specified record with the specified key.
      * This is simply a put operation on the internal map data
-     * without any CacheLoad. It also <b>DOES NOT</b> trigger eviction,
-     * be aware of the fact it might cause an OutOfMemoryException!
-     *
-     * @param key the key to the entry.
-     * @param record the value to be associated with the specified key.
-     */
-    void setRecord(Data key, CacheRecord record);
-
-    /**
-     * Associates the specified record with the specified key.
-     * This is simply a put operation on the internal map data
      * without any CacheLoad. It also <b>DOES</b> trigger eviction!
      *
      * @param key the key to the entry.
@@ -444,4 +433,13 @@ public interface ICacheRecordStore {
      */
     boolean isWanReplicationEnabled();
 
+    /**
+     * Transfers all records from source record store
+     * and drops previous records owned by this record store.
+     * Source record store should not be accessed anymore
+     * after transfer.
+     *
+     * @param src source record store whose records will be transferred
+     */
+    void transferRecordsFrom(ICacheRecordStore src);
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/ICacheService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/ICacheService.java
@@ -56,7 +56,7 @@ public interface ICacheService extends ManagedService, RemoteService, MigrationA
 
     CacheContext getOrCreateCacheContext(String name);
 
-    void destroyCache(String objectName, boolean isLocal, String callerUuid);
+    void deleteCache(String objectName, boolean isLocal, String callerUuid, boolean destroy);
 
     void deleteCacheStat(String name);
 

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheDestroyOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheDestroyOperation.java
@@ -28,9 +28,9 @@ import java.io.IOException;
 
 /**
  * <p>Destroys the cache on the cluster or on a single node by calling
- * {@link ICacheService#destroyCache(String, boolean, String)}.
+ * {@link CacheService#deleteCache(String, boolean, String, boolean)}.
  * </p>
- * @see ICacheService#destroyCache(String, boolean, String)
+ * @see CacheService#deleteCache(String, boolean, String, boolean)
  */
 public class CacheDestroyOperation
         extends AbstractNamedOperation
@@ -54,7 +54,7 @@ public class CacheDestroyOperation
     public void run()
             throws Exception {
         final ICacheService service = getService();
-        service.destroyCache(name, isLocal, getCallerUuid());
+        service.deleteCache(name, isLocal, getCallerUuid(), true);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/record/CacheRecordHashMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/record/CacheRecordHashMap.java
@@ -149,5 +149,4 @@ public class CacheRecordHashMap
     public Iterable<EvictableSamplingEntry> sample(int sampleCount) {
         return super.getRandomSamples(sampleCount);
     }
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/AbstractCacheConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/AbstractCacheConfig.java
@@ -94,6 +94,11 @@ abstract class AbstractCacheConfig<K, V> implements CacheConfiguration<K, V>, Da
      */
     protected boolean isManagementEnabled;
 
+    /**
+     * Whether Hot Restart is enabled
+     */
+    protected boolean isHotRestart;
+
     public AbstractCacheConfig() {
         this.keyType = (Class<K>) Object.class;
         this.valueType = (Class<V>) Object.class;
@@ -124,11 +129,8 @@ abstract class AbstractCacheConfig<K, V> implements CacheConfiguration<K, V>, Da
 
         this.isReadThrough = configuration.isReadThrough();
         this.isWriteThrough = configuration.isWriteThrough();
-
         this.isStatisticsEnabled = configuration.isStatisticsEnabled();
-
         this.isStoreByValue = configuration.isStoreByValue();
-
         this.isManagementEnabled = configuration.isManagementEnabled();
     }
 
@@ -197,7 +199,7 @@ abstract class AbstractCacheConfig<K, V> implements CacheConfiguration<K, V>, Da
     }
 
     /**
-     * Sets whether or not statistics gathering is enabled on a cache.
+     * Sets whether or not statistics gathering is enabled on this cache.
      * <p/>
      * Statistics may be enabled or disabled at runtime via
      * {@link javax.cache.CacheManager#enableStatistics(String, boolean)}.
@@ -216,7 +218,7 @@ abstract class AbstractCacheConfig<K, V> implements CacheConfiguration<K, V>, Da
     }
 
     /**
-     * Sets whether or not management is enabled on a cache.
+     * Sets whether or not management is enabled on this cache.
      * <p/>
      * Management may be enabled or disabled at runtime via
      * {@link javax.cache.CacheManager#enableManagement(String, boolean)}.
@@ -227,6 +229,19 @@ abstract class AbstractCacheConfig<K, V> implements CacheConfiguration<K, V>, Da
     public CacheConfiguration<K, V> setManagementEnabled(boolean enabled) {
         this.isManagementEnabled = enabled;
         return this;
+    }
+
+    /**
+     * Sets whether hot restart is enabled on this cache.
+     * @return this
+     */
+    public CacheConfiguration<K, V> setHotRestart(boolean hotRestart) {
+        this.isHotRestart = hotRestart;
+        return this;
+    }
+
+    public boolean isHotRestart() {
+        return isHotRestart;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/config/CacheConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CacheConfig.java
@@ -90,6 +90,7 @@ public class CacheConfig<K, V>
             this.asyncBackupCount = config.asyncBackupCount;
             this.backupCount = config.backupCount;
             this.inMemoryFormat = config.inMemoryFormat;
+            this.isHotRestart = config.isHotRestart;
             // Eviction config cannot be null
             if (config.evictionConfig != null) {
                 this.evictionConfig = new CacheEvictionConfig(config.evictionConfig);
@@ -504,6 +505,7 @@ public class CacheConfig<K, V>
         out.writeBoolean(isStoreByValue);
         out.writeBoolean(isManagementEnabled);
         out.writeBoolean(isStatisticsEnabled);
+        out.writeBoolean(isHotRestart);
 
         out.writeUTF(quorumName);
 
@@ -546,6 +548,7 @@ public class CacheConfig<K, V>
         isStoreByValue = in.readBoolean();
         isManagementEnabled = in.readBoolean();
         isStatisticsEnabled = in.readBoolean();
+        isHotRestart = in.readBoolean();
 
         quorumName = in.readUTF();
 
@@ -602,6 +605,7 @@ public class CacheConfig<K, V>
                 + ", managerPrefix='" + managerPrefix + '\''
                 + ", inMemoryFormat=" + inMemoryFormat
                 + ", backupCount=" + backupCount
+                + ", hotRestart=" + isHotRestart()
                 + '}';
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/config/CacheConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CacheConfigReadOnly.java
@@ -135,4 +135,8 @@ public class CacheConfigReadOnly<K, V> extends CacheConfig<K, V> {
         throw new UnsupportedOperationException("This config is read-only cache: " + getName());
     }
 
+    @Override
+    public CacheConfiguration<K, V> setHotRestart(boolean hotRestart) {
+        throw new UnsupportedOperationException("This config is read-only cache: " + getName());
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/nio/Disposable.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/Disposable.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.nio;
+
+/**
+ * A {@code Disposable} is a container of data and/or resources that can be disposed.
+ * {@link #dispose()} method is called to dispose contained data and/or resources.
+ */
+public interface Disposable {
+
+    /**
+     * Disposes this object and releases any data and/or resources associated
+     * with it. If this object is already disposed then invoking this
+     * method has no effect.
+     */
+    void dispose();
+}


### PR DESCRIPTION
- Allowed subclassing of CachePartitionSegment
- Separated cache close and destroy actions
- Encapsulated cache name in record store
- Added isHotRestart field to CacheConfig serialization.

**Also-By: Marko Topolnik <marko@hazelcast.com>**