### PR TITLE
Add namespace declaration for XmlClientConfig tests which test invalid configuration

### DIFF
--- a/hazelcast-client-legacy/src/test/java/com/hazelcast/client/config/XmlClientConfigImportVariableReplacementTest.java
+++ b/hazelcast-client-legacy/src/test/java/com/hazelcast/client/config/XmlClientConfigImportVariableReplacementTest.java
@@ -25,12 +25,13 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.Properties;
 
+import static com.hazelcast.client.config.XmlClientConfigBuilderTest.HAZELCAST_CLIENT_START_TAG;
+import static com.hazelcast.client.config.XmlClientConfigBuilderTest.buildConfig;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -39,10 +40,9 @@ import static org.junit.Assert.assertTrue;
 @Category({QuickTest.class, ParallelTest.class})
 public class XmlClientConfigImportVariableReplacementTest {
 
-
     @Test(expected = InvalidConfigurationException.class)
     public void testImportElementOnlyAppersInTopLevel() throws Exception {
-        String xml = "<hazelcast-client>\n" +
+        String xml = HAZELCAST_CLIENT_START_TAG +
                 "   <network>" +
                 "        <import resource=\"\"/>\n" +
                 "   </network>" +
@@ -53,7 +53,7 @@ public class XmlClientConfigImportVariableReplacementTest {
 
     @Test(expected = InvalidConfigurationException.class)
     public void testHazelcastElementOnlyAppearsOnce() throws Exception {
-        String xml = "<hazelcast-client>\n" +
+        String xml = HAZELCAST_CLIENT_START_TAG +
                 "   <hazelcast-client>" +
                 "   </hazelcast-client>" +
                 "</hazelcast-client>";
@@ -64,7 +64,7 @@ public class XmlClientConfigImportVariableReplacementTest {
     @Test
     public void readVariables() {
         String xml =
-                "<hazelcast-client xmlns=\"http://www.hazelcast.com/schema/client-config\">\n" +
+                HAZELCAST_CLIENT_START_TAG +
                         "<executor-pool-size>${executor.pool.size}</executor-pool-size>" +
                         "</hazelcast-client>";
 
@@ -76,7 +76,7 @@ public class XmlClientConfigImportVariableReplacementTest {
     public void testImportConfigFromResourceVariables() throws IOException {
         File file = createConfigFile("foo", "bar");
         FileOutputStream os = new FileOutputStream(file);
-        String networkConfig = "<hazelcast-client xmlns=\"http://www.hazelcast.com/schema/client-config\">" +
+        String networkConfig = HAZELCAST_CLIENT_START_TAG +
                 "<network>" +
                 "<cluster-members>" +
                 "<address>192.168.100.100</address>" +
@@ -95,7 +95,7 @@ public class XmlClientConfigImportVariableReplacementTest {
                 "</hazelcast-client>";
         writeStringToStreamAndClose(os, networkConfig);
 
-        String xml = "<hazelcast-client xmlns=\"http://www.hazelcast.com/schema/client-config\">\n" +
+        String xml = HAZELCAST_CLIENT_START_TAG +
                 "    <import resource=\"${config.location}\"/>\n" +
                 "</hazelcast-client>";
 
@@ -110,7 +110,7 @@ public class XmlClientConfigImportVariableReplacementTest {
     public void testImportedConfigVariableReplacement() throws IOException {
         File file = createConfigFile("foo", "bar");
         FileOutputStream os = new FileOutputStream(file);
-        String networkConfig = "<hazelcast-client xmlns=\"http://www.hazelcast.com/schema/client-config\">" +
+        String networkConfig = HAZELCAST_CLIENT_START_TAG +
                 "<network>" +
                 "<cluster-members>" +
                 "<address>${ip.address}</address>" +
@@ -119,7 +119,7 @@ public class XmlClientConfigImportVariableReplacementTest {
                 "</hazelcast-client>";
         writeStringToStreamAndClose(os, networkConfig);
 
-        String xml = "<hazelcast-client xmlns=\"http://www.hazelcast.com/schema/client-config\">\n" +
+        String xml = HAZELCAST_CLIENT_START_TAG +
                 "    <import resource=\"${config.location}\"/>\n" +
                 "</hazelcast-client>";
 
@@ -137,10 +137,10 @@ public class XmlClientConfigImportVariableReplacementTest {
         File config2 = createConfigFile("hz2", "xml");
         FileOutputStream os1 = new FileOutputStream(config1);
         FileOutputStream os2 = new FileOutputStream(config2);
-        String config1Xml = "<hazelcast-client xmlns=\"http://www.hazelcast.com/schema/client-config\">" +
+        String config1Xml = HAZELCAST_CLIENT_START_TAG +
                 "    <import resource=\"file://" + config2.getAbsolutePath() + "\"/>\n" +
                 "</hazelcast-client>";
-        String config2Xml = "<hazelcast-client xmlns=\"http://www.hazelcast.com/schema/client-config\">" +
+        String config2Xml = HAZELCAST_CLIENT_START_TAG +
                 "    <import resource=\"file://" + config1.getAbsolutePath() + "\"/>\n" +
                 "</hazelcast-client>";
         writeStringToStreamAndClose(os1, config1Xml);
@@ -157,13 +157,13 @@ public class XmlClientConfigImportVariableReplacementTest {
         FileOutputStream os1 = new FileOutputStream(config1);
         FileOutputStream os2 = new FileOutputStream(config2);
         FileOutputStream os3 = new FileOutputStream(config2);
-        String config1Xml = "<hazelcast-client xmlns=\"http://www.hazelcast.com/schema/client-config\">" +
+        String config1Xml = HAZELCAST_CLIENT_START_TAG +
                 "    <import resource=\"file://" + config2.getAbsolutePath() + "\"/>\n" +
                 "</hazelcast-client>";
-        String config2Xml = "<hazelcast-client xmlns=\"http://www.hazelcast.com/schema/client-config\">" +
+        String config2Xml = HAZELCAST_CLIENT_START_TAG +
                 "    <import resource=\"file://" + config3.getAbsolutePath() + "\"/>\n" +
                 "</hazelcast-client>";
-        String config3Xml = "<hazelcast-client xmlns=\"http://www.hazelcast.com/schema/client-config\">" +
+        String config3Xml = HAZELCAST_CLIENT_START_TAG +
                 "    <import resource=\"file://" + config1.getAbsolutePath() + "\"/>\n" +
                 "</hazelcast-client>";
         writeStringToStreamAndClose(os1, config1Xml);
@@ -176,7 +176,7 @@ public class XmlClientConfigImportVariableReplacementTest {
     public void testImportEmptyResourceContent() throws Exception {
         File config1 = createConfigFile("hz1", "xml");
         FileOutputStream os1 = new FileOutputStream(config1);
-        String config1Xml = "<hazelcast-client xmlns=\"http://www.hazelcast.com/schema/client-config\">" +
+        String config1Xml = HAZELCAST_CLIENT_START_TAG +
                 "    <import resource=\"file://" + config1.getAbsolutePath() + "\"/>\n" +
                 "</hazelcast-client>";
         writeStringToStreamAndClose(os1, "");
@@ -185,7 +185,7 @@ public class XmlClientConfigImportVariableReplacementTest {
 
     @Test(expected = InvalidConfigurationException.class)
     public void testImportEmptyResourceThrowsException() throws Exception {
-        String xml = "<hazelcast-client xmlns=\"http://www.hazelcast.com/schema/client-config\">\n" +
+        String xml = HAZELCAST_CLIENT_START_TAG +
                 "    <import resource=\"\"/>\n" +
                 "</hazelcast-client>";
 
@@ -194,7 +194,7 @@ public class XmlClientConfigImportVariableReplacementTest {
 
     @Test(expected = InvalidConfigurationException.class)
     public void testImportNotExistingResourceThrowsException() throws Exception {
-        String xml = "<hazelcast-client xmlns=\"http://www.hazelcast.com/schema/client-config\">\n" +
+        String xml = HAZELCAST_CLIENT_START_TAG +
                 "    <import resource=\"notexisting.xml\"/>\n" +
                 "</hazelcast-client>";
 
@@ -203,7 +203,7 @@ public class XmlClientConfigImportVariableReplacementTest {
 
     @Test
     public void testImportGroupConfigFromClassPath() throws Exception {
-        String xml = "<hazelcast-client xmlns=\"http://www.hazelcast.com/schema/client-config\">\n" +
+        String xml = HAZELCAST_CLIENT_START_TAG +
                 "    <import resource=\"classpath:hazelcast-client-c1.xml\"/>\n" +
                 "</hazelcast-client>";
 
@@ -225,23 +225,4 @@ public class XmlClientConfigImportVariableReplacementTest {
         os.flush();
         os.close();
     }
-
-    ClientConfig buildConfig(String xml, Properties properties) {
-        ByteArrayInputStream bis = new ByteArrayInputStream(xml.getBytes());
-        XmlClientConfigBuilder configBuilder = new XmlClientConfigBuilder(bis);
-        configBuilder.setProperties(properties);
-        ClientConfig config = configBuilder.build();
-        return config;
-    }
-
-    ClientConfig buildConfig(String xml, String key, String value) {
-        Properties properties = new Properties();
-        properties.setProperty(key, value);
-        return buildConfig(xml, properties);
-    }
-
-    ClientConfig buildConfig(String xml) {
-        return buildConfig(xml, null);
-    }
-
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/config/XmlClientConfigBuilderTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/config/XmlClientConfigBuilderTest.java
@@ -22,6 +22,7 @@ import com.hazelcast.config.EvictionPolicy;
 import com.hazelcast.config.GlobalSerializerConfig;
 import com.hazelcast.config.GroupConfig;
 import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.config.InvalidConfigurationException;
 import com.hazelcast.config.ListenerConfig;
 import com.hazelcast.config.MapIndexConfig;
 import com.hazelcast.config.NearCacheConfig;
@@ -46,6 +47,7 @@ import javax.xml.transform.stream.StreamSource;
 import javax.xml.validation.Schema;
 import javax.xml.validation.SchemaFactory;
 import javax.xml.validation.Validator;
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -56,6 +58,7 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -72,6 +75,9 @@ import static org.junit.Assert.fail;
 public class XmlClientConfigBuilderTest {
 
     ClientConfig clientConfig;
+
+    public static final String HAZELCAST_CLIENT_START_TAG =
+            "<hazelcast-client xmlns=\"http://www.hazelcast.com/schema/client-config\">\n";
 
     @Before
     public void init() throws IOException {
@@ -97,7 +103,7 @@ public class XmlClientConfigBuilderTest {
     @Test
     public void loadingThroughSystemProperty_existingFile() throws IOException {
         String xml =
-                "<hazelcast-client xmlns=\"http://www.hazelcast.com/schema/client-config\">\n" +
+                HAZELCAST_CLIENT_START_TAG +
                         "    <group>\n" +
                         "        <name>foobar</name>\n" +
                         "        <password>dev-pass</password>\n" +
@@ -310,6 +316,30 @@ public class XmlClientConfigBuilderTest {
         testXSDConfigXML("hazelcast-client-full.xml");
     }
 
+    @Test(expected = InvalidConfigurationException.class)
+    public void testMissingNamespace() {
+        String xml = "<hazelcast-client/>";
+        buildConfig(xml);
+    }
+
+    static ClientConfig buildConfig(String xml, Properties properties) {
+        ByteArrayInputStream bis = new ByteArrayInputStream(xml.getBytes());
+        XmlClientConfigBuilder configBuilder = new XmlClientConfigBuilder(bis);
+        configBuilder.setProperties(properties);
+        ClientConfig config = configBuilder.build();
+        return config;
+    }
+
+    static ClientConfig buildConfig(String xml, String key, String value) {
+        Properties properties = new Properties();
+        properties.setProperty(key, value);
+        return buildConfig(xml, properties);
+    }
+
+    static ClientConfig buildConfig(String xml) {
+        return buildConfig(xml, null);
+    }
+
     private void testXSDConfigXML(String xmlFileName) throws SAXException, IOException {
         SchemaFactory factory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
         URL schemaResource = XMLConfigBuilderTest.class.getClassLoader().getResource("hazelcast-client-config-3.6.xsd");
@@ -324,3 +354,4 @@ public class XmlClientConfigBuilderTest {
         }
     }
 }
+

--- a/hazelcast-client/src/test/java/com/hazelcast/client/config/XmlClientConfigImportVariableReplacementTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/config/XmlClientConfigImportVariableReplacementTest.java
@@ -25,12 +25,13 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.Properties;
 
+import static com.hazelcast.client.config.XmlClientConfigBuilderTest.HAZELCAST_CLIENT_START_TAG;
+import static com.hazelcast.client.config.XmlClientConfigBuilderTest.buildConfig;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -39,10 +40,9 @@ import static org.junit.Assert.assertTrue;
 @Category({QuickTest.class, ParallelTest.class})
 public class XmlClientConfigImportVariableReplacementTest {
 
-
     @Test(expected = InvalidConfigurationException.class)
     public void testImportElementOnlyAppersInTopLevel() throws Exception {
-        String xml = "<hazelcast-client>\n" +
+        String xml = HAZELCAST_CLIENT_START_TAG +
                 "   <network>" +
                 "        <import resource=\"\"/>\n" +
                 "   </network>" +
@@ -53,7 +53,7 @@ public class XmlClientConfigImportVariableReplacementTest {
 
     @Test(expected = InvalidConfigurationException.class)
     public void testHazelcastElementOnlyAppearsOnce() throws Exception {
-        String xml = "<hazelcast-client>\n" +
+        String xml = HAZELCAST_CLIENT_START_TAG +
                 "   <hazelcast-client>" +
                 "   </hazelcast-client>" +
                 "</hazelcast-client>";
@@ -64,7 +64,7 @@ public class XmlClientConfigImportVariableReplacementTest {
     @Test
     public void readVariables() {
         String xml =
-                "<hazelcast-client xmlns=\"http://www.hazelcast.com/schema/client-config\">\n" +
+                HAZELCAST_CLIENT_START_TAG +
                         "<executor-pool-size>${executor.pool.size}</executor-pool-size>" +
                         "</hazelcast-client>";
 
@@ -76,7 +76,7 @@ public class XmlClientConfigImportVariableReplacementTest {
     public void testImportConfigFromResourceVariables() throws IOException {
         File file = createConfigFile("foo", "bar");
         FileOutputStream os = new FileOutputStream(file);
-        String networkConfig = "<hazelcast-client xmlns=\"http://www.hazelcast.com/schema/client-config\">" +
+        String networkConfig = HAZELCAST_CLIENT_START_TAG +
                 "<network>" +
                 "<cluster-members>" +
                 "<address>192.168.100.100</address>" +
@@ -95,7 +95,7 @@ public class XmlClientConfigImportVariableReplacementTest {
                 "</hazelcast-client>";
         writeStringToStreamAndClose(os, networkConfig);
 
-        String xml = "<hazelcast-client xmlns=\"http://www.hazelcast.com/schema/client-config\">\n" +
+        String xml = HAZELCAST_CLIENT_START_TAG +
                 "    <import resource=\"${config.location}\"/>\n" +
                 "</hazelcast-client>";
 
@@ -110,7 +110,7 @@ public class XmlClientConfigImportVariableReplacementTest {
     public void testImportedConfigVariableReplacement() throws IOException {
         File file = createConfigFile("foo", "bar");
         FileOutputStream os = new FileOutputStream(file);
-        String networkConfig = "<hazelcast-client xmlns=\"http://www.hazelcast.com/schema/client-config\">" +
+        String networkConfig = HAZELCAST_CLIENT_START_TAG +
                 "<network>" +
                 "<cluster-members>" +
                 "<address>${ip.address}</address>" +
@@ -119,7 +119,7 @@ public class XmlClientConfigImportVariableReplacementTest {
                 "</hazelcast-client>";
         writeStringToStreamAndClose(os, networkConfig);
 
-        String xml = "<hazelcast-client xmlns=\"http://www.hazelcast.com/schema/client-config\">\n" +
+        String xml = HAZELCAST_CLIENT_START_TAG +
                 "    <import resource=\"${config.location}\"/>\n" +
                 "</hazelcast-client>";
 
@@ -137,10 +137,10 @@ public class XmlClientConfigImportVariableReplacementTest {
         File config2 = createConfigFile("hz2", "xml");
         FileOutputStream os1 = new FileOutputStream(config1);
         FileOutputStream os2 = new FileOutputStream(config2);
-        String config1Xml = "<hazelcast-client>" +
+        String config1Xml = HAZELCAST_CLIENT_START_TAG +
                 "    <import resource=\"file://" + config2.getAbsolutePath() + "\"/>\n" +
                 "</hazelcast-client>";
-        String config2Xml = "<hazelcast-client>" +
+        String config2Xml = HAZELCAST_CLIENT_START_TAG +
                 "    <import resource=\"file://" + config1.getAbsolutePath() + "\"/>\n" +
                 "</hazelcast-client>";
         writeStringToStreamAndClose(os1, config1Xml);
@@ -157,13 +157,13 @@ public class XmlClientConfigImportVariableReplacementTest {
         FileOutputStream os1 = new FileOutputStream(config1);
         FileOutputStream os2 = new FileOutputStream(config2);
         FileOutputStream os3 = new FileOutputStream(config2);
-        String config1Xml = "<hazelcast-client>" +
+        String config1Xml = HAZELCAST_CLIENT_START_TAG +
                 "    <import resource=\"file://" + config2.getAbsolutePath() + "\"/>\n" +
                 "</hazelcast-client>";
-        String config2Xml = "<hazelcast-client>" +
+        String config2Xml = HAZELCAST_CLIENT_START_TAG +
                 "    <import resource=\"file://" + config3.getAbsolutePath() + "\"/>\n" +
                 "</hazelcast-client>";
-        String config3Xml = "<hazelcast-client>" +
+        String config3Xml = HAZELCAST_CLIENT_START_TAG +
                 "    <import resource=\"file://" + config1.getAbsolutePath() + "\"/>\n" +
                 "</hazelcast-client>";
         writeStringToStreamAndClose(os1, config1Xml);
@@ -176,7 +176,7 @@ public class XmlClientConfigImportVariableReplacementTest {
     public void testImportEmptyResourceContent() throws Exception {
         File config1 = createConfigFile("hz1", "xml");
         FileOutputStream os1 = new FileOutputStream(config1);
-        String config1Xml = "<hazelcast-client>" +
+        String config1Xml = HAZELCAST_CLIENT_START_TAG +
                 "    <import resource=\"file://" + config1.getAbsolutePath() + "\"/>\n" +
                 "</hazelcast-client>";
         writeStringToStreamAndClose(os1, "");
@@ -185,7 +185,7 @@ public class XmlClientConfigImportVariableReplacementTest {
 
     @Test(expected = InvalidConfigurationException.class)
     public void testImportEmptyResourceThrowsException() throws Exception {
-        String xml = "<hazelcast-client>\n" +
+        String xml = HAZELCAST_CLIENT_START_TAG +
                 "    <import resource=\"\"/>\n" +
                 "</hazelcast-client>";
 
@@ -194,7 +194,7 @@ public class XmlClientConfigImportVariableReplacementTest {
 
     @Test(expected = InvalidConfigurationException.class)
     public void testImportNotExistingResourceThrowsException() throws Exception {
-        String xml = "<hazelcast-client>\n" +
+        String xml = HAZELCAST_CLIENT_START_TAG +
                 "    <import resource=\"notexisting.xml\"/>\n" +
                 "</hazelcast-client>";
 
@@ -203,7 +203,7 @@ public class XmlClientConfigImportVariableReplacementTest {
 
     @Test
     public void testImportGroupConfigFromClassPath() throws Exception {
-        String xml = "<hazelcast-client xmlns=\"http://www.hazelcast.com/schema/client-config\">\n" +
+        String xml = HAZELCAST_CLIENT_START_TAG +
                 "    <import resource=\"classpath:hazelcast-client-c1.xml\"/>\n" +
                 "</hazelcast-client>";
 
@@ -226,22 +226,5 @@ public class XmlClientConfigImportVariableReplacementTest {
         os.close();
     }
 
-    ClientConfig buildConfig(String xml, Properties properties) {
-        ByteArrayInputStream bis = new ByteArrayInputStream(xml.getBytes());
-        XmlClientConfigBuilder configBuilder = new XmlClientConfigBuilder(bis);
-        configBuilder.setProperties(properties);
-        ClientConfig config = configBuilder.build();
-        return config;
-    }
-
-    ClientConfig buildConfig(String xml, String key, String value) {
-        Properties properties = new Properties();
-        properties.setProperty(key, value);
-        return buildConfig(xml, properties);
-    }
-
-    ClientConfig buildConfig(String xml) {
-        return buildConfig(xml, null);
-    }
 
 }


### PR DESCRIPTION
Additionally, add a test for missing namespace declaration. Fixes issue #6633