### PR TITLE
Removed unnecessary `CacheLoader` dependency on client and server side at cache proxies

### DIFF
--- a/hazelcast-client-legacy/src/main/java/com/hazelcast/client/cache/impl/ClientCacheProxy.java
+++ b/hazelcast-client-legacy/src/main/java/com/hazelcast/client/cache/impl/ClientCacheProxy.java
@@ -121,7 +121,6 @@ public class ClientCacheProxy<K, V>
         for (K key : keys) {
             CacheProxyUtil.validateConfiguredTypes(cacheConfig, key);
         }
-        validateCacheLoader(completionListener);
         HashSet<Data> keysData = new HashSet<Data>();
         for (K key : keys) {
             keysData.add(toData(key));

--- a/hazelcast-client-legacy/src/test/java/com/hazelcast/client/cache/ClientReadWriteThroughJCacheTests.java
+++ b/hazelcast-client-legacy/src/test/java/com/hazelcast/client/cache/ClientReadWriteThroughJCacheTests.java
@@ -18,20 +18,19 @@ package com.hazelcast.client.cache;
 
 import com.hazelcast.cache.ICache;
 import com.hazelcast.cache.impl.HazelcastServerCachingProvider;
-import com.hazelcast.client.HazelcastClient;
 import com.hazelcast.client.cache.impl.HazelcastClientCachingProvider;
-import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.CacheConfig;
-import com.hazelcast.config.Config;
-import com.hazelcast.config.JoinConfig;
-import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.HazelcastInstanceAware;
+import com.hazelcast.instance.HazelcastInstanceImpl;
 import com.hazelcast.test.AssertTask;
-import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -39,6 +38,7 @@ import org.junit.runner.RunWith;
 import javax.cache.Cache;
 import javax.cache.CacheManager;
 import javax.cache.configuration.CompleteConfiguration;
+import javax.cache.configuration.Factory;
 import javax.cache.configuration.FactoryBuilder;
 import javax.cache.integration.CacheLoader;
 import javax.cache.integration.CacheLoaderException;
@@ -54,52 +54,45 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
-@RunWith(HazelcastSerialClassRunner.class)
-@Category(QuickTest.class)
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class ClientReadWriteThroughJCacheTests extends HazelcastTestSupport {
 
-    private static HazelcastInstance hz1;
-    private static HazelcastInstance hz2;
-    private static HazelcastInstance client;
+    private TestHazelcastFactory testHazelcastFactory = new TestHazelcastFactory();
 
-    private static HazelcastServerCachingProvider cachingProvider1;
-    private static HazelcastServerCachingProvider cachingProvider2;
-    private static HazelcastClientCachingProvider cachingProvider3;
+    private HazelcastInstance server1;
+    private HazelcastInstance server2;
+    private HazelcastInstance client;
 
-    @BeforeClass
-    public static void init() {
-        Config config = new Config();
-        JoinConfig join = config.getNetworkConfig().getJoin();
-        join.getMulticastConfig().setEnabled(false);
-        join.getTcpIpConfig().setEnabled(true);
-        join.getTcpIpConfig().addMember("127.0.0.1");
+    private HazelcastServerCachingProvider serverProvider1;
+    private HazelcastServerCachingProvider serverProvider2;
+    private HazelcastClientCachingProvider clientProvider;
 
-        hz1 = Hazelcast.newHazelcastInstance(config);
-        hz2 = Hazelcast.newHazelcastInstance(config);
+    @Before
+    public void setup() {
+        server1 = testHazelcastFactory.newHazelcastInstance();
+        server2 = testHazelcastFactory.newHazelcastInstance();
 
-        ClientConfig clientConfig = new ClientConfig();
-        clientConfig.getNetworkConfig().addAddress("127.0.0.1");
-        client = HazelcastClient.newHazelcastClient(clientConfig);
+        client = testHazelcastFactory.newHazelcastClient();
 
-        cachingProvider1 = HazelcastServerCachingProvider.createCachingProvider(hz1);
-        cachingProvider2 = HazelcastServerCachingProvider.createCachingProvider(hz2);
-        cachingProvider3 = HazelcastClientCachingProvider.createCachingProvider(client);
+        serverProvider1 = HazelcastServerCachingProvider.createCachingProvider(server1);
+        serverProvider2 = HazelcastServerCachingProvider.createCachingProvider(server2);
+        clientProvider = HazelcastClientCachingProvider.createCachingProvider(client);
     }
 
-    @AfterClass
-    public static void tear() {
-        cachingProvider1.close();
-        cachingProvider2.close();
-        cachingProvider3.close();
-        HazelcastClient.shutdownAll();
-        Hazelcast.shutdownAll();
+    @After
+    public void tearDown() {
+        clientProvider.close();
+        serverProvider1.close();
+        serverProvider2.close();
+        testHazelcastFactory.shutdownAll();
     }
 
     @Test
-    public void test_getall_readthrough() throws Exception {
+    public void getAllShouldReadThroughCacheLoaderSuccessfully() throws Exception {
         final String cacheName = randomMapName();
 
-        CacheManager cacheManager = cachingProvider3.getCacheManager();
+        CacheManager cacheManager = clientProvider.getCacheManager();
         assertNotNull(cacheManager);
 
         assertNull(cacheManager.getCache(cacheName));
@@ -115,9 +108,9 @@ public class ClientReadWriteThroughJCacheTests extends HazelcastTestSupport {
         assertTrueEventually(new AssertTask() {
             @Override
             public void run() throws Exception {
-                CacheManager cm1 = cachingProvider1.getCacheManager();
+                CacheManager cm1 = serverProvider1.getCacheManager();
                 assertNotNull(cm1.getCache(cacheName, Integer.class, Integer.class));
-                CacheManager cm2 = cachingProvider2.getCacheManager();
+                CacheManager cm2 = serverProvider2.getCacheManager();
                 assertNotNull(cm2.getCache(cacheName, Integer.class, Integer.class));
             }
         });
@@ -132,10 +125,10 @@ public class ClientReadWriteThroughJCacheTests extends HazelcastTestSupport {
     }
 
     @Test
-    public void test_loadall_readthrough() throws Exception {
+    public void loadAllShouldReadThroughCacheLoaderSuccessfully() throws Exception {
         final String cacheName = randomMapName();
 
-        CacheManager cacheManager = cachingProvider3.getCacheManager();
+        CacheManager cacheManager = clientProvider.getCacheManager();
         assertNotNull(cacheManager);
 
         assertNull(cacheManager.getCache(cacheName));
@@ -151,9 +144,9 @@ public class ClientReadWriteThroughJCacheTests extends HazelcastTestSupport {
         assertTrueEventually(new AssertTask() {
             @Override
             public void run() throws Exception {
-                CacheManager cm1 = cachingProvider1.getCacheManager();
+                CacheManager cm1 = serverProvider1.getCacheManager();
                 assertNotNull(cm1.getCache(cacheName, Integer.class, Integer.class));
-                CacheManager cm2 = cachingProvider2.getCacheManager();
+                CacheManager cm2 = serverProvider2.getCacheManager();
                 assertNotNull(cm2.getCache(cacheName, Integer.class, Integer.class));
             }
         });
@@ -190,7 +183,7 @@ public class ClientReadWriteThroughJCacheTests extends HazelcastTestSupport {
         @Override
         public Map<Integer, Integer> loadAll(Iterable<? extends Integer> keys) throws CacheLoaderException {
             Map<Integer, Integer> result = new HashMap<Integer, Integer>();
-            for (Integer key : keys ) {
+            for (Integer key : keys) {
                 Integer value = load(key);
                 if (value != null) {
                     result.put(key, value);
@@ -198,6 +191,81 @@ public class ClientReadWriteThroughJCacheTests extends HazelcastTestSupport {
             }
             return result;
         }
+    }
+
+    // https://github.com/hazelcast/hazelcast/issues/6676
+    @Test
+    public void cacheLoaderShouldBeAbleToUsedOnlyAtServerSide() {
+        final String cacheName = randomName();
+        CacheManager serverCacheManager = serverProvider1.getCacheManager();
+
+        CompleteConfiguration<Integer, String> config =
+                new CacheConfig<Integer, String>()
+                        .setTypes(Integer.class, String.class)
+                        .setReadThrough(true)
+                        .setCacheLoaderFactory(new ServerSideCacheLoaderFactory());
+
+        serverCacheManager.createCache(cacheName, config);
+
+        CacheManager clientCacheManager = clientProvider.getCacheManager();
+        Cache<Integer, String> cache = clientCacheManager.getCache(cacheName, Integer.class, String.class);
+
+        assertNotNull(cache);
+
+        Set<Integer> keys = new HashSet<Integer>();
+        for (int i = 0; i < 100; i++) {
+            keys.add(i);
+        }
+
+        Map<Integer, String> loaded = cache.getAll(keys);
+        assertEquals(keys.size(), loaded.size());
+        for (Map.Entry<Integer, String> entry  : loaded.entrySet()) {
+            assertEquals(ServerSideCacheLoader.valueOf(entry.getKey()), entry.getValue());
+        }
+    }
+
+    public static class ServerSideCacheLoaderFactory
+            implements Factory<ServerSideCacheLoader>, HazelcastInstanceAware {
+
+        private transient HazelcastInstance hazelcastInstance;
+
+        @Override
+        public void setHazelcastInstance(HazelcastInstance hazelcastInstance) {
+            this.hazelcastInstance = hazelcastInstance;
+        }
+
+        @Override
+        public ServerSideCacheLoader create() {
+            if (hazelcastInstance instanceof HazelcastInstanceImpl) {
+                return new ServerSideCacheLoader();
+            } else {
+                throw new IllegalStateException("This factory can only be used at server side!");
+            }
+        }
+
+    }
+
+    private static class ServerSideCacheLoader implements CacheLoader<Integer, String> {
+
+        static String valueOf(Integer key) {
+            return "value-of-" + key;
+        }
+
+        @Override
+        public String load(Integer key) {
+            return valueOf(key);
+        }
+
+        @Override
+        public Map<Integer, String> loadAll(Iterable<? extends Integer> keys) throws CacheLoaderException {
+            Map<Integer, String> result = new HashMap<Integer, String>();
+            for (Integer key : keys) {
+                String value = load(key);
+                result.put(key, value);
+            }
+            return result;
+        }
+
     }
 
 }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/ClientCacheProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/ClientCacheProxy.java
@@ -116,7 +116,6 @@ public class ClientCacheProxy<K, V>
         for (K key : keys) {
             CacheProxyUtil.validateConfiguredTypes(cacheConfig, key);
         }
-        validateCacheLoader(completionListener);
         HashSet<Data> keysData = new HashSet<Data>();
         for (K key : keys) {
             keysData.add(toData(key));

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/ClientReadWriteThroughJCacheTests.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/ClientReadWriteThroughJCacheTests.java
@@ -18,20 +18,19 @@ package com.hazelcast.client.cache;
 
 import com.hazelcast.cache.ICache;
 import com.hazelcast.cache.impl.HazelcastServerCachingProvider;
-import com.hazelcast.client.HazelcastClient;
 import com.hazelcast.client.cache.impl.HazelcastClientCachingProvider;
-import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.CacheConfig;
-import com.hazelcast.config.Config;
-import com.hazelcast.config.JoinConfig;
-import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.HazelcastInstanceAware;
+import com.hazelcast.instance.HazelcastInstanceImpl;
 import com.hazelcast.test.AssertTask;
-import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -39,6 +38,7 @@ import org.junit.runner.RunWith;
 import javax.cache.Cache;
 import javax.cache.CacheManager;
 import javax.cache.configuration.CompleteConfiguration;
+import javax.cache.configuration.Factory;
 import javax.cache.configuration.FactoryBuilder;
 import javax.cache.integration.CacheLoader;
 import javax.cache.integration.CacheLoaderException;
@@ -54,52 +54,45 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
-@RunWith(HazelcastSerialClassRunner.class)
-@Category(QuickTest.class)
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class ClientReadWriteThroughJCacheTests extends HazelcastTestSupport {
 
-    private static HazelcastInstance hz1;
-    private static HazelcastInstance hz2;
-    private static HazelcastInstance client;
+    private TestHazelcastFactory testHazelcastFactory = new TestHazelcastFactory();
 
-    private static HazelcastServerCachingProvider cachingProvider1;
-    private static HazelcastServerCachingProvider cachingProvider2;
-    private static HazelcastClientCachingProvider cachingProvider3;
+    private HazelcastInstance server1;
+    private HazelcastInstance server2;
+    private HazelcastInstance client;
 
-    @BeforeClass
-    public static void init() {
-        Config config = new Config();
-        JoinConfig join = config.getNetworkConfig().getJoin();
-        join.getMulticastConfig().setEnabled(false);
-        join.getTcpIpConfig().setEnabled(true);
-        join.getTcpIpConfig().addMember("127.0.0.1");
+    private HazelcastServerCachingProvider serverProvider1;
+    private HazelcastServerCachingProvider serverProvider2;
+    private HazelcastClientCachingProvider clientProvider;
 
-        hz1 = Hazelcast.newHazelcastInstance(config);
-        hz2 = Hazelcast.newHazelcastInstance(config);
+    @Before
+    public void setup() {
+        server1 = testHazelcastFactory.newHazelcastInstance();
+        server2 = testHazelcastFactory.newHazelcastInstance();
 
-        ClientConfig clientConfig = new ClientConfig();
-        clientConfig.getNetworkConfig().addAddress("127.0.0.1");
-        client = HazelcastClient.newHazelcastClient(clientConfig);
+        client = testHazelcastFactory.newHazelcastClient();
 
-        cachingProvider1 = HazelcastServerCachingProvider.createCachingProvider(hz1);
-        cachingProvider2 = HazelcastServerCachingProvider.createCachingProvider(hz2);
-        cachingProvider3 = HazelcastClientCachingProvider.createCachingProvider(client);
+        serverProvider1 = HazelcastServerCachingProvider.createCachingProvider(server1);
+        serverProvider2 = HazelcastServerCachingProvider.createCachingProvider(server2);
+        clientProvider = HazelcastClientCachingProvider.createCachingProvider(client);
     }
 
-    @AfterClass
-    public static void tear() {
-        cachingProvider1.close();
-        cachingProvider2.close();
-        cachingProvider3.close();
-        HazelcastClient.shutdownAll();
-        Hazelcast.shutdownAll();
+    @After
+    public void tearDown() {
+        clientProvider.close();
+        serverProvider1.close();
+        serverProvider2.close();
+        testHazelcastFactory.shutdownAll();
     }
 
     @Test
-    public void test_getall_readthrough() throws Exception {
+    public void getAllShouldReadThroughCacheLoaderSuccessfully() throws Exception {
         final String cacheName = randomMapName();
 
-        CacheManager cacheManager = cachingProvider3.getCacheManager();
+        CacheManager cacheManager = clientProvider.getCacheManager();
         assertNotNull(cacheManager);
 
         assertNull(cacheManager.getCache(cacheName));
@@ -115,9 +108,9 @@ public class ClientReadWriteThroughJCacheTests extends HazelcastTestSupport {
         assertTrueEventually(new AssertTask() {
             @Override
             public void run() throws Exception {
-                CacheManager cm1 = cachingProvider1.getCacheManager();
+                CacheManager cm1 = serverProvider1.getCacheManager();
                 assertNotNull(cm1.getCache(cacheName, Integer.class, Integer.class));
-                CacheManager cm2 = cachingProvider2.getCacheManager();
+                CacheManager cm2 = serverProvider2.getCacheManager();
                 assertNotNull(cm2.getCache(cacheName, Integer.class, Integer.class));
             }
         });
@@ -132,10 +125,10 @@ public class ClientReadWriteThroughJCacheTests extends HazelcastTestSupport {
     }
 
     @Test
-    public void test_loadall_readthrough() throws Exception {
+    public void loadAllShouldReadThroughCacheLoaderSuccessfully() throws Exception {
         final String cacheName = randomMapName();
 
-        CacheManager cacheManager = cachingProvider3.getCacheManager();
+        CacheManager cacheManager = clientProvider.getCacheManager();
         assertNotNull(cacheManager);
 
         assertNull(cacheManager.getCache(cacheName));
@@ -151,9 +144,9 @@ public class ClientReadWriteThroughJCacheTests extends HazelcastTestSupport {
         assertTrueEventually(new AssertTask() {
             @Override
             public void run() throws Exception {
-                CacheManager cm1 = cachingProvider1.getCacheManager();
+                CacheManager cm1 = serverProvider1.getCacheManager();
                 assertNotNull(cm1.getCache(cacheName, Integer.class, Integer.class));
-                CacheManager cm2 = cachingProvider2.getCacheManager();
+                CacheManager cm2 = serverProvider2.getCacheManager();
                 assertNotNull(cm2.getCache(cacheName, Integer.class, Integer.class));
             }
         });
@@ -198,6 +191,81 @@ public class ClientReadWriteThroughJCacheTests extends HazelcastTestSupport {
             }
             return result;
         }
+    }
+
+    // https://github.com/hazelcast/hazelcast/issues/6676
+    @Test
+    public void cacheLoaderShouldBeAbleToUsedOnlyAtServerSide() {
+        final String cacheName = randomName();
+        CacheManager serverCacheManager = serverProvider1.getCacheManager();
+
+        CompleteConfiguration<Integer, String> config =
+                new CacheConfig<Integer, String>()
+                        .setTypes(Integer.class, String.class)
+                        .setReadThrough(true)
+                        .setCacheLoaderFactory(new ServerSideCacheLoaderFactory());
+
+        serverCacheManager.createCache(cacheName, config);
+
+        CacheManager clientCacheManager = clientProvider.getCacheManager();
+        Cache<Integer, String> cache = clientCacheManager.getCache(cacheName, Integer.class, String.class);
+
+        assertNotNull(cache);
+
+        Set<Integer> keys = new HashSet<Integer>();
+        for (int i = 0; i < 100; i++) {
+            keys.add(i);
+        }
+
+        Map<Integer, String> loaded = cache.getAll(keys);
+        assertEquals(keys.size(), loaded.size());
+        for (Map.Entry<Integer, String> entry  : loaded.entrySet()) {
+            assertEquals(ServerSideCacheLoader.valueOf(entry.getKey()), entry.getValue());
+        }
+    }
+
+    public static class ServerSideCacheLoaderFactory
+            implements Factory<ServerSideCacheLoader>, HazelcastInstanceAware {
+
+        private transient HazelcastInstance hazelcastInstance;
+
+        @Override
+        public void setHazelcastInstance(HazelcastInstance hazelcastInstance) {
+            this.hazelcastInstance = hazelcastInstance;
+        }
+
+        @Override
+        public ServerSideCacheLoader create() {
+            if (hazelcastInstance instanceof HazelcastInstanceImpl) {
+                return new ServerSideCacheLoader();
+            } else {
+                throw new IllegalStateException("This factory can only be used at server side!");
+            }
+        }
+
+    }
+
+    private static class ServerSideCacheLoader implements CacheLoader<Integer, String> {
+
+        static String valueOf(Integer key) {
+            return "value-of-" + key;
+        }
+
+        @Override
+        public String load(Integer key) {
+            return valueOf(key);
+        }
+
+        @Override
+        public Map<Integer, String> loadAll(Iterable<? extends Integer> keys) throws CacheLoaderException {
+            Map<Integer, String> result = new HashMap<Integer, String>();
+            for (Integer key : keys) {
+                String value = load(key);
+                result.put(key, value);
+            }
+            return result;
+        }
+
     }
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheRecordStore.java
@@ -26,6 +26,7 @@ import com.hazelcast.config.CacheConfig;
 import com.hazelcast.config.EvictionConfig;
 import com.hazelcast.config.EvictionPolicy;
 import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.core.HazelcastInstanceAware;
 import com.hazelcast.internal.eviction.EvictionChecker;
 import com.hazelcast.internal.eviction.EvictionListener;
 import com.hazelcast.internal.eviction.EvictionPolicyEvaluator;
@@ -122,10 +123,16 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
         }
         if (cacheConfig.getCacheLoaderFactory() != null) {
             final Factory<CacheLoader> cacheLoaderFactory = cacheConfig.getCacheLoaderFactory();
+            if (cacheLoaderFactory instanceof HazelcastInstanceAware) {
+                ((HazelcastInstanceAware) cacheLoaderFactory).setHazelcastInstance(nodeEngine.getHazelcastInstance());
+            }
             cacheLoader = cacheLoaderFactory.create();
         }
         if (cacheConfig.getCacheWriterFactory() != null) {
             final Factory<CacheWriter> cacheWriterFactory = cacheConfig.getCacheWriterFactory();
+            if (cacheWriterFactory instanceof HazelcastInstanceAware) {
+                ((HazelcastInstanceAware) cacheWriterFactory).setHazelcastInstance(nodeEngine.getHazelcastInstance());
+            }
             cacheWriter = cacheWriterFactory.create();
         }
         if (cacheConfig.isStatisticsEnabled()) {

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheProxy.java
@@ -115,7 +115,6 @@ public class CacheProxy<K, V>
         for (K key : keys) {
             CacheProxyUtil.validateConfiguredTypes(cacheConfig, key);
         }
-        validateCacheLoader(completionListener);
         HashSet<Data> keysData = new HashSet<Data>(keys.size());
         for (K key : keys) {
             keysData.add(serializationService.toData(key));


### PR DESCRIPTION
* Removed unnecessary `CacheLoader` creation and closing codes at client and server side cache proxies
* If factory of `CacheLoader` and `CacheWriter` is `HazelcastInstanceAware`, `HazelcastInstance` is injected
* Refactor on `ClientReadWriteThroughJCacheTests` so tests are using mock instances (client and server) and can run with parallel runner. 

Fixes #6676 
