### PR TITLE
introduced init for RecordStore

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/PartitionContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/PartitionContainer.java
@@ -95,7 +95,9 @@ public class PartitionContainer {
         keyLoader.setMaxSize(getMaxSizePerNode(mapConfig.getMaxSizeConfig()));
         keyLoader.setHasBackup(mapConfig.getTotalBackupCount() > 0);
         keyLoader.setMapOperationProvider(serviceContext.getMapOperationProvider(name));
-        return serviceContext.createRecordStore(mapContainer, partitionId, keyLoader);
+        RecordStore recordStore = serviceContext.createRecordStore(mapContainer, partitionId, keyLoader);
+        recordStore.init();
+        return recordStore;
     }
 
     public ConcurrentMap<String, RecordStore> getMaps() {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/AbstractRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/AbstractRecordStore.java
@@ -52,7 +52,6 @@ import static com.hazelcast.map.impl.ExpirationTimeSetter.setExpirationTime;
  */
 abstract class AbstractRecordStore implements RecordStore<Record> {
 
-    protected final Storage<Data, Record> storage;
     protected final RecordFactory recordFactory;
     protected final String name;
     protected final MapContainer mapContainer;
@@ -66,6 +65,8 @@ abstract class AbstractRecordStore implements RecordStore<Record> {
     protected final int partitionId;
     protected final InMemoryFormat inMemoryFormat;
 
+    protected Storage<Data, Record> storage;
+
     protected AbstractRecordStore(MapContainer mapContainer, int partitionId) {
         this.mapContainer = mapContainer;
         this.partitionId = partitionId;
@@ -74,10 +75,14 @@ abstract class AbstractRecordStore implements RecordStore<Record> {
         this.name = mapContainer.getName();
         this.recordFactory = mapContainer.getRecordFactoryConstructor().createNew(null);
         this.inMemoryFormat = mapContainer.getMapConfig().getInMemoryFormat();
-        this.storage = createStorage(recordFactory, inMemoryFormat);
         this.mapStoreContext = mapContainer.getMapStoreContext();
         MapStoreManager mapStoreManager = mapStoreContext.getMapStoreManager();
         this.mapDataStore = mapStoreManager.getMapDataStore(partitionId);
+    }
+
+    @Override
+    public void init() {
+        this.storage = createStorage(recordFactory, inMemoryFormat);
     }
 
     @Override
@@ -212,7 +217,7 @@ abstract class AbstractRecordStore implements RecordStore<Record> {
         storage.dispose();
     }
 
-    public Storage<Data, Record> getStorage() {
+    public Storage<Data, ? extends Record> getStorage() {
         return storage;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStore.java
@@ -325,4 +325,9 @@ public interface RecordStore<R extends Record> {
      * Starts mapLoader
      */
     void startLoading();
+
+    /**
+     * Initialize the recordStore after creation
+     */
+    void init();
 }


### PR DESCRIPTION
The reason to introduce an `init` method is `createStorage` is overridden on `EnterpriseRecordStore` and we need to use some fields defined in `EnterpriseRecordStore` while creating storage.