### PR TITLE
Avoid starting threads from constructor

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
@@ -134,6 +134,7 @@ public class NodeEngineImpl implements NodeEngine {
     public void start() {
         serviceManager.start();
         proxyService.init();
+        operationService.start();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/classic/ClassicOperationExecutor.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/classic/ClassicOperationExecutor.java
@@ -106,6 +106,15 @@ public final class ClassicOperationExecutor implements OperationExecutor {
                 + partitionOperationThreads.length + " partition operation threads.");
     }
 
+    public void start() {
+        for (Thread t : partitionOperationThreads) {
+            t.start();
+        }
+        for (Thread t : genericOperationThreads) {
+            t.start();
+        }
+    }
+
     private OperationRunner[] initPartitionOperationRunners(GroupProperties properties, OperationRunnerFactory handlerFactory) {
         OperationRunner[] operationRunners = new OperationRunner[properties.getInteger(GroupProperty.PARTITION_COUNT)];
         for (int partitionId = 0; partitionId < operationRunners.length; partitionId++) {
@@ -146,7 +155,6 @@ public final class ClassicOperationExecutor implements OperationExecutor {
                     threadGroup, nodeExtension, partitionOperationRunners);
 
             threads[threadId] = operationThread;
-            operationThread.start();
 
             metricsRegistry.scanAndRegister(operationThread, "operation." + operationThread.getName());
         }
@@ -176,10 +184,7 @@ public final class ClassicOperationExecutor implements OperationExecutor {
                     logger, threadGroup, nodeExtension, operationRunner);
 
             threads[threadId] = operationThread;
-            operationThread.start();
-
             operationRunner.setCurrentThread(operationThread);
-
             metricsRegistry.scanAndRegister(operationThread, "operation." + operationThread.getName());
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
@@ -183,6 +183,10 @@ public final class OperationServiceImpl implements InternalOperationService, Pac
         metricsRegistry.scanAndRegister(this, "operation");
     }
 
+    public void start() {
+        ((ClassicOperationExecutor) operationExecutor).start();
+    }
+
     private SlowOperationDetector initSlowOperationDetector() {
         return new SlowOperationDetector(node.loggingService,
                 operationExecutor.getGenericOperationRunners(),

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/classic/AbstractClassicOperationExecutorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/classic/AbstractClassicOperationExecutorTest.java
@@ -86,6 +86,7 @@ public abstract class AbstractClassicOperationExecutorTest extends HazelcastTest
         executor = new ClassicOperationExecutor(
                 groupProperties, loggingService, thisAddress, handlerFactory,
                 threadGroup, nodeExtension, metricsRegistry);
+        executor.start();
         return executor;
     }
 


### PR DESCRIPTION
The threads access the object being constructed, therefore starting them from the constructor results in data races.