### PR TITLE
Increase transaction timeout in AdvancedClusterStateTest

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/cluster/impl/AdvancedClusterStateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/impl/AdvancedClusterStateTest.java
@@ -131,7 +131,7 @@ public class AdvancedClusterStateTest extends HazelcastTestSupport {
         clusterStateManager.lockClusterState(ClusterState.FROZEN, node.getThisAddress(), "fakeTxn", timeoutInMillis, partitionStateVersion);
     }
 
-    @Test
+    @Test(timeout = 60000)
     public void changeClusterState_shouldFail_whenInitiatorDies_beforePrepare() throws Exception {
         final TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(3);
         final HazelcastInstance[] instances = factory.newInstances();
@@ -139,7 +139,7 @@ public class AdvancedClusterStateTest extends HazelcastTestSupport {
         final HazelcastInstance hz = instances[instances.length - 1];
         TransactionManagerServiceImpl transactionManagerService = spyTransactionManagerService(hz);
 
-        TransactionOptions options = TransactionOptions.getDefault().setTimeout(10, TimeUnit.SECONDS);
+        TransactionOptions options = TransactionOptions.getDefault().setTimeout(30, TimeUnit.SECONDS);
         when(transactionManagerService.newAllowedDuringPassiveStateTransaction(options)).thenAnswer(new TransactionAnswer() {
             @Override
             protected void beforePrepare() {
@@ -192,7 +192,7 @@ public class AdvancedClusterStateTest extends HazelcastTestSupport {
         });
     }
 
-    @Test
+    @Test(timeout = 60000)
     public void changeClusterState_shouldFail_withoutBackup_whenInitiatorDies_beforePrepare() throws Exception {
         final TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(3);
         final HazelcastInstance[] instances = factory.newInstances();
@@ -200,7 +200,7 @@ public class AdvancedClusterStateTest extends HazelcastTestSupport {
         final HazelcastInstance hz = instances[instances.length - 1];
         TransactionManagerServiceImpl transactionManagerService = spyTransactionManagerService(hz);
 
-        TransactionOptions options = new TransactionOptions().setDurability(0).setTimeout(10, TimeUnit.SECONDS);
+        TransactionOptions options = new TransactionOptions().setDurability(0).setTimeout(30, TimeUnit.SECONDS);
         when(transactionManagerService.newAllowedDuringPassiveStateTransaction(options)).thenAnswer(new TransactionAnswer() {
             @Override
             protected void beforePrepare() {


### PR DESCRIPTION
Short transaction timeout duration is consumed by node termination and transaction timeouts before attempting to initiate operations.

Fixes #6383