### PR TITLE
Stricter type check when deciding if ClientAuthenticationCustomCodec should be used during authentication

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClusterListenerSupport.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClusterListenerSupport.java
@@ -133,7 +133,7 @@ public abstract class ClusterListenerSupport implements ConnectionListener, Conn
                 ownerUuid = principal.getOwnerUuid();
             }
             ClientMessage clientMessage;
-            if (credentials instanceof UsernamePasswordCredentials) {
+            if (credentials.getClass().equals(UsernamePasswordCredentials.class)) {
                 UsernamePasswordCredentials cr = (UsernamePasswordCredentials) credentials;
                 clientMessage = ClientAuthenticationCodec.encodeRequest(cr.getUsername(), cr.getPassword(), uuid, ownerUuid,
                         true, ClientTypes.JAVA, serializationVersion);


### PR DESCRIPTION
Fixes the issue when the custom credentials given extends UsernamePasswordCredentials. Added tests for both new and legacy client, however the issue only effects the new client. Fixes issue #6615