### PR TITLE
Fixed race-condition in IO during shutdown

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/NonBlockingSocketWriter.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/NonBlockingSocketWriter.java
@@ -335,6 +335,9 @@ public final class NonBlockingSocketWriter extends AbstractHandler implements Ru
         }
 
         fillOutputBuffer();
+        if (shutdown) {
+            return;
+        }
 
         if (dirtyOutputBuffer()) {
             writeOutputBufferToSocket();


### PR DESCRIPTION
When a shutdown task was executed by IOThread then we do not want to continue with further processing as the channel is closed & selection key is cancelled anyway.

I'm not quite sure how to test this, perhaps @pveentjer might have an idea.