### PR TITLE
ClientMapProxy checks isEmpty, not NearCached one

### DIFF
--- a/hazelcast-client-legacy/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
+++ b/hazelcast-client-legacy/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
@@ -743,8 +743,10 @@ public class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V> {
         for (final Map.Entry<Integer, List<Data>> entry : partitionToKeyData.entrySet()) {
             int partitionId = entry.getKey();
             List<Data> keyList = entry.getValue();
-            MapGetAllRequest request = new MapGetAllRequest(name, keyList, partitionId);
-            futures.add(new ClientInvocation(getClient(), request, partitionId).invoke());
+            if (!keyList.isEmpty()) {
+                MapGetAllRequest request = new MapGetAllRequest(name, keyList, partitionId);
+                futures.add(new ClientInvocation(getClient(), request, partitionId).invoke());
+            }
         }
 
         for (Future<Data> future : futures) {

--- a/hazelcast-client-legacy/src/main/java/com/hazelcast/client/proxy/NearCachedClientMapProxy.java
+++ b/hazelcast-client-legacy/src/main/java/com/hazelcast/client/proxy/NearCachedClientMapProxy.java
@@ -239,7 +239,6 @@ public class NearCachedClientMapProxy<K, V> extends ClientMapProxy<K, V> {
 
     @Override
     protected List<MapEntries> getAllInternal(Map<Integer, List<Data>> partitionToKeyData, Map<K, V> result) {
-        List<Integer> partitionsWithCachedEntries = new ArrayList<Integer>(partitionToKeyData.size());
         for (Entry<Integer, List<Data>> partitionKeyEntry : partitionToKeyData.entrySet()) {
             List<Data> keyList = partitionKeyEntry.getValue();
             Iterator<Data> iterator = keyList.iterator();
@@ -251,13 +250,6 @@ public class NearCachedClientMapProxy<K, V> extends ClientMapProxy<K, V> {
                     iterator.remove();
                 }
             }
-            if (keyList.isEmpty()) {
-                partitionsWithCachedEntries.add(partitionKeyEntry.getKey());
-            }
-        }
-
-        for (Integer partitionId : partitionsWithCachedEntries) {
-            partitionToKeyData.remove(partitionId);
         }
 
         List<MapEntries> responses = super.getAllInternal(partitionToKeyData, result);

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
@@ -985,8 +985,10 @@ public class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V> {
         for (final Map.Entry<Integer, List<Data>> entry : partitionToKeyData.entrySet()) {
             int partitionId = entry.getKey();
             List<Data> keyList = entry.getValue();
-            ClientMessage request = MapGetAllCodec.encodeRequest(name, keyList);
-            futures.add(new ClientInvocation(getClient(), request, partitionId).invoke());
+            if (!keyList.isEmpty()) {
+                ClientMessage request = MapGetAllCodec.encodeRequest(name, keyList);
+                futures.add(new ClientInvocation(getClient(), request, partitionId).invoke());
+            }
         }
 
         for (Future<ClientMessage> future : futures) {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/NearCachedClientMapProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/NearCachedClientMapProxy.java
@@ -39,7 +39,6 @@ import com.hazelcast.util.CollectionUtil;
 import com.hazelcast.util.MapUtil;
 import com.hazelcast.util.executor.CompletedFuture;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
@@ -239,7 +238,6 @@ public class NearCachedClientMapProxy<K, V> extends ClientMapProxy<K, V> {
 
     @Override
     protected List<MapGetAllCodec.ResponseParameters> getAllInternal(Map<Integer, List<Data>> pIdToKeyData, Map<K, V> result) {
-        List<Integer> partitionsWithCachedEntries = new ArrayList<Integer>(pIdToKeyData.size());
         for (Entry<Integer, List<Data>> partitionKeyEntry : pIdToKeyData.entrySet()) {
             List<Data> keyList = partitionKeyEntry.getValue();
             Iterator<Data> iterator = keyList.iterator();
@@ -251,13 +249,6 @@ public class NearCachedClientMapProxy<K, V> extends ClientMapProxy<K, V> {
                     iterator.remove();
                 }
             }
-            if (keyList.isEmpty()) {
-                partitionsWithCachedEntries.add(partitionKeyEntry.getKey());
-            }
-        }
-
-        for (Integer partitionId : partitionsWithCachedEntries) {
-            pIdToKeyData.remove(partitionId);
         }
 
         List<MapGetAllCodec.ResponseParameters> responses = super.getAllInternal(pIdToKeyData, result);


### PR DESCRIPTION
Followup to #6555, 
NearCachedClientMapProxy.getAllInternal - do not remove partitionIds even if there is an empty list of key Data. Delegate the checks for emptiness to the base instead, which will skip past them if so.