### PR TITLE
Cleanup usage of "this." before local method calls

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/ClientCacheProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/ClientCacheProxy.java
@@ -298,7 +298,7 @@ public class ClientCacheProxy<K, V>
         for (K key : keys) {
             CacheEntryProcessorResult<T> ceResult;
             try {
-                final T result = this.invoke(key, entryProcessor, arguments);
+                final T result = invoke(key, entryProcessor, arguments);
                 ceResult = result != null ? new CacheEntryProcessorResult<T>(result) : null;
             } catch (Exception e) {
                 ceResult = new CacheEntryProcessorResult<T>(e);

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientConditionProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientConditionProxy.java
@@ -37,8 +37,9 @@ public class ClientConditionProxy extends PartitionSpecificClientProxy implement
 
     public ClientConditionProxy(ClientLockProxy clientLockProxy, String name, ClientContext ctx) {
         super(LockService.SERVICE_NAME, clientLockProxy.getName());
-        this.setContext(ctx);
         this.conditionId = name;
+
+        setContext(ctx);
     }
 
     @Override

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocationFuture.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocationFuture.java
@@ -85,7 +85,7 @@ public class ClientInvocationFuture implements ICompletableFuture<ClientMessage>
                 synchronized (this) {
                     while (waitMillis > 0 && response == null) {
                         long start = Clock.currentTimeMillis();
-                        this.wait(waitMillis);
+                        wait(waitMillis);
                         long elapsed = Clock.currentTimeMillis() - start;
                         waitMillis -= elapsed;
                     }
@@ -115,7 +115,7 @@ public class ClientInvocationFuture implements ICompletableFuture<ClientMessage>
             }
 
             this.response = response;
-            this.notifyAll();
+            notifyAll();
             for (ExecutionCallbackNode node : callbackNodeList) {
                 runAsynchronous(node.callback, node.executor);
             }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/ClientEntryListenerDisconnectTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ClientEntryListenerDisconnectTest.java
@@ -119,7 +119,7 @@ public class ClientEntryListenerDisconnectTest {
         private int userId;
 
         public GenericEvent(int userId) {
-            this.setUserId(userId);
+            setUserId(userId);
         }
 
         public int getUserId() {

--- a/hazelcast-client/src/test/java/com/hazelcast/client/test/TestHazelcastFactory.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/test/TestHazelcastFactory.java
@@ -49,7 +49,7 @@ public class TestHazelcastFactory extends TestHazelcastInstanceFactory {
     }
 
     public HazelcastInstance newHazelcastClient() {
-        return this.newHazelcastClient(null);
+        return newHazelcastClient(null);
     }
 
     public HazelcastInstance newHazelcastClient(ClientConfig config) {

--- a/hazelcast-cloud/src/main/java/com/hazelcast/aws/impl/DescribeInstances.java
+++ b/hazelcast-cloud/src/main/java/com/hazelcast/aws/impl/DescribeInstances.java
@@ -60,7 +60,7 @@ public class DescribeInstances {
             getKeysFromIamRole();
         }
         rs = new EC2RequestSigner(awsConfig, timeStamp, endpoint);
-        attributes.put("Action", this.getClass().getSimpleName());
+        attributes.put("Action", getClass().getSimpleName());
         attributes.put("Version", DOC_VERSION);
         attributes.put("X-Amz-Algorithm", SIGNATURE_METHOD_V4);
         attributes.put("X-Amz-Credential", rs.createFormattedCredential());

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractHazelcastCachingProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractHazelcastCachingProvider.java
@@ -69,7 +69,7 @@ public abstract class AbstractHazelcastCachingProvider
     public AbstractHazelcastCachingProvider() {
         // We use a WeakHashMap to prevent strong references to a classLoader to avoid memory leak.
         this.cacheManagers = new WeakHashMap<ClassLoader, Map<URI, AbstractHazelcastCacheManager>>();
-        this.defaultClassLoader = this.getClass().getClassLoader();
+        this.defaultClassLoader = getClass().getClassLoader();
         try {
             defaultURI = new URI("hazelcast");
         } catch (URISyntaxException e) {

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheProxy.java
@@ -259,7 +259,7 @@ public class CacheProxy<K, V>
         for (K key : keys) {
             CacheEntryProcessorResult<T> ceResult;
             try {
-                final T result = this.invoke(key, entryProcessor, arguments);
+                final T result = invoke(key, entryProcessor, arguments);
                 ceResult = result != null ? new CacheEntryProcessorResult<T>(result) : null;
             } catch (Exception e) {
                 ceResult = new CacheEntryProcessorResult<T>(e);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEndpointImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEndpointImpl.java
@@ -237,7 +237,7 @@ public final class ClientEndpointImpl implements ClientEndpoint {
     }
 
     public void sendClientMessage(ClientMessage clientMessage) {
-        Connection conn = this.getConnection();
+        Connection conn = getConnection();
         //TODO framing not implemented yet, should be split into frames before writing to connection
         conn.write(clientMessage);
     }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/ConditionImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/ConditionImpl.java
@@ -40,8 +40,8 @@ final class ConditionImpl implements ICondition {
 
     private final LockProxy lockProxy;
     private final int partitionId;
-    private final String conditionId;
     private final ObjectNamespace namespace;
+    private final String conditionId;
 
     public ConditionImpl(LockProxy lockProxy, String id) {
         this.lockProxy = lockProxy;

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/LockReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/LockReplicationOperation.java
@@ -38,7 +38,7 @@ public class LockReplicationOperation extends AbstractOperation
     }
 
     public LockReplicationOperation(LockStoreContainer container, int partitionId, int replicaIndex) {
-        this.setPartitionId(partitionId).setReplicaIndex(replicaIndex);
+        setPartitionId(partitionId).setReplicaIndex(replicaIndex);
 
         Collection<LockStoreImpl> lockStores = container.getLockStores();
         for (LockStoreImpl ls : lockStores) {

--- a/hazelcast/src/main/java/com/hazelcast/config/AbstractConfigBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/AbstractConfigBuilder.java
@@ -83,7 +83,7 @@ public abstract class AbstractConfigBuilder extends AbstractXmlConfigHelper {
                     "<import> element can appear only in the top level of the XML");
         }
         NodeList importTags = (NodeList) xpath.evaluate(
-                String.format("/hz:%s/hz:%s", this.getXmlType().name, IMPORT.name), document, XPathConstants.NODESET);
+                String.format("/hz:%s/hz:%s", getXmlType().name, IMPORT.name), document, XPathConstants.NODESET);
         for (Node node : asElementIterable(importTags)) {
             loadAndReplaceImportElement(root, node);
         }

--- a/hazelcast/src/main/java/com/hazelcast/instance/Node.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/Node.java
@@ -635,8 +635,8 @@ public class Node {
         logger.finest("This node is being set as the master");
         masterAddress = address;
         setJoined();
-        this.getClusterService().getClusterClock().setClusterStartTime(Clock.currentTimeMillis());
-        this.getClusterService().setClusterId(UuidUtil.createClusterUuid());
+        getClusterService().getClusterClock().setClusterStartTime(Clock.currentTimeMillis());
+        getClusterService().setClusterId(UuidUtil.createClusterUuid());
     }
 
     public Config getConfig() {

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/MonitoredThread.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/MonitoredThread.java
@@ -52,7 +52,7 @@ public class MonitoredThread implements Comparable<MonitoredThread> {
     @Override
     public boolean equals(Object o) {
         if (o != null && o instanceof MonitoredThread) {
-            return this.compareTo((MonitoredThread) o) == 0;
+            return compareTo((MonitoredThread) o) == 0;
         }
         return false;
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapReplicationOperation.java
@@ -64,7 +64,7 @@ public class MapReplicationOperation extends AbstractOperation implements Mutati
 
     public MapReplicationOperation(MapService mapService, PartitionContainer container, int partitionId,
                                    int replicaIndex) {
-        this.setPartitionId(partitionId).setReplicaIndex(replicaIndex);
+        setPartitionId(partitionId).setReplicaIndex(replicaIndex);
 
         data = new HashMap<String, Set<RecordReplicationInfo>>(container.getMaps().size());
         for (Entry<String, RecordStore> entry : container.getMaps().entrySet()) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
@@ -717,7 +717,7 @@ public class MapProxyImpl<K, V> extends MapProxySupport implements IMap<K, V>, I
 
     @Override
     public Map<K, Object> executeOnEntries(EntryProcessor entryProcessor) {
-        return this.executeOnEntries(entryProcessor, TruePredicate.INSTANCE);
+        return executeOnEntries(entryProcessor, TruePredicate.INSTANCE);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/ReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/ReplicationOperation.java
@@ -51,7 +51,8 @@ public class ReplicationOperation extends AbstractOperation {
 
     public ReplicationOperation(SerializationService serializationService, PartitionContainer container, int partitionId) {
         this.serializationService = serializationService;
-        this.setPartitionId(partitionId);
+
+        setPartitionId(partitionId);
         fetchReplicatedMapRecords(container);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/InstancePermission.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/InstancePermission.java
@@ -66,7 +66,7 @@ public abstract class InstancePermission extends ClusterPermission {
             return false;
         }
 
-        if (!CONFIG_PATTERN_MATCHER.matches(that.getName(), this.getName())) {
+        if (!CONFIG_PATTERN_MATCHER.matches(that.getName(), getName())) {
             return false;
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/TransactionPermission.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/TransactionPermission.java
@@ -26,7 +26,7 @@ public class TransactionPermission extends ClusterPermission {
 
     @Override
     public boolean implies(Permission permission) {
-        return this.getClass() == permission.getClass();
+        return getClass() == permission.getClass();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/AbstractCompletableFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/AbstractCompletableFuture.java
@@ -227,7 +227,7 @@ public abstract class AbstractCompletableFuture<V> implements ICompletableFuture
 
             synchronized (this) {
                 if (!isDoneState(this.state)) {
-                    this.wait(millisToWait);
+                    wait(millisToWait);
                 }
             }
         }
@@ -290,7 +290,7 @@ public abstract class AbstractCompletableFuture<V> implements ICompletableFuture
 
     private void notifyThreadsWaitingOnGet() {
         synchronized (this) {
-            this.notifyAll();
+            notifyAll();
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/waitnotifyservice/impl/WaitingOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/waitnotifyservice/impl/WaitingOperation.java
@@ -48,7 +48,8 @@ class WaitingOperation extends AbstractOperation implements Delayed, PartitionAw
         this.waitSupport = waitSupport;
         this.queue = queue;
         this.expirationTime = getExpirationTime(waitSupport);
-        this.setPartitionId(op.getPartitionId());
+
+        setPartitionId(op.getPartitionId());
     }
 
     private long getExpirationTime(WaitSupport waitSupport) {

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/SerializerHookLoaderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/SerializerHookLoaderTest.java
@@ -32,7 +32,7 @@ public class SerializerHookLoaderTest extends HazelcastTestSupport {
         serializerConfig.setClassName("com.hazelcast.internal.serialization.impl.TestSerializerHook$TestSerializer");
         serializerConfig.setTypeClassName("com.hazelcast.nio.serialization.SampleIdentifiedDataSerializable");
 
-        SerializationConfig serializationConfig = this.getConfig().getSerializationConfig();
+        SerializationConfig serializationConfig = getConfig().getSerializationConfig();
         serializationConfig.addSerializerConfig(serializerConfig);
 
         SerializerHookLoader hook = new SerializerHookLoader(serializationConfig, classLoader);
@@ -46,7 +46,7 @@ public class SerializerHookLoaderTest extends HazelcastTestSupport {
         serializerConfig.setClassName("NOT FOUND CLASS");
         serializerConfig.setTypeClassName("com.hazelcast.nio.serialization.SampleIdentifiedDataSerializable");
 
-        SerializationConfig serializationConfig = this.getConfig().getSerializationConfig();
+        SerializationConfig serializationConfig = getConfig().getSerializationConfig();
         serializationConfig.addSerializerConfig(serializerConfig);
 
         new SerializerHookLoader(serializationConfig, classLoader);
@@ -58,7 +58,7 @@ public class SerializerHookLoaderTest extends HazelcastTestSupport {
         serializerConfig.setClassName("com.hazelcast.internal.serialization.impl.TestSerializerHook$TestSerializer");
         serializerConfig.setTypeClassName("NOT FOUND CLASS");
 
-        SerializationConfig serializationConfig = this.getConfig().getSerializationConfig();
+        SerializationConfig serializationConfig = getConfig().getSerializationConfig();
         serializationConfig.addSerializerConfig(serializerConfig);
 
         new SerializerHookLoader(serializationConfig, classLoader);

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/slowoperationdetector/SlowOperationDetectorBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/slowoperationdetector/SlowOperationDetectorBasicTest.java
@@ -229,7 +229,8 @@ public class SlowOperationDetectorBasicTest extends SlowOperationDetectorAbstrac
 
         private SlowOperation(int sleepSeconds, int partitionId) {
             this.sleepSeconds = sleepSeconds;
-            this.setPartitionId(partitionId);
+
+            setPartitionId(partitionId);
         }
 
         @Override
@@ -248,7 +249,7 @@ public class SlowOperationDetectorBasicTest extends SlowOperationDetectorAbstrac
             this.map = map;
             this.entryProcessor = new SlowEntryProcessor(sleepSeconds);
 
-            this.setPartitionId(partitionId);
+            setPartitionId(partitionId);
         }
 
         @Override

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/BackpressureRegulatorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/BackpressureRegulatorTest.java
@@ -206,7 +206,7 @@ public class BackpressureRegulatorTest extends HazelcastTestSupport {
     private class PartitionSpecificOperation extends AbstractOperation implements PartitionAwareOperation, BackupAwareOperation {
 
         public PartitionSpecificOperation(int partitionId) {
-            this.setPartitionId(partitionId);
+            setPartitionId(partitionId);
         }
 
         @Override

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_NestedAbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_NestedAbstractTest.java
@@ -79,7 +79,8 @@ public abstract class Invocation_NestedAbstractTest extends HazelcastTestSupport
 
         public InnerOperation(Object value, int partitionId) {
             this.value = value;
-            this.setPartitionId(partitionId);
+
+            setPartitionId(partitionId);
         }
 
         @Override


### PR DESCRIPTION
Due to the late state of the version we maybe should wait for 3.7 to merge this.