### PR TITLE
Clear near-caches of caches while node is shutdown (in `SHUTTING_DOWN` state)

### DIFF
--- a/hazelcast-client-legacy/src/test/java/com/hazelcast/client/cache/nearcache/ClientNearCacheTest.java
+++ b/hazelcast-client-legacy/src/test/java/com/hazelcast/client/cache/nearcache/ClientNearCacheTest.java
@@ -68,6 +68,16 @@ public class ClientNearCacheTest extends ClientNearCacheTestSupport {
     }
 
     @Test
+    public void putToCacheAndGetInvalidationEventWhenNodeShutdownWithBinaryInMemoryFormat() {
+        putToCacheAndGetInvalidationEventWhenNodeShutdown(InMemoryFormat.BINARY);
+    }
+
+    @Test
+    public void putToCacheAndGetInvalidationEventWhenNodeShutdownWithObjectInMemoryFormat() {
+        putToCacheAndGetInvalidationEventWhenNodeShutdown(InMemoryFormat.OBJECT);
+    }
+
+    @Test
     public void putToCacheAndRemoveFromOtherNodeThenCantGetUpdatedFromClientNearCacheWithBinaryInMemoryFormat() {
         putToCacheAndRemoveFromOtherNodeThenCantGetUpdatedFromClientNearCache(InMemoryFormat.BINARY);
     }

--- a/hazelcast-client-legacy/src/test/java/com/hazelcast/client/cache/nearcache/ClientNearCacheTestSupport.java
+++ b/hazelcast-client-legacy/src/test/java/com/hazelcast/client/cache/nearcache/ClientNearCacheTestSupport.java
@@ -29,6 +29,9 @@ import com.hazelcast.config.Config;
 import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.config.NearCacheConfig;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.LifecycleEvent;
+import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.instance.LifecycleServiceImpl;
 import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.test.AssertTask;
@@ -37,6 +40,11 @@ import org.junit.After;
 import org.junit.Before;
 
 import javax.cache.spi.CachingProvider;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -57,9 +65,7 @@ public abstract class ClientNearCacheTestSupport extends HazelcastTestSupport {
 
     @After
     public void tearDown() {
-        if (serverInstance != null) {
-            serverInstance.shutdown();
-        }
+        hazelcastFactory.shutdownAll();
     }
 
     protected Config createConfig() {
@@ -88,23 +94,18 @@ public abstract class ClientNearCacheTestSupport extends HazelcastTestSupport {
         protected final SerializationService serializationService;
         protected final HazelcastClientCacheManager cacheManager;
         protected final NearCacheManager nearCacheManager;
-        protected final ICache<Integer, String> cache;
+        protected final ICache<Object, String> cache;
         protected final NearCache<Data, String> nearCache;
 
         NearCacheTestContext(HazelcastClientProxy client,
                              HazelcastClientCacheManager cacheManager, NearCacheManager nearCacheManager,
-                             ICache<Integer, String> cache, NearCache<Data, String> nearCache) {
+                             ICache<Object, String> cache, NearCache<Data, String> nearCache) {
             this.client = client;
             this.serializationService = client.getSerializationService();
             this.cacheManager = cacheManager;
             this.nearCacheManager = nearCacheManager;
             this.cache = cache;
             this.nearCache = nearCache;
-        }
-
-        void close() {
-            cache.destroy();
-            client.shutdown();
         }
 
     }
@@ -121,8 +122,8 @@ public abstract class ClientNearCacheTestSupport extends HazelcastTestSupport {
         CachingProvider provider = HazelcastClientCachingProvider.createCachingProvider(client);
         HazelcastClientCacheManager cacheManager = (HazelcastClientCacheManager) provider.getCacheManager();
 
-        CacheConfig<Integer, String> cacheConfig = createCacheConfig(nearCacheConfig.getInMemoryFormat());
-        ICache<Integer, String> cache = cacheManager.createCache(cacheName, cacheConfig);
+        CacheConfig<Object, String> cacheConfig = createCacheConfig(nearCacheConfig.getInMemoryFormat());
+        ICache<Object, String> cache = cacheManager.createCache(cacheName, cacheConfig);
 
         NearCache<Data, String> nearCache =
                 nearCacheManager.getNearCache(cacheManager.getCacheNameWithPrefix(cacheName));
@@ -169,8 +170,6 @@ public abstract class ClientNearCacheTestSupport extends HazelcastTestSupport {
             Data keyData = nearCacheTestContext.serializationService.toData(i);
             assertEquals(expectedValue, nearCacheTestContext.nearCache.get(keyData));
         }
-
-        nearCacheTestContext.close();
     }
 
     protected void putToCacheAndThenGetFromClientNearCacheInternal(InMemoryFormat inMemoryFormat, boolean putIfAbsent) {
@@ -184,8 +183,6 @@ public abstract class ClientNearCacheTestSupport extends HazelcastTestSupport {
             Data keyData = nearCacheTestContext.serializationService.toData(i);
             assertEquals(expectedValue, nearCacheTestContext.nearCache.get(keyData));
         }
-
-        nearCacheTestContext.close();
     }
 
     protected void putToCacheAndThenGetFromClientNearCache(InMemoryFormat inMemoryFormat) {
@@ -257,9 +254,73 @@ public abstract class ClientNearCacheTestSupport extends HazelcastTestSupport {
                 }
             });
         }
+    }
 
-        nearCacheTestContext1.close();
-        nearCacheTestContext2.close();
+    protected void putToCacheAndGetInvalidationEventWhenNodeShutdown(InMemoryFormat inMemoryFormat) {
+        Config config = createConfig();
+        config.setProperty(GroupProperties.PROP_CACHE_INVALIDATION_MESSAGE_BATCH_SIZE,
+                           String.valueOf(Integer.MAX_VALUE));
+        config.setProperty(GroupProperties.PROP_CACHE_INVALIDATION_MESSAGE_BATCH_FREQUENCY_SECONDS,
+                           String.valueOf(Integer.MAX_VALUE));
+        HazelcastInstance instanceToShutdown = hazelcastFactory.newHazelcastInstance(config);
+
+        warmUpPartitions(serverInstance, instanceToShutdown);
+        waitAllForSafeState(serverInstance, instanceToShutdown);
+
+        NearCacheConfig nearCacheConfig = createNearCacheConfig(inMemoryFormat);
+        nearCacheConfig.setInvalidateOnChange(true);
+        nearCacheConfig.setLocalUpdatePolicy(NearCacheConfig.LocalUpdatePolicy.CACHE);
+        final NearCacheTestContext nearCacheTestContext1 = createNearCacheTest(DEFAULT_CACHE_NAME, nearCacheConfig);
+        final NearCacheTestContext nearCacheTestContext2 = createNearCacheTest(DEFAULT_CACHE_NAME, nearCacheConfig);
+
+        Map<String, String> keyAndValues = new HashMap<String, String>();
+
+        // Put cache record from client-1 to instance which is going to be shutdown
+        for (int i = 0; i < DEFAULT_RECORD_COUNT; i++) {
+            final String key = generateKeyOwnedBy(instanceToShutdown);
+            final String value = generateValueFromKey(i);
+            nearCacheTestContext1.cache.put(key, value);
+            keyAndValues.put(key, value);
+        }
+
+        // Verify that records are exist at near-cache of client-1 because `local-update-policy` is `CACHE`
+        for (Map.Entry<String, String> entry : keyAndValues.entrySet()) {
+            final String key = entry.getKey();
+            final String exceptedValue = entry.getValue();
+            final String actualValue =
+                    nearCacheTestContext1.nearCache.get(
+                            nearCacheTestContext1.serializationService.toData(key));
+            assertEquals(exceptedValue, actualValue);
+        }
+
+        // Remove records through client-2 so there will be invalidation events
+        // to send to client to invalidate its near-cache
+        for (Map.Entry<String, String> entry : keyAndValues.entrySet()) {
+            nearCacheTestContext2.cache.remove(entry.getKey());
+        }
+
+        // We don't shutdown the instance because in case of shutdown
+        // even though events are published to event queue,
+        // they may not be processed in the event queue due to shutdown event queue executor
+        // or may not be sent to client endpoint due to IO handler shutdown.
+        // For not to making test fragile,
+        // we just simulate shutting down by sending its event through `LifeCycleService`,
+        // so the node should flush invalidation events before shutdown.
+        ((LifecycleServiceImpl) instanceToShutdown.getLifecycleService())
+                .fireLifecycleEvent(LifecycleEvent.LifecycleState.SHUTTING_DOWN);
+
+        // Verify that records in the near-cache of client-1
+        // are invalidated eventually when instance shutdown
+        for (Map.Entry<String, String> entry : keyAndValues.entrySet()) {
+            final String key = entry.getKey();
+            HazelcastTestSupport.assertTrueEventually(new AssertTask() {
+                @Override
+                public void run() throws Exception {
+                    assertNull(nearCacheTestContext1.nearCache.get(
+                                    nearCacheTestContext1.serializationService.toData(key)));
+                }
+            });
+        }
     }
 
     protected void putToCacheAndRemoveFromOtherNodeThenCantGetUpdatedFromClientNearCache(InMemoryFormat inMemoryFormat) {
@@ -307,9 +368,6 @@ public abstract class ClientNearCacheTestSupport extends HazelcastTestSupport {
                 }
             });
         }
-
-        nearCacheTestContext1.close();
-        nearCacheTestContext2.close();
     }
 
     protected void putToCacheAndClearOrDestroyThenCantGetAnyRecordFromClientNearCache(InMemoryFormat inMemoryFormat) {
@@ -354,9 +412,6 @@ public abstract class ClientNearCacheTestSupport extends HazelcastTestSupport {
                 }
             });
         }
-
-        nearCacheTestContext1.close();
-        nearCacheTestContext2.close();
     }
 
     protected void doTestGetAllReturnsFromNearCache() {
@@ -379,8 +434,6 @@ public abstract class ClientNearCacheTestSupport extends HazelcastTestSupport {
             //check if same reference to verify data coming from near cache
             assertTrue(nearCacheTestContext.cache.get(i) == nearCacheTestContext.nearCache.get(keyData));
         }
-
-        nearCacheTestContext.close();
     }
 
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientNearCacheTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientNearCacheTest.java
@@ -68,6 +68,16 @@ public class ClientNearCacheTest extends ClientNearCacheTestSupport {
     }
 
     @Test
+    public void putToCacheAndGetInvalidationEventWhenNodeShutdownWithBinaryInMemoryFormat() {
+        putToCacheAndGetInvalidationEventWhenNodeShutdown(InMemoryFormat.BINARY);
+    }
+
+    @Test
+    public void putToCacheAndGetInvalidationEventWhenNodeShutdownWithObjectInMemoryFormat() {
+        putToCacheAndGetInvalidationEventWhenNodeShutdown(InMemoryFormat.OBJECT);
+    }
+
+    @Test
     public void putToCacheAndRemoveFromOtherNodeThenCantGetUpdatedFromClientNearCacheWithBinaryInMemoryFormat() {
         putToCacheAndRemoveFromOtherNodeThenCantGetUpdatedFromClientNearCache(InMemoryFormat.BINARY);
     }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheRecordStore.java
@@ -100,12 +100,14 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
     protected final EvictionChecker evictionChecker;
     protected final EvictionStrategy<Data, R, CRM> evictionStrategy;
     protected final boolean wanReplicationEnabled;
+    protected final boolean isOwner;
 
     //CHECKSTYLE:OFF
     public AbstractCacheRecordStore(final String name, final int partitionId, final NodeEngine nodeEngine,
                                     final AbstractCacheService cacheService) {
         this.name = name;
         this.partitionId = partitionId;
+        this.isOwner = nodeEngine.getPartitionService().isPartitionOwner(partitionId);
         this.nodeEngine = nodeEngine;
         this.partitionService = nodeEngine.getPartitionService();
         this.partitionCount = partitionService.getPartitionCount();
@@ -219,7 +221,7 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
     }
 
     protected boolean isInvalidationEnabled() {
-        return cacheContext.getInvalidationListenerCount() > 0;
+        return isOwner && cacheContext.getInvalidationListenerCount() > 0;
     }
 
     @Override


### PR DESCRIPTION
At the moment, while `ICacheService` is shutdown, there might be remaining and non-flushed invalidation events for cache when batch invalidation mode is enabled (which is default).

With this PR, while node is shutting down (in `SHUTTING_DOWN` state), `ICacheService` registers and listens state changes through `LifecycleService` and send clear near-cache events for all caches when state is `SHUTTING_DOWN`. We send clear near-cache event instead of flushing remaning invalidation events since sending all remaining invalidation events are more expensive than just sending a single clear event.  

However, even though events are published, they may not be received by clients due to these reasons:
* Events may not be processed in the event queue due to shutdown event queue executor. This may be happend after events are offered to event queue, before  event queue executor polls and dispatches, the executor itself might be shutdown while `EventService` shutdown. 
* The events may be dispatched to local invalidation event listeners and write to client endpoint but they may not be processed and sent to client endpoint due to `ClientWriteHandler` shutdown.
* ...

With this PR, as mentioned above there is still no guarantee to deliver invalidation events to clients in case of shutdown but at least it tries :)

**P.S:** Maybe we can skip event system layer (just for this case) and directly send to all registered client end points but as mentioned above, still there is no guarantee.

Fixes #6778 