### PR TITLE
[3.5.4] Check cache backup record due to possible cache record store destroy

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheGetAndReplaceOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheGetAndReplaceOperation.java
@@ -54,7 +54,11 @@ public class CacheGetAndReplaceOperation
 
     @Override
     public boolean shouldBackup() {
-        return response != null;
+        // Backup record may be null since record store might be cleared by destroy operation at the same time
+        // because destroy operation is not called from partition thread pool.
+        // In this case, we simply ignore backup operation
+        // because record store on backup will be cleared also by destroy operation.
+        return response != null && backupRecord != null;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CachePutBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CachePutBackupOperation.java
@@ -46,6 +46,9 @@ public class CachePutBackupOperation
 
     public CachePutBackupOperation(String name, Data key, CacheRecord cacheRecord) {
         super(name, key);
+        if (cacheRecord == null) {
+            throw new IllegalArgumentException("Cache record of backup operation cannot be null!");
+        }
         this.cacheRecord = cacheRecord;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CachePutIfAbsentOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CachePutIfAbsentOperation.java
@@ -57,7 +57,11 @@ public class CachePutIfAbsentOperation
 
     @Override
     public boolean shouldBackup() {
-        return Boolean.TRUE.equals(response);
+        // Backup record may be null since record store might be cleared by destroy operation at the same time
+        // because destroy operation is not called from partition thread pool.
+        // In this case, we simply ignore backup operation
+        // because record store on backup will be cleared also by destroy operation.
+        return Boolean.TRUE.equals(response) && backupRecord != null;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CachePutOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CachePutOperation.java
@@ -64,7 +64,11 @@ public class CachePutOperation
 
     @Override
     public boolean shouldBackup() {
-        return true;
+        // Backup record may be null since record store might be cleared by destroy operation at the same time
+        // because destroy operation is not called from partition thread pool.
+        // In this case, we simply ignore backup operation
+        // because record store on backup will be cleared also by destroy operation.
+        return backupRecord != null;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheReplaceOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheReplaceOperation.java
@@ -64,7 +64,11 @@ public class CacheReplaceOperation
 
     @Override
     public boolean shouldBackup() {
-        return Boolean.TRUE.equals(response);
+        // Backup record may be null since record store might be cleared by destroy operation at the same time
+        // because destroy operation is not called from partition thread pool.
+        // In this case, we simply ignore backup operation
+        // because record store on backup will be cleared also by destroy operation.
+        return Boolean.TRUE.equals(response) && backupRecord != null;
     }
 
     @Override


### PR DESCRIPTION
Backup record should be checked in `put`, `putIfAbsent`, `replace` and `getAndReplace` operations if it is null or not. Because it may be null due to destroying cache record store by `CacheDestroyOperation` outside of partition thread.

Should fix #6800 