### PR TITLE
Ignore lite members on cluster merge

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/JoinMessage.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/JoinMessage.java
@@ -35,17 +35,18 @@ public class JoinMessage implements DataSerializable {
     protected boolean liteMember;
     protected ConfigCheck configCheck;
     protected Collection<Address> memberAddresses;
+    protected int dataMemberCount;
 
     public JoinMessage() {
     }
 
     public JoinMessage(byte packetVersion, int buildNumber, Address address,
                        String uuid, boolean liteMember, ConfigCheck configCheck) {
-        this(packetVersion, buildNumber, address, uuid, liteMember, configCheck, Collections.<Address>emptySet());
+        this(packetVersion, buildNumber, address, uuid, liteMember, configCheck, Collections.<Address>emptySet(), 0);
     }
 
-    public JoinMessage(byte packetVersion, int buildNumber, Address address,
-                       String uuid, boolean liteMember, ConfigCheck configCheck, Collection<Address> memberAddresses) {
+    public JoinMessage(byte packetVersion, int buildNumber, Address address, String uuid, boolean liteMember,
+                       ConfigCheck configCheck, Collection<Address> memberAddresses, int dataMemberCount) {
         this.packetVersion = packetVersion;
         this.buildNumber = buildNumber;
         this.address = address;
@@ -53,6 +54,7 @@ public class JoinMessage implements DataSerializable {
         this.liteMember = liteMember;
         this.configCheck = configCheck;
         this.memberAddresses = memberAddresses;
+        this.dataMemberCount = dataMemberCount;
     }
 
     public byte getPacketVersion() {
@@ -87,6 +89,10 @@ public class JoinMessage implements DataSerializable {
         return memberAddresses != null ? memberAddresses : Collections.<Address>emptySet();
     }
 
+    public int getDataMemberCount() {
+        return dataMemberCount;
+    }
+
     @Override
     public void readData(ObjectDataInput in) throws IOException {
         packetVersion = in.readByte();
@@ -105,6 +111,7 @@ public class JoinMessage implements DataSerializable {
             member.readData(in);
             memberAddresses.add(member);
         }
+        dataMemberCount = in.readInt();
     }
 
     @Override
@@ -123,6 +130,7 @@ public class JoinMessage implements DataSerializable {
                 member.writeData(out);
             }
         }
+        out.writeInt(dataMemberCount);
     }
 
     @Override
@@ -134,6 +142,7 @@ public class JoinMessage implements DataSerializable {
                 + ", uuid='" + uuid + '\''
                 + ", liteMember=" + liteMember
                 + ", memberCount=" + getMemberCount()
+                + ", dataMemberCount=" + dataMemberCount
                 + '}';
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/instance/Node.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/Node.java
@@ -27,6 +27,7 @@ import com.hazelcast.cluster.impl.JoinRequest;
 import com.hazelcast.cluster.impl.MulticastJoiner;
 import com.hazelcast.cluster.impl.MulticastService;
 import com.hazelcast.cluster.impl.TcpIpJoiner;
+import com.hazelcast.cluster.memberselector.MemberSelectors;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.DiscoveryConfig;
 import com.hazelcast.config.JoinConfig;
@@ -536,7 +537,8 @@ public class Node {
 
     public JoinMessage createSplitBrainJoinMessage() {
         return new JoinMessage(Packet.VERSION, buildInfo.getBuildNumber(), address, localMember.getUuid(),
-                localMember.isLiteMember(), createConfigCheck(), clusterService.getMemberAddresses());
+                localMember.isLiteMember(), createConfigCheck(), clusterService.getMemberAddresses(),
+                clusterService.getSize(MemberSelectors.DATA_MEMBER_SELECTOR));
     }
 
     public JoinRequest createJoinRequest(boolean withCredentials) {


### PR DESCRIPTION
If a sub-cluster has less number of data members with some additional lite members, it should join to the other sub-cluster with more data members.