### PR TITLE
Fix for MergeOperation's shouldBackup logic.

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MergeOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MergeOperation.java
@@ -70,8 +70,7 @@ public class MergeOperation extends BasePutOperation {
 
     @Override
     public boolean shouldBackup() {
-        final Record record = recordStore.getRecord(dataKey);
-        return merged && record != null;
+        return merged;
     }
 
     @Override
@@ -93,7 +92,7 @@ public class MergeOperation extends BasePutOperation {
             return new RemoveBackupOperation(name, dataKey);
         } else {
             final Record record = recordStore.getRecord(dataKey);
-            final RecordInfo replicationInfo = record != null ? Records.buildRecordInfo(record) : null;
+            final RecordInfo replicationInfo = Records.buildRecordInfo(record);
             return new PutBackupOperation(name, dataKey, dataValue, replicationInfo);
         }
     }

--- a/hazelcast/src/test/java/com/hazelcast/map/DeleteMergePolicy.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/DeleteMergePolicy.java
@@ -1,0 +1,28 @@
+package com.hazelcast.map;
+
+import com.hazelcast.core.EntryView;
+import com.hazelcast.map.merge.MapMergePolicy;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+
+import java.io.IOException;
+
+/**
+ * Custom merge policy implementation that causes deletion of related entry.
+ */
+public class DeleteMergePolicy implements MapMergePolicy {
+    @Override
+    public Object merge(String mapName, EntryView mergingEntry, EntryView existingEntry) {
+        return null;
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
+
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) throws IOException {
+
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/wan/WanReplicationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/wan/WanReplicationTest.java
@@ -10,14 +10,13 @@ import com.hazelcast.core.IMap;
 import com.hazelcast.instance.HazelcastInstanceFactory;
 import com.hazelcast.map.EntryBackupProcessor;
 import com.hazelcast.map.EntryProcessor;
+import com.hazelcast.map.DeleteMergePolicy;
 import com.hazelcast.map.listener.EntryMergedListener;
 import com.hazelcast.map.merge.HigherHitsMapMergePolicy;
 import com.hazelcast.map.merge.LatestUpdateMapMergePolicy;
 import com.hazelcast.map.merge.PassThroughMergePolicy;
 import com.hazelcast.map.merge.PutIfAbsentMapMergePolicy;
-import com.hazelcast.nio.ObjectDataInput;
-import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.DataSerializable;
+import com.hazelcast.monitor.LocalMapStats;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
@@ -30,8 +29,6 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import java.io.IOException;
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -468,6 +465,20 @@ public class WanReplicationTest extends HazelcastTestSupport {
         assertKeysIn(clusterB, "map", 0, entryCount);
         assertDataSizeEventually(clusterB, "map", entryCount);
         assertOpenEventually(mergeEventFiredCounter);
+    }
+
+    @Test
+    public void checkErasingMapMergePolicy() {
+        setupReplicateFrom(configA, configB, clusterB.length, "atob", DeleteMergePolicy.class.getName());
+        initClusterA();
+        initClusterB();
+
+        createDataIn(clusterB, "map", 0, 100);
+        createDataIn(clusterA, "map", 0, 100);
+        assertKeysNotIn(clusterB, "map", 0, 100);
+        IMap map = clusterB[0].getMap("map");
+        LocalMapStats mapStats = map.getLocalMapStats();
+        assertEquals(0, mapStats.getBackupEntryCount());
     }
 
     private void initCluster(HazelcastInstance[] cluster, Config config) {


### PR DESCRIPTION
When a merge policy returns null, it endsup with the deletion of related entry. (see https://github.com/hazelcast/hazelcast/blob/master/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java#L747)

In that case backup of this entry should also be deleted, this is supposed to be done by `RemoveBackupOperation` generated in the `getBackupOperation` of `MergeOperation`. (https://github.com/hazelcast/hazelcast/blob/master/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MergeOperation.java#L93)

But this method is never called in that case since `shouldBackup` method returns `false` since it checks the existence of the record. 

Checking only `merged` property should be enough.