### PR TITLE
Fixes Ringbuffer readManyAsync when minValue is 0.

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/ReadManyOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/ReadManyOperation.java
@@ -73,13 +73,22 @@ public class ReadManyOperation extends AbstractRingBufferOperation implements Wa
             sequence = startSequence;
         }
 
-        if (resultSet.isMinSizeReached()) {
-            // if the minimum number of items are found, we don't need to wait anymore.
+        RingbufferContainer ringbuffer = getRingBufferContainer();
+        if (minSize == 0) {
+            if (!ringbuffer.shouldWait(sequence)) {
+                sequence = ringbuffer.readMany(sequence, resultSet);
+            }
+
             return false;
         }
 
-        RingbufferContainer ringbuffer = getRingBufferContainer();
+        if (resultSet.isMinSizeReached()) {
+            // enough items have been read, we are done.
+            return false;
+        }
+
         if (ringbuffer.shouldWait(sequence)) {
+            // the sequence is not readable
             return true;
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferBasicTest.java
@@ -20,6 +20,7 @@ import org.junit.runners.model.FrameworkMethod;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Random;
@@ -33,6 +34,8 @@ import static com.hazelcast.ringbuffer.OverflowPolicy.OVERWRITE;
 import static java.lang.Math.max;
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
+import static java.util.Collections.EMPTY_LIST;
+import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -592,13 +595,31 @@ public abstract class RingbufferBasicTest extends HazelcastTestSupport {
     }
 
     @Test
+    public void readManyAsync_whenMinZeroAndItemAvailable() throws ExecutionException, InterruptedException {
+        ringbuffer.add("1");
+
+        ICompletableFuture<ReadResultSet<String>> f = ringbuffer.readManyAsync(0, 0, 10, null);
+
+        assertCompletesEventually(f);
+        assertEquals(singletonList("1"), f.get());
+    }
+
+    @Test
+    public void readManyAsync_whenMinZeroAndNoItemAvailable() throws ExecutionException, InterruptedException {
+        ICompletableFuture<ReadResultSet<String>> f = ringbuffer.readManyAsync(0, 0, 10, null);
+
+        assertCompletesEventually(f);
+        assertEquals(EMPTY_LIST, f.get());
+    }
+
+    @Test
     public void readManyAsync_whenEnoughItems() throws ExecutionException, InterruptedException {
         ringbuffer.add("item1");
         ringbuffer.add("item2");
         ringbuffer.add("item3");
         ringbuffer.add("item4");
 
-        final ICompletableFuture<ReadResultSet<String>> f = ringbuffer.readManyAsync(1, 1, 2, null);
+        ICompletableFuture<ReadResultSet<String>> f = ringbuffer.readManyAsync(1, 1, 2, null);
         assertCompletesEventually(f);
 
         ReadResultSet<String> resultSet = f.get();
@@ -615,7 +636,7 @@ public abstract class RingbufferBasicTest extends HazelcastTestSupport {
         ringbuffer.add("item3");
         ringbuffer.add("item4");
 
-        final ICompletableFuture<ReadResultSet<String>> f = ringbuffer.readManyAsync(1, 1, 2, null);
+        ICompletableFuture<ReadResultSet<String>> f = ringbuffer.readManyAsync(1, 1, 2, null);
         assertCompletesEventually(f);
 
         ReadResultSet<String> resultSet = f.get();
@@ -641,8 +662,7 @@ public abstract class RingbufferBasicTest extends HazelcastTestSupport {
         ringbuffer.add("good3");
         ringbuffer.add("bad1");
 
-
-        final ICompletableFuture<ReadResultSet<String>> f = ringbuffer.readManyAsync(0, 2, 10, new GoodStringFunction());
+        ICompletableFuture<ReadResultSet<String>> f = ringbuffer.readManyAsync(0, 2, 10, new GoodStringFunction());
 
         assertCompletesEventually(f);
 


### PR DESCRIPTION
There was a logical error in the ReadManyOperation that in case of minSize = 0,
that the ringbuffer would not be read at all. So nothing gets returned.

Fixes #6787 