### PR TITLE
Cleanup of pom.xml files

### DIFF
--- a/hazelcast-all/pom.xml
+++ b/hazelcast-all/pom.xml
@@ -78,7 +78,6 @@
                                 <transformer
                                         implementation="com.hazelcast.buildutils.HazelcastManifestTransformer">
                                     <mainClass>com.hazelcast.console.ConsoleApp</mainClass>
-
                                     <overrideInstructions>
                                         <Import-Package>
                                             org.hibernate.*;resolution:=optional,
@@ -166,5 +165,4 @@
             <version>${project.version}</version>
         </dependency>
     </dependencies>
-
 </project>

--- a/hazelcast-build-utils/pom.xml
+++ b/hazelcast-build-utils/pom.xml
@@ -39,7 +39,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>animal-sniffer-maven-plugin</artifactId>
-                <version>${animal.sniffer.plugin.version}</version>
+                <version>${maven.animal.sniffer.plugin.version}</version>
                 <configuration>
                     <signature>
                         <groupId>org.codehaus.mojo.signature</groupId>
@@ -91,7 +91,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>${jacoco.version}</version>
+                <version>${maven.jacoco.plugin.version}</version>
                 <configuration>
                     <skip>true</skip>
                 </configuration>
@@ -100,23 +100,6 @@
     </build>
 
     <dependencies>
-        <dependency>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-shade-plugin</artifactId>
-            <version>${maven.shade.plugin.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>biz.aQute</groupId>
-            <artifactId>bndlib</artifactId>
-            <version>1.50.0</version>
-        </dependency>
-        <dependency>
-            <groupId>net.sourceforge.findbugs</groupId>
-            <artifactId>annotations</artifactId>
-            <version>1.3.2</version>
-            <scope>compile</scope>
-        </dependency>
         <dependency>
             <groupId>com.hazelcast</groupId>
             <artifactId>hazelcast</artifactId>
@@ -129,6 +112,22 @@
             <version>${project.parent.version}</version>
             <classifier>tests</classifier>
         </dependency>
+        <dependency>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-shade-plugin</artifactId>
+            <version>${maven.shade.plugin.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.sourceforge.findbugs</groupId>
+            <artifactId>annotations</artifactId>
+            <version>${findbugs.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>biz.aQute</groupId>
+            <artifactId>bndlib</artifactId>
+            <version>1.50.0</version>
+        </dependency>
     </dependencies>
-
 </project>

--- a/hazelcast-client-legacy/pom.xml
+++ b/hazelcast-client-legacy/pom.xml
@@ -32,15 +32,14 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.basedir}</main.basedir>
-        <atomikos-version>3.9.2</atomikos-version>
     </properties>
 
-     <build>
+    <build>
         <plugins>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>animal-sniffer-maven-plugin</artifactId>
-                <version>${animal.sniffer.plugin.version}</version>
+                <version>${maven.animal.sniffer.plugin.version}</version>
                 <configuration>
                     <signature>
                         <groupId>org.codehaus.mojo.signature</groupId>
@@ -163,7 +162,7 @@
             <groupId>com.atomikos</groupId>
             <artifactId>transactions-jdbc</artifactId>
             <scope>test</scope>
-            <version>${atomikos-version}</version>
+            <version>${atomikos.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.geronimo.specs</groupId>
@@ -176,7 +175,7 @@
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-library</artifactId>
-            <version>1.2</version>
+            <version>${hamcrest.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -193,5 +192,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-
 </project>

--- a/hazelcast-client/pom.xml
+++ b/hazelcast-client/pom.xml
@@ -32,15 +32,14 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.basedir}</main.basedir>
-        <atomikos-version>3.9.2</atomikos-version>
     </properties>
 
-     <build>
+    <build>
         <plugins>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>animal-sniffer-maven-plugin</artifactId>
-                <version>${animal.sniffer.plugin.version}</version>
+                <version>${maven.animal.sniffer.plugin.version}</version>
                 <configuration>
                     <signature>
                         <groupId>org.codehaus.mojo.signature</groupId>
@@ -163,7 +162,7 @@
             <groupId>com.atomikos</groupId>
             <artifactId>transactions-jdbc</artifactId>
             <scope>test</scope>
-            <version>${atomikos-version}</version>
+            <version>${atomikos.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.geronimo.specs</groupId>
@@ -193,5 +192,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-
 </project>

--- a/hazelcast-cloud/pom.xml
+++ b/hazelcast-cloud/pom.xml
@@ -39,7 +39,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>animal-sniffer-maven-plugin</artifactId>
-                <version>${animal.sniffer.plugin.version}</version>
+                <version>${maven.animal.sniffer.plugin.version}</version>
                 <configuration>
                     <signature>
                         <groupId>org.codehaus.mojo.signature</groupId>

--- a/hazelcast-code-generator/pom.xml
+++ b/hazelcast-code-generator/pom.xml
@@ -38,7 +38,7 @@
                     <perCoreThreadCount>true</perCoreThreadCount>
                     <parallel>methods</parallel -->
 
-                    <!-- the argLine variable is needed for jacoco-->
+                    <!-- the argLine variable is needed for JaCoco-->
                     <argLine>
                         -Xms128m -Xmx1G -XX:MaxPermSize=128M
                         -Dhazelcast.version.check.enabled=false
@@ -60,11 +60,11 @@
 
     <profiles>
         <profile>
-            <!-- This profile is needed to override configuration from the root pom.xml.
-
-                Otherwise a build of hazelcast-code-generation module is failing as the Surefire Maven plugin
-                cannot load com.hazelcast.test.annotation.ParallelTest classes
-                -->
+            <!--
+            This profile is needed to override configuration from the root pom.xml.
+            Otherwise a build of hazelcast-code-generation module is failing as the Surefire Maven plugin
+            cannot load com.hazelcast.test.annotation.ParallelTest classes
+            -->
             <id>parallelTest</id>
             <build>
                 <plugins>
@@ -126,7 +126,6 @@
                 </plugins>
             </build>
         </profile>
-
     </profiles>
 
     <dependencies>
@@ -136,10 +135,4 @@
             <version>2.3.23</version>
         </dependency>
     </dependencies>
-
-
-
-
-
-
 </project>

--- a/hazelcast-hibernate/hazelcast-hibernate3/pom.xml
+++ b/hazelcast-hibernate/hazelcast-hibernate3/pom.xml
@@ -29,10 +29,11 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
-     <properties>
-        <hibernate.core.version>3.6.10.Final</hibernate.core.version>
+    <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
+
+        <hibernate.core.version>3.6.10.Final</hibernate.core.version>
     </properties>
 
     <dependencies>
@@ -49,5 +50,4 @@
             </exclusions>
         </dependency>
     </dependencies>
-
 </project>

--- a/hazelcast-hibernate/hazelcast-hibernate4/pom.xml
+++ b/hazelcast-hibernate/hazelcast-hibernate4/pom.xml
@@ -30,9 +30,10 @@
     </parent>
 
     <properties>
-        <hibernate.core.version>4.3.8.Final</hibernate.core.version>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
+
+        <hibernate.core.version>4.3.8.Final</hibernate.core.version>
     </properties>
 
     <build>
@@ -74,5 +75,4 @@
             </exclusions>
         </dependency>
     </dependencies>
-
 </project>

--- a/hazelcast-hibernate/pom.xml
+++ b/hazelcast-hibernate/pom.xml
@@ -35,10 +35,11 @@
     </modules>
 
     <properties>
-        <hsqldb.version>2.2.9</hsqldb.version>
-        <javaassist.version>3.12.1.GA</javaassist.version>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.basedir}</main.basedir>
+
+        <hsqldb.version>2.2.9</hsqldb.version>
+        <javaassist.version>3.12.1.GA</javaassist.version>
     </properties>
 
     <build>
@@ -46,7 +47,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>animal-sniffer-maven-plugin</artifactId>
-                <version>${animal.sniffer.plugin.version}</version>
+                <version>${maven.animal.sniffer.plugin.version}</version>
                 <configuration>
                     <signature>
                         <groupId>org.codehaus.mojo.signature</groupId>
@@ -147,14 +148,14 @@
         </dependency>
         <dependency>
             <groupId>com.hazelcast</groupId>
-            <artifactId>hazelcast-client</artifactId>
+            <artifactId>hazelcast</artifactId>
             <scope>test</scope>
             <version>${project.parent.version}</version>
             <classifier>tests</classifier>
         </dependency>
         <dependency>
             <groupId>com.hazelcast</groupId>
-            <artifactId>hazelcast</artifactId>
+            <artifactId>hazelcast-client</artifactId>
             <scope>test</scope>
             <version>${project.parent.version}</version>
             <classifier>tests</classifier>
@@ -188,5 +189,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-
 </project>

--- a/hazelcast-jclouds/pom.xml
+++ b/hazelcast-jclouds/pom.xml
@@ -32,7 +32,7 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.basedir}</main.basedir>
-        <jclouds.version>1.9.1</jclouds.version>
+
         <jclouds.version>1.9.1</jclouds.version>
     </properties>
 
@@ -41,7 +41,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>animal-sniffer-maven-plugin</artifactId>
-                <version>${animal.sniffer.plugin.version}</version>
+                <version>${maven.animal.sniffer.plugin.version}</version>
                 <configuration>
                     <signature>
                         <groupId>org.codehaus.mojo.signature</groupId>

--- a/hazelcast-ra/hazelcast-jca-rar/pom.xml
+++ b/hazelcast-ra/hazelcast-jca-rar/pom.xml
@@ -31,10 +31,6 @@
     </parent>
 
     <properties>
-        <!--<ironjacamar.version>1.0.10.Final</ironjacamar.version>-->
-        <!--<h2.version>1.3.168</h2.version>-->
-        <atomikos-version>3.9.2</atomikos-version>
-
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
     </properties>

--- a/hazelcast-ra/hazelcast-jca/pom.xml
+++ b/hazelcast-ra/hazelcast-jca/pom.xml
@@ -41,7 +41,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>animal-sniffer-maven-plugin</artifactId>
-                <version>${animal.sniffer.plugin.version}</version>
+                <version>${maven.animal.sniffer.plugin.version}</version>
                 <configuration>
                     <signature>
                         <groupId>org.codehaus.mojo.signature</groupId>
@@ -74,7 +74,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.12</version>
+                <version>${maven.surefire.plugin.version}</version>
                 <executions>
                     <execution>
                         <id>default-test</id>
@@ -83,11 +83,11 @@
                         </goals>
                         <phase>test</phase>
                         <configuration>
-                        <excludes>
-                            <exclude>**/TestInContainer*</exclude>
-                            <exclude>**/XATransactionTest*</exclude>
-                        </excludes>
-                    </configuration>
+                            <excludes>
+                                <exclude>**/TestInContainer*</exclude>
+                                <exclude>**/XATransactionTest*</exclude>
+                            </excludes>
+                        </configuration>
                     </execution>
 
                     <execution>
@@ -112,47 +112,8 @@
             </plugin>
         </plugins>
     </build>
+
     <dependencies>
-        <dependency>
-            <groupId>com.h2database</groupId>
-            <artifactId>h2</artifactId>
-            <version>${h2.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.arquillian.container</groupId>
-            <artifactId>arquillian-glassfish-embedded-3.1</artifactId>
-            <version>1.0.0.CR4</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>javax.enterprise</groupId>
-            <artifactId>cdi-api</artifactId>
-            <version>1.0-SP1</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.arquillian.junit</groupId>
-            <artifactId>arquillian-junit-container</artifactId>
-            <version>1.0.3.Final</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>nl.jqno.equalsverifier</groupId>
-            <artifactId>equalsverifier</artifactId>
-            <version>1.7.3</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.extras</groupId>
-            <artifactId>glassfish-embedded-all</artifactId>
-            <version>3.1</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.geronimo.specs</groupId>
-            <artifactId>geronimo-j2ee-connector_1.5_spec</artifactId>
-            <version>2.0.0</version>
-            <scope>provided</scope>
-        </dependency>
         <dependency>
             <groupId>com.hazelcast</groupId>
             <artifactId>hazelcast</artifactId>
@@ -167,16 +128,61 @@
             <classifier>tests</classifier>
         </dependency>
         <dependency>
-            <groupId>org.apache.geronimo.specs</groupId>
-            <artifactId>geronimo-jta_1.1_spec</artifactId>
-            <scope>test</scope>
-            <version>1.1.1</version>
-        </dependency>
-        <dependency>
             <groupId>com.hazelcast</groupId>
             <artifactId>hazelcast-client</artifactId>
             <scope>test</scope>
             <version>${project.parent.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <version>${h2.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.enterprise</groupId>
+            <artifactId>cdi-api</artifactId>
+            <version>1.0-SP1</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.arquillian.container</groupId>
+            <artifactId>arquillian-glassfish-embedded-3.1</artifactId>
+            <version>1.0.0.CR4</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.junit</groupId>
+            <artifactId>arquillian-junit-container</artifactId>
+            <version>1.0.3.Final</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>nl.jqno.equalsverifier</groupId>
+            <artifactId>equalsverifier</artifactId>
+            <version>1.7.3</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.glassfish.extras</groupId>
+            <artifactId>glassfish-embedded-all</artifactId>
+            <version>3.1</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.geronimo.specs</groupId>
+            <artifactId>geronimo-j2ee-connector_1.5_spec</artifactId>
+            <version>2.0.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.geronimo.specs</groupId>
+            <artifactId>geronimo-jta_1.1_spec</artifactId>
+            <scope>test</scope>
+            <version>1.1.1</version>
         </dependency>
     </dependencies>
 </project>

--- a/hazelcast-ra/pom.xml
+++ b/hazelcast-ra/pom.xml
@@ -35,97 +35,91 @@
         <module>hazelcast-jca-rar</module>
     </modules>
 
-    <!--<properties>-->
-        <!--<ironjacamar.version>1.0.10.Final</ironjacamar.version>-->
-        <!--<h2.version>1.3.168</h2.version>-->
-        <!--<atomikos-version>3.9.2</atomikos-version>-->
-
-        <!--&lt;!&ndash; needed for checkstyle/findbugs &ndash;&gt;-->
-        <!--<main.basedir>${project.parent.basedir}</main.basedir>-->
-    <!--</properties>-->
+    <properties>
+        <!-- needed for checkstyle/findbugs -->
+        <main.basedir>${project.parent.basedir}</main.basedir>
+    </properties>
 
     <!--<dependencies>-->
-        <!--<dependency>-->
-            <!--<groupId>org.apache.geronimo.specs</groupId>-->
-            <!--<artifactId>geronimo-j2ee-connector_1.5_spec</artifactId>-->
-            <!--<version>2.0.0</version>-->
-            <!--<scope>provided</scope>-->
-        <!--</dependency>-->
-        <!--<dependency>-->
-            <!--<groupId>com.hazelcast</groupId>-->
-            <!--<artifactId>hazelcast</artifactId>-->
-            <!--<version>${project.parent.version}</version>-->
-            <!--<scope>provided</scope>-->
-        <!--</dependency>-->
-        <!--<dependency>-->
-            <!--<groupId>com.atomikos</groupId>-->
-            <!--<artifactId>transactions-jdbc</artifactId>-->
-            <!--<scope>test</scope>-->
-            <!--<version>${atomikos-version}</version>-->
-        <!--</dependency>-->
-        <!--<dependency>-->
-            <!--<groupId>com.hazelcast</groupId>-->
-            <!--<artifactId>hazelcast</artifactId>-->
-            <!--<scope>test</scope>-->
-            <!--<version>${project.parent.version}</version>-->
-            <!--<classifier>tests</classifier>-->
-        <!--</dependency>-->
-        <!--<dependency>-->
-            <!--<groupId>org.apache.geronimo.specs</groupId>-->
-            <!--<artifactId>geronimo-jta_1.1_spec</artifactId>-->
-            <!--<scope>test</scope>-->
-            <!--<version>1.1.1</version>-->
-        <!--</dependency>-->
-        <!--<dependency>-->
-            <!--<groupId>com.hazelcast</groupId>-->
-            <!--<artifactId>hazelcast-client</artifactId>-->
-            <!--<scope>test</scope>-->
-            <!--<version>${project.parent.version}</version>-->
-        <!--</dependency>-->
+    <!--<dependency>-->
+    <!--<groupId>org.apache.geronimo.specs</groupId>-->
+    <!--<artifactId>geronimo-j2ee-connector_1.5_spec</artifactId>-->
+    <!--<version>2.0.0</version>-->
+    <!--<scope>provided</scope>-->
+    <!--</dependency>-->
+    <!--<dependency>-->
+    <!--<groupId>com.hazelcast</groupId>-->
+    <!--<artifactId>hazelcast</artifactId>-->
+    <!--<version>${project.parent.version}</version>-->
+    <!--<scope>provided</scope>-->
+    <!--</dependency>-->
+    <!--<dependency>-->
+    <!--<groupId>com.atomikos</groupId>-->
+    <!--<artifactId>transactions-jdbc</artifactId>-->
+    <!--<scope>test</scope>-->
+    <!--<version>${atomikos.version}</version>-->
+    <!--</dependency>-->
+    <!--<dependency>-->
+    <!--<groupId>com.hazelcast</groupId>-->
+    <!--<artifactId>hazelcast</artifactId>-->
+    <!--<scope>test</scope>-->
+    <!--<version>${project.parent.version}</version>-->
+    <!--<classifier>tests</classifier>-->
+    <!--</dependency>-->
+    <!--<dependency>-->
+    <!--<groupId>org.apache.geronimo.specs</groupId>-->
+    <!--<artifactId>geronimo-jta_1.1_spec</artifactId>-->
+    <!--<scope>test</scope>-->
+    <!--<version>1.1.1</version>-->
+    <!--</dependency>-->
+    <!--<dependency>-->
+    <!--<groupId>com.hazelcast</groupId>-->
+    <!--<artifactId>hazelcast-client</artifactId>-->
+    <!--<scope>test</scope>-->
+    <!--<version>${project.parent.version}</version>-->
+    <!--</dependency>-->
     <!--</dependencies>-->
 
     <!--<build>-->
-        <!--&lt;!&ndash;<testResources>&ndash;&gt;-->
-            <!--&lt;!&ndash;<testResource>&ndash;&gt;-->
-                <!--&lt;!&ndash;<directory>src/main/rar/META-INF</directory>&ndash;&gt;-->
-            <!--&lt;!&ndash;</testResource>&ndash;&gt;-->
-            <!--&lt;!&ndash;<testResource>&ndash;&gt;-->
-                <!--&lt;!&ndash;<directory>src/test/resources</directory>&ndash;&gt;-->
-            <!--&lt;!&ndash;</testResource>&ndash;&gt;-->
-        <!--&lt;!&ndash;</testResources>&ndash;&gt;-->
+    <!--&lt;!&ndash;<testResources>&ndash;&gt;-->
+    <!--&lt;!&ndash;<testResource>&ndash;&gt;-->
+    <!--&lt;!&ndash;<directory>src/main/rar/META-INF</directory>&ndash;&gt;-->
+    <!--&lt;!&ndash;</testResource>&ndash;&gt;-->
+    <!--&lt;!&ndash;<testResource>&ndash;&gt;-->
+    <!--&lt;!&ndash;<directory>src/test/resources</directory>&ndash;&gt;-->
+    <!--&lt;!&ndash;</testResource>&ndash;&gt;-->
+    <!--&lt;!&ndash;</testResources>&ndash;&gt;-->
 
-        <!--<plugins>-->
-            <!--&lt;!&ndash; skip unit test run, tests to be executed during integration-test &ndash;&gt;-->
-            <!--&lt;!&ndash; plugin>-->
-                <!--<groupId>org.apache.maven.plugins</groupId>-->
-                <!--<artifactId>maven-surefire-plugin</artifactId>-->
-                <!--<configuration>-->
-                    <!--<skip>true</skip>-->
-                <!--</configuration>-->
-                <!--<executions>-->
-                    <!--<execution>-->
-                        <!--<id>surefire-it</id>-->
-                        <!--<phase>integration-test</phase>-->
-                        <!--<goals>-->
-                            <!--<goal>test</goal>-->
-                        <!--</goals>-->
-                        <!--<configuration>-->
-                            <!--<skip>false</skip>-->
-                        <!--</configuration>-->
-                    <!--</execution>-->
-                <!--</executions>-->
-            <!--</plugin &ndash;&gt;-->
+    <!--<plugins>-->
+    <!--&lt;!&ndash; skip unit test run, tests to be executed during integration-test &ndash;&gt;-->
+    <!--&lt;!&ndash; plugin>-->
+    <!--<groupId>org.apache.maven.plugins</groupId>-->
+    <!--<artifactId>maven-surefire-plugin</artifactId>-->
+    <!--<configuration>-->
+    <!--<skip>true</skip>-->
+    <!--</configuration>-->
+    <!--<executions>-->
+    <!--<execution>-->
+    <!--<id>surefire-it</id>-->
+    <!--<phase>integration-test</phase>-->
+    <!--<goals>-->
+    <!--<goal>test</goal>-->
+    <!--</goals>-->
+    <!--<configuration>-->
+    <!--<skip>false</skip>-->
+    <!--</configuration>-->
+    <!--</execution>-->
+    <!--</executions>-->
+    <!--</plugin &ndash;&gt;-->
 
-
-
-            <!--&lt;!&ndash;<plugin>&ndash;&gt;-->
-                <!--&lt;!&ndash;<groupId>org.apache.maven.plugins</groupId>&ndash;&gt;-->
-                <!--&lt;!&ndash;<artifactId>maven-rar-plugin</artifactId>&ndash;&gt;-->
-                <!--&lt;!&ndash;<version>${maven.rar.plugin.version}</version>&ndash;&gt;-->
-                <!--&lt;!&ndash;<configuration>&ndash;&gt;-->
-                    <!--&lt;!&ndash;<raXmlFile>src/main/rar/ra.xml</raXmlFile>&ndash;&gt;-->
-                <!--&lt;!&ndash;</configuration>&ndash;&gt;-->
-            <!--&lt;!&ndash;</plugin>&ndash;&gt;-->
-        <!--</plugins>-->
+    <!--&lt;!&ndash;<plugin>&ndash;&gt;-->
+    <!--&lt;!&ndash;<groupId>org.apache.maven.plugins</groupId>&ndash;&gt;-->
+    <!--&lt;!&ndash;<artifactId>maven-rar-plugin</artifactId>&ndash;&gt;-->
+    <!--&lt;!&ndash;<version>${maven.rar.plugin.version}</version>&ndash;&gt;-->
+    <!--&lt;!&ndash;<configuration>&ndash;&gt;-->
+    <!--&lt;!&ndash;<raXmlFile>src/main/rar/ra.xml</raXmlFile>&ndash;&gt;-->
+    <!--&lt;!&ndash;</configuration>&ndash;&gt;-->
+    <!--&lt;!&ndash;</plugin>&ndash;&gt;-->
+    <!--</plugins>-->
     <!--</build>-->
 </project>

--- a/hazelcast-spring/pom.xml
+++ b/hazelcast-spring/pom.xml
@@ -30,19 +30,19 @@
     </parent>
 
     <properties>
-        <org.springframework.version>4.0.2.RELEASE</org.springframework.version>
-        <jsr250.api.version>1.0</jsr250.api.version>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.basedir}</main.basedir>
+
+        <org.springframework.version>4.0.2.RELEASE</org.springframework.version>
+        <jsr250.api.version>1.0</jsr250.api.version>
     </properties>
 
     <build>
         <plugins>
-
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>animal-sniffer-maven-plugin</artifactId>
-                <version>${animal.sniffer.plugin.version}</version>
+                <version>${maven.animal.sniffer.plugin.version}</version>
                 <configuration>
                     <signature>
                         <groupId>org.codehaus.mojo.signature</groupId>
@@ -127,6 +127,7 @@
             </plugin>
         </plugins>
     </build>
+
     <profiles>
         <profile>
             <id>hibernate-4</id>
@@ -134,18 +135,6 @@
                 <activeByDefault>true</activeByDefault>
             </activation>
             <dependencies>
-                <dependency>
-                    <groupId>org.springframework</groupId>
-                    <artifactId>spring-context</artifactId>
-                    <version>${org.springframework.version}</version>
-                    <scope>provided</scope>
-                </dependency>
-                <dependency>
-                    <groupId>javax.annotation</groupId>
-                    <artifactId>jsr250-api</artifactId>
-                    <version>${jsr250.api.version}</version>
-                    <scope>provided</scope>
-                </dependency>
                 <dependency>
                     <groupId>com.hazelcast</groupId>
                     <artifactId>hazelcast</artifactId>
@@ -157,13 +146,26 @@
                     <version>${project.parent.version}</version>
                     <optional>true</optional>
                 </dependency>
+                <dependency>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>jsr250-api</artifactId>
+                    <version>${jsr250.api.version}</version>
+                    <scope>provided</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.springframework</groupId>
+                    <artifactId>spring-context</artifactId>
+                    <version>${org.springframework.version}</version>
+                    <scope>provided</scope>
+                </dependency>
 
                 <!--TEST DEPENDENCIES-->
                 <dependency>
-                    <groupId>org.springframework</groupId>
-                    <artifactId>spring-test</artifactId>
-                    <version>${org.springframework.version}</version>
+                    <groupId>com.hazelcast</groupId>
+                    <artifactId>hazelcast</artifactId>
                     <scope>test</scope>
+                    <version>${project.parent.version}</version>
+                    <classifier>tests</classifier>
                 </dependency>
                 <dependency>
                     <groupId>com.hazelcast</groupId>
@@ -173,21 +175,14 @@
                 </dependency>
                 <dependency>
                     <groupId>org.springframework</groupId>
-                    <artifactId>spring-tx</artifactId>
+                    <artifactId>spring-test</artifactId>
                     <version>${org.springframework.version}</version>
                     <scope>test</scope>
                 </dependency>
                 <dependency>
-                    <groupId>com.hazelcast</groupId>
-                    <artifactId>hazelcast</artifactId>
-                    <scope>test</scope>
-                    <version>${project.parent.version}</version>
-                    <classifier>tests</classifier>
-                </dependency>
-                <dependency>
-                    <groupId>org.hibernate</groupId>
-                    <artifactId>hibernate-core</artifactId>
-                    <version>4.3.8.Final</version>
+                    <groupId>org.springframework</groupId>
+                    <artifactId>spring-tx</artifactId>
+                    <version>${org.springframework.version}</version>
                     <scope>test</scope>
                 </dependency>
                 <dependency>
@@ -196,23 +191,18 @@
                     <version>${org.springframework.version}</version>
                     <scope>test</scope>
                 </dependency>
+                <dependency>
+                    <groupId>org.hibernate</groupId>
+                    <artifactId>hibernate-core</artifactId>
+                    <version>4.3.8.Final</version>
+                    <scope>test</scope>
+                </dependency>
             </dependencies>
         </profile>
+
         <profile>
             <id>hibernate-3</id>
             <dependencies>
-                <dependency>
-                    <groupId>org.springframework</groupId>
-                    <artifactId>spring-context</artifactId>
-                    <version>${org.springframework.version}</version>
-                    <scope>provided</scope>
-                </dependency>
-                <dependency>
-                    <groupId>javax.annotation</groupId>
-                    <artifactId>jsr250-api</artifactId>
-                    <version>${jsr250.api.version}</version>
-                    <scope>provided</scope>
-                </dependency>
                 <dependency>
                     <groupId>com.hazelcast</groupId>
                     <artifactId>hazelcast</artifactId>
@@ -224,24 +214,24 @@
                     <version>${project.parent.version}</version>
                     <optional>true</optional>
                 </dependency>
-
-                <!--TEST DEPENDENCIES-->
+                <dependency>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>jsr250-api</artifactId>
+                    <version>${jsr250.api.version}</version>
+                    <scope>provided</scope>
+                </dependency>
                 <dependency>
                     <groupId>org.springframework</groupId>
-                    <artifactId>spring-test</artifactId>
+                    <artifactId>spring-context</artifactId>
                     <version>${org.springframework.version}</version>
-                    <scope>test</scope>
+                    <scope>provided</scope>
                 </dependency>
+
+                <!--TEST DEPENDENCIES-->
                 <dependency>
                     <groupId>com.hazelcast</groupId>
                     <artifactId>hazelcast-hibernate3</artifactId>
                     <version>${project.parent.version}</version>
-                    <scope>test</scope>
-                </dependency>
-                <dependency>
-                    <groupId>org.springframework</groupId>
-                    <artifactId>spring-tx</artifactId>
-                    <version>${org.springframework.version}</version>
                     <scope>test</scope>
                 </dependency>
                 <dependency>
@@ -252,21 +242,33 @@
                     <classifier>tests</classifier>
                 </dependency>
                 <dependency>
-                    <groupId>org.hibernate</groupId>
-                    <artifactId>hibernate-core</artifactId>
-                    <version>3.6.10.Final</version>
+                    <groupId>javax.cache</groupId>
+                    <artifactId>cache-api</artifactId>
+                    <version>${jsr107.api.version}</version>
                     <scope>test</scope>
                 </dependency>
                 <dependency>
-                    <groupId>javax.cache</groupId>
-                    <artifactId>cache-api</artifactId>
-                    <version>1.0.0</version>
+                    <groupId>org.springframework</groupId>
+                    <artifactId>spring-test</artifactId>
+                    <version>${org.springframework.version}</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.springframework</groupId>
+                    <artifactId>spring-tx</artifactId>
+                    <version>${org.springframework.version}</version>
                     <scope>test</scope>
                 </dependency>
                 <dependency>
                     <groupId>org.springframework</groupId>
                     <artifactId>spring-context-support</artifactId>
                     <version>${org.springframework.version}</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.hibernate</groupId>
+                    <artifactId>hibernate-core</artifactId>
+                    <version>3.6.10.Final</version>
                     <scope>test</scope>
                 </dependency>
             </dependencies>

--- a/hazelcast-wm/pom.xml
+++ b/hazelcast-wm/pom.xml
@@ -24,7 +24,6 @@
     <artifactId>hazelcast-wm</artifactId>
     <packaging>jar</packaging>
 
-
     <parent>
         <groupId>com.hazelcast</groupId>
         <artifactId>hazelcast-root</artifactId>
@@ -33,22 +32,22 @@
     </parent>
 
     <properties>
+        <!-- needed for checkstyle/findbugs -->
+        <main.basedir>${project.parent.basedir}</main.basedir>
+
         <jsp.api.version>2.2.1</jsp.api.version>
         <servlet.api.version>3.0.1</servlet.api.version>
         <org.springframework.version>3.2.1.RELEASE</org.springframework.version>
         <jetty.maven.plugin.version>8.1.2.v20120308</jetty.maven.plugin.version>
         <tomcat.version>7.0.54</tomcat.version>
-        <!-- needed for checkstyle/findbugs -->
-        <main.basedir>${project.parent.basedir}</main.basedir>
     </properties>
 
     <build>
         <plugins>
-
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>animal-sniffer-maven-plugin</artifactId>
-                <version>${animal.sniffer.plugin.version}</version>
+                <version>${maven.animal.sniffer.plugin.version}</version>
                 <configuration>
                     <signature>
                         <groupId>org.codehaus.mojo.signature</groupId>
@@ -261,5 +260,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-
 </project>

--- a/hazelcast/pom.xml
+++ b/hazelcast/pom.xml
@@ -33,7 +33,7 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.basedir}</main.basedir>
-        <atomikos-version>3.9.3</atomikos-version>
+
         <jsp.api.version>2.2.1</jsp.api.version>
         <servlet.api.version>3.0.1</servlet.api.version>
     </properties>
@@ -50,7 +50,8 @@
                     <encoding>${project.build.sourceEncoding}</encoding>
                     <annotationProcessors>
                         <annotationProcessor>com.hazelcast.client.protocol.generator.CodecCodeGenerator</annotationProcessor>
-                        <annotationProcessor>com.hazelcast.client.protocol.generator.CodeGeneratorMessageTaskFactory</annotationProcessor>
+                        <annotationProcessor>com.hazelcast.client.protocol.generator.CodeGeneratorMessageTaskFactory
+                        </annotationProcessor>
                     </annotationProcessors>
                 </configuration>
                 <dependencies>
@@ -65,7 +66,7 @@
             <plugin>
                 <groupId>pl.project13.maven</groupId>
                 <artifactId>git-commit-id-plugin</artifactId>
-                <version>2.1.10</version>
+                <version>${maven.git.commit.id.plugin.version}</version>
                 <executions>
                     <execution>
                         <goals>
@@ -87,7 +88,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>animal-sniffer-maven-plugin</artifactId>
-                <version>${animal.sniffer.plugin.version}</version>
+                <version>${maven.animal.sniffer.plugin.version}</version>
                 <configuration>
                     <signature>
                         <groupId>org.codehaus.mojo.signature</groupId>
@@ -242,7 +243,6 @@
                     </execution>
                 </executions>
             </plugin>
-
         </plugins>
     </build>
 
@@ -250,7 +250,7 @@
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-library</artifactId>
-            <version>1.3</version>
+            <version>${hamcrest.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -338,7 +338,7 @@
             <groupId>com.atomikos</groupId>
             <artifactId>transactions-jdbc</artifactId>
             <scope>test</scope>
-            <version>${atomikos-version}</version>
+            <version>${atomikos.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.geronimo.specs</groupId>
@@ -391,7 +391,5 @@
             <version>4.3.1</version>
             <scope>test</scope>
         </dependency>
-
     </dependencies>
-
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -43,45 +43,58 @@
     </modules>
 
     <properties>
+        <main.basedir>${project.basedir}</main.basedir>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
         <jdk.version>1.6</jdk.version>
         <target.dir>target</target.dir>
         <maven.build.timestamp.format>yyyyMMdd</maven.build.timestamp.format>
         <timestamp>${maven.build.timestamp}</timestamp>
+
         <hazelcast.distribution>Hazelcast</hazelcast.distribution>
         <hazelcast.serialization.version>1</hazelcast.serialization.version>
 
-        <!--Not using 3.1 at the moment since it recompiles all classes everytime-->
-        <!--https://jira.codehaus.org/browse/MCOMPILER-205-->
+        <!-- Not using 3.1 at the moment since it recompiles all classes every time -->
+        <!-- https://jira.codehaus.org/browse/MCOMPILER-205 -->
         <!--<maven.compiler.plugin.version>3.1</maven.compiler.plugin.version>-->
         <maven.compiler.plugin.version>2.5.1</maven.compiler.plugin.version>
         <maven.jar.plugin.version>2.4</maven.jar.plugin.version>
         <maven.source.plugin.version>2.2.1</maven.source.plugin.version>
-        <maven.antrun.plugin.version>1.7</maven.antrun.plugin.version>
-        <maven.surefire.plugin.version>2.18.1</maven.surefire.plugin.version>
-        <maven.assembly.plugin.version>2.4</maven.assembly.plugin.version>
-        <maven.gpg.plugin.version>1.4</maven.gpg.plugin.version>
         <maven.javadoc.plugin.version>2.9</maven.javadoc.plugin.version>
+        <maven.antrun.plugin.version>1.7</maven.antrun.plugin.version>
+        <maven.gpg.plugin.version>1.4</maven.gpg.plugin.version>
+        <maven.assembly.plugin.version>2.4</maven.assembly.plugin.version>
         <maven.rar.plugin.version>2.2</maven.rar.plugin.version>
         <maven.bundle.plugin.version>2.3.7</maven.bundle.plugin.version>
-        <findbugs.maven.plugin.version>3.0.0</findbugs.maven.plugin.version>
-        <checkstyle.maven.plugin.version>2.12</checkstyle.maven.plugin.version>
-        <maven.dependency.plugin.version>2.6</maven.dependency.plugin.version>
         <maven.shade.plugin.version>2.2</maven.shade.plugin.version>
-        <junit.version>4.12</junit.version>
-        <h2.version>1.3.160</h2.version>
-        <mockito.all.version>1.10.19</mockito.all.version>
+        <maven.dependency.plugin.version>2.6</maven.dependency.plugin.version>
+        <maven.animal.sniffer.plugin.version>1.14</maven.animal.sniffer.plugin.version>
+        <maven.git.commit.id.plugin.version>2.1.10</maven.git.commit.id.plugin.version>
+
+        <maven.surefire.plugin.version>2.18.1</maven.surefire.plugin.version>
+        <maven.failsafe.plugin.version>2.14</maven.failsafe.plugin.version>
+        <maven.findbugs.plugin.version>3.0.0</maven.findbugs.plugin.version>
+        <maven.checkstyle.plugin.version>2.12</maven.checkstyle.plugin.version>
+        <maven.sonar.plugin.version>2.6</maven.sonar.plugin.version>
+        <maven.jacoco.plugin.version>0.7.4.201502262128</maven.jacoco.plugin.version>
+        <maven.cobertura.plugin.version>2.0</maven.cobertura.plugin.version>
+
         <log4j.version>1.2.12</log4j.version>
         <log4j2.version>2.0.1</log4j2.version>
         <slf4j.api.version>1.6.0</slf4j.api.version>
-        <main.basedir>${project.basedir}</main.basedir>
-        <jacoco.version>0.7.4.201502262128</jacoco.version>
+
+        <junit.version>4.12</junit.version>
+        <hamcrest.version>1.3</hamcrest.version>
+        <mockito.version>1.10.19</mockito.version>
+
+        <findbugs.version>1.3.2</findbugs.version>
+
         <sonar.jacoco.jar>${basedir}/lib/jacocoagent.jar</sonar.jacoco.jar>
         <!--<sonar.phase>post-integration-test</sonar.phase>-->
         <sonar.java.coveragePlugin>jacoco</sonar.java.coveragePlugin>
         <sonar.language>java</sonar.language>
         <sonar.verbose>true</sonar.verbose>
-        <animal.sniffer.plugin.version>1.14</animal.sniffer.plugin.version>
+
         <jsr107.api.version>1.0.0</jsr107.api.version>
         <CacheManagerImpl>com.hazelcast.cache.HazelcastCacheManager</CacheManagerImpl>
         <CacheImpl>com.hazelcast.cache.ICache</CacheImpl>
@@ -89,7 +102,11 @@
         <javax.management.builder.initial>com.hazelcast.cache.impl.TCKMBeanServerBuilder
         </javax.management.builder.initial>
         <org.jsr107.tck.management.agentId>TCKMbeanServer</org.jsr107.tck.management.agentId>
-        <javax.cache.annotation.CacheInvocationContext>javax.cache.annotation.impl.cdi.CdiCacheKeyInvocationContextImpl</javax.cache.annotation.CacheInvocationContext>
+        <javax.cache.annotation.CacheInvocationContext>javax.cache.annotation.impl.cdi.CdiCacheKeyInvocationContextImpl
+        </javax.cache.annotation.CacheInvocationContext>
+
+        <h2.version>1.3.160</h2.version>
+        <atomikos.version>3.9.3</atomikos.version>
     </properties>
     <licenses>
         <license>
@@ -168,7 +185,6 @@
         </resources>
 
         <plugins>
-
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
@@ -196,7 +212,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>findbugs-maven-plugin</artifactId>
-                <version>${findbugs.maven.plugin.version}</version>
+                <version>${maven.findbugs.plugin.version}</version>
                 <configuration>
                     <findbugsXmlOutput>true</findbugsXmlOutput>
                     <xmlOutput>true</xmlOutput>
@@ -233,7 +249,7 @@
                     <perCoreThreadCount>true</perCoreThreadCount>
                     <parallel>methods</parallel -->
 
-                    <!-- the argLine variable is needed for jacoco-->
+                    <!-- the argLine variable is needed for JaCoco -->
                     <argLine>
                         -Xms128m -Xmx1G -XX:MaxPermSize=128M
                         -Dhazelcast.version.check.enabled=false
@@ -278,8 +294,7 @@
                                     <!-- 1C means 1 process per cpu core -->
                                     <forkCount>4C</forkCount>
                                     <reuseForks>true</reuseForks>
-
-                                    <!-- the argLine variable is needed for jacoco-->
+                                    <!-- the argLine variable is needed for JaCoco -->
                                     <argLine>
                                         -Xms128m -Xmx1G -XX:MaxPermSize=128M
                                         -Dhazelcast.version.check.enabled=false
@@ -294,7 +309,9 @@
                                     <excludes>
                                         <exclude>**/jsr/**.java</exclude>
                                     </excludes>
-                                    <groups>com.hazelcast.test.annotation.ParallelTest AND com.hazelcast.test.annotation.QuickTest</groups>
+                                    <groups>com.hazelcast.test.annotation.ParallelTest AND
+                                        com.hazelcast.test.annotation.QuickTest
+                                    </groups>
                                     <excludedGroups>
                                         com.hazelcast.test.annotation.SlowTest,com.hazelcast.test.annotation.NightlyTest
                                     </excludedGroups>
@@ -303,8 +320,6 @@
                                     </systemPropertyVariables>
                                 </configuration>
                             </execution>
-
-
                             <execution>
                                 <id>singlejvm</id>
                                 <phase>test</phase>
@@ -314,7 +329,7 @@
                                 <configuration combine.self="override">
                                     <redirectTestOutputToFile>true</redirectTestOutputToFile>
 
-                                    <!-- the argLine variable is needed for jacoco-->
+                                    <!-- the argLine variable is needed for JaCoco -->
                                     <argLine>
                                         -Xms128m -Xmx1G -XX:MaxPermSize=128M
                                         -Dhazelcast.version.check.enabled=false
@@ -371,6 +386,7 @@
                 </plugins>
             </build>
         </profile>
+
         <profile>
             <id>test-coverage-Local</id>
             <build>
@@ -381,11 +397,10 @@
                         <version>2.0</version>
                         <configuration>
                             <instrumentation>
-                                <ignores>
-                                </ignores>
-                                <excludes>
-                                </excludes>
+                                <ignores/>
+                                <excludes/>
                             </instrumentation>
+                            <check/>
                         </configuration>
                         <executions>
                             <execution>
@@ -416,15 +431,11 @@
                                 -Dorg.jsr107.tck.management.agentId=${org.jsr107.tck.management.agentId}
                                 -Djavax.cache.annotation.CacheInvocationContext=${javax.cache.annotation.CacheInvocationContext}
                             </argLine>
-
-
                             <includes>
                                 <include>**/YourTestFileHear.java</include>
                             </includes>
-
                         </configuration>
                     </plugin>
-
                 </plugins>
             </build>
             <reporting>
@@ -432,14 +443,14 @@
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>cobertura-maven-plugin</artifactId>
-                        <version>2.0</version>
+                        <version>${maven.cobertura.plugin.version}</version>
                     </plugin>
                 </plugins>
             </reporting>
         </profile>
 
-
         <profile>
+            <id>test-coverage</id>
             <properties>
                 <argLine>
                     -Xms128m -Xmx1G -XX:MaxPermSize=128M
@@ -455,13 +466,12 @@
                     -Djavax.cache.annotation.CacheInvocationContext=${javax.cache.annotation.CacheInvocationContext}
                 </argLine>
             </properties>
-            <id>test-coverage</id>
             <build>
                 <plugins>
                     <plugin>
                         <groupId>org.jacoco</groupId>
                         <artifactId>jacoco-maven-plugin</artifactId>
-                        <version>${jacoco.version}</version>
+                        <version>${maven.jacoco.plugin.version}</version>
                         <configuration>
                             <excludes>
                                 <exclude>**DummyProperty**</exclude>
@@ -481,6 +491,7 @@
                             </execution>
                         </executions>
                     </plugin>
+
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
@@ -501,9 +512,8 @@
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>sonar-maven-plugin</artifactId>
-                        <version>2.6</version>
+                        <version>${maven.sonar.plugin.version}</version>
                     </plugin>
-
                 </plugins>
             </build>
         </profile>
@@ -517,11 +527,10 @@
             </properties>
             <build>
                 <plugins>
-
                     <plugin>
                         <groupId>org.jacoco</groupId>
                         <artifactId>jacoco-maven-plugin</artifactId>
-                        <version>${jacoco.version}</version>
+                        <version>${maven.jacoco.plugin.version}</version>
                         <configuration>
                             <append>true</append>
                         </configuration>
@@ -601,7 +610,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-failsafe-plugin</artifactId>
-                        <version>2.14</version>
+                        <version>${maven.failsafe.plugin.version}</version>
                         <configuration combine.self="override">
                             <redirectTestOutputToFile>true</redirectTestOutputToFile>
                             <argLine>
@@ -629,6 +638,12 @@
                             </execution>
                         </executions>
                     </plugin>
+
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>sonar-maven-plugin</artifactId>
+                        <version>${maven.sonar.plugin.version}</version>
+                    </plugin>
                 </plugins>
             </build>
         </profile>
@@ -654,6 +669,7 @@
                             </execution>
                         </executions>
                     </plugin>
+
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
@@ -680,6 +696,7 @@
                             </execution>
                         </executions>
                     </plugin>
+
                     <plugin>
                         <groupId>org.sonatype.plugins</groupId>
                         <artifactId>nexus-staging-maven-plugin</artifactId>
@@ -692,14 +709,13 @@
                         </configuration>
                     </plugin>
                 </plugins>
-
             </build>
             <modules>
                 <module>hazelcast-all</module>
             </modules>
         </profile>
 
-        <!-- unfortunately it isn't possible to chain profiles, so we need to duplicate the javadoc plugin-->
+        <!-- unfortunately it isn't possible to chain profiles, so we need to duplicate the javadoc plugin -->
         <profile>
             <id>release-snapshot</id>
             <properties>
@@ -726,11 +742,11 @@
                                 </property>
                             </javaApiLinks>
                             <excludePackageNames>
-                              *.impl:*.internal:*.operations:*.proxy:*.util:com.hazelcast.aws.security:
-                              *.handlermigration:*.client.connection.nio:*.client.console:*.buildutils:
-                              *.client.protocol.generator:*.cluster.client:*.concurrent:*.collection:
-                              *.nio.ascii:*.nio.ssl:*.nio.tcp:*.partition.client:*.transaction.client:
-                              *.core.server:com.hazelcast.instance:com.hazelcast.PlaceHolder
+                                *.impl:*.internal:*.operations:*.proxy:*.util:com.hazelcast.aws.security:
+                                *.handlermigration:*.client.connection.nio:*.client.console:*.buildutils:
+                                *.client.protocol.generator:*.cluster.client:*.concurrent:*.collection:
+                                *.nio.ascii:*.nio.ssl:*.nio.tcp:*.partition.client:*.transaction.client:
+                                *.core.server:com.hazelcast.instance:com.hazelcast.PlaceHolder
                             </excludePackageNames>
                         </configuration>
                         <executions>
@@ -750,7 +766,6 @@
             <id>zip</id>
             <modules>
                 <module>hazelcast-all</module>
-                <module>hazelcast-documentation</module>
             </modules>
         </profile>
 
@@ -761,7 +776,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-checkstyle-plugin</artifactId>
-                        <version>${checkstyle.maven.plugin.version}</version>
+                        <version>${maven.checkstyle.plugin.version}</version>
                         <executions>
                             <execution>
                                 <phase>validate</phase>
@@ -795,7 +810,7 @@
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>findbugs-maven-plugin</artifactId>
-                        <version>${findbugs.maven.plugin.version}</version>
+                        <version>${maven.findbugs.plugin.version}</version>
                         <executions>
                             <execution>
                                 <phase>compile</phase>
@@ -809,7 +824,6 @@
                             <excludeFilterFile>${main.basedir}/findbugs/findbugs-exclude.xml</excludeFilterFile>
                         </configuration>
                     </plugin>
-
                 </plugins>
             </build>
         </profile>
@@ -818,8 +832,6 @@
             <id>nightly-build</id>
             <build>
                 <plugins>
-
-
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
@@ -946,7 +958,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
-            <version>${mockito.all.version}</version>
+            <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -963,5 +975,4 @@
             <scope>provided</scope>
         </dependency>
     </dependencies>
-
 </project>


### PR DESCRIPTION
Mostly formatting, pulling out version numbers, naming of properties, grouping/ordering and alignment of version numbers.

**Renaming**
Was done mostly on Maven module properties which are now all like `maven.NAME.plugin.version`.

**Grouping/ordering**
* `<main.basedir>` is always the first property (since it's shared through all modules)
* Hazelcast dependencies are listed before other dependencies
* Properties in root pom.xml are grouped by general, Hazelcast, Maven, tests, logging, javax etc.

**Version changes**
* atomikos was used in version 3.9.2 and 3.9.3, now only 3.9.3
* hamcrest was used in version 1.2 and 1.3, now only 1.3
* surefire was used in version 2.12 and 2.18.1, now only 2.18.1