### PR TITLE
UpdateEntryProcessor test on real network

### DIFF
--- a/hazelcast-hibernate/hazelcast-hibernate3/src/test/java/com/hazelcast/hibernate/HibernateStatisticsTestSupport.java
+++ b/hazelcast-hibernate/hazelcast-hibernate3/src/test/java/com/hazelcast/hibernate/HibernateStatisticsTestSupport.java
@@ -56,10 +56,20 @@ public abstract class HibernateStatisticsTestSupport extends HibernateTestSuppor
 
     protected abstract Properties getCacheProperties();
 
+    /**
+     * Inserts entities with increasing id starting from 0
+     * @param count Number of entities to be added
+     */
     protected void insertDummyEntities(int count) {
         insertDummyEntities(count, 0);
     }
 
+    /**
+     * Inserts entities with increasing id starting from 0.
+     * Each entity has child entities.
+     * @param count Number of entities
+     * @param childCount Number of child entities each entity has
+     */
     protected void insertDummyEntities(int count, int childCount) {
         Session session = sf.openSession();
         Transaction tx = session.beginTransaction();

--- a/hazelcast-hibernate/hazelcast-hibernate3/src/test/java/com/hazelcast/hibernate/RegionFactoryDefaultSlowTest.java
+++ b/hazelcast-hibernate/hazelcast-hibernate3/src/test/java/com/hazelcast/hibernate/RegionFactoryDefaultSlowTest.java
@@ -17,15 +17,19 @@
 package com.hazelcast.hibernate;
 
 import com.hazelcast.config.MapConfig;
+import com.hazelcast.hibernate.entity.DummyEntity;
 import com.hazelcast.hibernate.region.HazelcastQueryResultsRegion;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.SlowTest;
+import org.hibernate.Session;
+import org.hibernate.Transaction;
 import org.hibernate.cfg.Environment;
 import org.hibernate.impl.SessionFactoryImpl;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import java.util.ArrayList;
 import java.util.Properties;
 
 import static org.junit.Assert.assertEquals;
@@ -61,4 +65,19 @@ public class RegionFactoryDefaultSlowTest extends HibernateSlowTestSupport {
         assertEquals(numberOfEntities - evictedItemCount, queryRegion.getCache().size());
     }
 
+    @Test
+    public void testUpdate() {
+        insertDummyEntities(1);
+        Session session = sf.openSession();
+        Transaction tx = session.beginTransaction();
+        DummyEntity ent = (DummyEntity) session.get(DummyEntity.class, 0L);
+        ent.setName("updatedName");
+        session.update(ent);
+        tx.commit();
+        session.close();
+
+        session = sf2.openSession();
+        DummyEntity entity = (DummyEntity) session.get(DummyEntity.class, 0L);
+        assertEquals("updatedName", entity.getName());
+    }
 }

--- a/hazelcast-hibernate/hazelcast-hibernate3/src/test/java/com/hazelcast/hibernate/local/LocalRegionCacheTest.java
+++ b/hazelcast-hibernate/hazelcast-hibernate3/src/test/java/com/hazelcast/hibernate/local/LocalRegionCacheTest.java
@@ -15,6 +15,7 @@ import org.junit.runner.RunWith;
 
 import java.util.Comparator;
 
+import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.*;
 
 @RunWith(HazelcastSerialClassRunner.class)
@@ -92,6 +93,16 @@ public class LocalRegionCacheTest {
         verify(instance).getConfig();
         verify(instance).getTopic(eq(CACHE_NAME));
         verify(topic).addMessageListener(isNotNull(MessageListener.class));
+    }
+
+    @Test
+    public void testTimestampToString() {
+        assertNotNull(new Timestamp().toString());
+    }
+
+    @Test
+    public void testInvalidationToString() {
+        assertNotNull(new Invalidation().toString());
     }
 
     public static void runCleanup(LocalRegionCache cache) {

--- a/hazelcast-hibernate/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/HibernateStatisticsTestSupport.java
+++ b/hazelcast-hibernate/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/HibernateStatisticsTestSupport.java
@@ -78,10 +78,20 @@ public abstract class HibernateStatisticsTestSupport extends HibernateTestSuppor
 
     protected abstract Properties getCacheProperties();
 
+    /**
+     * Inserts entities with increasing id starting from 0
+     * @param count Number of entities to be added
+     */
     protected void insertDummyEntities(int count) {
         insertDummyEntities(count, 0);
     }
 
+    /**
+     * Inserts entities with increasing id starting from 0.
+     * Each entity has child entities.
+     * @param count Number of entities
+     * @param childCount Number of child entities each entity has
+     */
     protected void insertDummyEntities(int count, int childCount) {
         Session session = sf.openSession();
         Transaction tx = session.beginTransaction();

--- a/hazelcast-hibernate/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/RegionFactoryDefaultSlowTest.java
+++ b/hazelcast-hibernate/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/RegionFactoryDefaultSlowTest.java
@@ -17,9 +17,12 @@
 package com.hazelcast.hibernate;
 
 import com.hazelcast.config.MapConfig;
+import com.hazelcast.hibernate.entity.DummyEntity;
 import com.hazelcast.hibernate.region.HazelcastQueryResultsRegion;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.SlowTest;
+import org.hibernate.Session;
+import org.hibernate.Transaction;
 import org.hibernate.cfg.Environment;
 import org.hibernate.internal.SessionFactoryImpl;
 import org.junit.Test;
@@ -60,6 +63,22 @@ public class RegionFactoryDefaultSlowTest
         sleep(defaultCleanupPeriod);
 
         assertEquals(numberOfEntities - evictedItemCount, queryRegion.getCache().size());
+    }
+
+    @Test
+    public void testUpdate() {
+        insertDummyEntities(1);
+        Session session = sf.openSession();
+        Transaction tx = session.beginTransaction();
+        DummyEntity ent = (DummyEntity) session.get(DummyEntity.class, 0L);
+        ent.setName("updatedName");
+        session.update(ent);
+        tx.commit();
+        session.close();
+
+        session = sf2.openSession();
+        DummyEntity entity = (DummyEntity) session.get(DummyEntity.class, 0L);
+        assertEquals("updatedName", entity.getName());
     }
 
 }

--- a/hazelcast-hibernate/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/local/LocalRegionCacheTest.java
+++ b/hazelcast-hibernate/hazelcast-hibernate4/src/test/java/com/hazelcast/hibernate/local/LocalRegionCacheTest.java
@@ -15,6 +15,7 @@ import org.junit.runner.RunWith;
 
 import java.util.Comparator;
 
+import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.*;
 
 @RunWith(HazelcastSerialClassRunner.class)
@@ -92,6 +93,16 @@ public class LocalRegionCacheTest {
         verify(instance).getConfig();
         verify(instance).getTopic(eq(CACHE_NAME));
         verify(topic).addMessageListener(isNotNull(MessageListener.class));
+    }
+
+    @Test
+    public void testTimestampToString() {
+        assertNotNull(new Timestamp().toString());
+    }
+
+    @Test
+    public void testInvalidationToString() {
+        assertNotNull(new Invalidation().toString());
     }
 
     public static void runCleanup(LocalRegionCache cache) {


### PR DESCRIPTION
Tests UpdateEntryProcessor in Hibernate. Also increases test coverage by testing toSrring methods.