### PR TITLE
Serialization binary format change to match 8 byte memory alignment

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/AbstractSerializationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/AbstractSerializationService.java
@@ -121,11 +121,12 @@ public abstract class AbstractSerializationService
         BufferObjectDataOutput out = pool.takeOutputBuffer();
         try {
             SerializerAdapter serializer = serializerFor(obj);
-            out.writeInt(serializer.getTypeId(), ByteOrder.BIG_ENDIAN);
-            serializer.write(out, obj);
-
             int partitionHash = calculatePartitionHash(obj, strategy);
             out.writeInt(partitionHash, ByteOrder.BIG_ENDIAN);
+
+            out.writeInt(serializer.getTypeId(), ByteOrder.BIG_ENDIAN);
+
+            serializer.write(out, obj);
             return out.toByteArray();
         } catch (Throwable e) {
             throw handleException(e);

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/HeapData.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/HeapData.java
@@ -31,11 +31,11 @@ import static com.hazelcast.nio.Bits.INT_SIZE_IN_BYTES;
 @SuppressFBWarnings("EI_EXPOSE_REP")
 public class HeapData implements Data {
     // type and partition_hash are always written with BIG_ENDIAN byte-order
-    public static final int TYPE_OFFSET = 0;
-    public static final int DATA_OFFSET = 4;
+    public static final int PARTITION_HASH_OFFSET = 0;
+    public static final int TYPE_OFFSET = 4;
+    public static final int DATA_OFFSET = 8;
 
-    //first 4 byte is type id + last 4 byte is partition hash code
-    public static final int HEAP_DATA_OVERHEAD = DATA_OFFSET + INT_SIZE_IN_BYTES;
+    public static final int HEAP_DATA_OVERHEAD = DATA_OFFSET;
 
     // array (12: array header, 4: length)
     private static final int ARRAY_HEADER_SIZE_IN_BYTES = 16;
@@ -46,7 +46,7 @@ public class HeapData implements Data {
     }
 
     public HeapData(byte[] payload) {
-        if (payload != null && payload.length > 0 && payload.length < (HEAP_DATA_OVERHEAD)) {
+        if (payload != null && payload.length > 0 && payload.length < HEAP_DATA_OVERHEAD) {
             throw new IllegalArgumentException(
                     "Data should be either empty or should contain more than " + HeapData.HEAP_DATA_OVERHEAD + " bytes! -> "
                             + Arrays.toString(payload));
@@ -67,15 +67,14 @@ public class HeapData implements Data {
     @Override
     public int getPartitionHash() {
         if (hasPartitionHash()) {
-            return Bits.readIntB(payload, payload.length - INT_SIZE_IN_BYTES);
+            return Bits.readIntB(payload, PARTITION_HASH_OFFSET);
         }
         return hashCode();
     }
 
     @Override
     public boolean hasPartitionHash() {
-        return payload != null && payload.length > HEAP_DATA_OVERHEAD
-                && Bits.readInt(payload, payload.length - INT_SIZE_IN_BYTES, true) != 0;
+        return payload != null && payload.length >= HEAP_DATA_OVERHEAD && Bits.readIntB(payload, PARTITION_HASH_OFFSET) != 0;
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/StringSerializationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/StringSerializationTest.java
@@ -35,8 +35,10 @@ import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
 import com.hazelcast.internal.serialization.impl.HeapData;
 import com.hazelcast.internal.serialization.impl.SerializationConstants;
+import com.hazelcast.nio.Bits;
 import com.hazelcast.nio.BufferObjectDataInput;
 import com.hazelcast.nio.BufferObjectDataOutput;
+import com.hazelcast.ringbuffer.impl.client.HeadSequenceRequest;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
@@ -113,7 +115,7 @@ public class StringSerializationTest {
         String allstr = new String(allChars);
         byte[] expected = allstr.getBytes(Charset.forName("utf8"));
         byte[] bytes = serializationService.toBytes(allstr);
-        byte[] actual = Arrays.copyOfRange(bytes, 8, bytes.length - 4);
+        byte[] actual = Arrays.copyOfRange(bytes, HeapData.DATA_OFFSET + Bits.INT_SIZE_IN_BYTES, bytes.length );
         assertArrayEquals(expected, actual);
     }
 
@@ -188,11 +190,11 @@ public class StringSerializationTest {
 
     private byte[] toDataByte(byte[] input, int length) {
         //the first 4 byte of type id, 4 byte string length and last 4 byte of partition hashCode
-        ByteBuffer bf = ByteBuffer.allocate(input.length + 8 + 4);
+        ByteBuffer bf = ByteBuffer.allocate(input.length + 12);
+        bf.putInt(0);
         bf.putInt(SerializationConstants.CONSTANT_TYPE_STRING);
         bf.putInt(length);
         bf.put(input);
-        bf.putInt(0);
         return bf.array();
     }
 }


### PR DESCRIPTION
Design comment from @mdogan :
>To support SPARC like cpus we will need to avoid unaligned memory access. This is handled by JVM >for heap memory but in off-heap region, this is something we have to handle ourselves. 
>If you use the same layout for offheap too then I suggest you to move Partition hash above byte[]. That >way Partition hash access will be guaranteed to be aligned. Also we will have 8 bytes before byte[] , >which will allow 8 bytes alignment in byte[]. 
>Even we can force byte[] to be 8 bytes aligned by adding padding at the end if needed.