### PR TITLE
Cleanup of query related tests. Fixed usage of wrong test method.

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryEntryFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryEntryFactory.java
@@ -24,12 +24,12 @@ import com.hazelcast.query.impl.QueryEntry;
 import com.hazelcast.query.impl.QueryableEntry;
 
 public final class QueryEntryFactory {
+
     private final boolean useCache;
 
     public QueryEntryFactory(boolean optimizeQueries) {
         useCache = optimizeQueries;
     }
-
 
     public QueryableEntry newEntry(SerializationService serializationService, Data key, Object value, Extractors extractors) {
         if (useCache) {

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/QueryEntry.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/QueryEntry.java
@@ -41,11 +41,11 @@ public class QueryEntry extends QueryableEntry {
      * <pre>
      * <code>Predicate predicate = ...
      * QueryEntry entry = new QueryEntry()
-     * for(i == 0; i < HUGE_NUMBER; i++) {
+     * for (i == 0; i < HUGE_NUMBER; i++) {
      *       entry.init(...)
      *       boolean valid = predicate.apply(queryEntry);
      *
-     *       if(valid) {
+     *       if (valid) {
      *          ....
      *       }
      *  }
@@ -113,5 +113,4 @@ public class QueryEntry extends QueryableEntry {
     public int hashCode() {
         return key.hashCode();
     }
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/QueryableEntry.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/QueryableEntry.java
@@ -33,7 +33,7 @@ import static com.hazelcast.query.impl.TypeConverters.IDENTITY_CONVERTER;
 import static com.hazelcast.query.impl.TypeConverters.NULL_CONVERTER;
 
 /**
- * This interface contains methods related to Queryable Entry which means searched an indexed by sql query or predicate.
+ * This abstract class contains methods related to Queryable Entry, which means searched an indexed by SQL query or predicate.
  */
 public abstract class QueryableEntry implements Map.Entry {
 
@@ -213,5 +213,4 @@ public abstract class QueryableEntry implements Map.Entry {
         }
         return ReflectionHelper.getAttributeType(firstResult.getClass());
     }
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/LocalKeySetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/LocalKeySetTest.java
@@ -25,32 +25,34 @@ import static org.junit.Assert.assertTrue;
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class LocalKeySetTest extends HazelcastTestSupport {
-    private HazelcastInstance local;
+
     private IMap<String, String> map;
     private SerializationService serializationService;
-    private HazelcastInstance remote;
-    private String remoteKey1;
-    private String remoteKey2;
-    private String remoteKey3;
+
     private String localKey1;
     private String localKey2;
     private String localKey3;
 
+    private String remoteKey1;
+    private String remoteKey2;
+    private String remoteKey3;
+
     @Before
     public void setup() {
         HazelcastInstance[] cluster = createHazelcastInstanceFactory(2).newInstances();
-        local = cluster[0];
-        remote = cluster[1];
+        HazelcastInstance local = cluster[0];
+        HazelcastInstance remote = cluster[1];
+
         map = local.getMap(randomName());
         serializationService = getSerializationService(local);
-
-        remoteKey1 = generateKeyOwnedBy(remote);
-        remoteKey2 = generateKeyOwnedBy(remote);
-        remoteKey3 = generateKeyOwnedBy(remote);
 
         localKey1 = generateKeyOwnedBy(local);
         localKey2 = generateKeyOwnedBy(local);
         localKey3 = generateKeyOwnedBy(local);
+
+        remoteKey1 = generateKeyOwnedBy(remote);
+        remoteKey2 = generateKeyOwnedBy(remote);
+        remoteKey3 = generateKeyOwnedBy(remote);
     }
 
     @Test(expected = NullPointerException.class)

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/MapEntrySetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/MapEntrySetTest.java
@@ -25,15 +25,15 @@ import static org.junit.Assert.assertTrue;
 @Category({QuickTest.class, ParallelTest.class})
 public class MapEntrySetTest extends HazelcastTestSupport {
 
-    private HazelcastInstance hz;
     private IMap<String, String> map;
     private SerializationService serializationService;
 
     @Before
     public void setup() {
-        hz = createHazelcastInstance();
-        map = hz.getMap(randomName());
-        serializationService = getSerializationService(hz);
+        HazelcastInstance instance = createHazelcastInstance();
+
+        map = instance.getMap(randomName());
+        serializationService = getSerializationService(instance);
     }
 
     @Test(expected = NullPointerException.class)
@@ -76,7 +76,7 @@ public class MapEntrySetTest extends HazelcastTestSupport {
     }
 
     private void assertResultContains(Set<Map.Entry<String, String>> result, String key, String value) {
-        assertTrue(result.contains(new SimpleEntry(key, value)));
+        assertTrue(result.contains(new SimpleEntry<String, String>(key, value)));
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/MapKeySetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/MapKeySetTest.java
@@ -26,15 +26,15 @@ import static org.junit.Assert.assertTrue;
 @Category({QuickTest.class, ParallelTest.class})
 public class MapKeySetTest extends HazelcastTestSupport {
 
-    private HazelcastInstance hz;
     private IMap<String, String> map;
     private SerializationService serializationService;
 
     @Before
     public void setup() {
-        hz = createHazelcastInstance();
-        map = hz.getMap(randomName());
-        serializationService = getSerializationService(hz);
+        HazelcastInstance instance = createHazelcastInstance();
+        
+        map = instance.getMap(randomName());
+        serializationService = getSerializationService(instance);
     }
 
     @Test(expected = NullPointerException.class)

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/MapQueryEngineImpl_queryLocalPartition_resultSizeLimitTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/MapQueryEngineImpl_queryLocalPartition_resultSizeLimitTest.java
@@ -12,12 +12,12 @@ import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
-import com.hazelcast.util.IterationType;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import static com.hazelcast.util.IterationType.ENTRY;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastParallelClassRunner.class)
@@ -54,7 +54,7 @@ public class MapQueryEngineImpl_queryLocalPartition_resultSizeLimitTest extends 
     public void whenLimitNotExceeded() throws Exception {
         fillPartition(limit - 1);
 
-        QueryResult result = queryEngine.queryLocalPartition(map.getName(), TruePredicate.INSTANCE, PARTITION_ID, IterationType.ENTRY);
+        QueryResult result = queryEngine.queryLocalPartition(map.getName(), TruePredicate.INSTANCE, PARTITION_ID, ENTRY);
 
         assertEquals(limit - 1, result.getRows().size());
     }
@@ -63,7 +63,7 @@ public class MapQueryEngineImpl_queryLocalPartition_resultSizeLimitTest extends 
     public void whenLimitEquals() throws Exception {
         fillPartition(limit);
 
-        QueryResult result = queryEngine.queryLocalPartition(map.getName(), TruePredicate.INSTANCE, PARTITION_ID, IterationType.ENTRY);
+        QueryResult result = queryEngine.queryLocalPartition(map.getName(), TruePredicate.INSTANCE, PARTITION_ID, ENTRY);
 
         assertEquals(limit, result.getRows().size());
     }
@@ -72,7 +72,7 @@ public class MapQueryEngineImpl_queryLocalPartition_resultSizeLimitTest extends 
     public void whenLimitExceeded() throws Exception {
         fillPartition(limit + 1);
 
-        queryEngine.queryLocalPartition(map.getName(), TruePredicate.INSTANCE, PARTITION_ID, IterationType.ENTRY);
+        queryEngine.queryLocalPartition(map.getName(), TruePredicate.INSTANCE, PARTITION_ID, ENTRY);
     }
 
     private void fillPartition(int count) {

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/MapQueryEngineImpl_queryLocalPartitions_resultSizeLimitTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/MapQueryEngineImpl_queryLocalPartitions_resultSizeLimitTest.java
@@ -11,12 +11,12 @@ import com.hazelcast.query.impl.predicates.RuleBasedQueryOptimizer;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.QuickTest;
-import com.hazelcast.util.IterationType;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import static com.hazelcast.util.IterationType.ENTRY;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastSerialClassRunner.class)
@@ -49,7 +49,7 @@ public class MapQueryEngineImpl_queryLocalPartitions_resultSizeLimitTest extends
 
     @Test
     public void checkResultLimit() throws Exception {
-        QueryResult result = queryEngine.queryLocalPartitions(map.getName(), TruePredicate.INSTANCE, IterationType.ENTRY);
+        QueryResult result = queryEngine.queryLocalPartitions(map.getName(), TruePredicate.INSTANCE, ENTRY);
 
         assertEquals(limit, result.getResultLimit());
     }
@@ -58,7 +58,7 @@ public class MapQueryEngineImpl_queryLocalPartitions_resultSizeLimitTest extends
     public void whenResultSizeLimitNotExceeded() throws Exception {
         fillMap(limit - 1);
 
-        QueryResult result = queryEngine.queryLocalPartitions(map.getName(), TruePredicate.INSTANCE, IterationType.ENTRY);
+        QueryResult result = queryEngine.queryLocalPartitions(map.getName(), TruePredicate.INSTANCE, ENTRY);
 
         assertEquals(limit - 1, result.getRows().size());
     }
@@ -67,7 +67,7 @@ public class MapQueryEngineImpl_queryLocalPartitions_resultSizeLimitTest extends
     public void whenResultSizeLimitEquals() throws Exception {
         fillMap(limit);
 
-        QueryResult result = queryEngine.queryLocalPartitions(map.getName(), TruePredicate.INSTANCE, IterationType.ENTRY);
+        QueryResult result = queryEngine.queryLocalPartitions(map.getName(), TruePredicate.INSTANCE, ENTRY);
 
         assertEquals(limit, result.getRows().size());
     }
@@ -76,7 +76,7 @@ public class MapQueryEngineImpl_queryLocalPartitions_resultSizeLimitTest extends
     public void whenResultSizeLimitExceeded() throws Exception {
         fillMap(limit + 1);
 
-        queryEngine.queryLocalPartitions(map.getName(), TruePredicate.INSTANCE, IterationType.ENTRY);
+        queryEngine.queryLocalPartitions(map.getName(), TruePredicate.INSTANCE, ENTRY);
     }
 
     private void fillMap(long count) {

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/MapQueryEngineImpl_queryLocalPartitions_resultSizeNoLimitTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/MapQueryEngineImpl_queryLocalPartitions_resultSizeNoLimitTest.java
@@ -6,10 +6,10 @@ import com.hazelcast.map.impl.MapService;
 import com.hazelcast.query.TruePredicate;
 import com.hazelcast.query.impl.predicates.RuleBasedQueryOptimizer;
 import com.hazelcast.test.HazelcastTestSupport;
-import com.hazelcast.util.IterationType;
 import org.junit.Before;
 import org.junit.Test;
 
+import static com.hazelcast.util.IterationType.ENTRY;
 import static org.junit.Assert.assertEquals;
 
 public class MapQueryEngineImpl_queryLocalPartitions_resultSizeNoLimitTest extends HazelcastTestSupport {
@@ -28,7 +28,7 @@ public class MapQueryEngineImpl_queryLocalPartitions_resultSizeNoLimitTest exten
 
     @Test
     public void checkResultLimit() throws Exception {
-        QueryResult result = queryEngine.queryLocalPartitions(map.getName(), TruePredicate.INSTANCE, IterationType.ENTRY);
+        QueryResult result = queryEngine.queryLocalPartitions(map.getName(), TruePredicate.INSTANCE, ENTRY);
 
         assertEquals(Long.MAX_VALUE, result.getResultLimit());
     }

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/MapValuesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/MapValuesTest.java
@@ -25,15 +25,15 @@ import static org.junit.Assert.assertTrue;
 @Category({QuickTest.class, ParallelTest.class})
 public class MapValuesTest extends HazelcastTestSupport {
 
-    private HazelcastInstance hz;
     private IMap<String, String> map;
     private SerializationService serializationService;
 
     @Before
     public void setup() {
-        hz = createHazelcastInstance();
-        map = hz.getMap(randomName());
-        serializationService = getSerializationService(hz);
+        HazelcastInstance instance = createHazelcastInstance();
+
+        map = instance.getMap(randomName());
+        serializationService = getSerializationService(instance);
     }
 
     @Test(expected = NullPointerException.class)

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryBasicTest.java
@@ -82,21 +82,21 @@ public class QueryBasicTest extends HazelcastTestSupport {
     @Test(timeout = 1000 * 60)
     public void issue393SqlIn() {
         HazelcastInstance instance = createHazelcastInstance(getConfig());
-        IMap<String, SampleObjects.Value> map = instance.getMap("default");
+        IMap<String, Value> map = instance.getMap("default");
         map.addIndex("name", true);
         for (int i = 0; i < 4; i++) {
             Value v = new Value("name" + i);
             map.put("" + i, v);
         }
         Predicate predicate = new SqlPredicate("name IN ('name0', 'name2')");
-        Collection<SampleObjects.Value> values = map.values(predicate);
+        Collection<Value> values = map.values(predicate);
         String[] expectedValues = new String[]{"name0", "name2"};
         assertEquals(expectedValues.length, values.size());
         List<String> names = new ArrayList<String>();
         for (Value configObject : values) {
             names.add(configObject.getName());
         }
-        String[] array = names.toArray(new String[0]);
+        String[] array = names.toArray(new String[names.size()]);
         Arrays.sort(array);
         assertArrayEquals(names.toString(), expectedValues, array);
     }
@@ -104,21 +104,21 @@ public class QueryBasicTest extends HazelcastTestSupport {
     @Test(timeout = 1000 * 60)
     public void issue393SqlInInteger() {
         HazelcastInstance instance = createHazelcastInstance(getConfig());
-        IMap<String, SampleObjects.Value> map = instance.getMap("default");
+        IMap<String, Value> map = instance.getMap("default");
         map.addIndex("index", false);
         for (int i = 0; i < 4; i++) {
             Value v = new Value("name" + i, new ValueType("type" + i), i);
             map.put("" + i, v);
         }
         Predicate predicate = new SqlPredicate("index IN (0, 2)");
-        Collection<SampleObjects.Value> values = map.values(predicate);
+        Collection<Value> values = map.values(predicate);
         String[] expectedValues = new String[]{"name0", "name2"};
         assertEquals(expectedValues.length, values.size());
         List<String> names = new ArrayList<String>();
         for (Value configObject : values) {
             names.add(configObject.getName());
         }
-        String[] array = names.toArray(new String[0]);
+        String[] array = names.toArray(new String[names.size()]);
         Arrays.sort(array);
         assertArrayEquals(names.toString(), expectedValues, array);
     }
@@ -142,14 +142,14 @@ public class QueryBasicTest extends HazelcastTestSupport {
     }
 
     @Test(timeout = 1000 * 60)
-    public void testInstanceofPredicate() {
+    public void testInstanceOfPredicate() {
         HazelcastInstance instance = createHazelcastInstance(getConfig());
-        IMap<String, Object> map = instance.getMap("testInstanceofPredicate");
+        IMap<String, Object> map = instance.getMap("testInstanceOfPredicate");
 
         LinkedList linkedList = new LinkedList();
 
         Predicate linkedListPredicate = Predicates.instanceOf(LinkedList.class);
-        map.put("1", "somestring");
+        map.put("1", "someString");
         map.put("2", new ArrayList());
         map.put("3", linkedList);
 
@@ -192,7 +192,7 @@ public class QueryBasicTest extends HazelcastTestSupport {
     @Test(timeout = 1000 * 60)
     public void issue393Fail() {
         HazelcastInstance instance = createHazelcastInstance(getConfig());
-        IMap<String, SampleObjects.Value> map = instance.getMap("default");
+        IMap<String, Value> map = instance.getMap("default");
         map.addIndex("qwe", true);
         Value v = new Value("name");
         try {
@@ -206,14 +206,14 @@ public class QueryBasicTest extends HazelcastTestSupport {
     @Test(timeout = 1000 * 60)
     public void negativeDouble() {
         HazelcastInstance instance = createHazelcastInstance(getConfig());
-        IMap<String, SampleObjects.Employee> map = instance.getMap("default");
+        IMap<String, Employee> map = instance.getMap("default");
         map.addIndex("salary", false);
         map.put("" + 4, new Employee(1, "default", 1, true, -70D));
         map.put("" + 3, new Employee(1, "default", 1, true, -60D));
         map.put("" + 1, new Employee(1, "default", 1, true, -10D));
         map.put("" + 2, new Employee(2, "default", 2, true, 10D));
         Predicate predicate = new SqlPredicate("salary >= -60");
-        Collection<SampleObjects.Employee> values = map.values(predicate);
+        Collection<Employee> values = map.values(predicate);
         assertEquals(3, values.size());
         predicate = new SqlPredicate("salary between -20 and 20");
         values = map.values(predicate);
@@ -223,21 +223,21 @@ public class QueryBasicTest extends HazelcastTestSupport {
     @Test(timeout = 1000 * 60)
     public void issue393SqlEq() {
         HazelcastInstance instance = createHazelcastInstance(getConfig());
-        IMap<String, SampleObjects.Value> map = instance.getMap("default");
+        IMap<String, Value> map = instance.getMap("default");
         map.addIndex("name", true);
         for (int i = 0; i < 4; i++) {
             Value v = new Value("name" + i);
             map.put("" + i, v);
         }
         Predicate predicate = new SqlPredicate("name='name0'");
-        Collection<SampleObjects.Value> values = map.values(predicate);
+        Collection<Value> values = map.values(predicate);
         String[] expectedValues = new String[]{"name0"};
         assertEquals(expectedValues.length, values.size());
         List<String> names = new ArrayList<String>();
         for (Value configObject : values) {
             names.add(configObject.getName());
         }
-        String[] array = names.toArray(new String[0]);
+        String[] array = names.toArray(new String[names.size()]);
         Arrays.sort(array);
         assertArrayEquals(names.toString(), expectedValues, array);
     }
@@ -245,37 +245,37 @@ public class QueryBasicTest extends HazelcastTestSupport {
     @Test(timeout = 1000 * 60)
     public void issue393() {
         HazelcastInstance instance = createHazelcastInstance(getConfig());
-        IMap<String, SampleObjects.Value> map = instance.getMap("default");
+        IMap<String, Value> map = instance.getMap("default");
         map.addIndex("name", true);
         for (int i = 0; i < 4; i++) {
             Value v = new Value("name" + i);
             map.put("" + i, v);
         }
         Predicate predicate = new PredicateBuilder().getEntryObject().get("name").in("name0", "name2");
-        Collection<SampleObjects.Value> values = map.values(predicate);
+        Collection<Value> values = map.values(predicate);
         String[] expectedValues = new String[]{"name0", "name2"};
         assertEquals(expectedValues.length, values.size());
         List<String> names = new ArrayList<String>();
         for (Value configObject : values) {
             names.add(configObject.getName());
         }
-        String[] array = names.toArray(new String[0]);
+        String[] array = names.toArray(new String[names.size()]);
         Arrays.sort(array);
         assertArrayEquals(names.toString(), expectedValues, array);
     }
 
     @Test(timeout = 1000 * 60)
     public void testWithDashInTheNameAndSqlPredicate() {
-        HazelcastInstance h1 = createHazelcastInstance(getConfig());
-        IMap<String, SampleObjects.Employee> map = h1.getMap("employee");
+        HazelcastInstance instance = createHazelcastInstance(getConfig());
+        IMap<String, Employee> map = instance.getMap("employee");
         Employee toto = new Employee("toto", 23, true, 165765.0);
         map.put("1", toto);
         Employee toto2 = new Employee("toto-super+hero", 23, true, 165765.0);
         map.put("2", toto2);
-        //Works well
-        Set<Map.Entry<String, SampleObjects.Employee>> entries = map.entrySet(new SqlPredicate("name='toto-super+hero'"));
+        // works well
+        Set<Map.Entry<String, Employee>> entries = map.entrySet(new SqlPredicate("name='toto-super+hero'"));
         assertTrue(entries.size() > 0);
-        for (Map.Entry<String, SampleObjects.Employee> entry : entries) {
+        for (Map.Entry<String, Employee> entry : entries) {
             Employee e = entry.getValue();
             assertEquals(e, toto2);
         }
@@ -301,7 +301,7 @@ public class QueryBasicTest extends HazelcastTestSupport {
     @Test(timeout = 1000 * 60)
     public void testPredicateWithEntryKeyObject() {
         HazelcastInstance instance = createHazelcastInstance(getConfig());
-        IMap map = instance.getMap("testPredicateWithEntryKeyObject");
+        IMap<String, Integer> map = instance.getMap("testPredicateWithEntryKeyObject");
         map.put("1", 11);
         map.put("2", 22);
         map.put("3", 33);
@@ -322,7 +322,7 @@ public class QueryBasicTest extends HazelcastTestSupport {
     @Test(timeout = 1000 * 60)
     public void testPredicateStringAttribute() {
         HazelcastInstance instance = createHazelcastInstance(getConfig());
-        IMap map = instance.getMap("testPredicateStringWithString");
+        IMap<Integer, Value> map = instance.getMap("testPredicateStringWithString");
         testPredicateStringAttribute(map);
     }
 
@@ -332,12 +332,12 @@ public class QueryBasicTest extends HazelcastTestSupport {
     @Test(timeout = 1000 * 60)
     public void testPredicateStringAttributesWithIndex() {
         HazelcastInstance instance = createHazelcastInstance(getConfig());
-        IMap map = instance.getMap("testPredicateStringWithStringIndex");
+        IMap<Integer, Value> map = instance.getMap("testPredicateStringWithStringIndex");
         map.addIndex("name", false);
         testPredicateStringAttribute(map);
     }
 
-    private void testPredicateStringAttribute(IMap map) {
+    private void testPredicateStringAttribute(IMap<Integer, Value> map) {
         map.put(1, new Value("abc"));
         map.put(2, new Value("xyz"));
         map.put(3, new Value("aaa"));
@@ -360,38 +360,38 @@ public class QueryBasicTest extends HazelcastTestSupport {
     @Test(timeout = 1000 * 60)
     public void testPredicateDateAttribute() {
         HazelcastInstance instance = createHazelcastInstance(getConfig());
-        IMap map = instance.getMap("testPredicateDateAttribute");
+        IMap<Integer, Date> map = instance.getMap("testPredicateDateAttribute");
         testPredicateDateAttribute(map);
     }
 
     @Test(timeout = 1000 * 60)
     public void testPredicateDateAttributeWithIndex() {
         HazelcastInstance instance = createHazelcastInstance(getConfig());
-        IMap map = instance.getMap("testPredicateDateAttribute");
+        IMap<Integer, Date> map = instance.getMap("testPredicateDateAttribute");
         map.addIndex("this", true);
         testPredicateDateAttribute(map);
     }
 
-    private void testPredicateDateAttribute(IMap map) {
+    private void testPredicateDateAttribute(IMap<Integer, Date> map) {
         Calendar cal = Calendar.getInstance();
-        cal.set(2012, 5, 5);
+        cal.set(2012, Calendar.JUNE, 5);
         map.put(1, cal.getTime());
-        cal.set(2011, 10, 10);
+        cal.set(2011, Calendar.NOVEMBER, 10);
         map.put(2, cal.getTime());
-        cal.set(2011, 1, 1);
+        cal.set(2011, Calendar.FEBRUARY, 1);
         map.put(3, cal.getTime());
-        cal.set(2010, 8, 5);
+        cal.set(2010, Calendar.SEPTEMBER, 5);
         map.put(4, cal.getTime());
-        cal.set(2000, 5, 5);
+        cal.set(2000, Calendar.JUNE, 5);
         map.put(5, cal.getTime());
-        cal.set(2011, 0, 1);
+        cal.set(2011, Calendar.JANUARY, 1);
         assertEquals(3, map.values(new PredicateBuilder().getEntryObject().get("this").greaterThan(cal.getTime())).size());
         assertEquals(3, map.values(new SqlPredicate("this > 'Sat Jan 01 11:43:05 EET 2011'")).size());
         assertEquals(2, map.values(new PredicateBuilder().getEntryObject().get("this").lessThan(cal.getTime())).size());
         assertEquals(2, map.values(new SqlPredicate("this < 'Sat Jan 01 11:43:05 EET 2011'")).size());
-        cal.set(2003, 10, 10);
+        cal.set(2003, Calendar.NOVEMBER, 10);
         Date d1 = cal.getTime();
-        cal.set(2012, 1, 10);
+        cal.set(2012, Calendar.FEBRUARY, 10);
         Date d2 = cal.getTime();
         assertEquals(3, map.values(new PredicateBuilder().getEntryObject().get("this").between(d1, d2)).size());
         assertEquals(3, map.values(new SqlPredicate("this between 'Mon Nov 10 11:43:05 EET 2003'" +
@@ -401,19 +401,19 @@ public class QueryBasicTest extends HazelcastTestSupport {
     @Test(timeout = 1000 * 60)
     public void testPredicateEnumAttribute() {
         HazelcastInstance instance = createHazelcastInstance(getConfig());
-        IMap map = instance.getMap("testPredicateEnumAttribute");
+        IMap<Integer, NodeType> map = instance.getMap("testPredicateEnumAttribute");
         testPredicateEnumAttribute(map);
     }
 
     @Test(timeout = 1000 * 60)
     public void testPredicateEnumAttributeWithIndex() {
         HazelcastInstance instance = createHazelcastInstance(getConfig());
-        IMap map = instance.getMap("testPredicateEnumAttribute");
+        IMap<Integer, NodeType> map = instance.getMap("testPredicateEnumAttribute");
         map.addIndex("this", true);
-        testPredicateDateAttribute(map);
+        testPredicateEnumAttribute(map);
     }
 
-    private void testPredicateEnumAttribute(IMap map) {
+    private void testPredicateEnumAttribute(IMap<Integer, NodeType> map) {
         map.put(1, NodeType.MEMBER);
         map.put(2, NodeType.LITE_MEMBER);
         map.put(3, NodeType.JAVA_CLIENT);
@@ -428,136 +428,117 @@ public class QueryBasicTest extends HazelcastTestSupport {
                 .get("this").in(NodeType.LITE_MEMBER, NodeType.MEMBER)).size());
     }
 
-
-    public enum NodeType {
-        MEMBER(1),
-        LITE_MEMBER(2),
-        JAVA_CLIENT(3),
-        CSHARP_CLIENT(4);
-
-        private int value;
-
-        private NodeType(int type) {
-            this.value = type;
-        }
-
-        public int getValue() {
-            return value;
-        }
-
-        public static NodeType create(int value) {
-            switch (value) {
-                case 1:
-                    return MEMBER;
-                case 2:
-                    return LITE_MEMBER;
-                case 3:
-                    return JAVA_CLIENT;
-                case 4:
-                    return CSHARP_CLIENT;
-                default:
-                    return null;
-            }
-        }
+    private enum NodeType {
+        MEMBER,
+        LITE_MEMBER,
+        JAVA_CLIENT,
+        CSHARP_CLIENT
     }
 
     @Test(timeout = 1000 * 60)
     public void testPredicateCustomAttribute() {
         HazelcastInstance instance = createHazelcastInstance(getConfig());
-        IMap map = instance.getMap("testPredicateCustomAttribute");
+        IMap<Integer, CustomObject> map = instance.getMap("testPredicateCustomAttribute");
 
         CustomAttribute attribute = new CustomAttribute(78, 145);
-        CustomObject object = new CustomObject("name1", UuidUtil.newUnsecureUUID(), attribute);
-        map.put(1, object);
+        CustomObject customObject = new CustomObject("name1", UuidUtil.newUnsecureUUID(), attribute);
+        map.put(1, customObject);
 
         CustomObject object2 = new CustomObject("name2", UuidUtil.newUnsecureUUID(), attribute);
         map.put(2, object2);
 
-        assertEquals(object, map.values(new PredicateBuilder().getEntryObject().get("uuid").equal(object.getUuid())).iterator().next());
+        assertEquals(customObject, map.values(new PredicateBuilder().getEntryObject().get("uuid").equal(customObject.getUuid()))
+                .iterator().next());
         assertEquals(2, map.values(new PredicateBuilder().getEntryObject().get("attribute").equal(attribute)).size());
 
-        assertEquals(object2, map.values(new PredicateBuilder().getEntryObject().get("uuid").in(object2.getUuid())).iterator().next());
+        assertEquals(object2, map.values(new PredicateBuilder().getEntryObject().get("uuid").in(object2.getUuid()))
+                .iterator().next());
         assertEquals(2, map.values(new PredicateBuilder().getEntryObject().get("attribute").in(attribute)).size());
     }
 
-    public static void doFunctionalSQLQueryTest(IMap imap) {
-        imap.put("1", new Employee("joe", 33, false, 14.56));
-        imap.put("2", new Employee("ali", 23, true, 15.00));
+    public static void doFunctionalSQLQueryTest(IMap<String, Employee> map) {
+        map.put("1", new Employee("joe", 33, false, 14.56));
+        map.put("2", new Employee("ali", 23, true, 15.00));
         for (int i = 3; i < 103; i++) {
-            imap.put(String.valueOf(i), new Employee("name" + i, i % 60, ((i & 1) == 1), Double.valueOf(i)));
+            map.put(String.valueOf(i), new Employee("name" + i, i % 60, ((i & 1) == 1), i));
         }
-        Set<Map.Entry> entries = imap.entrySet();
+        Set<Map.Entry<String, Employee>> entries = map.entrySet();
         assertEquals(102, entries.size());
-        int itCount = 0;
+
+        int entryCount = 0;
         for (Map.Entry entry : entries) {
-            Employee c = (Employee) entry.getValue();
-            itCount++;
+            Employee employee = (Employee) entry.getValue();
+            assertNotNull(employee);
+            entryCount++;
         }
-        assertEquals(102, itCount);
-        entries = imap.entrySet(new SqlPredicate("active=true and age=23"));
+        assertEquals(102, entryCount);
+
+        entries = map.entrySet(new SqlPredicate("active=true and age=23"));
         assertEquals(3, entries.size());
         for (Map.Entry entry : entries) {
-            Employee c = (Employee) entry.getValue();
-            assertEquals(c.getAge(), 23);
-            assertTrue(c.isActive());
+            Employee employee = (Employee) entry.getValue();
+            assertEquals(employee.getAge(), 23);
+            assertTrue(employee.isActive());
         }
-        imap.remove("2");
-        entries = imap.entrySet(new SqlPredicate("active=true and age=23"));
+        map.remove("2");
+        entries = map.entrySet(new SqlPredicate("active=true and age=23"));
         assertEquals(2, entries.size());
         for (Map.Entry entry : entries) {
-            Employee c = (Employee) entry.getValue();
-            assertEquals(c.getAge(), 23);
-            assertTrue(c.isActive());
+            Employee employee = (Employee) entry.getValue();
+            assertEquals(employee.getAge(), 23);
+            assertTrue(employee.isActive());
         }
-        entries = imap.entrySet(new SqlPredicate("age!=33"));
+        entries = map.entrySet(new SqlPredicate("age!=33"));
         for (Map.Entry entry : entries) {
-            Employee c = (Employee) entry.getValue();
-            assertTrue(c.getAge() != 33);
+            Employee employee = (Employee) entry.getValue();
+            assertTrue(employee.getAge() != 33);
         }
-        entries = imap.entrySet(new SqlPredicate("active!=false"));
+        entries = map.entrySet(new SqlPredicate("active!=false"));
         for (Map.Entry entry : entries) {
-            Employee c = (Employee) entry.getValue();
-            assertTrue(c.isActive());
+            Employee employee = (Employee) entry.getValue();
+            assertTrue(employee.isActive());
         }
     }
 
-    public static void doFunctionalQueryTest(IMap imap) {
-        imap.put("1", new Employee("joe", 33, false, 14.56));
-        imap.put("2", new Employee("ali", 23, true, 15.00));
+    public static void doFunctionalQueryTest(IMap<String, Employee> map) {
+        map.put("1", new Employee("joe", 33, false, 14.56));
+        map.put("2", new Employee("ali", 23, true, 15.00));
         for (int i = 3; i < 103; i++) {
-            imap.put(String.valueOf(i), new Employee("name" + i, i % 60, ((i & 1) == 1), Double.valueOf(i)));
+            map.put(String.valueOf(i), new Employee("name" + i, i % 60, ((i & 1) == 1), i));
         }
-        Set<Map.Entry> entries = imap.entrySet();
+        Set<Map.Entry<String, Employee>> entries = map.entrySet();
         assertEquals(102, entries.size());
-        int itCount = 0;
+
+        int entryCount = 0;
         for (Map.Entry entry : entries) {
-            Employee c = (Employee) entry.getValue();
-            itCount++;
+            Employee employee = (Employee) entry.getValue();
+            assertNotNull(employee);
+            entryCount++;
         }
-        assertEquals(102, itCount);
-        EntryObject e = new PredicateBuilder().getEntryObject();
-        Predicate predicate = e.is("active").and(e.get("age").equal(23));
-        entries = imap.entrySet(predicate);
-//        assertEquals(3, entries.size());
+        assertEquals(102, entryCount);
+
+        EntryObject entryObject = new PredicateBuilder().getEntryObject();
+        Predicate predicate = entryObject.is("active").and(entryObject.get("age").equal(23));
+        entries = map.entrySet(predicate);
         for (Map.Entry entry : entries) {
-            Employee c = (Employee) entry.getValue();
-            assertEquals(c.getAge(), 23);
-            assertTrue(c.isActive());
+            Employee employee = (Employee) entry.getValue();
+            assertEquals(employee.getAge(), 23);
+            assertTrue(employee.isActive());
         }
-        imap.remove("2");
-        entries = imap.entrySet(predicate);
+        map.remove("2");
+        entries = map.entrySet(predicate);
         assertEquals(2, entries.size());
         for (Map.Entry entry : entries) {
-            Employee c = (Employee) entry.getValue();
-            assertEquals(c.getAge(), 23);
-            assertTrue(c.isActive());
+            Employee employee = (Employee) entry.getValue();
+            assertEquals(employee.getAge(), 23);
+            assertTrue(employee.isActive());
         }
-        entries = imap.entrySet(new SqlPredicate(" (age >= " + 30 + ") AND (age <= " + 40 + ")"));
+        entries = map.entrySet(new SqlPredicate(" (age >= " + 30 + ") AND (age <= " + 40 + ")"));
         assertEquals(23, entries.size());
         for (Map.Entry entry : entries) {
-            Employee c = (Employee) entry.getValue();
-            assertTrue(c.getAge() >= 30);
-            assertTrue(c.getAge() <= 40);
+            Employee employee = (Employee) entry.getValue();
+            assertTrue(employee.getAge() >= 30);
+            assertTrue(employee.getAge() <= 40);
         }
     }
 
@@ -566,7 +547,8 @@ public class QueryBasicTest extends HazelcastTestSupport {
         Config cfg = getConfig();
         TestHazelcastInstanceFactory nodeFactory = createHazelcastInstanceFactory(1);
         HazelcastInstance instance = nodeFactory.newHazelcastInstance(cfg);
-        IMap map = instance.getMap("employee");
+
+        IMap<Integer, Employee> map = instance.getMap("employee");
         map.put(1, new Employee("e", 1, false, 0));
         map.put(2, new Employee("e2", 1, false, 0));
         try {
@@ -605,14 +587,14 @@ public class QueryBasicTest extends HazelcastTestSupport {
     @Test(timeout = 1000 * 60)
     public void testIndexingEnumAttributeIssue597() {
         HazelcastInstance instance = createHazelcastInstance(getConfig());
-        IMap<Integer, SampleObjects.Value> map = instance.getMap("default");
+        IMap<Integer, Value> map = instance.getMap("default");
         map.addIndex("state", true);
         for (int i = 0; i < 4; i++) {
             Value v = new Value(i % 2 == 0 ? State.STATE1 : State.STATE2, new ValueType(), i);
             map.put(i, v);
         }
         Predicate predicate = new PredicateBuilder().getEntryObject().get("state").equal(State.STATE1);
-        Collection<SampleObjects.Value> values = map.values(predicate);
+        Collection<Value> values = map.values(predicate);
         int[] expectedValues = new int[]{0, 2};
         assertEquals(expectedValues.length, values.size());
         int[] indexes = new int[2];
@@ -630,14 +612,14 @@ public class QueryBasicTest extends HazelcastTestSupport {
     @Test(timeout = 1000 * 60)
     public void testIndexingEnumAttributeWithSqlIssue597() {
         HazelcastInstance instance = createHazelcastInstance(getConfig());
-        IMap<Integer, SampleObjects.Value> map = instance.getMap("default");
+        IMap<Integer, Value> map = instance.getMap("default");
         map.addIndex("state", true);
         for (int i = 0; i < 4; i++) {
             Value v = new Value(i % 2 == 0 ? State.STATE1 : State.STATE2, new ValueType(), i);
             map.put(i, v);
         }
 
-        Collection<SampleObjects.Value> values = map.values(new SqlPredicate("state = 'STATE1'"));
+        Collection<Value> values = map.values(new SqlPredicate("state = 'STATE1'"));
         int[] expectedValues = new int[]{0, 2};
         assertEquals(expectedValues.length, values.size());
         int[] indexes = new int[2];
@@ -654,7 +636,7 @@ public class QueryBasicTest extends HazelcastTestSupport {
         TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(2);
         HazelcastInstance instance = factory.newHazelcastInstance(getConfig());
         factory.newHazelcastInstance(new Config());
-        IMap<Integer, SampleObjects.Employee> map = instance.getMap("default");
+        IMap<Integer, Employee> map = instance.getMap("default");
         testMultipleOrPredicates(map);
     }
 
@@ -663,7 +645,7 @@ public class QueryBasicTest extends HazelcastTestSupport {
         TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(2);
         HazelcastInstance instance = factory.newHazelcastInstance(getConfig());
         factory.newHazelcastInstance(new Config());
-        IMap<Integer, SampleObjects.Employee> map = instance.getMap("default");
+        IMap<Integer, Employee> map = instance.getMap("default");
         map.addIndex("name", true);
         testMultipleOrPredicates(map);
     }
@@ -673,18 +655,18 @@ public class QueryBasicTest extends HazelcastTestSupport {
         TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(2);
         HazelcastInstance instance = factory.newHazelcastInstance(getConfig());
         factory.newHazelcastInstance(new Config());
-        IMap<Integer, SampleObjects.Employee> map = instance.getMap("default");
+        IMap<Integer, Employee> map = instance.getMap("default");
         map.addIndex("name", true);
         map.addIndex("city", true);
         testMultipleOrPredicates(map);
     }
 
-    private void testMultipleOrPredicates(IMap<Integer, SampleObjects.Employee> map) {
+    private void testMultipleOrPredicates(IMap<Integer, Employee> map) {
         for (int i = 0; i < 10; i++) {
             map.put(i, new Employee(i, "name" + i, "city" + i, i, true, i));
         }
 
-        Collection<SampleObjects.Employee> values;
+        Collection<Employee> values;
 
         values = map.values(new SqlPredicate("name = 'name1' OR name = 'name2' OR name LIKE 'name3'"));
         assertEquals(3, values.size());
@@ -721,12 +703,12 @@ public class QueryBasicTest extends HazelcastTestSupport {
     public void testSqlQueryUsing__KeyField() {
         Config config = getConfig();
         TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(2);
-        HazelcastInstance hz1 = factory.newHazelcastInstance(config);
-        HazelcastInstance hz2 = factory.newHazelcastInstance(config);
+        HazelcastInstance instance1 = factory.newHazelcastInstance(config);
+        HazelcastInstance instance2 = factory.newHazelcastInstance(config);
 
-        IMap<Object, Object> map = hz2.getMap(randomMapName());
+        IMap<Object, Object> map = instance2.getMap(randomMapName());
 
-        Object key = generateKeyOwnedBy(hz1);
+        Object key = generateKeyOwnedBy(instance1);
         Object value = "value";
         map.put(key, value);
 
@@ -739,10 +721,10 @@ public class QueryBasicTest extends HazelcastTestSupport {
     public void testSqlQueryUsingNested__KeyField() {
         Config config = getConfig();
         TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(2);
-        HazelcastInstance hz1 = factory.newHazelcastInstance(config);
-        HazelcastInstance hz2 = factory.newHazelcastInstance(config);
+        factory.newHazelcastInstance(config);
+        HazelcastInstance instance = factory.newHazelcastInstance(config);
 
-        IMap<Object, Object> map = hz2.getMap(randomMapName());
+        IMap<Object, Object> map = instance.getMap(randomMapName());
 
         Object key = new CustomAttribute(12, 123L);
         Object value = "value";
@@ -757,10 +739,10 @@ public class QueryBasicTest extends HazelcastTestSupport {
     public void testSqlQueryUsingPortable__KeyField() {
         Config config = getConfig();
         TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(2);
-        HazelcastInstance hz1 = factory.newHazelcastInstance(config);
-        HazelcastInstance hz2 = factory.newHazelcastInstance(config);
+        factory.newHazelcastInstance(config);
+        HazelcastInstance instance = factory.newHazelcastInstance(config);
 
-        IMap<Object, Object> map = hz2.getMap(randomMapName());
+        IMap<Object, Object> map = instance.getMap(randomMapName());
 
         Object key = new ChildPortableObject(123L);
         Object value = "value";
@@ -794,18 +776,17 @@ public class QueryBasicTest extends HazelcastTestSupport {
     }
 
     private void testQueryUsingPortableObject(Config config, String mapName) {
-
         addPortableFactories(config);
 
         TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(2);
-        HazelcastInstance hz1 = factory.newHazelcastInstance(config);
-        HazelcastInstance hz2 = factory.newHazelcastInstance(config);
+        HazelcastInstance instance1 = factory.newHazelcastInstance(config);
+        HazelcastInstance instance2 = factory.newHazelcastInstance(config);
 
-        IMap<Object, Object> map = hz2.getMap(mapName);
+        IMap<Object, Object> map = instance2.getMap(mapName);
 
-        Object key = generateKeyOwnedBy(hz1);
+        Object key = generateKeyOwnedBy(instance1);
         map.put(key, new ParentPortableObject(1L));
-        waitAllForSafeState(hz1, hz2);
+        waitAllForSafeState(instance1, instance2);
 
         Collection<Object> values = map.values(new SqlPredicate("timestamp > 0"));
         assertEquals(1, values.size());
@@ -834,8 +815,8 @@ public class QueryBasicTest extends HazelcastTestSupport {
     @Test(expected = QueryException.class)
     public void testQueryPortableField() {
         Config config = getConfig();
-        HazelcastInstance hz = createHazelcastInstance(config);
-        IMap<Object, Object> map = hz.getMap(randomMapName());
+        HazelcastInstance instance = createHazelcastInstance(config);
+        IMap<Object, Object> map = instance.getMap(randomMapName());
 
         map.put(1, new GrandParentPortableObject(1, new ParentPortableObject(1L, new ChildPortableObject(1L))));
         Collection<Object> values = map.values(new SqlPredicate("child > 0"));
@@ -852,7 +833,8 @@ public class QueryBasicTest extends HazelcastTestSupport {
     public void testQueryUsingNestedPortableObjectWithIndex() {
         String name = randomMapName();
         Config config = getConfig();
-        config.addMapConfig(new MapConfig(name).addMapIndexConfig(new MapIndexConfig("child.timestamp", false))
+        config.addMapConfig(new MapConfig(name)
+                .addMapIndexConfig(new MapIndexConfig("child.timestamp", false))
                 .addMapIndexConfig(new MapIndexConfig("child.child.timestamp", true)));
 
         testQueryUsingNestedPortableObject(config, name);
@@ -862,11 +844,8 @@ public class QueryBasicTest extends HazelcastTestSupport {
     public void testQueryPortableObjectWithIndex() {
         String name = randomMapName();
         Config config = getConfig();
-
-        MapConfig mapConfig = new MapConfig(name)
-                .addMapIndexConfig(new MapIndexConfig("timestamp", true));
-
-        config.addMapConfig(mapConfig);
+        config.addMapConfig(new MapConfig(name)
+                .addMapIndexConfig(new MapIndexConfig("timestamp", true)));
 
         testQueryUsingPortableObject(config, name);
     }
@@ -875,33 +854,30 @@ public class QueryBasicTest extends HazelcastTestSupport {
     public void testQueryPortableObjectWithIndexAndOptimizeQueries() {
         String name = randomMapName();
         Config config = getConfig();
-        MapConfig mapConfig = new MapConfig(name)
+        config.addMapConfig(new MapConfig(name)
                 .setOptimizeQueries(true)
-                .addMapIndexConfig(new MapIndexConfig("timestamp", true));
-        config.addMapConfig(mapConfig);
+                .addMapIndexConfig(new MapIndexConfig("timestamp", true)));
 
         testQueryUsingPortableObject(config, name);
     }
 
     private void testQueryUsingNestedPortableObject(Config config, String name) {
-
         addPortableFactories(config);
 
         TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(2);
-        HazelcastInstance hz1 = factory.newHazelcastInstance(config);
-        HazelcastInstance hz2 = factory.newHazelcastInstance(config);
+        HazelcastInstance instance1 = factory.newHazelcastInstance(config);
+        HazelcastInstance instance2 = factory.newHazelcastInstance(config);
 
-        IMap<Object, Object> map = hz2.getMap(name);
+        IMap<String, GrandParentPortableObject> map = instance2.getMap(name);
 
-        Object key = generateKeyOwnedBy(hz1);
+        String key = generateKeyOwnedBy(instance1);
         map.put(key, new GrandParentPortableObject(1, new ParentPortableObject(1L, new ChildPortableObject(1L))));
-        waitAllForSafeState(hz1, hz2);
+        waitAllForSafeState(instance1, instance2);
 
-        Collection<Object> values = map.values(new SqlPredicate("child.timestamp > 0"));
+        Collection<GrandParentPortableObject> values = map.values(new SqlPredicate("child.timestamp > 0"));
         assertEquals(1, values.size());
 
         values = map.values(new SqlPredicate("child.child.timestamp > 0"));
         assertEquals(1, values.size());
     }
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryIndexTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryIndexTest.java
@@ -30,6 +30,9 @@ import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -37,21 +40,15 @@ import java.util.Collection;
 import java.util.List;
 
 import static java.util.UUID.randomUUID;
-
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
-
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class QueryIndexTest extends HazelcastTestSupport {
 
     @Test
-    public void testResultsReturned_whenCustomAttributeIndexed() throws Exception {
-
+    public void testResultsReturned_whenCustomAttributeIndexed() {
         HazelcastInstance h1 = createHazelcastInstance();
 
         IMap<String, CustomObject> imap = h1.getMap("objects");
@@ -96,7 +93,7 @@ public class QueryIndexTest extends HazelcastTestSupport {
         for (Value configObject : values) {
             typeNames.add(configObject.getType().getTypeName());
         }
-        String[] array = typeNames.toArray(new String[0]);
+        String[] array = typeNames.toArray(new String[typeNames.size()]);
         Arrays.sort(array);
         assertArrayEquals(typeNames.toString(), new String[]{"type6", "type8"}, array);
     }
@@ -118,7 +115,7 @@ public class QueryIndexTest extends HazelcastTestSupport {
         for (Value configObject : values) {
             typeNames.add(configObject.getType().getTypeName());
         }
-        assertArrayEquals(typeNames.toString(), new String[]{"type1"}, typeNames.toArray(new String[0]));
+        assertArrayEquals(typeNames.toString(), new String[]{"type1"}, typeNames.toArray(new String[typeNames.size()]));
     }
 
     @Test(timeout = 1000 * 60)
@@ -137,7 +134,7 @@ public class QueryIndexTest extends HazelcastTestSupport {
     }
 
     @Test(timeout = 1000 * 60)
-    public void testQueryDoesntMatchOldResults_whenEntriesAreUpdated() {
+    public void testQueryDoesNotMatchOldResults_whenEntriesAreUpdated() {
         HazelcastInstance instance = createHazelcastInstance();
         IMap<String, SampleObjects.Value> map = instance.getMap("default");
         map.addIndex("name", true);
@@ -150,29 +147,28 @@ public class QueryIndexTest extends HazelcastTestSupport {
     }
 
     @Test(timeout = 1000 * 60)
-        public void testOneIndexedFieldsWithTwoCriteriaField() throws Exception {
-            HazelcastInstance h1 = createHazelcastInstance();
-            IMap imap = h1.getMap("employees");
-            imap.addIndex("name", false);
-    //        imap.addIndex("age", false);
-            imap.put("1", new Employee(1L, "joe", 30, true, 100D));
-            EntryObject e = new PredicateBuilder().getEntryObject();
-            PredicateBuilder a = e.get("name").equal("joe");
-            Predicate b = e.get("age").equal("30");
-            Collection<Object> actual = imap.values(a.and(b));
-            assertEquals(1, actual.size());
-        }
+    public void testOneIndexedFieldsWithTwoCriteriaField() {
+        HazelcastInstance h1 = createHazelcastInstance();
+        IMap<String, Employee> map = h1.getMap("employees");
+        map.addIndex("name", false);
+        map.put("1", new Employee(1L, "joe", 30, true, 100D));
+        EntryObject e = new PredicateBuilder().getEntryObject();
+        PredicateBuilder a = e.get("name").equal("joe");
+        Predicate b = e.get("age").equal("30");
+        Collection<Employee> actual = map.values(a.and(b));
+        assertEquals(1, actual.size());
+    }
 
     @Test(timeout = 1000 * 60)
     public void testPredicateNotEqualWithIndex() {
         HazelcastInstance instance = createHazelcastInstance();
-        IMap map1 = instance.getMap("testPredicateNotEqualWithIndex-ordered");
-        IMap map2 = instance.getMap("testPredicateNotEqualWithIndex-unordered");
+        IMap<Integer, Value> map1 = instance.getMap("testPredicateNotEqualWithIndex-ordered");
+        IMap<Integer, Value> map2 = instance.getMap("testPredicateNotEqualWithIndex-unordered");
         testPredicateNotEqualWithIndex(map1, true);
         testPredicateNotEqualWithIndex(map2, false);
     }
 
-    private void testPredicateNotEqualWithIndex(IMap map, boolean ordered) {
+    private void testPredicateNotEqualWithIndex(IMap<Integer, Value> map, boolean ordered) {
         map.addIndex("name", ordered);
         map.put(1, new Value("abc", 1));
         map.put(2, new Value("xyz", 2));
@@ -184,6 +180,4 @@ public class QueryIndexTest extends HazelcastTestSupport {
         assertEquals(3, map.values(new PredicateBuilder().getEntryObject().get("name").notEqual("aac")).size());
         assertEquals(2, map.values(new PredicateBuilder().getEntryObject().get("index").notEqual(2)).size());
     }
-
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryNullIndexingTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryNullIndexingTest.java
@@ -25,6 +25,9 @@ import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import java.sql.Timestamp;
 import java.util.ArrayList;
@@ -34,109 +37,83 @@ import java.util.List;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
-
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class QueryNullIndexingTest extends HazelcastTestSupport {
 
     @Test
     public void testIndexedNullValueOnUnorderedIndexStoreWithLessPredicate() {
-        final List<Long> dates =
-                queryIndexedDateFieldAsNullValue(false,
-                                                 Predicates.lessThan("date", 5000000L));
+        List<Long> dates = queryIndexedDateFieldAsNullValue(false, Predicates.lessThan("date", 5000000L));
         assertEquals(2, dates.size());
         assertTrue(dates.containsAll(Arrays.asList(2000000L, 4000000L)));
     }
 
     @Test
     public void testIndexedNullValueOnUnorderedIndexStoreWithLessEqualPredicate() {
-        final List<Long> dates =
-                queryIndexedDateFieldAsNullValue(false,
-                                                 Predicates.lessEqual("date", 5000000L));
+        List<Long> dates = queryIndexedDateFieldAsNullValue(false, Predicates.lessEqual("date", 5000000L));
         assertEquals(2, dates.size());
         assertTrue(dates.containsAll(Arrays.asList(2000000L, 4000000L)));
     }
 
     @Test
     public void testIndexedNullValueOnUnorderedIndexStoreWithGreaterPredicate() {
-        final List<Long> dates =
-                queryIndexedDateFieldAsNullValue(false,
-                                                 Predicates.greaterThan("date", 5000000L));
+        List<Long> dates = queryIndexedDateFieldAsNullValue(false, Predicates.greaterThan("date", 5000000L));
         assertEquals(3, dates.size());
         assertTrue(dates.containsAll(Arrays.asList(6000000L, 8000000L, 10000000L)));
     }
 
     @Test
     public void testIndexedNullValueOnUnorderedIndexStoreWithGreaterEqualPredicate() {
-        final List<Long> dates =
-                queryIndexedDateFieldAsNullValue(false,
-                                                 Predicates.greaterEqual("date", 6000000L));
+        List<Long> dates = queryIndexedDateFieldAsNullValue(false, Predicates.greaterEqual("date", 6000000L));
         assertEquals(3, dates.size());
         assertTrue(dates.containsAll(Arrays.asList(6000000L, 8000000L, 10000000L)));
     }
 
     @Test
     public void testIndexedNullValueOnUnorderedIndexStoreWithNotEqualPredicate() {
-        final List<Long> dates =
-                queryIndexedDateFieldAsNullValue(false,
-                                                 Predicates.notEqual("date", 2000000L));
+        List<Long> dates = queryIndexedDateFieldAsNullValue(false, Predicates.notEqual("date", 2000000L));
         assertEquals(9, dates.size());
-        assertTrue(dates.containsAll(
-                Arrays.asList(4000000L, 6000000L, 8000000L, 10000000L, null)));
+        assertTrue(dates.containsAll(Arrays.asList(4000000L, 6000000L, 8000000L, 10000000L, null)));
     }
 
     @Test
     public void testIndexedNullValueOnOrderedIndexStoreWithLessPredicate() {
-        final List<Long> dates =
-                queryIndexedDateFieldAsNullValue(true,
-                                                 Predicates.lessThan("date", 5000000L));
+        List<Long> dates = queryIndexedDateFieldAsNullValue(true, Predicates.lessThan("date", 5000000L));
         assertEquals(2, dates.size());
         assertTrue(dates.containsAll(Arrays.asList(2000000L, 4000000L)));
     }
 
     @Test
     public void testIndexedNullValueOnOrderedIndexStoreWithLessEqualPredicate() {
-        final List<Long> dates =
-                queryIndexedDateFieldAsNullValue(true,
-                                                 Predicates.lessEqual("date", 5000000L));
+        List<Long> dates = queryIndexedDateFieldAsNullValue(true, Predicates.lessEqual("date", 5000000L));
         assertEquals(2, dates.size());
         assertTrue(dates.containsAll(Arrays.asList(2000000L, 4000000L)));
     }
 
     @Test
     public void testIndexedNullValueOnOrderedIndexStoreWithGreaterPredicate() {
-        final List<Long> dates =
-                queryIndexedDateFieldAsNullValue(true,
-                                                 Predicates.greaterThan("date", 5000000L));
+        List<Long> dates = queryIndexedDateFieldAsNullValue(true, Predicates.greaterThan("date", 5000000L));
         assertEquals(3, dates.size());
         assertTrue(dates.containsAll(Arrays.asList(6000000L, 8000000L, 10000000L)));
     }
 
     @Test
     public void testIndexedNullValueOnOrderedIndexStoreWithGreaterEqualPredicate() {
-        final List<Long> dates =
-                queryIndexedDateFieldAsNullValue(true,
-                                                 Predicates.greaterEqual("date", 6000000L));
+        List<Long> dates = queryIndexedDateFieldAsNullValue(true, Predicates.greaterEqual("date", 6000000L));
         assertEquals(3, dates.size());
         assertTrue(dates.containsAll(Arrays.asList(6000000L, 8000000L, 10000000L)));
     }
 
     @Test
     public void testIndexedNullValueOnOrderedIndexStoreWithNotEqualPredicate() {
-        final List<Long> dates =
-                queryIndexedDateFieldAsNullValue(true,
-                                                 Predicates.notEqual("date", 2000000L));
+        List<Long> dates = queryIndexedDateFieldAsNullValue(true, Predicates.notEqual("date", 2000000L));
         assertEquals(9, dates.size());
-        assertTrue(dates.containsAll(
-                Arrays.asList(4000000L, 6000000L, 8000000L, 10000000L, null)));
+        assertTrue(dates.containsAll(Arrays.asList(4000000L, 6000000L, 8000000L, 10000000L, null)));
     }
 
     private List<Long> queryIndexedDateFieldAsNullValue(boolean ordered, Predicate pred) {
-        final HazelcastInstance instance = createHazelcastInstance();
-        final IMap<Integer, SampleObjects.Employee> map = instance.getMap("default");
+        HazelcastInstance instance = createHazelcastInstance();
+        IMap<Integer, SampleObjects.Employee> map = instance.getMap("default");
 
         map.addIndex("date", ordered);
         for (int i = 10; i >= 1; i--) {
@@ -149,7 +126,7 @@ public class QueryNullIndexingTest extends HazelcastTestSupport {
             map.put(i, employee);
         }
 
-        final List<Long> dates = new ArrayList<Long>();
+        List<Long> dates = new ArrayList<Long>();
         for (SampleObjects.Employee employee : map.values(pred)) {
             Timestamp date = employee.getDate();
             dates.add(date == null ? null : date.getTime());
@@ -157,5 +134,4 @@ public class QueryNullIndexingTest extends HazelcastTestSupport {
 
         return dates;
     }
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/query/ParserTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/ParserTest.java
@@ -40,14 +40,14 @@ public class ParserTest {
 
     @Test
     public void parseEmpty() {
-        List<String> l = parser.toPrefix("");
-        assertEquals(Arrays.asList(), l);
+        List<String> list = parser.toPrefix("");
+        assertTrue(list.isEmpty());
     }
 
     @Test
     public void parseAEqB() {
-        String s = "a = b";
-        List<String> list = parser.toPrefix(s);
+        String query = "a = b";
+        List<String> list = parser.toPrefix(query);
         assertEquals(Arrays.asList("a", "b", "="), list);
     }
 
@@ -61,36 +61,38 @@ public class ParserTest {
 
     @Test
     public void parseAeqBandOpenBsmlCorDgtEclose() {
-        String s = "A = B AND ( B < C OR D > E )";
-        List<String> list = parser.toPrefix(s);
+        String query = "A = B AND ( B < C OR D > E )";
+        List<String> list = parser.toPrefix(query);
         assertEquals(Arrays.asList("A", "B", "=", "B", "C", "<", "D", "E", ">", "OR", "AND"), list);
     }
 
     @Test
     public void testComplexStatement() {
-        String s = "age > 5 AND ( ( ( active = true ) AND ( age = 23 ) ) OR age > 40 ) AND ( salary > 10 ) OR age = 10";
-        List<String> list = parser.toPrefix(s);
-        assertEquals(Arrays.asList("age", "5", ">", "active", "true", "=", "age", "23", "=", "AND", "age", "40", ">", "OR", "AND", "salary", "10", ">", "AND", "age", "10", "=", "OR"), list);
+        String query = "age > 5 AND ( ( ( active = true ) AND ( age = 23 ) ) OR age > 40 ) AND ( salary > 10 ) OR age = 10";
+        List<String> list = parser.toPrefix(query);
+        assertEquals(Arrays.asList("age", "5", ">", "active", "true", "=", "age", "23", "=", "AND", "age", "40", ">", "OR",
+                "AND", "salary", "10", ">", "AND", "age", "10", "=", "OR"), list);
     }
 
     @Test
-    public void testTwoInnerParanthesis() {
-        String s = "a and b AND ( ( ( a > c AND b > d ) OR ( x = y ) ) ) OR t > u";
-        List<String> list = parser.toPrefix(s);
-        assertEquals(Arrays.asList("a", "b", "and", "a", "c", ">", "b", "d", ">", "AND", "x", "y", "=", "OR", "AND", "t", "u", ">", "OR"), list);
+    public void testTwoInnerParenthesis() {
+        String query = "a and b AND ( ( ( a > c AND b > d ) OR ( x = y ) ) ) OR t > u";
+        List<String> list = parser.toPrefix(query);
+        assertEquals(Arrays.asList("a", "b", "and", "a", "c", ">", "b", "d", ">", "AND", "x", "y", "=", "OR", "AND", "t", "u",
+                ">", "OR"), list);
     }
 
     @Test
     public void testBetweenAnd() {
-        String s = "a and b between 10 and 15";
-        List<String> list = parser.toPrefix(s);
+        String query = "a and b between 10 and 15";
+        List<String> list = parser.toPrefix(query);
         assertEquals(Arrays.asList("a", "b", "10", "15", "between", "and"), list);
     }
 
     @Test
     public void testBetween() {
-        String s = "b between 10 and 15";
-        List<String> list = parser.toPrefix(s);
+        String query = "b between 10 and 15";
+        List<String> list = parser.toPrefix(query);
         assertEquals(Arrays.asList("b", "10", "15", "between"), list);
     }
 
@@ -103,29 +105,29 @@ public class ParserTest {
 
     @Test
     public void testIn() {
-        String s = "a and b OR c in ( 4, 5, 6 )";
-        List<String> list = parser.toPrefix(s);
+        String query = "a and b OR c in ( 4, 5, 6 )";
+        List<String> list = parser.toPrefix(query);
         assertEquals(Arrays.asList("a", "b", "and", "c", "4,5,6", "in", "OR"), list);
     }
 
     @Test
     public void testNot() {
-        String s = "a and not(b) OR c not in ( 4, 5, 6 )";
-        List<String> list = parser.toPrefix(s);
+        String query = "a and not(b) OR c not in ( 4, 5, 6 )";
+        List<String> list = parser.toPrefix(query);
         assertEquals(Arrays.asList("a", "b", "not", "and", "c", "4,5,6", "in", "not", "OR"), list);
     }
 
     @Test
     public void testNotEqual1() {
-        String s = "b != 30";
-        List<String> list = parser.toPrefix(s);
+        String query = "b != 30";
+        List<String> list = parser.toPrefix(query);
         assertEquals(Arrays.asList("b", "30", "!="), list);
     }
 
     @Test
     public void testNotEqual2() {
-        String s = "b <> 30";
-        List<String> list = parser.toPrefix(s);
+        String query = "b <> 30";
+        List<String> list = parser.toPrefix(query);
         assertEquals(Arrays.asList("b", "30", "<>"), list);
     }
 
@@ -150,20 +152,23 @@ public class ParserTest {
     @Test
     public void split4() {
         List<String> tokens = parser.split("a and b AND(((a>c AND b> d) OR (x = y )) ) OR t>u");
-        assertEquals(Arrays.asList("a", "and", "b", "AND", "(", "(", "(", "a", ">", "c", "AND", "b", ">", "d", ")", "OR", "(", "x", "=", "y", ")", ")", ")", "OR", "t", ">", "u"), tokens);
+        assertEquals(Arrays.asList("a", "and", "b", "AND", "(", "(", "(", "a", ">", "c", "AND", "b", ">", "d", ")", "OR", "(",
+                "x", "=", "y", ")", ")", ")", "OR", "t", ">", "u"), tokens);
     }
 
     @Test
     public void split5() {
         List<String> tokens = parser.split("a and b AND(((a>=c AND b> d) OR (x <> y )) ) OR t>u");
-        assertEquals(Arrays.asList("a", "and", "b", "AND", "(", "(", "(", "a", ">=", "c", "AND", "b", ">", "d", ")", "OR", "(", "x", "<>", "y", ")", ")", ")", "OR", "t", ">", "u"), tokens);
+        assertEquals(Arrays.asList("a", "and", "b", "AND", "(", "(", "(", "a", ">=", "c", "AND", "b", ">", "d", ")", "OR", "(",
+                "x", "<>", "y", ")", ")", ")", "OR", "t", ">", "u"), tokens);
     }
 
     @Test
     public void testComplexStatementWithGreaterAndEqueals() {
         String s = "age>=5 AND ((( active = true ) AND (age = 23 )) OR age > 40) AND( salary>10 ) OR age=10";
         List<String> list = parser.toPrefix(s);
-        assertEquals(Arrays.asList("age", "5", ">=", "active", "true", "=", "age", "23", "=", "AND", "age", "40", ">", "OR", "AND", "salary", "10", ">", "AND", "age", "10", "=", "OR"), list);
+        assertEquals(Arrays.asList("age", "5", ">=", "active", "true", "=", "age", "23", "=", "AND", "age", "40", ">", "OR",
+                "AND", "salary", "10", ">", "AND", "age", "10", "=", "OR"), list);
     }
 
     @Test(expected = NullPointerException.class)

--- a/hazelcast/src/test/java/com/hazelcast/query/PortablePredicatesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/PortablePredicatesTest.java
@@ -16,14 +16,15 @@
 
 package com.hazelcast.query;
 
+import com.hazelcast.internal.serialization.SerializationService;
+import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
 import com.hazelcast.nio.serialization.FieldType;
+import com.hazelcast.nio.serialization.Portable;
+import com.hazelcast.nio.serialization.PortableFactory;
 import com.hazelcast.nio.serialization.PortableReader;
 import com.hazelcast.nio.serialization.PortableWriter;
-import com.hazelcast.internal.serialization.SerializationService;
-import com.hazelcast.nio.serialization.*;
-import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
-import com.hazelcast.query.impl.getters.Extractors;
 import com.hazelcast.query.impl.QueryEntry;
+import com.hazelcast.query.impl.getters.Extractors;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
@@ -44,8 +45,10 @@ import static org.junit.Assert.assertTrue;
 public class PortablePredicatesTest {
 
     private static final short FACTORY_ID = 1;
-    private final SerializationService ss = new DefaultSerializationServiceBuilder()
-            .addPortableFactory(FACTORY_ID, new TestPortableFactory()).build();
+
+    private final SerializationService serializationService = new DefaultSerializationServiceBuilder()
+            .addPortableFactory(FACTORY_ID, new TestPortableFactory())
+            .build();
 
     @Test
     public void testPortablePredicate() {
@@ -55,11 +58,7 @@ public class PortablePredicatesTest {
         assertFalse(new SqlPredicate("character == 'Bizarro'").apply(toQueryEntry("1", data)));
     }
 
-    private PortableData createData(String id,
-                                    String firstName,
-                                    String lastName,
-                                    String character,
-                                    long strength) {
+    private PortableData createData(String id, String firstName, String lastName, String character, long strength) {
         PortableData modelData = new PortableData();
         modelData.put("id", id);
         modelData.put("firstName", firstName);
@@ -70,7 +69,7 @@ public class PortablePredicatesTest {
     }
 
     private QueryEntry toQueryEntry(Object key, Object value) {
-        return new QueryEntry(ss, ss.toData(key), value, Extractors.empty());
+        return new QueryEntry(serializationService, serializationService.toData(key), value, Extractors.empty());
     }
 
     class TestPortableFactory implements PortableFactory {
@@ -148,6 +147,5 @@ public class PortablePredicatesTest {
                 }
             }
         }
-
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/query/PredicateBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/PredicateBuilderTest.java
@@ -20,7 +20,6 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
-import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -36,16 +35,14 @@ import static org.junit.Assert.assertTrue;
 @Category(QuickTest.class)
 public class PredicateBuilderTest extends HazelcastTestSupport {
 
-
     @Test
     public void get_keyAttribute() {
         HazelcastInstance hz = createHazelcastInstance();
 
-        EntryObject e = new PredicateBuilder().getEntryObject();
+        EntryObject entryObject = new PredicateBuilder().getEntryObject();
+        Predicate predicate = entryObject.key().get("id").equal("10").and(entryObject.get("name").equal("value1"));
 
-        Predicate predicate = e.key().get("id").equal("10").and(e.get("name").equal("value1"));
-
-        IMap<Id, Value> hazelcastLookupMap = hz.getMap("somemap");
+        IMap<Id, Value> hazelcastLookupMap = hz.getMap("someMap");
 
         hazelcastLookupMap.put(new Id("10"), new Value("value1"));
         hazelcastLookupMap.put(new Id("20"), new Value("value2"));
@@ -58,13 +55,12 @@ public class PredicateBuilderTest extends HazelcastTestSupport {
 
     @Test
     public void get_key() {
-         HazelcastInstance hz = createHazelcastInstance();
+        HazelcastInstance hz = createHazelcastInstance();
 
-        EntryObject e = new PredicateBuilder().getEntryObject();
+        EntryObject entryObject = new PredicateBuilder().getEntryObject();
+        Predicate predicate = entryObject.key().equal(10L);
 
-        Predicate predicate = e.key().equal(10L);
-
-        IMap<Integer, Integer> hazelcastLookupMap = hz.getMap("somemap");
+        IMap<Integer, Integer> hazelcastLookupMap = hz.getMap("someMap");
 
         hazelcastLookupMap.put(10, 1);
         hazelcastLookupMap.put(30, 2);
@@ -76,13 +72,12 @@ public class PredicateBuilderTest extends HazelcastTestSupport {
 
     @Test
     public void get_this() {
-         HazelcastInstance hz = createHazelcastInstance();
+        HazelcastInstance hz = createHazelcastInstance();
 
-        EntryObject e = new PredicateBuilder().getEntryObject();
+        EntryObject entryObject = new PredicateBuilder().getEntryObject();
+        Predicate predicate = entryObject.get("this").equal(1L);
 
-        Predicate predicate = e.get("this").equal(1L);
-
-        IMap<Integer, Integer> hazelcastLookupMap = hz.getMap("somemap");
+        IMap<Integer, Integer> hazelcastLookupMap = hz.getMap("someMap");
 
         hazelcastLookupMap.put(10, 1);
         hazelcastLookupMap.put(30, 2);
@@ -94,17 +89,16 @@ public class PredicateBuilderTest extends HazelcastTestSupport {
 
     @Test
     public void get_attribute() {
-       HazelcastInstance hz = createHazelcastInstance();
+        HazelcastInstance hz = createHazelcastInstance();
 
-        EntryObject e = new PredicateBuilder().getEntryObject();
+        EntryObject entryObject = new PredicateBuilder().getEntryObject();
+        Predicate predicate = entryObject.get("id").equal("10");
 
-        Predicate predicate = e.get("id").equal("10");
+        IMap<Integer, Id> hazelcastLookupMap = hz.getMap("someMap");
 
-        IMap<Integer, Id> hazelcastLookupMap = hz.getMap("somemap");
-
-        hazelcastLookupMap.put(1,new Id("10"));
-        hazelcastLookupMap.put(2,new Id("20"));
-        hazelcastLookupMap.put(3,new Id("30"));
+        hazelcastLookupMap.put(1, new Id("10"));
+        hazelcastLookupMap.put(2, new Id("20"));
+        hazelcastLookupMap.put(3, new Id("30"));
 
         Collection<Id> result = hazelcastLookupMap.values(predicate);
         assertEquals(1, result.size());
@@ -112,6 +106,7 @@ public class PredicateBuilderTest extends HazelcastTestSupport {
     }
 
     private static class Id implements Serializable {
+
         private String id;
 
         public Id(String id) {
@@ -124,12 +119,17 @@ public class PredicateBuilderTest extends HazelcastTestSupport {
 
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
 
             Id id1 = (Id) o;
-
-            if (id != null ? !id.equals(id1.id) : id1.id != null) return false;
+            if (id != null ? !id.equals(id1.id) : id1.id != null) {
+                return false;
+            }
 
             return true;
         }
@@ -141,6 +141,7 @@ public class PredicateBuilderTest extends HazelcastTestSupport {
     }
 
     private static class Value implements Serializable {
+
         private String name;
 
         private Value(String name) {
@@ -153,12 +154,18 @@ public class PredicateBuilderTest extends HazelcastTestSupport {
 
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
 
             Value value = (Value) o;
 
-            if (name != null ? !name.equals(value.name) : value.name != null) return false;
+            if (name != null ? !name.equals(value.name) : value.name != null) {
+                return false;
+            }
 
             return true;
         }

--- a/hazelcast/src/test/java/com/hazelcast/query/SampleObjects.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/SampleObjects.java
@@ -28,17 +28,14 @@ import java.sql.Timestamp;
 import java.util.Date;
 import java.util.UUID;
 
-/**
- * @author mdogan 6/6/13
- */
 public final class SampleObjects {
 
     public static class PortableEmployee implements Portable {
+
         private int age;
         private String name;
 
         public PortableEmployee() {
-
         }
 
         public PortableEmployee(int age, String name) {
@@ -78,6 +75,7 @@ public final class SampleObjects {
     }
 
     public static class ValueType implements Serializable, Comparable<ValueType> {
+
         String typeName;
 
         public ValueType(String typeName) {
@@ -111,13 +109,16 @@ public final class SampleObjects {
 
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
 
             ValueType valueType = (ValueType) o;
 
             return !(typeName != null ? !typeName.equals(valueType.typeName) : valueType.typeName != null);
-
         }
 
         @Override
@@ -127,6 +128,7 @@ public final class SampleObjects {
     }
 
     public static class Value implements Serializable {
+
         String name;
         ValueType type;
         State state;
@@ -179,14 +181,24 @@ public final class SampleObjects {
 
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
 
             Value value = (Value) o;
 
-            if (index != value.index) return false;
-            if (name != null ? !name.equals(value.name) : value.name != null) return false;
-            if (type != null ? !type.equals(value.type) : value.type != null) return false;
+            if (index != value.index) {
+                return false;
+            }
+            if (name != null ? !name.equals(value.name) : value.name != null) {
+                return false;
+            }
+            if (type != null ? !type.equals(value.type) : value.type != null) {
+                return false;
+            }
 
             return true;
         }
@@ -201,22 +213,22 @@ public final class SampleObjects {
 
         @Override
         public String toString() {
-            final StringBuilder sb = new StringBuilder();
-            sb.append("Value");
-            sb.append("{name=").append(name);
-            sb.append(", index=").append(index);
-            sb.append(", type=").append(type);
-            sb.append('}');
-            return sb.toString();
+            return "Value{"
+                    + "name=" + name
+                    + ", index=" + index
+                    + ", type=" + type
+                    + '}';
         }
     }
 
-
-    public static enum State {
-        STATE1, STATE2
+    public enum State {
+        STATE1,
+        STATE2
     }
 
+    @SuppressWarnings("unused")
     public static class Employee implements Serializable {
+
         long id;
         String name;
         String city;
@@ -332,13 +344,25 @@ public final class SampleObjects {
 
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
             Employee employee = (Employee) o;
-            if (active != employee.active) return false;
-            if (age != employee.age) return false;
-            if (Double.compare(employee.salary, salary) != 0) return false;
-            if (name != null ? !name.equals(employee.name) : employee.name != null) return false;
+            if (active != employee.active) {
+                return false;
+            }
+            if (age != employee.age) {
+                return false;
+            }
+            if (Double.compare(employee.salary, salary) != 0) {
+                return false;
+            }
+            if (name != null ? !name.equals(employee.name) : employee.name != null) {
+                return false;
+            }
             return true;
         }
 
@@ -356,15 +380,13 @@ public final class SampleObjects {
 
         @Override
         public String toString() {
-            final StringBuilder sb = new StringBuilder();
-            sb.append("Employee");
-            sb.append("{name='").append(name).append('\'');
-            sb.append(", city=").append(city);
-            sb.append(", age=").append(age);
-            sb.append(", active=").append(active);
-            sb.append(", salary=").append(salary);
-            sb.append('}');
-            return sb.toString();
+            return "Employee{"
+                    + "name='" + name + '\''
+                    + ", city=" + city
+                    + ", age=" + age
+                    + ", active=" + active
+                    + ", salary=" + salary
+                    + '}';
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/query/SqlPredicateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/SqlPredicateTest.java
@@ -16,8 +16,6 @@
 
 package com.hazelcast.query;
 
-import static com.hazelcast.instance.TestUtil.toData;
-
 import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
 import com.hazelcast.query.SampleObjects.Employee;
@@ -39,6 +37,9 @@ import com.hazelcast.query.impl.getters.Extractors;
 import com.hazelcast.query.impl.QueryEntry;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -50,49 +51,46 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
+import static com.hazelcast.instance.TestUtil.toData;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
-
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
 public class SqlPredicateTest {
 
-    final SerializationService ss = new DefaultSerializationServiceBuilder().build();
+    final SerializationService serializationService = new DefaultSerializationServiceBuilder().build();
 
     @Test
-    public void testEqualsWhenSqlMatches() throws Exception {
+    public void testEqualsWhenSqlMatches() {
         SqlPredicate sql1 = new SqlPredicate("foo='bar'");
         SqlPredicate sql2 = new SqlPredicate("foo='bar'");
         assertEquals(sql1, sql2);
     }
 
     @Test
-    public void testEqualsWhenSqlDifferent() throws Exception {
+    public void testEqualsWhenSqlDifferent() {
         SqlPredicate sql1 = new SqlPredicate("foo='bar'");
         SqlPredicate sql2 = new SqlPredicate("foo='baz'");
         assertNotEquals(sql1, sql2);
     }
 
     @Test
-    public void testEqualsNull() throws Exception {
+    public void testEqualsNull() {
         SqlPredicate sql = new SqlPredicate("foo='bar'");
         assertNotEquals(sql, null);
     }
 
     @Test
-    public void testEqualsSameObject() throws Exception {
+    public void testEqualsSameObject() {
         SqlPredicate sql = new SqlPredicate("foo='bar'");
         assertEquals(sql, sql);
     }
 
     @Test
-    public void testHashCode() throws Exception {
+    public void testHashCode() {
         SqlPredicate sql = new SqlPredicate("foo='bar'");
         assertEquals("foo='bar'".hashCode(), sql.hashCode());
     }
@@ -309,7 +307,8 @@ public class SqlPredicateTest {
         assertEquals("active=true", sql("active"));
         assertEquals("(active=true AND name=abc xyz 123)", sql("active AND name='abc xyz 123'"));
         assertEquals("(name LIKE 'abc-xyz+(123)' AND name=abc xyz 123)", sql("name like 'abc-xyz+(123)' AND name='abc xyz 123'"));
-        assertEquals("(name REGEX '\\w{3}-\\w{3}+\\(\\d{3}\\)' AND name=abc xyz 123)", sql("name regex '\\w{3}-\\w{3}+\\(\\d{3}\\)' AND name='abc xyz 123'"));
+        assertEquals("(name REGEX '\\w{3}-\\w{3}+\\(\\d{3}\\)' AND name=abc xyz 123)",
+                sql("name regex '\\w{3}-\\w{3}+\\(\\d{3}\\)' AND name='abc xyz 123'"));
         assertEquals("(active=true AND age>4)", sql("active and age > 4"));
         assertEquals("(active=true AND age>4)", sql("active and age>4"));
         assertEquals("(active=false AND age<=4)", sql("active=false AND age<=4"));
@@ -340,10 +339,12 @@ public class SqlPredicateTest {
         assertEquals("(active=true AND age BETWEEN 10 AND 15)", sql("active and age between 10 and 15"));
         assertEquals("(age BETWEEN 10 AND 15 AND active=true)", sql("age between 10 and 15 and active"));
         assertEquals("(active=true OR age BETWEEN 10 AND 15)", sql("active or (age between 10 and 15)"));
-        assertEquals("(age>10 AND (active=true OR age BETWEEN 10 AND 15))", sql("age>10 AND (active or (age between 10 and 15))"));
-        assertEquals("(age<=10 AND (active=true OR NOT(age BETWEEN 10 AND 15)))", sql("age<=10 AND (active or (age not between 10 and 15))"));
+        assertEquals("(age>10 AND (active=true OR age BETWEEN 10 AND 15))",
+                sql("age>10 AND (active or (age between 10 and 15))"));
+        assertEquals("(age<=10 AND (active=true OR NOT(age BETWEEN 10 AND 15)))",
+                sql("age<=10 AND (active or (age not between 10 and 15))"));
         assertEquals("name ILIKE 'J%'", sql("name ilike 'J%'"));
-        //issue #594
+        // issue #594
         assertEquals("(name IN (name0,name2) AND age IN (2,5,8))", sql("name in('name0', 'name2') and age   IN ( 2, 5  ,8)"));
     }
 
@@ -368,7 +369,7 @@ public class SqlPredicateTest {
     }
 
     private Map.Entry createEntry(final Object key, final Object value) {
-        return new QueryEntry(ss, toData(key), value, Extractors.empty());
+        return new QueryEntry(serializationService, toData(key), value, Extractors.empty());
     }
 
     private void assertSqlTrue(String s, Object value) {
@@ -389,9 +390,5 @@ public class SqlPredicateTest {
 
     private Employee createValue(String name) {
         return new Employee(name, 34, true, 10D);
-    }
-
-    private Employee createValue(int age) {
-        return new Employee("abc-123-xvz", age, true, 10D);
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/AndResultSetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/AndResultSetTest.java
@@ -23,9 +23,10 @@ import static org.junit.Assert.assertFalse;
 @Category({QuickTest.class, ParallelTest.class})
 public class AndResultSetTest extends HazelcastTestSupport {
 
-    //https://github.com/hazelcast/hazelcast/issues/1501
-    //tests that this method is not running into a stackoverflow.
+    // https://github.com/hazelcast/hazelcast/issues/1501
+    // tests that this method is not running into a stackoverflow
     @Test
+    @SuppressWarnings("unchecked")
     public void issue_1501() {
         Set<QueryableEntry> entries = generateEntries(100000);
         System.out.println(entries.size());
@@ -35,7 +36,7 @@ public class AndResultSetTest extends HazelcastTestSupport {
         assertFalse(result);
     }
 
-    //todo: we need to have more methods for regular behavior.
+    // TODO: we need to have more methods for regular behavior
 
     class FalsePredicate implements Predicate {
         @Override

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/DateHelperTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/DateHelperTest.java
@@ -31,9 +31,6 @@ import java.util.Locale;
 
 import static org.junit.Assert.assertEquals;
 
-/**
- * @author mdogan 7/4/13
- */
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
 public class DateHelperTest {
@@ -44,10 +41,10 @@ public class DateHelperTest {
 
     @Test
     public void testSqlDate() {
-        final long now = System.currentTimeMillis();
+        long now = System.currentTimeMillis();
 
-        final java.sql.Date date1 = new java.sql.Date(now);
-        final java.sql.Date date2 = DateHelper.parseSqlDate(date1.toString());
+        java.sql.Date date1 = new java.sql.Date(now);
+        java.sql.Date date2 = DateHelper.parseSqlDate(date1.toString());
 
         Calendar cal1 = Calendar.getInstance(Locale.US);
         cal1.setTimeInMillis(date1.getTime());
@@ -61,10 +58,10 @@ public class DateHelperTest {
 
     @Test
     public void testUtilDate() {
-        final long now = System.currentTimeMillis();
+        long now = System.currentTimeMillis();
 
-        final Date date1 = new Date(now);
-        final Date date2 = DateHelper.parseDate(new SimpleDateFormat(DateHelperTest.DATE_FORMAT, Locale.US).format(date1));
+        Date date1 = new Date(now);
+        Date date2 = DateHelper.parseDate(new SimpleDateFormat(DateHelperTest.DATE_FORMAT, Locale.US).format(date1));
 
         Calendar cal1 = Calendar.getInstance(Locale.US);
         cal1.setTimeInMillis(date1.getTime());
@@ -81,10 +78,10 @@ public class DateHelperTest {
 
     @Test
     public void testTimestamp() {
-        final long now = System.currentTimeMillis();
+        long now = System.currentTimeMillis();
 
-        final Timestamp date1 = new Timestamp(now);
-        final Timestamp date2 = DateHelper.parseTimeStamp(date1.toString());
+        Timestamp date1 = new Timestamp(now);
+        Timestamp date2 = DateHelper.parseTimeStamp(date1.toString());
 
         Calendar cal1 = Calendar.getInstance(Locale.US);
         cal1.setTimeInMillis(date1.getTime());
@@ -101,10 +98,10 @@ public class DateHelperTest {
 
     @Test
     public void testTime() {
-        final long now = System.currentTimeMillis();
+        long now = System.currentTimeMillis();
 
-        final Time time1 = new Time(now);
-        final Time time2 = DateHelper.parseSqlTime(time1.toString());
+        Time time1 = new Time(now);
+        Time time2 = DateHelper.parseSqlTime(time1.toString());
 
         Calendar cal1 = Calendar.getInstance(Locale.US);
         cal1.setTimeInMillis(time1.getTime());
@@ -116,4 +113,3 @@ public class DateHelperTest {
         assertEquals(cal1.get(Calendar.SECOND), cal2.get(Calendar.SECOND));
     }
 }
-

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/DefaultValueCollectorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/DefaultValueCollectorTest.java
@@ -70,5 +70,4 @@ public class DefaultValueCollectorTest {
         assertTrue(result instanceof MultiResult);
         return ((MultiResult<T>) collector.getResult()).getResults();
     }
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/IndexIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/IndexIntegrationTest.java
@@ -84,7 +84,6 @@ public class IndexIntegrationTest extends HazelcastTestSupport {
         assertNull(map.get(1));
     }
 
-
     @Test(timeout = 1000 * 60)
     public void putAndQuery_whenMultipleMappingFound_thenDoNotReturnDuplicatedEntry() {
         HazelcastInstance instance = createHazelcastInstance();
@@ -131,12 +130,15 @@ public class IndexIntegrationTest extends HazelcastTestSupport {
 
     static class Nail implements Serializable {
         String colour;
+
         private Nail(String colour) {
             this.colour = colour;
         }
     }
 
+    @SuppressWarnings("unused")
     public static class Trade implements Serializable {
+
         private String currency;
         private Long amount;
 
@@ -186,7 +188,9 @@ public class IndexIntegrationTest extends HazelcastTestSupport {
         assertThat(result, hasSize(1));
     }
 
+    @SuppressWarnings("unused")
     static class SillySequence implements DataSerializable {
+
         int count;
         Collection<Integer> payloadField;
 
@@ -224,5 +228,4 @@ public class IndexIntegrationTest extends HazelcastTestSupport {
             payloadField = in.readObject();
         }
     }
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/IndexSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/IndexSplitBrainTest.java
@@ -165,7 +165,6 @@ public class IndexSplitBrainTest extends HazelcastTestSupport {
         public void memberAttributeChanged(MemberAttributeEvent memberAttributeEvent) {
 
         }
-
     }
 
     protected NetworkConfig getLocalhostTcpIpNetworkConfig(int port) {

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/IndexTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/IndexTest.java
@@ -84,13 +84,13 @@ public class IndexTest {
         Indexes is = new Indexes(ss, Extractors.empty());
         is.addOrGetIndex("favoriteCity", false);
         Data key = ss.toData(1);
-        Data value = ss.toData(new SerializableWithEnum(SerializableWithEnum.City.Istanbul));
+        Data value = ss.toData(new SerializableWithEnum(SerializableWithEnum.City.ISTANBUL));
         is.saveEntryIndex(new QueryEntry(ss, key, value, Extractors.empty()), null);
         assertNotNull(is.getIndex("favoriteCity"));
         Record record = recordFactory.newRecord(value);
         ((AbstractRecord) record).setKey(key);
         is.removeEntryIndex(key, Records.getValueOrCachedValue(record, ss));
-        assertEquals(0, is.getIndex("favoriteCity").getRecords(SerializableWithEnum.City.Istanbul).size());
+        assertEquals(0, is.getIndex("favoriteCity").getRecords(SerializableWithEnum.City.ISTANBUL).size());
     }
 
     @Test
@@ -98,14 +98,14 @@ public class IndexTest {
         Indexes is = new Indexes(ss, Extractors.empty());
         is.addOrGetIndex("favoriteCity", false);
         Data key = ss.toData(1);
-        Data value = ss.toData(new SerializableWithEnum(SerializableWithEnum.City.Istanbul));
+        Data value = ss.toData(new SerializableWithEnum(SerializableWithEnum.City.ISTANBUL));
         is.saveEntryIndex(new QueryEntry(ss, key, value, Extractors.empty()), null);
 
-        Data newValue = ss.toData(new SerializableWithEnum(SerializableWithEnum.City.Krakow));
+        Data newValue = ss.toData(new SerializableWithEnum(SerializableWithEnum.City.KRAKOW));
         is.saveEntryIndex(new QueryEntry(ss, key, newValue, Extractors.empty()), value);
 
-        assertEquals(0, is.getIndex("favoriteCity").getRecords(SerializableWithEnum.City.Istanbul).size());
-        assertEquals(1, is.getIndex("favoriteCity").getRecords(SerializableWithEnum.City.Krakow).size());
+        assertEquals(0, is.getIndex("favoriteCity").getRecords(SerializableWithEnum.City.ISTANBUL).size());
+        assertEquals(1, is.getIndex("favoriteCity").getRecords(SerializableWithEnum.City.KRAKOW).size());
     }
 
     @Test
@@ -190,8 +190,7 @@ public class IndexTest {
             is.saveEntryIndex(new QueryEntry(ss, key, value, Extractors.empty()), null);
         }
 
-        Comparable c = null;
-        assertEquals(2, strIndex.getRecords(c).size());
+        assertEquals(2, strIndex.getRecords((Comparable) null).size());
         assertEquals(998, strIndex.getSubRecords(ComparisonType.NOT_EQUAL, null).size());
     }
 
@@ -213,10 +212,10 @@ public class IndexTest {
     private static class SerializableWithEnum implements DataSerializable {
 
         enum City {
-            Istanbul,
-            Rize,
-            Krakow,
-            Trabzon;
+            ISTANBUL,
+            RIZE,
+            KRAKOW,
+            TRABZON
         }
 
         private City favoriteCity;
@@ -260,8 +259,7 @@ public class IndexTest {
             this.str = str;
         }
 
-        private MainPortable(byte b, boolean bool, char c, short s, int i, long l, float f,
-                             double d, String str) {
+        private MainPortable(byte b, boolean bool, char c, short s, int i, long l, float f, double d, String str) {
             this.b = b;
             this.bool = bool;
             this.c = c;
@@ -303,18 +301,40 @@ public class IndexTest {
 
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
             MainPortable that = (MainPortable) o;
-            if (b != that.b) return false;
-            if (bool != that.bool) return false;
-            if (c != that.c) return false;
-            if (Double.compare(that.d, d) != 0) return false;
-            if (Float.compare(that.f, f) != 0) return false;
-            if (i != that.i) return false;
-            if (l != that.l) return false;
-            if (s != that.s) return false;
-            if (str != null ? !str.equals(that.str) : that.str != null) return false;
+            if (b != that.b) {
+                return false;
+            }
+            if (bool != that.bool) {
+                return false;
+            }
+            if (c != that.c) {
+                return false;
+            }
+            if (Double.compare(that.d, d) != 0) {
+                return false;
+            }
+            if (Float.compare(that.f, f) != 0) {
+                return false;
+            }
+            if (i != that.i) {
+                return false;
+            }
+            if (l != that.l) {
+                return false;
+            }
+            if (s != that.s) {
+                return false;
+            }
+            if (str != null ? !str.equals(that.str) : that.str != null) {
+                return false;
+            }
             return true;
         }
 
@@ -356,6 +376,7 @@ public class IndexTest {
     }
 
     class QueryRecord extends QueryableEntry {
+
         Data key;
         Comparable attributeValue;
 
@@ -374,7 +395,7 @@ public class IndexTest {
 
         @Override
         public Object getTargetObject(boolean key) {
-            return key ? key : attributeValue;
+            return key ? true : attributeValue;
         }
 
         public Data getKeyData() {
@@ -448,7 +469,7 @@ public class IndexTest {
         assertEquals(1, index.getSubRecordsBetween(555L, 555L).size());
         QueryRecord record50 = newRecord(50L, 555L);
         index.saveEntryIndex(record50, null);
-        assertEquals(new HashSet(asList(record5, record50)), index.getRecords(555L));
+        assertEquals(new HashSet<QueryableEntry>(asList(record5, record50)), index.getRecords(555L));
 
         ConcurrentMap<Data, QueryableEntry> records = index.getRecordMap(555L);
         assertNotNull(records);

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/QueryEntryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/QueryEntryTest.java
@@ -113,7 +113,9 @@ public class QueryEntryTest extends HazelcastTestSupport {
         assertTrue("Old dataValue should not be here", dataValue != queryEntry.getValueData());
     }
 
+    @SuppressWarnings("unused")
     private static class SerializableObject implements DataSerializable {
+
         private int serializationCount;
         private int deserializationCount;
         private String name;

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/extractor/AbstractExtractionSpecification.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/extractor/AbstractExtractionSpecification.java
@@ -116,5 +116,4 @@ public class AbstractExtractionSpecification extends HazelcastTestSupport {
         }
         return combinations;
     }
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/extractor/AbstractExtractionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/extractor/AbstractExtractionTest.java
@@ -25,9 +25,7 @@ public abstract class AbstractExtractionTest extends AbstractExtractionSpecifica
     @Rule
     public ExpectedException expected = ExpectedException.none();
 
-    // instance and map used in the tests
-    private HazelcastInstance instance;
-    protected IMap map;
+    protected IMap<String, Object> map;
 
     // three parametrisation axes
     private InMemoryFormat inMemoryFormat;
@@ -49,7 +47,7 @@ public abstract class AbstractExtractionTest extends AbstractExtractionSpecifica
     }
 
     /**
-     * Method may be overriden in sub-classes to tweak the HZ instance for purposes of each test.
+     * Method may be overridden in sub-classes to tweak the HZ instance for purposes of each test.
      */
     protected Configurator getInstanceConfigurator() {
         return null;
@@ -98,7 +96,7 @@ public abstract class AbstractExtractionTest extends AbstractExtractionSpecifica
      * Initializes the instance and the map used in the tests
      */
     private void setupInstance(Config config) {
-        instance = createHazelcastInstance(config);
+        HazelcastInstance instance = createHazelcastInstance(config);
         map = instance.getMap("map");
     }
 
@@ -162,5 +160,4 @@ public abstract class AbstractExtractionTest extends AbstractExtractionSpecifica
             }
         }
     }
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/extractor/predicates/CollectionAllPredicatesExtractorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/extractor/predicates/CollectionAllPredicatesExtractorTest.java
@@ -26,16 +26,18 @@ import static com.hazelcast.query.impl.extractor.predicates.CollectionDataStruct
  * <p/>
  * This test is parametrised. See CollectionAllPredicatesReflectionTest for more details.
  */
+@SuppressWarnings("unused")
 public class CollectionAllPredicatesExtractorTest extends CollectionAllPredicatesReflectionTest {
 
-    public CollectionAllPredicatesExtractorTest(InMemoryFormat inMemoryFormat, AbstractExtractionTest.Index index, AbstractExtractionTest.Multivalue multivalue) {
+    public CollectionAllPredicatesExtractorTest(InMemoryFormat inMemoryFormat, AbstractExtractionTest.Index index,
+                                                Multivalue multivalue) {
         super(inMemoryFormat, index, multivalue);
     }
 
     protected AbstractExtractionTest.Configurator getInstanceConfigurator() {
         return new AbstractExtractionTest.Configurator() {
             @Override
-            public void doWithConfig(Config config, AbstractExtractionTest.Multivalue mv) {
+            public void doWithConfig(Config config, Multivalue mv) {
                 MapConfig mapConfig = config.getMapConfig("map");
 
                 MapAttributeConfig reducedNameAttribute = new AbstractExtractionTest.TestMapAttributeIndexConfig();
@@ -96,6 +98,4 @@ public class CollectionAllPredicatesExtractorTest extends CollectionAllPredicate
             }
         }
     }
-
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/extractor/predicates/CollectionAllPredicatesReflectionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/extractor/predicates/CollectionAllPredicatesReflectionTest.java
@@ -175,5 +175,4 @@ public class CollectionAllPredicatesReflectionTest extends AbstractExtractionTes
                 asList(ARRAY, LIST)
         );
     }
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/extractor/predicates/CollectionDataStructure.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/extractor/predicates/CollectionDataStructure.java
@@ -61,5 +61,4 @@ public class CollectionDataStructure {
         person.limbs_array = limbs;
         return person;
     }
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/extractor/predicates/SingleValueAllPredicatesExtractorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/extractor/predicates/SingleValueAllPredicatesExtractorTest.java
@@ -28,14 +28,15 @@ import static com.hazelcast.query.impl.extractor.predicates.SingleValueDataStruc
 @RunWith(Parameterized.class)
 public class SingleValueAllPredicatesExtractorTest extends SingleValueAllPredicatesReflectionTest {
 
-    public SingleValueAllPredicatesExtractorTest(InMemoryFormat inMemoryFormat, AbstractExtractionTest.Index index, AbstractExtractionTest.Multivalue multivalue) {
+    public SingleValueAllPredicatesExtractorTest(InMemoryFormat inMemoryFormat, AbstractExtractionTest.Index index,
+                                                 Multivalue multivalue) {
         super(inMemoryFormat, index, multivalue);
     }
 
     protected AbstractExtractionTest.Configurator getInstanceConfigurator() {
         return new AbstractExtractionTest.Configurator() {
             @Override
-            public void doWithConfig(Config config, AbstractExtractionTest.Multivalue mv) {
+            public void doWithConfig(Config config, Multivalue mv) {
                 MapConfig mapConfig = config.getMapConfig("map");
 
                 MapAttributeConfig iqConfig = new AbstractExtractionTest.TestMapAttributeIndexConfig();
@@ -64,5 +65,4 @@ public class SingleValueAllPredicatesExtractorTest extends SingleValueAllPredica
             collector.addObject(target.brain.name);
         }
     }
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/extractor/predicates/SingleValueAllPredicatesReflectionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/extractor/predicates/SingleValueAllPredicatesReflectionTest.java
@@ -21,6 +21,7 @@ import static com.hazelcast.query.impl.extractor.AbstractExtractionSpecification
 import static com.hazelcast.query.impl.extractor.predicates.SingleValueDataStructure.Person;
 import static com.hazelcast.query.impl.extractor.predicates.SingleValueDataStructure.person;
 import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 
 /**
  * Tests whether all predicates work with the extraction in attributes that are not collections.
@@ -111,8 +112,7 @@ public class SingleValueAllPredicatesReflectionTest extends AbstractExtractionTe
         return axes(
                 asList(BINARY, OBJECT),
                 asList(NO_INDEX, UNORDERED, ORDERED),
-                asList(SINGLE_VALUE)
+                singletonList(SINGLE_VALUE)
         );
     }
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/extractor/predicates/SingleValueDataStructure.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/extractor/predicates/SingleValueDataStructure.java
@@ -5,17 +5,20 @@ import com.hazelcast.test.ObjectTestUtils;
 import java.io.Serializable;
 
 /**
- * Data structure used in the tests of extraction in single-value attributes (not in collections)
+ * Data structure used in the tests of extraction in single-value attributes (not in collections).
  */
 public class SingleValueDataStructure {
 
     public static class Person implements Serializable {
+
         Brain brain;
 
         @Override
         public boolean equals(Object o) {
-            if (!(o instanceof Person)) return false;
-            final Person other = (Person) o;
+            if (!(o instanceof Person)) {
+                return false;
+            }
+            Person other = (Person) o;
             return ObjectTestUtils.equals(this.brain, other.brain);
         }
 
@@ -26,13 +29,16 @@ public class SingleValueDataStructure {
     }
 
     public static class Brain implements Serializable {
+
         Integer iq;
         String name;
 
         @Override
         public boolean equals(Object o) {
-            if (!(o instanceof Brain)) return false;
-            final Brain other = (Brain) o;
+            if (!(o instanceof Brain)) {
+                return false;
+            }
+            Brain other = (Brain) o;
             return ObjectTestUtils.equals(this.iq, other.iq);
         }
 
@@ -50,5 +56,4 @@ public class SingleValueDataStructure {
         person.brain = brain;
         return person;
     }
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/getters/FieldGetterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/getters/FieldGetterTest.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.query.impl.getters;
 
-
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -77,26 +76,26 @@ public class FieldGetterTest {
         body = new Body("bodyName", leg, hand, unnamedLimb);
     }
 
-
     @Test(expected = IllegalArgumentException.class)
-    public void constructor_whenModifierIsNotNullAndFieldTypeIsNotArrayOrCollection_thenThrowIllegalArgumentException() throws NoSuchFieldException {
+    public void constructor_whenModifierIsNotNullAndFieldTypeIsNotArrayOrCollection_thenThrowIllegalArgumentException()
+            throws Exception {
         Field field = Body.class.getDeclaredField("name");
         new FieldGetter(null, field, "[any]", null);
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void constructor_whenModifierIsNegative_thenThrowIllegalArgumentException() throws NoSuchFieldException {
+    public void constructor_whenModifierIsNegative_thenThrowIllegalArgumentException() throws Exception {
         Field field = Body.class.getDeclaredField("name");
         new FieldGetter(null, field, "[-1]", null);
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void constructor_whenModifierIsStarAndFieldTypeIsCollection_thenThrowIllegalArgumentException() throws NoSuchFieldException {
+    public void constructor_whenModifierIsStarAndFieldTypeIsCollection_thenThrowIllegalArgumentException() throws Exception {
         new FieldGetter(null, limbCollectionField, "[any]", null);
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void constructor_whenModifierIsPositionAndFieldTypeIsCollection_thenThrowIllegalArgumentException() throws NoSuchFieldException {
+    public void constructor_whenModifierIsPositionAndFieldTypeIsCollection_thenThrowIllegalArgumentException() throws Exception {
         new FieldGetter(null, limbCollectionField, "[0]", null);
     }
 
@@ -109,7 +108,8 @@ public class FieldGetterTest {
     }
 
     @Test
-    public void getValue_whenParentIsMultiValueAndModifierOnArrayIsStar_thenReturnMultiValueResultWithAllItems() throws Exception {
+    public void getValue_whenParentIsMultiValueAndModifierOnArrayIsStar_thenReturnMultiValueResultWithAllItems()
+            throws Exception {
         FieldGetter limbGetter = new FieldGetter(null, limbArrayField, "[any]", null);
         FieldGetter nailGetter = new FieldGetter(limbGetter, nailArrayField, "[any]", null);
 
@@ -119,7 +119,8 @@ public class FieldGetterTest {
     }
 
     @Test
-    public void getValue_whenParentIsMultiValueAndModifierOnArrayIsPosition_thenReturnMultiValueResultWithItemsAtPosition() throws Exception {
+    public void getValue_whenParentIsMultiValueAndModifierOnArrayIsPosition_thenReturnMultiValueResultWithItemsAtPosition()
+            throws Exception {
         FieldGetter limbGetter = new FieldGetter(null, limbArrayField, "[any]", null);
         FieldGetter nailGetter = new FieldGetter(limbGetter, nailArrayField, "[0]", null);
 
@@ -129,7 +130,8 @@ public class FieldGetterTest {
     }
 
     @Test
-    public void getValue_whenParentIsMultiValueAndModifierOnCollectionIsStar_thenReturnMultiValueResultWithAllItems() throws Exception {
+    public void getValue_whenParentIsMultiValueAndModifierOnCollectionIsStar_thenReturnMultiValueResultWithAllItems()
+            throws Exception {
         FieldGetter limbGetter = new FieldGetter(null, limbArrayField, "[any]", null);
         FieldGetter nailGetter = new FieldGetter(limbGetter, nailCollectionField, "[any]", Nail.class);
 
@@ -139,7 +141,8 @@ public class FieldGetterTest {
     }
 
     @Test
-    public void getValue_whenParentIsMultiValueAndModifierOnCollectionIsPosition_thenReturnMultiValueResultWithItemsAtPosition() throws Exception {
+    public void getValue_whenParentIsMultiValueAndModifierOnCollectionIsPosition_thenReturnMultiValueResultWithItemsAtPosition()
+            throws Exception {
         FieldGetter limbGetter = new FieldGetter(null, limbArrayField, "[any]", null);
         FieldGetter nailGetter = new FieldGetter(limbGetter, nailArrayField, "[0]", Nail.class);
 
@@ -190,6 +193,7 @@ public class FieldGetterTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void getValue_whenNoModifierOnCollection_thenReturnTheCollection() throws Exception {
         FieldGetter getter = new FieldGetter(null, limbCollectionField, null, null);
         Collection<Limb> result = (Collection<Limb>) getter.getValue(body);
@@ -255,8 +259,8 @@ public class FieldGetterTest {
         assertEquals(Limb[].class, returnType);
     }
 
-    private void assertContainsInAnyOrder(MultiResult multiResult, Object...items) {
-        List<Object> results = multiResult.getResults();
+    private void assertContainsInAnyOrder(MultiResult multiResult, Object... items) {
+        List results = multiResult.getResults();
         if (results.size() != items.length) {
             fail("MultiResult " + multiResult + " has size " + results.size() + ", but expected size is " + items.length);
         }
@@ -293,6 +297,7 @@ public class FieldGetterTest {
 
     static class Nail {
         String colour;
+
         private Nail(String colour) {
             this.colour = colour;
         }

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/getters/GetterFactoryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/getters/GetterFactoryTest.java
@@ -67,7 +67,8 @@ public class GetterFactoryTest {
     }
 
     @Test
-    public void newFieldGetter_whenExtractingFromEmptyCollectionAndReducerSuffixInNotEmpty_thenReturnNullGetter() throws Exception {
+    public void newFieldGetter_whenExtractingFromEmptyCollectionAndReducerSuffixInNotEmpty_thenReturnNullGetter()
+            throws Exception {
         OuterObject object = new OuterObject("name");
         Getter getter = GetterFactory.newFieldGetter(object, null, innersField, "[any]");
 
@@ -75,7 +76,8 @@ public class GetterFactoryTest {
     }
 
     @Test
-    public void newFieldGetter_whenExtractingFromNonEmptyCollectionAndReducerSuffixInNotEmpty_thenInferTypeFromCollectionItem() throws Exception {
+    public void newFieldGetter_whenExtractingFromNonEmptyCollectionAndReducerSuffixInNotEmpty_thenInferTypeFromCollectionItem()
+            throws Exception {
         OuterObject object = new OuterObject("name", new InnerObject("inner"));
         Getter getter = GetterFactory.newFieldGetter(object, null, innersField, "[any]");
 
@@ -84,7 +86,8 @@ public class GetterFactoryTest {
     }
 
     @Test
-    public void newFieldGetter_whenExtractingFromSimpleFieldAndParentIsNonEmptyMultiResult_thenInferReturnType() throws Exception {
+    public void newFieldGetter_whenExtractingFromSimpleFieldAndParentIsNonEmptyMultiResult_thenInferReturnType()
+            throws Exception {
         OuterObject object = new OuterObject("name", new InnerObject("inner"));
 
         Getter parentGetter = GetterFactory.newFieldGetter(object, null, innersField, "[any]");
@@ -95,7 +98,8 @@ public class GetterFactoryTest {
     }
 
     @Test
-    public void newFieldGetter_whenExtractingFromEmptyCollectionFieldAndParentIsNonEmptyMultiResult_thenInferReturnType() throws Exception {
+    public void newFieldGetter_whenExtractingFromEmptyCollectionFieldAndParentIsNonEmptyMultiResult_thenInferReturnType()
+            throws Exception {
         OuterObject object = new OuterObject("name", new InnerObject("inner"));
 
         Getter parentGetter = GetterFactory.newFieldGetter(object, null, innersField, "[any]");
@@ -105,7 +109,8 @@ public class GetterFactoryTest {
     }
 
     @Test
-    public void newFieldGetter_whenExtractingFromNonEmptyCollectionFieldAndParentIsNonEmptyMultiResult_thenInferReturnType() throws Exception {
+    public void newFieldGetter_whenExtractingFromNonEmptyCollectionFieldAndParentIsNonEmptyMultiResult_thenInferReturnType()
+            throws Exception {
         OuterObject object = new OuterObject("name", new InnerObject("inner", 0, 1, 2, 3));
 
         Getter parentGetter = GetterFactory.newFieldGetter(object, null, innersField, "[any]");
@@ -114,7 +119,6 @@ public class GetterFactoryTest {
         Class returnType = innerObjectNameGetter.getReturnType();
         assertEquals(Integer.class, returnType);
     }
-
 
     public static class OuterObject {
         final String name;

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/getters/MethodGetterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/getters/MethodGetterTest.java
@@ -64,7 +64,6 @@ public class MethodGetterTest {
         nailArrayMethod = Limb.class.getMethod("getNailArray");
         nailCollectionMethod = Limb.class.getMethod("getNailCollection");
 
-
         redNail = new Nail("red");
         greenNail = new Nail("green");
         leg = new Limb("leg", redNail, greenNail);
@@ -77,15 +76,15 @@ public class MethodGetterTest {
         body = new Body("bodyName", leg, hand, unnamedLimb);
     }
 
-
     @Test(expected = IllegalArgumentException.class)
-    public void constructor_whenModifierIsNotNullAndMethodReturnTypeIsNotArrayOrCollection_thenThrowIllegalArgumentException() throws NoSuchMethodException {
+    public void constructor_whenModifierIsNotNullAndMethodReturnTypeIsNotArrayOrCollection_thenThrowIllegalArgumentException()
+            throws Exception {
         Method method = Body.class.getMethod("getName");
         new MethodGetter(null, method, "[any]", null);
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void constructor_whenModifierIsNegative_thenThrowIllegalArgumentException() throws NoSuchMethodException {
+    public void constructor_whenModifierIsNegative_thenThrowIllegalArgumentException() throws Exception {
         Method method = Body.class.getMethod("getName");
         new MethodGetter(null, method, "[-1]", null);
     }
@@ -109,7 +108,8 @@ public class MethodGetterTest {
     }
 
     @Test
-    public void getValue_whenParentIsMultiValueAndModifierOnArrayIsStar_thenReturnMultiValueResultWithAllItems() throws Exception {
+    public void getValue_whenParentIsMultiValueAndModifierOnArrayIsStar_thenReturnMultiValueResultWithAllItems()
+            throws Exception {
         MethodGetter limbGetter = new MethodGetter(null, limbArrayMethod, "[any]", null);
         MethodGetter nailGetter = new MethodGetter(limbGetter, nailArrayMethod, "[any]", null);
 
@@ -119,7 +119,8 @@ public class MethodGetterTest {
     }
 
     @Test
-    public void getValue_whenParentIsMultiValueAndModifierOnArrayIsPosition_thenReturnMultiValueResultWithItemsAtPosition() throws Exception {
+    public void getValue_whenParentIsMultiValueAndModifierOnArrayIsPosition_thenReturnMultiValueResultWithItemsAtPosition()
+            throws Exception {
         MethodGetter limbGetter = new MethodGetter(null, limbArrayMethod, "[any]", null);
         MethodGetter nailGetter = new MethodGetter(limbGetter, nailArrayMethod, "[0]", null);
 
@@ -129,7 +130,8 @@ public class MethodGetterTest {
     }
 
     @Test
-    public void getValue_whenParentIsMultiValueAndModifierOnCollectionIsStar_thenReturnMultiValueResultWithAllItems() throws Exception {
+    public void getValue_whenParentIsMultiValueAndModifierOnCollectionIsStar_thenReturnMultiValueResultWithAllItems()
+            throws Exception {
         MethodGetter limbGetter = new MethodGetter(null, limbArrayMethod, "[any]", null);
         MethodGetter nailGetter = new MethodGetter(limbGetter, nailCollectionMethod, "[any]", Nail.class);
 
@@ -139,7 +141,8 @@ public class MethodGetterTest {
     }
 
     @Test
-    public void getValue_whenParentIsMultiValueAndModifierOnCollectionIsPosition_thenReturnMultiValueResultWithItemsAtPosition() throws Exception {
+    public void getValue_whenParentIsMultiValueAndModifierOnCollectionIsPosition_thenReturnMultiValueResultWithItemsAtPosition()
+            throws Exception {
         MethodGetter limbGetter = new MethodGetter(null, limbArrayMethod, "[any]", null);
         MethodGetter nailGetter = new MethodGetter(limbGetter, nailArrayMethod, "[0]", Nail.class);
 
@@ -155,7 +158,6 @@ public class MethodGetterTest {
 
         assertContainsInAnyOrder(result, leg, hand, unnamedLimb);
     }
-
 
     @Test
     public void getValue_whenModifierOnArrayIsPositionAndElementAtGivenPositionExist_thenReturnTheItem() throws Exception {
@@ -190,6 +192,7 @@ public class MethodGetterTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void getValue_whenNoModifierOnCollection_thenReturnTheCollection() throws Exception {
         MethodGetter getter = new MethodGetter(null, limbCollectionMethod, null, null);
         Collection<Limb> result = (Collection<Limb>) getter.getValue(body);
@@ -198,7 +201,8 @@ public class MethodGetterTest {
     }
 
     @Test
-    public void getValue_whenParentIsMultiResultAndNoModifier_thenReturnTheMultiResultContainingCurrentObjects() throws Exception {
+    public void getValue_whenParentIsMultiResultAndNoModifier_thenReturnTheMultiResultContainingCurrentObjects()
+            throws Exception {
         MethodGetter limbGetter = new MethodGetter(null, limbArrayMethod, "[any]", null);
         Method getLimbNameMethod = Limb.class.getMethod("getName");
         MethodGetter nailNameGetter = new MethodGetter(limbGetter, getLimbNameMethod, null, null);
@@ -255,8 +259,8 @@ public class MethodGetterTest {
         assertEquals(Limb[].class, returnType);
     }
 
-    private void assertContainsInAnyOrder(MultiResult multiResult, Object...items) {
-        List<Object> results = multiResult.getResults();
+    private void assertContainsInAnyOrder(MultiResult multiResult, Object... items) {
+        List results = multiResult.getResults();
         if (results.size() != items.length) {
             fail("MultiResult " + multiResult + " has size " + results.size() + ", but expected size is " + items.length);
         }
@@ -267,6 +271,7 @@ public class MethodGetterTest {
         }
     }
 
+    @SuppressWarnings("unused")
     static class Body {
         String name;
         Limb[] limbArray = new Limb[0];
@@ -291,6 +296,7 @@ public class MethodGetterTest {
         }
     }
 
+    @SuppressWarnings("unused")
     static class Limb {
         String name;
         Nail[] nailArray = new Nail[0];
@@ -317,6 +323,7 @@ public class MethodGetterTest {
 
     static class Nail {
         String colour;
+
         private Nail(String colour) {
             this.colour = colour;
         }

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/getters/ReflectionHelperTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/getters/ReflectionHelperTest.java
@@ -16,7 +16,8 @@ import static org.junit.Assert.fail;
 public class ReflectionHelperTest {
 
     @Test
-    public void extractValue_whenIntermediateFieldIsInterfaceAndDoesNotContainField_thenThrowIllegalArgumentException() throws Exception {
+    public void extractValue_whenIntermediateFieldIsInterfaceAndDoesNotContainField_thenThrowIllegalArgumentException()
+            throws Exception {
         OuterObject object = new OuterObject();
         try {
             ReflectionHelper.extractValue(object, "emptyInterface.doesNotExist");
@@ -30,14 +31,11 @@ public class ReflectionHelperTest {
         }
     }
 
-
-
+    @SuppressWarnings("unused")
     private static class OuterObject {
         private EmptyInterface emptyInterface;
     }
 
     private interface EmptyInterface {
-
     }
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/getters/SuffixModifierUtilsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/getters/SuffixModifierUtilsTest.java
@@ -39,7 +39,7 @@ public class SuffixModifierUtilsTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void removeModifierSuffix_whenMultipleOpeningTokensArePresnet_thenThrowIllegalArgumentException() {
+    public void removeModifierSuffix_whenMultipleOpeningTokensArePresent_thenThrowIllegalArgumentException() {
         String attribute = "foo[[";
         SuffixModifierUtils.removeModifierSuffix(attribute);
     }


### PR DESCRIPTION
* Cleanup of query related tests.
* Fixed a copy & paste bug which was hidden by not using Generics in tests.

I was actually searching for a test to extend to help out for missing code coverage of query related features. To not mix up cleanups and changes I made this PR. Nothing exiting here, mostly driven by IntelliJ warnings.

The only behavior change should be the found copy & paste bug, which was uncovered by adding Generics to the test maps. I'll make a line comment to point out the fix.