### PR TITLE
Listener service should listen for events after clusterService has been started to prevent receiving duplicate events.

### DIFF
--- a/hazelcast-client-legacy/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
+++ b/hazelcast-client-legacy/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
@@ -306,6 +306,7 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
             lifecycleService.shutdown();
             throw ExceptionUtil.rethrow(e);
         }
+        listenerService.start();
         loadBalancer.init(getCluster(), config);
         partitionService.start();
         clientExtension.afterStart(this);

--- a/hazelcast-client-legacy/src/main/java/com/hazelcast/client/spi/impl/listener/ClientListenerServiceImpl.java
+++ b/hazelcast-client-legacy/src/main/java/com/hazelcast/client/spi/impl/listener/ClientListenerServiceImpl.java
@@ -79,6 +79,9 @@ public abstract class ClientListenerServiceImpl implements ClientListenerService
         }
     }
 
+    public void start() {
+    }
+
     public void shutdown() {
         eventExecutor.shutdown();
     }

--- a/hazelcast-client-legacy/src/main/java/com/hazelcast/client/spi/impl/listener/ClientNonSmartListenerService.java
+++ b/hazelcast-client-legacy/src/main/java/com/hazelcast/client/spi/impl/listener/ClientNonSmartListenerService.java
@@ -46,7 +46,6 @@ public class ClientNonSmartListenerService extends ClientListenerServiceImpl imp
     public ClientNonSmartListenerService(HazelcastClientInstanceImpl client,
                                          int eventThreadCount, int eventQueueCapacity) {
         super(client, eventThreadCount, eventQueueCapacity);
-        client.getConnectionManager().addConnectionListener(this);
     }
 
     @Override
@@ -108,6 +107,11 @@ public class ClientNonSmartListenerService extends ClientListenerServiceImpl imp
             }
             return true;
         }
+    }
+
+    @Override
+    public void start() {
+        client.getConnectionManager().addConnectionListener(this);
     }
 
     @Override

--- a/hazelcast-client-legacy/src/main/java/com/hazelcast/client/spi/impl/listener/ClientSmartListenerService.java
+++ b/hazelcast-client-legacy/src/main/java/com/hazelcast/client/spi/impl/listener/ClientSmartListenerService.java
@@ -46,11 +46,11 @@ public class ClientSmartListenerService extends ClientListenerServiceImpl implem
     private final Map<ClientRegistrationKey, Map<Address, ClientEventRegistration>> registrations
             = new ConcurrentHashMap<ClientRegistrationKey, Map<Address, ClientEventRegistration>>();
     private final Object listenerRegLock = new Object();
+    private String membershipListenerId;
 
     public ClientSmartListenerService(HazelcastClientInstanceImpl client,
                                       int eventThreadCount, int eventQueueCapacity) {
         super(client, eventThreadCount, eventQueueCapacity);
-        client.getClientClusterService().addMembershipListener(this);
     }
 
     @Override
@@ -129,6 +129,19 @@ public class ClientSmartListenerService extends ClientListenerServiceImpl implem
             return successful;
         }
 
+    }
+
+    @Override
+    public void start() {
+        membershipListenerId = client.getClientClusterService().addMembershipListener(this);
+    }
+
+    @Override
+    public void shutdown() {
+        super.shutdown();
+        if (membershipListenerId != null) {
+            client.getClientClusterService().removeMembershipListener(membershipListenerId);
+        }
     }
 
     @Override

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
@@ -305,6 +305,7 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
             lifecycleService.shutdown();
             throw ExceptionUtil.rethrow(e);
         }
+        listenerService.start();
         loadBalancer.init(getCluster(), config);
         partitionService.start();
         clientExtension.afterStart(this);

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/listener/ClientListenerServiceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/listener/ClientListenerServiceImpl.java
@@ -85,6 +85,10 @@ public abstract class ClientListenerServiceImpl implements ClientListenerService
         return eventExecutor;
     }
 
+    public void start() {
+
+    }
+
     private final class ClientEventProcessor implements StripedRunnable {
         final ClientMessage clientMessage;
         final ClientConnection connection;

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/listener/ClientNonSmartListenerService.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/listener/ClientNonSmartListenerService.java
@@ -44,7 +44,6 @@ public class ClientNonSmartListenerService extends ClientListenerServiceImpl imp
     public ClientNonSmartListenerService(HazelcastClientInstanceImpl client,
                                          int eventThreadCount, int eventQueueCapacity) {
         super(client, eventThreadCount, eventQueueCapacity);
-        client.getConnectionManager().addConnectionListener(this);
     }
 
     @Override
@@ -99,6 +98,11 @@ public class ClientNonSmartListenerService extends ClientListenerServiceImpl imp
             }
             return true;
         }
+    }
+
+    @Override
+    public void start() {
+        client.getConnectionManager().addConnectionListener(this);
     }
 
     @Override

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/listener/ClientSmartListenerService.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/listener/ClientSmartListenerService.java
@@ -45,11 +45,11 @@ public class ClientSmartListenerService extends ClientListenerServiceImpl implem
     private final Map<ClientRegistrationKey, Map<Address, ClientEventRegistration>> registrations
             = new ConcurrentHashMap<ClientRegistrationKey, Map<Address, ClientEventRegistration>>();
     private final Object listenerRegLock = new Object();
+    private String membershipListenerId;
 
     public ClientSmartListenerService(HazelcastClientInstanceImpl client,
                                       int eventThreadCount, int eventQueueCapacity) {
         super(client, eventThreadCount, eventQueueCapacity);
-        client.getClientClusterService().addMembershipListener(this);
     }
 
     @Override
@@ -126,6 +126,19 @@ public class ClientSmartListenerService extends ClientListenerServiceImpl implem
             return successful;
         }
 
+    }
+
+    @Override
+    public void start() {
+        membershipListenerId = client.getClientClusterService().addMembershipListener(this);
+    }
+
+    @Override
+    public void shutdown() {
+        super.shutdown();
+        if (membershipListenerId != null) {
+            client.getClientClusterService().removeMembershipListener(membershipListenerId);
+        }
     }
 
     @Override


### PR DESCRIPTION
Fix for #6620