### PR TITLE
Fixes for Long/IntHashSet

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -351,6 +351,7 @@
     <suppress checks="MethodCount" files="com/hazelcast/util/collection/\w*Hash\w*"/>
     <suppress checks="MethodCount" files="com/hazelcast/collection/impl/collection/CollectionContainer"/>
     <suppress checks="MagicNumber|Header" files="com/hazelcast/util/collection/"/>
+    <suppress checks="Header" files="com/hazelcast/util/QuickMath"/>
     <suppress checks="SuperClone" files="com/hazelcast/util/collection/InflatableSet"/>
 
     <!-- Queue -->

--- a/hazelcast/src/main/java/com/hazelcast/util/QuickMath.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/QuickMath.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ * Portions Copyright 2014 Real Logic Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/util/collection/LongHashSetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/collection/LongHashSetTest.java
@@ -40,10 +40,10 @@ import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class IntHashSetTest {
+public class LongHashSetTest {
     @Rule public final ExpectedException rule = ExpectedException.none();
 
-    private final IntHashSet set = new IntHashSet(100, -1);
+    private final LongHashSet set = new LongHashSet(100, -1);
 
     @Test public void initiallyContainsNoElements() throws Exception {
         for (int i = 0; i < 10000; i++) {
@@ -53,7 +53,7 @@ public class IntHashSetTest {
 
     @Test public void initiallyContainsNoBoxedElements() {
         for (int i = 0; i < 10000; i++) {
-            assertFalse(set.contains(Integer.valueOf(i)));
+            assertFalse(set.contains(Long.valueOf(i)));
         }
     }
 
@@ -71,9 +71,9 @@ public class IntHashSetTest {
 
     @Test public void containsAddedBoxedElements() {
         assertTrue(set.add(1));
-        assertTrue(set.add(Integer.valueOf(2)));
+        assertTrue(set.add(Long.valueOf(2)));
 
-        assertTrue(set.contains(Integer.valueOf(1)));
+        assertTrue(set.contains(Long.valueOf(1)));
         assertTrue(set.contains(2));
     }
 
@@ -135,7 +135,7 @@ public class IntHashSetTest {
         set.add(1);
         set.add(2);
 
-        final IntHashSet other = new IntHashSet(100, -1);
+        final LongHashSet other = new LongHashSet(100, -1);
         other.add(1);
         other.add(2);
 
@@ -146,36 +146,36 @@ public class IntHashSetTest {
         set.add(1);
         set.add(2);
 
-        final IntHashSet other = new IntHashSet(100, -1);
+        final LongHashSet other = new LongHashSet(100, -1);
         other.add(1);
 
-        final IntHashSet diff = set.difference(other);
+        final LongHashSet diff = set.difference(other);
         assertEquals(1, diff.size());
         assertTrue(diff.contains(2));
     }
 
-    @Test public void copiesOtherIntHashSet() {
+    @Test public void copiesOtherLongHashSet() {
         set.add(1);
         set.add(2);
 
-        final IntHashSet other = new IntHashSet(100, -1);
+        final LongHashSet other = new LongHashSet(100, -1);
         other.copy(set);
 
-        assertThat(other, contains(1, 2));
+        assertThat(other, contains(1L, 2L));
     }
 
     @Test public void twoEmptySetsAreEqual() {
-        final IntHashSet other = new IntHashSet(100, -1);
+        final LongHashSet other = new LongHashSet(100, -1);
         assertEquals(set, other);
     }
 
     @Test public void equalityRequiresTheSameMissingValue() {
-        final IntHashSet other = new IntHashSet(100, 1);
+        final LongHashSet other = new LongHashSet(100, 1);
         assertNotEquals(set, other);
     }
 
     @Test public void setsWithTheSameValuesAreEqual() {
-        final IntHashSet other = new IntHashSet(100, -1);
+        final LongHashSet other = new LongHashSet(100, -1);
 
         set.add(1);
         set.add(1001);
@@ -187,7 +187,7 @@ public class IntHashSetTest {
     }
 
     @Test public void setsWithTheDifferentSizesAreNotEqual() {
-        final IntHashSet other = new IntHashSet(100, -1);
+        final LongHashSet other = new LongHashSet(100, -1);
 
         set.add(1);
         set.add(1001);
@@ -198,7 +198,7 @@ public class IntHashSetTest {
     }
 
     @Test public void setsWithTheDifferentValuesAreNotEqual() {
-        final IntHashSet other = new IntHashSet(100, -1);
+        final LongHashSet other = new LongHashSet(100, -1);
 
         set.add(1);
         set.add(1001);
@@ -210,12 +210,12 @@ public class IntHashSetTest {
     }
 
     @Test public void twoEmptySetsHaveTheSameHashcode() {
-        final IntHashSet other = new IntHashSet(100, -1);
+        final LongHashSet other = new LongHashSet(100, -1);
         assertEquals(set.hashCode(), other.hashCode());
     }
 
     @Test public void setsWithTheSameValuesHaveTheSameHashcode() {
-        final IntHashSet other = new IntHashSet(100, -1);
+        final LongHashSet other = new LongHashSet(100, -1);
 
         set.add(1);
         set.add(1001);
@@ -227,7 +227,7 @@ public class IntHashSetTest {
     }
 
     @Test public void worksCorrectlyWhenFull() {
-        final IntHashSet set = new IntHashSet(2, 0);
+        final LongHashSet set = new LongHashSet(2, 0);
         set.add(1);
         set.add(2);
         assertTrue(set.contains(2));
@@ -235,14 +235,14 @@ public class IntHashSetTest {
     }
 
     @Test public void failsWhenOverCapacity() {
-        final IntHashSet set = new IntHashSet(1, 0);
+        final LongHashSet set = new LongHashSet(1, 0);
         set.add(1);
         rule.expect(IllegalStateException.class);
         set.add(2);
     }
 
     @Test public void toArrayReturnsArrayOfAllElements() {
-        final IntHashSet initial = new IntHashSet(100, -1);
+        final LongHashSet initial = new LongHashSet(100, -1);
         initial.add(1);
         initial.add(13);
         final Object[] ary = initial.toArray();
@@ -251,21 +251,21 @@ public class IntHashSetTest {
     }
 
     @Test public void intoArrayReturnsArrayOfAllElements() {
-        final IntHashSet initial = new IntHashSet(100, -1);
+        final LongHashSet initial = new LongHashSet(100, -1);
         initial.add(1);
         initial.add(13);
-        final Object[] ary = initial.toArray(new Integer[2]);
+        final Object[] ary = initial.toArray(new Long[2]);
         final Set<Object> fromArray = new HashSet<Object>(Arrays.asList(ary));
         assertEquals(new HashSet<Object>(initial), fromArray);
     }
 
     private void assertIteratorHasElements() {
-        final Iterator<Integer> iter = set.iterator();
+        final Iterator<Long> iter = set.iterator();
 
         assertTrue(iter.hasNext());
-        assertEquals(Integer.valueOf(1), iter.next());
+        assertEquals(Long.valueOf(1), iter.next());
         assertTrue(iter.hasNext());
-        assertEquals(Integer.valueOf(2), iter.next());
+        assertEquals(Long.valueOf(2), iter.next());
         assertFalse(iter.hasNext());
     }
 }


### PR DESCRIPTION
1. The set entered an infinite loop when full; now works correctly when full and `add()`
   throws `IllegalStateException` if capacity is exceeded.
1. The set did not ensure a good load factor (could be almost 1 in the worst case).
2. `toArray()` copied "missing value" sentinels into the array as if they were set members.
3. Also fixed a legal issue: a copyright line in QuickMath.