### PR TITLE
Discovery SPI minor changes.

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/DiscoveryJoiner.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/DiscoveryJoiner.java
@@ -29,10 +29,12 @@ public class DiscoveryJoiner
         extends TcpIpJoiner {
 
     private final DiscoveryService discoveryService;
+    private final boolean usePublicAddress;
 
-    public DiscoveryJoiner(Node node, DiscoveryService discoveryService) {
+    public DiscoveryJoiner(Node node, DiscoveryService discoveryService, boolean usePublicAddress) {
         super(node);
         this.discoveryService = discoveryService;
+        this.usePublicAddress = usePublicAddress;
     }
 
     @Override
@@ -44,7 +46,7 @@ public class DiscoveryJoiner
 
         Collection<Address> possibleMembers = new ArrayList<Address>();
         for (DiscoveryNode discoveryNode : discoveredNodes) {
-            Address discoveredAddress = discoveryNode.getPrivateAddress();
+            Address discoveredAddress = usePublicAddress ? discoveryNode.getPublicAddress() : discoveryNode.getPrivateAddress();
             if (localAddress.equals(discoveredAddress)) {
                 continue;
             }

--- a/hazelcast/src/main/java/com/hazelcast/config/JoinConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/JoinConfig.java
@@ -118,16 +118,27 @@ public class JoinConfig {
         if (getMulticastConfig().isEnabled() && getAwsConfig().isEnabled()) {
             throw new InvalidConfigurationException("Multicast and AWS join can't be enabled at the same time");
         }
+        verifyDiscoveryProviderConfig();
+    }
 
+    /**
+     * Verifies this JoinConfig is valid. When Discovery SPI enabled other discovery
+     * methods should be disabled
+     *
+     * @throws IllegalStateException when the join config is not valid.
+     */
+    private void verifyDiscoveryProviderConfig() {
         Collection<DiscoveryStrategyConfig> discoveryStrategyConfigs = discoveryConfig.getDiscoveryStrategyConfigs();
-        if (getMulticastConfig().isEnabled() && discoveryStrategyConfigs.size() > 0) {
-            throw new InvalidConfigurationException(
-                    "Multicast and DiscoveryProviders join can't be enabled at the same time");
-        }
+        if (discoveryStrategyConfigs.size() > 0) {
+            if (getMulticastConfig().isEnabled()) {
+                throw new InvalidConfigurationException(
+                        "Multicast and DiscoveryProviders join can't be enabled at the same time");
+            }
 
-        if (getAwsConfig().isEnabled() && discoveryStrategyConfigs.size() > 0) {
-            throw new InvalidConfigurationException(
-                    "Multicast and DiscoveryProviders join can't be enabled at the same time");
+            if (getAwsConfig().isEnabled()) {
+                throw new InvalidConfigurationException(
+                        "AWS and DiscoveryProviders join can't be enabled at the same time");
+            }
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/instance/GroupProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/GroupProperty.java
@@ -563,6 +563,13 @@ public enum GroupProperty implements HazelcastProperty {
     DISCOVERY_SPI_ENABLED("hazelcast.discovery.enabled", false),
 
     /**
+     * <p>Enables the Discovery Joiner to use public ips from DiscoveredNode. This property is temporary and will
+     * eventually be removed when the experimental marker is removed.</p>
+     * <p>Discovery SPI is <b>disabled</b> by default</p>
+     */
+    DISCOVERY_SPI_PUBLIC_IP_ENABLED("hazelcast.discovery.public.ip.enabled", false),
+
+    /**
      * Hazelcast serialization version. This is single byte value between 1 and Max supported serialization version.
      * @see BuildInfo#getSerializationVersion()
      */

--- a/hazelcast/src/main/java/com/hazelcast/instance/Node.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/Node.java
@@ -586,7 +586,8 @@ public class Node {
         if (groupProperties.getBoolean(GroupProperty.DISCOVERY_SPI_ENABLED)) {
             //TODO: Auto-Upgrade Multicast+AWS configuration!
             logger.info("Activating Discovery SPI Joiner");
-            return new DiscoveryJoiner(this, discoveryService);
+            return new DiscoveryJoiner(this, discoveryService,
+                    groupProperties.getBoolean(GroupProperty.DISCOVERY_SPI_PUBLIC_IP_ENABLED));
         } else {
             if (join.getMulticastConfig().isEnabled() && multicastService != null) {
                 logger.info("Creating MulticastJoiner");

--- a/hazelcast/src/test/java/com/hazelcast/cluster/impl/DiscoveryJoinerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/impl/DiscoveryJoinerTest.java
@@ -1,0 +1,70 @@
+package com.hazelcast.cluster.impl;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.instance.TestUtil;
+import com.hazelcast.nio.Address;
+import com.hazelcast.spi.discovery.DiscoveryNode;
+import com.hazelcast.spi.discovery.SimpleDiscoveryNode;
+import com.hazelcast.spi.discovery.integration.DiscoveryService;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class DiscoveryJoinerTest {
+
+    @Mock
+    private DiscoveryService service = mock(DiscoveryService.class);
+
+    List<DiscoveryNode> discoveryNodes;
+    private TestHazelcastInstanceFactory factory;
+    private HazelcastInstance hz;
+
+    @Before
+    public void init() throws Exception{
+        discoveryNodes = new ArrayList<DiscoveryNode>(2);
+        Address publicAddress = new Address("127.0.0.1", 50001);
+        Address privateAddress = new Address("127.0.0.2", 50001);
+        discoveryNodes.add(new SimpleDiscoveryNode(privateAddress, publicAddress));
+        publicAddress = new Address("127.0.0.1", 50002);
+        privateAddress = new Address("127.0.0.2", 50002);
+        discoveryNodes.add(new SimpleDiscoveryNode(privateAddress, publicAddress));
+        factory = new TestHazelcastInstanceFactory(1);
+        hz = factory.newHazelcastInstance();
+    }
+    @After
+    public void cleanup() {
+        factory.terminateAll();
+    }
+
+    @Test
+    public void test_DiscoveryJoiner_returns_public_address () throws Exception {
+        DiscoveryJoiner joiner = new DiscoveryJoiner(TestUtil.getNode(hz),service, true);
+        doReturn(discoveryNodes).when(service).discoverNodes();
+        Collection<Address> addresses = joiner.getPossibleAddresses();
+        assertEquals("[Address[127.0.0.1]:50001, Address[127.0.0.1]:50002]", addresses.toString());
+    }
+
+    @Test
+    public void test_DiscoveryJoiner_returns_private_address () throws Exception {
+        DiscoveryJoiner joiner = new DiscoveryJoiner(TestUtil.getNode(hz),service, false);
+        doReturn(discoveryNodes).when(service).discoverNodes();
+        Collection<Address> addresses = joiner.getPossibleAddresses();
+        assertEquals("[Address[127.0.0.2]:50001, Address[127.0.0.2]:50002]", addresses.toString());
+    }
+}


### PR DESCRIPTION
Adds fail fast to JoinConfig for Discovery SPI when enabled with TCP/IP discovery.
Adds a property to enable use of public IP addresses in DiscoveryJoiner.