### PR TITLE
Async connection creation for client invocations

### DIFF
--- a/hazelcast-client-legacy/src/main/java/com/hazelcast/client/connection/ClientConnectionManager.java
+++ b/hazelcast-client-legacy/src/main/java/com/hazelcast/client/connection/ClientConnectionManager.java
@@ -62,6 +62,14 @@ public interface ClientConnectionManager {
     Connection getOrConnect(Address address, Authenticator authenticator) throws IOException;
 
     /**
+     * @param address       to be connected
+     * @param authenticator Authenticator implementation to send appropriate Authentication Request after connection
+     * @return associated connection if available, triggers new connection creation otherwise
+     * @throws IOException if connection is not available at the time of call
+     */
+    Connection getOrTriggerConnect(Address address, Authenticator authenticator) throws IOException;
+
+    /**
      * Destroys the connection
      * Clears related resources of given connection.
      * ConnectionListener.connectionRemoved is called on registered listeners.

--- a/hazelcast-client-legacy/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
+++ b/hazelcast-client-legacy/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
@@ -28,8 +28,8 @@ import com.hazelcast.client.impl.HazelcastClientInstanceImpl;
 import com.hazelcast.client.spi.ClientInvocationService;
 import com.hazelcast.client.spi.impl.ClientExecutionServiceImpl;
 import com.hazelcast.client.spi.impl.ClientInvocation;
-import com.hazelcast.client.spi.impl.listener.ClientListenerServiceImpl;
 import com.hazelcast.client.spi.impl.ConnectionHeartbeatListener;
+import com.hazelcast.client.spi.impl.listener.ClientListenerServiceImpl;
 import com.hazelcast.cluster.client.ClientPingRequest;
 import com.hazelcast.config.SocketInterceptorConfig;
 import com.hazelcast.core.HazelcastException;
@@ -50,6 +50,7 @@ import com.hazelcast.util.ExceptionUtil;
 import java.io.IOException;
 import java.net.Socket;
 import java.nio.channels.SocketChannel;
+import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -91,6 +92,8 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
     private final AddressTranslator addressTranslator;
     private final ConcurrentMap<Address, ClientConnection> connections
             = new ConcurrentHashMap<Address, ClientConnection>();
+    private final Set<Address> connectionsInProgress =
+            Collections.newSetFromMap(new ConcurrentHashMap<Address, Boolean>());
 
     private final Set<ConnectionListener> connectionListeners = new CopyOnWriteArraySet<ConnectionListener>();
     private final Set<ConnectionHeartbeatListener> heartbeatListeners =
@@ -191,26 +194,53 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
     }
 
     public ClientConnection getOrConnect(Address target, Authenticator authenticator) throws IOException {
-        Address address = addressTranslator.translate(target);
+        Address remoteAddress = addressTranslator.translate(target);
 
-        if (address == null) {
+        if (remoteAddress == null) {
             throw new IOException("Address is required!");
         }
 
         ClientConnection connection = connections.get(target);
+        Object lock = getLock(target);
+
         if (connection == null) {
-            final Object lock = getLock(target);
             synchronized (lock) {
                 connection = connections.get(target);
                 if (connection == null) {
-                    connection = createSocketConnection(address);
-                    authenticate(authenticator, connection);
-                    connections.put(connection.getRemoteEndpoint(), connection);
-                    fireConnectionAddedEvent(connection);
+                    connection = initializeConnection(remoteAddress, authenticator);
                 }
             }
         }
         return connection;
+    }
+
+    private ClientConnection initializeConnection(Address address, Authenticator authenticator) throws IOException {
+        ClientConnection connection = createSocketConnection(address);
+        authenticate(authenticator, connection);
+        connections.put(connection.getRemoteEndpoint(), connection);
+        fireConnectionAddedEvent(connection);
+        return connection;
+    }
+
+    public ClientConnection getOrTriggerConnect(Address target, Authenticator authenticator) throws IOException {
+        Address remoteAddress = addressTranslator.translate(target);
+
+        if (remoteAddress == null) {
+            throw new IOException("Address is required!");
+        }
+
+        ClientExecutionServiceImpl executionService = (ClientExecutionServiceImpl) client.getClientExecutionService();
+        ClientConnection connection = connections.get(target);
+
+        if (connection != null) {
+            return connection;
+        }
+
+        if (connectionsInProgress.add(target)) {
+            executionService.executeInternal(new InitConnectionTask(target, remoteAddress, authenticator));
+        }
+
+        throw new IOException("No available connection to address " + target);
     }
 
     private void authenticate(Authenticator authenticator, ClientConnection connection) throws IOException {
@@ -362,5 +392,37 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
     @Override
     public void addConnectionHeartbeatListener(ConnectionHeartbeatListener connectionHeartbeatListener) {
         heartbeatListeners.add(connectionHeartbeatListener);
+    }
+
+    private class InitConnectionTask implements Runnable {
+
+        private final Address target;
+        private final Address remoteAddress;
+        private final Authenticator authenticator;
+
+        InitConnectionTask(Address target, Address remoteAddress, Authenticator authenticator) {
+            this.target = target;
+            this.remoteAddress = remoteAddress;
+            this.authenticator = authenticator;
+        }
+
+        @Override
+        public void run() {
+            final Object lock = getLock(target);
+            synchronized (lock) {
+                ClientConnection connection = connections.get(target);
+                if (connection != null) {
+                    return;
+                }
+                try {
+                    initializeConnection(remoteAddress, authenticator);
+                } catch (IOException e) {
+                    LOGGER.finest(e);
+                } finally {
+                    connectionsInProgress.remove(target);
+                }
+
+            }
+        }
     }
 }

--- a/hazelcast-client-legacy/src/main/java/com/hazelcast/client/proxy/ClientMapReduceProxy.java
+++ b/hazelcast-client-legacy/src/main/java/com/hazelcast/client/proxy/ClientMapReduceProxy.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.client.proxy;
 
+import com.hazelcast.client.connection.nio.ClientConnection;
 import com.hazelcast.client.impl.client.InvocationClientRequest;
 import com.hazelcast.client.spi.ClientProxy;
 import com.hazelcast.client.spi.impl.ClientInvocation;
@@ -80,9 +81,10 @@ public class ClientMapReduceProxy
     private <T> T invoke(InvocationClientRequest request, String jobId) throws Exception {
         ClientTrackableJob trackableJob = trackableJobs.get(jobId);
         if (trackableJob != null) {
-            Address runningMember = trackableJob.jobOwner;
+            ClientConnection sendConnection = trackableJob.clientInvocation.getSendConnection();
+            Address runningMember = sendConnection.getEndPoint();
             final ClientInvocation clientInvocation = new ClientInvocation(getClient(), request, runningMember);
-            final ICompletableFuture<T> future = clientInvocation.invoke();
+            ICompletableFuture<T> future = clientInvocation.invoke();
             return future.get();
         }
         return null;
@@ -137,8 +139,7 @@ public class ClientMapReduceProxy
                     }
                 });
 
-                Address runningMember = clientInvocation.getSendConnection().getRemoteEndpoint();
-                trackableJobs.putIfAbsent(jobId, new ClientTrackableJob<T>(jobId, runningMember, completableFuture));
+                trackableJobs.putIfAbsent(jobId, new ClientTrackableJob<T>(jobId, clientInvocation, completableFuture));
                 return completableFuture;
             } catch (Exception e) {
                 throw new RuntimeException(e);
@@ -184,13 +185,13 @@ public class ClientMapReduceProxy
             implements TrackableJob<V> {
 
         private final String jobId;
-        private final Address jobOwner;
+        private final ClientInvocation clientInvocation;
         private final AbstractCompletableFuture<V> completableFuture;
 
-        private ClientTrackableJob(String jobId, Address jobOwner,
+        private ClientTrackableJob(String jobId, ClientInvocation clientInvocation,
                                    AbstractCompletableFuture<V> completableFuture) {
             this.jobId = jobId;
-            this.jobOwner = jobOwner;
+            this.clientInvocation = clientInvocation;
             this.completableFuture = completableFuture;
         }
 

--- a/hazelcast-client-legacy/src/main/java/com/hazelcast/client/spi/impl/ClientSmartInvocationServiceImpl.java
+++ b/hazelcast-client-legacy/src/main/java/com/hazelcast/client/spi/impl/ClientSmartInvocationServiceImpl.java
@@ -74,7 +74,7 @@ public final class ClientSmartInvocationServiceImpl extends ClientInvocationServ
 
     private Connection getConnection(Address target) throws IOException {
         ensureOwnerConnectionAvailable();
-        return connectionManager.getOrConnect(target, authenticator);
+        return connectionManager.getOrTriggerConnect(target, authenticator);
     }
 
     private void ensureOwnerConnectionAvailable() throws IOException {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/ClientConnectionManager.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/ClientConnectionManager.java
@@ -62,6 +62,14 @@ public interface ClientConnectionManager {
     Connection getOrConnect(Address address, Authenticator authenticator) throws IOException;
 
     /**
+     * @param address       to be connected
+     * @param authenticator Authenticator implementation to send appropriate Authentication Request after connection
+     * @return associated connection if available, triggers new connection creation otherwise
+     * @throws IOException if connection is not available at the time of call
+     */
+    Connection getOrTriggerConnect(Address address, Authenticator authenticator) throws IOException;
+
+    /**
      * Destroys the connection
      * Clears related resources of given connection.
      * ConnectionListener.connectionRemoved is called on registered listeners.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapReduceProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapReduceProxy.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.client.proxy;
 
+import com.hazelcast.client.connection.nio.ClientConnection;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.MapReduceCancelCodec;
 import com.hazelcast.client.impl.protocol.codec.MapReduceForCustomCodec;
@@ -99,11 +100,11 @@ public class ClientMapReduceProxy
         return "JobTracker{" + "name='" + name + '\'' + '}';
     }
 
-    private ClientMessage invoke(ClientMessage request, String jobId)
-            throws Exception {
+    private ClientMessage invoke(ClientMessage request, String jobId) throws Exception {
         ClientTrackableJob trackableJob = trackableJobs.get(jobId);
         if (trackableJob != null) {
-            Address runningMember = trackableJob.jobOwner;
+            ClientConnection sendConnection = trackableJob.clientInvocation.getSendConnectionOrWait();
+            Address runningMember = sendConnection.getEndPoint();
             final ClientInvocation clientInvocation = new ClientInvocation(getClient(), request, runningMember);
             ClientInvocationFuture future = clientInvocation.invoke();
             return future.get();
@@ -161,8 +162,7 @@ public class ClientMapReduceProxy
                     }
                 });
 
-                Address runningMember = clientInvocation.getSendConnection().getRemoteEndpoint();
-                trackableJobs.putIfAbsent(jobId, new ClientTrackableJob<T>(jobId, runningMember, completableFuture));
+                trackableJobs.putIfAbsent(jobId, new ClientTrackableJob<T>(jobId, clientInvocation, completableFuture));
                 return completableFuture;
             } catch (Exception e) {
                 throw new RuntimeException(e);
@@ -271,12 +271,13 @@ public class ClientMapReduceProxy
             implements TrackableJob<V> {
 
         private final String jobId;
-        private final Address jobOwner;
+        private final ClientInvocation clientInvocation;
         private final AbstractCompletableFuture<V> completableFuture;
 
-        private ClientTrackableJob(String jobId, Address jobOwner, AbstractCompletableFuture<V> completableFuture) {
+        private ClientTrackableJob(String jobId, ClientInvocation clientInvocation,
+                                   AbstractCompletableFuture<V> completableFuture) {
             this.jobId = jobId;
-            this.jobOwner = jobOwner;
+            this.clientInvocation = clientInvocation;
             this.completableFuture = completableFuture;
         }
 

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientSmartInvocationServiceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientSmartInvocationServiceImpl.java
@@ -75,7 +75,7 @@ public final class ClientSmartInvocationServiceImpl extends ClientInvocationServ
 
     private Connection getConnection(Address target) throws IOException {
         ensureOwnerConnectionAvailable();
-        return connectionManager.getOrConnect(target, authenticator);
+        return connectionManager.getOrTriggerConnect(target, authenticator);
     }
 
     private void ensureOwnerConnectionAvailable() throws IOException {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/util/ClientAddressCancellableDelegatingFuture.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/util/ClientAddressCancellableDelegatingFuture.java
@@ -48,10 +48,14 @@ public class ClientAddressCancellableDelegatingFuture<V> extends ClientCancellab
             return false;
         }
 
-        waitForRequestToBeSend();
-        ClientInvocationFuture f = invokeCancelRequest(mayInterruptIfRunning);
+        boolean cancelSuccessful = false;
         try {
-            boolean cancelSuccessful = ExecutorServiceCancelOnAddressCodec.decodeResponse(f.get()).response;
+            cancelSuccessful = invokeCancelRequest(mayInterruptIfRunning);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+
+        try {
             if (cancelSuccessful) {
                 setError(new CancellationException());
                 cancelled = true;
@@ -65,13 +69,16 @@ public class ClientAddressCancellableDelegatingFuture<V> extends ClientCancellab
         }
     }
 
-    private ClientInvocationFuture invokeCancelRequest(boolean mayInterruptIfRunning) {
+    private boolean invokeCancelRequest(boolean mayInterruptIfRunning) throws InterruptedException {
+        waitForRequestToBeSend();
+
         ClientInvocation clientInvocation;
         final HazelcastClientInstanceImpl client = (HazelcastClientInstanceImpl) context.getHazelcastInstance();
         ClientMessage request = ExecutorServiceCancelOnAddressCodec.encodeRequest(uuid, target, mayInterruptIfRunning);
         clientInvocation = new ClientInvocation(client, request, target);
         try {
-            return clientInvocation.invoke();
+            ClientInvocationFuture f = clientInvocation.invoke();
+            return ExecutorServiceCancelOnAddressCodec.decodeResponse(f.get()).response;
         } catch (Exception e) {
             throw rethrow(e);
         }


### PR DESCRIPTION
When an invocation needs to be done and connection to destination
is not established yet, connection establishment used to be a blocking
operation. With this pr, if connection is not available yet, we only
trigger a new connect task async and related user request will be
handled by retry mechanism.

Secondly, invocation timeout handling is changed. # of times an
invocation made is used to be count with 1 second sleeps. Since
invocation itself can take time, user configured timeout was
used to be violated. It is now checked by comparing
System.currentTimeMillis and starting time.

backport https://github.com/hazelcast/hazelcast/pull/6702