### PR TITLE
Async connection creation for client invocations

### DIFF
--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/connection/ClientConnectionManager.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/connection/ClientConnectionManager.java
@@ -62,6 +62,14 @@ public interface ClientConnectionManager {
     Connection getOrConnect(Address address, Authenticator authenticator) throws IOException;
 
     /**
+     * @param address       to be connected
+     * @param authenticator Authenticator implementation to send appropriate Authentication Request after connection
+     * @return associated connection if available, triggers new connection creation otherwise
+     * @throws IOException if connection is not available at the time of call
+     */
+    Connection getOrTriggerConnect(Address address, Authenticator authenticator) throws IOException;
+
+    /**
      * Destroys the connection
      * Clears related resources of given connection.
      * ConnectionListener.connectionRemoved is called on registered listeners.

--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
@@ -52,6 +52,7 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.nio.channels.SocketChannel;
+import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -93,6 +94,8 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
     private final AddressTranslator addressTranslator;
     private final ConcurrentMap<Address, ClientConnection> connections
             = new ConcurrentHashMap<Address, ClientConnection>();
+    private final Set<Address> connectionsInProgress =
+            Collections.newSetFromMap(new ConcurrentHashMap<Address, Boolean>());
 
     private final Set<ConnectionListener> connectionListeners = new CopyOnWriteArraySet<ConnectionListener>();
     private final Set<ConnectionHeartbeatListener> heartbeatListeners =
@@ -194,9 +197,9 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
     }
 
     public ClientConnection getOrConnect(Address target, Authenticator authenticator) throws IOException {
-        Address address = addressTranslator.translate(target);
+        Address remoteAddress = addressTranslator.translate(target);
 
-        if (address == null) {
+        if (remoteAddress == null) {
             throw new IOException("Address is required!");
         }
 
@@ -206,14 +209,40 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
             synchronized (lock) {
                 connection = connections.get(target);
                 if (connection == null) {
-                    connection = createSocketConnection(address);
-                    authenticate(authenticator, connection);
-                    connections.put(connection.getRemoteEndpoint(), connection);
-                    fireConnectionAddedEvent(connection);
+                    connection = initializeConnection(remoteAddress, authenticator);
                 }
             }
         }
         return connection;
+    }
+
+    private ClientConnection initializeConnection(Address address, Authenticator authenticator) throws IOException {
+        ClientConnection connection = createSocketConnection(address);
+        authenticate(authenticator, connection);
+        connections.put(connection.getRemoteEndpoint(), connection);
+        fireConnectionAddedEvent(connection);
+        return connection;
+    }
+
+    public ClientConnection getOrTriggerConnect(Address target, Authenticator authenticator) throws IOException {
+        Address remoteAddress = addressTranslator.translate(target);
+
+        if (remoteAddress == null) {
+            throw new IOException("Address is required!");
+        }
+
+        ClientExecutionServiceImpl executionService = (ClientExecutionServiceImpl) client.getClientExecutionService();
+        ClientConnection connection = connections.get(target);
+
+        if (connection != null) {
+            return connection;
+        }
+
+        if (connectionsInProgress.add(target)) {
+            executionService.executeInternal(new InitConnectionTask(target, remoteAddress, authenticator));
+        }
+
+        throw new IOException("No available connection to address " + target);
     }
 
     private void authenticate(Authenticator authenticator, ClientConnection connection) throws IOException {
@@ -370,5 +399,38 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
     @Override
     public void addConnectionHeartbeatListener(ConnectionHeartbeatListener connectionHeartbeatListener) {
         heartbeatListeners.add(connectionHeartbeatListener);
+    }
+
+
+    private class InitConnectionTask implements Runnable {
+
+        private final Address target;
+        private final Address remoteAddress;
+        private final Authenticator authenticator;
+
+        InitConnectionTask(Address target, Address remoteAddress, Authenticator authenticator) {
+            this.target = target;
+            this.remoteAddress = remoteAddress;
+            this.authenticator = authenticator;
+        }
+
+        @Override
+        public void run() {
+            final Object lock = getLock(target);
+            synchronized (lock) {
+                ClientConnection connection = connections.get(target);
+                if (connection != null) {
+                    return;
+                }
+                try {
+                    initializeConnection(remoteAddress, authenticator);
+                } catch (IOException e) {
+                    LOGGER.finest(e);
+                } finally {
+                    connectionsInProgress.remove(target);
+                }
+
+            }
+        }
     }
 }

--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/spi/impl/ClientSmartInvocationServiceImpl.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/spi/impl/ClientSmartInvocationServiceImpl.java
@@ -76,7 +76,7 @@ public final class ClientSmartInvocationServiceImpl extends ClientInvocationServ
 
     private Connection getConnection(Address target) throws IOException {
         ensureOwnerConnectionAvailable();
-        return connectionManager.getOrConnect(target, authenticator);
+        return connectionManager.getOrTriggerConnect(target, authenticator);
     }
 
     private void ensureOwnerConnectionAvailable() throws IOException {

--- a/hazelcast-client-new/src/test/java/com/hazelcast/client/ClientConnectionTest.java
+++ b/hazelcast-client-new/src/test/java/com/hazelcast/client/ClientConnectionTest.java
@@ -24,22 +24,35 @@ import com.hazelcast.client.impl.HazelcastClientInstanceImpl;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.core.Client;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IExecutorService;
+import com.hazelcast.core.Member;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.ConnectionListener;
+import com.hazelcast.security.UsernamePasswordCredentials;
+import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.util.EmptyStatement;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import java.io.Serializable;
 import java.net.InetSocketAddress;
 import java.util.Collection;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category(QuickTest.class)
@@ -141,4 +154,77 @@ public class ClientConnectionTest extends HazelcastTestSupport {
         }
     }
 
+    @Test
+    public void testAsyncConnectionCreationInAsyncMethods() throws ExecutionException, InterruptedException {
+        hazelcastFactory.newHazelcastInstance();
+        CountDownLatch countDownLatch = new CountDownLatch(1);
+        ClientConfig config = new ClientConfig();
+        WaitingCredentials credentials = new WaitingCredentials("dev", "dev-pass", countDownLatch);
+        config.setCredentials(credentials);
+        HazelcastInstance client = hazelcastFactory.newHazelcastClient(config);
+        final IExecutorService executorService = client.getExecutorService(randomString());
+
+        credentials.waitFlag.set(true);
+
+        final HazelcastInstance secondInstance = hazelcastFactory.newHazelcastInstance();
+        final AtomicReference<Future> atomicReference = new AtomicReference<Future>();
+        Thread thread = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                Member secondMember = secondInstance.getCluster().getLocalMember();
+                Future future = executorService.submitToMember(new DummySerializableCallable(), secondMember);
+                atomicReference.set(future);
+            }
+        });
+        thread.start();
+        try {
+            assertTrueEventually(new AssertTask() {
+                @Override
+                public void run() throws Exception {
+                    assertNotNull(atomicReference.get());
+                }
+            }, 30);
+        } finally {
+            thread.interrupt();
+            thread.join();
+            countDownLatch.countDown();
+        }
+
+    }
+
+
+    static class WaitingCredentials extends UsernamePasswordCredentials {
+
+        private final CountDownLatch countDownLatch;
+        AtomicBoolean waitFlag = new AtomicBoolean();
+
+        public WaitingCredentials(String username, String password, CountDownLatch countDownLatch) {
+            super(username, password);
+            this.countDownLatch = countDownLatch;
+        }
+
+        @Override
+        public String getUsername() {
+            return super.getUsername();
+        }
+
+        @Override
+        public String getPassword() {
+            if (waitFlag.get()) {
+                try {
+                    countDownLatch.await();
+                } catch (InterruptedException e) {
+                    EmptyStatement.ignore(e);
+                }
+            }
+            return super.getPassword();
+        }
+    }
+
+    static class DummySerializableCallable implements Callable, Serializable {
+        @Override
+        public Object call() throws Exception {
+            return null;
+        }
+    }
 }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/ClientConnectionManager.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/ClientConnectionManager.java
@@ -62,6 +62,14 @@ public interface ClientConnectionManager {
     Connection getOrConnect(Address address, Authenticator authenticator) throws IOException;
 
     /**
+     * @param address       to be connected
+     * @param authenticator Authenticator implementation to send appropriate Authentication Request after connection
+     * @return associated connection if available, triggers new connection creation otherwise
+     * @throws IOException if connection is not available at the time of call
+     */
+    Connection getOrTriggerConnect(Address address, Authenticator authenticator) throws IOException;
+
+    /**
      * Destroys the connection
      * Clears related resources of given connection.
      * ConnectionListener.connectionRemoved is called on registered listeners.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
@@ -51,6 +51,7 @@ import com.hazelcast.util.ExceptionUtil;
 import java.io.IOException;
 import java.net.Socket;
 import java.nio.channels.SocketChannel;
+import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -92,6 +93,8 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
     private final AddressTranslator addressTranslator;
     private final ConcurrentMap<Address, ClientConnection> connections
             = new ConcurrentHashMap<Address, ClientConnection>();
+    private final Set<Address> connectionsInProgress =
+            Collections.newSetFromMap(new ConcurrentHashMap<Address, Boolean>());
 
     private final Set<ConnectionListener> connectionListeners = new CopyOnWriteArraySet<ConnectionListener>();
     private final Set<ConnectionHeartbeatListener> heartbeatListeners =
@@ -194,9 +197,9 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
     }
 
     public ClientConnection getOrConnect(Address target, Authenticator authenticator) throws IOException {
-        Address address = addressTranslator.translate(target);
+        Address remoteAddress = addressTranslator.translate(target);
 
-        if (address == null) {
+        if (remoteAddress == null) {
             throw new IOException("Address is required!");
         }
 
@@ -206,14 +209,40 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
             synchronized (lock) {
                 connection = connections.get(target);
                 if (connection == null) {
-                    connection = createSocketConnection(address);
-                    authenticate(authenticator, connection);
-                    connections.put(connection.getRemoteEndpoint(), connection);
-                    fireConnectionAddedEvent(connection);
+                    connection = initializeConnection(remoteAddress, authenticator);
                 }
             }
         }
         return connection;
+    }
+
+    private ClientConnection initializeConnection(Address address, Authenticator authenticator) throws IOException {
+        ClientConnection connection = createSocketConnection(address);
+        authenticate(authenticator, connection);
+        connections.put(connection.getRemoteEndpoint(), connection);
+        fireConnectionAddedEvent(connection);
+        return connection;
+    }
+
+    public ClientConnection getOrTriggerConnect(Address target, Authenticator authenticator) throws IOException {
+        Address remoteAddress = addressTranslator.translate(target);
+
+        if (remoteAddress == null) {
+            throw new IOException("Address is required!");
+        }
+
+        ClientExecutionServiceImpl executionService = (ClientExecutionServiceImpl) client.getClientExecutionService();
+        ClientConnection connection = connections.get(target);
+
+        if (connection != null) {
+            return connection;
+        }
+
+        if (connectionsInProgress.add(target)) {
+            executionService.executeInternal(new InitConnectionTask(target, remoteAddress, authenticator));
+        }
+
+        throw new IOException("No available connection to address " + target);
     }
 
     private void authenticate(Authenticator authenticator, ClientConnection connection) throws IOException {
@@ -365,5 +394,37 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
     @Override
     public void addConnectionHeartbeatListener(ConnectionHeartbeatListener connectionHeartbeatListener) {
         heartbeatListeners.add(connectionHeartbeatListener);
+    }
+
+    private class InitConnectionTask implements Runnable {
+
+        private final Address target;
+        private final Address remoteAddress;
+        private final Authenticator authenticator;
+
+        InitConnectionTask(Address target, Address remoteAddress, Authenticator authenticator) {
+            this.target = target;
+            this.remoteAddress = remoteAddress;
+            this.authenticator = authenticator;
+        }
+
+        @Override
+        public void run() {
+            final Object lock = getLock(target);
+            synchronized (lock) {
+                ClientConnection connection = connections.get(target);
+                if (connection != null) {
+                    return;
+                }
+                try {
+                    initializeConnection(remoteAddress, authenticator);
+                } catch (IOException e) {
+                    LOGGER.finest(e);
+                } finally {
+                    connectionsInProgress.remove(target);
+                }
+
+            }
+        }
     }
 }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocation.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocation.java
@@ -39,7 +39,6 @@ import com.hazelcast.spi.exception.RetryableHazelcastException;
 import java.io.IOException;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.hazelcast.client.config.ClientProperties.PROP_HEARTBEAT_INTERVAL_DEFAULT;
 
@@ -55,14 +54,13 @@ public class ClientInvocation implements Runnable {
     private final ClientListenerServiceImpl listenerService;
     private final ClientRequest request;
     private final EventHandler handler;
-    private final long retryCountLimit;
 
     private final ClientInvocationFuture clientInvocationFuture;
     private final int heartBeatInterval;
-    private final AtomicInteger reSendCount = new AtomicInteger();
     private final Address address;
     private final int partitionId;
     private final Connection connection;
+    private long retryTimeoutPointInMillis;
     private volatile ClientConnection sendConnection;
 
     private ClientInvocation(HazelcastClientInstanceImpl client, EventHandler handler,
@@ -84,7 +82,7 @@ public class ClientInvocation implements Runnable {
                 : Integer.parseInt(ClientProperties.PROP_INVOCATION_TIMEOUT_SECONDS_DEFAULT);
 
         clientInvocationFuture = new ClientInvocationFuture(this, client, request, handler);
-        this.retryCountLimit = retryTimeoutInSeconds / RETRY_WAIT_TIME_IN_SECONDS;
+        this.retryTimeoutPointInMillis = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(retryTimeoutInSeconds);
 
         int interval = clientProperties.getHeartbeatInterval().getInteger();
         this.heartBeatInterval = interval > 0 ? interval : Integer.parseInt(PROP_HEARTBEAT_INTERVAL_DEFAULT);
@@ -221,7 +219,7 @@ public class ClientInvocation implements Runnable {
         if (isBindToSingleConnection()) {
             return false;
         }
-        if (handler == null && reSendCount.incrementAndGet() > retryCountLimit) {
+        if (handler == null && System.currentTimeMillis() > retryTimeoutPointInMillis) {
             return false;
         }
         if (handler != null) {
@@ -285,11 +283,14 @@ public class ClientInvocation implements Runnable {
         this.sendConnection = connection;
     }
 
-    public ClientConnection getSendConnection() {
+    public ClientConnection getSendConnectionOrWait() throws InterruptedException {
+        while (sendConnection == null && !clientInvocationFuture.isDone()) {
+            Thread.sleep(TimeUnit.SECONDS.toMillis(RETRY_WAIT_TIME_IN_SECONDS));
+        }
         return sendConnection;
     }
 
-    public boolean isInvoked() {
-        return sendConnection != null;
+    public ClientConnection getSendConnection() {
+        return sendConnection;
     }
 }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientSmartInvocationServiceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientSmartInvocationServiceImpl.java
@@ -75,7 +75,7 @@ public final class ClientSmartInvocationServiceImpl extends ClientInvocationServ
 
     private Connection getConnection(Address target) throws IOException {
         ensureOwnerConnectionAvailable();
-        return connectionManager.getOrConnect(target, authenticator);
+        return connectionManager.getOrTriggerConnect(target, authenticator);
     }
 
     private void ensureOwnerConnectionAvailable() throws IOException {

--- a/hazelcast-client/src/test/java/com/hazelcast/client/ClientConnectionTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ClientConnectionTest.java
@@ -24,22 +24,35 @@ import com.hazelcast.client.impl.HazelcastClientInstanceImpl;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.core.Client;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IExecutorService;
+import com.hazelcast.core.Member;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.ConnectionListener;
+import com.hazelcast.security.UsernamePasswordCredentials;
+import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.util.EmptyStatement;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import java.io.Serializable;
 import java.net.InetSocketAddress;
 import java.util.Collection;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category(QuickTest.class)
@@ -141,4 +154,77 @@ public class ClientConnectionTest extends HazelcastTestSupport {
         }
     }
 
+    @Test
+    public void testAsyncConnectionCreationInAsyncMethods() throws ExecutionException, InterruptedException {
+        hazelcastFactory.newHazelcastInstance();
+        CountDownLatch countDownLatch = new CountDownLatch(1);
+        ClientConfig config = new ClientConfig();
+        WaitingCredentials credentials = new WaitingCredentials("dev", "dev-pass", countDownLatch);
+        config.setCredentials(credentials);
+        HazelcastInstance client = hazelcastFactory.newHazelcastClient(config);
+        final IExecutorService executorService = client.getExecutorService(randomString());
+
+        credentials.waitFlag.set(true);
+
+        final HazelcastInstance secondInstance = hazelcastFactory.newHazelcastInstance();
+        final AtomicReference<Future> atomicReference = new AtomicReference<Future>();
+        Thread thread = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                Member secondMember = secondInstance.getCluster().getLocalMember();
+                Future future = executorService.submitToMember(new DummySerializableCallable(), secondMember);
+                atomicReference.set(future);
+            }
+        });
+        thread.start();
+        try {
+            assertTrueEventually(new AssertTask() {
+                @Override
+                public void run() throws Exception {
+                    assertNotNull(atomicReference.get());
+                }
+            }, 30);
+        } finally {
+            thread.interrupt();
+            thread.join();
+            countDownLatch.countDown();
+        }
+
+    }
+
+
+    static class WaitingCredentials extends UsernamePasswordCredentials {
+
+        private final CountDownLatch countDownLatch;
+        AtomicBoolean waitFlag = new AtomicBoolean();
+
+        public WaitingCredentials(String username, String password, CountDownLatch countDownLatch) {
+            super(username, password);
+            this.countDownLatch = countDownLatch;
+        }
+
+        @Override
+        public String getUsername() {
+            return super.getUsername();
+        }
+
+        @Override
+        public String getPassword() {
+            if (waitFlag.get()) {
+                try {
+                    countDownLatch.await();
+                } catch (InterruptedException e) {
+                    EmptyStatement.ignore(e);
+                }
+            }
+            return super.getPassword();
+        }
+    }
+
+    static class DummySerializableCallable implements Callable, Serializable {
+        @Override
+        public Object call() throws Exception {
+            return null;
+        }
+    }
 }


### PR DESCRIPTION
When an invocation needs to be done and connection to destination
is not established yet, connection establishment used to be a blocking
operation. With this pr, if connection is not available yet, we only
trigger a new connect task async and related user request will be
handled by retry mechanism.

Secondly, invocation timeout handling is changed. # of times an
invocation made is used to be count with 1 second sleeps. Since
invocation itself can take time, user configured timeout was
used to be violated. It is now checked by comparing
System.currentTimeMillis and starting time.