### PR TITLE
Reconnecting to instance on same address should preserve member list correctly

### DIFF
--- a/hazelcast-client-legacy/src/main/java/com/hazelcast/client/spi/impl/ClientMembershipListener.java
+++ b/hazelcast-client-legacy/src/main/java/com/hazelcast/client/spi/impl/ClientMembershipListener.java
@@ -181,12 +181,16 @@ class ClientMembershipListener implements EventHandler<ClientInitialMembershipEv
     private List<MembershipEvent> detectMembershipEvents(Map<String, Member> prevMembers) {
         final List<MembershipEvent> events = new LinkedList<MembershipEvent>();
         final Set<Member> eventMembers = Collections.unmodifiableSet(new LinkedHashSet<Member>(members));
+
+        final List<Member> newMembers = new LinkedList<Member>();
         for (Member member : members) {
             final Member former = prevMembers.remove(member.getUuid());
             if (former == null) {
-                events.add(new MembershipEvent(client.getCluster(), member, MembershipEvent.MEMBER_ADDED, eventMembers));
+                newMembers.add(member);
             }
         }
+
+        // removal events should be added before added events
         for (Member member : prevMembers.values()) {
             events.add(new MembershipEvent(client.getCluster(), member, MembershipEvent.MEMBER_REMOVED, eventMembers));
             Address address = member.getAddress();
@@ -197,6 +201,10 @@ class ClientMembershipListener implements EventHandler<ClientInitialMembershipEv
                 }
             }
         }
+        for (Member member : newMembers) {
+            events.add(new MembershipEvent(client.getCluster(), member, MembershipEvent.MEMBER_ADDED, eventMembers));
+        }
+
         return events;
     }
 

--- a/hazelcast-client-legacy/src/test/java/com/hazelcast/client/ClientReconnectTest.java
+++ b/hazelcast-client-legacy/src/test/java/com/hazelcast/client/ClientReconnectTest.java
@@ -22,6 +22,11 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.core.LifecycleEvent;
 import com.hazelcast.core.LifecycleListener;
+import com.hazelcast.core.Member;
+import com.hazelcast.core.MembershipAdapter;
+import com.hazelcast.core.MembershipEvent;
+import com.hazelcast.nio.Address;
+import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
@@ -31,6 +36,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import java.util.Iterator;
 import java.util.concurrent.CountDownLatch;
 
 import static org.junit.Assert.assertEquals;
@@ -67,6 +73,36 @@ public class ClientReconnectTest extends HazelcastTestSupport {
         assertOpenEventually(connectedLatch, 10);
         assertNull(m.put("test", "test"));
         assertEquals("test", m.get("test"));
+    }
+
+    @Test
+    public void testReconnectToNewInstanceAtSameAddress() throws InterruptedException {
+        HazelcastInstance instance = hazelcastFactory.newHazelcastInstance();
+        Address localAddress = instance.getCluster().getLocalMember().getAddress();
+        final HazelcastInstance client = hazelcastFactory.newHazelcastClient();
+
+        final CountDownLatch memberRemovedLatch = new CountDownLatch(1);
+        client.getCluster().addMembershipListener(new MembershipAdapter() {
+            @Override
+            public void memberRemoved(MembershipEvent membershipEvent) {
+                memberRemovedLatch.countDown();
+            }
+        });
+
+        instance.shutdown();
+        final HazelcastInstance instance2 = hazelcastFactory.newHazelcastInstance(localAddress);
+
+        assertOpenEventually(memberRemovedLatch);
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertEquals(1, client.getCluster().getMembers().size());
+                Iterator<Member> iterator = client.getCluster().getMembers().iterator();
+                Member member = iterator.next();
+                assertEquals(instance2.getCluster().getLocalMember(), member);
+            }
+        });
     }
 
 }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientMembershipListener.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientMembershipListener.java
@@ -181,12 +181,16 @@ class ClientMembershipListener extends ClientAddMembershipListenerCodec.Abstract
     private List<MembershipEvent> detectMembershipEvents(Map<String, Member> prevMembers) {
         final List<MembershipEvent> events = new LinkedList<MembershipEvent>();
         final Set<Member> eventMembers = Collections.unmodifiableSet(new LinkedHashSet<Member>(members));
+
+        final List<Member> newMembers = new LinkedList<Member>();
         for (Member member : members) {
             final Member former = prevMembers.remove(member.getUuid());
             if (former == null) {
-                events.add(new MembershipEvent(client.getCluster(), member, MembershipEvent.MEMBER_ADDED, eventMembers));
+                newMembers.add(member);
             }
         }
+
+        // removal events should be added before added events
         for (Member member : prevMembers.values()) {
             events.add(new MembershipEvent(client.getCluster(), member, MembershipEvent.MEMBER_REMOVED, eventMembers));
             Address address = member.getAddress();
@@ -197,6 +201,10 @@ class ClientMembershipListener extends ClientAddMembershipListenerCodec.Abstract
                 }
             }
         }
+        for (Member member : newMembers) {
+            events.add(new MembershipEvent(client.getCluster(), member, MembershipEvent.MEMBER_ADDED, eventMembers));
+        }
+
         return events;
     }
 

--- a/hazelcast-client/src/test/java/com/hazelcast/client/ClientReconnectTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ClientReconnectTest.java
@@ -22,6 +22,11 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.core.LifecycleEvent;
 import com.hazelcast.core.LifecycleListener;
+import com.hazelcast.core.Member;
+import com.hazelcast.core.MembershipAdapter;
+import com.hazelcast.core.MembershipEvent;
+import com.hazelcast.nio.Address;
+import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
@@ -31,6 +36,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import java.util.Iterator;
 import java.util.concurrent.CountDownLatch;
 
 import static org.junit.Assert.assertEquals;
@@ -69,4 +75,33 @@ public class ClientReconnectTest extends HazelcastTestSupport {
         assertEquals("test", m.get("test"));
     }
 
+    @Test
+    public void testReconnectToNewInstanceAtSameAddress() throws InterruptedException {
+        HazelcastInstance instance = hazelcastFactory.newHazelcastInstance();
+        Address localAddress = instance.getCluster().getLocalMember().getAddress();
+        final HazelcastInstance client = hazelcastFactory.newHazelcastClient();
+
+        final CountDownLatch memberRemovedLatch = new CountDownLatch(1);
+        client.getCluster().addMembershipListener(new MembershipAdapter() {
+            @Override
+            public void memberRemoved(MembershipEvent membershipEvent) {
+                memberRemovedLatch.countDown();
+            }
+        });
+
+        instance.shutdown();
+        final HazelcastInstance instance2 = hazelcastFactory.newHazelcastInstance(localAddress);
+
+        assertOpenEventually(memberRemovedLatch);
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertEquals(1, client.getCluster().getMembers().size());
+                Iterator<Member> iterator = client.getCluster().getMembers().iterator();
+                Member member = iterator.next();
+                assertEquals(instance2.getCluster().getLocalMember(), member);
+            }
+        });
+    }
 }


### PR DESCRIPTION
needs backport as well. Fixes #6467 