### PR TITLE
Fix Data Race in Record classes

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/record/DataRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/record/DataRecord.java
@@ -20,7 +20,7 @@ import com.hazelcast.nio.serialization.Data;
 
 class DataRecord extends AbstractRecord<Data> {
 
-    protected Data value;
+    protected volatile Data value;
 
     DataRecord(Data value) {
         this.value = value;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/record/DataRecordWithStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/record/DataRecordWithStats.java
@@ -20,7 +20,7 @@ import com.hazelcast.nio.serialization.Data;
 
 class DataRecordWithStats extends AbstractRecordWithStats<Data> {
 
-    protected Data value;
+    protected volatile Data value;
 
     DataRecordWithStats() {
         super();

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/record/ObjectRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/record/ObjectRecord.java
@@ -18,7 +18,7 @@ package com.hazelcast.map.impl.record;
 
 class ObjectRecord extends AbstractRecord<Object> implements Record<Object> {
 
-    private Object value;
+    private volatile Object value;
 
     ObjectRecord() {
         super();

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/record/ObjectRecordWithStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/record/ObjectRecordWithStats.java
@@ -18,7 +18,7 @@ package com.hazelcast.map.impl.record;
 
 class ObjectRecordWithStats extends AbstractRecordWithStats<Object> {
 
-    private Object value;
+    private volatile Object value;
 
     public ObjectRecordWithStats() {
         super();


### PR DESCRIPTION
Multiple threads access the value field.
It has to be volatile to avoid data races.