### PR TITLE
Removed unnecessary method getMapEntry from RecordStore

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/AbstractMultipleEntryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/AbstractMultipleEntryOperation.java
@@ -278,11 +278,6 @@ abstract class AbstractMultipleEntryOperation extends MapOperation implements Mu
         backupProcessor.processBackup(entry);
     }
 
-    protected Object getValueFor(Data dataKey, long now) {
-        final Map.Entry<Data, Object> mapEntry = recordStore.getMapEntry(dataKey, now);
-        return mapEntry.getValue();
-    }
-
     protected boolean keyNotOwnedByThisPartition(Data key) {
         final InternalPartitionService partitionService = getNodeEngine().getPartitionService();
         return partitionService.getPartitionId(key) != getPartitionId();

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryBackupOperation.java
@@ -63,7 +63,7 @@ public class EntryBackupOperation extends KeyBasedMapOperation implements Backup
     @Override
     public void run() {
         final long now = getNow();
-        oldValue = getValueFor(dataKey, now);
+        oldValue = recordStore.get(dataKey, true);
 
         Map.Entry entry = createMapEntry(dataKey, oldValue);
 
@@ -146,11 +146,6 @@ public class EntryBackupOperation extends KeyBasedMapOperation implements Backup
 
     private Map.Entry createMapEntry(Data key, Object value) {
         return new LazyMapEntry(key, value, getNodeEngine().getSerializationService());
-    }
-
-    private Object getValueFor(Data dataKey, long now) {
-        Map.Entry<Data, Object> mapEntry = recordStore.getMapEntry(dataKey, now);
-        return mapEntry.getValue();
     }
 
     private long getNow() {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOperation.java
@@ -78,7 +78,7 @@ public class EntryOperation extends LockAwareOperation implements BackupAwareOpe
     @Override
     public void run() {
         final long now = getNow();
-        oldValue = getValueFor(dataKey, now);
+        oldValue = recordStore.get(dataKey, false);
 
         Map.Entry entry = createMapEntry(dataKey, oldValue);
 
@@ -212,11 +212,6 @@ public class EntryOperation extends LockAwareOperation implements BackupAwareOpe
         recordStore.put(key, value, DEFAULT_TTL);
     }
 
-
-    private Object getValueFor(Data dataKey, long now) {
-        final Map.Entry<Data, Object> mapEntry = recordStore.getMapEntry(dataKey, now);
-        return mapEntry.getValue();
-    }
 
     private Data process(Map.Entry entry) {
         final Object result = entryProcessor.process(entry);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MultipleEntryBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MultipleEntryBackupOperation.java
@@ -48,7 +48,7 @@ public class MultipleEntryBackupOperation extends AbstractMultipleEntryBackupOpe
             if (keyNotOwnedByThisPartition(dataKey)) {
                 continue;
             }
-            final Object oldValue = getValueFor(dataKey, now);
+            final Object oldValue = recordStore.get(dataKey, true);
 
             final Map.Entry entry = createMapEntry(dataKey, oldValue);
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MultipleEntryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MultipleEntryOperation.java
@@ -59,7 +59,7 @@ public class MultipleEntryOperation extends AbstractMultipleEntryOperation imple
             if (keyNotOwnedByThisPartition(dataKey)) {
                 continue;
             }
-            final Object oldValue = getValueFor(dataKey, now);
+            final Object oldValue = recordStore.get(dataKey, false);
 
             final Map.Entry entry = createMapEntry(dataKey, oldValue);
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
@@ -40,7 +40,7 @@ import com.hazelcast.spi.exception.RetryableHazelcastException;
 import com.hazelcast.util.CollectionUtil;
 import com.hazelcast.util.ExceptionUtil;
 import com.hazelcast.util.FutureUtil;
-import java.util.AbstractMap;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -359,20 +359,6 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
             tempMap.put(key, value);
         }
         return tempMap.entrySet();
-    }
-
-    @Override
-    public Map.Entry<Data, Object> getMapEntry(Data key, long now) {
-        checkIfLoaded();
-
-        Record record = getRecordOrNull(key, now, false);
-        if (record == null) {
-            record = loadRecordOrNull(key, false);
-        } else {
-            accessRecord(record);
-        }
-        final Object value = record != null ? record.getValue() : null;
-        return new AbstractMap.SimpleImmutableEntry<Data, Object>(key, value);
     }
 
     protected Record loadRecordOrNull(Data key, boolean backup) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStore.java
@@ -220,8 +220,6 @@ public interface RecordStore<R extends Record> {
 
     Set<Map.Entry<Data, Data>> entrySetData();
 
-    Map.Entry<Data, Object> getMapEntry(Data dataKey, long now);
-
     void flush();
 
     void clearPartition();

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/IsStillRunningServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/IsStillRunningServiceTest.java
@@ -22,15 +22,16 @@ import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.test.annotation.SlowTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;


### PR DESCRIPTION
- It is duplicate of `RecordStore#get` method.
- It is creating unnecessary Map.Entry in order to get value of entry.