### PR TITLE
Simplify getBooleanValue

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/AbstractXmlConfigHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/AbstractXmlConfigHelper.java
@@ -58,6 +58,7 @@ import java.util.Properties;
 
 import static com.hazelcast.nio.IOUtil.closeResource;
 import static com.hazelcast.util.StringUtil.upperCaseInternal;
+import static java.lang.Boolean.parseBoolean;
 
 /**
  * Contains Hazelcast Xml Configuration helper methods and variables.
@@ -288,10 +289,7 @@ public abstract class AbstractXmlConfigHelper {
     }
 
     protected static boolean getBooleanValue(final String value) {
-        String lowerCaseValue = StringUtil.lowerCaseInternal(value);
-        return "true".equals(lowerCaseValue)
-                || "yes".equals(lowerCaseValue)
-                || "on".equals(lowerCaseValue);
+        return parseBoolean(StringUtil.lowerCaseInternal(value));
     }
 
     protected static int getIntegerValue(final String parameterName, final String value) {

--- a/hazelcast/src/main/java/com/hazelcast/config/Config.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/Config.java
@@ -47,6 +47,7 @@ import static java.text.MessageFormat.format;
  * Config instances can be shared between threads, but should not be modified after they are used to
  * create HazelcastInstances.
  */
+@SuppressWarnings("checkstyle:classfanoutcomplexity")
 public class Config {
 
     private static final ILogger LOGGER = Logger.getLogger(Config.class);

--- a/hazelcast/src/main/java/com/hazelcast/config/HotRestartConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/HotRestartConfig.java
@@ -33,10 +33,7 @@ import static com.hazelcast.util.Preconditions.checkPositive;
  * sync or async etc.
  */
 public class HotRestartConfig {
-
-    /**
-     * Default hot-restart home directory
-     */
+    /** Default directory name for the Hot Restart store's home */
     public static final String HOT_RESTART_HOME_DEFAULT = "hot-restart";
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/config/XmlElements.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/XmlElements.java
@@ -48,7 +48,8 @@ enum XmlElements {
     NATIVE_MEMORY("native-memory", false),
     QUORUM("quorum", true),
     LITE_MEMBER("lite-member", false),
-    HOT_RESTART("hot-restart", false);
+    HOT_RESTART("hot-restart", false),
+    ;
 
     final String name;
     final boolean multipleOccurrence;

--- a/hazelcast/src/main/java/com/hazelcast/instance/NodeExtension.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/NodeExtension.java
@@ -58,7 +58,6 @@ public interface NodeExtension {
 
     /**
      * Returns true if the instance has started
-     * @return true if the instance has started
      */
     boolean isStartCompleted();
 


### PR DESCRIPTION
`getBoolean()` was needlessly permissive and complex because XML Schema already prevents anything else but "true" and "false"