### PR TITLE
Inject HazelcastInstance to HazelcastInstanceAware listeners configured by classname.

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
@@ -199,7 +199,7 @@ abstract class MapProxySupport extends AbstractDistributedObject<MapService> imp
             listener = (T) listenerConfig.getImplementation();
         } else if (listenerConfig.getClassName() != null) {
             try {
-                return ClassLoaderUtil
+                listener = ClassLoaderUtil
                         .newInstance(getNodeEngine().getConfigClassLoader(), listenerConfig.getClassName());
             } catch (Exception e) {
                 throw ExceptionUtil.rethrow(e);


### PR DESCRIPTION
Hazelcast injects its instance to an EntryListener when the listener is configured by providing an instance.
This changeset makes it the same if a listener is configured by its classname. It's a consistency fix.

 See https://groups.google.com/forum/#!topic/hazelcast/7hh1OyrMCaY