### PR TITLE
Check value of key if it is null or not while iterating on cache since entry might be removed or evicted.

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheRecordStore.java
@@ -190,8 +190,8 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
 
     protected EvictionPolicyEvaluator<Data, R> createEvictionPolicyEvaluator(EvictionConfig cacheEvictionConfig) {
         final EvictionPolicy evictionPolicy = cacheEvictionConfig.getEvictionPolicy();
-        if (evictionPolicy == null || evictionPolicy == EvictionPolicy.NONE) {
-            throw new IllegalArgumentException("Eviction policy cannot be null or NONE");
+        if (evictionPolicy == null || evictionPolicy == EvictionPolicy.NONE || evictionPolicy == EvictionPolicy.RANDOM) {
+            throw new IllegalArgumentException("Eviction policy cannot be `null`, `NONE` or `RANDOM`");
         }
         return EvictionPolicyEvaluatorProvider.getEvictionPolicyEvaluator(cacheEvictionConfig);
     }
@@ -222,6 +222,7 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
         if (isEvictionEnabled()) {
             evictedCount = evictionStrategy.evict(records, evictionPolicyEvaluator, evictionChecker, this);
             if (isStatisticsEnabled() && evictedCount > 0) {
+
                 statistics.increaseCacheEvictions(evictedCount);
             }
         }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractClusterWideIterator.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractClusterWideIterator.java
@@ -109,15 +109,18 @@ public abstract class AbstractClusterWideIterator<K, V>
 
     @Override
     public Cache.Entry<K, V> next() {
-        if (!hasNext()) {
-            throw new NoSuchElementException();
+        while (hasNext()) {
+            currentIndex = index;
+            index++;
+            final Data keyData = result.getKey(currentIndex);
+            final K key = toObject(keyData);
+            final V value = cache.get(key);
+            // Value might be removed or evicted
+            if (value != null) {
+                return new CacheEntry<K, V>(key, value);
+            }
         }
-        currentIndex = index;
-        index++;
-        final Data keyData = result.getKey(currentIndex);
-        final K key = toObject(keyData);
-        final V value = cache.get(key);
-        return new CacheEntry<K, V>(key, value);
+        throw new NoSuchElementException();
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/cache/CacheTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CacheTestSupport.java
@@ -90,7 +90,6 @@ public abstract class CacheTestSupport extends HazelcastTestSupport {
 
     protected <K, V> CacheConfig<K, V> getCacheConfigWithMaxSize(int maxCacheSize) {
         CacheConfig<K, V> config = createCacheConfig();
-        config.getEvictionConfig().setEvictionPolicy(EvictionPolicy.RANDOM);
         config.getEvictionConfig().setMaximumSizePolicy(EvictionConfig.MaxSizePolicy.ENTRY_COUNT);
         config.getEvictionConfig().setSize(maxCacheSize);
         return config;
@@ -103,6 +102,12 @@ public abstract class CacheTestSupport extends HazelcastTestSupport {
     protected int getMaxCacheSizeWithoutEviction(CacheConfig cacheConfig) {
         int maxEntryCount = cacheConfig.getEvictionConfig().getSize();
         return calculateMaxPartitionSize(maxEntryCount, getPartitionCount());
+    }
+
+    protected int getMaxCacheSizeWithEviction(CacheConfig cacheConfig) {
+        int maxEntryCount = cacheConfig.getEvictionConfig().getSize();
+        int partitionCount = getPartitionCount();
+        return 10 * partitionCount * calculateMaxPartitionSize(maxEntryCount, partitionCount);
     }
 
     private int getPartitionCount() {


### PR DESCRIPTION
Fixes #6234 