### PR TITLE
Preparation for hot restart cache integration

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheReplicationOperation.java
@@ -128,13 +128,12 @@ public class CacheReplicationOperation extends AbstractOperation {
             for (Map.Entry<Data, CacheRecord> e : cacheMap.entrySet()) {
                 final Data key = e.getKey();
                 final CacheRecord record = e.getValue();
-                final long expirationTime = record.getExpirationTime();
 
-                // If entry is already expired we skip it
-                if (expirationTime > now) {
-                    out.writeData(key);
-                    out.writeObject(record);
+                if (record.isExpiredAt(now) || record.isTombstone()) {
+                    continue;
                 }
+                out.writeData(key);
+                out.writeObject(record);
             }
             // Empty data will terminate the iteration for read in case
             // expired entries were found while serializing, since the

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/record/AbstractCacheRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/record/AbstractCacheRecord.java
@@ -36,6 +36,7 @@ public abstract class AbstractCacheRecord<V> implements CacheRecord<V>, DataSeri
     protected volatile long expirationTime = -1;
     protected volatile long accessTime = -1;
     protected volatile int accessHit;
+    protected long tombstoneSequence;
 
     protected AbstractCacheRecord() {
     }
@@ -99,6 +100,21 @@ public abstract class AbstractCacheRecord<V> implements CacheRecord<V>, DataSeri
     @Override
     public boolean isExpiredAt(long now) {
         return expirationTime > -1 && expirationTime <= now;
+    }
+
+    @Override
+    public boolean isTombstone() {
+        return getValue() == null;
+    }
+
+    @Override
+    public long getTombstoneSequence() {
+        return tombstoneSequence;
+    }
+
+    @Override
+    public void setTombstoneSequence(long seq) {
+        this.tombstoneSequence = seq;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/record/CacheRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/record/CacheRecord.java
@@ -78,4 +78,25 @@ public interface CacheRecord<V> extends Expirable, Evictable {
      */
     void resetAccessHit();
 
+    /**
+     * Tells whether this record is a tombstone or not.
+     *
+     * @return true if this record is tombstone, false otherwise
+     */
+    boolean isTombstone();
+
+    /**
+     * Returns tombstone sequence associated with this record.
+     * Return value is undefined if this is record is not a tombstone.
+     *
+     * @return tombstone sequence
+     */
+    long getTombstoneSequence();
+
+    /**
+     * Sets tombstone sequence associated with this record.
+     *
+     * @param seq tombstone sequence
+     */
+    void setTombstoneSequence(long seq);
 }

--- a/hazelcast/src/main/java/com/hazelcast/util/counters/Counter.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/counters/Counter.java
@@ -35,8 +35,9 @@ public interface Counter {
 
     /**
      * Increments the counter by one.
+     * @return the new counter state
      */
-    void inc();
+    long inc();
 
     /**
      * Increments (or decrements) the counter by the given amount.
@@ -44,6 +45,7 @@ public interface Counter {
      * If the amount is negative, the counter is decremented.
      *
      * @param amount the amount to increase or decrease the counter with.
+     * @return the new counter state
      */
-    void inc(long amount);
+    long inc(long amount);
 }

--- a/hazelcast/src/main/java/com/hazelcast/util/counters/MwCounter.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/counters/MwCounter.java
@@ -44,13 +44,13 @@ public final class MwCounter implements Counter {
     }
 
     @Override
-    public void inc() {
-        COUNTER.incrementAndGet(this);
+    public long inc() {
+        return COUNTER.incrementAndGet(this);
     }
 
     @Override
-    public void inc(long amount) {
-        COUNTER.addAndGet(this, amount);
+    public long inc(long amount) {
+        return COUNTER.addAndGet(this, amount);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/util/counters/SwCounter.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/counters/SwCounter.java
@@ -100,15 +100,17 @@ public abstract class SwCounter implements Counter {
         }
 
         @Override
-        public void inc() {
+        public long inc() {
             long newLocalValue = localValue += 1;
             UNSAFE.putOrderedLong(this, OFFSET, newLocalValue);
+            return newLocalValue;
         }
 
         @Override
-        public void inc(long amount) {
+        public long inc(long amount) {
             long newLocalValue = localValue += amount;
             UNSAFE.putOrderedLong(this, OFFSET, newLocalValue);
+            return newLocalValue;
         }
 
         @Override
@@ -139,13 +141,17 @@ public abstract class SwCounter implements Counter {
         }
 
         @Override
-        public void inc() {
-            COUNTER.lazySet(this, value + 1);
+        public long inc() {
+            final long newValue = value + 1;
+            COUNTER.lazySet(this, newValue);
+            return newValue;
         }
 
         @Override
-        public void inc(long amount) {
-            COUNTER.lazySet(this, value + amount);
+        public long inc(long amount) {
+            final long newValue = value + amount;
+            COUNTER.lazySet(this, newValue);
+            return newValue;
         }
 
         @Override

--- a/hazelcast/src/test/java/com/hazelcast/util/counters/SwCounterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/counters/SwCounterTest.java
@@ -27,17 +27,14 @@ public class SwCounterTest {
 
     @Test
     public void inc() {
-        counter.inc();
-        assertEquals(1, counter.get());
+        assertEquals(1, counter.inc());
     }
 
     @Test
     public void inc_withAmount() {
-        counter.inc(10);
-        assertEquals(10, counter.get());
-
-        counter.inc(0);
-        assertEquals(10, counter.get());
+        assertEquals(10, counter.inc(10));
+        assertEquals(10, counter.inc(0));
+        assertEquals(0, counter.inc(-10));
     }
 
     @Test


### PR DESCRIPTION

To support hot-restart, a cache record can be a tombstone. For hot-restart,
when a record is requested to be removed (either explicitly or by eviction or expiration),
only it's value is cleared and it becomes a tombstone.
A tombstone is only removed when requested by hot-restart store.