### PR TITLE
Adds id to WanAcknowledgeType

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/WanAcknowledgeType.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/WanAcknowledgeType.java
@@ -24,11 +24,42 @@ public enum WanAcknowledgeType {
     /**
      * ACK when operation is invoked successfully on target cluster
      */
-    ACK_ON_TRANSMIT,
+    ACK_ON_TRANSMIT(0),
 
     /**
      * Wait till the operation is complete on target cluster
      */
-    ACK_ON_OPERATION_COMPLETE
+    ACK_ON_OPERATION_COMPLETE(1);
 
+    private final int id;
+
+    WanAcknowledgeType(int id) {
+        this.id = id;
+    }
+
+    /**
+     * Gets the id for the given {@link WanAcknowledgeType}.
+     *
+     * This reason this id is used instead of an the ordinal value is that the ordinal value is more prone to changes due to
+     * reordering.
+     *
+     * @return the id.
+     */
+    public int getId() {
+        return id;
+    }
+
+    /**
+     * Returns the {@link WanAcknowledgeType} for the given id.
+     *
+     * @return the {@link WanAcknowledgeType} found or null if not found
+     */
+    public static WanAcknowledgeType getById(final int id) {
+        for (WanAcknowledgeType type : values()) {
+            if (type.id == id) {
+                return type;
+            }
+        }
+        return null;
+    }
 }

--- a/hazelcast/src/test/java/com/hazelcast/wan/WanAcknowledgeTypeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/wan/WanAcknowledgeTypeTest.java
@@ -1,0 +1,26 @@
+package com.hazelcast.wan;
+
+import com.hazelcast.config.WanAcknowledgeType;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static com.hazelcast.config.WanAcknowledgeType.ACK_ON_OPERATION_COMPLETE;
+import static com.hazelcast.config.WanAcknowledgeType.ACK_ON_TRANSMIT;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class WanAcknowledgeTypeTest {
+
+    @Test
+    public void test() {
+        assertSame(ACK_ON_TRANSMIT, WanAcknowledgeType.getById(ACK_ON_TRANSMIT.getId()));
+        assertSame(ACK_ON_OPERATION_COMPLETE, WanAcknowledgeType.getById(ACK_ON_OPERATION_COMPLETE.getId()));
+        assertNull(WanAcknowledgeType.getById(-1));
+    }
+}


### PR DESCRIPTION
It's used by `WanOperation`, please see https://github.com/hazelcast/hazelcast-enterprise/pull/440/files#diff-810bbdfb125796feb02d43414c02d997R49