### PR TITLE
Version Check code is refactored with phone home code. 

### DIFF
--- a/hazelcast-client-legacy/src/test/java/com/hazelcast/client/SimpleMapTestFromClient.java
+++ b/hazelcast-client-legacy/src/test/java/com/hazelcast/client/SimpleMapTestFromClient.java
@@ -35,7 +35,7 @@ public class SimpleMapTestFromClient {
         GroupProperty.WAIT_SECONDS_BEFORE_JOIN.setSystemProperty("0");
         System.setProperty("java.net.preferIPv4Stack", "true");
         System.setProperty("hazelcast.local.localAddress", "127.0.0.1");
-        GroupProperty.VERSION_CHECK_ENABLED.setSystemProperty("false");
+        GroupProperty.PHONE_HOME_ENABLED.setSystemProperty("false");
         GroupProperty.SOCKET_BIND_ANY.setSystemProperty("false");
 
         Random rand = new Random();

--- a/hazelcast-client/src/test/java/com/hazelcast/client/SimpleMapTestFromClient.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/SimpleMapTestFromClient.java
@@ -35,7 +35,7 @@ public class SimpleMapTestFromClient {
         GroupProperty.WAIT_SECONDS_BEFORE_JOIN.setSystemProperty("0");
         System.setProperty("java.net.preferIPv4Stack", "true");
         System.setProperty("hazelcast.local.localAddress", "127.0.0.1");
-        GroupProperty.VERSION_CHECK_ENABLED.setSystemProperty("false");
+        GroupProperty.PHONE_HOME_ENABLED.setSystemProperty("false");
         GroupProperty.SOCKET_BIND_ANY.setSystemProperty("false");
 
         Random rand = new Random();

--- a/hazelcast-code-generator/pom.xml
+++ b/hazelcast-code-generator/pom.xml
@@ -41,7 +41,7 @@
                     <!-- the argLine variable is needed for JaCoco-->
                     <argLine>
                         -Xms128m -Xmx1G -XX:MaxPermSize=128M
-                        -Dhazelcast.version.check.enabled=false
+                        -Dhazelcast.phone.home.enabled=false
                         -Dhazelcast.mancenter.enabled=false
                         -Dhazelcast.logging.type=none
                         -Dhazelcast.test.use.network=false
@@ -83,7 +83,7 @@
                                     <redirectTestOutputToFile>true</redirectTestOutputToFile>
                                     <argLine>
                                         -Xms128m -Xmx1G -XX:MaxPermSize=128M
-                                        -Dhazelcast.version.check.enabled=false
+                                        -Dhazelcast.phone.home.enabled=false
                                         -Dhazelcast.mancenter.enabled=false
                                         -Dhazelcast.logging.type=none
                                         -Dhazelcast.test.use.network=false
@@ -114,7 +114,7 @@
                             <redirectTestOutputToFile>true</redirectTestOutputToFile>
                             <argLine>
                                 -Xms128m -Xmx1G
-                                -Dhazelcast.version.check.enabled=false
+                                -Dhazelcast.phone.home.enabled=false
                                 -Dhazelcast.mancenter.enabled=false
                                 -Dhazelcast.test.use.network=false
                             </argLine>

--- a/hazelcast-spring/src/main/resources/hazelcast-spring-3.6.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-3.6.xsd
@@ -1546,7 +1546,7 @@
             <xs:enumeration value="hazelcast.mc.queue.excludes"/>
             <xs:enumeration value="hazelcast.mc.semaphore.excludes"/>
             <xs:enumeration value="hazelcast.mc.topic.excludes"/>
-            <xs:enumeration value="hazelcast.version.check.enabled"/>
+            <xs:enumeration value="hazelcast.phone.home.enabled"/>
             <xs:enumeration value="hazelcast.map.max.backup.count"/>
             <xs:enumeration value="hazelcast.max.wait.seconds.before.join"/>
             <xs:enumeration value="hazelcast.mc.max.visible.instance.count"/>

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/CustomSpringJUnit4ClassRunner.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/CustomSpringJUnit4ClassRunner.java
@@ -28,7 +28,7 @@ public class CustomSpringJUnit4ClassRunner extends SpringJUnit4ClassRunner {
     static {
         System.setProperty("java.net.preferIPv4Stack", "true");
         GroupProperty.WAIT_SECONDS_BEFORE_JOIN.setSystemProperty("1");
-        GroupProperty.VERSION_CHECK_ENABLED.setSystemProperty("false");
+        GroupProperty.PHONE_HOME_ENABLED.setSystemProperty("false");
         System.setProperty("hazelcast.local.localAddress", "127.0.0.1");
     }
 

--- a/hazelcast-wm/src/test/java/com/hazelcast/wm/test/AbstractWebFilterTest.java
+++ b/hazelcast-wm/src/test/java/com/hazelcast/wm/test/AbstractWebFilterTest.java
@@ -63,7 +63,7 @@ public abstract class AbstractWebFilterTest extends HazelcastTestSupport {
         if (System.getProperty(TestEnvironment.HAZELCAST_TEST_USE_NETWORK) == null) {
             System.setProperty(TestEnvironment.HAZELCAST_TEST_USE_NETWORK, "false");
         }
-        System.setProperty("hazelcast.version.check.enabled", "false");
+        System.setProperty("hazelcast.phone.home.enabled", "false");
         System.setProperty("hazelcast.mancenter.enabled", "false");
         System.setProperty("hazelcast.wait.seconds.before.join", "0");
         System.setProperty("hazelcast.local.localAddress", "127.0.0.1");

--- a/hazelcast/src/main/java/com/hazelcast/instance/GroupProperties.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/GroupProperties.java
@@ -56,7 +56,7 @@ public class GroupProperties extends HazelcastProperties {
     public static final String PROP_PERFORMANCE_MONITOR_HUMAN_FRIENDLY_FORMAT
             = GroupProperty.PERFORMANCE_MONITOR_HUMAN_FRIENDLY_FORMAT.getName();
     @Deprecated
-    public static final String PROP_VERSION_CHECK_ENABLED = GroupProperty.VERSION_CHECK_ENABLED.getName();
+    public static final String PROP_PHONE_HOME_ENABLED = GroupProperty.PHONE_HOME_ENABLED.getName();
     @Deprecated
     public static final String PROP_PREFER_IPv4_STACK = GroupProperty.PREFER_IPv4_STACK.getName();
     @Deprecated

--- a/hazelcast/src/main/java/com/hazelcast/instance/GroupProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/GroupProperty.java
@@ -181,7 +181,10 @@ public enum GroupProperty implements HazelcastProperty {
 
     PREFER_IPv4_STACK("hazelcast.prefer.ipv4.stack", true),
 
+    @Deprecated
     VERSION_CHECK_ENABLED("hazelcast.version.check.enabled", true),
+
+    PHONE_HOME_ENABLED("hazelcast.phone.home.enabled", true),
 
     CONNECT_ALL_WAIT_SECONDS("hazelcast.connect.all.wait.seconds", 120, SECONDS),
 

--- a/hazelcast/src/main/java/com/hazelcast/instance/Node.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/Node.java
@@ -65,7 +65,7 @@ import com.hazelcast.util.Clock;
 import com.hazelcast.util.EmptyStatement;
 import com.hazelcast.util.ExceptionUtil;
 import com.hazelcast.util.UuidUtil;
-import com.hazelcast.util.VersionCheck;
+import com.hazelcast.util.PhoneHome;
 
 import java.lang.reflect.Constructor;
 import java.nio.channels.ServerSocketChannel;
@@ -135,7 +135,7 @@ public class Node {
 
     private final BuildInfo buildInfo;
 
-    private final VersionCheck versionCheck = new VersionCheck();
+    private final PhoneHome phoneHome = new PhoneHome();
 
     private final HazelcastThreadGroup hazelcastThreadGroup;
 
@@ -340,7 +340,7 @@ public class Node {
             logger.warning("ManagementCenterService could not be constructed!", e);
         }
         nodeExtension.afterStart();
-        versionCheck.check(this, getBuildInfo().getVersion(), buildInfo.isEnterprise());
+        phoneHome.check(this, getBuildInfo().getVersion(), buildInfo.isEnterprise());
     }
 
     public void shutdown(final boolean terminate) {
@@ -385,7 +385,7 @@ public class Node {
         }
 
         nodeExtension.beforeShutdown();
-        versionCheck.shutdown();
+        phoneHome.shutdown();
         if (managementCenterService != null) {
             managementCenterService.shutdown();
         }

--- a/hazelcast/src/test/java/com/hazelcast/core/standalone/LongRunningTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/core/standalone/LongRunningTest.java
@@ -296,7 +296,7 @@ public class LongRunningTest {
     }
 
     static {
-        System.setProperty("hazelcast.version.check.enabled", "false");
+        System.setProperty("hazelcast.phone.home.enabled", "false");
         System.setProperty("hazelcast.socket.bind.any", "false");
         System.setProperty("hazelcast.partition.migration.interval", "0");
     }

--- a/hazelcast/src/test/java/com/hazelcast/map/standalone/SimpleMapTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/standalone/SimpleMapTest.java
@@ -55,7 +55,7 @@ public final class SimpleMapTest {
     private final boolean load;
 
     static {
-        System.setProperty("hazelcast.version.check.enabled", "false");
+        System.setProperty("hazelcast.phone.home.enabled", "false");
         System.setProperty("java.net.preferIPv4Stack", "true");
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/IndexSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/IndexSplitBrainTest.java
@@ -183,7 +183,7 @@ public class IndexSplitBrainTest extends HazelcastTestSupport {
 
     protected void setCommonProperties(Config config) {
         config.setProperty(GroupProperty.LOGGING_TYPE, "log4j");
-        config.setProperty(GroupProperty.VERSION_CHECK_ENABLED, "false");
+        config.setProperty(GroupProperty.PHONE_HOME_ENABLED, "false");
         config.setProperty("hazelcast.mancenter.enabled", "false");
         config.setProperty(GroupProperty.WAIT_SECONDS_BEFORE_JOIN, "1");
         config.setProperty(GroupProperty.CONNECT_ALL_WAIT_SECONDS, "5");

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/standalone/SimpleReplicatedMapTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/standalone/SimpleReplicatedMapTest.java
@@ -52,7 +52,7 @@ public class SimpleReplicatedMapTest {
     private final boolean load;
 
     static {
-        System.setProperty("hazelcast.version.check.enabled", "false");
+        System.setProperty("hazelcast.phone.home.enabled", "false");
         System.setProperty("java.net.preferIPv4Stack", "true");
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/test/AbstractHazelcastClassRunner.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/AbstractHazelcastClassRunner.java
@@ -53,7 +53,7 @@ public abstract class AbstractHazelcastClassRunner extends AbstractParameterized
         if (System.getProperty(TestEnvironment.HAZELCAST_TEST_USE_NETWORK) == null) {
             System.setProperty(TestEnvironment.HAZELCAST_TEST_USE_NETWORK, "false");
         }
-        System.setProperty("hazelcast.version.check.enabled", "false");
+        System.setProperty("hazelcast.phone.home.enabled", "false");
         System.setProperty("hazelcast.mancenter.enabled", "false");
         System.setProperty("hazelcast.wait.seconds.before.join", "1");
         System.setProperty("hazelcast.local.localAddress", "127.0.0.1");

--- a/hazelcast/src/test/java/com/hazelcast/util/PhoneHomeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/PhoneHomeTest.java
@@ -15,14 +15,13 @@ import org.junit.runner.RunWith;
 
 import java.util.Map;
 
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class VersionCheckTest extends HazelcastTestSupport {
-
+public class PhoneHomeTest extends HazelcastTestSupport {
 
     private TestHazelcastInstanceFactory factory;
     private HazelcastInstance hz1;
@@ -39,11 +38,11 @@ public class VersionCheckTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void testVersionCheckParameters() throws Exception {
+    public void testPhoneHomeParameters() throws Exception {
 
         Node node1 = TestUtil.getNode(hz1);
-        VersionCheck check = new VersionCheck();
-        Map<String, String> parameters = check.doCheck(node1, "test_version", false);
+        PhoneHome phoneHome = new PhoneHome();
+        Map<String, String> parameters = phoneHome.phoneHome(node1, "test_version", false);
 
         assertEquals(parameters.get("version"), "test_version");
         assertEquals(parameters.get("m"), node1.getLocalMember().getUuid() );
@@ -64,16 +63,16 @@ public class VersionCheckTest extends HazelcastTestSupport {
     @Test
     public void testConvertToLetter() throws Exception {
 
-        VersionCheck check = new VersionCheck();
-        assertEquals("A", check.convertToLetter(4));
-        assertEquals("B", check.convertToLetter(9));
-        assertEquals("C", check.convertToLetter(19));
-        assertEquals("D", check.convertToLetter(39));
-        assertEquals("E", check.convertToLetter(59));
-        assertEquals("F", check.convertToLetter(99));
-        assertEquals("G", check.convertToLetter(149));
-        assertEquals("H", check.convertToLetter(299));
-        assertEquals("J", check.convertToLetter(599));
-        assertEquals("I", check.convertToLetter(1000));
+        PhoneHome phoneHome = new PhoneHome();
+        assertEquals("A", phoneHome.convertToLetter(4));
+        assertEquals("B", phoneHome.convertToLetter(9));
+        assertEquals("C", phoneHome.convertToLetter(19));
+        assertEquals("D", phoneHome.convertToLetter(39));
+        assertEquals("E", phoneHome.convertToLetter(59));
+        assertEquals("F", phoneHome.convertToLetter(99));
+        assertEquals("G", phoneHome.convertToLetter(149));
+        assertEquals("H", phoneHome.convertToLetter(299));
+        assertEquals("J", phoneHome.convertToLetter(599));
+        assertEquals("I", phoneHome.convertToLetter(1000));
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -252,7 +252,7 @@
                     <!-- the argLine variable is needed for JaCoco -->
                     <argLine>
                         -Xms128m -Xmx1G -XX:MaxPermSize=128M
-                        -Dhazelcast.version.check.enabled=false
+                        -Dhazelcast.phone.home.enabled=false
                         -Dhazelcast.mancenter.enabled=false
                         -Dhazelcast.logging.type=none
                         -Dhazelcast.test.use.network=false
@@ -303,7 +303,7 @@
                                     <!-- the argLine variable is needed for JaCoco -->
                                     <argLine>
                                         -Xms128m -Xmx1G -XX:MaxPermSize=128M
-                                        -Dhazelcast.version.check.enabled=false
+                                        -Dhazelcast.phone.home.enabled=false
                                         -Dhazelcast.mancenter.enabled=false
                                         -Dhazelcast.logging.type=none
                                         -Dhazelcast.test.use.network=false
@@ -338,7 +338,7 @@
                                     <!-- the argLine variable is needed for JaCoco -->
                                     <argLine>
                                         -Xms128m -Xmx1G -XX:MaxPermSize=128M
-                                        -Dhazelcast.version.check.enabled=false
+                                        -Dhazelcast.phone.home.enabled=false
                                         -Dhazelcast.mancenter.enabled=false
                                         -Dhazelcast.logging.type=none
                                         -Dhazelcast.test.use.network=false
@@ -373,7 +373,7 @@
                             <redirectTestOutputToFile>true</redirectTestOutputToFile>
                             <argLine>
                                 -Xms128m -Xmx1G -XX:MaxPermSize=128M
-                                -Dhazelcast.version.check.enabled=false
+                                -Dhazelcast.phone.home.enabled=false
                                 -Dhazelcast.mancenter.enabled=false
                                 -Dhazelcast.test.use.network=false
                             </argLine>
@@ -426,7 +426,7 @@
                             <testFailureIgnore>true</testFailureIgnore>
                             <argLine>
                                 -Xms128m -Xmx1G -XX:MaxPermSize=128M
-                                -Dhazelcast.version.check.enabled=false
+                                -Dhazelcast.phone.home.enabled=false
                                 -Dhazelcast.mancenter.enabled=false
                                 -Dhazelcast.logging.type=none
                                 -Dhazelcast.test.use.network=false
@@ -460,7 +460,7 @@
             <properties>
                 <argLine>
                     -Xms128m -Xmx1G -XX:MaxPermSize=128M
-                    -Dhazelcast.version.check.enabled=false
+                    -Dhazelcast.phone.home.enabled=false
                     -Dhazelcast.mancenter.enabled=false
                     -Dhazelcast.logging.type=none
                     -Dhazelcast.test.use.network=false
@@ -581,7 +581,7 @@
                             <testFailureIgnore>true</testFailureIgnore>
                             <argLine>
                                 -Xms128m -Xmx1G -XX:MaxPermSize=128M
-                                -Dhazelcast.version.check.enabled=false
+                                -Dhazelcast.phone.home.enabled=false
                                 -Dhazelcast.mancenter.enabled=false
                                 -Dhazelcast.logging.type=none
                                 -Dhazelcast.test.use.network=false
@@ -616,7 +616,7 @@
                             <argLine>
                                 ${jacoco.agent.argLine}
                                 -Xms129m -Xmx1G -XX:MaxPermSize=129M
-                                -Dhazelcast.version.check.enabled=false
+                                -Dhazelcast.phone.home.enabled=false
                                 -Dhazelcast.mancenter.enabled=false
                                 -Dhazelcast.logging.type=none
                                 -Dhazelcast.test.use.network=true
@@ -834,7 +834,7 @@
                             <parallel>none</parallel>
                             <redirectTestOutputToFile>true</redirectTestOutputToFile>
                             <argLine>-Xms128m -Xmx1G -XX:MaxPermSize=128M
-                                -Dhazelcast.version.check.enabled=false
+                                -Dhazelcast.phone.home.enabled=false
                                 -Dhazelcast.mancenter.enabled=false
                                 -Dhazelcast.logging.type=none
                                 -Dhazelcast.test.use.network=true
@@ -865,7 +865,7 @@
                             <redirectTestOutputToFile>true</redirectTestOutputToFile>
                             <parallel>none</parallel>
                             <argLine>-Xms128m -Xmx1G -XX:MaxPermSize=128M
-                                -Dhazelcast.version.check.enabled=false
+                                -Dhazelcast.phone.home.enabled=false
                                 -Dhazelcast.mancenter.enabled=false
                                 -Dhazelcast.logging.type=none
                                 -Dhazelcast.test.use.network=true
@@ -900,7 +900,7 @@
                             <redirectTestOutputToFile>true</redirectTestOutputToFile>
                             <argLine>
                                 -Xms128m -Xmx1G
-                                -Dhazelcast.version.check.enabled=false
+                                -Dhazelcast.phone.home.enabled=false
                                 -Dhazelcast.mancenter.enabled=false
                                 -Dhazelcast.test.use.network=false
                             </argLine>


### PR DESCRIPTION
After hazelcast 3.x version check functionality is deprecated but class
names,properties and urls were still containing `version check` related
stuff. This pr refactors `VersionCheck` to `PhoneHome` Fixes https://github.com/hazelcast/hazelcast/issues/5880