### PR TITLE
Fix split-brain test failures of Replicated Map

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/replicatedmap/ClientReplicatedMapListenerTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/replicatedmap/ClientReplicatedMapListenerTest.java
@@ -27,8 +27,6 @@ import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.QuickTest;
 import java.util.concurrent.atomic.AtomicLong;
-
-import com.hazelcast.test.annotation.Repeat;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/ReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/ReplicationOperation.java
@@ -57,7 +57,11 @@ public class ReplicationOperation extends AbstractOperation {
 
     @Override
     public void run() throws Exception {
-        logger.finest("Moving partition -> " + getPartitionId() + " to the new owner -> " + getNodeEngine().getThisAddress());
+        if (logger.isFinestEnabled()) {
+            logger.finest("Moving partition -> " + getPartitionId()
+                    + " to the new owner -> " + getNodeEngine().getThisAddress()
+                    + " from -> " + getCallerAddress());
+        }
         ReplicatedMapService service = getService();
         if (data == null) {
             return;
@@ -83,7 +87,15 @@ public class ReplicationOperation extends AbstractOperation {
                 ReplicatedRecord record = iterator.next();
                 Data dataKey = serializationService.toData(record.getKeyInternal());
                 Data dataValue = serializationService.toData(record.getValueInternal());
-                recordSet.add(new RecordMigrationInfo(dataKey, dataValue, record.getTtlMillis()));
+                RecordMigrationInfo migrationInfo = new RecordMigrationInfo();
+                migrationInfo.setKey(dataKey);
+                migrationInfo.setValue(dataValue);
+                migrationInfo.setTtl(record.getTtlMillis());
+                migrationInfo.setHits(record.getHits());
+                migrationInfo.setCreationTime(record.getCreationTime());
+                migrationInfo.setLastAccessTime(record.getLastAccessTime());
+                migrationInfo.setLastUpdateTime(record.getUpdateTime());
+                recordSet.add(migrationInfo);
             }
             data.put(name, recordSet);
             versions.put(name, store.getVersion());

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/AbstractReplicatedRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/AbstractReplicatedRecordStore.java
@@ -280,7 +280,12 @@ public abstract class AbstractReplicatedRecordStore<K, V> extends AbstractBaseRe
     public void putRecord(RecordMigrationInfo record) {
         K key = (K) marshall(record.getKey());
         V value = (V) marshall(record.getValue());
-        getStorage().putInternal(key, buildReplicatedRecord(key, value, record.getTtl()));
+        ReplicatedRecord newRecord = buildReplicatedRecord(key, value, record.getTtl());
+        newRecord.setHits(record.getHits());
+        newRecord.setCreationTime(record.getCreationTime());
+        newRecord.setLastAccessTime(record.getLastAccessTime());
+        newRecord.setUpdateTime(record.getLastUpdateTime());
+        getStorage().putInternal(key, newRecord);
     }
 
     private ReplicatedRecord buildReplicatedRecord(Object key, Object value, long ttlMillis) {

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/RecordMigrationInfo.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/RecordMigrationInfo.java
@@ -27,6 +27,14 @@ public class RecordMigrationInfo implements DataSerializable {
     private Data key;
     private Data value;
     private long ttl;
+    private long hits;
+    private long lastAccessTime;
+    private long lastUpdateTime;
+    private long creationTime;
+
+    public RecordMigrationInfo() {
+    }
+
 
     public RecordMigrationInfo(Data key, Data value, long ttl) {
         this.key = key;
@@ -34,19 +42,60 @@ public class RecordMigrationInfo implements DataSerializable {
         this.ttl = ttl;
     }
 
-    public RecordMigrationInfo() {
-    }
-
     public Data getKey() {
         return key;
+    }
+
+    public void setKey(Data key) {
+        this.key = key;
     }
 
     public Data getValue() {
         return value;
     }
 
+    public void setValue(Data value) {
+        this.value = value;
+    }
+
     public long getTtl() {
         return ttl;
+    }
+
+    public void setTtl(long ttl) {
+        this.ttl = ttl;
+    }
+
+    public long getHits() {
+        return hits;
+    }
+
+    public void setHits(long hits) {
+        this.hits = hits;
+    }
+
+    public long getLastAccessTime() {
+        return lastAccessTime;
+    }
+
+    public void setLastAccessTime(long lastAccessTime) {
+        this.lastAccessTime = lastAccessTime;
+    }
+
+    public long getLastUpdateTime() {
+        return lastUpdateTime;
+    }
+
+    public void setLastUpdateTime(long lastUpdateTime) {
+        this.lastUpdateTime = lastUpdateTime;
+    }
+
+    public long getCreationTime() {
+        return creationTime;
+    }
+
+    public void setCreationTime(long creationTime) {
+        this.creationTime = creationTime;
     }
 
     @Override
@@ -54,6 +103,10 @@ public class RecordMigrationInfo implements DataSerializable {
         out.writeData(key);
         out.writeData(value);
         out.writeLong(ttl);
+        out.writeLong(hits);
+        out.writeLong(lastAccessTime);
+        out.writeLong(lastUpdateTime);
+        out.writeLong(creationTime);
     }
 
     @Override
@@ -61,6 +114,10 @@ public class RecordMigrationInfo implements DataSerializable {
         key = in.readData();
         value = in.readData();
         ttl = in.readLong();
+        hits = in.readLong();
+        lastAccessTime = in.readLong();
+        lastUpdateTime = in.readLong();
+        creationTime = in.readLong();
     }
 
     @Override
@@ -68,6 +125,11 @@ public class RecordMigrationInfo implements DataSerializable {
         return "RecordMigrationInfo{"
                 + "key=" + key
                 + ", value=" + value
-                + "} ";
+                + ", ttl=" + ttl
+                + ", hits=" + hits
+                + ", lastAccessTime=" + lastAccessTime
+                + ", lastUpdateTime=" + lastUpdateTime
+                + ", creationTime=" + creationTime
+                + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/ReplicatedRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/ReplicatedRecord.java
@@ -101,6 +101,10 @@ public class ReplicatedRecord<K, V> implements IdentifiedDataSerializable {
         return updateTime;
     }
 
+    public void setUpdateTime(long updateTime) {
+        this.updateTime = updateTime;
+    }
+
     public long getHits() {
         return hits;
     }
@@ -113,8 +117,16 @@ public class ReplicatedRecord<K, V> implements IdentifiedDataSerializable {
         return lastAccessTime;
     }
 
+    public void setLastAccessTime(long lastAccessTime) {
+        this.lastAccessTime = lastAccessTime;
+    }
+
     public long getCreationTime() {
         return creationTime;
+    }
+
+    public void setCreationTime(long creationTime) {
+        this.creationTime = creationTime;
     }
 
     private void access() {


### PR DESCRIPTION
Carry record metadata (hits, lastAccessTime, creationTime, lastUpdateTime) with the record on migration. Fixes #6489
