### PR TITLE
Fixing NPE on ReplicatedMap TTL eviction

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/EvictionOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/EvictionOperation.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.replicatedmap.impl.operation;
+
+import com.hazelcast.replicatedmap.impl.record.ReplicatedRecordStore;
+import com.hazelcast.spi.AbstractOperation;
+import com.hazelcast.util.scheduler.ScheduledEntry;
+import java.util.Collection;
+
+/**
+ * Evicts set of entries from the record store. Runs locally.
+ */
+public class EvictionOperation extends AbstractOperation {
+
+    private final ReplicatedRecordStore store;
+    private final Collection<ScheduledEntry<Object, Object>> entries;
+
+    public EvictionOperation(ReplicatedRecordStore store, Collection<ScheduledEntry<Object, Object>> entries) {
+        this.store = store;
+        this.entries = entries;
+    }
+
+    @Override
+    public void run() throws Exception {
+        for (ScheduledEntry<Object, Object> entry : entries) {
+            Object key = entry.getKey();
+            store.evict(key);
+        }
+    }
+
+    @Override
+    public boolean returnsResponse() {
+        return false;
+    }
+
+    @Override
+    public boolean validatesTarget() {
+        return false;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/SyncReplicatedMapDataOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/SyncReplicatedMapDataOperation.java
@@ -67,6 +67,9 @@ public class SyncReplicatedMapDataOperation<K, V> extends AbstractOperation {
             if (oldRecord != null) {
                 replicatedRecord.setHits(oldRecord.getHits());
             }
+            if (record.getTtl() > 0) {
+                store.scheduleTtlEntry(record.getTtl(), key, value);
+            }
             newStorage.putInternal(key, replicatedRecord);
         }
         newStorage.setVersion(version);

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/AbstractBaseReplicatedRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/AbstractBaseReplicatedRecordStore.java
@@ -39,7 +39,7 @@ import java.util.concurrent.atomic.AtomicReference;
  * @param <K> key type
  * @param <V> value type
  */
-abstract class AbstractBaseReplicatedRecordStore<K, V> implements ReplicatedRecordStore {
+public abstract class AbstractBaseReplicatedRecordStore<K, V> implements ReplicatedRecordStore {
 
     protected final AtomicReference<InternalReplicatedMapStorage<K, V>> storageRef;
     protected final ReplicatedMapService replicatedMapService;
@@ -67,8 +67,7 @@ abstract class AbstractBaseReplicatedRecordStore<K, V> implements ReplicatedReco
         this.storageRef.set(new InternalReplicatedMapStorage<K, V>());
         this.ttlEvictionScheduler = EntryTaskSchedulerFactory
                 .newScheduler(nodeEngine.getExecutionService().getDefaultScheduledExecutor(),
-                        new ReplicatedMapEvictionProcessor(nodeEngine, replicatedMapService, name)
-                        , ScheduleType.POSTPONE);
+                        new ReplicatedMapEvictionProcessor(this, nodeEngine, partitionId), ScheduleType.POSTPONE);
     }
 
     public InternalReplicatedMapStorage<K, V> getStorage() {
@@ -107,12 +106,14 @@ abstract class AbstractBaseReplicatedRecordStore<K, V> implements ReplicatedReco
     }
 
 
-    ScheduledEntry<K, V> cancelTtlEntry(K key) {
+    @Override
+    public ScheduledEntry cancelTtlEntry(Object key) {
         return ttlEvictionScheduler.cancel(key);
     }
 
-    boolean scheduleTtlEntry(long delayMillis, K key, V object) {
-        return ttlEvictionScheduler.schedule(delayMillis, key, object);
+    @Override
+    public boolean scheduleTtlEntry(long delayMillis, Object key, Object value) {
+        return ttlEvictionScheduler.schedule(delayMillis, key, value);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/ReplicatedRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/ReplicatedRecordStore.java
@@ -17,6 +17,7 @@
 package com.hazelcast.replicatedmap.impl.record;
 
 import com.hazelcast.replicatedmap.merge.ReplicatedMapMergePolicy;
+import com.hazelcast.util.scheduler.ScheduledEntry;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.Iterator;
@@ -33,8 +34,6 @@ public interface ReplicatedRecordStore {
     Object remove(Object key);
 
     void evict(Object key);
-
-    void removeTombstone(Object key);
 
     Object get(Object key);
 
@@ -79,6 +78,10 @@ public interface ReplicatedRecordStore {
     void putRecord(RecordMigrationInfo record);
 
     InternalReplicatedMapStorage getStorage();
+
+    ScheduledEntry<Object, Object> cancelTtlEntry(Object key);
+
+    boolean scheduleTtlEntry(long delayMillis, Object key, Object object);
 
     boolean isLoaded();
 

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapBaseTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapBaseTest.java
@@ -3,6 +3,7 @@ package com.hazelcast.replicatedmap;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.config.ReplicatedMapConfig;
+import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.ReplicatedMap;
 import com.hazelcast.replicatedmap.impl.ReplicatedMapProxy;
 import com.hazelcast.replicatedmap.impl.ReplicatedMapService;
@@ -11,6 +12,8 @@ import com.hazelcast.replicatedmap.impl.record.ReplicatedRecordStore;
 import com.hazelcast.test.HazelcastTestSupport;
 import java.lang.reflect.Field;
 import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Random;
 
 import static org.junit.Assert.fail;
@@ -72,6 +75,14 @@ public abstract class ReplicatedMapBaseTest extends HazelcastTestSupport {
     }
 
     @SuppressWarnings("unchecked")
+    protected <K, V> ReplicatedRecordStore getStore(ReplicatedMap<K, V> map, K key) throws Exception {
+        ReplicatedMapProxy<K, V> proxy = (ReplicatedMapProxy<K, V>) map;
+        ReplicatedMapService service = (ReplicatedMapService) REPLICATED_MAP_SERVICE.get(proxy);
+        return service.getReplicatedRecordStore(map.getName(), false, key);
+    }
+
+
+    @SuppressWarnings("unchecked")
     protected AbstractMap.SimpleEntry<Integer, Integer>[] buildTestValues() {
         Random random = new Random();
         AbstractMap.SimpleEntry<Integer, Integer>[] testValues = new AbstractMap.SimpleEntry[100];
@@ -79,5 +90,23 @@ public abstract class ReplicatedMapBaseTest extends HazelcastTestSupport {
             testValues[i] = new AbstractMap.SimpleEntry<Integer, Integer>(random.nextInt(), random.nextInt());
         }
         return testValues;
+    }
+
+    public List<ReplicatedMap> createMapOnEachInstance(HazelcastInstance[] instances, String replicatedMapName) {
+        ArrayList<ReplicatedMap> maps = new ArrayList<ReplicatedMap>();
+        for (int i = 0; i < instances.length; i++) {
+            ReplicatedMap<Object, Object> replicatedMap = instances[i].getReplicatedMap(replicatedMapName);
+            maps.add(replicatedMap);
+        }
+        return maps;
+    }
+
+    public ArrayList<Integer> generateRandomIntegerList(int count) {
+        final ArrayList<Integer> keys = new ArrayList<Integer>();
+        final Random random = new Random();
+        for (int i = 0; i < count; i++) {
+            keys.add(random.nextInt());
+        }
+        return keys;
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapTtlTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapTtlTest.java
@@ -1,0 +1,73 @@
+package com.hazelcast.replicatedmap;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.ReplicatedMap;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.SlowTest;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category(value = {SlowTest.class, ParallelTest.class})
+public class ReplicatedMapTtlTest extends ReplicatedMapBaseTest {
+
+    @Test
+    public void testPutWithTTL() throws Exception {
+        int nodeCount = 5;
+        int keyCount = 20000;
+        int operationCount = 20000;
+        int threadCount = 15;
+        int ttl = 500;
+        TimeUnit timeUnit = TimeUnit.MILLISECONDS;
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+        HazelcastInstance[] instances = factory.newInstances(null, nodeCount);
+        String mapName = randomMapName();
+        List<ReplicatedMap> maps = createMapOnEachInstance(instances, mapName);
+        ArrayList<Integer> keys = generateRandomIntegerList(keyCount);
+        Thread[] threads = createThreads(threadCount, maps, keys, ttl, timeUnit, operationCount);
+        for (Thread thread : threads) {
+            thread.start();
+        }
+        for (Thread thread : threads) {
+            thread.join();
+        }
+        for (ReplicatedMap map : maps) {
+            assertSizeEventually(0, map, 60);
+        }
+
+    }
+
+    private Thread[] createThreads(int count, List<ReplicatedMap> maps, ArrayList<Integer> keys,
+                                   long ttl, TimeUnit timeunit, int operations) {
+        Thread[] threads = new Thread[count];
+        int size = maps.size();
+        for (int i = 0; i < count; i++) {
+            threads[i] = createPutOperationThread(maps.get(i % size), keys, ttl, timeunit, operations);
+        }
+        return threads;
+    }
+
+    private Thread createPutOperationThread(final ReplicatedMap<String, Object> map, final ArrayList<Integer> keys,
+                                            final long ttl, final TimeUnit timeunit, final int operations) {
+        return new Thread(new Runnable() {
+            @Override
+            public void run() {
+                Random random = new Random();
+                int size = keys.size();
+                for (int i = 0; i < operations; i++) {
+                    int index = i % size;
+                    String key = "foo-" + keys.get(index);
+                    map.put(key, random.nextLong(), 1 + random.nextInt((int) ttl), timeunit);
+                }
+            }
+        });
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/impl/record/LazyIteratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/impl/record/LazyIteratorTest.java
@@ -21,6 +21,7 @@ import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.util.scheduler.ScheduledEntry;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashSet;
@@ -565,11 +566,6 @@ public class LazyIteratorTest
         }
 
         @Override
-        public void removeTombstone(Object key) {
-
-        }
-
-        @Override
         public Object get(Object key) {
             return null;
         }
@@ -675,6 +671,16 @@ public class LazyIteratorTest
         @Override
         public InternalReplicatedMapStorage getStorage() {
             return null;
+        }
+
+        @Override
+        public ScheduledEntry<Object, Object> cancelTtlEntry(Object key) {
+            return null;
+        }
+
+        @Override
+        public boolean scheduleTtlEntry(long delayMillis, Object key, Object object) {
+            return false;
         }
 
         @Override


### PR DESCRIPTION
Fixed NPE and race condition between put and eviction operations by making evictions on partition threads.

Fixes #6776
Fixes #6549