### PR TITLE
[DONT MERGE] IExecutorService gets private NamedThreadPoolExecutor

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/executionservice/impl/ExecutionServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/executionservice/impl/ExecutionServiceImpl.java
@@ -80,7 +80,7 @@ public final class ExecutionServiceImpl implements InternalExecutionService {
                 public ManagedExecutorService createNew(String name) {
                     final ExecutorConfig cfg = nodeEngine.getConfig().findExecutorConfig(name);
                     final int queueCapacity = cfg.getQueueCapacity() <= 0 ? Integer.MAX_VALUE : cfg.getQueueCapacity();
-                    return createExecutor(name, cfg.getPoolSize(), queueCapacity, ExecutorType.CACHED);
+                    return createExecutor(name, cfg.getPoolSize(), queueCapacity, ExecutorType.CONCRETE);
                 }
             };
 
@@ -117,6 +117,11 @@ public final class ExecutionServiceImpl implements InternalExecutionService {
         // Register CompletableFuture task
         completableFutureTask = new CompletableFutureTask();
         scheduleWithFixedDelay(completableFutureTask, INITIAL_DELAY, PERIOD, TimeUnit.MILLISECONDS);
+    }
+
+    // for testing
+    public ManagedExecutorService findExecutorService(String name) {
+        return executors.get(name);
     }
 
     private void enableRemoveOnCancelIfAvailable() {

--- a/hazelcast/src/test/java/com/hazelcast/executor/ExecutorServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/executor/ExecutorServiceTest.java
@@ -32,10 +32,13 @@ import com.hazelcast.core.PartitionAware;
 import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.monitor.LocalExecutorStats;
 import com.hazelcast.spi.ExecutionService;
+import com.hazelcast.spi.impl.executionservice.impl.ExecutionServiceImpl;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.util.executor.ManagedExecutorService;
+import com.hazelcast.util.executor.NamedThreadPoolExecutor;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -73,6 +76,16 @@ public class ExecutorServiceTest extends ExecutorServiceTestSupport {
     public static final int NODE_COUNT = 3;
 
     public static final int TASK_COUNT = 1000;
+
+    @Test
+    public void testIExecutorServiceGetsNamedThreadPoolExecutor()throws Exception{
+        HazelcastInstance hz = createHazelcastInstance();
+        ExecutionServiceImpl executionService = getExecutionService(hz);
+        hz.getExecutorService("foo").submit(new EmptyRunnable()).get();
+        ManagedExecutorService managedExecutorService = executionService.findExecutorService("foo");
+
+        assertInstanceOf(NamedThreadPoolExecutor.class, managedExecutorService);
+    }
 
     /* ############ andThen ############ */
 

--- a/hazelcast/src/test/java/com/hazelcast/executor/ExecutorServiceTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/executor/ExecutorServiceTestSupport.java
@@ -24,7 +24,9 @@ import com.hazelcast.core.IExecutorService;
 import com.hazelcast.core.Member;
 import com.hazelcast.core.MultiExecutionCallback;
 import com.hazelcast.core.PartitionAware;
+import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.impl.executionservice.InternalExecutionService;
+import com.hazelcast.spi.impl.executionservice.impl.ExecutionServiceImpl;
 import com.hazelcast.test.HazelcastTestSupport;
 
 import java.io.Serializable;
@@ -56,8 +58,9 @@ public class ExecutorServiceTestSupport extends HazelcastTestSupport {
         return key;
     }
 
-    InternalExecutionService getExecutionService(HazelcastInstance instance) {
-        return getNode(instance).getNodeEngine().getExecutionService();
+    ExecutionServiceImpl getExecutionService(HazelcastInstance instance) {
+        NodeEngineImpl nodeEngine = getNode(instance).getNodeEngine();
+        return (ExecutionServiceImpl) nodeEngine.getExecutionService();
     }
 
     static class CountDownLatchAwaitingCallable


### PR DESCRIPTION
Having a shared one causes isolation and contention problems. It also makes debugging problematic since each thread is called 'cached'.  So no more cached, but concrete. 


See https://github.com/hazelcast/hazelcast/issues/6600