### PR TITLE
[Backport] Fix distributed object listener unnecessary proxy creation

### DIFF
--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/spi/impl/LazyDistributedObjectEvent.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/spi/impl/LazyDistributedObjectEvent.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.spi.impl;
+
+import com.hazelcast.client.spi.ProxyManager;
+import com.hazelcast.core.DistributedObject;
+import com.hazelcast.core.DistributedObjectEvent;
+
+public final class LazyDistributedObjectEvent extends DistributedObjectEvent {
+
+    private ProxyManager proxyManager;
+
+    /**
+     * Constructs a DistributedObject Event.
+     *
+     * @param eventType         The event type as an enum {@link EventType} integer.
+     * @param serviceName       The service name of the DistributedObject.
+     * @param objectName        The name of the DistributedObject.
+     * @param distributedObject The DistributedObject for the event.
+     * @param proxyManager      The ProxyManager for lazily creating the proxy if not available on the client.
+     */
+    public LazyDistributedObjectEvent(EventType eventType, String serviceName, String objectName,
+                                      DistributedObject distributedObject,
+                                      ProxyManager proxyManager) {
+        super(eventType, serviceName, objectName, distributedObject);
+        this.proxyManager = proxyManager;
+    }
+
+    @Override
+    public DistributedObject getDistributedObject() {
+        distributedObject = super.getDistributedObject();
+        if (distributedObject == null) {
+            distributedObject = proxyManager.getOrCreateProxy(getServiceName(), (String) getObjectId());
+        }
+        return distributedObject;
+    }
+
+}

--- a/hazelcast-client-new/src/test/java/com/hazelcast/client/proxy/DistributedObjectListenerTest.java
+++ b/hazelcast-client-new/src/test/java/com/hazelcast/client/proxy/DistributedObjectListenerTest.java
@@ -17,19 +17,24 @@
 package com.hazelcast.client.proxy;
 
 import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.core.DistributedObject;
 import com.hazelcast.core.DistributedObjectEvent;
 import com.hazelcast.core.DistributedObjectListener;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.ITopic;
+import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.QuickTest;
+import java.util.Collection;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.util.concurrent.CountDownLatch;
+
+import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category(QuickTest.class)
@@ -45,7 +50,7 @@ public class DistributedObjectListenerTest extends HazelcastTestSupport {
     @Test
     public void destroyedNotReceivedOnClient() throws Exception {
         HazelcastInstance instance = hazelcastFactory.newHazelcastInstance();
-        HazelcastInstance client = hazelcastFactory.newHazelcastClient();
+        final HazelcastInstance client = hazelcastFactory.newHazelcastClient();
         final CountDownLatch createdLatch = new CountDownLatch(1);
         final CountDownLatch destroyedLatch = new CountDownLatch(1);
         client.addDistributedObjectListener(new DistributedObjectListener() {
@@ -64,6 +69,14 @@ public class DistributedObjectListenerTest extends HazelcastTestSupport {
         assertOpenEventually(createdLatch, 10);
         topic.destroy();
         assertOpenEventually(destroyedLatch, 10);
+        assertTrueAllTheTime(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                Collection<DistributedObject> distributedObjects = client.getDistributedObjects();
+                assertTrue(distributedObjects.isEmpty());
+            }
+        }, 5);
+
     }
 
 }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/ProxyManager.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/ProxyManager.java
@@ -41,6 +41,7 @@ import com.hazelcast.client.proxy.ClientSemaphoreProxy;
 import com.hazelcast.client.proxy.ClientSetProxy;
 import com.hazelcast.client.proxy.ClientTopicProxy;
 import com.hazelcast.client.spi.impl.ClientInvocation;
+import com.hazelcast.client.spi.impl.LazyDistributedObjectEvent;
 import com.hazelcast.client.txn.proxy.xa.XAResourceProxy;
 import com.hazelcast.collection.impl.list.ListService;
 import com.hazelcast.collection.impl.queue.QueueService;
@@ -71,7 +72,6 @@ import com.hazelcast.spi.impl.PortableDistributedObjectEvent;
 import com.hazelcast.topic.impl.TopicService;
 import com.hazelcast.transaction.impl.xa.XAService;
 import com.hazelcast.util.ExceptionUtil;
-
 import java.lang.reflect.Constructor;
 import java.util.Collection;
 import java.util.LinkedList;
@@ -233,34 +233,47 @@ public final class ProxyManager {
     }
 
     public String addDistributedObjectListener(final DistributedObjectListener listener) {
-        final DistributedObjectListenerRequest request = new DistributedObjectListenerRequest();
-        final EventHandler<PortableDistributedObjectEvent> eventHandler = new EventHandler<PortableDistributedObjectEvent>() {
-            public void handle(PortableDistributedObjectEvent e) {
-                final ObjectNamespace ns = new DefaultObjectNamespace(e.getServiceName(), e.getName());
-                ClientProxyFuture future = proxies.get(ns);
-                ClientProxy proxy = future == null ? null : future.get();
-                if (proxy == null) {
-                    proxy = getOrCreateProxy(e.getServiceName(), e.getName());
-                }
-
-                DistributedObjectEvent event = new DistributedObjectEvent(e.getEventType(), e.getServiceName(), proxy);
-                if (DistributedObjectEvent.EventType.CREATED.equals(e.getEventType())) {
-                    listener.distributedObjectCreated(event);
-                } else if (DistributedObjectEvent.EventType.DESTROYED.equals(e.getEventType())) {
-                    listener.distributedObjectDestroyed(event);
-                }
-            }
-
-            @Override
-            public void beforeListenerRegister() {
-            }
-
-            @Override
-            public void onListenerRegister() {
-
-            }
-        };
+        DistributedObjectListenerRequest request = new DistributedObjectListenerRequest();
+        EventHandler<PortableDistributedObjectEvent> eventHandler = new DistributedObjectEventHandler(listener, this);
         return client.getListenerService().startListening(request, null, eventHandler);
+    }
+
+    private final class DistributedObjectEventHandler implements EventHandler<PortableDistributedObjectEvent> {
+
+        private final DistributedObjectListener listener;
+        private final ProxyManager proxyManager;
+
+        public DistributedObjectEventHandler(DistributedObjectListener listener, ProxyManager proxyManager) {
+            this.listener = listener;
+            this.proxyManager = proxyManager;
+        }
+
+        @Override
+        public void handle(PortableDistributedObjectEvent e) {
+            String name = e.getName();
+            String serviceName = e.getServiceName();
+            DistributedObjectEvent.EventType eventType = e.getEventType();
+            ObjectNamespace ns = new DefaultObjectNamespace(serviceName, name);
+            ClientProxyFuture future = proxies.get(ns);
+            ClientProxy proxy = future == null ? null : future.get();
+            LazyDistributedObjectEvent event = new LazyDistributedObjectEvent(eventType, serviceName, name, proxy,
+                    proxyManager);
+            if (DistributedObjectEvent.EventType.CREATED.equals(eventType)) {
+                listener.distributedObjectCreated(event);
+            } else if (DistributedObjectEvent.EventType.DESTROYED.equals(eventType)) {
+                listener.distributedObjectDestroyed(event);
+            }
+        }
+
+        @Override
+        public void beforeListenerRegister() {
+
+        }
+
+        @Override
+        public void onListenerRegister() {
+
+        }
     }
 
     public boolean removeDistributedObjectListener(String id) {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/LazyDistributedObjectEvent.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/LazyDistributedObjectEvent.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.spi.impl;
+
+import com.hazelcast.client.spi.ProxyManager;
+import com.hazelcast.core.DistributedObject;
+import com.hazelcast.core.DistributedObjectEvent;
+
+public final class LazyDistributedObjectEvent extends DistributedObjectEvent {
+
+    private ProxyManager proxyManager;
+
+    /**
+     * Constructs a DistributedObject Event.
+     *
+     * @param eventType         The event type as an enum {@link EventType} integer.
+     * @param serviceName       The service name of the DistributedObject.
+     * @param objectName        The name of the DistributedObject.
+     * @param distributedObject The DistributedObject for the event.
+     * @param proxyManager      The ProxyManager for lazily creating the proxy if not available on the client.
+     */
+    public LazyDistributedObjectEvent(EventType eventType, String serviceName, String objectName,
+                                      DistributedObject distributedObject,
+                                      ProxyManager proxyManager) {
+        super(eventType, serviceName, objectName, distributedObject);
+        this.proxyManager = proxyManager;
+    }
+
+    @Override
+    public DistributedObject getDistributedObject() {
+        distributedObject = super.getDistributedObject();
+        if (distributedObject == null) {
+            distributedObject = proxyManager.getOrCreateProxy(getServiceName(), (String) getObjectId());
+        }
+        return distributedObject;
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/client/DistributedObjectListenerRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/client/DistributedObjectListenerRequest.java
@@ -72,7 +72,7 @@ public class DistributedObjectListenerRequest extends CallableClientRequest impl
     private void send(DistributedObjectEvent event) {
         if (endpoint.isAlive()) {
             PortableDistributedObjectEvent portableEvent = new PortableDistributedObjectEvent(
-                    event.getEventType(), event.getDistributedObject().getName(), event.getServiceName());
+                    event.getEventType(), (String) event.getObjectId(), event.getServiceName());
             endpoint.sendEvent(null, portableEvent, getCallId());
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AddDistributedObjectListenerMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AddDistributedObjectListenerMessageTask.java
@@ -97,7 +97,7 @@ public class AddDistributedObjectListenerMessageTask
 
     private void send(DistributedObjectEvent event) {
         if (endpoint.isAlive()) {
-            String name = event.getDistributedObject().getName();
+            String name = (String) event.getObjectId();
             String serviceName = event.getServiceName();
             ClientMessage eventMessage =
                     ClientAddDistributedObjectListenerCodec.encodeDistributedObjectEvent(name,

--- a/hazelcast/src/main/java/com/hazelcast/core/DistributedObjectEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/DistributedObjectEvent.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.core;
 
+import com.hazelcast.spi.exception.DistributedObjectDestroyedException;
+
 /**
  * DistributedObjectEvent is fired when a {@link DistributedObject}
  * is created or destroyed cluster-wide.
@@ -25,11 +27,13 @@ package com.hazelcast.core;
  */
 public class DistributedObjectEvent {
 
+    protected DistributedObject distributedObject;
+
     private EventType eventType;
 
     private String serviceName;
 
-    private DistributedObject distributedObject;
+    private String objectName;
 
     /**
      * Constructs a DistributedObject Event.
@@ -38,9 +42,11 @@ public class DistributedObjectEvent {
      * @param serviceName       The service name of the DistributedObject.
      * @param distributedObject The DistributedObject for the event.
      */
-    public DistributedObjectEvent(EventType eventType, String serviceName, DistributedObject distributedObject) {
+    public DistributedObjectEvent(EventType eventType, String serviceName, String objectName,
+                                  DistributedObject distributedObject) {
         this.eventType = eventType;
         this.serviceName = serviceName;
+        this.objectName = objectName;
         this.distributedObject = distributedObject;
     }
 
@@ -68,15 +74,19 @@ public class DistributedObjectEvent {
      * @return the identifier of DistributedObject
      */
     public Object getObjectId() {
-        return distributedObject.getId();
+        return objectName;
     }
 
     /**
      * Returns the DistributedObject instance.
      *
      * @return the DistributedObject instance
+     * @throws DistributedObjectDestroyedException if distributed object is destroyed.
      */
     public DistributedObject getDistributedObject() {
+        if (EventType.DESTROYED.equals(eventType)) {
+            throw new DistributedObjectDestroyedException(objectName + " destroyed!");
+        }
         return distributedObject;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/ProxyEventProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/ProxyEventProcessor.java
@@ -20,7 +20,6 @@ import com.hazelcast.core.DistributedObject;
 import com.hazelcast.core.DistributedObjectEvent;
 import com.hazelcast.core.DistributedObjectListener;
 import com.hazelcast.util.executor.StripedRunnable;
-
 import java.util.Collection;
 
 final class ProxyEventProcessor implements StripedRunnable {
@@ -28,19 +27,21 @@ final class ProxyEventProcessor implements StripedRunnable {
     private final Collection<DistributedObjectListener> listeners;
     private final DistributedObjectEvent.EventType type;
     private final String serviceName;
+    private final String objectName;
     private final DistributedObject object;
 
     ProxyEventProcessor(Collection<DistributedObjectListener> listeners, DistributedObjectEvent.EventType eventType,
-                        String serviceName, DistributedObject object) {
+                        String serviceName, String name, DistributedObject object) {
         this.listeners = listeners;
         this.type = eventType;
         this.serviceName = serviceName;
+        this.objectName = name;
         this.object = object;
     }
 
     @Override
     public void run() {
-        DistributedObjectEvent event = new DistributedObjectEvent(type, serviceName, object);
+        DistributedObjectEvent event = new DistributedObjectEvent(type, serviceName, objectName, object);
         for (DistributedObjectListener listener : listeners) {
             switch (type) {
                 case CREATED:

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/ProxyRegistry.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/ProxyRegistry.java
@@ -27,7 +27,6 @@ import com.hazelcast.spi.impl.DistributedObjectEventPacket;
 import com.hazelcast.spi.impl.eventservice.InternalEventService;
 import com.hazelcast.util.EmptyStatement;
 import com.hazelcast.util.ExceptionUtil;
-
 import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -206,7 +205,8 @@ public final class ProxyRegistry {
         }
 
         InternalEventService eventService = proxyService.nodeEngine.getEventService();
-        ProxyEventProcessor callback = new ProxyEventProcessor(proxyService.listeners.values(), CREATED, serviceName, proxy);
+        ProxyEventProcessor callback = new ProxyEventProcessor(proxyService.listeners.values(), CREATED, serviceName,
+                name, proxy);
         eventService.executeEventCallback(callback);
         if (publishEvent) {
             publish(new DistributedObjectEventPacket(CREATED, serviceName, name));
@@ -236,7 +236,8 @@ public final class ProxyRegistry {
             return;
         }
         InternalEventService eventService = proxyService.nodeEngine.getEventService();
-        ProxyEventProcessor callback = new ProxyEventProcessor(proxyService.listeners.values(), DESTROYED, serviceName, proxy);
+        ProxyEventProcessor callback = new ProxyEventProcessor(proxyService.listeners.values(), DESTROYED, serviceName,
+                name, proxy);
         eventService.executeEventCallback(callback);
         if (publishEvent) {
             publish(new DistributedObjectEventPacket(DESTROYED, serviceName, name));

--- a/hazelcast/src/test/java/com/hazelcast/core/DistributedObjectListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/core/DistributedObjectListenerTest.java
@@ -20,6 +20,7 @@ import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.QuickTest;
+import java.util.Collection;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
@@ -39,7 +40,7 @@ public class DistributedObjectListenerTest extends HazelcastTestSupport {
 
     @Test
     public void testDestroyJustAfterCreate() {
-        HazelcastInstance instance = Hazelcast.newHazelcastInstance();
+        final HazelcastInstance instance = Hazelcast.newHazelcastInstance();
         instance.addDistributedObjectListener(new EventCountListener());
         IMap<Object, Object> map = instance.getMap(randomString());
         map.destroy();
@@ -48,6 +49,8 @@ public class DistributedObjectListenerTest extends HazelcastTestSupport {
             public void run() throws Exception {
                 Assert.assertEquals(1, EventCountListener.createdCount.get());
                 Assert.assertEquals(1, EventCountListener.destroyedCount.get());
+                Collection<DistributedObject> distributedObjects = instance.getDistributedObjects();
+                Assert.assertTrue(distributedObjects.isEmpty());
             }
         };
         assertTrueEventually(task, 5);


### PR DESCRIPTION
Distributed object listener no longer re-creates the proxy on DESTROYED event and proxy creation made lazily.

Fixes #5554
