### PR TITLE
[Backport] Reconnecting to instance on same address should preserve member list correctly

### DIFF
--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/spi/impl/ClientMembershipListener.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/spi/impl/ClientMembershipListener.java
@@ -204,12 +204,16 @@ class ClientMembershipListener extends ClientMembershipListenerCodec.AbstractEve
     private List<MembershipEvent> detectMembershipEvents(Map<String, Member> prevMembers) {
         final List<MembershipEvent> events = new LinkedList<MembershipEvent>();
         final Set<Member> eventMembers = Collections.unmodifiableSet(new LinkedHashSet<Member>(members));
+
+        final List<Member> newMembers = new LinkedList<Member>();
         for (Member member : members) {
             final Member former = prevMembers.remove(member.getUuid());
             if (former == null) {
-                events.add(new MembershipEvent(client.getCluster(), member, MembershipEvent.MEMBER_ADDED, eventMembers));
+                newMembers.add(member);
             }
         }
+
+        // removal events should be added before added events
         for (Member member : prevMembers.values()) {
             events.add(new MembershipEvent(client.getCluster(), member, MembershipEvent.MEMBER_REMOVED, eventMembers));
             Address address = ((AbstractMember) member).getAddress();
@@ -220,6 +224,10 @@ class ClientMembershipListener extends ClientMembershipListenerCodec.AbstractEve
                 }
             }
         }
+        for (Member member : newMembers) {
+            events.add(new MembershipEvent(client.getCluster(), member, MembershipEvent.MEMBER_ADDED, eventMembers));
+        }
+
         return events;
     }
 

--- a/hazelcast-client-new/src/test/java/com/hazelcast/client/ClientReconnectTest.java
+++ b/hazelcast-client-new/src/test/java/com/hazelcast/client/ClientReconnectTest.java
@@ -22,6 +22,12 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.core.LifecycleEvent;
 import com.hazelcast.core.LifecycleListener;
+import com.hazelcast.core.Member;
+import com.hazelcast.core.MembershipAdapter;
+import com.hazelcast.core.MembershipEvent;
+import com.hazelcast.instance.MemberImpl;
+import com.hazelcast.nio.Address;
+import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.QuickTest;
@@ -30,6 +36,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import java.util.Iterator;
 import java.util.concurrent.CountDownLatch;
 
 import static org.junit.Assert.assertEquals;
@@ -66,6 +73,36 @@ public class ClientReconnectTest extends HazelcastTestSupport {
         assertOpenEventually(connectedLatch, 10);
         assertNull(m.put("test", "test"));
         assertEquals("test", m.get("test"));
+    }
+
+    @Test
+    public void testReconnectToNewInstanceAtSameAddress() throws InterruptedException {
+        HazelcastInstance instance = hazelcastFactory.newHazelcastInstance();
+        Address localAddress = ((MemberImpl)instance.getCluster().getLocalMember()).getAddress();
+        final HazelcastInstance client = hazelcastFactory.newHazelcastClient();
+
+        final CountDownLatch memberRemovedLatch = new CountDownLatch(1);
+        client.getCluster().addMembershipListener(new MembershipAdapter() {
+            @Override
+            public void memberRemoved(MembershipEvent membershipEvent) {
+                memberRemovedLatch.countDown();
+            }
+        });
+
+        instance.shutdown();
+        final HazelcastInstance instance2 = hazelcastFactory.newHazelcastInstance(localAddress);
+
+        assertOpenEventually(memberRemovedLatch);
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertEquals(1, client.getCluster().getMembers().size());
+                Iterator<Member> iterator = client.getCluster().getMembers().iterator();
+                Member member = iterator.next();
+                assertEquals(instance2.getCluster().getLocalMember(), member);
+            }
+        });
     }
 
 }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientMembershipListener.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientMembershipListener.java
@@ -190,12 +190,16 @@ class ClientMembershipListener implements EventHandler<ClientInitialMembershipEv
     private List<MembershipEvent> detectMembershipEvents(Map<String, Member> prevMembers) {
         final List<MembershipEvent> events = new LinkedList<MembershipEvent>();
         final Set<Member> eventMembers = Collections.unmodifiableSet(new LinkedHashSet<Member>(members));
+
+        final List<Member> newMembers = new LinkedList<Member>();
         for (Member member : members) {
             final Member former = prevMembers.remove(member.getUuid());
             if (former == null) {
-                events.add(new MembershipEvent(client.getCluster(), member, MembershipEvent.MEMBER_ADDED, eventMembers));
+                newMembers.add(member);
             }
         }
+
+        // removal events should be added before added events
         for (Member member : prevMembers.values()) {
             events.add(new MembershipEvent(client.getCluster(), member, MembershipEvent.MEMBER_REMOVED, eventMembers));
             Address address = ((AbstractMember) member).getAddress();
@@ -206,6 +210,10 @@ class ClientMembershipListener implements EventHandler<ClientInitialMembershipEv
                 }
             }
         }
+        for (Member member : newMembers) {
+            events.add(new MembershipEvent(client.getCluster(), member, MembershipEvent.MEMBER_ADDED, eventMembers));
+        }
+
         return events;
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/map/IssuesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/IssuesTest.java
@@ -56,7 +56,7 @@ public class IssuesTest extends HazelcastTestSupport {
         int n = 1;
         TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(n);
 
-        final IMap<Integer, Integer> imap = factory.newHazelcastInstance(null).getMap("testIssue321_1");
+        final IMap<Integer, Integer> imap = factory.newHazelcastInstance((Config)null).getMap("testIssue321_1");
         final BlockingQueue<com.hazelcast.core.EntryEvent<Integer, Integer>> events1 = new LinkedBlockingQueue<com.hazelcast.core.EntryEvent<Integer, Integer>>();
         final BlockingQueue<com.hazelcast.core.EntryEvent<Integer, Integer>> events2 = new LinkedBlockingQueue<com.hazelcast.core.EntryEvent<Integer, Integer>>();
         imap.addEntryListener(new EntryAdapter<Integer, Integer>() {
@@ -85,7 +85,7 @@ public class IssuesTest extends HazelcastTestSupport {
         int n = 1;
         TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(n);
 
-        final IMap<Integer, Integer> imap = factory.newHazelcastInstance(null).getMap("testIssue321_2");
+        final IMap<Integer, Integer> imap = factory.newHazelcastInstance((Config)null).getMap("testIssue321_2");
         final BlockingQueue<com.hazelcast.core.EntryEvent<Integer, Integer>> events1 = new LinkedBlockingQueue<com.hazelcast.core.EntryEvent<Integer, Integer>>();
         final BlockingQueue<com.hazelcast.core.EntryEvent<Integer, Integer>> events2 = new LinkedBlockingQueue<com.hazelcast.core.EntryEvent<Integer, Integer>>();
         imap.addEntryListener(new EntryAdapter<Integer, Integer>() {
@@ -115,7 +115,7 @@ public class IssuesTest extends HazelcastTestSupport {
         int n = 1;
         TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(n);
 
-        final IMap<Integer, Integer> imap = factory.newHazelcastInstance(null).getMap("testIssue321_3");
+        final IMap<Integer, Integer> imap = factory.newHazelcastInstance((Config)null).getMap("testIssue321_3");
         final BlockingQueue<com.hazelcast.core.EntryEvent<Integer, Integer>> events = new LinkedBlockingQueue<com.hazelcast.core.EntryEvent<Integer, Integer>>();
         final EntryAdapter<Integer, Integer> listener = new EntryAdapter<Integer, Integer>() {
             @Override
@@ -139,7 +139,7 @@ public class IssuesTest extends HazelcastTestSupport {
     public void testIssue304() {
         int n = 1;
         TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(n);
-        IMap<String, String> map = factory.newHazelcastInstance(null).getMap("testIssue304");
+        IMap<String, String> map = factory.newHazelcastInstance((Config)null).getMap("testIssue304");
         map.lock("1");
         assertEquals(0, map.size());
         assertEquals(0, map.entrySet().size());

--- a/hazelcast/src/test/java/com/hazelcast/test/TestHazelcastInstanceFactory.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/TestHazelcastInstanceFactory.java
@@ -81,6 +81,29 @@ public class TestHazelcastInstanceFactory {
         return HazelcastInstanceFactory.newHazelcastInstance(config);
     }
 
+    /**
+     * Creates a new test Hazelcast instance.
+     * @param address the address to use as Member's address instead of picking the next address
+     */
+    public HazelcastInstance newHazelcastInstance(Address address) {
+        return newHazelcastInstance(address, null);
+    }
+
+    /**
+     * Creates a new test Hazelcast instance.
+     * @param address the address to use as Member's address instead of picking the next address
+     * @param config the config to use; use <code>null</code> to get the default config.
+     */
+    public HazelcastInstance newHazelcastInstance(Address address, Config config) {
+        final String instanceName = config != null? config.getInstanceName() : null;
+        if (mockNetwork) {
+            init(config);
+            NodeContext nodeContext = registry.createNodeContext(address);
+            return HazelcastInstanceFactory.newHazelcastInstance(config, instanceName, nodeContext);
+        }
+        throw new UnsupportedOperationException("Explicit address is only available for mock network setup!");
+    }
+
     private Address pickAddress() {
         int id = nodeIndex.getAndIncrement();
         if (addresses.size() > id) {


### PR DESCRIPTION
When the client reconnects to the cluster and receives the initial member list, it will rebuild a list of events according to the changes. The ordering of these events should be removals first and then the new members.