### PR TITLE
Introduce the 'fine' logging level

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/logging/AbstractLogger.java
+++ b/hazelcast/src/main/java/com/hazelcast/logging/AbstractLogger.java
@@ -41,8 +41,18 @@ public abstract class AbstractLogger implements ILogger {
     }
 
     @Override
+    public void fine(String message) {
+        log(Level.FINE, message);
+    }
+
+    @Override
     public boolean isFinestEnabled() {
         return isLoggable(Level.FINEST);
+    }
+
+    @Override
+    public boolean isFineEnabled() {
+        return isLoggable(Level.FINE);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/logging/ILogger.java
+++ b/hazelcast/src/main/java/com/hazelcast/logging/ILogger.java
@@ -27,13 +27,6 @@ import java.util.logging.Level;
 public interface ILogger {
 
     /**
-     * Logs a message at {@link Level#INFO}.
-     *
-     * @param message the message to log.
-     */
-    void info(String message);
-
-    /**
      * Logs a message at {@link Level#FINEST}.
      *
      * @param message the message to log.
@@ -63,26 +56,25 @@ public interface ILogger {
     boolean isFinestEnabled();
 
     /**
-     * Logs a message at {@link Level#SEVERE}.
+     * Logs a message at {@link Level#FINE}.
      *
      * @param message the message to log.
      */
-    void severe(String message);
+    void fine(String message);
 
     /**
-     * Logs a throwable at {@link Level#SEVERE}.  The message of the Throwable will be the message.
+     * Checks if the {@link Level#FINE} is enabled.
      *
-     * @param thrown the Throwable to log.
+     * @return true if enabled, false otherwise.
      */
-    void severe(Throwable thrown);
+    boolean isFineEnabled();
 
     /**
-     * Logs message with associated throwable information at {@link Level#SEVERE}.
+     * Logs a message at {@link Level#INFO}.
      *
-     * @param message the message to log
-     * @param thrown  the Throwable associated to the message.
+     * @param message the message to log.
      */
-    void severe(String message, Throwable thrown);
+    void info(String message);
 
     /**
      * Logs a message at {@link Level#WARNING}.
@@ -105,6 +97,28 @@ public interface ILogger {
      * @param thrown  the Throwable associated to the message.
      */
     void warning(String message, Throwable thrown);
+
+    /**
+     * Logs a message at {@link Level#SEVERE}.
+     *
+     * @param message the message to log.
+     */
+    void severe(String message);
+
+    /**
+     * Logs a throwable at {@link Level#SEVERE}.  The message of the Throwable will be the message.
+     *
+     * @param thrown the Throwable to log.
+     */
+    void severe(Throwable thrown);
+
+    /**
+     * Logs message with associated throwable information at {@link Level#SEVERE}.
+     *
+     * @param message the message to log
+     * @param thrown  the Throwable associated to the message.
+     */
+    void severe(String message, Throwable thrown);
 
     /**
      * Logs a message at the provided Level.

--- a/hazelcast/src/main/java/com/hazelcast/logging/Log4j2Factory.java
+++ b/hazelcast/src/main/java/com/hazelcast/logging/Log4j2Factory.java
@@ -33,7 +33,7 @@ public class Log4j2Factory extends LoggerFactorySupport {
         return new Log4j2Logger(LogManager.getContext().getLogger(name));
     }
 
-    class Log4j2Logger extends AbstractLogger {
+    static class Log4j2Logger extends AbstractLogger {
         private final ExtendedLogger logger;
 
         public Log4j2Logger(ExtendedLogger logger) {
@@ -51,61 +51,40 @@ public class Log4j2Factory extends LoggerFactorySupport {
 
         @Override
         public void log(Level level, String message) {
-            logger.logIfEnabled(FQCN, getLevel(level), null, message);
+            logger.logIfEnabled(FQCN, toLog4j2Level(level), null, message);
         }
 
         @Override
         public void log(Level level, String message, Throwable thrown) {
-            logger.logIfEnabled(FQCN, getLevel(level), null, message, thrown);
+            logger.logIfEnabled(FQCN, toLog4j2Level(level), null, message, thrown);
         }
 
         @Override
         public Level getLevel() {
-            if (logger.isDebugEnabled()) {
-                return Level.FINEST;
-            } else if (logger.isInfoEnabled()) {
-                return Level.INFO;
-            } else if (logger.isWarnEnabled()) {
-                return Level.WARNING;
-            } else if (logger.isFatalEnabled()) {
-                return Level.SEVERE;
-            } else {
-                return Level.OFF;
-            }
+            return logger.isTraceEnabled() ? Level.FINEST
+                 : logger.isDebugEnabled() ? Level.FINE
+                 : logger.isInfoEnabled()  ? Level.INFO
+                 : logger.isWarnEnabled()  ? Level.WARNING
+                 : logger.isErrorEnabled() ? Level.SEVERE
+                 : logger.isFatalEnabled() ? Level.SEVERE
+                 : Level.OFF;
         }
 
         @Override
         public boolean isLoggable(Level level) {
-            if (Level.OFF == level) {
-                return false;
-            } else {
-                return logger.isEnabled(getLevel(level), null);
-            }
+            return level != Level.OFF && logger.isEnabled(toLog4j2Level(level), null);
         }
 
-        // need more than 5 returns from this method
-        //CHECKSTYLE:OFF
-        private org.apache.logging.log4j.Level getLevel(Level level) {
-            if (Level.SEVERE == level) {
-                return org.apache.logging.log4j.Level.ERROR;
-            } else if (Level.WARNING == level) {
-                return org.apache.logging.log4j.Level.WARN;
-            } else if (Level.INFO == level) {
-                return org.apache.logging.log4j.Level.INFO;
-            } else if (Level.CONFIG == level) {
-                return org.apache.logging.log4j.Level.INFO;
-            } else if (Level.FINE == level) {
-                return org.apache.logging.log4j.Level.DEBUG;
-            } else if (Level.FINER == level) {
-                return org.apache.logging.log4j.Level.DEBUG;
-            } else if (Level.FINEST == level) {
-                return org.apache.logging.log4j.Level.DEBUG;
-            } else if (Level.OFF == level) {
-                return org.apache.logging.log4j.Level.OFF;
-            } else {
-                return org.apache.logging.log4j.Level.INFO;
-            }
+        private static org.apache.logging.log4j.Level toLog4j2Level(Level level) {
+            return level == Level.FINEST  ? org.apache.logging.log4j.Level.TRACE
+                 : level == Level.FINE    ? org.apache.logging.log4j.Level.DEBUG
+                 : level == Level.INFO    ? org.apache.logging.log4j.Level.INFO
+                 : level == Level.WARNING ? org.apache.logging.log4j.Level.WARN
+                 : level == Level.SEVERE  ? org.apache.logging.log4j.Level.ERROR
+                 : level == Level.FINER   ? org.apache.logging.log4j.Level.DEBUG
+                 : level == Level.CONFIG  ? org.apache.logging.log4j.Level.INFO
+                 : level == Level.OFF     ? org.apache.logging.log4j.Level.OFF
+                 : org.apache.logging.log4j.Level.INFO;
         }
-        //CHECKSTYLE:ON
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/logging/Log4jFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/logging/Log4jFactory.java
@@ -37,32 +37,17 @@ public class Log4jFactory extends LoggerFactorySupport implements LoggerFactory 
         public Log4jLogger(Logger logger) {
             this.logger = logger;
             org.apache.log4j.Level log4jLevel = logger.getLevel();
-            if (log4jLevel == org.apache.log4j.Level.DEBUG) {
-                this.level = Level.FINEST;
-            } else if (log4jLevel == org.apache.log4j.Level.INFO) {
-                this.level = Level.INFO;
-            } else if (log4jLevel == org.apache.log4j.Level.WARN) {
-                this.level = Level.WARNING;
-            } else if (log4jLevel == org.apache.log4j.Level.FATAL) {
-                this.level = Level.SEVERE;
-            } else if (log4jLevel == org.apache.log4j.Level.OFF) {
-                this.level = Level.OFF;
-            } else {
-                this.level = Level.INFO;
-            }
+            this.level = toStandardLevel(log4jLevel);
         }
 
         @Override
         public void log(Level level, String message) {
-            if (Level.FINEST == level) {
-                logger.debug(message);
-            } else if (Level.SEVERE == level) {
-                logger.fatal(message);
-            } else if (Level.WARNING == level) {
-                logger.warn(message);
-            } else if (level != Level.OFF) {
-                logger.info(message);
-            }
+            logger.log(toLog4jLevel(level), message);
+        }
+
+        @Override
+        public void log(Level level, String message, Throwable thrown) {
+            logger.log(toLog4jLevel(level), message, thrown);
         }
 
         @Override
@@ -72,56 +57,44 @@ public class Log4jFactory extends LoggerFactorySupport implements LoggerFactory 
 
         @Override
         public boolean isLoggable(Level level) {
-            if (Level.OFF == level) {
-                return false;
-            } else if (Level.FINEST == level) {
-                return logger.isDebugEnabled();
-            } else if (Level.WARNING == level) {
-                return logger.isEnabledFor(org.apache.log4j.Level.WARN);
-            } else if (Level.SEVERE == level) {
-                return logger.isEnabledFor(org.apache.log4j.Level.FATAL);
-            } else if (Level.OFF == level) {
-                return false;
-            } else {
-                return logger.isEnabledFor(org.apache.log4j.Level.INFO);
-            }
-        }
-
-        @Override
-        public void log(Level level, String message, Throwable thrown) {
-            if (Level.FINEST == level) {
-                logger.debug(message, thrown);
-            } else if (Level.WARNING == level) {
-                logger.warn(message, thrown);
-            } else if (Level.SEVERE == level) {
-                logger.fatal(message, thrown);
-            } else if (Level.OFF != level) {
-                logger.info(message, thrown);
-            }
+            return level != Level.OFF && logger.isEnabledFor(toLog4jLevel(level));
         }
 
         @Override
         public void log(LogEvent logEvent) {
             LogRecord logRecord = logEvent.getLogRecord();
+            if (logRecord.getLevel() == Level.OFF) {
+                return;
+            }
             String name = logEvent.getLogRecord().getLoggerName();
             org.apache.log4j.Logger logger = org.apache.log4j.Logger.getLogger(name);
-            org.apache.log4j.Level level;
-            if (logRecord.getLevel() == Level.FINEST) {
-                level = org.apache.log4j.Level.DEBUG;
-            } else if (logRecord.getLevel() == Level.INFO) {
-                level = org.apache.log4j.Level.INFO;
-            } else if (logRecord.getLevel() == Level.WARNING) {
-                level = org.apache.log4j.Level.WARN;
-            } else if (logRecord.getLevel() == Level.SEVERE) {
-                level = org.apache.log4j.Level.FATAL;
-            } else if (logRecord.getLevel() == Level.OFF) {
-                return;
-            } else {
-                level = org.apache.log4j.Level.INFO;
-            }
+            org.apache.log4j.Level level = toLog4jLevel(logRecord.getLevel());
             String message = logRecord.getMessage();
             Throwable throwable = logRecord.getThrown();
             logger.callAppenders(new LoggingEvent(name, logger, level, message, throwable));
+        }
+
+        private static org.apache.log4j.Level toLog4jLevel(Level level) {
+            return level == Level.FINEST  ? org.apache.log4j.Level.TRACE
+                 : level == Level.FINE    ? org.apache.log4j.Level.DEBUG
+                 : level == Level.INFO    ? org.apache.log4j.Level.INFO
+                 : level == Level.WARNING ? org.apache.log4j.Level.WARN
+                 : level == Level.SEVERE  ? org.apache.log4j.Level.ERROR
+                 : level == Level.CONFIG  ? org.apache.log4j.Level.INFO
+                 : level == Level.FINER   ? org.apache.log4j.Level.DEBUG
+                 : level == Level.OFF     ? org.apache.log4j.Level.OFF
+                 : org.apache.log4j.Level.INFO;
+        }
+
+        private static Level toStandardLevel(org.apache.log4j.Level log4jLevel) {
+            return log4jLevel == org.apache.log4j.Level.TRACE ? Level.FINEST
+                 : log4jLevel == org.apache.log4j.Level.DEBUG ? Level.FINE
+                 : log4jLevel == org.apache.log4j.Level.INFO  ? Level.INFO
+                 : log4jLevel == org.apache.log4j.Level.WARN  ? Level.WARNING
+                 : log4jLevel == org.apache.log4j.Level.ERROR ? Level.SEVERE
+                 : log4jLevel == org.apache.log4j.Level.FATAL ? Level.SEVERE
+                 : log4jLevel == org.apache.log4j.Level.OFF   ? Level.OFF
+                 : Level.INFO;
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/logging/LoggingServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/logging/LoggingServiceImpl.java
@@ -142,7 +142,7 @@ public class LoggingServiceImpl implements LoggingService {
         }
     }
 
-    private class DefaultLogger implements ILogger {
+    private class DefaultLogger extends AbstractLogger {
         final String name;
         final ILogger logger;
 
@@ -151,63 +151,7 @@ public class LoggingServiceImpl implements LoggingService {
             this.logger = loggerFactory.getLogger(name);
         }
 
-        @Override
-        public void finest(String message) {
-            log(Level.FINEST, message);
-        }
-
-        @Override
-        public void finest(String message, Throwable thrown) {
-            log(Level.FINEST, message, thrown);
-        }
-
-        @Override
-        public void finest(Throwable thrown) {
-            log(Level.FINEST, thrown.getMessage(), thrown);
-        }
-
-        @Override
-        public boolean isFinestEnabled() {
-            return isLoggable(Level.FINEST);
-        }
-
-        @Override
-        public void info(String message) {
-            log(Level.INFO, message);
-        }
-
-        @Override
-        public void severe(String message) {
-            log(Level.SEVERE, message);
-        }
-
-        @Override
-        public void severe(Throwable thrown) {
-            log(Level.SEVERE, thrown.getMessage(), thrown);
-        }
-
-        @Override
-        public void severe(String message, Throwable thrown) {
-            log(Level.SEVERE, message, thrown);
-        }
-
-        @Override
-        public void warning(String message) {
-            log(Level.WARNING, message);
-        }
-
-        @Override
-        public void warning(Throwable thrown) {
-            log(Level.WARNING, thrown.getMessage(), thrown);
-        }
-
-        @Override
-        public void warning(String message, Throwable thrown) {
-            log(Level.WARNING, message, thrown);
-        }
-
-        @Override
-        public void log(Level level, String message) {
+        @Override public void log(Level level, String message) {
             log(level, message, null);
         }
 
@@ -217,8 +161,7 @@ public class LoggingServiceImpl implements LoggingService {
             if (loggable || level.intValue() >= minLevel.intValue()) {
                 String address = thisAddressString;
                 String logMessage = (address != null ? address : "")
-                        + " [" + groupName + "] "
-                        + "[" + buildInfo.getVersion() + "] " + message;
+                        + " [" + groupName + "] [" + buildInfo.getVersion() + "] " + message;
 
                 if (loggable) {
                     logger.log(level, logMessage, thrown);

--- a/hazelcast/src/main/java/com/hazelcast/logging/NoLogFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/logging/NoLogFactory.java
@@ -27,70 +27,60 @@ public class NoLogFactory implements LoggerFactory {
     }
 
     static class NoLogger implements ILogger {
-        @Override
-        public void finest(String message) {
+        @Override public void finest(String message) {
         }
 
-        @Override
-        public void finest(String message, Throwable thrown) {
+        @Override public void finest(String message, Throwable thrown) {
         }
 
-        @Override
-        public void finest(Throwable thrown) {
+        @Override public void finest(Throwable thrown) {
         }
 
-        @Override
-        public boolean isFinestEnabled() {
+        @Override public boolean isFinestEnabled() {
             return false;
         }
 
-        @Override
-        public void info(String message) {
+        @Override public void fine(String message) {
         }
 
-        @Override
-        public void severe(String message) {
+        @Override public boolean isFineEnabled() {
+            return false;
         }
 
-        @Override
-        public void severe(Throwable thrown) {
+        @Override public void info(String message) {
         }
 
-        @Override
-        public void severe(String message, Throwable thrown) {
+        @Override public void severe(String message) {
         }
 
-        @Override
-        public void warning(String message) {
+        @Override public void severe(Throwable thrown) {
         }
 
-        @Override
-        public void warning(Throwable thrown) {
+        @Override public void severe(String message, Throwable thrown) {
         }
 
-        @Override
-        public void warning(String message, Throwable thrown) {
+        @Override public void warning(String message) {
         }
 
-        @Override
-        public void log(Level level, String message) {
+        @Override public void warning(Throwable thrown) {
         }
 
-        @Override
-        public void log(Level level, String message, Throwable thrown) {
+        @Override public void warning(String message, Throwable thrown) {
         }
 
-        @Override
-        public void log(LogEvent logEvent) {
+        @Override public void log(Level level, String message) {
         }
 
-        @Override
-        public Level getLevel() {
+        @Override public void log(Level level, String message, Throwable thrown) {
+        }
+
+        @Override public void log(LogEvent logEvent) {
+        }
+
+        @Override public Level getLevel() {
             return Level.OFF;
         }
-
-        @Override
-        public boolean isLoggable(Level level) {
+        @Override public boolean isLoggable(Level level) {
             return false;
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/logging/Slf4jFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/logging/Slf4jFactory.java
@@ -39,62 +39,58 @@ public class Slf4jFactory extends LoggerFactorySupport {
 
         @Override
         public void log(Level level, String message) {
-            if (Level.FINEST == level) {
+            if (level == Level.FINEST) {
+                logger.trace(message);
+            } else if (level == Level.FINER || level == Level.FINE) {
                 logger.debug(message);
-            } else if (Level.SEVERE == level) {
-                logger.error(message);
-            } else if (Level.WARNING == level) {
+            } else if (level == Level.CONFIG || level == Level.INFO) {
+                logger.info(message);
+            } else if (level == Level.WARNING) {
                 logger.warn(message);
-            } else if (Level.OFF != level) {
+            } else if (level == Level.SEVERE) {
+                logger.error(message);
+            } else if (level != Level.OFF) {
                 logger.info(message);
             }
         }
 
         @Override
-        public Level getLevel() {
-            if (logger.isDebugEnabled()) {
-                return Level.FINEST;
-            } else if (logger.isInfoEnabled()) {
-                return Level.INFO;
-            } else if (logger.isWarnEnabled()) {
-                return Level.WARNING;
-            } else if (logger.isErrorEnabled()) {
-                return Level.SEVERE;
-            } else {
-                return Level.OFF;
+        public void log(Level level, String message, Throwable thrown) {
+            if (level == Level.FINEST) {
+                logger.trace(message, thrown);
+            } else if (level == Level.FINER || level == Level.FINE) {
+                logger.debug(message, thrown);
+            } else if (level == Level.CONFIG || level == Level.INFO) {
+                logger.info(message, thrown);
+            } else if (level == Level.WARNING) {
+                logger.warn(message, thrown);
+            } else if (level == Level.SEVERE) {
+                logger.error(message, thrown);
+            } else if (level != Level.OFF) {
+                logger.info(message, thrown);
             }
+        }
+
+        @Override
+        public Level getLevel() {
+            return logger.isTraceEnabled() ? Level.FINEST
+                 : logger.isDebugEnabled() ? Level.FINE
+                 : logger.isInfoEnabled()  ? Level.INFO
+                 : logger.isWarnEnabled()  ? Level.WARNING
+                 : logger.isErrorEnabled() ? Level.SEVERE
+                 : Level.OFF;
         }
 
         @Override
         public boolean isLoggable(Level level) {
-            if (Level.OFF == level) {
-                return false;
-            } else if (Level.FINEST == level) {
-                return logger.isDebugEnabled();
-            } else if (Level.INFO == level) {
-                return logger.isInfoEnabled();
-            } else if (Level.WARNING == level) {
-                return logger.isWarnEnabled();
-            } else if (Level.SEVERE == level) {
-                return logger.isErrorEnabled();
-            } else {
-                return logger.isInfoEnabled();
-            }
-        }
-
-        @Override
-        public void log(Level level, String message, Throwable thrown) {
-            if (Level.FINEST == level) {
-                logger.debug(message, thrown);
-            } else if (Level.INFO == level) {
-                logger.info(message, thrown);
-            } else if (Level.WARNING == level) {
-                logger.warn(message, thrown);
-            } else if (Level.SEVERE == level) {
-                logger.error(message, thrown);
-            } else if (Level.OFF != level) {
-                logger.info(message, thrown);
-            }
+            return level == Level.FINEST  ? logger.isTraceEnabled()
+                 : level == Level.FINER   ? logger.isDebugEnabled()
+                 : level == Level.FINE    ? logger.isDebugEnabled()
+                 : level == Level.CONFIG  ? logger.isInfoEnabled()
+                 : level == Level.INFO    ? logger.isInfoEnabled()
+                 : level == Level.WARNING ? logger.isWarnEnabled()
+                 : level == Level.SEVERE  ? logger.isErrorEnabled()
+                 : level != Level.OFF && logger.isInfoEnabled();
         }
 
         @Override

--- a/hazelcast/src/test/java/com/hazelcast/logging/Log4j2LoggerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/logging/Log4j2LoggerTest.java
@@ -19,6 +19,7 @@ package com.hazelcast.logging;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
+import org.apache.logging.log4j.spi.ExtendedLogger;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -27,23 +28,22 @@ import org.junit.runner.RunWith;
 import java.util.logging.Level;
 
 import static org.junit.Assert.assertFalse;
-import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class Log4jLoggerTest {
+public class Log4j2LoggerTest {
+    private static final String LOGGER_NAME = Log4j2Factory.Log4j2Logger.class.getName();
 
-    private org.apache.log4j.Logger mockLogger;
+    private ExtendedLogger mockLogger;
     private ILogger hazelcastLogger;
 
     @Before
     public void setUp() {
-        mockLogger = mock(org.apache.log4j.Logger.class);
-        hazelcastLogger = new Log4jFactory.Log4jLogger(mockLogger);
+        mockLogger = mock(ExtendedLogger.class);
+        hazelcastLogger = new Log4j2Factory.Log4j2Logger(mockLogger);
     }
 
     @Test
@@ -55,42 +55,43 @@ public class Log4jLoggerTest {
     public void logWithThrowable_shouldCallLogWithThrowable() {
         final Exception thrown = new Exception();
         hazelcastLogger.warning("message", thrown);
-        verify(mockLogger, times(1)).log(org.apache.log4j.Level.WARN, "message", thrown);
+        verify(mockLogger, times(1)).logIfEnabled(
+                LOGGER_NAME, org.apache.logging.log4j.Level.WARN, null, "message", thrown);
     }
 
     @Test
     public void logAtLevelOff_shouldLogAtLevelOff() {
         hazelcastLogger.log(Level.OFF, "message");
-        verify(mockLogger, times(1)).log(org.apache.log4j.Level.OFF, "message");
+        verify(mockLogger, times(1)).logIfEnabled(LOGGER_NAME, org.apache.logging.log4j.Level.OFF, null, "message");
     }
 
     @Test
     public void logFinest_shouldLogTrace() {
         hazelcastLogger.finest("message");
-        verify(mockLogger, times(1)).log(org.apache.log4j.Level.TRACE, "message");
+        verify(mockLogger, times(1)).logIfEnabled(LOGGER_NAME, org.apache.logging.log4j.Level.TRACE, null, "message");
     }
 
     @Test
     public void logFine_shouldLogDebug() {
         hazelcastLogger.fine("message");
-        verify(mockLogger, times(1)).log(org.apache.log4j.Level.DEBUG, "message");
+        verify(mockLogger, times(1)).logIfEnabled(LOGGER_NAME, org.apache.logging.log4j.Level.DEBUG, null, "message");
     }
 
     @Test
     public void logInfo_shouldLogInfo() {
         hazelcastLogger.info("message");
-        verify(mockLogger, times(1)).log(org.apache.log4j.Level.INFO, "message");
+        verify(mockLogger, times(1)).logIfEnabled(LOGGER_NAME, org.apache.logging.log4j.Level.INFO, null, "message");
     }
 
     @Test
     public void logWarning_shouldLogWarn() {
         hazelcastLogger.warning("message");
-        verify(mockLogger, times(1)).log(org.apache.log4j.Level.WARN, "message");
+        verify(mockLogger, times(1)).logIfEnabled(LOGGER_NAME, org.apache.logging.log4j.Level.WARN, null, "message");
     }
 
     @Test
     public void logSevere_shouldLogError() {
         hazelcastLogger.severe("message");
-        verify(mockLogger, times(1)).log(org.apache.log4j.Level.ERROR, "message");
+        verify(mockLogger, times(1)).logIfEnabled(LOGGER_NAME, org.apache.logging.log4j.Level.ERROR, null, "message");
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/logging/LoggerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/logging/LoggerTest.java
@@ -25,7 +25,7 @@ public class LoggerTest {
     private static final String LOGGING_TYPE_LOG4J2 = "log4j2";
 
     private static Field LOGGER_FACTORY_FIELD;
-    private static String actualLoggingTypePropertyValue;
+    private static String backupLoggingTypeProperty;
 
     @BeforeClass
     public static void beforeClass() {
@@ -33,20 +33,15 @@ public class LoggerTest {
             LOGGER_FACTORY_FIELD = Logger.class.getDeclaredField("loggerFactory");
             LOGGER_FACTORY_FIELD.setAccessible(true);
         } catch (NoSuchFieldException e) {
-            throw
-                    new IllegalStateException(
-                            "Couldn't retrieve \"loggerFactory\" field from "
-                                    + Logger.class.getName() + " class !", e);
+            throw new IllegalStateException(
+                    "Couldn't retrieve \"loggerFactory\" field from " + Logger.class.getName() + " class !", e);
         }
-
-        // Store actual logging type property value to set this current value after all tests
-        actualLoggingTypePropertyValue = System.getProperty(LOGGING_TYPE_PROPERTY_NAME);
+        backupLoggingTypeProperty = System.getProperty(LOGGING_TYPE_PROPERTY_NAME);
     }
 
     @AfterClass
     public static void afterClass() {
-        // Back to the old (actual) value of logging type property after all tests
-        System.setProperty(LOGGING_TYPE_PROPERTY_NAME, actualLoggingTypePropertyValue);
+        System.setProperty(LOGGING_TYPE_PROPERTY_NAME, backupLoggingTypeProperty);
     }
 
     @Before
@@ -55,10 +50,8 @@ public class LoggerTest {
             // Reset logger factory field
             LOGGER_FACTORY_FIELD.set(null, null);
         } catch (IllegalAccessException e) {
-            throw
-                new IllegalStateException(
-                        "Couldn't clear \"loggerFactory\" field from "
-                            + Logger.class.getName() + " class !", e);
+            throw new IllegalStateException(
+                    "Couldn't clear \"loggerFactory\" field from " + Logger.class.getName() + " class !", e);
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/logging/Slf4jLoggerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/logging/Slf4jLoggerTest.java
@@ -29,6 +29,8 @@ import java.util.logging.Level;
 
 import static org.junit.Assert.assertFalse;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 
 @RunWith(HazelcastParallelClassRunner.class)
@@ -45,22 +47,50 @@ public class Slf4jLoggerTest {
     }
 
     @Test
-    public void logLevelAndMessage_whenOffLevel_thenDoNotLogMessage() {
+    public void isLoggable_whenLevelOff_shouldReturnFalse() {
+        assertFalse(hazelcastLogger.isLoggable(Level.OFF));
+    }
+
+    @Test
+    public void logWithThrowable_shouldCallLogWithThrowable() {
+        final Exception thrown = new Exception();
+        hazelcastLogger.warning("message", thrown);
+        verify(mockLogger, times(1)).warn("message", thrown);
+    }
+
+    @Test
+    public void logAtLevelOff_shouldNotLog() {
         hazelcastLogger.log(Level.OFF, "message");
         verifyZeroInteractions(mockLogger);
     }
 
     @Test
-    public void logLevelAndMessageAndThrowable_whenOffLevel_thenDoNotLogMessage() {
-        hazelcastLogger.log(Level.OFF, "message", new Exception());
-        verifyZeroInteractions(mockLogger);
+    public void logFinest_shouldLogTrace() {
+        hazelcastLogger.finest("message");
+        verify(mockLogger, times(1)).trace("message");
     }
 
     @Test
-    public void isLoggable_whenOffLevel_thenReturnFalse() {
-        boolean loggable = hazelcastLogger.isLoggable(Level.OFF);
-        assertFalse(loggable);
+    public void logFine_shouldLogDebug() {
+        hazelcastLogger.fine("message");
+        verify(mockLogger, times(1)).debug("message");
     }
 
+    @Test
+    public void logInfo_shouldLogInfo() {
+        hazelcastLogger.info("message");
+        verify(mockLogger, times(1)).info("message");
+    }
 
+    @Test
+    public void logWarning_shouldLogWarn() {
+        hazelcastLogger.warning("message");
+        verify(mockLogger, times(1)).warn("message");
+    }
+
+    @Test
+    public void logSevere_shouldLogError() {
+        hazelcastLogger.severe("message");
+        verify(mockLogger, times(1)).error("message");
+    }
 }

--- a/hazelcast/src/test/resources/log4j.properties
+++ b/hazelcast/src/test/resources/log4j.properties
@@ -28,5 +28,6 @@ log4j.appender.stdout.layout.ConversionPattern=%d{ABSOLUTE} %5p [%c{1}] %t - %m%
 #log4j.logger.com.hazelcast.nio=debug
 #log4j.logger.com.hazelcast.nio=info
 #log4j.logger.com.hazelcast.hibernate=debug
+log4j.logger.com.hazelcast.spi.hotrestart=debug
 
 log4j.rootLogger=info, stdout


### PR DESCRIPTION
The Hot Restart module needs a distinction between `debug` and `trace` logging levels. Currently we have `finest` which maps to `debug`. This PR changes `finest` to `trace` and introduces `fine` which now maps to `debug`.