### PR TITLE
Check node's start completion before applying received partition table

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/partition/impl/InternalPartitionServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/impl/InternalPartitionServiceImpl.java
@@ -718,6 +718,11 @@ public class InternalPartitionServiceImpl implements InternalPartitionService, M
         lock.lock();
         try {
             final Address sender = partitionState.getEndpoint();
+            if (!node.getNodeExtension().isStartCompleted()) {
+                logger.warning("Ignoring received partition table, startup is not completed yet. Sender: " + sender);
+                return;
+            }
+
             final Address master = node.getMasterAddress();
             if (node.isMaster()) {
                 logger.warning("This is the master node and received a PartitionRuntimeState from "

--- a/hazelcast/src/main/java/com/hazelcast/partition/impl/PartitionStateOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/impl/PartitionStateOperation.java
@@ -17,14 +17,12 @@
 package com.hazelcast.partition.impl;
 
 import com.hazelcast.cluster.impl.operations.JoinOperation;
-import com.hazelcast.instance.Node;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.partition.InternalPartitionService;
 import com.hazelcast.partition.MigrationCycleOperation;
 import com.hazelcast.partition.PartitionRuntimeState;
 import com.hazelcast.spi.AbstractOperation;
-import com.hazelcast.spi.impl.NodeEngineImpl;
 
 import java.io.IOException;
 
@@ -48,11 +46,6 @@ public final class PartitionStateOperation extends AbstractOperation
 
     @Override
     public void run() {
-        final Node node = ((NodeEngineImpl) getNodeEngine()).getNode();
-        if (!node.getNodeExtension().isStartCompleted()) {
-            getLogger().warning("Partition table received before startup is completed. Caller: " + getCallerAddress());
-            return;
-        }
         partitionState.setEndpoint(getCallerAddress());
         InternalPartitionServiceImpl partitionService = getService();
         partitionService.processPartitionRuntimeState(partitionState);


### PR DESCRIPTION
In PartitionStateOperation checks node start before processing partition
table but FinalizeJoinOperation directly applies without doing any check.
This is causing failure when a node restarts while restoring hot-restart data.

_This problem is introduced by commit: a1851f7a8598745035f9b64eec43d93d4de5bd32_

Fixes hazelcast/hazelcast-enterprise#490