### PR TITLE
Remove XML namespace injection during schema validation

### DIFF
--- a/hazelcast-client-legacy/src/test/java/com/hazelcast/client/config/XmlClientConfigBuilderTest.java
+++ b/hazelcast-client-legacy/src/test/java/com/hazelcast/client/config/XmlClientConfigBuilderTest.java
@@ -321,6 +321,18 @@ public class XmlClientConfigBuilderTest {
         buildConfig(xml);
     }
 
+    @Test(expected = InvalidConfigurationException.class)
+    public void testInvalidNamespace() {
+        String xml = "<hazelcast-client xmlns=\"http://foo.bar\"/>";
+        buildConfig(xml);
+    }
+
+    @Test
+    public void testValidNamespace() {
+        String xml = HAZELCAST_CLIENT_START_TAG + "</hazelcast-client>";
+        buildConfig(xml);
+    }
+
     private void testXSDConfigXML(String xmlFileName) throws SAXException, IOException {
         SchemaFactory factory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
         URL schemaResource = XMLConfigBuilderTest.class.getClassLoader().getResource("hazelcast-client-config-3.6.xsd");

--- a/hazelcast-client/src/test/java/com/hazelcast/client/config/XmlClientConfigBuilderTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/config/XmlClientConfigBuilderTest.java
@@ -322,6 +322,18 @@ public class XmlClientConfigBuilderTest {
         buildConfig(xml);
     }
 
+    @Test(expected = InvalidConfigurationException.class)
+    public void testInvalidNamespace() {
+        String xml = "<hazelcast-client xmlns=\"http://foo.bar\"/>";
+        buildConfig(xml);
+    }
+
+    @Test
+    public void testValidNamespace() {
+        String xml = HAZELCAST_CLIENT_START_TAG + "</hazelcast-client>";
+        buildConfig(xml);
+    }
+
     static ClientConfig buildConfig(String xml, Properties properties) {
         ByteArrayInputStream bis = new ByteArrayInputStream(xml.getBytes());
         XmlClientConfigBuilder configBuilder = new XmlClientConfigBuilder(bis);

--- a/hazelcast/src/main/java/com/hazelcast/config/AbstractXmlConfigHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/AbstractXmlConfigHelper.java
@@ -27,7 +27,6 @@ import com.hazelcast.memory.MemoryUnit;
 import com.hazelcast.util.StringUtil;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.w3c.dom.Document;
-import org.w3c.dom.Element;
 import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -167,13 +166,6 @@ public abstract class AbstractXmlConfigHelper {
 
         // include hazelcast schema
         schemas.add(new StreamSource(getClass().getClassLoader().getResourceAsStream(hazelcastSchemaLocation)));
-        Element root = doc.getDocumentElement();
-
-        // set schema settings, so user don't have to set hazelcast xsd namespace,uri
-        root.setAttribute("xmlns", xmlns);
-        String xsi = "http://www.w3.org/2001/XMLSchema-instance";
-        root.setAttribute("xmlns:xsi", xsi);
-        root.setAttribute("xsi:schemaLocation", hazelcastSchemaLocation);
 
         // document to inputstream conversion
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();

--- a/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
@@ -1116,4 +1116,22 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertEquals(validationTimeout, hotRestartConfig.getValidationTimeoutSeconds());
         assertEquals(dataLoadTimeout, hotRestartConfig.getDataLoadTimeoutSeconds());
     }
+
+    @Test(expected = InvalidConfigurationException.class)
+    public void testMissingNamespace() {
+        String xml = "<hazelcast/>";
+        buildConfig(xml);
+    }
+
+    @Test(expected = InvalidConfigurationException.class)
+    public void testInvalidNamespace() {
+        String xml = "<hazelcast xmlns=\"http://foo.bar\"/>";
+        buildConfig(xml);
+    }
+
+    @Test
+    public void testValidNamespace() {
+        String xml = HAZELCAST_START_TAG + "</hazelcast>";
+        buildConfig(xml);
+    }
 }


### PR DESCRIPTION
This injection doesn't work on JDKs other than the IBM one. The user
should be required to specify the namespace in all cases.