### PR TITLE
fix unneccessary instance-name set in properties

### DIFF
--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/cache/SpringHazelcastCachingProvider.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/cache/SpringHazelcastCachingProvider.java
@@ -54,9 +54,6 @@ public final class SpringHazelcastCachingProvider {
                 ExceptionUtil.rethrow(e);
             }
         }
-        if (props.getProperty(HazelcastCachingProvider.HAZELCAST_INSTANCE_NAME) == null) {
-            props.setProperty(HazelcastCachingProvider.HAZELCAST_INSTANCE_NAME, instance.getName());
-        }
         if (instance instanceof HazelcastClientProxy) {
             return HazelcastClientCachingProvider.createCachingProvider(instance).getCacheManager(uri, null, props);
         } else {


### PR DESCRIPTION
Setting instance name in properties is unneccessary now as https://github.com/hazelcast/hazelcast/issues/6454 solved.