### PR TITLE
Fixes Ringbuffer readManyAsync when minValue is 0.

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/ReadManyOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/ReadManyOperation.java
@@ -62,13 +62,22 @@ public class ReadManyOperation extends AbstractRingBufferOperation implements Wa
             sequence = startSequence;
         }
 
-        if (resultSet.isMinSizeReached()) {
-            // if the minimum number of items are found, we don't need to wait anymore.
+        RingbufferContainer ringbuffer = getRingBufferContainer();
+        if (minSize == 0) {
+            if (!ringbuffer.shouldWait(sequence)) {
+                sequence = ringbuffer.readMany(sequence, resultSet);
+            }
+
             return false;
         }
 
-        RingbufferContainer ringbuffer = getRingBufferContainer();
+        if (resultSet.isMinSizeReached()) {
+            // enough items have been read, we are done.
+            return false;
+        }
+
         if (ringbuffer.shouldWait(sequence)) {
+            // the sequence is not readable
             return true;
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferBasicTest.java
@@ -592,13 +592,23 @@ public abstract class RingbufferBasicTest extends HazelcastTestSupport {
     }
 
     @Test
+    public void readManyAsync_whenMinZeroAndItemAvailable() throws ExecutionException, InterruptedException {
+        ringbuffer.add("1");
+
+        ICompletableFuture<ReadResultSet<String>> f = ringbuffer.readManyAsync(0, 0, 10, null);
+
+        assertCompletesEventually(f);
+        assertEquals(asList("1"), f.get());
+    }
+
+    @Test
     public void readManyAsync_whenEnoughItems() throws ExecutionException, InterruptedException {
         ringbuffer.add("item1");
         ringbuffer.add("item2");
         ringbuffer.add("item3");
         ringbuffer.add("item4");
 
-        final ICompletableFuture<ReadResultSet<String>> f = ringbuffer.readManyAsync(1, 1, 2, null);
+        ICompletableFuture<ReadResultSet<String>> f = ringbuffer.readManyAsync(1, 1, 2, null);
         assertCompletesEventually(f);
 
         ReadResultSet<String> resultSet = f.get();
@@ -615,7 +625,7 @@ public abstract class RingbufferBasicTest extends HazelcastTestSupport {
         ringbuffer.add("item3");
         ringbuffer.add("item4");
 
-        final ICompletableFuture<ReadResultSet<String>> f = ringbuffer.readManyAsync(1, 1, 2, null);
+        ICompletableFuture<ReadResultSet<String>> f = ringbuffer.readManyAsync(1, 1, 2, null);
         assertCompletesEventually(f);
 
         ReadResultSet<String> resultSet = f.get();
@@ -641,8 +651,7 @@ public abstract class RingbufferBasicTest extends HazelcastTestSupport {
         ringbuffer.add("good3");
         ringbuffer.add("bad1");
 
-
-        final ICompletableFuture<ReadResultSet<String>> f = ringbuffer.readManyAsync(0, 2, 10, new GoodStringFunction());
+        ICompletableFuture<ReadResultSet<String>> f = ringbuffer.readManyAsync(0, 2, 10, new GoodStringFunction());
 
         assertCompletesEventually(f);
 


### PR DESCRIPTION
There was a logical error in the ReadManyOperation that in case of minSize = 0,
that the ringbuffer would not be read at all. So nothing gets returned.

Fixes #6787