### PR TITLE
Remove batched events after publishing them in `AbstractCacheRecordStore`

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheRecordStore.java
@@ -417,7 +417,7 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
                         new CacheEventDataImpl(name, cacheEventContext.getEventType(), cacheEventContext.getDataKey(),
                                                cacheEventContext.getDataValue(), cacheEventContext.getDataOldValue(),
                                                cacheEventContext.isOldValueAvailable());
-                Set<CacheEventData> cacheEventDataSet = batchEvent.get(cacheEventContext.getEventType());
+                Set<CacheEventData> cacheEventDataSet = batchEvent.remove(cacheEventContext.getEventType());
                 if (cacheEventDataSet == null) {
                     cacheEventDataSet = new HashSet<CacheEventData>();
                     batchEvent.put(cacheEventContext.getEventType(), cacheEventDataSet);
@@ -431,9 +431,11 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
 
     protected void publishBatchedEvents(String cacheName, CacheEventType cacheEventType, int orderKey) {
         if (isEventsEnabled()) {
-            final Set<CacheEventData> cacheEventDatas = batchEvent.get(cacheEventType);
-            CacheEventSet ces = new CacheEventSet(cacheEventType, cacheEventDatas);
-            cacheService.publishEvent(cacheName, ces, orderKey);
+            final Set<CacheEventData> cacheEventDatas = batchEvent.remove(cacheEventType);
+            if (cacheEventDatas != null) {
+                CacheEventSet ces = new CacheEventSet(cacheEventType, cacheEventDatas);
+                cacheService.publishEvent(cacheName, ces, orderKey);
+            }
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/cache/CacheBasicAbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CacheBasicAbstractTest.java
@@ -509,6 +509,45 @@ public abstract class CacheBasicAbstractTest extends CacheTestSupport {
     }
 
     @Test
+    public void testRemovingSameEntryTwiceShouldTriggerEntryListenerOnlyOnce() {
+        String cacheName = randomString();
+
+        CacheConfig<Integer, String> config = createCacheConfig();
+        final CacheFromDifferentNodesTest.SimpleEntryListener<Integer, String> listener =
+                new CacheFromDifferentNodesTest.SimpleEntryListener<Integer, String>();
+        MutableCacheEntryListenerConfiguration<Integer, String> listenerConfiguration =
+                new MutableCacheEntryListenerConfiguration<Integer, String>(
+                        FactoryBuilder.factoryOf(listener), null, true, true);
+
+        config.addCacheEntryListenerConfiguration(listenerConfiguration);
+
+        Cache<Integer, String> cache = cacheManager.createCache(cacheName, config);
+        assertNotNull(cache);
+
+        Integer key = 1;
+        String value = "value";
+        cache.put(key, value);
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run()
+                    throws Exception {
+                assertEquals(1, listener.created.get());
+            }
+        });
+
+        cache.removeAll();
+        cache.removeAll();
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run()
+                    throws Exception {
+                assertEquals(1, listener.removed.get());
+            }
+        });
+    }
+
+    @Test
     public void testCompletionEvent() {
         String cacheName = randomString();
 

--- a/hazelcast/src/test/java/com/hazelcast/cache/impl/InternalCacheRecorStoreTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/impl/InternalCacheRecorStoreTest.java
@@ -1,0 +1,67 @@
+package com.hazelcast.cache.impl;
+
+import com.hazelcast.cache.CacheFromDifferentNodesTest;
+import com.hazelcast.cache.CacheTestSupport;
+import com.hazelcast.cache.HazelcastCacheManager;
+import com.hazelcast.config.CacheConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.instance.TestUtil;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import org.junit.Test;
+
+import javax.cache.Cache;
+import javax.cache.configuration.FactoryBuilder;
+import javax.cache.configuration.MutableCacheEntryListenerConfiguration;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class InternalCacheRecorStoreTest extends CacheTestSupport {
+
+    TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+
+    //https://github.com/hazelcast/hazelcast/issues/6618
+    @Test
+    public void testBatchEventMapShouldBeCleanedAfterRemoveAll() {
+        String cacheName = randomString();
+
+        CacheConfig<Integer, String> config = createCacheConfig();
+        final CacheFromDifferentNodesTest.SimpleEntryListener<Integer, String> listener =
+                new CacheFromDifferentNodesTest.SimpleEntryListener<Integer, String>();
+        MutableCacheEntryListenerConfiguration<Integer, String> listenerConfiguration =
+                new MutableCacheEntryListenerConfiguration<Integer, String>(
+                        FactoryBuilder.factoryOf(listener), null, true, true);
+
+        config.addCacheEntryListenerConfiguration(listenerConfiguration);
+
+        Cache<Integer, String> cache = cacheManager.createCache(cacheName, config);
+        assertNotNull(cache);
+
+        Integer key = 1;
+        String value = "value";
+        cache.put(key, value);
+
+        HazelcastInstance instance = ((HazelcastCacheManager) cacheManager).getHazelcastInstance();
+        int partitionId = instance.getPartitionService().getPartition(key).getPartitionId();
+
+        cache.removeAll();
+
+        ICacheService cacheService = TestUtil.getNode(instance).getNodeEngine().getService(ICacheService.SERVICE_NAME);
+        AbstractCacheRecordStore recordStore = (AbstractCacheRecordStore) cacheService.getRecordStore("/hz/" + cacheName, partitionId);
+        assertEquals(0, recordStore.batchEvent.size());
+    }
+
+    @Override
+    protected void onSetup() {
+    }
+
+    @Override
+    protected void onTearDown() {
+        factory.terminateAll();
+    }
+
+    @Override
+    protected HazelcastInstance getHazelcastInstance() {
+        return factory.newHazelcastInstance(createConfig());
+    }
+}


### PR DESCRIPTION
Key should be removed from BatchEvent when event is published.

Fixes #6618 