### PR TITLE
Hot Restart Requests for mancenter

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/management/ManagementCenterService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/ManagementCenterService.java
@@ -32,12 +32,14 @@ import com.hazelcast.instance.HazelcastThreadGroup;
 import com.hazelcast.instance.MemberImpl;
 import com.hazelcast.internal.ascii.rest.HttpCommand;
 import com.hazelcast.internal.management.operation.UpdateManagementCenterUrlOperation;
+import com.hazelcast.internal.management.request.ChangeClusterStateRequest;
 import com.hazelcast.internal.management.request.ChangeWanStateRequest;
 import com.hazelcast.internal.management.request.AsyncConsoleRequest;
 import com.hazelcast.internal.management.request.ClusterPropsRequest;
 import com.hazelcast.internal.management.request.ConsoleCommandRequest;
 import com.hazelcast.internal.management.request.ConsoleRequest;
 import com.hazelcast.internal.management.request.ExecuteScriptRequest;
+import com.hazelcast.internal.management.request.GetClusterStateRequest;
 import com.hazelcast.internal.management.request.GetLogsRequest;
 import com.hazelcast.internal.management.request.GetMapEntryRequest;
 import com.hazelcast.internal.management.request.GetMemberSystemPropertiesRequest;
@@ -45,6 +47,7 @@ import com.hazelcast.internal.management.request.GetSystemWarningsRequest;
 import com.hazelcast.internal.management.request.MapConfigRequest;
 import com.hazelcast.internal.management.request.MemberConfigRequest;
 import com.hazelcast.internal.management.request.RunGcRequest;
+import com.hazelcast.internal.management.request.ShutdownClusterRequest;
 import com.hazelcast.internal.management.request.ShutdownMemberRequest;
 import com.hazelcast.internal.management.request.ThreadDumpRequest;
 import com.hazelcast.logging.ILogger;
@@ -443,6 +446,9 @@ public class ManagementCenterService {
             register(new GetMemberSystemPropertiesRequest());
             register(new GetMapEntryRequest());
             register(new ShutdownMemberRequest());
+            register(new GetClusterStateRequest());
+            register(new ChangeClusterStateRequest());
+            register(new ShutdownClusterRequest());
             register(new GetSystemWarningsRequest());
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/request/ChangeClusterStateRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/request/ChangeClusterStateRequest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.management.request;
+
+import com.eclipsesource.json.JsonObject;
+import com.hazelcast.cluster.ClusterState;
+import com.hazelcast.core.Cluster;
+import com.hazelcast.internal.management.ManagementCenterService;
+import com.hazelcast.logging.ILogger;
+
+import java.io.IOException;
+
+import static com.hazelcast.util.JsonUtil.getString;
+
+/**
+ * Request coming from Management Center for changing the {@link ClusterState}
+ */
+public class ChangeClusterStateRequest implements AsyncConsoleRequest {
+
+    private String state;
+
+    public ChangeClusterStateRequest() {
+    }
+
+    public ChangeClusterStateRequest(String state) {
+        this.state = state;
+    }
+
+    @Override
+    public int getType() {
+        return ConsoleRequestConstants.REQUEST_TYPE_CHANGE_CLUSTER_STATE;
+    }
+
+    @Override
+    public Object readResponse(JsonObject in) throws IOException {
+        return getString(in, "result", "FAIL");
+    }
+
+    @Override
+    public void writeResponse(ManagementCenterService mcs, JsonObject out) throws Exception {
+        String resultString = "SUCCESS";
+        try {
+            Cluster cluster = mcs.getHazelcastInstance().getCluster();
+            cluster.changeClusterState(getClusterState(state));
+        } catch (Exception e) {
+            ILogger logger = mcs.getHazelcastInstance().node.nodeEngine.getLogger(getClass());
+            logger.warning("Cluster state can not be changed: ", e);
+            resultString = e.getMessage();
+        }
+        JsonObject result = new JsonObject().add("result", resultString);
+        out.add("result", result);
+    }
+
+    private static ClusterState getClusterState(String state) {
+        return ClusterState.valueOf(state);
+    }
+
+    @Override
+    public JsonObject toJson() {
+        JsonObject root = new JsonObject();
+        root.add("state", state);
+        return root;
+    }
+
+    @Override
+    public void fromJson(JsonObject json) {
+        state = getString(json, "state");
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/request/ConsoleRequestConstants.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/request/ConsoleRequestConstants.java
@@ -37,6 +37,9 @@ public final class ConsoleRequestConstants {
     public static final int REQUEST_TYPE_MEMBER_SHUTDOWN = 18;
     public static final int REQUEST_TYPE_SYSTEM_WARNINGS = 20;
     public static final int REQUEST_TYPE_WAN_PUBLISHER = 33;
+    public static final int REQUEST_TYPE_GET_CLUSTER_STATE = 34;
+    public static final int REQUEST_TYPE_CHANGE_CLUSTER_STATE = 35;
+    public static final int REQUEST_TYPE_CLUSTER_SHUTDOWN = 36;
 
     private ConsoleRequestConstants() {
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/request/GetClusterStateRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/request/GetClusterStateRequest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.management.request;
+
+import com.eclipsesource.json.JsonObject;
+import com.hazelcast.cluster.ClusterState;
+import com.hazelcast.internal.management.ManagementCenterService;
+
+import java.io.IOException;
+
+import static com.hazelcast.util.JsonUtil.getString;
+
+/**
+ * Request coming from Management Center for getting the {@link ClusterState}
+ */
+public class GetClusterStateRequest implements ConsoleRequest {
+
+    @Override
+    public int getType() {
+        return ConsoleRequestConstants.REQUEST_TYPE_GET_CLUSTER_STATE;
+    }
+
+    @Override
+    public Object readResponse(JsonObject in) throws IOException {
+        return getString(in, "result", "UNKNOWN");
+    }
+
+    @Override
+    public void writeResponse(ManagementCenterService mcs, JsonObject out) throws Exception {
+        ClusterState clusterState = mcs.getHazelcastInstance().getCluster().getClusterState();
+        JsonObject result = new JsonObject();
+        result.add("result", clusterState.toString());
+        out.add("result", result);
+    }
+
+    @Override
+    public JsonObject toJson() {
+        return new JsonObject();
+    }
+
+    @Override
+    public void fromJson(JsonObject json) {
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/request/ShutdownClusterRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/request/ShutdownClusterRequest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.management.request;
+
+import com.eclipsesource.json.JsonObject;
+import com.hazelcast.internal.management.ManagementCenterService;
+import com.hazelcast.logging.ILogger;
+
+import java.io.IOException;
+
+import static com.hazelcast.util.JsonUtil.getString;
+
+/**
+ * Request coming from Management Center for shutting down the {@link com.hazelcast.core.Cluster}
+ */
+public class ShutdownClusterRequest implements AsyncConsoleRequest {
+
+    @Override
+    public int getType() {
+        return ConsoleRequestConstants.REQUEST_TYPE_CLUSTER_SHUTDOWN;
+    }
+
+    @Override
+    public Object readResponse(JsonObject in) throws IOException {
+        return getString(in, "result", "FAIL");
+    }
+
+    @Override
+    public void writeResponse(ManagementCenterService mcs, JsonObject out) throws Exception {
+        String resultString = "SUCCESS";
+        try {
+            mcs.getHazelcastInstance().getCluster().shutdown();
+        } catch (Exception e) {
+            ILogger logger = mcs.getHazelcastInstance().node.nodeEngine.getLogger(getClass());
+            logger.warning("Cluster can not be shutdown: ", e);
+            resultString = e.getMessage();
+        }
+
+        JsonObject result = new JsonObject().add("result", resultString);
+        out.add("result", result);
+    }
+
+    @Override
+    public JsonObject toJson() {
+        return new JsonObject();
+    }
+
+    @Override
+    public void fromJson(JsonObject json) {
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/ChangeClusterStateRequestTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/ChangeClusterStateRequestTest.java
@@ -1,0 +1,71 @@
+package com.hazelcast.internal.management;
+
+import com.eclipsesource.json.JsonObject;
+import com.hazelcast.cluster.ClusterState;
+import com.hazelcast.core.Cluster;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.instance.Node;
+import com.hazelcast.internal.management.request.ChangeClusterStateRequest;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ChangeClusterStateRequestTest extends HazelcastTestSupport {
+
+    private final String INTERNAL_STATE_ERROR = "IN_TRANSITION is an internal state!";
+    private final String NO_ENUM_CONSTANT = "No enum constant com.hazelcast.cluster.ClusterState.MURAT";
+
+    private HazelcastInstance hz;
+    private Cluster cluster;
+    private ManagementCenterService managementCenterService;
+
+    @Before
+    public void setUp() {
+        hz = createHazelcastInstance();
+        Node node = getNode(hz);
+        managementCenterService = node.getManagementCenterService();
+        cluster = hz.getCluster();
+    }
+
+    @Test
+    public void testChangeClusterState() throws Exception {
+        ChangeClusterStateRequest changeClusterStateRequest = new ChangeClusterStateRequest("FROZEN");
+        JsonObject jsonObject = new JsonObject();
+        changeClusterStateRequest.writeResponse(managementCenterService, jsonObject);
+
+        JsonObject result = (JsonObject) jsonObject.get("result");
+        assertEquals("SUCCESS", changeClusterStateRequest.readResponse(result));
+
+        assertEquals(ClusterState.valueOf("FROZEN"), cluster.getClusterState());
+    }
+
+    @Test
+    public void testChangeClusterState_withInvalidState() throws Exception {
+        ChangeClusterStateRequest changeClusterStateRequest = new ChangeClusterStateRequest("IN_TRANSITION");
+        JsonObject jsonObject = new JsonObject();
+        changeClusterStateRequest.writeResponse(managementCenterService, jsonObject);
+
+        JsonObject result = (JsonObject) jsonObject.get("result");
+        assertEquals(INTERNAL_STATE_ERROR, changeClusterStateRequest.readResponse(result));
+    }
+
+    @Test
+    public void testChangeClusterState_withNonExistent() throws Exception {
+        ChangeClusterStateRequest changeClusterStateRequest = new ChangeClusterStateRequest("MURAT");
+        JsonObject jsonObject = new JsonObject();
+        changeClusterStateRequest.writeResponse(managementCenterService, jsonObject);
+
+        JsonObject result = (JsonObject) jsonObject.get("result");
+        assertEquals(NO_ENUM_CONSTANT, changeClusterStateRequest.readResponse(result));
+    }
+}
+

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/GetClusterStateRequestTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/GetClusterStateRequestTest.java
@@ -1,0 +1,47 @@
+package com.hazelcast.internal.management;
+
+import com.eclipsesource.json.JsonObject;
+import com.hazelcast.cluster.ClusterState;
+import com.hazelcast.core.Cluster;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.instance.Node;
+import com.hazelcast.internal.management.request.GetClusterStateRequest;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class GetClusterStateRequestTest extends HazelcastTestSupport{
+
+    private HazelcastInstance hz;
+    private Cluster cluster;
+    private GetClusterStateRequest getClusterStateRequest;
+    private ManagementCenterService managementCenterService;
+
+    @Before
+    public void setUp() {
+        hz = createHazelcastInstance();
+        Node node = getNode(hz);
+        managementCenterService = node.getManagementCenterService();
+        cluster = hz.getCluster();
+        getClusterStateRequest = new GetClusterStateRequest();
+    }
+
+    @Test
+    public void testGetClusterState() throws Exception {
+        ClusterState clusterState = cluster.getClusterState();
+        JsonObject jsonObject = new JsonObject();
+        getClusterStateRequest.writeResponse(managementCenterService, jsonObject);
+
+        JsonObject result = (JsonObject) jsonObject.get("result");
+        assertEquals(clusterState.name(), getClusterStateRequest.readResponse(result));
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/ShutdownClusterRequestTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/ShutdownClusterRequestTest.java
@@ -1,0 +1,62 @@
+package com.hazelcast.internal.management;
+
+import com.eclipsesource.json.JsonObject;
+import com.hazelcast.cluster.ClusterState;
+import com.hazelcast.core.Cluster;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.LifecycleService;
+import com.hazelcast.instance.Node;
+import com.hazelcast.internal.management.request.ShutdownClusterRequest;
+import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ShutdownClusterRequestTest extends HazelcastTestSupport {
+
+    private final String SUCCESS = "SUCCESS";
+
+    private HazelcastInstance hz;
+    private LifecycleService lifecycleService;
+    private Cluster cluster;
+    private ShutdownClusterRequest shutdownClusterRequest;
+    private ManagementCenterService managementCenterService;
+
+    @Before
+    public void setUp() {
+        hz = createHazelcastInstance();
+        lifecycleService = hz.getLifecycleService();
+        Node node = getNode(hz);
+        managementCenterService = node.getManagementCenterService();
+        cluster = hz.getCluster();
+        shutdownClusterRequest = new ShutdownClusterRequest();
+    }
+
+    @Test
+    public void testShutdownCluster() throws Exception {
+        ClusterState clusterState = cluster.getClusterState();
+        JsonObject jsonObject = new JsonObject();
+        shutdownClusterRequest.writeResponse(managementCenterService, jsonObject);
+
+        JsonObject result = (JsonObject) jsonObject.get("result");
+        assertEquals(SUCCESS, shutdownClusterRequest.readResponse(result));
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertFalse(lifecycleService.isRunning());
+            }
+        });
+    }
+}
+


### PR DESCRIPTION
This PR makes mancenter enable to manage Hot Restart events such as `GetState` `ChangeState` and `Shutdown`