### PR TITLE
[BACKPORT] Fix Replicated Map TTL issue 

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/ReplicatedMapEvictionProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/ReplicatedMapEvictionProcessor.java
@@ -24,6 +24,8 @@ import com.hazelcast.util.scheduler.ScheduledEntry;
 import com.hazelcast.util.scheduler.ScheduledEntryProcessor;
 import java.util.Collection;
 
+import static com.hazelcast.replicatedmap.impl.ReplicatedMapService.SERVICE_NAME;
+
 /**
  * Actual eviction processor implementation to remove values to evict values from the replicated map
  */
@@ -42,6 +44,6 @@ public class ReplicatedMapEvictionProcessor implements ScheduledEntryProcessor<O
     public void process(EntryTaskScheduler<Object, Object> scheduler, Collection<ScheduledEntry<Object, Object>> entries) {
         EvictionOperation evictionOperation = new EvictionOperation(store, entries);
         evictionOperation.setPartitionId(partitionId);
-        nodeEngine.getOperationService().executeOperation(evictionOperation);
+        nodeEngine.getOperationService().invokeOnTarget(SERVICE_NAME, evictionOperation, nodeEngine.getThisAddress());
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/ReplicatedMapService.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/ReplicatedMapService.java
@@ -80,7 +80,7 @@ public class ReplicatedMapService implements ManagedService, RemoteService, Even
     public static final String SERVICE_NAME = "hz:impl:replicatedMapService";
     public static final int INVOCATION_TRY_COUNT = 3;
 
-    private static final int SYNC_INTERVAL_SECONDS = 10;
+    private static final int SYNC_INTERVAL_SECONDS = 30;
     private static final int MAX_CLEAR_EXECUTION_RETRY = 5;
 
     private final Config config;

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/EvictionOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/EvictionOperation.java
@@ -43,11 +43,6 @@ public class EvictionOperation extends AbstractOperation {
     }
 
     @Override
-    public boolean returnsResponse() {
-        return false;
-    }
-
-    @Override
     public boolean validatesTarget() {
         return false;
     }

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/SyncReplicatedMapDataOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/SyncReplicatedMapDataOperation.java
@@ -67,10 +67,10 @@ public class SyncReplicatedMapDataOperation<K, V> extends AbstractOperation {
             if (oldRecord != null) {
                 replicatedRecord.setHits(oldRecord.getHits());
             }
+            newStorage.putInternal(key, replicatedRecord);
             if (record.getTtl() > 0) {
                 store.scheduleTtlEntry(record.getTtl(), key, value);
             }
-            newStorage.putInternal(key, replicatedRecord);
         }
         newStorage.setVersion(version);
         AtomicReference<InternalReplicatedMapStorage<K, V>> storageRef = store.getStorageRef();

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/AbstractReplicatedRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/AbstractReplicatedRecordStore.java
@@ -274,6 +274,9 @@ public abstract class AbstractReplicatedRecordStore<K, V> extends AbstractBaseRe
         newRecord.setCreationTime(record.getCreationTime());
         newRecord.setLastAccessTime(record.getLastAccessTime());
         newRecord.setUpdateTime(record.getLastUpdateTime());
+        if (record.getTtl() > 0) {
+            scheduleTtlEntry(record.getTtl(), key, value);
+        }
         getStorage().putInternal(key, newRecord);
     }
 


### PR DESCRIPTION
schedule TTL eviction on records when they are migrated to new destination. Retry eviction operation when a failure happens due to migration. Increase sync interval since anti-entropy proces is happening too frequently

Fixes #6799
