### PR TITLE
[DONT MERGE] Option to configure AwsConfig with an AWSCredentialsProvider instance

### DIFF
--- a/hazelcast-cloud/pom.xml
+++ b/hazelcast-cloud/pom.xml
@@ -137,5 +137,11 @@
             <version>${project.parent.version}</version>
             <classifier>tests</classifier>
         </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-core</artifactId>
+            <version>1.10.30</version>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
 </project>

--- a/hazelcast-cloud/src/main/java/com/hazelcast/aws/AWSClient.java
+++ b/hazelcast-cloud/src/main/java/com/hazelcast/aws/AWSClient.java
@@ -24,7 +24,6 @@ import java.util.Map;
 
 public class AWSClient {
 
-    private String endpoint;
     private final AwsConfig awsConfig;
 
     public AWSClient(AwsConfig awsConfig) {
@@ -38,26 +37,14 @@ public class AWSClient {
             throw new IllegalArgumentException("AWS secret key or Iam Role is required!");
         }
         this.awsConfig = awsConfig;
-        endpoint = awsConfig.getHostHeader();
-        if (awsConfig.getRegion() != null && awsConfig.getRegion().length() > 0) {
-            setEndpoint("ec2." + awsConfig.getRegion() + ".amazonaws.com");
-        }
     }
 
     public Collection<String> getPrivateIpAddresses() throws Exception {
-        final Map<String, String> result = new DescribeInstances(awsConfig, endpoint).execute();
+        final Map<String, String> result = new DescribeInstances(awsConfig).execute();
         return result.keySet();
     }
 
     public Map<String, String> getAddresses() throws Exception {
-        return new DescribeInstances(awsConfig, endpoint).execute();
-    }
-
-    public void setEndpoint(String s) {
-        this.endpoint = s;
-    }
-
-    public String getEndpoint() {
-        return this.endpoint;
+        return new DescribeInstances(awsConfig).execute();
     }
 }

--- a/hazelcast-cloud/src/main/java/com/hazelcast/aws/AWSClient.java
+++ b/hazelcast-cloud/src/main/java/com/hazelcast/aws/AWSClient.java
@@ -30,11 +30,13 @@ public class AWSClient {
         if (awsConfig == null) {
             throw new IllegalArgumentException("AwsConfig is required!");
         }
-        if (awsConfig.getAccessKey() == null && awsConfig.getIamRole() == null) {
-            throw new IllegalArgumentException("AWS access key or IAM Role is required!");
-        }
-        if (awsConfig.getSecretKey() == null && awsConfig.getIamRole() == null) {
-            throw new IllegalArgumentException("AWS secret key or Iam Role is required!");
+        if (awsConfig.getIamRole() == null && awsConfig.getAwsCredentialsProvider() == null) {
+            if (awsConfig.getAccessKey() == null) {
+                throw new IllegalArgumentException("AWS access key or IAM Role is required!");
+            }
+            if (awsConfig.getSecretKey() == null) {
+                throw new IllegalArgumentException("AWS secret key or Iam Role is required!");
+            }
         }
         this.awsConfig = awsConfig;
     }

--- a/hazelcast-cloud/src/main/java/com/hazelcast/aws/impl/DescribeInstances.java
+++ b/hazelcast-cloud/src/main/java/com/hazelcast/aws/impl/DescribeInstances.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.aws.impl;
 
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSSessionCredentials;
 import com.hazelcast.aws.security.EC2RequestSigner;
 import com.hazelcast.aws.utility.CloudyUtility;
 import com.hazelcast.config.AwsConfig;
@@ -42,17 +44,18 @@ import static com.hazelcast.nio.IOUtil.closeResource;
 public class DescribeInstances {
     private static final String IAM_ROLE_ENDPOINT = "169.254.169.254";
     String timeStamp = getFormattedTimestamp();
+    String endpoint;
+    Map<String, String> attributes = new HashMap<String, String>();
     private EC2RequestSigner rs;
     private AwsConfig awsConfig;
-    String endpoint;
-    private Map<String, String> attributes = new HashMap<String, String>();
 
     public DescribeInstances(AwsConfig awsConfig) {
         if (awsConfig == null) {
             throw new IllegalArgumentException("AwsConfig is required!");
         }
-        if (awsConfig.getAccessKey() == null && awsConfig.getIamRole() == null) {
-            throw new IllegalArgumentException("AWS access key or IAM Role is required!");
+        if (awsConfig.getAccessKey() == null && awsConfig.getIamRole() == null
+                && awsConfig.getAwsCredentialsProvider() == null) {
+            throw new IllegalArgumentException("AWS access key, IAM Role, or credentials provider is required!");
         }
         this.awsConfig = awsConfig;
 
@@ -61,9 +64,12 @@ public class DescribeInstances {
             this.endpoint = "ec2." + awsConfig.getRegion() + ".amazonaws.com";
         }
 
-        if (awsConfig.getIamRole() != null) {
+        if (awsConfig.getAwsCredentialsProvider() != null) {
+            getKeysFromCredentialsProvider();
+        } else if (awsConfig.getIamRole() != null) {
             getKeysFromIamRole();
         }
+
         rs = new EC2RequestSigner(awsConfig, timeStamp, endpoint);
         attributes.put("Action", this.getClass().getSimpleName());
         attributes.put("Version", DOC_VERSION);
@@ -72,6 +78,17 @@ public class DescribeInstances {
         attributes.put("X-Amz-Date", timeStamp);
         attributes.put("X-Amz-SignedHeaders", "host");
         attributes.put("X-Amz-Expires", "30");
+    }
+
+    private void getKeysFromCredentialsProvider() {
+        AWSCredentials creds = awsConfig.getAwsCredentialsProvider().getCredentials();
+        awsConfig.setAccessKey(creds.getAWSAccessKeyId());
+        awsConfig.setSecretKey(creds.getAWSSecretKey());
+
+        if (creds instanceof AWSSessionCredentials) {
+            attributes.put("X-Amz-Security-Token",
+                    ((AWSSessionCredentials) creds).getSessionToken());
+        }
     }
 
     private void getKeysFromIamRole() {
@@ -89,8 +106,8 @@ public class DescribeInstances {
         }
     }
 
-    public Map parseIamRole(BufferedReader reader) throws IOException {
-        Map map = new HashMap();
+    public Map<String, String> parseIamRole(BufferedReader reader) throws IOException {
+        Map<String, String> map = new HashMap<String, String>();
         Pattern keyPattern = Pattern.compile("\"(.*?)\" : ");
         Pattern valuePattern = Pattern.compile(" : \"(.*?)\",");
         String line;
@@ -116,11 +133,11 @@ public class DescribeInstances {
 
     public Map<String, String> execute() throws Exception {
         final String signature = rs.sign("ec2", attributes);
-        Map response = null;
+        Map response;
         InputStream stream = null;
         attributes.put("X-Amz-Signature", signature);
         try {
-            stream = callService(endpoint, signature);
+            stream = callService(endpoint);
             response = CloudyUtility.unmarshalTheResponse(stream, awsConfig);
             return response;
         } finally {
@@ -128,7 +145,7 @@ public class DescribeInstances {
         }
     }
 
-    private InputStream callService(String endpoint, String signature) throws Exception {
+    private InputStream callService(String endpoint) throws Exception {
         String query = rs.getCanonicalizedQueryString(attributes);
         URL url = new URL("https", endpoint, -1, "/?" + query);
         HttpURLConnection httpConnection = (HttpURLConnection) (url.openConnection());

--- a/hazelcast-cloud/src/main/java/com/hazelcast/aws/impl/DescribeInstances.java
+++ b/hazelcast-cloud/src/main/java/com/hazelcast/aws/impl/DescribeInstances.java
@@ -44,10 +44,10 @@ public class DescribeInstances {
     String timeStamp = getFormattedTimestamp();
     private EC2RequestSigner rs;
     private AwsConfig awsConfig;
-    private String endpoint;
+    String endpoint;
     private Map<String, String> attributes = new HashMap<String, String>();
 
-    public DescribeInstances(AwsConfig awsConfig, String endpoint) {
+    public DescribeInstances(AwsConfig awsConfig) {
         if (awsConfig == null) {
             throw new IllegalArgumentException("AwsConfig is required!");
         }
@@ -55,7 +55,12 @@ public class DescribeInstances {
             throw new IllegalArgumentException("AWS access key or IAM Role is required!");
         }
         this.awsConfig = awsConfig;
-        this.endpoint = endpoint;
+
+        this.endpoint = awsConfig.getHostHeader();
+        if (awsConfig.getRegion() != null && awsConfig.getRegion().length() > 0) {
+            this.endpoint = "ec2." + awsConfig.getRegion() + ".amazonaws.com";
+        }
+
         if (awsConfig.getIamRole() != null) {
             getKeysFromIamRole();
         }

--- a/hazelcast-cloud/src/test/java/com/hazelcast/aws/AwsClientTest.java
+++ b/hazelcast-cloud/src/test/java/com/hazelcast/aws/AwsClientTest.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.aws;
 
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.internal.StaticCredentialsProvider;
 import com.hazelcast.config.AwsConfig;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
@@ -44,5 +46,22 @@ public class AwsClientTest {
     @Test(expected = IllegalArgumentException.class)
     public void testAwsClient_whenNoAwsConfig() {
         new AWSClient(null);
+    }
+
+    @Test
+    public void testAwsClient_whenCredentialsProvider() {
+        AwsConfig awsConfig = new AwsConfig();
+        awsConfig.setAwsCredentialsProvider(new StaticCredentialsProvider(
+                new BasicAWSCredentials("accesskey", "secretkey")));
+
+        new AWSClient(awsConfig); // no exception
+    }
+
+    @Test
+    public void testAwsClient_whenIamRole() {
+        AwsConfig awsConfig = new AwsConfig();
+        awsConfig.setIamRole("role");
+
+        new AWSClient(awsConfig); // no exception
     }
 }

--- a/hazelcast-cloud/src/test/java/com/hazelcast/aws/AwsClientTest.java
+++ b/hazelcast-cloud/src/test/java/com/hazelcast/aws/AwsClientTest.java
@@ -24,8 +24,6 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import static org.junit.Assert.assertEquals;
-
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class AwsClientTest {
@@ -47,13 +45,4 @@ public class AwsClientTest {
     public void testAwsClient_whenNoAwsConfig() {
         new AWSClient(null);
     }
-
-    @Test
-    public void testAwsClient_getEndPoint() {
-        AwsConfig awsConfig = new AwsConfig();
-        awsConfig.setIamRole("test");
-        AWSClient awsClient = new AWSClient(awsConfig);
-        assertEquals("ec2.us-east-1.amazonaws.com", awsClient.getEndpoint());
-    }
-
 }

--- a/hazelcast-cloud/src/test/java/com/hazelcast/aws/impl/DescribeInstancesTest.java
+++ b/hazelcast-cloud/src/test/java/com/hazelcast/aws/impl/DescribeInstancesTest.java
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 
-package com.hazelcast.aws;
+package com.hazelcast.aws.impl;
 
-import com.hazelcast.aws.impl.DescribeInstances;
 import com.hazelcast.config.AwsConfig;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
@@ -25,18 +24,20 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import static org.junit.Assert.assertEquals;
+
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class DescribeInstancesTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void test_whenAwsConfigIsNull() {
-        new DescribeInstances(null,"endpoint");
+        new DescribeInstances(null);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void test_whenAccessKeyNull() {
-        new DescribeInstances(new AwsConfig(),"endpoint");
+        new DescribeInstances(new AwsConfig());
     }
     
     @Test
@@ -44,6 +45,16 @@ public class DescribeInstancesTest {
         AwsConfig awsConfig = new AwsConfig();
         awsConfig.setAccessKey("accesskey");
         awsConfig.setSecretKey("secretkey");
-        new DescribeInstances(awsConfig,"endpoint");
+        new DescribeInstances(awsConfig);
+    }
+
+    @Test
+    public void test_endpointInNonUsEast1Region() {
+        AwsConfig awsConfig = new AwsConfig();
+        awsConfig.setAccessKey("accesskey");
+        awsConfig.setSecretKey("secretkey");
+        awsConfig.setRegion("us-west-1");
+
+        assertEquals("ec2.us-west-1.amazonaws.com", new DescribeInstances(awsConfig).endpoint);
     }
 }

--- a/hazelcast-cloud/src/test/java/com/hazelcast/aws/impl/DescribeInstancesTest.java
+++ b/hazelcast-cloud/src/test/java/com/hazelcast/aws/impl/DescribeInstancesTest.java
@@ -16,6 +16,9 @@
 
 package com.hazelcast.aws.impl;
 
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.auth.BasicSessionCredentials;
+import com.amazonaws.internal.StaticCredentialsProvider;
 import com.hazelcast.config.AwsConfig;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
@@ -23,6 +26,8 @@ import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+
+import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 
@@ -46,6 +51,23 @@ public class DescribeInstancesTest {
         awsConfig.setAccessKey("accesskey");
         awsConfig.setSecretKey("secretkey");
         new DescribeInstances(awsConfig);
+    }
+
+    @Test
+    public void test_whenGivenCredentialsProvider() {
+        AwsConfig awsConfig = new AwsConfig();
+        awsConfig.setAwsCredentialsProvider(new StaticCredentialsProvider(
+                new BasicAWSCredentials("accesskey", "secretkey")));
+        new DescribeInstances(awsConfig);
+
+        assertEquals("accesskey", awsConfig.getAccessKey());
+        assertEquals("secretkey", awsConfig.getSecretKey());
+
+        awsConfig.setAwsCredentialsProvider(new StaticCredentialsProvider(
+                new BasicSessionCredentials("accesskey", "secretkey", "token")));
+        Map<String, String> attributes = new DescribeInstances(awsConfig).attributes;
+
+        assertEquals("token", attributes.get("X-Amz-Security-Token"));
     }
 
     @Test

--- a/hazelcast-cloud/src/test/java/com/hazelcast/aws/security/EC2RequestSignerTest.java
+++ b/hazelcast-cloud/src/test/java/com/hazelcast/aws/security/EC2RequestSignerTest.java
@@ -91,7 +91,7 @@ public class EC2RequestSignerTest {
                 setAccessKey(TEST_ACCESS_KEY).
                 setSecretKey(TEST_SECRET_KEY);
 
-        DescribeInstances di = new DescribeInstances(awsConfig, TEST_HOST);
+        DescribeInstances di = new DescribeInstances(awsConfig);
         // Override the attributes map. We need to change values. Not pretty, but
         // no real alternative, and in this case : testing only
 
@@ -122,7 +122,7 @@ public class EC2RequestSignerTest {
                 setAccessKey(TEST_ACCESS_KEY).
                 setSecretKey(TEST_SECRET_KEY);
 
-        DescribeInstances di = new DescribeInstances(awsConfig, TEST_HOST);
+        DescribeInstances di = new DescribeInstances(awsConfig);
 
         Field attributesField = di.getClass().getDeclaredField("attributes");
         attributesField.setAccessible(true);

--- a/hazelcast-cloud/src/test/java/com/hazelcast/aws/utility/CloudyUtilityTest.java
+++ b/hazelcast-cloud/src/test/java/com/hazelcast/aws/utility/CloudyUtilityTest.java
@@ -100,7 +100,7 @@ public class CloudyUtilityTest {
         awsConfig1.setAccessKey("some-access-key");
         awsConfig1.setSecretKey("some-secret-key");
         awsConfig1.setSecurityGroupName("hazelcast");
-        DescribeInstances describeInstances = new DescribeInstances(awsConfig, "");
+        DescribeInstances describeInstances = new DescribeInstances(awsConfig);
 
         Map map = describeInstances.parseIamRole(br);
         assertEquals("Success", map.get("Code"));

--- a/hazelcast/pom.xml
+++ b/hazelcast/pom.xml
@@ -314,6 +314,13 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-core</artifactId>
+            <version>1.10.30</version>
+            <optional>true</optional>
+        </dependency>
+
         <!-- dependencies for XATransaction tests -->
         <dependency>
             <groupId>com.atomikos</groupId>

--- a/hazelcast/src/main/java/com/hazelcast/config/AwsConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/AwsConfig.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.config;
 
+import com.amazonaws.auth.AWSCredentialsProvider;
+
 import static com.hazelcast.util.Preconditions.checkHasText;
 
 /**
@@ -50,6 +52,7 @@ public class AwsConfig {
     private String tagValue;
     private String hostHeader = "ec2.amazonaws.com";
     private String iamRole;
+    private AWSCredentialsProvider awsCredentialsProvider;
     private int connectionTimeoutSeconds = CONNECTION_TIMEOUT;
 
     /**
@@ -272,6 +275,29 @@ public class AwsConfig {
      */
     public AwsConfig setIamRole(String iamRole) {
         this.iamRole = iamRole;
+        return this;
+    }
+
+    /**
+     * Gets the AWS credentials provider, which will be preferred over an explicit accessKey/secretKey or IAM role if
+     * provided.
+     *
+     * @return the credentials provider. null if nothing is returned.
+     * @see #setAwsCredentialsProvider(AWSCredentialsProvider)
+     */
+    public AWSCredentialsProvider getAwsCredentialsProvider() {
+        return awsCredentialsProvider;
+    }
+
+    /**
+     * Sets the AWS credentials provider.
+     *
+     * @param awsCredentialsProvider the provider.
+     * @return the updated AwsConfig
+     * @see #getAwsCredentialsProvider()
+     */
+    public AwsConfig setAwsCredentialsProvider(AWSCredentialsProvider awsCredentialsProvider) {
+        this.awsCredentialsProvider = awsCredentialsProvider;
         return this;
     }
 


### PR DESCRIPTION
Two main use cases exist for this:

1.  I have a service which has an `AWSCredentialsProvider` instance that it is using to source credentials to aspects of the AWS SDK that it is already using for non-Hazelcast related reasons.  It is convenient to simply inject this same instance into `AwsConfig`. 

2.  I am developing locally and wish to use a more sophisticated custom `AWSCredentialsProvider` that, for example, SSH tunnels through a jump host to a running instance and snags temporary credentials.  The current implementation requires me to be running in EC2 in order to use temporary (a.k.a. session) credentials.

The AWS SDK is an optional dependency so we don't pollute dependency graphs with an unnecessary dependency when folks elect to use one of the existing methods.

Lastly, I cleaned up the manipulation of the EC2 endpoint host so that `DescribeInstances` wholly owns this responsibility.

Thanks!