### PR TITLE
Fixes OperationTimeoutException on long running executor tasks

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/executor/impl/ExecutorServiceProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/executor/impl/ExecutorServiceProxy.java
@@ -388,7 +388,8 @@ public class ExecutorServiceProxy
 
         NodeEngine nodeEngine = getNodeEngine();
         Data taskData = nodeEngine.toData(task);
-        MemberCallableTaskOperation op = new MemberCallableTaskOperation(name, null, taskData);
+        String uuid = newUnsecureUuidString();
+        MemberCallableTaskOperation op = new MemberCallableTaskOperation(name, uuid, taskData);
         OperationService operationService = nodeEngine.getOperationService();
         Address address = ((MemberImpl) member).getAddress();
         operationService

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/IsStillRunningServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/IsStillRunningServiceTest.java
@@ -2,6 +2,9 @@ package com.hazelcast.spi.impl.operationservice.impl;
 
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IExecutorService;
+import com.hazelcast.core.Member;
+import com.hazelcast.core.MultiExecutionCallback;
 import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
@@ -18,17 +21,20 @@ import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import java.io.IOException;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutionException;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
@@ -229,6 +235,63 @@ public class IsStillRunningServiceTest extends HazelcastTestSupport {
                 assertEquals(Boolean.TRUE, future.get());
             }
         }, 2);
+    }
+
+
+    @Test
+    public void testExecutionShouldNotTimeoutIfTraceable_WithMultiCallback() throws Exception {
+        Config config = new Config();
+        long timeoutMs = 3000;
+        config.setProperty("hazelcast.operation.call.timeout.millis", String.valueOf(timeoutMs));
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+        HazelcastInstance instance1 = factory.newHazelcastInstance(config);
+        HazelcastInstance instance2 = factory.newHazelcastInstance(config);
+
+        CountDownLatch latch = new CountDownLatch(1);
+        Callback callback = new Callback(latch);
+
+        IExecutorService executorService = instance1.getExecutorService(randomName());
+        executorService.submitToAllMembers(new SleepingTask(), callback);
+        assertOpenEventually(latch);
+        for (Object result : callback.values.values()) {
+            if (!result.equals("Success")) {
+                fail("Non-success result: " + result);
+            }
+        }
+    }
+
+    private static class SleepingTask implements Callable<String>, Serializable {
+
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public String call() throws Exception {
+            Thread.sleep(15000);
+            return "Success";
+        }
+
+    }
+
+    private static class Callback implements MultiExecutionCallback {
+
+        private final CountDownLatch latch;
+
+        private Map<Member, Object> values;
+
+        public Callback(CountDownLatch latch) {
+            this.latch = latch;
+        }
+
+        @Override
+        public void onResponse(Member member, Object value) {
+        }
+
+        @Override
+        public void onComplete(Map<Member, Object> values) {
+            this.values = values;
+            latch.countDown();
+        }
+
     }
 
     public static class DummyOperation extends AbstractOperation {


### PR DESCRIPTION
Added missing uuid to MemberCallableTaskOperation on ExecutorServiceProxy

Fixes #5564 

Thanks @lukasblu for the bug report and a reproducer !