### PR TITLE
Fix distributed object listener unnecessary proxy creation 

### DIFF
--- a/hazelcast-client-legacy/src/main/java/com/hazelcast/client/spi/impl/listener/LazyDistributedObjectEvent.java
+++ b/hazelcast-client-legacy/src/main/java/com/hazelcast/client/spi/impl/listener/LazyDistributedObjectEvent.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.spi.impl.listener;
+
+import com.hazelcast.client.spi.ProxyManager;
+import com.hazelcast.core.DistributedObject;
+import com.hazelcast.core.DistributedObjectEvent;
+
+public final class LazyDistributedObjectEvent extends DistributedObjectEvent {
+
+    private ProxyManager proxyManager;
+
+    /**
+     * Constructs a DistributedObject Event.
+     *
+     * @param eventType         The event type as an enum {@link EventType} integer.
+     * @param serviceName       The service name of the DistributedObject.
+     * @param objectName        The name of the DistributedObject.
+     * @param distributedObject The DistributedObject for the event.
+     * @param proxyManager      The ProxyManager for lazily creating the proxy if not available on the client.
+     */
+    public LazyDistributedObjectEvent(EventType eventType, String serviceName, String objectName,
+                                      DistributedObject distributedObject,
+                                      ProxyManager proxyManager) {
+        super(eventType, serviceName, objectName, distributedObject);
+        this.proxyManager = proxyManager;
+    }
+
+    @Override
+    public DistributedObject getDistributedObject() {
+        distributedObject = super.getDistributedObject();
+        if (distributedObject == null) {
+            distributedObject = proxyManager.getOrCreateProxy(getServiceName(), (String) getObjectName());
+        }
+        return distributedObject;
+    }
+
+}

--- a/hazelcast-client-legacy/src/test/java/com/hazelcast/client/proxy/DistributedObjectListenerTest.java
+++ b/hazelcast-client-legacy/src/test/java/com/hazelcast/client/proxy/DistributedObjectListenerTest.java
@@ -17,20 +17,24 @@
 package com.hazelcast.client.proxy;
 
 import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.core.DistributedObject;
 import com.hazelcast.core.DistributedObjectEvent;
 import com.hazelcast.core.DistributedObjectListener;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.ITopic;
+import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
+import java.util.Collection;
+import java.util.concurrent.CountDownLatch;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import java.util.concurrent.CountDownLatch;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
@@ -46,7 +50,7 @@ public class DistributedObjectListenerTest extends HazelcastTestSupport {
     @Test
     public void destroyedNotReceivedOnClient() throws Exception {
         HazelcastInstance instance = hazelcastFactory.newHazelcastInstance();
-        HazelcastInstance client = hazelcastFactory.newHazelcastClient();
+        final HazelcastInstance client = hazelcastFactory.newHazelcastClient();
         final CountDownLatch createdLatch = new CountDownLatch(1);
         final CountDownLatch destroyedLatch = new CountDownLatch(1);
         client.addDistributedObjectListener(new DistributedObjectListener() {
@@ -65,6 +69,13 @@ public class DistributedObjectListenerTest extends HazelcastTestSupport {
         assertOpenEventually(createdLatch, 10);
         topic.destroy();
         assertOpenEventually(destroyedLatch, 10);
+        assertTrueAllTheTime(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                Collection<DistributedObject> distributedObjects = client.getDistributedObjects();
+                assertTrue(distributedObjects.isEmpty());
+            }
+        }, 5);
     }
 
 }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/listener/LazyDistributedObjectEvent.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/listener/LazyDistributedObjectEvent.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.spi.impl.listener;
+
+import com.hazelcast.client.spi.ProxyManager;
+import com.hazelcast.core.DistributedObject;
+import com.hazelcast.core.DistributedObjectEvent;
+
+public final class LazyDistributedObjectEvent extends DistributedObjectEvent {
+
+    private ProxyManager proxyManager;
+
+    /**
+     * Constructs a DistributedObject Event.
+     *
+     * @param eventType         The event type as an enum {@link EventType} integer.
+     * @param serviceName       The service name of the DistributedObject.
+     * @param objectName        The name of the DistributedObject.
+     * @param distributedObject The DistributedObject for the event.
+     * @param proxyManager      The ProxyManager for lazily creating the proxy if not available on the client.
+     */
+    public LazyDistributedObjectEvent(EventType eventType, String serviceName, String objectName,
+                                      DistributedObject distributedObject,
+                                      ProxyManager proxyManager) {
+        super(eventType, serviceName, objectName, distributedObject);
+        this.proxyManager = proxyManager;
+    }
+
+    @Override
+    public DistributedObject getDistributedObject() {
+        distributedObject = super.getDistributedObject();
+        if (distributedObject == null) {
+            distributedObject = proxyManager.getOrCreateProxy(getServiceName(), (String) getObjectName());
+        }
+        return distributedObject;
+    }
+
+}

--- a/hazelcast-client/src/test/java/com/hazelcast/client/proxy/DistributedObjectListenerTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/proxy/DistributedObjectListenerTest.java
@@ -17,20 +17,24 @@
 package com.hazelcast.client.proxy;
 
 import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.core.DistributedObject;
 import com.hazelcast.core.DistributedObjectEvent;
 import com.hazelcast.core.DistributedObjectListener;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.ITopic;
+import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
+import java.util.Collection;
+import java.util.concurrent.CountDownLatch;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import java.util.concurrent.CountDownLatch;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
@@ -46,7 +50,7 @@ public class DistributedObjectListenerTest extends HazelcastTestSupport {
     @Test
     public void destroyedNotReceivedOnClient() throws Exception {
         HazelcastInstance instance = hazelcastFactory.newHazelcastInstance();
-        HazelcastInstance client = hazelcastFactory.newHazelcastClient();
+        final HazelcastInstance client = hazelcastFactory.newHazelcastClient();
         final CountDownLatch createdLatch = new CountDownLatch(1);
         final CountDownLatch destroyedLatch = new CountDownLatch(1);
         client.addDistributedObjectListener(new DistributedObjectListener() {
@@ -65,6 +69,13 @@ public class DistributedObjectListenerTest extends HazelcastTestSupport {
         assertOpenEventually(createdLatch, 10);
         topic.destroy();
         assertOpenEventually(destroyedLatch, 10);
+        assertTrueAllTheTime(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                Collection<DistributedObject> distributedObjects = client.getDistributedObjects();
+                assertTrue(distributedObjects.isEmpty());
+            }
+        }, 5);
     }
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/client/AddDistributedObjectListenerRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/client/AddDistributedObjectListenerRequest.java
@@ -76,7 +76,7 @@ public class AddDistributedObjectListenerRequest extends BaseClientAddListenerRe
         }
 
         PortableDistributedObjectEvent portableEvent = new PortableDistributedObjectEvent(
-                event.getEventType(), event.getDistributedObject().getName(), event.getServiceName());
+                event.getEventType(), (String) event.getObjectName(), event.getServiceName());
         endpoint.sendEvent(null, portableEvent, getCallId());
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AddDistributedObjectListenerMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AddDistributedObjectListenerMessageTask.java
@@ -101,7 +101,7 @@ public class AddDistributedObjectListenerMessageTask
             return;
         }
 
-        String name = event.getDistributedObject().getName();
+        String name = (String) event.getObjectName();
         String serviceName = event.getServiceName();
         ClientMessage eventMessage =
                 ClientAddDistributedObjectListenerCodec.encodeDistributedObjectEvent(name,

--- a/hazelcast/src/main/java/com/hazelcast/core/DistributedObjectEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/DistributedObjectEvent.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.core;
 
+import com.hazelcast.spi.exception.DistributedObjectDestroyedException;
+
 /**
  * DistributedObjectEvent is fired when a {@link DistributedObject}
  * is created or destroyed cluster-wide.
@@ -25,22 +27,27 @@ package com.hazelcast.core;
  */
 public class DistributedObjectEvent {
 
+    protected DistributedObject distributedObject;
+
     private EventType eventType;
 
     private String serviceName;
 
-    private DistributedObject distributedObject;
+    private String objectName;
 
     /**
      * Constructs a DistributedObject Event.
      *
      * @param eventType         The event type as an enum {@link EventType} integer.
      * @param serviceName       The service name of the DistributedObject.
+     * @param objectName        The name of the DistributedObject.
      * @param distributedObject The DistributedObject for the event.
      */
-    public DistributedObjectEvent(EventType eventType, String serviceName, DistributedObject distributedObject) {
+    public DistributedObjectEvent(EventType eventType, String serviceName, String objectName,
+                                  DistributedObject distributedObject) {
         this.eventType = eventType;
         this.serviceName = serviceName;
+        this.objectName = objectName;
         this.distributedObject = distributedObject;
     }
 
@@ -79,15 +86,19 @@ public class DistributedObjectEvent {
      * @see DistributedObject#getName()
      */
     public Object getObjectName() {
-        return distributedObject.getName();
+        return objectName;
     }
 
     /**
      * Returns the DistributedObject instance.
      *
      * @return the DistributedObject instance
+     * @throws DistributedObjectDestroyedException if distributed object is destroyed.
      */
     public DistributedObject getDistributedObject() {
+        if (EventType.DESTROYED.equals(eventType)) {
+            throw new DistributedObjectDestroyedException(objectName + " destroyed!");
+        }
         return distributedObject;
     }
 
@@ -103,6 +114,7 @@ public class DistributedObjectEvent {
         return "DistributedObjectEvent{"
                 + "eventType=" + eventType
                 + ", serviceName='" + serviceName + '\''
+                + ", objectName='" + objectName + '\''
                 + ", distributedObject=" + distributedObject
                 + '}';
     }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/ProxyEventProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/ProxyEventProcessor.java
@@ -28,19 +28,21 @@ final class ProxyEventProcessor implements StripedRunnable {
     private final Collection<DistributedObjectListener> listeners;
     private final DistributedObjectEvent.EventType type;
     private final String serviceName;
+    private final String objectName;
     private final DistributedObject object;
 
     ProxyEventProcessor(Collection<DistributedObjectListener> listeners, DistributedObjectEvent.EventType eventType,
-                        String serviceName, DistributedObject object) {
+                        String serviceName, String objectName, DistributedObject object) {
         this.listeners = listeners;
         this.type = eventType;
         this.serviceName = serviceName;
+        this.objectName = objectName;
         this.object = object;
     }
 
     @Override
     public void run() {
-        DistributedObjectEvent event = new DistributedObjectEvent(type, serviceName, object);
+        DistributedObjectEvent event = new DistributedObjectEvent(type, serviceName, objectName, object);
         for (DistributedObjectListener listener : listeners) {
             switch (type) {
                 case CREATED:

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/ProxyRegistry.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/ProxyRegistry.java
@@ -26,7 +26,6 @@ import com.hazelcast.spi.RemoteService;
 import com.hazelcast.spi.impl.eventservice.InternalEventService;
 import com.hazelcast.util.EmptyStatement;
 import com.hazelcast.util.ExceptionUtil;
-
 import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -205,7 +204,8 @@ public final class ProxyRegistry {
         }
 
         InternalEventService eventService = proxyService.nodeEngine.getEventService();
-        ProxyEventProcessor callback = new ProxyEventProcessor(proxyService.listeners.values(), CREATED, serviceName, proxy);
+        ProxyEventProcessor callback = new ProxyEventProcessor(proxyService.listeners.values(), CREATED, serviceName,
+                name, proxy);
         eventService.executeEventCallback(callback);
         if (publishEvent) {
             publish(new DistributedObjectEventPacket(CREATED, serviceName, name));
@@ -235,7 +235,8 @@ public final class ProxyRegistry {
             return;
         }
         InternalEventService eventService = proxyService.nodeEngine.getEventService();
-        ProxyEventProcessor callback = new ProxyEventProcessor(proxyService.listeners.values(), DESTROYED, serviceName, proxy);
+        ProxyEventProcessor callback = new ProxyEventProcessor(proxyService.listeners.values(), DESTROYED, serviceName,
+                name, proxy);
         eventService.executeEventCallback(callback);
         if (publishEvent) {
             publish(new DistributedObjectEventPacket(DESTROYED, serviceName, name));

--- a/hazelcast/src/test/java/com/hazelcast/core/DistributedObjectListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/core/DistributedObjectListenerTest.java
@@ -20,6 +20,7 @@ import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.QuickTest;
+import java.util.Collection;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
@@ -39,7 +40,7 @@ public class DistributedObjectListenerTest extends HazelcastTestSupport {
 
     @Test
     public void testDestroyJustAfterCreate() {
-        HazelcastInstance instance = Hazelcast.newHazelcastInstance();
+        final HazelcastInstance instance = Hazelcast.newHazelcastInstance();
         instance.addDistributedObjectListener(new EventCountListener());
         IMap<Object, Object> map = instance.getMap(randomString());
         map.destroy();
@@ -48,6 +49,8 @@ public class DistributedObjectListenerTest extends HazelcastTestSupport {
             public void run() throws Exception {
                 Assert.assertEquals(1, EventCountListener.createdCount.get());
                 Assert.assertEquals(1, EventCountListener.destroyedCount.get());
+                Collection<DistributedObject> distributedObjects = instance.getDistributedObjects();
+                Assert.assertTrue(distributedObjects.isEmpty());
             }
         };
         assertTrueEventually(task, 5);


### PR DESCRIPTION
Distributed object listener no longer re-creates the proxy on DESTROYED event and proxy creation made lazily. 

Fixes #5554