### PR TITLE
Fix for failing ChangeClusterStateRequestTest

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/management/request/ChangeClusterStateRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/request/ChangeClusterStateRequest.java
@@ -31,6 +31,8 @@ import static com.hazelcast.util.JsonUtil.getString;
  */
 public class ChangeClusterStateRequest implements AsyncConsoleRequest {
 
+    private final String failure = "FAILURE: ";
+
     private String state;
 
     public ChangeClusterStateRequest() {
@@ -47,7 +49,7 @@ public class ChangeClusterStateRequest implements AsyncConsoleRequest {
 
     @Override
     public Object readResponse(JsonObject in) throws IOException {
-        return getString(in, "result", "FAIL");
+        return getString(in, "result", "FAILURE");
     }
 
     @Override
@@ -59,7 +61,7 @@ public class ChangeClusterStateRequest implements AsyncConsoleRequest {
         } catch (Exception e) {
             ILogger logger = mcs.getHazelcastInstance().node.nodeEngine.getLogger(getClass());
             logger.warning("Cluster state can not be changed: ", e);
-            resultString = e.getMessage();
+            resultString = failure + e.getMessage();
         }
         JsonObject result = new JsonObject().add("result", resultString);
         out.add("result", result);

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/ChangeClusterStateRequestTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/ChangeClusterStateRequestTest.java
@@ -16,14 +16,12 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class ChangeClusterStateRequestTest extends HazelcastTestSupport {
-
-    private final String INTERNAL_STATE_ERROR = "IN_TRANSITION is an internal state!";
-    private final String NO_ENUM_CONSTANT = "No enum constant com.hazelcast.cluster.ClusterState.MURAT";
-
+    
     private HazelcastInstance hz;
     private Cluster cluster;
     private ManagementCenterService managementCenterService;
@@ -55,7 +53,8 @@ public class ChangeClusterStateRequestTest extends HazelcastTestSupport {
         changeClusterStateRequest.writeResponse(managementCenterService, jsonObject);
 
         JsonObject result = (JsonObject) jsonObject.get("result");
-        assertEquals(INTERNAL_STATE_ERROR, changeClusterStateRequest.readResponse(result));
+        String resultString = (String) changeClusterStateRequest.readResponse(result);
+        assertTrue(resultString.startsWith("FAILURE"));
     }
 
     @Test
@@ -65,7 +64,8 @@ public class ChangeClusterStateRequestTest extends HazelcastTestSupport {
         changeClusterStateRequest.writeResponse(managementCenterService, jsonObject);
 
         JsonObject result = (JsonObject) jsonObject.get("result");
-        assertEquals(NO_ENUM_CONSTANT, changeClusterStateRequest.readResponse(result));
+        String resultString = (String) changeClusterStateRequest.readResponse(result);
+        assertTrue(resultString.startsWith("FAILURE"));
     }
 }
 


### PR DESCRIPTION
Before this test was relying on the `Exception`'s error message. Apparently, Oracle and IBM jdk's provide different error messages for `Enum.valueOf()` method.

fixes #6602 