### PR TITLE
For JCache, put to near-cache as sync if put is sync, put as async if put is async

### DIFF
--- a/hazelcast-client-legacy/src/main/java/com/hazelcast/client/cache/impl/AbstractClientCacheProxy.java
+++ b/hazelcast-client-legacy/src/main/java/com/hazelcast/client/cache/impl/AbstractClientCacheProxy.java
@@ -157,7 +157,7 @@ abstract class AbstractClientCacheProxy<K, V>
 
     @Override
     public ICompletableFuture<Void> putAsync(K key, V value, ExpiryPolicy expiryPolicy) {
-        return putAsyncInternal(key, value, expiryPolicy, false, true, true);
+        return (ICompletableFuture<Void>) putInternal(key, value, expiryPolicy, false, true, true);
     }
 
     @Override
@@ -177,7 +177,7 @@ abstract class AbstractClientCacheProxy<K, V>
 
     @Override
     public ICompletableFuture<V> getAndPutAsync(K key, V value, ExpiryPolicy expiryPolicy) {
-        return putAsyncInternal(key, value, expiryPolicy, true, false, true);
+        return (ICompletableFuture<V>) putInternal(key, value, expiryPolicy, true, false, true);
     }
 
     @Override
@@ -279,31 +279,12 @@ abstract class AbstractClientCacheProxy<K, V>
 
     @Override
     public void put(K key, V value, ExpiryPolicy expiryPolicy) {
-        final long start = System.nanoTime();
-        final ICompletableFuture<Object> f = putAsyncInternal(key, value, expiryPolicy, false, true, false);
-        try {
-            f.get();
-            if (statisticsEnabled) {
-                handleStatisticsOnPut(false, start, null);
-            }
-        } catch (Throwable e) {
-            throw ExceptionUtil.rethrowAllowedTypeFirst(e, CacheException.class);
-        }
+        putInternal(key, value, expiryPolicy, false, true, false);
     }
 
     @Override
     public V getAndPut(K key, V value, ExpiryPolicy expiryPolicy) {
-        final long start = System.nanoTime();
-        final ICompletableFuture<V> f = putAsyncInternal(key, value, expiryPolicy, true, true, false);
-        try {
-            V oldValue = f.get();
-            if (statisticsEnabled) {
-                handleStatisticsOnPut(true, start, oldValue);
-            }
-            return oldValue;
-        } catch (Throwable e) {
-            throw ExceptionUtil.rethrowAllowedTypeFirst(e, CacheException.class);
-        }
+        return (V) putInternal(key, value, expiryPolicy, true, true, false);
     }
 
     @Override

--- a/hazelcast-client-legacy/src/main/java/com/hazelcast/client/cache/impl/AbstractClientInternalCacheProxy.java
+++ b/hazelcast-client-legacy/src/main/java/com/hazelcast/client/cache/impl/AbstractClientInternalCacheProxy.java
@@ -369,9 +369,9 @@ abstract class AbstractClientInternalCacheProxy<K, V>
         }
     }
 
-    protected <T> ICompletableFuture<T> putAsyncInternal(final K key, final V value, final ExpiryPolicy expiryPolicy,
-                                                         final boolean isGet, final boolean withCompletionEvent,
-                                                         final boolean async) {
+    protected Object putInternal(final K key, final V value, final ExpiryPolicy expiryPolicy,
+                                 final boolean isGet, final boolean withCompletionEvent,
+                                 final boolean async) {
         final long start = System.nanoTime();
         ensureOpen();
         validateNotNull(key, value);
@@ -387,29 +387,48 @@ abstract class AbstractClientInternalCacheProxy<K, V>
         } catch (Exception e) {
             throw ExceptionUtil.rethrow(e);
         }
-        if (nearCache != null || (async && statisticsEnabled)) {
-            future.andThen(new ExecutionCallback<Object>() {
-                @Override
-                public void onResponse(Object responseData) {
-                    if (nearCache != null) {
-                        if (cacheOnUpdate) {
-                            storeInNearCache(keyData, valueData, value);
-                        } else {
-                            invalidateNearCache(keyData);
+        if (!async) {
+            try {
+                Object response = future.get();
+                if (nearCache != null) {
+                    if (cacheOnUpdate) {
+                        storeInNearCache(keyData, valueData, value);
+                    } else {
+                        invalidateNearCache(keyData);
+                    }
+                }
+                if (statisticsEnabled) {
+                    handleStatisticsOnPut(isGet, start, response);
+                }
+                return response;
+            } catch (Throwable e) {
+                throw ExceptionUtil.rethrowAllowedTypeFirst(e, CacheException.class);
+            }
+        } else {
+            if (nearCache != null || statisticsEnabled) {
+                future.andThen(new ExecutionCallback<Object>() {
+                    @Override
+                    public void onResponse(Object responseData) {
+                        if (nearCache != null) {
+                            if (cacheOnUpdate) {
+                                storeInNearCache(keyData, valueData, value);
+                            } else {
+                                invalidateNearCache(keyData);
+                            }
+                        }
+                        if (statisticsEnabled) {
+                            handleStatisticsOnPut(isGet, start, responseData);
                         }
                     }
-                    if (async && statisticsEnabled) {
-                        handleStatisticsOnPut(isGet, start, responseData);
+
+                    @Override
+                    public void onFailure(Throwable t) {
+
                     }
-                }
-
-                @Override
-                public void onFailure(Throwable t) {
-
-                }
-            });
+                });
+            }
+            return future;
         }
-        return future;
     }
 
     protected void handleStatisticsOnPut(boolean isGet, long start, Object response) {

--- a/hazelcast-client-legacy/src/test/java/com/hazelcast/client/cache/nearcache/ClientNearCacheTestSupport.java
+++ b/hazelcast-client-legacy/src/test/java/com/hazelcast/client/cache/nearcache/ClientNearCacheTestSupport.java
@@ -155,16 +155,9 @@ public abstract class ClientNearCacheTestSupport extends HazelcastTestSupport {
         }
 
         for (int i = 0; i < DEFAULT_RECORD_COUNT; i++) {
-            final String expectedValue = generateValueFromKey(i);
-            final Data keyData = nearCacheTestContext.serializationService.toData(i);
-            // Entries are stored in the near-cache as async not sync.
-            // So these records will be there in near-cache eventually.
-            HazelcastTestSupport.assertTrueEventually(new AssertTask() {
-                @Override
-                public void run() throws Exception {
-                    assertEquals(expectedValue, nearCacheTestContext.nearCache.get(keyData));
-                }
-            });
+            String expectedValue = generateValueFromKey(i);
+            Data keyData = nearCacheTestContext.serializationService.toData(i);
+            assertEquals(expectedValue, nearCacheTestContext.nearCache.get(keyData));
         }
 
         nearCacheTestContext.close();
@@ -177,16 +170,9 @@ public abstract class ClientNearCacheTestSupport extends HazelcastTestSupport {
                 createNearCacheTestAndFillWithData(DEFAULT_CACHE_NAME, nearCacheConfig);
 
         for (int i = 0; i < DEFAULT_RECORD_COUNT; i++) {
-            final String expectedValue = generateValueFromKey(i);
-            final Data keyData = nearCacheTestContext.serializationService.toData(i);
-            // Entries are stored in the near-cache as async not sync.
-            // So these records will be there in near-cache eventually.
-            HazelcastTestSupport.assertTrueEventually(new AssertTask() {
-                @Override
-                public void run() throws Exception {
-                    assertEquals(expectedValue, nearCacheTestContext.nearCache.get(keyData));
-                }
-            });
+            String expectedValue = generateValueFromKey(i);
+            Data keyData = nearCacheTestContext.serializationService.toData(i);
+            assertEquals(expectedValue, nearCacheTestContext.nearCache.get(keyData));
         }
 
         nearCacheTestContext.close();

--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/AbstractClientCacheProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/AbstractClientCacheProxy.java
@@ -167,7 +167,7 @@ abstract class AbstractClientCacheProxy<K, V>
 
     @Override
     public ICompletableFuture<Void> putAsync(K key, V value, ExpiryPolicy expiryPolicy) {
-        return putAsyncInternal(key, value, expiryPolicy, false, true, true);
+        return (ICompletableFuture<Void>) putInternal(key, value, expiryPolicy, false, true, true);
     }
 
     @Override
@@ -187,7 +187,7 @@ abstract class AbstractClientCacheProxy<K, V>
 
     @Override
     public ICompletableFuture<V> getAndPutAsync(K key, V value, ExpiryPolicy expiryPolicy) {
-        return putAsyncInternal(key, value, expiryPolicy, true, false, true);
+        return (ICompletableFuture<V>) putInternal(key, value, expiryPolicy, true, false, true);
     }
 
     @Override
@@ -294,31 +294,12 @@ abstract class AbstractClientCacheProxy<K, V>
 
     @Override
     public void put(K key, V value, ExpiryPolicy expiryPolicy) {
-        final long start = System.nanoTime();
-        final ICompletableFuture<Object> f = putAsyncInternal(key, value, expiryPolicy, false, true, false);
-        try {
-            f.get();
-            if (statisticsEnabled) {
-                handleStatisticsOnPut(false, start, null);
-            }
-        } catch (Throwable e) {
-            throw ExceptionUtil.rethrowAllowedTypeFirst(e, CacheException.class);
-        }
+        putInternal(key, value, expiryPolicy, false, true, false);
     }
 
     @Override
     public V getAndPut(K key, V value, ExpiryPolicy expiryPolicy) {
-        final long start = System.nanoTime();
-        final ICompletableFuture<V> f = putAsyncInternal(key, value, expiryPolicy, true, true, false);
-        try {
-            V oldValue = f.get();
-            if (statisticsEnabled) {
-                handleStatisticsOnPut(true, start, oldValue);
-            }
-            return oldValue;
-        } catch (Throwable e) {
-            throw ExceptionUtil.rethrowAllowedTypeFirst(e, CacheException.class);
-        }
+        return (V) putInternal(key, value, expiryPolicy, true, true, false);
     }
 
     @Override

--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/ClientCacheProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/ClientCacheProxy.java
@@ -85,6 +85,10 @@ public class ClientCacheProxy<K, V>
         super(cacheConfig, clientContext, cacheManager);
     }
 
+    public NearCache getNearCache() {
+        return nearCache;
+    }
+
     @Override
     public V get(K key) {
         return get(key, null);

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientNearCacheTestSupport.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientNearCacheTestSupport.java
@@ -155,16 +155,9 @@ public abstract class ClientNearCacheTestSupport extends HazelcastTestSupport {
         }
 
         for (int i = 0; i < DEFAULT_RECORD_COUNT; i++) {
-            final String expectedValue = generateValueFromKey(i);
-            final Data keyData = nearCacheTestContext.serializationService.toData(i);
-            // Entries are stored in the near-cache as async not sync.
-            // So these records will be there in near-cache eventually.
-            HazelcastTestSupport.assertTrueEventually(new AssertTask() {
-                @Override
-                public void run() throws Exception {
-                    assertEquals(expectedValue, nearCacheTestContext.nearCache.get(keyData));
-                }
-            });
+            String expectedValue = generateValueFromKey(i);
+            Data keyData = nearCacheTestContext.serializationService.toData(i);
+            assertEquals(expectedValue, nearCacheTestContext.nearCache.get(keyData));
         }
 
         nearCacheTestContext.close();
@@ -177,16 +170,9 @@ public abstract class ClientNearCacheTestSupport extends HazelcastTestSupport {
                 createNearCacheTestAndFillWithData(DEFAULT_CACHE_NAME, nearCacheConfig);
 
         for (int i = 0; i < DEFAULT_RECORD_COUNT; i++) {
-            final String expectedValue = generateValueFromKey(i);
-            final Data keyData = nearCacheTestContext.serializationService.toData(i);
-            // Entries are stored in the near-cache as async not sync.
-            // So these records will be there in near-cache eventually.
-            HazelcastTestSupport.assertTrueEventually(new AssertTask() {
-                @Override
-                public void run() throws Exception {
-                    assertEquals(expectedValue, nearCacheTestContext.nearCache.get(keyData));
-                }
-            });
+            String expectedValue = generateValueFromKey(i);
+            Data keyData = nearCacheTestContext.serializationService.toData(i);
+            assertEquals(expectedValue, nearCacheTestContext.nearCache.get(keyData));
         }
 
         nearCacheTestContext.close();

--- a/hazelcast/src/main/java/com/hazelcast/internal/eviction/impl/evaluator/LFUEvictionPolicyEvaluator.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/eviction/impl/evaluator/LFUEvictionPolicyEvaluator.java
@@ -26,10 +26,19 @@ public class LFUEvictionPolicyEvaluator<A, E extends Evictable>
 
     @Override
     protected Evictable selectEvictableAsPolicy(Evictable current, Evictable candidate) {
-        if (candidate.getAccessHit() < current.getAccessHit()) {
+        int candidateAccessHit = candidate.getAccessHit();
+        int currentAccessHit = current.getAccessHit();
+        if (candidateAccessHit < currentAccessHit) {
             return candidate;
-        } else {
+        } else if (currentAccessHit < candidateAccessHit) {
             return current;
+        } else {
+            // If access times are same, we select the oldest entry to evict
+            if (candidate.getCreationTime() < current.getCreationTime()) {
+                return candidate;
+            } else {
+                return current;
+            }
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/eviction/impl/evaluator/LRUEvictionPolicyEvaluator.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/eviction/impl/evaluator/LRUEvictionPolicyEvaluator.java
@@ -26,10 +26,19 @@ public class LRUEvictionPolicyEvaluator<A, E extends Evictable>
 
     @Override
     protected Evictable selectEvictableAsPolicy(Evictable current, Evictable candidate) {
-        if (candidate.getAccessTime() < current.getAccessTime()) {
+        long currentAccessTime = current.getAccessTime();
+        long candidateAccessTime = candidate.getAccessTime();
+        if (candidateAccessTime < currentAccessTime) {
             return candidate;
-        } else {
+        } else if (currentAccessTime < candidateAccessTime) {
             return current;
+        } else {
+            // If access times are same, we select the oldest entry to evict
+            if (candidate.getCreationTime() < current.getCreationTime()) {
+                return candidate;
+            } else {
+                return current;
+            }
         }
     }
 


### PR DESCRIPTION
If put to cache is sync no need to put it to near-cache as async but sync.
Async puts are still same by putting to near-cache as async

This PR also contains some updates on eviction policies:
* Compare creation times of records if access times are same for LRU based eviction
* Compare creation times of records if access hits are same for LFU based eviction