### PR TITLE
Adds Live API Tests for jclouds

### DIFF
--- a/hazelcast-jclouds/src/test/java/com/hazelcast/jclouds/ComputeServiceBuilderInvalidConfigTest.java
+++ b/hazelcast-jclouds/src/test/java/com/hazelcast/jclouds/ComputeServiceBuilderInvalidConfigTest.java
@@ -113,7 +113,7 @@ public class ComputeServiceBuilderInvalidConfigTest extends HazelcastTestSupport
     }
 
     @Test(expected = InvalidConfigurationException.class)
-      public void test_invalid_config_when_port_config_exceed_max_value() throws Exception {
+    public void test_invalid_config_when_port_config_exceed_max_value() throws Exception {
 
         String propertiesUnderTest = "<property name=\"provider\">aws-ec2</property>" +
                 "<property name=\"identity\">test</property>" +
@@ -142,5 +142,11 @@ public class ComputeServiceBuilderInvalidConfigTest extends HazelcastTestSupport
     public void test_getCredentialFromFile_when_IOException() throws Exception {
         ComputeServiceBuilder builder = new ComputeServiceBuilder(new HashMap<String, Comparable>());
         builder.getCredentialFromFile("google-compute-engine", "blahblah.json");
+    }
+
+    @Test(expected = InvalidConfigurationException.class)
+    public void test_InvalidCloudProvider() throws Exception {
+        ComputeServiceBuilder builder = new ComputeServiceBuilder(new HashMap<String, Comparable>());
+        builder.newContextBuilder("invalid-cloud-provider", "identity", "credential", null);
     }
 }

--- a/hazelcast-jclouds/src/test/java/com/hazelcast/jclouds/ComputeServiceBuilderTest.java
+++ b/hazelcast-jclouds/src/test/java/com/hazelcast/jclouds/ComputeServiceBuilderTest.java
@@ -38,6 +38,15 @@ import static org.mockito.Mockito.verify;
 public class ComputeServiceBuilderTest extends HazelcastTestSupport {
 
     @Test
+    public void test_getProperties() throws Exception {
+        Map<String,Comparable> properties = new HashMap<String, Comparable>();
+        properties.put("key", "value");
+        ComputeServiceBuilder builder = new ComputeServiceBuilder(properties);
+        assertEquals(1, builder.getProperties().size());
+        assertEquals("value", builder.getProperties().get("key"));
+    }
+    
+    @Test
     public void test_getServicePort_returns_default_hz_port() throws Exception {
         ComputeServiceBuilder builder = new ComputeServiceBuilder(new HashMap<String, Comparable>());
         assertEquals(builder.getServicePort(), NetworkConfig.DEFAULT_PORT);
@@ -100,7 +109,6 @@ public class ComputeServiceBuilderTest extends HazelcastTestSupport {
         assertTrue(builder.getZonesSet().contains("zone1"));
         assertTrue(builder.getZonesSet().contains("zone2"));
         assertTrue(builder.getZonesSet().contains("zone3"));
-        assertFalse(builder.getZonesSet().contains("zone4"));
     }
 
     @Test
@@ -123,7 +131,6 @@ public class ComputeServiceBuilderTest extends HazelcastTestSupport {
         assertTrue(builder.getRegionsSet().contains("region1"));
         assertTrue(builder.getRegionsSet().contains("region2"));
         assertTrue(builder.getRegionsSet().contains("region3"));
-        assertFalse(builder.getRegionsSet().contains("region4"));
     }
 
     @Test
@@ -250,6 +257,26 @@ public class ComputeServiceBuilderTest extends HazelcastTestSupport {
 
         Map<String, String> userMetaData = new HashMap<String, String>();
         userMetaData.put("tag1", "value1");
+
+        NodeMetadata metadata = new NodeMetadataBuilder().
+                userMetadata(userMetaData).id(UuidUtil.newSecureUuidString()).
+                status(NodeMetadata.Status.RUNNING).build();
+
+        assertFalse(nodeFilter.apply(metadata));
+
+    }
+
+    @Test
+    public void test_buildNodeFilter_with_NodeMetadata_with_single_tag() throws Exception {
+        Map<String, Comparable> properties = new HashMap<String, Comparable>();
+        properties.put("tag-keys", "tag1");
+        properties.put("tag-values", "value1");
+        ComputeServiceBuilder builder = new ComputeServiceBuilder(properties);
+        builder.buildTagConfig();
+        Predicate<ComputeMetadata> nodeFilter = builder.buildNodeFilter();
+
+        Map<String, String> userMetaData = new HashMap<String, String>();
+        userMetaData.put("tag1", "value2");
 
         NodeMetadata metadata = new NodeMetadataBuilder().
                 userMetadata(userMetaData).id(UuidUtil.newSecureUuidString()).

--- a/hazelcast-jclouds/src/test/java/com/hazelcast/jclouds/integration/AWSEC2LiveTest.java
+++ b/hazelcast-jclouds/src/test/java/com/hazelcast/jclouds/integration/AWSEC2LiveTest.java
@@ -1,0 +1,55 @@
+package com.hazelcast.jclouds.integration;
+
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.JCloudsTest;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Category(JCloudsTest.class)
+@RunWith(HazelcastSerialClassRunner.class)
+public class AWSEC2LiveTest extends AbstractLiveTest {
+
+    public static final String AWS_PROVIDER   = "aws-ec2";
+    public static final String AWS_IDENTITY   =  System.getProperty("test.aws-ec2.identity");
+    public static final String AWS_CREDENTIAL =  System.getProperty("test.aws-ec2.credential");
+
+    public static LiveComputeServiceUtil builder =
+            new LiveComputeServiceUtil(AWS_PROVIDER, AWS_IDENTITY,
+                    AWS_CREDENTIAL);
+
+
+    @BeforeClass
+    public static void provisionNodes() throws Exception {
+        builder.provisionNodes();
+    }
+
+    @AfterClass
+    public static void destroyNodes() throws Exception {
+        builder.destroyNodes();
+    }
+
+
+    @Override
+    protected Map<String, Comparable> getProperties() {
+        Map<String, Comparable> properties = new HashMap<String, Comparable>();
+        properties.put("provider", AWS_PROVIDER);
+        properties.put("identity", AWS_IDENTITY);
+        properties.put("credential", AWS_CREDENTIAL);
+        return properties;
+    }
+
+    @Override
+    protected String getRegion1() {
+        return LiveComputeServiceUtil.AWS_REGION1;
+    }
+
+    @Override
+    protected String getRegion2() {
+        return LiveComputeServiceUtil.AWS_REGION2;
+    }
+}

--- a/hazelcast-jclouds/src/test/java/com/hazelcast/jclouds/integration/AbstractLiveTest.java
+++ b/hazelcast-jclouds/src/test/java/com/hazelcast/jclouds/integration/AbstractLiveTest.java
@@ -1,0 +1,83 @@
+package com.hazelcast.jclouds.integration;
+
+
+import com.google.common.collect.Iterators;
+import com.hazelcast.jclouds.JCloudsDiscoveryStrategy;
+import org.junit.Test;
+
+import java.util.Map;
+
+import static com.hazelcast.jclouds.integration.LiveComputeServiceUtil.GROUP_NAME1;
+import static com.hazelcast.jclouds.integration.LiveComputeServiceUtil.GROUP_NAME2;
+import static com.hazelcast.jclouds.integration.LiveComputeServiceUtil.tag1;
+import static com.hazelcast.jclouds.integration.LiveComputeServiceUtil.tag2;
+import static com.hazelcast.jclouds.integration.LiveComputeServiceUtil.tag3;
+import static org.junit.Assert.assertEquals;
+
+public abstract class AbstractLiveTest {
+
+    protected abstract Map<String,Comparable> getProperties();
+    protected abstract String getRegion1();
+    protected abstract String getRegion2();
+
+    @Test
+    public void test_DiscoveryStrategyFiltersNodesByGroup() throws Exception {
+        Map<String, Comparable> properties1 = getProperties();
+        properties1.put("group", GROUP_NAME1);
+        JCloudsDiscoveryStrategy strategy1 = new JCloudsDiscoveryStrategy(properties1);
+        strategy1.start();
+
+        Map<String, Comparable> properties2 = getProperties();
+        properties2.put("group", GROUP_NAME2);
+        JCloudsDiscoveryStrategy strategy2 = new JCloudsDiscoveryStrategy(properties2);
+        strategy2.start();
+
+        assertEquals(3,
+                Iterators.size(strategy1.discoverNodes().iterator()));
+        assertEquals(2,
+                Iterators.size(strategy2.discoverNodes().iterator()));
+    }
+
+    @Test
+    public void test_DiscoveryStrategyFiltersNodesByRegion() throws Exception {
+
+        Map<String, Comparable> properties1 = getProperties();
+        properties1.put("group", GROUP_NAME1);
+        properties1.put("regions", getRegion1());
+        JCloudsDiscoveryStrategy strategy1 = new JCloudsDiscoveryStrategy(properties1);
+        strategy1.start();
+
+        Map<String, Comparable> properties2 = getProperties();
+        properties2.put("group", GROUP_NAME2);
+        properties2.put("regions",getRegion1()+ "," + getRegion2());
+        JCloudsDiscoveryStrategy strategy2 = new JCloudsDiscoveryStrategy(properties2);
+        strategy2.start();
+
+        assertEquals(2,
+                Iterators.size(strategy1.discoverNodes().iterator()));
+
+        assertEquals(2,
+                Iterators.size(strategy2.discoverNodes().iterator()));
+    }
+
+    @Test
+    public void test_DiscoveryStrategyFiltersNodesByTags() throws Exception {
+        Map<String, Comparable> properties1 = getProperties();
+        properties1.put("tag-keys", tag1.getKey());
+        properties1.put("tag-values", tag1.getValue());
+        JCloudsDiscoveryStrategy strategy1 = new JCloudsDiscoveryStrategy(properties1);
+        strategy1.start();
+
+        Map<String, Comparable> properties2 = getProperties();
+        properties2.put("tag-keys", tag2.getKey() + "," + tag3.getKey());
+        properties2.put("tag-values", tag2.getValue() + "," + tag3.getValue());
+        JCloudsDiscoveryStrategy strategy2 = new JCloudsDiscoveryStrategy(properties2);
+        strategy2.start();
+
+        assertEquals(3,
+                Iterators.size(strategy1.discoverNodes().iterator()));
+
+        assertEquals(2,
+                Iterators.size(strategy2.discoverNodes().iterator()));
+    }
+}

--- a/hazelcast-jclouds/src/test/java/com/hazelcast/jclouds/integration/LiveComputeServiceUtil.java
+++ b/hazelcast-jclouds/src/test/java/com/hazelcast/jclouds/integration/LiveComputeServiceUtil.java
@@ -1,0 +1,141 @@
+package com.hazelcast.jclouds.integration;
+
+import com.google.common.base.Predicates;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
+import org.jclouds.ContextBuilder;
+import org.jclouds.compute.ComputeService;
+import org.jclouds.compute.ComputeServiceContext;
+import org.jclouds.compute.domain.NodeMetadata;
+import org.jclouds.compute.domain.Template;
+import org.jclouds.compute.domain.TemplateBuilder;
+import org.jclouds.compute.predicates.NodePredicates;
+
+import java.text.MessageFormat;
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+
+import static com.google.common.base.Predicates.not;
+import static com.google.common.collect.Iterables.concat;
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static com.hazelcast.util.Preconditions.checkNotNull;
+import static org.jclouds.compute.options.TemplateOptions.Builder.userMetadata;
+import static org.jclouds.compute.predicates.NodePredicates.inGroup;
+
+
+public class LiveComputeServiceUtil {
+
+    private  ComputeService computeService;
+    private  List<NodeMetadata> nodes = new ArrayList<NodeMetadata>();
+    private  String provider;
+    private  String identity;
+    private  String credential;
+
+    private static final ILogger LOGGER = Logger.getLogger("com.hazelcast.jclouds");
+
+
+    public static final String GROUP_NAME1 = "livetest-group1";
+    public static final String GROUP_NAME2 = "livetest-group2";
+
+    public static final String AWS_REGION1 = "us-east-1";
+    public static final String AWS_REGION2 = "us-west-2";
+
+    public static final Map.Entry<String, String> tag1 =
+            new AbstractMap.SimpleImmutableEntry<String, String>("Owner", "DbAdmin");
+    public static final Map.Entry<String, String> tag2 =
+            new AbstractMap.SimpleImmutableEntry<String, String>("Stack", "Test");
+    public static final Map.Entry<String, String> tag3 =
+            new AbstractMap.SimpleImmutableEntry<String, String>("Type", "Micro");
+
+    public LiveComputeServiceUtil(String provider, String identity, String credential) {
+        this.provider = provider;
+        this.identity = identity;
+        this.credential = credential;
+        init();
+    }
+
+    public void init() {
+        if (computeService == null) {
+            checkNotNull(provider);
+            checkNotNull(identity);
+            checkNotNull(credential);
+            computeService = initComputeService(provider, identity, credential);
+        }
+    }
+
+    public void provisionNodes() {
+        Map<String, String> singleTagConfig = new HashMap<String, String>();
+        singleTagConfig.put(tag1.getKey(), tag1.getValue());
+
+        Map<String, String> multiTagConfig  = new HashMap<String, String>();
+        multiTagConfig.put(tag2.getKey(), tag2.getValue());
+        multiTagConfig.put(tag3.getKey(), tag3.getValue());
+
+        Template region1Template =
+                getTemplateInRegion1(singleTagConfig);
+
+        Template region2Template =
+                getTemplateInRegion2(multiTagConfig);
+
+        try {
+            createNode(GROUP_NAME1, region1Template);
+            createNode(GROUP_NAME1, region1Template);
+            createNode(GROUP_NAME1, region2Template);
+            createNode(GROUP_NAME2, region2Template);
+            createNode(GROUP_NAME2, region1Template);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    public ComputeService initComputeService(String provider, String identity, String credential) {
+        Properties properties = new Properties();
+        ContextBuilder builder = ContextBuilder.newBuilder(provider)
+                .credentials(identity, credential)
+                .overrides(properties);
+        LOGGER.info(MessageFormat.format(">> initializing Compute Service {0}", builder.getApiMetadata()));
+        return builder.buildView(ComputeServiceContext.class).getComputeService();
+    }
+
+
+    public  Template getTemplateInRegion1(Map<String, String> tags) {
+        TemplateBuilder templateBuilder = computeService.templateBuilder();
+        templateBuilder.locationId(AWS_REGION1);
+        templateBuilder.smallest();
+        templateBuilder.options(userMetadata(tags));
+        return templateBuilder.build();
+    }
+
+    public  Template getTemplateInRegion2(Map<String, String> tags) {
+        TemplateBuilder templateBuilder = computeService.templateBuilder();
+        templateBuilder.locationId(AWS_REGION2);
+        templateBuilder.smallest();
+        templateBuilder.options(userMetadata(tags));
+        return templateBuilder.build();
+    }
+
+    public NodeMetadata createNode(String groupName, Template template) throws Exception{
+        NodeMetadata node = getOnlyElement(computeService.createNodesInGroup(groupName, 1, template));
+        LOGGER.info(MessageFormat.format("<< node created {0}: {1}", node.getId(),
+                concat(node.getPrivateAddresses(), node.getPublicAddresses())));
+        nodes.add(node);
+        return node;
+    }
+
+    public void destroyNodes() {
+        LOGGER.info(MessageFormat.format(">> destroying nodes in group {0}", GROUP_NAME1));
+        Set<? extends NodeMetadata> destroyed1 = computeService.destroyNodesMatching(
+                Predicates.<NodeMetadata> and(not(NodePredicates.TERMINATED), inGroup(GROUP_NAME1)));
+        LOGGER.info(MessageFormat.format("<< destroyed nodes {0}", destroyed1));
+
+        LOGGER.info(MessageFormat.format(">> destroying nodes in group {0}", GROUP_NAME2));
+        Set<? extends NodeMetadata> destroyed2 = computeService.destroyNodesMatching(
+                Predicates.<NodeMetadata> and(not(NodePredicates.TERMINATED), inGroup(GROUP_NAME2)));
+        LOGGER.info(MessageFormat.format("<< destroyed nodes {0}", destroyed2));
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/annotation/JCloudsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/annotation/JCloudsTest.java
@@ -1,0 +1,10 @@
+package com.hazelcast.test.annotation;
+
+
+/**
+ * Annotates tests which requires integration tests over a live api.
+ * <p/>
+ * Will be executed in regular builds and for jclouds live tests
+ */
+public final class JCloudsTest {
+}

--- a/pom.xml
+++ b/pom.xml
@@ -394,6 +394,39 @@
         </profile>
 
         <profile>
+            <id>jclouds-test</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>${maven.surefire.plugin.version}</version>
+                        <configuration combine.self="override">
+                            <redirectTestOutputToFile>true</redirectTestOutputToFile>
+                            <argLine>
+                                -Xms128m -Xmx1G -XX:MaxPermSize=128M
+                                -Dhazelcast.phone.home.enabled=false
+                                -Dhazelcast.mancenter.enabled=false
+                                -Dhazelcast.test.use.network=false
+                            </argLine>
+                            <includes>
+                                <include>**/**.java</include>
+                            </includes>
+                            <excludes>
+                                <exclude>**/jsr/**.java</exclude>
+                            </excludes>
+                            <groups>com.hazelcast.test.annotation.JCloudsTest</groups>
+                            <excludedGroups>
+                                com.hazelcast.test.annotation.SlowTest,com.hazelcast.test.annotation.NightlyTest,
+                                com.hazelcast.test.annotation.QuickTest
+                            </excludedGroups>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
             <id>test-coverage-Local</id>
             <build>
                 <plugins>


### PR DESCRIPTION
- Introduced LiveTest category to distinguish jclouds integration test from out normal test.
- Test marked with LiveTest annotation runs in our `code-coverage` profile
- To run tests run this command from maven ` mvn clean install -Pjclouds-test -Dtest.aws-ec2.identity="<aws-key>" -Dtest.aws-ec2.credential="<aws-credential>"` valid credentials must be provided as System property.

What we do is basically create five cloud instances with different zones,tag configurations via jclouds apis and tests are run over `JCloudsDiscoveryStrategy`. We are only verifying our jclouds integration over live apis.

Also, could not run google-compute-engine live tests, because I could not create more than one cloud instances with java api of jclouds I get a time-out exception.(https://www.mail-archive.com/user@jclouds.apache.org/msg01300.html). Right now, we only have live tests for AWS.
 