### PR TITLE
Backport: Fix for MergeOperation's shouldBackup logic.

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MergeOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MergeOperation.java
@@ -70,8 +70,7 @@ public class MergeOperation extends BasePutOperation {
 
     @Override
     public boolean shouldBackup() {
-        final Record record = recordStore.getRecord(dataKey);
-        return merged && record != null;
+        return merged;
     }
 
     @Override
@@ -93,7 +92,7 @@ public class MergeOperation extends BasePutOperation {
             return new RemoveBackupOperation(name, dataKey);
         } else {
             final Record record = recordStore.getRecord(dataKey);
-            final RecordInfo replicationInfo = record != null ? Records.buildRecordInfo(record) : null;
+            final RecordInfo replicationInfo = Records.buildRecordInfo(record);
             return new PutBackupOperation(name, dataKey, dataValue, replicationInfo);
         }
     }

--- a/hazelcast/src/test/java/com/hazelcast/map/DeleteMergePolicy.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/DeleteMergePolicy.java
@@ -1,0 +1,28 @@
+package com.hazelcast.map;
+
+import com.hazelcast.core.EntryView;
+import com.hazelcast.map.merge.MapMergePolicy;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+
+import java.io.IOException;
+
+/**
+ * Custom merge policy implementation that causes deletion of related entry.
+ */
+public class DeleteMergePolicy implements MapMergePolicy {
+    @Override
+    public Object merge(String mapName, EntryView mergingEntry, EntryView existingEntry) {
+        return null;
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
+
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) throws IOException {
+
+    }
+}


### PR DESCRIPTION
Backport of https://github.com/hazelcast/hazelcast/pull/6632