### PR TITLE
add getAll/putAll methods in TransactionalMap interface

### DIFF
--- a/hazelcast-client-legacy/src/main/java/com/hazelcast/client/txn/proxy/ClientTxnMapProxy.java
+++ b/hazelcast-client-legacy/src/main/java/com/hazelcast/client/txn/proxy/ClientTxnMapProxy.java
@@ -22,13 +22,17 @@ import com.hazelcast.map.impl.MapKeySet;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.map.impl.MapValueCollection;
 import com.hazelcast.map.impl.client.TxnMapRequest;
+import com.hazelcast.map.impl.client.TxnMapRequestWithDataMap;
+import com.hazelcast.map.impl.client.TxnMapRequestWithKeySet;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.query.Predicate;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
@@ -60,6 +64,21 @@ public class ClientTxnMapProxy<K, V> extends ClientTxnProxy implements Transacti
     }
 
     @Override
+    public Map<K, V> getAll(Set<K> keys) {
+        final Set<Data> dataKeySet = new HashSet<Data>(keys.size());
+        for (K key : keys) {
+            dataKeySet.add(toData(key));
+        }
+        TxnMapRequestWithKeySet request = new TxnMapRequestWithKeySet(getName(),
+                TxnMapRequest.TxnMapRequestType.GET_ALL, dataKeySet);
+        Map<Data, Data> dataMap = invoke(request);
+        Map<K, V> result = new HashMap<K, V>(dataMap.size());
+        for (Map.Entry<Data, Data> entry : dataMap.entrySet()) {
+            result.put((K) toObject(entry.getKey()), (V) toObject(entry.getValue()));
+        }
+        return result;
+    }
+
     public int size() {
         TxnMapRequest request = new TxnMapRequest(getName(), TxnMapRequest.TxnMapRequestType.SIZE);
         return this.<Integer>invoke(request);
@@ -83,9 +102,21 @@ public class ClientTxnMapProxy<K, V> extends ClientTxnProxy implements Transacti
         return invoke(request);
     }
 
-    @Override
     public void set(K key, V value) {
-        TxnMapRequest request = new TxnMapRequest(getName(), TxnMapRequest.TxnMapRequestType.SET, toData(key), toData(value));
+        TxnMapRequest request = new TxnMapRequest(
+                getName(), TxnMapRequest.TxnMapRequestType.SET, toData(key), toData(value));
+        invoke(request);
+    }
+
+    @Override
+    public void putAll(Map<? extends K, ? extends V> entries) {
+        final Map<Data, Data> dataMap = new HashMap<Data, Data>(entries.size());
+        for (Object o : entries.entrySet()) {
+            Map.Entry<K, V> entry = (Map.Entry<K, V>) o;
+            dataMap.put(toData(entry.getKey()), toData(entry.getValue()));
+        }
+        TxnMapRequestWithDataMap request = new TxnMapRequestWithDataMap(getName(),
+                TxnMapRequest.TxnMapRequestType.PUT_ALL, dataMap);
         invoke(request);
     }
 
@@ -191,7 +222,7 @@ public class ClientTxnMapProxy<K, V> extends ClientTxnProxy implements Transacti
         return MapService.SERVICE_NAME;
     }
 
-    @Override
-    void onDestroy() {
+    @Override void onDestroy() {
     }
+
 }

--- a/hazelcast-client-legacy/src/test/java/com/hazelcast/client/txn/ClientTxnMapTest.java
+++ b/hazelcast-client-legacy/src/test/java/com/hazelcast/client/txn/ClientTxnMapTest.java
@@ -36,6 +36,8 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -545,5 +547,25 @@ public class ClientTxnMapTest {
         final TransactionalMap<Object, Object> txMap = context.getMap(mapName);
 
         txMap.values(null);
+    }
+
+    @Test
+    public void testTxnMapPutGetAll() throws Exception {
+        final String mapName = randomString();
+        final IMap map = client.getMap(mapName);
+
+        final TransactionContext context = client.newTransactionContext();
+        context.beginTransaction();
+        final TransactionalMap<Object, Object> txnMap = context.getMap(mapName);
+        Map<String, String> values = new HashMap<String, String>(3);
+        values.put("key1", "value1");
+        values.put("key2", "value2");
+        values.put("key3", "value3");
+        txnMap.putAll(values);
+        context.commitTransaction();
+        Map<String, String> result = map.getAll(values.keySet());
+        for (String key: values.keySet()) {
+            assertEquals(values.get(key), result.get(key));
+        }
     }
 }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/txn/ClientTxnMapProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/txn/ClientTxnMapProxy.java
@@ -44,6 +44,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
@@ -75,6 +76,23 @@ public class ClientTxnMapProxy<K, V> extends ClientTxnProxy implements Transacti
     }
 
     @Override
+    public Map<K, V> getAll(Set<K> keys) {
+//        final Set<Data> dataKeySet = new HashSet<Data>(keys.size());
+//        for (K key : keys) {
+//            dataKeySet.add(toData(key));
+//        }
+//        TxnMapRequestWithKeySet request = new TxnMapRequestWithKeySet(getName(),
+//                TxnMapRequest.TxnMapRequestType.GET_ALL, dataKeySet);
+//        Map<Data, Data> dataMap = invoke(request);
+//        Map<K, V> result = new HashMap<K, V>(dataMap.size());
+//        for (Map.Entry<Data, Data> entry: dataMap.entrySet()) {
+//            result.put((K) toObject(entry.getKey()), (V) toObject(entry.getValue()));
+//        }
+//        return result;
+        return null;
+    }
+
+    @Override
     public V getForUpdate(Object key) {
         ClientMessage request = TransactionalMapGetForUpdateCodec.encodeRequest(name, getTransactionId(),
                 ThreadUtil.getThreadId(), toData(key));
@@ -98,6 +116,18 @@ public class ClientTxnMapProxy<K, V> extends ClientTxnProxy implements Transacti
     @Override
     public V put(K key, V value) {
         return put(key, value, -1, TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    public void putAll(Map<? extends K, ? extends V> entries) {
+//        final Map<Data, Data> dataMap = new HashMap<Data, Data>(entries.size());
+//        for (Object o : entries.entrySet()) {
+//            Map.Entry<K, V> entry = (Map.Entry<K, V>) o;
+//            dataMap.put(toData(entry.getKey()), toData(entry.getValue()));
+//        }
+//        TxnMapRequestWithDataMap request = new TxnMapRequestWithDataMap(getName(),
+//                TxnMapRequest.TxnMapRequestType.PUT_ALL, dataMap);
+//        invoke(request);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/core/BaseMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/BaseMap.java
@@ -16,6 +16,11 @@
 
 package com.hazelcast.core;
 
+import java.util.Map;
+import java.util.Set;
+
+import com.hazelcast.query.Predicate;
+
 /**
  * Base interface for Hazelcast distributed maps.
  *
@@ -44,6 +49,26 @@ public interface BaseMap<K, V> extends DistributedObject {
     V get(Object key);
 
     /**
+     * Returns the entries for the given keys. If any keys are not present in the Map, it will
+     * call {@link MapStore#loadAll(java.util.Collection)}.
+     * <p/>
+     * <p><b>Warning:</b></p>
+     * The returned map is <b>NOT</b> backed by the original map,
+     * so changes to the original map are <b>NOT</b> reflected in the returned map, and vice-versa.
+     * <p/>
+     * <p><b>Warning-2:</b></p>
+     * This method uses <tt>hashCode</tt> and <tt>equals</tt> of binary form of
+     * the <tt>keys</tt>, not the actual implementations of <tt>hashCode</tt> and <tt>equals</tt>
+     * defined in <tt>key</tt>'s class.
+     * <p/>
+     *
+     * @param keys keys to get
+     * @return map of entries
+     * @throws NullPointerException if any of the specified keys are null
+     */
+    Map<K, V> getAll(Set<K> keys);
+
+    /**
      * Associates the specified value with the specified key in this map.
      * If the map previously contained a mapping for
      * the key, the old value is replaced by the specified value.
@@ -54,6 +79,14 @@ public interface BaseMap<K, V> extends DistributedObject {
      * if there was no mapping for {@code key}.
      */
     V put(K key, V value);
+
+    /**
+     * Copies all of the mappings from the specified map to this map.
+     * The effect of this call is equivalent to that of calling put(k, v) on this map once
+     * for each mapping from key k to value v in the specified map. The behavior of this
+     * operation is undefined if the specified map is modified while the operation is in progress.
+     */
+    void putAll(Map<? extends K, ? extends V> entries);
 
     /**
      * Associates the specified value with the specified key in this map.
@@ -172,4 +205,29 @@ public interface BaseMap<K, V> extends DistributedObject {
      * @return the number of entries in this map.
      */
     int size();
+
+    /**
+     * Returns a set clone of the keys contained in this map.
+     * The set is <b>NOT</b> backed by the map,
+     * so changes to the map are <b>NOT</b> reflected in the set, and vice-versa.
+     *
+     * @return a set clone of the keys contained in this map
+     */
+    Set<K> keySet();
+
+    /**
+     * Queries the map based on the specified predicate and
+     * returns the keys of matching entries.
+     * <p/>
+     * Specified predicate runs on all members in parallel.
+     * <p/>
+     * <p><b>Warning:</b></p>
+     * The set is <b>NOT</b> backed by the map,
+     * so changes to the map are <b>NOT</b> reflected in the set, and vice-versa.
+     *
+     * @param predicate specified query criteria
+     * @return result key set of the query
+     */
+    Set<K> keySet(Predicate predicate);
+
 }

--- a/hazelcast/src/main/java/com/hazelcast/core/TransactionalMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/TransactionalMap.java
@@ -20,7 +20,6 @@ import com.hazelcast.query.Predicate;
 import com.hazelcast.transaction.TransactionalObject;
 
 import java.util.Collection;
-import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -194,14 +193,14 @@ public interface TransactionalMap<K, V> extends TransactionalObject, BaseMap<K, 
      *
      * @see IMap#keySet()
      */
-    Set<K> keySet();
+    //Set<K> keySet();
 
     /**
      * Transactional implementation of {@link IMap#keySet(com.hazelcast.query.Predicate)}.
      *
      * @see IMap#keySet(com.hazelcast.query.Predicate)
      */
-    Set<K> keySet(Predicate predicate);
+    //Set<K> keySet(Predicate predicate);
 
     /**
      * Transactional implementation of {@link IMap#values()}.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapPortableHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapPortableHook.java
@@ -63,6 +63,8 @@ import com.hazelcast.map.impl.client.MapTryPutRequest;
 import com.hazelcast.map.impl.client.MapTryRemoveRequest;
 import com.hazelcast.map.impl.client.MapUnlockRequest;
 import com.hazelcast.map.impl.client.TxnMapRequest;
+import com.hazelcast.map.impl.client.TxnMapRequestWithDataMap;
+import com.hazelcast.map.impl.client.TxnMapRequestWithKeySet;
 import com.hazelcast.map.impl.client.TxnMapRequestWithSQLQuery;
 import com.hazelcast.nio.serialization.ClassDefinition;
 import com.hazelcast.nio.serialization.Portable;
@@ -127,6 +129,8 @@ public class MapPortableHook implements PortableHook {
     public static final int ADD_MAP_PARTITION_LOST_LISTENER = 51;
     public static final int REMOVE_MAP_PARTITION_LOST_LISTENER = 52;
     public static final int CLEAR_NEAR_CACHE = 53;
+    public static final int TXN_REQUEST_WITH_KEYSET = 54;
+    public static final int TXN_REQUEST_WITH_DATAMAP = 55;
 
     @Override
     public int getFactoryId() {
@@ -137,7 +141,7 @@ public class MapPortableHook implements PortableHook {
     public PortableFactory createFactory() {
         return new PortableFactory() {
             final ConstructorFunction<Integer, Portable>[] constructors
-                    = new ConstructorFunction[CLEAR_NEAR_CACHE + 1];
+                    = new ConstructorFunction[TXN_REQUEST_WITH_DATAMAP + 1];
 
             {
                 constructors[GET] = new ConstructorFunction<Integer, Portable>() {
@@ -412,6 +416,17 @@ public class MapPortableHook implements PortableHook {
                 constructors[CLEAR_NEAR_CACHE] = new ConstructorFunction<Integer, Portable>() {
                     public Portable createNew(Integer arg) {
                         return new MapClearNearCacheRequest();
+                    }
+                };
+                constructors[TXN_REQUEST_WITH_KEYSET] = new ConstructorFunction<Integer, Portable>() {
+                    public Portable createNew(Integer arg) {
+                        return new TxnMapRequestWithKeySet();
+                    }
+                };
+
+                constructors[TXN_REQUEST_WITH_DATAMAP] = new ConstructorFunction<Integer, Portable>() {
+                    public Portable createNew(Integer arg) {
+                        return new TxnMapRequestWithDataMap();
                     }
                 };
             }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/client/AbstractTxnMapRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/client/AbstractTxnMapRequest.java
@@ -72,8 +72,9 @@ public abstract class AbstractTxnMapRequest extends BaseTransactionRequest {
         this(name, requestType, key, value);
         this.newValue = newValue;
     }
+
     public AbstractTxnMapRequest(String name, TxnMapRequestType requestType, Data key, Data value,
-            long ttl, TimeUnit timeUnit) {
+                                 long ttl, TimeUnit timeUnit) {
         this(name, requestType, key, value);
         this.ttl = timeUnit == null ? ttl : timeUnit.toMillis(ttl);
     }
@@ -85,8 +86,7 @@ public abstract class AbstractTxnMapRequest extends BaseTransactionRequest {
         return innerCallInternal(map);
     }
 
-
-    private Object innerCallInternal(final TransactionalMap map) {
+    protected Object innerCallInternal(final TransactionalMap map) {
         Object result = null;
         switch (requestType) {
             case CONTAINS_KEY:
@@ -204,108 +204,102 @@ public abstract class AbstractTxnMapRequest extends BaseTransactionRequest {
 
     public enum TxnMapRequestType {
         CONTAINS_KEY(1) {
-            @Override
-            Permission getRequiredPermission(String name) {
+            @Override Permission getRequiredPermission(String name) {
                 return getMapReadPermission(name);
             }
         },
 
         GET(2) {
-            @Override
-            Permission getRequiredPermission(String name) {
+            @Override Permission getRequiredPermission(String name) {
                 return getMapReadPermission(name);
             }
         },
         SIZE(3) {
-            @Override
-            Permission getRequiredPermission(String name) {
+            @Override Permission getRequiredPermission(String name) {
                 return getMapReadPermission(name);
             }
         },
         PUT(4) {
-            @Override
-            Permission getRequiredPermission(String name) {
+            @Override Permission getRequiredPermission(String name) {
                 return getMapLockedWritePermission(name);
             }
         },
         PUT_IF_ABSENT(5) {
-            @Override
-            Permission getRequiredPermission(String name) {
+            @Override Permission getRequiredPermission(String name) {
                 return getMapLockedWritePermission(name);
             }
         },
         REPLACE(6) {
-            @Override
-            Permission getRequiredPermission(String name) {
+            @Override Permission getRequiredPermission(String name) {
                 return getMapLockedWritePermission(name);
             }
         },
         REPLACE_IF_SAME(7) {
-            @Override
-            Permission getRequiredPermission(String name) {
+            @Override Permission getRequiredPermission(String name) {
                 return getMapLockedWritePermission(name);
             }
         },
         SET(8) {
-            @Override
-            Permission getRequiredPermission(String name) {
+            @Override Permission getRequiredPermission(String name) {
                 return getMapLockedWritePermission(name);
             }
         },
         REMOVE(9) {
-            @Override
-            Permission getRequiredPermission(String name) {
+            @Override Permission getRequiredPermission(String name) {
                 return getMapLockedRemovePermission(name);
             }
         },
         DELETE(10) {
-            @Override
-            Permission getRequiredPermission(String name) {
+            @Override Permission getRequiredPermission(String name) {
                 return getMapLockedRemovePermission(name);
             }
         },
         REMOVE_IF_SAME(11) {
-            @Override
-            Permission getRequiredPermission(String name) {
+            @Override Permission getRequiredPermission(String name) {
                 return getMapLockedRemovePermission(name);
             }
         },
         KEYSET(12) {
-            @Override
-            Permission getRequiredPermission(String name) {
+            @Override Permission getRequiredPermission(String name) {
                 return getMapReadPermission(name);
             }
         },
         KEYSET_BY_PREDICATE(13) {
-            @Override
-            Permission getRequiredPermission(String name) {
+            @Override Permission getRequiredPermission(String name) {
                 return getMapReadPermission(name);
             }
         },
         VALUES(14) {
-            @Override
-            Permission getRequiredPermission(String name) {
+            @Override Permission getRequiredPermission(String name) {
                 return getMapReadPermission(name);
             }
         },
         VALUES_BY_PREDICATE(15) {
-            @Override
-            Permission getRequiredPermission(String name) {
+            @Override Permission getRequiredPermission(String name) {
                 return getMapReadPermission(name);
             }
         },
         GET_FOR_UPDATE(16) {
-            @Override
-            Permission getRequiredPermission(String name) {
+            @Override Permission getRequiredPermission(String name) {
                 return getMapLockedReadPermission(name);
             }
         },
         PUT_WITH_TTL(17) {
-            @Override
-            Permission getRequiredPermission(String name) {
+            @Override Permission getRequiredPermission(String name) {
+                return getMapLockedWritePermission(name);
+            }
+        },
+        GET_ALL(18) {
+            @Override Permission getRequiredPermission(String name) {
+                return getMapReadPermission(name);
+            }
+        },
+        PUT_ALL(19) {
+            @Override Permission getRequiredPermission(String name) {
                 return getMapLockedWritePermission(name);
             }
         };
+
         int type;
 
         TxnMapRequestType(int i) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/client/TxnMapRequestWithDataMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/client/TxnMapRequestWithDataMap.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.client;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.hazelcast.core.TransactionalMap;
+import com.hazelcast.map.impl.MapPortableHook;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.query.Predicate;
+
+public class TxnMapRequestWithDataMap extends AbstractTxnMapRequest {
+
+    private Map<Data, Data> dataMap = new HashMap<Data, Data>();
+
+    public TxnMapRequestWithDataMap() {
+    }
+
+    public TxnMapRequestWithDataMap(String name, TxnMapRequestType requestType, Map<Data, Data> dataMap) {
+        super(name, requestType, null, null, null);
+        if (dataMap != null) {
+            this.dataMap.putAll(dataMap);
+        }
+    }
+
+    protected Predicate getPredicate() {
+        return null;
+    }
+
+    public int getClassId() {
+        return MapPortableHook.TXN_REQUEST_WITH_DATAMAP;
+    }
+
+    @Override
+    protected Object innerCallInternal(final TransactionalMap map) {
+        map.putAll(dataMap);
+        return null;
+    }
+
+    protected void readDataInner(ObjectDataInput in) throws IOException {
+        int size = in.readInt();
+        for (int i = 0; i < size; i++) {
+            dataMap.put(in.readData(), in.readData());
+        }
+    }
+
+    protected void writeDataInner(ObjectDataOutput out) throws IOException {
+        out.writeInt(dataMap.size());
+        for (Map.Entry<Data, Data> entry : dataMap.entrySet()) {
+            out.writeData(entry.getKey());
+            out.writeData(entry.getValue());
+        }
+    }
+
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/client/TxnMapRequestWithKeySet.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/client/TxnMapRequestWithKeySet.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.client;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
+
+import com.hazelcast.core.TransactionalMap;
+import com.hazelcast.map.impl.MapPortableHook;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.query.Predicate;
+
+public class TxnMapRequestWithKeySet extends AbstractTxnMapRequest {
+
+    private Set<Data> keySet = new HashSet<Data>();
+
+    public TxnMapRequestWithKeySet() {
+    }
+
+    public TxnMapRequestWithKeySet(String name, TxnMapRequestType requestType, Set<Data> keySet) {
+        super(name, requestType, null, null, null);
+        if (keySet != null) {
+            this.keySet.addAll(keySet);
+        }
+    }
+
+    protected Predicate getPredicate() {
+        return null;
+    }
+
+    public int getClassId() {
+        return MapPortableHook.TXN_REQUEST_WITH_KEYSET;
+    }
+
+    @Override
+    protected Object innerCallInternal(final TransactionalMap map) {
+        return map.getAll(keySet);
+    }
+
+    protected void readDataInner(ObjectDataInput in) throws IOException {
+        int size = in.readInt();
+        for (int i = 0; i < size; i++) {
+            keySet.add(in.readData());
+        }
+    }
+
+    protected void writeDataInner(ObjectDataOutput out) throws IOException {
+        out.writeInt(keySet.size());
+        for (Data key : keySet) {
+            out.writeData(key);
+        }
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TransactionalMapProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TransactionalMapProxy.java
@@ -123,6 +123,27 @@ public class TransactionalMapProxy extends TransactionalMapProxySupport implemen
     }
 
     @Override
+    public Map getAll(Set keys) {
+        checkTransactionState();
+        final MapService service = getService();
+        final MapServiceContext mapServiceContext = service.getMapServiceContext();
+        Map result = new HashMap(keys.size());
+        for (Object key: keys) {
+            Data keyData = mapServiceContext.toData(key, partitionStrategy);
+            TxnValueWrapper currentValue = txMap.get(keyData);
+            if (currentValue != null) {
+                result.put(key, checkIfRemoved(currentValue));
+            } else {
+                Object data = getInternal(keyData);
+                if (data != null) {
+                    result.put(key, mapServiceContext.toObject(data));
+                }
+            }
+        }
+        // todo: optimize it via getAllInternal ?
+        return result;
+    }
+
     public Object put(Object key, Object value) {
         checkTransactionState();
         MapService service = getService();
@@ -160,6 +181,24 @@ public class TransactionalMapProxy extends TransactionalMapProxySupport implemen
     }
 
     @Override
+    public void putAll(Map entries) {
+        checkTransactionState();
+        MapService service = getService();
+        final MapServiceContext mapServiceContext = service.getMapServiceContext();
+        for (Object e: entries.entrySet()) {
+            final Map.Entry entry = (Map.Entry) e;
+            Data keyData = mapServiceContext.toData(entry.getKey(), partitionStrategy);
+            final Object valueBeforeTxn = mapServiceContext.toObject(putInternal(keyData,
+                    mapServiceContext.toData(entry.getValue())));
+            if (entry.getValue() != null) {
+                TxnValueWrapper wrapper = valueBeforeTxn == null
+                        ? new TxnValueWrapper(entry.getValue(), TxnValueWrapper.Type.NEW)
+                        : new TxnValueWrapper(entry.getValue(), TxnValueWrapper.Type.UPDATED);
+                txMap.put(keyData, wrapper);
+            }
+        }
+    }
+
     public void set(Object key, Object value) {
         checkTransactionState();
         MapService service = getService();


### PR DESCRIPTION
Revives #4768 which needed rebasing.

Related to issue #4698.

Note that this PR contains client code from the days before the New Client. Therefore the implementation of the added getAll and putAll methods needs to be filled in.
