### PR TITLE
Reverting a precondition in AbstractPredicate introduced by #6659

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/AbstractPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/AbstractPredicate.java
@@ -25,7 +25,6 @@ import com.hazelcast.query.extractor.MultiResult;
 import com.hazelcast.query.impl.AttributeType;
 import com.hazelcast.query.impl.IndexImpl;
 import com.hazelcast.query.impl.QueryableEntry;
-import com.hazelcast.util.Preconditions;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -45,7 +44,7 @@ public abstract class AbstractPredicate implements Predicate, DataSerializable {
     }
 
     protected AbstractPredicate(String attributeName) {
-        this.attributeName = Preconditions.checkHasText(attributeName, "attributeName must not be null");
+        this.attributeName = attributeName;
     }
 
     @Override


### PR DESCRIPTION
Reverting a precondition in AbstractPredicate introduced by #6659
PredicateBuilder may init the abstract predicate with attributeName set to null.

It's a quick revert to unblock PR builder. 