### PR TITLE
[3.6-RC1] Check cache backup record due to possible cache record store destroy

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheGetAndReplaceOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheGetAndReplaceOperation.java
@@ -65,7 +65,11 @@ public class CacheGetAndReplaceOperation
 
     @Override
     public boolean shouldBackup() {
-        return response != null;
+        // Backup record may be null since record store might be cleared by destroy operation at the same time
+        // because destroy operation is not called from partition thread pool.
+        // In this case, we simply ignore backup operation
+        // because record store on backup will be cleared also by destroy operation.
+        return response != null && backupRecord != null;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CachePutBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CachePutBackupOperation.java
@@ -50,11 +50,17 @@ public class CachePutBackupOperation
 
     public CachePutBackupOperation(String name, Data key, CacheRecord cacheRecord) {
         super(name, key);
+        if (cacheRecord == null) {
+            throw new IllegalArgumentException("Cache record of backup operation cannot be null!");
+        }
         this.cacheRecord = cacheRecord;
     }
 
     public CachePutBackupOperation(String name, Data key, CacheRecord cacheRecord, boolean wanOriginated) {
         this(name, key, cacheRecord);
+        if (cacheRecord == null) {
+            throw new IllegalArgumentException("Cache record of backup operation cannot be null!");
+        }
         this.wanOriginated = wanOriginated;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CachePutIfAbsentOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CachePutIfAbsentOperation.java
@@ -69,7 +69,11 @@ public class CachePutIfAbsentOperation
 
     @Override
     public boolean shouldBackup() {
-        return Boolean.TRUE.equals(response);
+        // Backup record may be null since record store might be cleared by destroy operation at the same time
+        // because destroy operation is not called from partition thread pool.
+        // In this case, we simply ignore backup operation
+        // because record store on backup will be cleared also by destroy operation.
+        return Boolean.TRUE.equals(response) && backupRecord != null;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CachePutOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CachePutOperation.java
@@ -75,7 +75,11 @@ public class CachePutOperation
 
     @Override
     public boolean shouldBackup() {
-        return true;
+        // Backup record may be null since record store might be cleared by destroy operation at the same time
+        // because destroy operation is not called from partition thread pool.
+        // In this case, we simply ignore backup operation
+        // because record store on backup will be cleared also by destroy operation.
+        return backupRecord != null;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheReplaceOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheReplaceOperation.java
@@ -76,7 +76,11 @@ public class CacheReplaceOperation
 
     @Override
     public boolean shouldBackup() {
-        return Boolean.TRUE.equals(response);
+        // Backup record may be null since record store might be cleared by destroy operation at the same time
+        // because destroy operation is not called from partition thread pool.
+        // In this case, we simply ignore backup operation
+        // because record store on backup will be cleared also by destroy operation.
+        return Boolean.TRUE.equals(response) && backupRecord != null;
     }
 
     @Override


### PR DESCRIPTION
Backup record should be checked in `put`, `putIfAbsent`, `replace` and `getAndReplace` operations if it is null or not. Because it may be null due to destroying cache record store by `CacheDestroyOperation` outside of partition thread.

Should fix #6800 