### PR TITLE
Decrement Pending packets for events also

### DIFF
--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/connection/nio/ClientConnection.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/connection/nio/ClientConnection.java
@@ -82,15 +82,15 @@ public class ClientConnection implements Connection, Closeable {
         socketChannelWrapper = null;
     }
 
-    public void incrementPacketCount() {
+    public void incrementPendingPacketCount() {
         packetCount.incrementAndGet();
     }
 
-    public void decrementPacketCount() {
+    public void decrementPendingPacketCount() {
         packetCount.decrementAndGet();
     }
 
-    public int getPacketCount() {
+    public int getPendingPacketCount() {
         return packetCount.get();
     }
 

--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
@@ -296,10 +296,10 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
     public void handleClientMessage(ClientMessage message, Connection connection) {
         final ClientConnection conn = (ClientConnection) connection;
         ClientInvocationService invocationService = client.getInvocationService();
-        conn.incrementPacketCount();
+        conn.incrementPendingPacketCount();
         if (message.isFlagSet(ClientMessage.LISTENER_EVENT_FLAG)) {
             final ClientListenerServiceImpl listenerService = (ClientListenerServiceImpl) client.getListenerService();
-            listenerService.handleClientMessage(message);
+            listenerService.handleClientMessage(message, connection);
         } else {
             invocationService.handleClientMessage(message, connection);
         }

--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/spi/impl/ClientInvocationServiceSupport.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/spi/impl/ClientInvocationServiceSupport.java
@@ -266,7 +266,7 @@ abstract class ClientInvocationServiceSupport implements ClientInvocationService
 
         private void waitForPacketsProcessed() {
             final long begin = System.currentTimeMillis();
-            int count = connection.getPacketCount();
+            int count = connection.getPendingPacketCount();
             while (count != 0) {
                 try {
                     Thread.sleep(WAIT_TIME_FOR_PACKETS_TO_BE_CONSUMED);
@@ -279,7 +279,7 @@ abstract class ClientInvocationServiceSupport implements ClientInvocationService
                     logger.warning("There are packets which are not processed " + count);
                     break;
                 }
-                count = connection.getPacketCount();
+                count = connection.getPendingPacketCount();
             }
         }
     }
@@ -353,7 +353,7 @@ abstract class ClientInvocationServiceSupport implements ClientInvocationService
             } catch (Exception e) {
                 logger.severe("Failed to process task: " + packet + " on responseThread :" + getName(), e);
             } finally {
-                conn.decrementPacketCount();
+                conn.decrementPendingPacketCount();
             }
         }
 

--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnection.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnection.java
@@ -48,7 +48,7 @@ public class ClientConnection implements Connection, Closeable {
     private final AtomicBoolean live = new AtomicBoolean(true);
     private final ILogger logger = Logger.getLogger(ClientConnection.class);
 
-    private final AtomicInteger packetCount = new AtomicInteger(0);
+    private final AtomicInteger pendingPacketCount = new AtomicInteger(0);
     private final ClientWriteHandler writeHandler;
     private final ClientReadHandler readHandler;
     private final SocketChannelWrapper socketChannelWrapper;
@@ -82,16 +82,16 @@ public class ClientConnection implements Connection, Closeable {
         socketChannelWrapper = null;
     }
 
-    public void incrementPacketCount() {
-        packetCount.incrementAndGet();
+    public void incrementPendingPacketCount() {
+        pendingPacketCount.incrementAndGet();
     }
 
-    public void decrementPacketCount() {
-        packetCount.decrementAndGet();
+    public void decrementPendingPacketCount() {
+        pendingPacketCount.decrementAndGet();
     }
 
-    public int getPacketCount() {
-        return packetCount.get();
+    public int getPendingPacketCount() {
+        return pendingPacketCount.get();
     }
 
     public SerializationService getSerializationService() {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
@@ -294,7 +294,7 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
     @Override
     public void handlePacket(Packet packet) {
         final ClientConnection conn = (ClientConnection) packet.getConn();
-        conn.incrementPacketCount();
+        conn.incrementPendingPacketCount();
         if (packet.isHeaderSet(Packet.HEADER_EVENT)) {
             final ClientListenerServiceImpl listenerService = (ClientListenerServiceImpl) client.getListenerService();
             listenerService.handleEventPacket(packet);

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocationServiceSupport.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocationServiceSupport.java
@@ -266,7 +266,7 @@ abstract class ClientInvocationServiceSupport implements ClientInvocationService
 
         private void waitForPacketsProcessed() {
             final long begin = System.currentTimeMillis();
-            int count = connection.getPacketCount();
+            int count = connection.getPendingPacketCount();
             while (count != 0) {
                 try {
                     Thread.sleep(WAIT_TIME_FOR_PACKETS_TO_BE_CONSUMED);
@@ -279,7 +279,7 @@ abstract class ClientInvocationServiceSupport implements ClientInvocationService
                     logger.warning("There are packets which are not processed " + count);
                     break;
                 }
-                count = connection.getPacketCount();
+                count = connection.getPendingPacketCount();
             }
         }
     }
@@ -338,7 +338,7 @@ abstract class ClientInvocationServiceSupport implements ClientInvocationService
             } catch (Exception e) {
                 logger.severe("Failed to process task: " + packet + " on responseThread :" + getName());
             } finally {
-                conn.decrementPacketCount();
+                conn.decrementPendingPacketCount();
             }
         }
 

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientListenerServiceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientListenerServiceImpl.java
@@ -160,11 +160,15 @@ public final class ClientListenerServiceImpl implements ClientListenerService {
 
         @Override
         public void run() {
-            final ClientConnection conn = (ClientConnection) packet.getConn();
-            final ClientResponse clientResponse = serializationService.toObject(packet.getData());
-            final int callId = clientResponse.getCallId();
-            final Data response = clientResponse.getResponse();
-            handleEvent(response, callId, conn);
+            ClientConnection conn = (ClientConnection) packet.getConn();
+            try {
+                ClientResponse clientResponse = serializationService.toObject(packet.getData());
+                int callId = clientResponse.getCallId();
+                Data response = clientResponse.getResponse();
+                handleEvent(response, callId, conn);
+            } finally {
+                conn.decrementPendingPacketCount();
+            }
         }
 
         private void handleEvent(Data event, int callId, ClientConnection conn) {

--- a/hazelcast-client/src/test/java/com/hazelcast/client/ClientServiceTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ClientServiceTest.java
@@ -17,6 +17,10 @@
 package com.hazelcast.client;
 
 import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.connection.ClientConnectionManager;
+import com.hazelcast.client.connection.nio.ClientConnection;
+import com.hazelcast.client.impl.ClientTestUtil;
+import com.hazelcast.client.impl.HazelcastClientInstanceImpl;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.ListenerConfig;
@@ -29,6 +33,7 @@ import com.hazelcast.core.IMap;
 import com.hazelcast.core.LifecycleEvent;
 import com.hazelcast.core.LifecycleListener;
 import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.nio.Address;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
@@ -39,6 +44,8 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.concurrent.CountDownLatch;
@@ -353,6 +360,29 @@ public class ClientServiceTest extends HazelcastTestSupport {
                 }
             }, 5);
         }
+    }
+
+    @Test
+    public void testPendingEventPacketsWithEvents() throws InterruptedException, UnknownHostException {
+        HazelcastInstance hazelcastInstance = hazelcastFactory.newHazelcastInstance();
+
+        HazelcastInstance client = hazelcastFactory.newHazelcastClient();
+        IMap map = client.getMap(randomName());
+        map.addEntryListener(new EntryAdapter(), false);
+        for (int i = 0; i < 100; i++) {
+            map.put(randomString(), randomString());
+        }
+        HazelcastClientInstanceImpl clientInstanceImpl = ClientTestUtil.getHazelcastClientInstanceImpl(client);
+        InetSocketAddress socketAddress = hazelcastInstance.getCluster().getLocalMember().getSocketAddress();
+        Address address = new Address(socketAddress.getAddress().getHostAddress(), socketAddress.getPort());
+        ClientConnectionManager connectionManager = clientInstanceImpl.getConnectionManager();
+        final ClientConnection connection = (ClientConnection) connectionManager.getConnection(address);
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertEquals(0, connection.getPendingPacketCount());
+            }
+        });
     }
 
     static class ClientConnectedListenerLatch extends CountDownLatch implements ClientListener {


### PR DESCRIPTION
Pending packet count is kept per connection, incremented each
time a new packet from that connection is arrived and should be
decremented back when processing is over. For event packages
decrementing was missing. It is added in this pr.