### PR TITLE
Member list order fixed for clients

### DIFF
--- a/hazelcast-client-legacy/src/test/java/com/hazelcast/client/cluster/ClientClusterServiceMemberListTest.java
+++ b/hazelcast-client-legacy/src/test/java/com/hazelcast/client/cluster/ClientClusterServiceMemberListTest.java
@@ -16,6 +16,7 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.util.Collection;
+import java.util.Set;
 
 import static com.hazelcast.client.impl.ClientTestUtil.getClientClusterService;
 import static com.hazelcast.cluster.memberselector.MemberSelectors.DATA_MEMBER_SELECTOR;
@@ -25,6 +26,7 @@ import static com.hazelcast.test.HazelcastTestSupport.getNode;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
@@ -85,6 +87,13 @@ public class ClientClusterServiceMemberListTest {
                 assertEquals(2, clusterService.getSize(DATA_MEMBER_SELECTOR));
             }
         });
+    }
+
+    @Test
+    public void testMemberListOrderConsistentWithServer() {
+        Set<Member> membersFromClient = client.getCluster().getMembers();
+        Set<Member> membersFromServer = dataInstance.getCluster().getMembers();
+        assertArrayEquals(membersFromClient.toArray(), membersFromServer.toArray());
     }
 
     private void verifyMembers(Collection<Member> membersToCheck, Collection<HazelcastInstance> membersToExpect) {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/AbstractClientCacheProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/AbstractClientCacheProxy.java
@@ -260,8 +260,8 @@ abstract class AbstractClientCacheProxy<K, V>
         Data expiryPolicyData = toData(expiryPolicy);
         ClientMessage request = CacheGetAllCodec.encodeRequest(nameWithPrefix, keySet, expiryPolicyData);
         ClientMessage responseMessage = invoke(request);
-        Set<Map.Entry<Data, Data>> entrySet = CacheGetAllCodec.decodeResponse(responseMessage).entrySet;
-        for (Map.Entry<Data, Data> dataEntry : entrySet) {
+        List<Map.Entry<Data, Data>> entries = CacheGetAllCodec.decodeResponse(responseMessage).entries;
+        for (Map.Entry<Data, Data> dataEntry : entries) {
             Data keyData = dataEntry.getKey();
             Data valueData = dataEntry.getValue();
             K key = toObject(keyData);
@@ -270,7 +270,7 @@ abstract class AbstractClientCacheProxy<K, V>
             storeInNearCache(keyData, valueData, value);
         }
         if (statisticsEnabled) {
-            statistics.increaseCacheHits(entrySet.size());
+            statistics.increaseCacheHits(entries.size());
             statistics.addGetTimeNanos(System.nanoTime() - start);
         }
         return result;

--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/AbstractClientInternalCacheProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/AbstractClientInternalCacheProxy.java
@@ -66,7 +66,6 @@ import javax.cache.expiry.ExpiryPolicy;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -806,7 +805,7 @@ abstract class AbstractClientInternalCacheProxy<K, V>
         }
 
         @Override
-        public void handle(int type, Set<CacheEventData> keys, int completionId) {
+        public void handle(int type, Collection<CacheEventData> keys, int completionId) {
             adaptor.handle(type, keys, completionId);
         }
 
@@ -819,7 +818,6 @@ abstract class AbstractClientInternalCacheProxy<K, V>
         public void onListenerRegister() {
 
         }
-
     }
 
     protected ICompletableFuture createCompletedFuture(Object value) {
@@ -850,7 +848,7 @@ abstract class AbstractClientInternalCacheProxy<K, V>
         }
 
         @Override
-        public void handle(String name, List<Data> keys, List<String> sourceUuids) {
+        public void handle(String name, Collection<Data> keys, Collection<String> sourceUuids) {
             if (sourceUuids != null && !sourceUuids.isEmpty()) {
                 Iterator<Data> keysIt = keys.iterator();
                 Iterator<String> sourceUuidsIt = sourceUuids.iterator();

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
@@ -161,7 +161,7 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
         threadGroup = new ThreadGroup(instanceName);
         lifecycleService = new LifecycleServiceImpl(this);
         clientProperties = new ClientProperties(config);
-        serializationService = clientExtension.createSerializationService((byte)-1);
+        serializationService = clientExtension.createSerializationService((byte) -1);
         proxyManager = new ProxyManager(this);
         executionService = initExecutionService();
         loadBalancer = initLoadBalancer(config);
@@ -455,7 +455,7 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
             ClientGetDistributedObjectsCodec.ResponseParameters resultParameters =
                     ClientGetDistributedObjectsCodec.decodeResponse(response);
 
-            Collection<DistributedObjectInfo> infoCollection = resultParameters.infoCollection;
+            Collection<DistributedObjectInfo> infoCollection = resultParameters.infoList;
             for (DistributedObjectInfo distributedObjectInfo : infoCollection) {
                 getDistributedObject(distributedObjectInfo.getServiceName(), distributedObjectInfo.getName());
             }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
@@ -984,7 +984,7 @@ public class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V> {
     protected List<MapGetAllCodec.ResponseParameters> getAllInternal(Map<Integer, List<Data>> partitionToKeyData, Map<K, V> result) {
         List<Future<ClientMessage>> futures = new ArrayList<Future<ClientMessage>>(partitionToKeyData.size());
         List<MapGetAllCodec.ResponseParameters> responses = new ArrayList<MapGetAllCodec.ResponseParameters>(partitionToKeyData.size());
-        
+
         for (final Map.Entry<Integer, List<Data>> entry : partitionToKeyData.entrySet()) {
             int partitionId = entry.getKey();
             List<Data> keyList = entry.getValue();
@@ -996,8 +996,8 @@ public class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V> {
             try {
                 ClientMessage response = future.get();
                 MapGetAllCodec.ResponseParameters resultParameters = MapGetAllCodec.decodeResponse(response);
-        
-                for (Entry<Data, Data> entry : resultParameters.entrySet) {
+
+                for (Entry<Data, Data> entry : resultParameters.entries) {
                     final V value = toObject(entry.getValue());
                     final K key = toObject(entry.getKey());
                     result.put(key, value);
@@ -1031,9 +1031,9 @@ public class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V> {
         ClientMessage response = invoke(request);
         MapEntrySetCodec.ResponseParameters resultParameters = MapEntrySetCodec.decodeResponse(response);
 
-        InflatableSet.Builder<Entry<K, V>> setBuilder = InflatableSet.newBuilder(resultParameters.entrySet.size());
+        InflatableSet.Builder<Entry<K, V>> setBuilder = InflatableSet.newBuilder(resultParameters.entries.size());
         SerializationService serializationService = getContext().getSerializationService();
-        for (Entry<Data, Data> row : resultParameters.entrySet) {
+        for (Entry<Data, Data> row : resultParameters.entries) {
             LazyMapEntry entry = new LazyMapEntry(row.getKey(), row.getValue(), serializationService);
             setBuilder.add(entry);
         }
@@ -1086,9 +1086,9 @@ public class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V> {
         ClientMessage response = invoke(request);
         MapEntriesWithPredicateCodec.ResponseParameters resultParameters = MapEntriesWithPredicateCodec.decodeResponse(response);
 
-        InflatableSet.Builder<Entry<K, V>> setBuilder = InflatableSet.newBuilder(resultParameters.entrySet.size());
+        InflatableSet.Builder<Entry<K, V>> setBuilder = InflatableSet.newBuilder(resultParameters.entries.size());
         SerializationService serializationService = getContext().getSerializationService();
-        for (Entry<Data, Data> row : resultParameters.entrySet) {
+        for (Entry<Data, Data> row : resultParameters.entries) {
             LazyMapEntry entry = new LazyMapEntry(row.getKey(), row.getValue(), serializationService);
             setBuilder.add(entry);
         }
@@ -1105,7 +1105,7 @@ public class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V> {
         MapEntriesWithPagingPredicateCodec.ResponseParameters resultParameters = MapEntriesWithPagingPredicateCodec.decodeResponse(response);
 
         ArrayList<Map.Entry> resultList = new ArrayList<Map.Entry>();
-        for (Entry<Data, Data> entry : resultParameters.entrySet) {
+        for (Entry<Data, Data> entry : resultParameters.entries) {
             K key = toObject(entry.getKey());
             V value = toObject(entry.getValue());
             resultList.add(new AbstractMap.SimpleEntry<K, V>(key, value));
@@ -1139,8 +1139,8 @@ public class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V> {
         ClientMessage response = invoke(request);
         MapValuesWithPagingPredicateCodec.ResponseParameters resultParameters = MapValuesWithPagingPredicateCodec.decodeResponse(response);
 
-        List<Entry> resultList = new ArrayList<Entry>(resultParameters.entrySet.size());
-        for (Entry<Data, Data> entry : resultParameters.entrySet) {
+        List<Entry> resultList = new ArrayList<Entry>(resultParameters.entries.size());
+        for (Entry<Data, Data> entry : resultParameters.entries) {
             K key = toObject(entry.getKey());
             V value = toObject(entry.getValue());
             resultList.add(new AbstractMap.SimpleImmutableEntry<K, V>(key, value));
@@ -1213,16 +1213,16 @@ public class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V> {
         ClientMessage request = MapExecuteOnAllKeysCodec.encodeRequest(name, toData(entryProcessor));
         ClientMessage response = invoke(request);
         MapExecuteOnAllKeysCodec.ResponseParameters resultParameters = MapExecuteOnAllKeysCodec.decodeResponse(response);
-        return prepareResult(resultParameters.entrySet);
+        return prepareResult(resultParameters.entries);
     }
 
-    protected Map<K, Object> prepareResult(Set<Entry<Data, Data>> entrySet) {
-        if (CollectionUtil.isEmpty(entrySet)) {
+    protected Map<K, Object> prepareResult(Collection<Entry<Data, Data>> entries) {
+        if (CollectionUtil.isEmpty(entries)) {
             return emptyMap();
         }
 
-        Map<K, Object> result = MapUtil.createHashMap(entrySet.size());
-        for (Entry<Data, Data> entry : entrySet) {
+        Map<K, Object> result = MapUtil.createHashMap(entries.size());
+        for (Entry<Data, Data> entry : entries) {
             K key = toObject(entry.getKey());
             result.put(key, toObject(entry.getValue()));
         }
@@ -1237,7 +1237,7 @@ public class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V> {
         ClientMessage response = invoke(request);
 
         MapExecuteWithPredicateCodec.ResponseParameters resultParameters = MapExecuteWithPredicateCodec.decodeResponse(response);
-        return prepareResult(resultParameters.entrySet);
+        return prepareResult(resultParameters.entries);
     }
 
     @Override
@@ -1288,7 +1288,7 @@ public class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V> {
         ClientMessage request = MapExecuteOnKeysCodec.encodeRequest(name, toData(entryProcessor), dataKeys);
         ClientMessage response = invoke(request);
         MapExecuteOnKeysCodec.ResponseParameters resultParameters = MapExecuteOnKeysCodec.decodeResponse(response);
-        return prepareResult(resultParameters.entrySet);
+        return prepareResult(resultParameters.entries);
 
     }
 

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapReduceProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapReduceProxy.java
@@ -62,7 +62,6 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -173,9 +172,9 @@ public class ClientMapReduceProxy
 
     private Map toObjectMap(ClientMessage res) {
         SerializationService serializationService = getContext().getSerializationService();
-        Set<Map.Entry<Data, Data>> entrySet = MapReduceForCustomCodec.decodeResponse(res).entrySet;
+        Collection<Map.Entry<Data, Data>> entries = MapReduceForCustomCodec.decodeResponse(res).entries;
         HashMap hashMap = new HashMap();
-        for (Map.Entry<Data, Data> entry : entrySet) {
+        for (Map.Entry<Data, Data> entry : entries) {
             Object key = serializationService.toObject(entry.getKey());
             Object value = serializationService.toObject(entry.getValue());
             hashMap.put(key, value);

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMultiMapProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMultiMapProxy.java
@@ -158,7 +158,7 @@ public class ClientMultiMapProxy<K, V> extends ClientProxy implements MultiMap<K
         ClientMessage request = MultiMapKeySetCodec.encodeRequest(name);
         ClientMessage response = invoke(request);
         MultiMapKeySetCodec.ResponseParameters resultParameters = MultiMapKeySetCodec.decodeResponse(response);
-        Collection<Data> result = resultParameters.set;
+        Collection<Data> result = resultParameters.list;
         Set<K> keySet = new HashSet<K>(result.size());
         for (Data data : result) {
             final K key = toObject(data);
@@ -185,8 +185,8 @@ public class ClientMultiMapProxy<K, V> extends ClientProxy implements MultiMap<K
         ClientMessage response = invoke(request);
         MultiMapEntrySetCodec.ResponseParameters resultParameters = MultiMapEntrySetCodec.decodeResponse(response);
 
-        Set<Map.Entry<K, V>> entrySet = new HashSet<Map.Entry<K, V>>(resultParameters.entrySet.size());
-        for (Map.Entry<Data, Data> entry : resultParameters.entrySet) {
+        Set<Map.Entry<K, V>> entrySet = new HashSet<Map.Entry<K, V>>(resultParameters.entries.size());
+        for (Map.Entry<Data, Data> entry : resultParameters.entries) {
             K key = toObject(entry.getKey());
             V value = toObject(entry.getValue());
             entrySet.add(new AbstractMap.SimpleEntry<K, V>(key, value));

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientReplicatedMapProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientReplicatedMapProxy.java
@@ -392,8 +392,8 @@ public class ClientReplicatedMapProxy<K, V> extends ClientProxy implements Repli
         ClientMessage request = ReplicatedMapEntrySetCodec.encodeRequest(name);
         ClientMessage response = invokeOnPartition(request, getOrInitTargetPartitionId());
         ReplicatedMapEntrySetCodec.ResponseParameters result = ReplicatedMapEntrySetCodec.decodeResponse(response);
-        List<Entry<K, V>> entries = new ArrayList<Entry<K, V>>(result.entrySet.size());
-        for (Entry<Data, Data> dataEntry : result.entrySet) {
+        List<Entry<K, V>> entries = new ArrayList<Entry<K, V>>(result.entries.size());
+        for (Entry<Data, Data> dataEntry : result.entries) {
             K key = toObject(dataEntry.getKey());
             V value = toObject(dataEntry.getValue());
             entries.add(new AbstractMap.SimpleImmutableEntry<K, V>(key, value));

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/NearCachedClientMapProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/NearCachedClientMapProxy.java
@@ -40,6 +40,7 @@ import com.hazelcast.util.CollectionUtil;
 import com.hazelcast.util.MapUtil;
 import com.hazelcast.util.executor.CompletedFuture;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
@@ -51,8 +52,6 @@ import java.util.concurrent.TimeUnit;
 import static com.hazelcast.cache.impl.nearcache.NearCache.NULL_OBJECT;
 import static com.hazelcast.map.impl.MapListenerFlagOperator.ALL_LISTENER_FLAGS;
 import static java.util.Collections.emptyMap;
-
-import java.util.ArrayList;
 
 /**
  * A Client-side {@code IMap} implementation which is fronted by a near-cache.
@@ -264,7 +263,7 @@ public class NearCachedClientMapProxy<K, V> extends ClientMapProxy<K, V> {
 
         List<MapGetAllCodec.ResponseParameters> responses = super.getAllInternal(pIdToKeyData, result);
         for (MapGetAllCodec.ResponseParameters resultParameters : responses) {
-            for (Entry<Data, Data> entry : resultParameters.entrySet) {
+            for (Entry<Data, Data> entry : resultParameters.entries) {
                 nearCache.put(entry.getKey(), entry.getValue());
             }
         }
@@ -280,7 +279,7 @@ public class NearCachedClientMapProxy<K, V> extends ClientMapProxy<K, V> {
     }
 
     @Override
-    protected Map<K, Object> prepareResult(Set<Entry<Data, Data>> entrySet) {
+    protected Map<K, Object> prepareResult(Collection<Entry<Data, Data>> entrySet) {
         if (CollectionUtil.isEmpty(entrySet)) {
             return emptyMap();
         }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/txn/ClientTxnMapProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/txn/ClientTxnMapProxy.java
@@ -167,7 +167,7 @@ public class ClientTxnMapProxy<K, V> extends ClientTxnProxy implements Transacti
     public Set<K> keySet() {
         ClientMessage request = TransactionalMapKeySetCodec.encodeRequest(name, getTransactionId(), ThreadUtil.getThreadId());
         ClientMessage response = invoke(request);
-        Collection<Data> dataKeySet = TransactionalMapKeySetCodec.decodeResponse(response).set;
+        Collection<Data> dataKeySet = TransactionalMapKeySetCodec.decodeResponse(response).list;
 
         HashSet<K> keySet = new HashSet<K>(dataKeySet.size());
         for (Data data : dataKeySet) {
@@ -183,7 +183,7 @@ public class ClientTxnMapProxy<K, V> extends ClientTxnProxy implements Transacti
         ClientMessage request = TransactionalMapKeySetWithPredicateCodec.encodeRequest(name, getTransactionId(),
                 ThreadUtil.getThreadId(), toData(predicate));
         ClientMessage response = invoke(request);
-        Collection<Data> dataKeySet = TransactionalMapKeySetWithPredicateCodec.decodeResponse(response).set;
+        Collection<Data> dataKeySet = TransactionalMapKeySetWithPredicateCodec.decodeResponse(response).list;
 
         HashSet<K> keySet = new HashSet<K>(dataKeySet.size());
         for (Data data : dataKeySet) {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/txn/xa/XAResourceProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/txn/xa/XAResourceProxy.java
@@ -205,7 +205,7 @@ public class XAResourceProxy extends ClientProxy implements HazelcastXAResource 
     public Xid[] recover(int flag) throws XAException {
         ClientMessage request = XATransactionCollectTransactionsCodec.encodeRequest();
         ClientMessage response = invoke(request);
-        Collection<Data> list = XATransactionCollectTransactionsCodec.decodeResponse(response).set;
+        Collection<Data> list = XATransactionCollectTransactionsCodec.decodeResponse(response).list;
         SerializableXID[] xidArray = new SerializableXID[list.size()];
         SerializationService serializationService = getContext().getSerializationService();
         int index = 0;

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientMembershipListener.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientMembershipListener.java
@@ -31,6 +31,7 @@ import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.Connection;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -78,7 +79,7 @@ class ClientMembershipListener extends ClientAddMembershipListenerCodec.Abstract
     }
 
     @Override
-    public void handle(Set<Member> initialMembers) {
+    public void handle(Collection<Member> initialMembers) {
         Map<String, Member> prevMembers = Collections.emptyMap();
         if (!members.isEmpty()) {
             prevMembers = new HashMap<String, Member>(members.size());

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientPartitionServiceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientPartitionServiceImpl.java
@@ -35,8 +35,8 @@ import com.hazelcast.partition.NoDataMemberInClusterException;
 import com.hazelcast.util.EmptyStatement;
 import com.hazelcast.util.HashUtil;
 
+import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionException;
@@ -132,8 +132,8 @@ public final class ClientPartitionServiceImpl
     }
 
     private boolean processPartitionResponse(ClientGetPartitionsCodec.ResponseParameters response) {
-        Map<Address, Set<Integer>> partitionResponse = response.partitions;
-        for (Map.Entry<Address, Set<Integer>> entry : partitionResponse.entrySet()) {
+        Map<Address, List<Integer>> partitionResponse = response.partitions;
+        for (Map.Entry<Address, List<Integer>> entry : partitionResponse.entrySet()) {
             Address address = entry.getKey();
             for (Integer partition : entry.getValue()) {
                 this.partitions.put(partition, address);

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cluster/ClientClusterServiceMemberListTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cluster/ClientClusterServiceMemberListTest.java
@@ -17,6 +17,7 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.util.Collection;
+import java.util.Set;
 
 import static com.hazelcast.cluster.memberselector.MemberSelectors.DATA_MEMBER_SELECTOR;
 import static com.hazelcast.cluster.memberselector.MemberSelectors.LITE_MEMBER_SELECTOR;
@@ -25,6 +26,7 @@ import static com.hazelcast.test.HazelcastTestSupport.getNode;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
@@ -86,6 +88,13 @@ public class ClientClusterServiceMemberListTest {
                 assertEquals(2, clusterService.getSize(DATA_MEMBER_SELECTOR));
             }
         });
+    }
+
+    @Test
+    public void testMemberListOrderConsistentWithServer() {
+        Set<Member> membersFromClient = client.getCluster().getMembers();
+        Set<Member> membersFromServer = dataInstance.getCluster().getMembers();
+        assertArrayEquals(membersFromClient.toArray(), membersFromServer.toArray());
     }
 
     private void verifyMembers(Collection<Member> membersToCheck, Collection<HazelcastInstance> membersToExpect) {

--- a/hazelcast-code-generator/src/main/resources/codec-template-java.ftl
+++ b/hazelcast-code-generator/src/main/resources/codec-template-java.ftl
@@ -21,7 +21,7 @@ public final class ${model.className} {
         public ${param.type} ${param.name};
 </#list>
 
-        public static int calculateDataSize(<#list model.requestParams as param>${param.type} ${param.name}<#if param_has_next>, </#if></#list>) {
+        public static int calculateDataSize(<#list model.requestParams as param><@methodParam type=param.type/> ${param.name}<#if param_has_next>, </#if></#list>) {
             int dataSize = ClientMessage.HEADER_SIZE;
 <#list model.requestParams as p>
     <@sizeText varName=p.name type=p.type isNullable=p.nullable/>
@@ -30,7 +30,7 @@ public final class ${model.className} {
         }
     }
 
-    public static ClientMessage encodeRequest(<#list model.requestParams as param>${param.type} ${param.name}<#if param_has_next>, </#if></#list>) {
+    public static ClientMessage encodeRequest(<#list model.requestParams as param><@methodParam type=param.type/> ${param.name}<#if param_has_next>, </#if></#list>) {
         final int requiredDataSize = RequestParameters.calculateDataSize(<#list model.requestParams as param>${param.name}<#if param_has_next>, </#if></#list>);
         ClientMessage clientMessage = ClientMessage.createForEncode(requiredDataSize);
         clientMessage.setMessageType(REQUEST_TYPE.id());
@@ -57,7 +57,7 @@ public final class ${model.className} {
         public ${param.type} ${param.name};
 </#list>
 
-        public static int calculateDataSize(<#list model.responseParams as param>${param.type} ${param.name}<#if param_has_next>, </#if></#list>) {
+        public static int calculateDataSize(<#list model.responseParams as param><@methodParam type=param.type/> ${param.name}<#if param_has_next>, </#if></#list>) {
             int dataSize = ClientMessage.HEADER_SIZE;
 <#list model.responseParams as p>
     <@sizeText varName=p.name type=p.type isNullable=p.nullable/>
@@ -66,7 +66,7 @@ public final class ${model.className} {
         }
     }
 
-    public static ClientMessage encodeResponse(<#list model.responseParams as param>${param.type} ${param.name}<#if param_has_next>, </#if></#list>) {
+    public static ClientMessage encodeResponse(<#list model.responseParams as param><@methodParam type=param.type/> ${param.name}<#if param_has_next>, </#if></#list>) {
         final int requiredDataSize = ResponseParameters.calculateDataSize(<#list model.responseParams as param>${param.name}<#if param_has_next>, </#if></#list>);
         ClientMessage clientMessage = ClientMessage.createForEncode(requiredDataSize);
         clientMessage.setMessageType(RESPONSE_TYPE);
@@ -91,7 +91,7 @@ public final class ${model.className} {
     //************************ EVENTS *************************//
 
 <#list model.events as event>
-    public static ClientMessage encode${event.name}Event(<#list event.eventParams as param>${param.type} ${param.name}<#if param_has_next>, </#if></#list>){
+    public static ClientMessage encode${event.name}Event(<#list event.eventParams as param><@methodParam type=param.type/> ${param.name}<#if param_has_next>, </#if></#list>){
         int dataSize = ClientMessage.HEADER_SIZE;
     <#list event.eventParams as p>
         <@sizeText varName=p.name type=p.type isNullable=p.nullable/>
@@ -128,7 +128,7 @@ public final class ${model.className} {
         }
 
     <#list model.events as event>
-        public abstract void handle(<#list event.eventParams as param>${param.type} ${param.name}<#if param_has_next>, </#if></#list>);
+        public abstract void handle(<#list event.eventParams as param><@methodParam type=param.type/> ${param.name}<#if param_has_next>, </#if></#list>);
 
     </#list>
    }
@@ -146,6 +146,15 @@ public final class ${model.className} {
 <#if isNullable>
             }
 </#if>
+</#macro>
+
+
+<#--METHOD PARAM MACRO -->
+<#macro methodParam type><#local cat= util.getTypeCategory(type)>
+<#switch cat>
+<#case "COLLECTION"><#local genericType= util.getGenericType(type)>java.util.Collection<${genericType}><#break>
+<#default>${type}
+</#switch>
 </#macro>
 
 <#--SIZE MACRO -->
@@ -292,7 +301,7 @@ public final class ${model.className} {
             ${varName} = ${util.getTypeCodec(varType)}.decode(clientMessage);
         <#break >
     <#case "COLLECTION">
-    <#local collectionType><#if varType?starts_with("java.util.List")>java.util.ArrayList<#else>java.util.HashSet</#if></#local>
+    <#local collectionType>java.util.ArrayList</#local>
     <#local itemVariableType= util.getGenericType(varType)>
     <#local itemVariableName= "${varName}_item">
     <#local sizeVariableName= "${varName}_size">

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/EventMessageConst.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/EventMessageConst.java
@@ -29,7 +29,7 @@ package com.hazelcast.client.impl.protocol;
 public final class EventMessageConst {
 
     public static final int EVENT_MEMBER = 200;
-    public static final int EVENT_MEMBERSET = 201;
+    public static final int EVENT_MEMBERLIST = 201;
     public static final int EVENT_MEMBERATTRIBUTECHANGE = 202;
     public static final int EVENT_ENTRY = 203;
     public static final int EVENT_ITEM = 204;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/ResponseMessageConst.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/ResponseMessageConst.java
@@ -22,7 +22,7 @@ package com.hazelcast.client.impl.protocol;
  * <p/>
  * Response classes are defined    {@link com.hazelcast.client.impl.protocol.template.ResponseTemplate}
  * <p/>
- * see {@link   com.hazelcast.client.impl.protocol.template.ClientMessageTemplate#membershipListener()}
+ * see {@link   com.hazelcast.client.impl.protocol.template.ClientMessageTemplate#addMembershipListener(boolean)} ()}
  * for  a sample usage of responses in a request.
  */
 public final class ResponseMessageConst {
@@ -37,11 +37,11 @@ public final class ResponseMessageConst {
     public static final int AUTHENTICATION = 107;
     public static final int PARTITIONS = 108;
     public static final int EXCEPTION = 109;
-    public static final int SET_DISTRIBUTED_OBJECT = 110;
+    public static final int LIST_DISTRIBUTED_OBJECT = 110;
     public static final int ENTRY_VIEW = 111;
     public static final int JOB_PROCESS_INFO = 112;
-    public static final int SET_DATA = 113;
-    public static final int SET_ENTRY = 114;
+//    public static final int SET_DATA = 113;
+//    public static final int SET_ENTRY = 114;
     public static final int READ_RESULT_SET = 115;
     public static final int CACHE_KEY_ITERATOR_RESULT = 116;
     public static final int LIST_ENTRY = 117;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AddMembershipListenerMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AddMembershipListenerMessageTask.java
@@ -31,7 +31,7 @@ import com.hazelcast.instance.Node;
 import com.hazelcast.nio.Connection;
 
 import java.security.Permission;
-import java.util.Set;
+import java.util.Collection;
 
 public class AddMembershipListenerMessageTask
         extends AbstractCallableMessageTask<ClientAddMembershipListenerCodec.RequestParameters> {
@@ -95,8 +95,8 @@ public class AddMembershipListenerMessageTask
         @Override
         public void init(InitialMembershipEvent membershipEvent) {
             ClusterService service = getService(ClusterServiceImpl.SERVICE_NAME);
-            Set members = (Set) service.getMemberImpls();
-            ClientMessage eventMessage = ClientAddMembershipListenerCodec.encodeMemberSetEvent(members);
+            Collection members = service.getMemberImpls();
+            ClientMessage eventMessage = ClientAddMembershipListenerCodec.encodeMemberListEvent(members);
             sendClientMessage(endpoint.getUuid(), eventMessage);
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/GetDistributedObjectsMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/GetDistributedObjectsMessageTask.java
@@ -25,9 +25,9 @@ import com.hazelcast.nio.Connection;
 import com.hazelcast.spi.impl.proxyservice.impl.ProxyServiceImpl;
 
 import java.security.Permission;
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.List;
 
 public class GetDistributedObjectsMessageTask
         extends AbstractCallableMessageTask<ClientGetDistributedObjectsCodec.RequestParameters> {
@@ -41,7 +41,7 @@ public class GetDistributedObjectsMessageTask
             throws Exception {
         Collection<DistributedObject> distributedObjects = clientEngine.getProxyService().getAllDistributedObjects();
 
-        Set<DistributedObjectInfo> coll = new HashSet<DistributedObjectInfo>(distributedObjects.size());
+        List<DistributedObjectInfo> coll = new ArrayList<DistributedObjectInfo>(distributedObjects.size());
         for (DistributedObject distributedObject : distributedObjects) {
             coll.add(new DistributedObjectInfo(distributedObject.getServiceName(), distributedObject.getName()));
         }
@@ -55,7 +55,7 @@ public class GetDistributedObjectsMessageTask
 
     @Override
     protected ClientMessage encodeResponse(Object response) {
-        return ClientGetDistributedObjectsCodec.encodeResponse((Set<DistributedObjectInfo>) response);
+        return ClientGetDistributedObjectsCodec.encodeResponse((List<DistributedObjectInfo>) response);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/GetPartitionsMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/GetPartitionsMessageTask.java
@@ -26,9 +26,9 @@ import com.hazelcast.partition.InternalPartitionService;
 
 import java.security.Permission;
 import java.util.HashMap;
-import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 public class GetPartitionsMessageTask
         extends AbstractCallableMessageTask<ClientGetPartitionsCodec.RequestParameters> {
@@ -41,7 +41,7 @@ public class GetPartitionsMessageTask
         InternalPartitionService service = getService(InternalPartitionService.SERVICE_NAME);
         service.firstArrangement();
 
-        Map<Address, Set<Integer>> partitionsMap = new HashMap<Address, Set<Integer>>();
+        Map<Address, List<Integer>> partitionsMap = new HashMap<Address, List<Integer>>();
 
         for (InternalPartition partition : service.getPartitions()) {
             Address owner = partition.getOwnerOrNull();
@@ -49,9 +49,9 @@ public class GetPartitionsMessageTask
                 partitionsMap.clear();
                 return ClientGetPartitionsCodec.encodeResponse(partitionsMap);
             }
-            Set<Integer> indexes = partitionsMap.get(owner);
+            List<Integer> indexes = partitionsMap.get(owner);
             if (indexes == null) {
-                indexes = new HashSet<Integer>();
+                indexes = new LinkedList<Integer>();
                 partitionsMap.put(owner, indexes);
             }
             indexes.add(partition.getPartitionId());

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheGetAllMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheGetAllMessageTask.java
@@ -31,7 +31,9 @@ import com.hazelcast.spi.OperationFactory;
 
 import javax.cache.expiry.ExpiryPolicy;
 import java.security.Permission;
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -54,7 +56,7 @@ public class CacheGetAllMessageTask
 
     @Override
     protected ClientMessage encodeResponse(Object response) {
-        return CacheGetAllCodec.encodeResponse((Set<Map.Entry<Data, Data>>) response);
+        return CacheGetAllCodec.encodeResponse((List<Map.Entry<Data, Data>>) response);
     }
 
     @Override
@@ -62,12 +64,13 @@ public class CacheGetAllMessageTask
         CacheOperationProvider operationProvider = getOperationProvider(parameters.name);
         CacheService service = getService(getServiceName());
         ExpiryPolicy expiryPolicy = (ExpiryPolicy) service.toObject(parameters.expiryPolicy);
-        return operationProvider.createGetAllOperationFactory((Set<Data>) parameters.keys, expiryPolicy);
+        Set<Data> keys = new HashSet<Data>(parameters.keys);
+        return operationProvider.createGetAllOperationFactory(keys, expiryPolicy);
     }
 
     @Override
     protected Object reduce(Map<Integer, Object> map) {
-        Set<Map.Entry<Data, Data>> reducedMap = new HashSet<Map.Entry<Data, Data>>(map.size());
+        List<Map.Entry<Data, Data>> reducedMap = new ArrayList<Map.Entry<Data, Data>>(map.size());
         for (Map.Entry<Integer, Object> entry : map.entrySet()) {
             MapEntries mapEntries = (MapEntries) nodeEngine.toObject(entry.getValue());
             for (Map.Entry<Data, Data> dataEntry : mapEntries) {
@@ -86,6 +89,7 @@ public class CacheGetAllMessageTask
     public String getDistributedObjectName() {
         return parameters.name;
     }
+
     @Override
     public String getMethodName() {
         return "getAll";

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheLoadAllMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheLoadAllMessageTask.java
@@ -29,6 +29,7 @@ import com.hazelcast.spi.OperationFactory;
 
 import javax.cache.CacheException;
 import java.security.Permission;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -57,7 +58,8 @@ public class CacheLoadAllMessageTask
     @Override
     protected OperationFactory createOperationFactory() {
         CacheOperationProvider operationProvider = getOperationProvider(parameters.name);
-        return operationProvider.createLoadAllOperationFactory((Set<Data>) parameters.keys, parameters.replaceExistingValues);
+        Set<Data> keys = new HashSet<Data>(parameters.keys);
+        return operationProvider.createLoadAllOperationFactory(keys, parameters.replaceExistingValues);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheRemoveAllKeysMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheRemoveAllKeysMessageTask.java
@@ -23,13 +23,16 @@ import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.CacheRemoveAllKeysCodec;
 import com.hazelcast.instance.Node;
 import com.hazelcast.nio.Connection;
+import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.security.permission.ActionConstants;
 import com.hazelcast.security.permission.CachePermission;
 import com.hazelcast.spi.OperationFactory;
 
 import javax.cache.CacheException;
 import java.security.Permission;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * This client request  specifically calls {@link CacheRemoveAllOperationFactory} on the server side.
@@ -56,7 +59,8 @@ public class CacheRemoveAllKeysMessageTask
     @Override
     protected OperationFactory createOperationFactory() {
         CacheOperationProvider operationProvider = getOperationProvider(parameters.name);
-        return operationProvider.createRemoveAllOperationFactory(parameters.keys, parameters.completionId);
+        Set<Data> keys = new HashSet<Data>(parameters.keys);
+        return operationProvider.createRemoveAllOperationFactory(keys, parameters.completionId);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/ListCompareAndRemoveAllMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/ListCompareAndRemoveAllMessageTask.java
@@ -29,6 +29,7 @@ import com.hazelcast.security.permission.ListPermission;
 import com.hazelcast.spi.Operation;
 
 import java.security.Permission;
+import java.util.HashSet;
 import java.util.Set;
 
 /**
@@ -44,7 +45,8 @@ public class ListCompareAndRemoveAllMessageTask
 
     @Override
     protected Operation prepareOperation() {
-        return new CollectionCompareAndRemoveOperation(parameters.name, false, (Set<Data>) parameters.valueSet);
+        Set<Data> values = new HashSet<Data>(parameters.values);
+        return new CollectionCompareAndRemoveOperation(parameters.name, false, values);
     }
 
     @Override
@@ -64,7 +66,7 @@ public class ListCompareAndRemoveAllMessageTask
 
     @Override
     public Object[] getParameters() {
-        return new Object[]{parameters.valueSet};
+        return new Object[]{parameters.values};
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/ListCompareAndRetainAllMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/ListCompareAndRetainAllMessageTask.java
@@ -29,7 +29,7 @@ import com.hazelcast.security.permission.ListPermission;
 import com.hazelcast.spi.Operation;
 
 import java.security.Permission;
-import java.util.Set;
+import java.util.HashSet;
 
 /**
  * Client Protocol Task for handling messages with type id:
@@ -44,7 +44,8 @@ public class ListCompareAndRetainAllMessageTask
 
     @Override
     protected Operation prepareOperation() {
-        return new CollectionCompareAndRemoveOperation(parameters.name, true, (Set<Data>) parameters.valueSet);
+        HashSet<Data> values = new HashSet<Data>(parameters.values);
+        return new CollectionCompareAndRemoveOperation(parameters.name, true, values);
     }
 
     @Override
@@ -64,7 +65,7 @@ public class ListCompareAndRetainAllMessageTask
 
     @Override
     public Object[] getParameters() {
-        return new Object[]{parameters.valueSet};
+        return new Object[]{parameters.values};
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/ListContainsAllMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/list/ListContainsAllMessageTask.java
@@ -23,11 +23,14 @@ import com.hazelcast.collection.impl.collection.operations.CollectionContainsOpe
 import com.hazelcast.collection.impl.list.ListService;
 import com.hazelcast.instance.Node;
 import com.hazelcast.nio.Connection;
+import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.security.permission.ActionConstants;
 import com.hazelcast.security.permission.ListPermission;
 import com.hazelcast.spi.Operation;
 
 import java.security.Permission;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * Client Protocol Task for handling messages with type id:
@@ -42,7 +45,8 @@ public class ListContainsAllMessageTask
 
     @Override
     protected Operation prepareOperation() {
-        return new CollectionContainsOperation(parameters.name, parameters.valueSet);
+        Set<Data> values = new HashSet<Data>(parameters.values);
+        return new CollectionContainsOperation(parameters.name, values);
     }
 
     @Override
@@ -62,7 +66,7 @@ public class ListContainsAllMessageTask
 
     @Override
     public Object[] getParameters() {
-        return new Object[]{parameters.valueSet};
+        return new Object[]{parameters.values};
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapExecuteOnAllKeysMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapExecuteOnAllKeysMessageTask.java
@@ -30,9 +30,9 @@ import com.hazelcast.security.permission.MapPermission;
 import com.hazelcast.spi.OperationFactory;
 
 import java.security.Permission;
-import java.util.HashSet;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 public class MapExecuteOnAllKeysMessageTask
         extends AbstractMapAllPartitionsMessageTask<MapExecuteOnAllKeysCodec.RequestParameters> {
@@ -50,7 +50,7 @@ public class MapExecuteOnAllKeysMessageTask
 
     @Override
     protected Object reduce(Map<Integer, Object> map) {
-        Set<Map.Entry<Data, Data>> dataMap = new HashSet<Map.Entry<Data, Data>>();
+        List<Map.Entry<Data, Data>> dataMap = new ArrayList<Map.Entry<Data, Data>>();
         MapService mapService = getService(MapService.SERVICE_NAME);
         for (Object o : map.values()) {
             if (o != null) {
@@ -70,7 +70,7 @@ public class MapExecuteOnAllKeysMessageTask
 
     @Override
     protected ClientMessage encodeResponse(Object response) {
-        return MapExecuteOnAllKeysCodec.encodeResponse((Set<Map.Entry<Data, Data>>) response);
+        return MapExecuteOnAllKeysCodec.encodeResponse((List<Map.Entry<Data, Data>>) response);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapExecuteOnKeysMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapExecuteOnKeysMessageTask.java
@@ -32,10 +32,11 @@ import com.hazelcast.security.permission.MapPermission;
 import com.hazelcast.spi.OperationFactory;
 
 import java.security.Permission;
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -49,23 +50,24 @@ public class MapExecuteOnKeysMessageTask
     @Override
     protected OperationFactory createOperationFactory() {
         EntryProcessor entryProcessor = serializationService.toObject(parameters.entryProcessor);
-        return new MultipleEntryOperationFactory(parameters.name, parameters.keys, entryProcessor);
+        Set<Data> keys = new HashSet<Data>(parameters.keys);
+        return new MultipleEntryOperationFactory(parameters.name, keys, entryProcessor);
     }
 
     @Override
     protected Object reduce(Map<Integer, Object> map) {
-        Map<Data, Data> dataMap = new HashMap<Data, Data>();
+        List<Map.Entry<Data, Data>> entries = new ArrayList<Map.Entry<Data, Data>>();
 
         MapService mapService = getService(MapService.SERVICE_NAME);
         for (Object o : map.values()) {
             if (o != null) {
                 MapEntries mapEntries = (MapEntries) mapService.getMapServiceContext().toObject(o);
                 for (Map.Entry<Data, Data> entry : mapEntries) {
-                    dataMap.put(entry.getKey(), entry.getValue());
+                    entries.add(entry);
                 }
             }
         }
-        return dataMap.entrySet();
+        return entries;
     }
 
     @Override
@@ -89,7 +91,7 @@ public class MapExecuteOnKeysMessageTask
 
     @Override
     protected ClientMessage encodeResponse(Object response) {
-        return MapExecuteOnKeysCodec.encodeResponse((Set<Map.Entry<Data, Data>>) response);
+        return MapExecuteOnKeysCodec.encodeResponse((List<Map.Entry<Data, Data>>) response);
     }
 
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapExecuteWithPredicateMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapExecuteWithPredicateMessageTask.java
@@ -31,9 +31,9 @@ import com.hazelcast.security.permission.MapPermission;
 import com.hazelcast.spi.OperationFactory;
 
 import java.security.Permission;
-import java.util.HashSet;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 public class MapExecuteWithPredicateMessageTask
         extends AbstractMapAllPartitionsMessageTask<MapExecuteWithPredicateCodec.RequestParameters> {
@@ -53,7 +53,7 @@ public class MapExecuteWithPredicateMessageTask
 
     @Override
     protected Object reduce(Map<Integer, Object> map) {
-        Set<Map.Entry<Data, Data>> dataMap = new HashSet<Map.Entry<Data, Data>>();
+        List<Map.Entry<Data, Data>> dataMap = new ArrayList<Map.Entry<Data, Data>>();
         MapService mapService = getService(MapService.SERVICE_NAME);
         for (Object o : map.values()) {
             if (o != null) {
@@ -73,7 +73,7 @@ public class MapExecuteWithPredicateMessageTask
 
     @Override
     protected ClientMessage encodeResponse(Object response) {
-        return MapExecuteWithPredicateCodec.encodeResponse((Set<Map.Entry<Data, Data>>) response);
+        return MapExecuteWithPredicateCodec.encodeResponse((List<Map.Entry<Data, Data>>) response);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/mapreduce/AbstractMapReduceTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/mapreduce/AbstractMapReduceTask.java
@@ -42,9 +42,10 @@ import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.Operation;
 
 import java.security.Permission;
+import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
@@ -165,13 +166,13 @@ public abstract class AbstractMapReduceTask<Parameters>
     @Override
     public void onResponse(Object response) {
         Map<Object, Object> m = (Map<Object, Object>) response;
-        Map<Data, Data> hashMap = new HashMap<Data, Data>();
+        List<Map.Entry<Data, Data>> entries = new ArrayList<Map.Entry<Data, Data>>();
         for (Map.Entry<Object, Object> entry : m.entrySet()) {
             Data key = serializationService.toData(entry.getKey());
             Data value = serializationService.toData(entry.getValue());
-            hashMap.put(key, value);
+            entries.add(new AbstractMap.SimpleEntry<Data, Data>(key, value));
         }
-        sendResponse(hashMap.entrySet());
+        sendResponse(entries);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/mapreduce/MapReduceForCustomMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/mapreduce/MapReduceForCustomMessageTask.java
@@ -28,8 +28,8 @@ import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.serialization.Data;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 public class MapReduceForCustomMessageTask
         extends AbstractMapReduceTask<MapReduceForCustomCodec.RequestParameters> {
@@ -89,7 +89,7 @@ public class MapReduceForCustomMessageTask
     }
 
     protected ClientMessage encodeResponse(Object response) {
-        return MapReduceForCustomCodec.encodeResponse((Set<Map.Entry<Data, Data>>) response);
+        return MapReduceForCustomCodec.encodeResponse((List<Map.Entry<Data, Data>>) response);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/mapreduce/MapReduceForListMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/mapreduce/MapReduceForListMessageTask.java
@@ -29,8 +29,8 @@ import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.serialization.Data;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 public class MapReduceForListMessageTask
         extends AbstractMapReduceTask<MapReduceForListCodec.RequestParameters> {
@@ -90,7 +90,7 @@ public class MapReduceForListMessageTask
     }
 
     protected ClientMessage encodeResponse(Object response) {
-        return MapReduceForListCodec.encodeResponse((Set<Map.Entry<Data, Data>>) response);
+        return MapReduceForListCodec.encodeResponse((List<Map.Entry<Data, Data>>) response);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/mapreduce/MapReduceForMapMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/mapreduce/MapReduceForMapMessageTask.java
@@ -29,8 +29,8 @@ import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.serialization.Data;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 public class MapReduceForMapMessageTask
         extends AbstractMapReduceTask<MapReduceForMapCodec.RequestParameters> {
@@ -90,7 +90,7 @@ public class MapReduceForMapMessageTask
     }
 
     protected ClientMessage encodeResponse(Object response) {
-        return MapReduceForMapCodec.encodeResponse((Set<Map.Entry<Data, Data>>) response);
+        return MapReduceForMapCodec.encodeResponse((List<Map.Entry<Data, Data>>) response);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/mapreduce/MapReduceForMultiMapMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/mapreduce/MapReduceForMultiMapMessageTask.java
@@ -29,8 +29,8 @@ import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.serialization.Data;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 public class MapReduceForMultiMapMessageTask
         extends AbstractMapReduceTask<MapReduceForMultiMapCodec.RequestParameters> {
@@ -90,7 +90,7 @@ public class MapReduceForMultiMapMessageTask
     }
 
     protected ClientMessage encodeResponse(Object response) {
-        return MapReduceForMultiMapCodec.encodeResponse((Set<Map.Entry<Data, Data>>) response);
+        return MapReduceForMultiMapCodec.encodeResponse((List<Map.Entry<Data, Data>>) response);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/mapreduce/MapReduceForSetMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/mapreduce/MapReduceForSetMessageTask.java
@@ -29,8 +29,8 @@ import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.serialization.Data;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 public class MapReduceForSetMessageTask
         extends AbstractMapReduceTask<MapReduceForSetCodec.RequestParameters> {
@@ -90,7 +90,7 @@ public class MapReduceForSetMessageTask
     }
 
     protected ClientMessage encodeResponse(Object response) {
-        return MapReduceForSetCodec.encodeResponse((Set<Map.Entry<Data, Data>>) response);
+        return MapReduceForSetCodec.encodeResponse((List<Map.Entry<Data, Data>>) response);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapEntrySetMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapEntrySetMessageTask.java
@@ -30,7 +30,8 @@ import com.hazelcast.security.permission.MultiMapPermission;
 import com.hazelcast.spi.OperationFactory;
 
 import java.security.Permission;
-import java.util.HashSet;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -52,18 +53,18 @@ public class MultiMapEntrySetMessageTask
 
     @Override
     protected Object reduce(Map<Integer, Object> map) {
-        Set<Map.Entry<Data, Data>> reduced = new HashSet<Map.Entry<Data, Data>>();
+        List<Map.Entry<Data, Data>> entries = new ArrayList<Map.Entry<Data, Data>>();
         for (Object obj : map.values()) {
             if (obj == null) {
                 continue;
             }
             EntrySetResponse response = (EntrySetResponse) obj;
-            Set<Map.Entry<Data, Data>> entries = response.getDataEntrySet();
-            for (Map.Entry<Data, Data> entry : entries) {
-                reduced.add(entry);
+            Set<Map.Entry<Data, Data>> entrySet = response.getDataEntrySet();
+            for (Map.Entry<Data, Data> entry : entrySet) {
+                entries.add(entry);
             }
         }
-        return reduced;
+        return entries;
     }
 
     @Override
@@ -73,7 +74,7 @@ public class MultiMapEntrySetMessageTask
 
     @Override
     protected ClientMessage encodeResponse(Object response) {
-        return MultiMapEntrySetCodec.encodeResponse((Set<Map.Entry<Data, Data>>) response);
+        return MultiMapEntrySetCodec.encodeResponse((List<Map.Entry<Data, Data>>) response);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapKeySetMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/multimap/MultiMapKeySetMessageTask.java
@@ -30,10 +30,10 @@ import com.hazelcast.security.permission.MultiMapPermission;
 import com.hazelcast.spi.OperationFactory;
 
 import java.security.Permission;
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 
 /**
@@ -54,7 +54,7 @@ public class MultiMapKeySetMessageTask
 
     @Override
     protected Object reduce(Map<Integer, Object> map) {
-        Set<Data> keys = new HashSet<Data>();
+        List<Data> keys = new ArrayList<Data>();
 
         for (Object obj : map.values()) {
             if (obj == null) {
@@ -76,7 +76,7 @@ public class MultiMapKeySetMessageTask
 
     @Override
     protected ClientMessage encodeResponse(Object response) {
-        return MultiMapKeySetCodec.encodeResponse((Set<Data>) response);
+        return MultiMapKeySetCodec.encodeResponse((List<Data>) response);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/set/SetCompareAndRemoveAllMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/set/SetCompareAndRemoveAllMessageTask.java
@@ -29,6 +29,7 @@ import com.hazelcast.security.permission.SetPermission;
 import com.hazelcast.spi.Operation;
 
 import java.security.Permission;
+import java.util.HashSet;
 import java.util.Set;
 
 /**
@@ -43,7 +44,8 @@ public class SetCompareAndRemoveAllMessageTask
 
     @Override
     protected Operation prepareOperation() {
-        return new CollectionCompareAndRemoveOperation(parameters.name, false, (Set<Data>) parameters.valueSet);
+        Set<Data> values = new HashSet<Data>(parameters.values);
+        return new CollectionCompareAndRemoveOperation(parameters.name, false, values);
     }
 
     @Override
@@ -63,7 +65,7 @@ public class SetCompareAndRemoveAllMessageTask
 
     @Override
     public Object[] getParameters() {
-        return new Object[]{parameters.valueSet};
+        return new Object[]{parameters.values};
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/set/SetCompareAndRetainAllMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/set/SetCompareAndRetainAllMessageTask.java
@@ -29,6 +29,7 @@ import com.hazelcast.security.permission.SetPermission;
 import com.hazelcast.spi.Operation;
 
 import java.security.Permission;
+import java.util.HashSet;
 import java.util.Set;
 
 /**
@@ -43,7 +44,8 @@ public class SetCompareAndRetainAllMessageTask
 
     @Override
     protected Operation prepareOperation() {
-        return new CollectionCompareAndRemoveOperation(parameters.name, true, (Set<Data>) parameters.valueSet);
+        Set<Data> values = new HashSet<Data>(parameters.values);
+        return new CollectionCompareAndRemoveOperation(parameters.name, true, values);
     }
 
     @Override
@@ -63,7 +65,7 @@ public class SetCompareAndRetainAllMessageTask
 
     @Override
     public Object[] getParameters() {
-        return new Object[]{parameters.valueSet};
+        return new Object[]{parameters.values};
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/set/SetContainsAllMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/set/SetContainsAllMessageTask.java
@@ -29,6 +29,7 @@ import com.hazelcast.security.permission.SetPermission;
 import com.hazelcast.spi.Operation;
 
 import java.security.Permission;
+import java.util.HashSet;
 import java.util.Set;
 
 /**
@@ -43,7 +44,8 @@ public class SetContainsAllMessageTask
 
     @Override
     protected Operation prepareOperation() {
-        return new CollectionContainsOperation(parameters.name, (Set<Data>) parameters.valueSet);
+        Set<Data> values = new HashSet<Data>(parameters.items);
+        return new CollectionContainsOperation(parameters.name, values);
     }
 
     @Override
@@ -63,7 +65,7 @@ public class SetContainsAllMessageTask
 
     @Override
     public Object[] getParameters() {
-        return new Object[]{parameters.valueSet};
+        return new Object[]{parameters.items};
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transaction/XACollectTransactionsMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transaction/XACollectTransactionsMessageTask.java
@@ -31,10 +31,11 @@ import com.hazelcast.transaction.impl.xa.XAService;
 import com.hazelcast.transaction.impl.xa.operations.CollectRemoteTransactionsOperationFactory;
 
 import java.security.Permission;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 public class XACollectTransactionsMessageTask
         extends AbstractMultiTargetMessageTask<XATransactionCollectTransactionsCodec.RequestParameters> {
@@ -50,7 +51,7 @@ public class XACollectTransactionsMessageTask
 
     @Override
     protected ClientMessage encodeResponse(Object response) {
-        return XATransactionCollectTransactionsCodec.encodeResponse((Set<Data>) response);
+        return XATransactionCollectTransactionsCodec.encodeResponse((List<Data>) response);
     }
 
     @Override
@@ -60,12 +61,12 @@ public class XACollectTransactionsMessageTask
 
     @Override
     protected Object reduce(Map<Address, Object> map) throws Throwable {
-        HashSet<Data> set = new HashSet<Data>();
+        List<Data> list = new ArrayList<Data>();
         for (Object o : map.values()) {
             SerializableList xidSet = (SerializableList) o;
-            set.addAll(xidSet.getCollection());
+            list.addAll(xidSet.getCollection());
         }
-        return set;
+        return list;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transactionalmap/TransactionalMapKeySetMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transactionalmap/TransactionalMapKeySetMessageTask.java
@@ -29,7 +29,8 @@ import com.hazelcast.security.permission.MapPermission;
 import com.hazelcast.transaction.TransactionContext;
 
 import java.security.Permission;
-import java.util.HashSet;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 
 public class TransactionalMapKeySetMessageTask
@@ -44,11 +45,11 @@ public class TransactionalMapKeySetMessageTask
         final TransactionContext context = getEndpoint().getTransactionContext(parameters.txnId);
         final TransactionalMap map = context.getMap(parameters.name);
         Set keySet = map.keySet();
-        Set<Data> set = new HashSet<Data>(keySet.size());
+        List<Data> list = new ArrayList<Data>(keySet.size());
         for (Object o : keySet) {
-            set.add(serializationService.toData(o));
+            list.add(serializationService.toData(o));
         }
-        return set;
+        return list;
     }
 
     @Override
@@ -63,7 +64,7 @@ public class TransactionalMapKeySetMessageTask
 
     @Override
     protected ClientMessage encodeResponse(Object response) {
-        return TransactionalMapKeySetCodec.encodeResponse((Set<Data>) response);
+        return TransactionalMapKeySetCodec.encodeResponse((List<Data>) response);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transactionalmap/TransactionalMapKeySetWithPredicateMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transactionalmap/TransactionalMapKeySetWithPredicateMessageTask.java
@@ -30,7 +30,8 @@ import com.hazelcast.security.permission.MapPermission;
 import com.hazelcast.transaction.TransactionContext;
 
 import java.security.Permission;
-import java.util.HashSet;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 
 public class TransactionalMapKeySetWithPredicateMessageTask
@@ -47,11 +48,11 @@ public class TransactionalMapKeySetWithPredicateMessageTask
 
         Predicate predicate = serializationService.toObject(parameters.predicate);
         Set keySet = map.keySet(predicate);
-        Set<Data> set = new HashSet<Data>(keySet.size());
+        List<Data> list = new ArrayList<Data>(keySet.size());
         for (Object o : keySet) {
-            set.add(serializationService.toData(o));
+            list.add(serializationService.toData(o));
         }
-        return set;
+        return list;
     }
 
     @Override
@@ -66,7 +67,7 @@ public class TransactionalMapKeySetWithPredicateMessageTask
 
     @Override
     protected ClientMessage encodeResponse(Object response) {
-        return TransactionalMapKeySetWithPredicateCodec.encodeResponse((Set<Data>) response);
+        return TransactionalMapKeySetWithPredicateCodec.encodeResponse((List<Data>) response);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/CacheCodecTemplate.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/CacheCodecTemplate.java
@@ -67,7 +67,7 @@ public interface CacheCodecTemplate {
      *                     the request in the cluster.
      */
     @Request(id = 4, retryable = false, response = ResponseMessageConst.VOID)
-    void removeAllKeys(String name, Set<Data> keys, int completionId);
+    void removeAllKeys(String name, List<Data> keys, int completionId);
 
     /**
      * Removes all of the mappings from this cache. The order that the individual entries are removed is undefined.
@@ -137,8 +137,8 @@ public interface CacheCodecTemplate {
      * @return A map of entries that were found for the given keys. Keys not found
      * in the cache are not in the returned map.
      */
-    @Request(id = 10, retryable = false, response = ResponseMessageConst.SET_ENTRY)
-    Object getAll(String name, Set<Data> keys, @Nullable Data expiryPolicy);
+    @Request(id = 10, retryable = false, response = ResponseMessageConst.LIST_ENTRY)
+    Object getAll(String name, List<Data> keys, @Nullable Data expiryPolicy);
 
     /**
      * Atomically removes the entry for a key only if currently mapped to some value.
@@ -225,7 +225,7 @@ public interface CacheCodecTemplate {
      *                              be replaced by those loaded from a CacheLoader
      */
     @Request(id = 17, retryable = false, response = ResponseMessageConst.VOID)
-    void loadAll(String name, Set<Data> keys, boolean replaceExistingValues);
+    void loadAll(String name, List<Data> keys, boolean replaceExistingValues);
 
     /**
      * @param name    Name of the cache.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/ClientMessageTemplate.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/ClientMessageTemplate.java
@@ -62,7 +62,7 @@ public interface ClientMessageTemplate {
      * @return Returns the registration id for the listener.
      */
     @Request(id = 4, retryable = false, response = ResponseMessageConst.STRING,
-            event = {EventMessageConst.EVENT_MEMBER, EventMessageConst.EVENT_MEMBERSET, EventMessageConst.EVENT_MEMBERATTRIBUTECHANGE})
+            event = {EventMessageConst.EVENT_MEMBER, EventMessageConst.EVENT_MEMBERLIST, EventMessageConst.EVENT_MEMBERATTRIBUTECHANGE})
     Object addMembershipListener(boolean localOnly);
 
     /**
@@ -147,7 +147,7 @@ public interface ClientMessageTemplate {
     /**
      * @return An array of distributed object info in the cluster.
      */
-    @Request(id = 12, retryable = false, response = ResponseMessageConst.SET_DISTRIBUTED_OBJECT)
+    @Request(id = 12, retryable = false, response = ResponseMessageConst.LIST_DISTRIBUTED_OBJECT)
     Object getDistributedObjects();
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/EnterpriseMapCodecTemplate.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/EnterpriseMapCodecTemplate.java
@@ -38,7 +38,7 @@ public interface EnterpriseMapCodecTemplate {
      *                 batch, otherwise all changed values are included in the update.
      * @return Array of key-value pairs.
      */
-    @Request(id = 1, retryable = true, response = ResponseMessageConst.SET_ENTRY)
+    @Request(id = 1, retryable = true, response = ResponseMessageConst.LIST_ENTRY)
     Object publisherCreateWithValue(String mapName, String cacheName, Data predicate, int batchSize, int bufferSize,
                                   long delaySeconds, boolean populate, boolean coalesce);
 
@@ -55,7 +55,7 @@ public interface EnterpriseMapCodecTemplate {
      *                 batch, otherwise all changed values are included in the update.
      * @return Array of keys.
      */
-    @Request(id = 2, retryable = true, response = ResponseMessageConst.SET_DATA)
+    @Request(id = 2, retryable = true, response = ResponseMessageConst.LIST_DATA)
     Object publisherCreate(String mapName, String cacheName, Data predicate, int batchSize, int bufferSize, long delaySeconds,
                          boolean populate, boolean coalesce);
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/EventResponseTemplate.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/EventResponseTemplate.java
@@ -62,8 +62,8 @@ public interface EventResponseTemplate {
      * @param members The list of members in the cluster. It is used to retrieve the initial list in the cluster when the client
      *                registers for the membership events.
      */
-    @EventResponse(EventMessageConst.EVENT_MEMBERSET)
-    void MemberSet(Set<Member> members);
+    @EventResponse(EventMessageConst.EVENT_MEMBERLIST)
+    void MemberList(List<Member> members);
 
     /**
      *
@@ -168,7 +168,7 @@ public interface EventResponseTemplate {
      *                     the request in the cluster.
      */
     @EventResponse(EventMessageConst.EVENT_CACHE)
-    void Cache(int type, Set<CacheEventData> keys, int completionId);
+    void Cache(int type, List<CacheEventData> keys, int completionId);
 
     /**
      *

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/ListCodecTemplate.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/ListCodecTemplate.java
@@ -23,7 +23,6 @@ import com.hazelcast.client.impl.protocol.ResponseMessageConst;
 import com.hazelcast.nio.serialization.Data;
 
 import java.util.List;
-import java.util.Set;
 
 @GenerateCodec(id = TemplateConstants.LIST_TEMPLATE_ID, name = "List", ns = "Hazelcast.Client.Protocol.Codec")
 public interface ListCodecTemplate {
@@ -51,12 +50,12 @@ public interface ListCodecTemplate {
      * Returns true if this list contains all of the elements of the specified collection.
      *
      * @param name     Name of the List
-     * @param valueSet Collection to be checked for containment in this list
+     * @param values Collection to be checked for containment in this list
      * @return True if this list contains all of the elements of the
      * specified collection
      */
     @Request(id = 3, retryable = true, response = ResponseMessageConst.BOOLEAN)
-    Object containsAll(String name, Set<Data> valueSet);
+    Object containsAll(String name, List<Data> values);
 
     /**
      * Appends the specified element to the end of this list (optional operation). Lists that support this operation may
@@ -101,22 +100,22 @@ public interface ListCodecTemplate {
      * Removes from this list all of its elements that are contained in the specified collection (optional operation).
      *
      * @param name     Name of the List
-     * @param valueSet The list of values to compare for removal.
+     * @param values The list of values to compare for removal.
      * @return True if removed at least one of the items, false otherwise.
      */
     @Request(id = 7, retryable = false, response = ResponseMessageConst.BOOLEAN)
-    Object compareAndRemoveAll(String name, Set<Data> valueSet);
+    Object compareAndRemoveAll(String name, List<Data> values);
 
     /**
      * Retains only the elements in this list that are contained in the specified collection (optional operation).
      * In other words, removes from this list all of its elements that are not contained in the specified collection.
      *
      * @param name     Name of the List
-     * @param valueSet The list of values to compare for retaining.
+     * @param values The list of values to compare for retaining.
      * @return True if this list changed as a result of the call, false otherwise.
      */
     @Request(id = 8, retryable = false, response = ResponseMessageConst.BOOLEAN)
-    Object compareAndRetainAll(String name, Set<Data> valueSet);
+    Object compareAndRetainAll(String name, List<Data> values);
 
     /**
      * Removes all of the elements from this list (optional operation). The list will be empty after this call returns.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/MapCodecTemplate.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/MapCodecTemplate.java
@@ -498,7 +498,7 @@ public interface MapCodecTemplate {
      * @param replaceExistingValues when <code>true</code>, existing values in the Map will be replaced by those loaded from the MapLoader
      */
     @Request(id = 37, retryable = false, response = ResponseMessageConst.VOID)
-    void loadGivenKeys(String name, Set<Data> keys, boolean replaceExistingValues);
+    void loadGivenKeys(String name, List<Data> keys, boolean replaceExistingValues);
 
     /**
      * Returns a set clone of the keys contained in this map. The set is NOT backed by the map, so changes to the map
@@ -523,7 +523,7 @@ public interface MapCodecTemplate {
      * @param keys keys to get
      * @return values for the provided keys.
      */
-    @Request(id = 39, retryable = false, response = ResponseMessageConst.SET_ENTRY)
+    @Request(id = 39, retryable = false, response = ResponseMessageConst.LIST_ENTRY)
     Object getAll(String name, List<Data> keys);
 
     /**
@@ -688,7 +688,7 @@ public interface MapCodecTemplate {
      * @param entryProcessor entry processor to be executed.
      * @return results of entry process on the entries
      */
-    @Request(id = 52, retryable = false, response = ResponseMessageConst.SET_ENTRY)
+    @Request(id = 52, retryable = false, response = ResponseMessageConst.LIST_ENTRY)
     Object executeOnAllKeys(String name, Data entryProcessor);
 
     /**
@@ -700,7 +700,7 @@ public interface MapCodecTemplate {
      * @param predicate      specified query criteria.
      * @return results of entry process on the entries matching the query criteria
      */
-    @Request(id = 53, retryable = false, response = ResponseMessageConst.SET_ENTRY)
+    @Request(id = 53, retryable = false, response = ResponseMessageConst.LIST_ENTRY)
     Object executeWithPredicate(String name, Data entryProcessor, Data predicate);
 
     /**
@@ -712,8 +712,8 @@ public interface MapCodecTemplate {
      * @param keys           The keys for the entries for which the entry processor shall be executed on.
      * @return results of entry process on the entries with the provided keys
      */
-    @Request(id = 54, retryable = false, response = ResponseMessageConst.SET_ENTRY)
-    Object executeOnKeys(String name, Data entryProcessor, Set<Data> keys);
+    @Request(id = 54, retryable = false, response = ResponseMessageConst.LIST_ENTRY)
+    Object executeOnKeys(String name, Data entryProcessor, List<Data> keys);
 
     /**
      * Releases the lock for the specified key regardless of the lock owner.It always successfully unlocks the key,

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/MapReduceCodecTemplate.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/MapReduceCodecTemplate.java
@@ -59,7 +59,7 @@ public interface MapReduceCodecTemplate {
      * @param topologyChangedStrategy The strategy to use if a topology change is detected.
      * @return The resulting key-value pairs.
      */
-    @Request(id = 3, retryable = false, response = ResponseMessageConst.SET_ENTRY)
+    @Request(id = 3, retryable = false, response = ResponseMessageConst.LIST_ENTRY)
     Object forMap(String name, String jobId, @Nullable Data predicate, Data mapper, @Nullable Data combinerFactory,
                 @Nullable Data reducerFactory, String mapName, int chunkSize, @Nullable List<Data> keys,
                 @Nullable String topologyChangedStrategy);
@@ -78,7 +78,7 @@ public interface MapReduceCodecTemplate {
      * @param topologyChangedStrategy The strategy to use if a topology change is detected.
      * @return The resulting key-value pairs.
      */
-    @Request(id = 4, retryable = false, response = ResponseMessageConst.SET_ENTRY)
+    @Request(id = 4, retryable = false, response = ResponseMessageConst.LIST_ENTRY)
     Object forList(String name, String jobId, @Nullable Data predicate, Data mapper, @Nullable Data combinerFactory,
                  @Nullable Data reducerFactory, String listName, int chunkSize, @Nullable List<Data> keys,
                  @Nullable String topologyChangedStrategy);
@@ -97,7 +97,7 @@ public interface MapReduceCodecTemplate {
      * @param topologyChangedStrategy The strategy to use if a topology change is detected.
      * @return The resulting key-value pairs.
      */
-    @Request(id = 5, retryable = false, response = ResponseMessageConst.SET_ENTRY)
+    @Request(id = 5, retryable = false, response = ResponseMessageConst.LIST_ENTRY)
     Object forSet(String name, String jobId, @Nullable Data predicate, Data mapper, @Nullable Data combinerFactory,
                 @Nullable Data reducerFactory, String setName, int chunkSize, @Nullable List<Data> keys,
                 @Nullable String topologyChangedStrategy);
@@ -116,7 +116,7 @@ public interface MapReduceCodecTemplate {
      * @param topologyChangedStrategy The strategy to use if a topology change is detected.
      * @return The resulting key-value pairs.
      */
-    @Request(id = 6, retryable = false, response = ResponseMessageConst.SET_ENTRY)
+    @Request(id = 6, retryable = false, response = ResponseMessageConst.LIST_ENTRY)
     Object forMultiMap(String name, String jobId, @Nullable Data predicate, Data mapper, @Nullable Data combinerFactory,
                      @Nullable Data reducerFactory, String multiMapName, int chunkSize, @Nullable List<Data> keys,
                      @Nullable String topologyChangedStrategy);
@@ -136,7 +136,7 @@ public interface MapReduceCodecTemplate {
      * @param topologyChangedStrategy The strategy to use if a topology change is detected.
      * @return The resulting key-value pairs.
      */
-    @Request(id = 7, retryable = false, response = ResponseMessageConst.SET_ENTRY)
+    @Request(id = 7, retryable = false, response = ResponseMessageConst.LIST_ENTRY)
     Object forCustom(String name, String jobId, @Nullable Data predicate, Data mapper, @Nullable Data combinerFactory,
                    @Nullable Data reducerFactory, Data keyValueSource, int chunkSize, @Nullable List<Data> keys,
                    @Nullable String topologyChangedStrategy);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/MultiMapCodecTemplate.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/MultiMapCodecTemplate.java
@@ -66,7 +66,7 @@ public interface MultiMapCodecTemplate {
      * @param name Name of the MultiMap
      * @return The set of keys in the multimap. The returned set might be modifiable but it has no effect on the multimap.
      */
-    @Request(id = 4, retryable = true, response = ResponseMessageConst.SET_DATA)
+    @Request(id = 4, retryable = true, response = ResponseMessageConst.LIST_DATA)
     Object keySet(String name);
 
     /**
@@ -86,7 +86,7 @@ public interface MultiMapCodecTemplate {
      * @param name Name of the MultiMap
      * @return The set of key-value pairs in the multimap. The returned set might be modifiable but it has no effect on the multimap.
      */
-    @Request(id = 6, retryable = true, response = ResponseMessageConst.SET_ENTRY)
+    @Request(id = 6, retryable = true, response = ResponseMessageConst.LIST_ENTRY)
     Object entrySet(String name);
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/QueueCodecTemplate.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/QueueCodecTemplate.java
@@ -155,7 +155,7 @@ public interface QueueCodecTemplate {
      * @return <tt>true</tt> if this collection contains all of the elements in the specified collection
      */
     @Request(id = 12, retryable = false, response = ResponseMessageConst.BOOLEAN)
-    Object containsAll(String name, Set<Data> dataList);
+    Object containsAll(String name, List<Data> dataList);
 
     /**
      * Removes all of this collection's elements that are also contained in the specified collection (optional operation).
@@ -166,7 +166,7 @@ public interface QueueCodecTemplate {
      * @return <tt>true</tt> if this collection changed as a result of the call
      */
     @Request(id = 13, retryable = false, response = ResponseMessageConst.BOOLEAN)
-    Object compareAndRemoveAll(String name, Set<Data> dataList);
+    Object compareAndRemoveAll(String name, List<Data> dataList);
 
     /**
      * Retains only the elements in this collection that are contained in the specified collection (optional operation).
@@ -177,7 +177,7 @@ public interface QueueCodecTemplate {
      * @return <tt>true</tt> if this collection changed as a result of the call
      */
     @Request(id = 14, retryable = false, response = ResponseMessageConst.BOOLEAN)
-    Object compareAndRetainAll(String name, Set<Data> dataList);
+    Object compareAndRetainAll(String name, List<Data> dataList);
 
     /**
      * Removes all of the elements from this collection (optional operation). The collection will be empty after this

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/ResponseTemplate.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/ResponseTemplate.java
@@ -28,7 +28,6 @@ import com.hazelcast.nio.serialization.Data;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * Client Protocol Responses
@@ -83,24 +82,10 @@ public interface ResponseTemplate {
 
     /**
      *
-     * @param set The operation result as an array of serialized byte-array.
-     */
-    @Response(ResponseMessageConst.SET_DATA)
-    void SetData(Set<Data> set);
-
-    /**
-     *
-     * @param entrySet The operation result as an array of serialized key-value byte-arrays.
-     */
-    @Response(ResponseMessageConst.SET_ENTRY)
-    void SetEntry(Set<Map.Entry<Data, Data>> entrySet);
-
-    /**
-     *
-     * @param entrySet The operation result as an array of serialized key-value byte-arrays.
+     * @param entries The operation result as an array of serialized key-value byte-arrays.
      */
     @Response(ResponseMessageConst.LIST_ENTRY)
-    void ListEntry(List<Map.Entry<Data, Data>> entrySet);
+    void ListEntry(List<Map.Entry<Data, Data>> entries);
 
     /**
      *
@@ -119,18 +104,16 @@ public interface ResponseTemplate {
                           byte serializationVersion);
 
     /**
-     *
-     * @param partitions An array of member server address to partitions mapping.
+     * @param partitions mappings from member address to list of partition id 's that member owns
      */
     @Response(ResponseMessageConst.PARTITIONS)
-    void Partitions(Map<Address, Set<Integer>> partitions);
+    void Partitions(Map<Address, List<Integer>> partitions);
 
     /**
-     *
-     * @param infoCollection An array of DistributedObjectInfo (service name and object name).
+     * @param infoList An list of DistributedObjectInfo (service name and object name).
      */
-    @Response(ResponseMessageConst.SET_DISTRIBUTED_OBJECT)
-    void SetDistributedObject(Set<DistributedObjectInfo> infoCollection);
+    @Response(ResponseMessageConst.LIST_DISTRIBUTED_OBJECT)
+    void ListDistributedObject(List<DistributedObjectInfo> infoList);
 
     /**
      *

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/SetCodecTemplate.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/SetCodecTemplate.java
@@ -23,7 +23,6 @@ import com.hazelcast.client.impl.protocol.ResponseMessageConst;
 import com.hazelcast.nio.serialization.Data;
 
 import java.util.List;
-import java.util.Set;
 
 @GenerateCodec(id = TemplateConstants.SET_TEMPLATE_ID, name = "Set", ns = "Hazelcast.Client.Protocol.Codec")
 public interface SetCodecTemplate {
@@ -40,7 +39,7 @@ public interface SetCodecTemplate {
     /**
      * Returns true if this set contains the specified element.
      *
-     * @param name Name of the Set
+     * @param name  Name of the Set
      * @param value Element whose presence in this set is to be tested
      * @return True if this set contains the specified element, false otherwise
      */
@@ -51,13 +50,13 @@ public interface SetCodecTemplate {
      * Returns true if this set contains all of the elements of the specified collection. If the specified collection is
      * also a set, this method returns true if it is a subset of this set.
      *
-     * @param name Name of the Set
-     * @param valueSet Collection to be checked for containment in this set
+     * @param name     Name of the Set
+     * @param items Collection to be checked for containment in this list
      * @return true if this set contains all of the elements of the
-     *         specified collection
+     * specified collection
      */
     @Request(id = 3, retryable = false, response = ResponseMessageConst.BOOLEAN)
-    Object containsAll(String name, Set<Data> valueSet);
+    Object containsAll(String name, List<Data> items);
 
     /**
      * Adds the specified element to this set if it is not already present (optional operation).
@@ -67,11 +66,10 @@ public interface SetCodecTemplate {
      * element, including null, and throw an exception, as described in the specification for Collection
      * Individual set implementations should clearly document any restrictions on the elements that they may contain.
      *
-     *
-     * @param name Name of the Set
+     * @param name  Name of the Set
      * @param value Element to be added to this set
      * @return True if this set did not already contain the specified
-     *         element and the element is added, returns false otherwise.
+     * element and the element is added, returns false otherwise.
      */
     @Request(id = 4, retryable = false, response = ResponseMessageConst.BOOLEAN)
     Object add(String name, Data value);
@@ -81,7 +79,7 @@ public interface SetCodecTemplate {
      * Returns true if this set contained the element (or equivalently, if this set changed as a result of the call).
      * (This set will not contain the element once the call returns.)
      *
-     * @param name Name of the Set
+     * @param name  Name of the Set
      * @param value Object to be removed from this set, if present
      * @return True if this set contained the specified element and it is removed successfully
      */
@@ -94,7 +92,7 @@ public interface SetCodecTemplate {
      * set so that its value is the union of the two sets. The behavior of this operation is undefined if the specified
      * collection is modified while the operation is in progress.
      *
-     * @param name Name of the Set
+     * @param name      Name of the Set
      * @param valueList Collection containing elements to be added to this set
      * @return True if this set changed as a result of the call
      */
@@ -106,12 +104,12 @@ public interface SetCodecTemplate {
      * If the specified collection is also a set, this operation effectively modifies this set so that its value is the
      * asymmetric set difference of the two sets.
      *
-     * @param name Name of the Set
-     * @param valueSet The set of values to test for matching the item to remove.
-     * @return true if at least one item in valueSet existed and removed, false otherwise.
+     * @param name     Name of the Set
+     * @param values The list of values to test for matching the item to remove.
+     * @return true if at least one item in values existed and removed, false otherwise.
      */
     @Request(id = 7, retryable = false, response = ResponseMessageConst.BOOLEAN)
-    Object compareAndRemoveAll(String name, Set<Data> valueSet);
+    Object compareAndRemoveAll(String name, List<Data> values);
 
     /**
      * Retains only the elements in this set that are contained in the specified collection (optional operation).
@@ -119,13 +117,13 @@ public interface SetCodecTemplate {
      * If the specified collection is also a set, this operation effectively modifies this set so that its value is the
      * intersection of the two sets.
      *
-     * @param name Name of the Set
-     * @param valueSet The set of values to test for matching the item to retain.
-     * @return true if at least one item in valueSet existed and it is retained, false otherwise. All items not in valueSet but
-     *        in the Set are removed.
+     * @param name   Name of the Set
+     * @param values The list of values to test for matching the item to retain.
+     * @return true if at least one item in values existed and it is retained, false otherwise. All items not in valueSet but
+     * in the Set are removed.
      */
     @Request(id = 8, retryable = false, response = ResponseMessageConst.BOOLEAN)
-    Object compareAndRetainAll(String name, Set<Data> valueSet);
+    Object compareAndRetainAll(String name, List<Data> values);
 
     /**
      * Removes all of the elements from this set (optional operation). The set will be empty after this call returns.
@@ -147,25 +145,25 @@ public interface SetCodecTemplate {
     /**
      * Adds an item listener for this collection. Listener will be notified for all collection add/remove events.
      *
-     * @param name Name of the Set
+     * @param name         Name of the Set
      * @param includeValue if set to true, the event shall also include the value.
-     * @param localOnly if true fires events that originated from this node only, otherwise fires all events
+     * @param localOnly    if true fires events that originated from this node only, otherwise fires all events
      * @return The registration id.
      */
     @Request(id = 11, retryable = true, response = ResponseMessageConst.STRING,
-    event = {EventMessageConst.EVENT_ITEM})
+            event = {EventMessageConst.EVENT_ITEM})
     Object addListener(String name, boolean includeValue, boolean localOnly);
 
     /**
      * Removes the specified item listener. Returns silently if the specified listener was not added before.
      *
-     * @param name Name of the Set
+     * @param name           Name of the Set
      * @param registrationId The id retrieved during registration.
      * @return true if the listener with the provided id existed and removed, false otherwise.
      */
     @Request(id = 12, retryable = true, response = ResponseMessageConst.BOOLEAN)
     Object removeListener(String name, String registrationId);
-    
+
     /**
      * Returns true if this set contains no elements.
      *

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/TransactionalMapCodecTemplate.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/TransactionalMapCodecTemplate.java
@@ -209,7 +209,7 @@ public interface TransactionalMapCodecTemplate {
      * @return A set clone of the keys contained in this map.
      * @see com.hazelcast.instance.GroupProperty#QUERY_RESULT_SIZE_LIMIT
      */
-    @Request(id = 14, retryable = false, response = ResponseMessageConst.SET_DATA)
+    @Request(id = 14, retryable = false, response = ResponseMessageConst.LIST_DATA)
     Object keySet(String name, String txnId, long threadId);
 
     /**
@@ -225,7 +225,7 @@ public interface TransactionalMapCodecTemplate {
      * @return Result key set for the query.
      * @see com.hazelcast.instance.GroupProperty#QUERY_RESULT_SIZE_LIMIT
      */
-    @Request(id = 15, retryable = false, response = ResponseMessageConst.SET_DATA)
+    @Request(id = 15, retryable = false, response = ResponseMessageConst.LIST_DATA)
     Object keySetWithPredicate(String name, String txnId, long threadId, Data predicate);
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/XATransactionalCodecTemplate.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/XATransactionalCodecTemplate.java
@@ -37,7 +37,7 @@ public interface XATransactionalCodecTemplate {
      *
      * @return Array of Xids.
      */
-    @Request(id = 2, retryable = false, response = ResponseMessageConst.SET_DATA)
+    @Request(id = 2, retryable = false, response = ResponseMessageConst.LIST_DATA)
     Object collectTransactions();
 
     /**


### PR DESCRIPTION
Member list order was broken because we used HashSet in protocol
related code generation part. ArrayList will be used in all
collections in code generation.
A test is added to verify memberlist of server and client is in
same order.