### PR TITLE
ClientMapProxy.getAll to invoke-by-partition

### DIFF
--- a/hazelcast-client-legacy/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
+++ b/hazelcast-client-legacy/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
@@ -713,26 +713,51 @@ public class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V> {
             return Collections.emptyMap();
         }
 
-        List<Data> keySet = new ArrayList<Data>(keys.size());
+        Map<Integer, List<Data>> partitionToKeyData = new HashMap<Integer, List<Data>>();
+        ClientPartitionService partitionService = getContext().getPartitionService();
+
         for (Object key : keys) {
-            keySet.add(toData(key));
+            Data keyData = toData(key);
+            int partitionId = partitionService.getPartitionId(keyData);
+            List<Data> keyList = partitionToKeyData.get(partitionId);
+            if (keyList == null) {
+                keyList = new ArrayList<Data>();
+                partitionToKeyData.put(partitionId, keyList);
+            }
+            keyList.add(keyData);
         }
 
         Map<K, V> result = new HashMap<K, V>();
-        getAllInternal(keySet, result);
+        getAllInternal(partitionToKeyData, result);
         return result;
     }
 
     // This method is overriden.
-    protected MapEntries getAllInternal(List<Data> keySet, Map<K, V> result) {
-        MapGetAllRequest request = new MapGetAllRequest(name, keySet);
-        MapEntries entries = invoke(request);
-        for (Entry<Data, Data> entry : entries.entries()) {
-            V value = toObject(entry.getValue());
-            K key = toObject(entry.getKey());
-            result.put(key, value);
+    protected List<MapEntries> getAllInternal(Map<Integer, List<Data>> partitionToKeyData, Map<K, V> result) {
+        List<Future<Data>> futures = new ArrayList<Future<Data>>(partitionToKeyData.size());
+        List<MapEntries> responses = new ArrayList<MapEntries>(partitionToKeyData.size());
+        
+        for (final Map.Entry<Integer, List<Data>> entry : partitionToKeyData.entrySet()) {
+            int partitionId = entry.getKey();
+            List<Data> keyList = entry.getValue();
+            MapGetAllRequest request = new MapGetAllRequest(name, keyList, partitionId);
+            futures.add(new ClientInvocation(getClient(), request, partitionId).invoke());
         }
-        return entries;
+
+        for (Future<Data> future : futures) {
+            try {                
+                MapEntries entries = toObject(future.get());        
+                for (Entry<Data, Data> entry : entries.entries()) {
+                    final V value = toObject(entry.getValue());
+                    final K key = toObject(entry.getKey());
+                    result.put(key, value);
+                }                
+                responses.add(entries);
+            } catch (Exception e) {
+                ExceptionUtil.rethrow(e);
+            }
+        }
+        return responses;
     }
 
     @Override

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
@@ -961,25 +961,53 @@ public class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V> {
             return emptyMap();
         }
 
-        List<Data> keyList = new ArrayList<Data>(keys.size());
+        Map<Integer, List<Data>> partitionToKeyData = new HashMap<Integer, List<Data>>();
+        ClientPartitionService partitionService = getContext().getPartitionService();
+
         for (Object key : keys) {
-            keyList.add(toData(key));
+            Data keyData = toData(key);
+            int partitionId = partitionService.getPartitionId(keyData);
+            List<Data> keyList = partitionToKeyData.get(partitionId);
+            if (keyList == null) {
+                keyList = new ArrayList<Data>();
+                partitionToKeyData.put(partitionId, keyList);
+            }
+            keyList.add(keyData);
         }
 
         Map<K, V> result = new HashMap<K, V>();
-        MapGetAllCodec.ResponseParameters resultParameters = getAllInternal(keyList, result);
-        for (Entry<Data, Data> entry : resultParameters.entrySet) {
-            V value = toObject(entry.getValue());
-            K key = toObject(entry.getKey());
-            result.put(key, value);
-        }
+        getAllInternal(partitionToKeyData, result);
         return result;
     }
 
-    protected MapGetAllCodec.ResponseParameters getAllInternal(List<Data> keyList, Map<K, V> result) {
-        ClientMessage request = MapGetAllCodec.encodeRequest(name, keyList);
-        ClientMessage response = invoke(request);
-        return MapGetAllCodec.decodeResponse(response);
+    protected List<MapGetAllCodec.ResponseParameters> getAllInternal(Map<Integer, List<Data>> partitionToKeyData, Map<K, V> result) {
+        List<Future<ClientMessage>> futures = new ArrayList<Future<ClientMessage>>(partitionToKeyData.size());
+        List<MapGetAllCodec.ResponseParameters> responses = new ArrayList<MapGetAllCodec.ResponseParameters>(partitionToKeyData.size());
+        
+        for (final Map.Entry<Integer, List<Data>> entry : partitionToKeyData.entrySet()) {
+            int partitionId = entry.getKey();
+            List<Data> keyList = entry.getValue();
+            ClientMessage request = MapGetAllCodec.encodeRequest(name, keyList);
+            futures.add(new ClientInvocation(getClient(), request, partitionId).invoke());
+        }
+
+        for (Future<ClientMessage> future : futures) {
+            try {
+                ClientMessage response = future.get();
+                MapGetAllCodec.ResponseParameters resultParameters = MapGetAllCodec.decodeResponse(response);
+        
+                for (Entry<Data, Data> entry : resultParameters.entrySet) {
+                    final V value = toObject(entry.getValue());
+                    final K key = toObject(entry.getKey());
+                    result.put(key, value);
+                }
+
+                responses.add(resultParameters);
+            } catch (Exception e) {
+                ExceptionUtil.rethrow(e);
+            }
+        }
+        return responses;
     }
 
     @Override

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/NearCachedClientMapProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/NearCachedClientMapProxy.java
@@ -52,6 +52,8 @@ import static com.hazelcast.cache.impl.nearcache.NearCache.NULL_OBJECT;
 import static com.hazelcast.map.impl.MapListenerFlagOperator.ALL_LISTENER_FLAGS;
 import static java.util.Collections.emptyMap;
 
+import java.util.ArrayList;
+
 /**
  * A Client-side {@code IMap} implementation which is fronted by a near-cache.
  *
@@ -60,7 +62,7 @@ import static java.util.Collections.emptyMap;
  */
 public class NearCachedClientMapProxy<K, V> extends ClientMapProxy<K, V> {
 
-    protected NearCache nearCache;
+    protected NearCache<Data, Object> nearCache;
     protected volatile String invalidationListenerId;
 
     public NearCachedClientMapProxy(String serviceName, String name) {
@@ -238,22 +240,35 @@ public class NearCachedClientMapProxy<K, V> extends ClientMapProxy<K, V> {
     }
 
     @Override
-    protected MapGetAllCodec.ResponseParameters getAllInternal(List<Data> keyList, Map<K, V> result) {
-        Iterator<Data> iterator = keyList.iterator();
-        while (iterator.hasNext()) {
-            Data key = iterator.next();
-            Object cached = nearCache.get(key);
-            if (cached != null && NULL_OBJECT != cached) {
-                result.put((K) toObject(key), (V) cached);
-                iterator.remove();
+    protected List<MapGetAllCodec.ResponseParameters> getAllInternal(Map<Integer, List<Data>> pIdToKeyData, Map<K, V> result) {
+        List<Integer> partitionsWithCachedEntries = new ArrayList<Integer>(pIdToKeyData.size());
+        for (Entry<Integer, List<Data>> partitionKeyEntry : pIdToKeyData.entrySet()) {
+            List<Data> keyList = partitionKeyEntry.getValue();
+            Iterator<Data> iterator = keyList.iterator();
+            while (iterator.hasNext()) {
+                Data key = iterator.next();
+                Object cached = nearCache.get(key);
+                if (cached != null && NULL_OBJECT != cached) {
+                    result.put((K) toObject(key), (V) cached);
+                    iterator.remove();
+                }
+            }
+            if (keyList.isEmpty()) {
+                partitionsWithCachedEntries.add(partitionKeyEntry.getKey());
             }
         }
 
-        MapGetAllCodec.ResponseParameters resultParameters = super.getAllInternal(keyList, result);
-        for (Entry<Data, Data> entry : resultParameters.entrySet) {
-            nearCache.put(entry.getKey(), entry.getValue());
+        for (Integer partitionId : partitionsWithCachedEntries) {
+            pIdToKeyData.remove(partitionId);
         }
-        return resultParameters;
+
+        List<MapGetAllCodec.ResponseParameters> responses = super.getAllInternal(pIdToKeyData, result);
+        for (MapGetAllCodec.ResponseParameters resultParameters : responses) {
+            for (Entry<Data, Data> entry : resultParameters.entrySet) {
+                nearCache.put(entry.getKey(), entry.getValue());
+            }
+        }
+        return responses;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/client/MapGetAllRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/client/MapGetAllRequest.java
@@ -18,9 +18,10 @@ package com.hazelcast.map.impl.client;
 
 import com.hazelcast.client.impl.client.RetryableRequest;
 import com.hazelcast.client.impl.client.SecureRequest;
-import com.hazelcast.map.impl.MapEntries;
 import com.hazelcast.map.impl.MapPortableHook;
 import com.hazelcast.map.impl.MapService;
+import com.hazelcast.client.impl.client.PartitionClientRequest;
+import com.hazelcast.map.impl.operation.GetAllOperation;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -29,24 +30,27 @@ import com.hazelcast.nio.serialization.PortableReader;
 import com.hazelcast.nio.serialization.PortableWriter;
 import com.hazelcast.security.permission.ActionConstants;
 import com.hazelcast.security.permission.MapPermission;
-import com.hazelcast.spi.OperationFactory;
+
+import com.hazelcast.spi.Operation;
 
 import java.io.IOException;
 import java.security.Permission;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
-public class MapGetAllRequest extends MapAllPartitionsClientRequest implements Portable, RetryableRequest, SecureRequest {
+public class MapGetAllRequest extends PartitionClientRequest implements Portable, RetryableRequest, SecureRequest {
 
+    private String name;
     private List<Data> keys = new ArrayList<Data>();
+    private int partitionId;
 
     public MapGetAllRequest() {
     }
 
-    public MapGetAllRequest(String name, List<Data> keys) {
+    public MapGetAllRequest(String name, List<Data> keys, int partitionId) {
         this.name = name;
         this.keys = keys;
+        this.partitionId = partitionId;
     }
 
     @Override
@@ -60,21 +64,15 @@ public class MapGetAllRequest extends MapAllPartitionsClientRequest implements P
     }
 
     @Override
-    protected OperationFactory createOperationFactory() {
-        return getOperationProvider().createGetAllOperationFactory(name, keys);
+    protected Operation prepareOperation() {
+        GetAllOperation operation = new GetAllOperation(name, keys);
+        operation.setPartitionId(partitionId);
+        return operation;
     }
 
     @Override
-    protected Object reduce(Map<Integer, Object> map) {
-        MapEntries result = new MapEntries();
-        MapService mapService = getService();
-        for (Map.Entry<Integer, Object> entry : map.entrySet()) {
-            MapEntries mapEntries = (MapEntries) mapService.getMapServiceContext().toObject(entry.getValue());
-            for (Map.Entry<Data, Data> dataEntry : mapEntries) {
-                result.add(dataEntry);
-            }
-        }
-        return result;
+    protected int getPartition() {
+        return partitionId;
     }
 
     @Override
@@ -85,6 +83,7 @@ public class MapGetAllRequest extends MapAllPartitionsClientRequest implements P
     @Override
     public void write(PortableWriter writer) throws IOException {
         writer.writeUTF("n", name);
+        writer.writeInt("p", partitionId);
         writer.writeInt("size", keys.size());
         if (!keys.isEmpty()) {
             ObjectDataOutput out = writer.getRawDataOutput();
@@ -97,6 +96,7 @@ public class MapGetAllRequest extends MapAllPartitionsClientRequest implements P
     @Override
     public void read(PortableReader reader) throws IOException {
         name = reader.readUTF("n");
+        partitionId = reader.readInt("p");
         int size = reader.readInt("size");
         if (size > 0) {
             ObjectDataInput input = reader.getRawDataInput();


### PR DESCRIPTION
* Convert MapGetAllRequest/MessageTask to ClientPartitionRequest to allow invocation-by-partition

* Re-implement ClientMapProxy.getAll by porting code from putAll, so that keys are grouped by corresponding partitions. For each key set, send a request to the partition owner. This approach has two advantages:
  * Allows the client to gather data directly from owners rather than depend on a randomly-chosen node
  * Because the requests are made asynchronously, the client can work on caching and populating the return value with some of the data while waiting for the other data to be fully received.

This fixes #6083, and is a rebase of #6135

Previously reviewed by @sancar and @cangencer.

Create a gist found at https://gist.github.com/LoneRifle/ff9c6c658327ffe39e79 documenting ad-hoc benchmark.
I obtained old vs new times for 1, 2, 4 nodes to getAll integer keys mapping to randomly-generated UUIDs for key counts in increasing powers of two up till 2^20.

I expect that similar timings will be obtained for getAlls on fewer keys but more expensive values.

![ClientMapProxy.getAll - old vs new](https://cloud.githubusercontent.com/assets/10572368/9852073/cfa9396e-5b2e-11e5-8173-14b2ebaa018f.png)