### PR TITLE
Moved Maven SonarQube plugin from profiles to build section

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -270,6 +270,12 @@
                     </excludedGroups>
                 </configuration>
             </plugin>
+
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>sonar-maven-plugin</artifactId>
+                <version>${maven.sonar.plugin.version}</version>
+            </plugin>
         </plugins>
     </build>
 
@@ -508,12 +514,6 @@
                             </excludedGroups>
                         </configuration>
                     </plugin>
-
-                    <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>sonar-maven-plugin</artifactId>
-                        <version>${maven.sonar.plugin.version}</version>
-                    </plugin>
                 </plugins>
             </build>
         </profile>
@@ -637,12 +637,6 @@
                                 </goals>
                             </execution>
                         </executions>
-                    </plugin>
-
-                    <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>sonar-maven-plugin</artifactId>
-                        <version>${maven.sonar.plugin.version}</version>
                     </plugin>
                 </plugins>
             </build>


### PR DESCRIPTION
Since there is no further configuration we can safely move the plugin to the most general section. This should fix the Sonar build, since the plugin version should be takes for all profiles and builds.