### PR TITLE
For JCache, put to near-cache as sync if putIfAbsent is sync, put as async if putIfAbsent is async

### DIFF
--- a/hazelcast-client-legacy/src/main/java/com/hazelcast/client/cache/impl/AbstractClientCacheProxy.java
+++ b/hazelcast-client-legacy/src/main/java/com/hazelcast/client/cache/impl/AbstractClientCacheProxy.java
@@ -162,12 +162,12 @@ abstract class AbstractClientCacheProxy<K, V>
 
     @Override
     public ICompletableFuture<Boolean> putIfAbsentAsync(K key, V value) {
-        return putIfAbsentAsyncInternal(key, value, null, false, true);
+        return (ICompletableFuture<Boolean>) putIfAbsentInternal(key, value, null, false, true);
     }
 
     @Override
     public ICompletableFuture<Boolean> putIfAbsentAsync(K key, V value, ExpiryPolicy expiryPolicy) {
-        return putIfAbsentAsyncInternal(key, value, expiryPolicy, false, true);
+        return (ICompletableFuture<Boolean>) putIfAbsentInternal(key, value, expiryPolicy, false, true);
     }
 
     @Override
@@ -432,17 +432,7 @@ abstract class AbstractClientCacheProxy<K, V>
 
     @Override
     public boolean putIfAbsent(K key, V value, ExpiryPolicy expiryPolicy) {
-        final long start = System.nanoTime();
-        final Future<Boolean> f = putIfAbsentAsyncInternal(key, value, expiryPolicy, true, false);
-        try {
-            boolean saved = f.get();
-            if (statisticsEnabled) {
-                handleStatisticsOnPutIfAbsent(start, saved);
-            }
-            return saved;
-        } catch (Throwable e) {
-            throw ExceptionUtil.rethrowAllowedTypeFirst(e, CacheException.class);
-        }
+        return (Boolean) putIfAbsentInternal(key, value, expiryPolicy, true, false);
     }
 
     @Override

--- a/hazelcast-client-legacy/src/test/java/com/hazelcast/client/cache/nearcache/ClientNearCacheTest.java
+++ b/hazelcast-client-legacy/src/test/java/com/hazelcast/client/cache/nearcache/ClientNearCacheTest.java
@@ -48,6 +48,16 @@ public class ClientNearCacheTest extends ClientNearCacheTestSupport {
     }
 
     @Test
+    public void putIfAbsentToCacheAndThenGetFromClientNearCacheWithBinaryInMemoryFormat() {
+        putIfAbsentToCacheAndThenGetFromClientNearCache(InMemoryFormat.BINARY);
+    }
+
+    @Test
+    public void putIfAbsentToCacheAndThenGetFromClientNearCacheWithObjectInMemoryFormat() {
+        putIfAbsentToCacheAndThenGetFromClientNearCache(InMemoryFormat.OBJECT);
+    }
+
+    @Test
     public void putToCacheAndUpdateFromOtherNodeThenGetUpdatedFromClientNearCacheWithBinaryInMemoryFormat() {
         putToCacheAndUpdateFromOtherNodeThenGetUpdatedFromClientNearCache(InMemoryFormat.BINARY);
     }

--- a/hazelcast-client-legacy/src/test/java/com/hazelcast/client/cache/nearcache/ClientNearCacheTestSupport.java
+++ b/hazelcast-client-legacy/src/test/java/com/hazelcast/client/cache/nearcache/ClientNearCacheTestSupport.java
@@ -72,14 +72,14 @@ public abstract class ClientNearCacheTestSupport extends HazelcastTestSupport {
 
     protected CacheConfig createCacheConfig(InMemoryFormat inMemoryFormat) {
         return new CacheConfig()
-                    .setName(DEFAULT_CACHE_NAME)
-                    .setInMemoryFormat(inMemoryFormat);
+                .setName(DEFAULT_CACHE_NAME)
+                .setInMemoryFormat(inMemoryFormat);
     }
 
     protected NearCacheConfig createNearCacheConfig(InMemoryFormat inMemoryFormat) {
         return new NearCacheConfig()
-                        .setName(DEFAULT_CACHE_NAME)
-                        .setInMemoryFormat(inMemoryFormat);
+                .setName(DEFAULT_CACHE_NAME)
+                .setInMemoryFormat(inMemoryFormat);
     }
 
     protected class NearCacheTestContext {
@@ -132,9 +132,19 @@ public abstract class ClientNearCacheTestSupport extends HazelcastTestSupport {
 
     protected NearCacheTestContext createNearCacheTestAndFillWithData(String cacheName,
                                                                       NearCacheConfig nearCacheConfig) {
+        return createNearCacheTestAndFillWithData(cacheName, nearCacheConfig, false);
+    }
+
+    protected NearCacheTestContext createNearCacheTestAndFillWithData(String cacheName,
+                                                                      NearCacheConfig nearCacheConfig,
+                                                                      boolean putIfAbsent) {
         NearCacheTestContext nearCacheTestContext = createNearCacheTest(cacheName, nearCacheConfig);
         for (int i = 0; i < DEFAULT_RECORD_COUNT; i++) {
-            nearCacheTestContext.cache.put(i, generateValueFromKey(i));
+            if (putIfAbsent) {
+                nearCacheTestContext.cache.putIfAbsent(i, generateValueFromKey(i));
+            } else {
+                nearCacheTestContext.cache.put(i, generateValueFromKey(i));
+            }
         }
         return nearCacheTestContext;
     }
@@ -146,7 +156,7 @@ public abstract class ClientNearCacheTestSupport extends HazelcastTestSupport {
 
         for (int i = 0; i < DEFAULT_RECORD_COUNT; i++) {
             assertNull(nearCacheTestContext.nearCache.get(
-                            nearCacheTestContext.serializationService.toData(i)));
+                    nearCacheTestContext.serializationService.toData(i)));
         }
 
         for (int i = 0; i < DEFAULT_RECORD_COUNT; i++) {
@@ -163,11 +173,11 @@ public abstract class ClientNearCacheTestSupport extends HazelcastTestSupport {
         nearCacheTestContext.close();
     }
 
-    protected void putToCacheAndThenGetFromClientNearCache(InMemoryFormat inMemoryFormat) {
+    protected void putToCacheAndThenGetFromClientNearCacheInternal(InMemoryFormat inMemoryFormat, boolean putIfAbsent) {
         NearCacheConfig nearCacheConfig = createNearCacheConfig(inMemoryFormat);
         nearCacheConfig.setLocalUpdatePolicy(NearCacheConfig.LocalUpdatePolicy.CACHE);
         final NearCacheTestContext nearCacheTestContext =
-                createNearCacheTestAndFillWithData(DEFAULT_CACHE_NAME, nearCacheConfig);
+                createNearCacheTestAndFillWithData(DEFAULT_CACHE_NAME, nearCacheConfig, putIfAbsent);
 
         for (int i = 0; i < DEFAULT_RECORD_COUNT; i++) {
             String expectedValue = generateValueFromKey(i);
@@ -176,6 +186,14 @@ public abstract class ClientNearCacheTestSupport extends HazelcastTestSupport {
         }
 
         nearCacheTestContext.close();
+    }
+
+    protected void putToCacheAndThenGetFromClientNearCache(InMemoryFormat inMemoryFormat) {
+        putToCacheAndThenGetFromClientNearCacheInternal(inMemoryFormat, false);
+    }
+
+    protected void putIfAbsentToCacheAndThenGetFromClientNearCache(InMemoryFormat inMemoryFormat) {
+        putToCacheAndThenGetFromClientNearCacheInternal(inMemoryFormat, true);
     }
 
     protected void putToCacheAndUpdateFromOtherNodeThenGetUpdatedFromClientNearCache(InMemoryFormat inMemoryFormat) {
@@ -199,7 +217,7 @@ public abstract class ClientNearCacheTestSupport extends HazelcastTestSupport {
                 @Override
                 public void run() throws Exception {
                     assertEquals(value,
-                                 nearCacheTestContext2.nearCache.get(
+                            nearCacheTestContext2.nearCache.get(
                                     nearCacheTestContext2.serializationService.toData(key)));
                 }
             });
@@ -219,7 +237,7 @@ public abstract class ClientNearCacheTestSupport extends HazelcastTestSupport {
                 @Override
                 public void run() throws Exception {
                     assertNull(nearCacheTestContext2.nearCache.get(
-                                    nearCacheTestContext2.serializationService.toData(key)));
+                            nearCacheTestContext2.serializationService.toData(key)));
                 }
             });
         }
@@ -234,7 +252,7 @@ public abstract class ClientNearCacheTestSupport extends HazelcastTestSupport {
                 @Override
                 public void run() throws Exception {
                     assertEquals(value,
-                                 nearCacheTestContext2.nearCache.get(
+                            nearCacheTestContext2.nearCache.get(
                                     nearCacheTestContext2.serializationService.toData(key)));
                 }
             });
@@ -265,7 +283,7 @@ public abstract class ClientNearCacheTestSupport extends HazelcastTestSupport {
                 @Override
                 public void run() throws Exception {
                     assertEquals(value,
-                                 nearCacheTestContext2.nearCache.get(
+                            nearCacheTestContext2.nearCache.get(
                                     nearCacheTestContext2.serializationService.toData(key)));
                 }
             });
@@ -285,7 +303,7 @@ public abstract class ClientNearCacheTestSupport extends HazelcastTestSupport {
                 @Override
                 public void run() throws Exception {
                     assertNull(nearCacheTestContext2.nearCache.get(
-                                    nearCacheTestContext2.serializationService.toData(key)));
+                            nearCacheTestContext2.serializationService.toData(key)));
                 }
             });
         }
@@ -315,7 +333,7 @@ public abstract class ClientNearCacheTestSupport extends HazelcastTestSupport {
                 @Override
                 public void run() throws Exception {
                     assertEquals(value,
-                                 nearCacheTestContext2.nearCache.get(
+                            nearCacheTestContext2.nearCache.get(
                                     nearCacheTestContext2.serializationService.toData(key)));
                 }
             });
@@ -332,7 +350,7 @@ public abstract class ClientNearCacheTestSupport extends HazelcastTestSupport {
                 @Override
                 public void run() throws Exception {
                     assertNull(nearCacheTestContext2.nearCache.get(
-                                    nearCacheTestContext2.serializationService.toData(key)));
+                            nearCacheTestContext2.serializationService.toData(key)));
                 }
             });
         }
@@ -348,7 +366,7 @@ public abstract class ClientNearCacheTestSupport extends HazelcastTestSupport {
 
         for (int i = 0; i < DEFAULT_RECORD_COUNT; i++) {
             assertNull(nearCacheTestContext.nearCache.get(
-                            nearCacheTestContext.serializationService.toData(i)));
+                    nearCacheTestContext.serializationService.toData(i)));
         }
 
         for (int i = 0; i < DEFAULT_RECORD_COUNT; i++) {
@@ -366,4 +384,3 @@ public abstract class ClientNearCacheTestSupport extends HazelcastTestSupport {
     }
 
 }
-

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientNearCacheTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientNearCacheTest.java
@@ -48,6 +48,16 @@ public class ClientNearCacheTest extends ClientNearCacheTestSupport {
     }
 
     @Test
+    public void putIfAbsentToCacheAndThenGetFromClientNearCacheWithBinaryInMemoryFormat() {
+        putIfAbsentToCacheAndThenGetFromClientNearCache(InMemoryFormat.BINARY);
+    }
+
+    @Test
+    public void putIfAbsentToCacheAndThenGetFromClientNearCacheWithObjectInMemoryFormat() {
+        putIfAbsentToCacheAndThenGetFromClientNearCache(InMemoryFormat.OBJECT);
+    }
+
+    @Test
     public void putToCacheAndUpdateFromOtherNodeThenGetUpdatedFromClientNearCacheWithBinaryInMemoryFormat() {
         putToCacheAndUpdateFromOtherNodeThenGetUpdatedFromClientNearCache(InMemoryFormat.BINARY);
     }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientNearCacheTestSupport.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientNearCacheTestSupport.java
@@ -132,9 +132,19 @@ public abstract class ClientNearCacheTestSupport extends HazelcastTestSupport {
 
     protected NearCacheTestContext createNearCacheTestAndFillWithData(String cacheName,
                                                                       NearCacheConfig nearCacheConfig) {
+        return createNearCacheTestAndFillWithData(cacheName, nearCacheConfig, false);
+    }
+
+    protected NearCacheTestContext createNearCacheTestAndFillWithData(String cacheName,
+                                                                      NearCacheConfig nearCacheConfig,
+                                                                      boolean putIfAbsent) {
         NearCacheTestContext nearCacheTestContext = createNearCacheTest(cacheName, nearCacheConfig);
         for (int i = 0; i < DEFAULT_RECORD_COUNT; i++) {
-            nearCacheTestContext.cache.put(i, generateValueFromKey(i));
+            if (putIfAbsent) {
+                nearCacheTestContext.cache.putIfAbsent(i, generateValueFromKey(i));
+            } else {
+                nearCacheTestContext.cache.put(i, generateValueFromKey(i));
+            }
         }
         return nearCacheTestContext;
     }
@@ -163,11 +173,11 @@ public abstract class ClientNearCacheTestSupport extends HazelcastTestSupport {
         nearCacheTestContext.close();
     }
 
-    protected void putToCacheAndThenGetFromClientNearCache(InMemoryFormat inMemoryFormat) {
+    protected void putToCacheAndThenGetFromClientNearCacheInternal(InMemoryFormat inMemoryFormat, boolean putIfAbsent) {
         NearCacheConfig nearCacheConfig = createNearCacheConfig(inMemoryFormat);
         nearCacheConfig.setLocalUpdatePolicy(NearCacheConfig.LocalUpdatePolicy.CACHE);
         final NearCacheTestContext nearCacheTestContext =
-                createNearCacheTestAndFillWithData(DEFAULT_CACHE_NAME, nearCacheConfig);
+                createNearCacheTestAndFillWithData(DEFAULT_CACHE_NAME, nearCacheConfig, putIfAbsent);
 
         for (int i = 0; i < DEFAULT_RECORD_COUNT; i++) {
             String expectedValue = generateValueFromKey(i);
@@ -176,6 +186,14 @@ public abstract class ClientNearCacheTestSupport extends HazelcastTestSupport {
         }
 
         nearCacheTestContext.close();
+    }
+
+    protected void putToCacheAndThenGetFromClientNearCache(InMemoryFormat inMemoryFormat) {
+        putToCacheAndThenGetFromClientNearCacheInternal(inMemoryFormat, false);
+    }
+
+    protected void putIfAbsentToCacheAndThenGetFromClientNearCache(InMemoryFormat inMemoryFormat) {
+        putToCacheAndThenGetFromClientNearCacheInternal(inMemoryFormat, true);
     }
 
     protected void putToCacheAndUpdateFromOtherNodeThenGetUpdatedFromClientNearCache(InMemoryFormat inMemoryFormat) {


### PR DESCRIPTION
If putIfAbsent to cache is sync no need to put it to near-cache as async but sync.
Async putIfAbsents are still same by putting to near-cache as async

putIfAbsent version of https://github.com/hazelcast/hazelcast/pull/6749