### PR TITLE
Fix migration state problems on node shutdown and join

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/instance/DefaultNodeExtension.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/DefaultNodeExtension.java
@@ -97,6 +97,11 @@ public class DefaultNodeExtension implements NodeExtension {
     }
 
     @Override
+    public boolean isStartCompleted() {
+        return node.joined();
+    }
+
+    @Override
     public SecurityContext getSecurityContext() {
         logger.warning("Security features are only available on Hazelcast Enterprise!");
         return null;

--- a/hazelcast/src/main/java/com/hazelcast/instance/NodeExtension.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/NodeExtension.java
@@ -57,6 +57,12 @@ public interface NodeExtension {
     void afterStart();
 
     /**
+     * Returns true if the instance has started
+     * @return true if the instance has started
+     */
+    boolean isStartCompleted();
+
+    /**
      * Creates a <tt>SerializationService</tt> instance to be used by this <tt>Node</tt>.
      *
      * @return a <tt>SerializationService</tt> instance

--- a/hazelcast/src/main/java/com/hazelcast/partition/PartitionDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/PartitionDataSerializerHook.java
@@ -29,6 +29,7 @@ public final class PartitionDataSerializerHook implements DataSerializerHook {
 
     public static final int F_ID = FactoryIdHelper.getFactoryId(PARTITION_DS_FACTORY, PARTITION_DS_FACTORY_ID);
 
+    public static final int PARTITION_STATE = 1;
     public static final int PARTITIONS = 2;
 
     @Override
@@ -42,6 +43,8 @@ public final class PartitionDataSerializerHook implements DataSerializerHook {
             @Override
             public IdentifiedDataSerializable create(int typeId) {
                 switch (typeId) {
+                    case PARTITION_STATE:
+                        return new PartitionRuntimeState();
                     case PARTITIONS:
                         return new PartitionsResponse();
                     default:

--- a/hazelcast/src/main/java/com/hazelcast/partition/PartitionRuntimeState.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/PartitionRuntimeState.java
@@ -22,6 +22,7 @@ import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.DataSerializable;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -32,10 +33,9 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
-public class PartitionRuntimeState implements DataSerializable {
+public final class PartitionRuntimeState implements IdentifiedDataSerializable {
 
-    protected final ArrayList<MemberInfo> members = new ArrayList<MemberInfo>(100);
-
+    private final List<MemberInfo> members = new ArrayList<MemberInfo>(100);
     private final Collection<ShortPartitionInfo> partitionInfos = new LinkedList<ShortPartitionInfo>();
     private ILogger logger;
     private int version;
@@ -62,12 +62,12 @@ public class PartitionRuntimeState implements DataSerializable {
         completedMigrations = migrationInfos != null ? migrationInfos : new ArrayList<MigrationInfo>(0);
     }
 
-    protected void addMemberInfo(MemberInfo memberInfo, Map<Address, Integer> addressIndexes, int memberIndex) {
+    private void addMemberInfo(MemberInfo memberInfo, Map<Address, Integer> addressIndexes, int memberIndex) {
         members.add(memberIndex, memberInfo);
         addressIndexes.put(memberInfo.getAddress(), memberIndex);
     }
 
-    protected void setPartitions(InternalPartition[] partitions, Map<Address, Integer> addressIndexes) {
+    private void setPartitions(InternalPartition[] partitions, Map<Address, Integer> addressIndexes) {
         List<String> unmatchAddresses = new LinkedList<String>();
         for (InternalPartition partition : partitions) {
             ShortPartitionInfo partitionInfo = new ShortPartitionInfo(partition.getPartitionId());
@@ -243,5 +243,15 @@ public class PartitionRuntimeState implements DataSerializable {
                 addressIndexes[i] = in.readInt();
             }
         }
+    }
+
+    @Override
+    public int getFactoryId() {
+        return PartitionDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return PartitionDataSerializerHook.PARTITION_STATE;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/partition/impl/InternalPartitionServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/impl/InternalPartitionServiceImpl.java
@@ -492,8 +492,7 @@ public class InternalPartitionServiceImpl implements InternalPartitionService, M
                     }
 
                     // send initial partition table to newly joined node.
-                    Collection<MemberImpl> members = getCurrentMembersAndMembersRemovedWhileNotClusterNotActive();
-                    PartitionStateOperation op = new PartitionStateOperation(createPartitionState(members));
+                    PartitionStateOperation op = new PartitionStateOperation(createPartitionState());
                     nodeEngine.getOperationService().send(op, member.getAddress());
                 }
             } finally {
@@ -608,7 +607,15 @@ public class InternalPartitionServiceImpl implements InternalPartitionService, M
         }
     }
 
+    public PartitionRuntimeState createPartitionState() {
+        return createPartitionState(getCurrentMembersAndMembersRemovedWhileNotClusterNotActive());
+    }
+
     private PartitionRuntimeState createPartitionState(Collection<MemberImpl> members) {
+        if (!initialized) {
+            return null;
+        }
+
         lock.lock();
         try {
             List<MemberInfo> memberInfos = new ArrayList<MemberInfo>(members.size());
@@ -707,7 +714,7 @@ public class InternalPartitionServiceImpl implements InternalPartitionService, M
         return calls;
     }
 
-    void processPartitionRuntimeState(PartitionRuntimeState partitionState) {
+    public void processPartitionRuntimeState(PartitionRuntimeState partitionState) {
         lock.lock();
         try {
             final Address sender = partitionState.getEndpoint();

--- a/hazelcast/src/main/java/com/hazelcast/partition/impl/InternalPartitionServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/impl/InternalPartitionServiceImpl.java
@@ -486,7 +486,10 @@ public class InternalPartitionServiceImpl implements InternalPartitionService, M
             try {
                 migrationQueue.clear();
                 if (initialized) {
-                    migrationQueue.add(new RepartitioningTask());
+                    final ClusterState clusterState = nodeEngine.getClusterService().getClusterState();
+                    if (clusterState == ClusterState.ACTIVE) {
+                        migrationQueue.add(new RepartitioningTask());
+                    }
 
                     // send initial partition table to newly joined node.
                     Collection<MemberImpl> members = getCurrentMembersAndMembersRemovedWhileNotClusterNotActive();
@@ -631,7 +634,7 @@ public class InternalPartitionServiceImpl implements InternalPartitionService, M
             return;
         }
 
-        if (!isMigrationAllowed()) {
+        if (!isReplicaSyncAllowed()) {
             // migration is disabled because of a member leave, wait till enabled!
             return;
         }

--- a/hazelcast/src/main/java/com/hazelcast/partition/impl/PartitionStateOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/impl/PartitionStateOperation.java
@@ -17,7 +17,7 @@
 package com.hazelcast.partition.impl;
 
 import com.hazelcast.cluster.impl.operations.JoinOperation;
-import com.hazelcast.instance.NodeState;
+import com.hazelcast.instance.Node;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.partition.InternalPartitionService;
@@ -48,8 +48,8 @@ public final class PartitionStateOperation extends AbstractOperation
 
     @Override
     public void run() {
-        NodeEngineImpl nodeEngine = (NodeEngineImpl) getNodeEngine();
-        if (nodeEngine.getNode().getState() == NodeState.PASSIVE) {
+        final Node node = ((NodeEngineImpl) getNodeEngine()).getNode();
+        if (!node.getNodeExtension().isStartCompleted()) {
             getLogger().warning("Partition table received before startup is completed. Caller: " + getCallerAddress());
             return;
         }

--- a/hazelcast/src/test/java/com/hazelcast/partition/impl/FrozenPartitionTableTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/partition/impl/FrozenPartitionTableTest.java
@@ -4,11 +4,13 @@ import com.hazelcast.cluster.ClusterState;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.nio.Address;
+import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.test.annotation.Repeat;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -28,7 +30,7 @@ import static org.junit.Assert.assertNotNull;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class FrozenPartitionTableTest  extends HazelcastTestSupport {
+public class FrozenPartitionTableTest extends HazelcastTestSupport {
 
     @Test
     public void partitionTable_isFrozen_whenNodesLeave_duringClusterStateIsFrozen() {
@@ -40,6 +42,7 @@ public class FrozenPartitionTableTest  extends HazelcastTestSupport {
         testPartitionTableIsFrozenDuring(ClusterState.PASSIVE);
     }
 
+    @Repeat(100)
     @Test
     public void partitionTable_isFrozen_whenMemberReJoins_duringClusterStateIsFrozen() {
         Config config = new Config();
@@ -63,7 +66,14 @@ public class FrozenPartitionTableTest  extends HazelcastTestSupport {
         assertClusterSizeEventually(3, hz3);
 
         for (HazelcastInstance instance : Arrays.asList(hz1, hz2, hz3)) {
-            assertPartitionTablesSame(partitionTable, getPartitionTable(instance));
+            final HazelcastInstance hz = instance;
+            assertTrueEventually(new AssertTask() {
+                @Override
+                public void run()
+                        throws Exception {
+                    assertPartitionTablesSame(partitionTable, getPartitionTable(hz));
+                }
+            });
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/partition/impl/FrozenPartitionTableTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/partition/impl/FrozenPartitionTableTest.java
@@ -10,7 +10,6 @@ import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
-import com.hazelcast.test.annotation.Repeat;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -42,7 +41,6 @@ public class FrozenPartitionTableTest extends HazelcastTestSupport {
         testPartitionTableIsFrozenDuring(ClusterState.PASSIVE);
     }
 
-    @Repeat(100)
     @Test
     public void partitionTable_isFrozen_whenMemberReJoins_duringClusterStateIsFrozen() {
         Config config = new Config();


### PR DESCRIPTION
* Do not trigger RepartitioningTask if cluster state is not active. It causes infinite retries and prevents nodes to shutdown since they think that there is an ongoing migration
* Introduce NodeExtension.isStartCompleted() method and use it in PartitionStateOperation instead of checking NodeState. It is a no-op method for OSS and has an implementation on enterprise.
* Send initial partition table with finalize-join operation 

Fixes #6663
Fixes #6655
Fixes #6656