### PR TITLE
Fixes for open-addresesed hashtables

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/util/collection/Hashing.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/collection/Hashing.java
@@ -24,14 +24,19 @@ public final class Hashing {
     private Hashing() { }
 
     public static int intHash(final int value, final int mask) {
-        final int hash = (value << 1) - (value << 8);
+        final int hash = value ^ (value >>> 16);
         return hash & mask;
     }
 
     public static int longHash(final long value, final int mask) {
         int hash = (int) value ^ (int) (value >>> 32);
-        hash = (hash << 1) - (hash << 8);
+        hash ^= (hash >>> 16);
         return hash & mask;
     }
 
+    public static int evenLongHash(final long value, final int mask) {
+        int hash = (int) value ^ (int) (value >>> 32);
+        hash = (hash << 1) - (hash << 8);
+        return hash & mask;
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/util/collection/InflatableSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/collection/InflatableSet.java
@@ -33,20 +33,20 @@ import java.util.Set;
  *
  * It requires creation via {@link com.hazelcast.util.collection.InflatableSet.Builder}
  *
- * The builder doesn't not call equals/hash methods on initial data insertion hence it avoids
+ * The builder doesn't call equals/hash methods on initial data insertion, hence it avoids
  * performance penalty in the case these methods are expensive. It also means it does
- * not detect duplicates - it's a responsibility of a caller to make sure no duplicated
+ * not detect duplicates - it's the responsibility of the caller to make sure no duplicated
  * entries are inserted.
  *
- * Once InflatableSet is constructed via {@link Builder#build()} then it act as regular set. It has
- * been designed to mimic {@link HashSet}. On new entry insertion or look-up via
+ * Once InflatableSet is constructed via {@link Builder#build()} then it acts as a regular set. It has
+ * been designed to mimic {@link HashSet}. On new entry insertion or lookup via
  * {@link #contains(Object)} it inflates itself: The backing list is copied into
- * internal {@link HashSet}. This obviously costs time and space. We are make a bet the
+ * internal {@link HashSet}. This obviously costs time and space. We are making a bet the
  * Set won't be modified in most cases.
  *
- * It's intended to be use in cases where a contract mandates us to return Set,
- * but we know our data contains not duplicates. It performs the best in cases
- * biased towards sequential iterations.
+ * It's intended to be used in cases where the contract mandates us to return Set,
+ * but we know our data does not contain duplicates. It performs best in cases
+ * biased towards sequential iteration.
  *
  * @param <T> the type of elements maintained by this set
  */

--- a/hazelcast/src/main/java/com/hazelcast/util/collection/Int2ObjectHashMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/collection/Int2ObjectHashMap.java
@@ -32,6 +32,7 @@ import java.util.NoSuchElementException;
 import java.util.Set;
 
 import static com.hazelcast.util.Preconditions.checkNotNull;
+import static com.hazelcast.util.collection.Hashing.intHash;
 
 /**
  * {@link java.util.Map} implementation specialised for int keys using open addressing and
@@ -132,7 +133,7 @@ public class Int2ObjectHashMap<V> implements Map<Integer, V> {
      * @return true if the key is found otherwise false.
      */
     public boolean containsKey(final int key) {
-        int index = hash(key);
+        int index = intHash(key, mask);
 
         while (null != values[index]) {
             if (key == keys[index]) {
@@ -175,7 +176,7 @@ public class Int2ObjectHashMap<V> implements Map<Integer, V> {
      */
     @SuppressWarnings("unchecked")
     public V get(final int key) {
-        int index = hash(key);
+        int index = intHash(key, mask);
 
         Object value;
         while (null != (value = values[index])) {
@@ -229,7 +230,7 @@ public class Int2ObjectHashMap<V> implements Map<Integer, V> {
     public V put(final int key, final V value) {
         checkNotNull(value, "Value cannot be null");
         V oldValue = null;
-        int index = hash(key);
+        int index = intHash(key, mask);
         while (null != values[index]) {
             if (key == keys[index]) {
                 oldValue = (V) values[index];
@@ -263,7 +264,7 @@ public class Int2ObjectHashMap<V> implements Map<Integer, V> {
      */
     @SuppressWarnings("unchecked")
     public V remove(final int key) {
-        int index = hash(key);
+        int index = intHash(key, mask);
         Object value;
         while (null != (value = values[index])) {
             if (key == keys[index]) {
@@ -377,7 +378,7 @@ public class Int2ObjectHashMap<V> implements Map<Integer, V> {
             final Object value = values[i];
             if (null != value) {
                 final int key = keys[i];
-                int newHash = hash(key);
+                int newHash = intHash(key, mask);
                 while (null != tempValues[newHash]) {
                     newHash = ++newHash & mask;
                 }
@@ -396,7 +397,7 @@ public class Int2ObjectHashMap<V> implements Map<Integer, V> {
             if (null == values[index]) {
                 return;
             }
-            final int hash = hash(keys[index]);
+            final int hash = intHash(keys[index], mask);
             if ((index < hash && (hash <= deleteIndex || deleteIndex <= index))
                     || (hash <= deleteIndex && deleteIndex <= index)) {
                 keys[deleteIndex] = keys[index];
@@ -405,11 +406,6 @@ public class Int2ObjectHashMap<V> implements Map<Integer, V> {
                 deleteIndex = index;
             }
         }
-    }
-
-    private int hash(final int key) {
-        final int hash = (key << 1) - (key << 8);
-        return hash & mask;
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////////

--- a/hazelcast/src/main/java/com/hazelcast/util/collection/Long2LongHashMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/collection/Long2LongHashMap.java
@@ -31,6 +31,8 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
 
+import static com.hazelcast.util.collection.Hashing.evenLongHash;
+
 /**
  * A Probing hashmap specialised for long key and value pairs.
  */
@@ -93,7 +95,7 @@ public class Long2LongHashMap implements Map<Long, Long> {
 
     public long get(final long key) {
         final long[] entries = this.entries;
-        int index = hash(key);
+        int index = evenLongHash(key, mask);
         long candidateKey;
         while ((candidateKey = entries[index]) != missingValue) {
             if (candidateKey == key) {
@@ -106,7 +108,7 @@ public class Long2LongHashMap implements Map<Long, Long> {
 
     public long put(final long key, final long value) {
         long oldValue = missingValue;
-        int index = hash(key);
+        int index = evenLongHash(key, mask);
         long candidateKey;
         while ((candidateKey = entries[index]) != missingValue) {
             if (candidateKey == key) {
@@ -143,12 +145,6 @@ public class Long2LongHashMap implements Map<Long, Long> {
                 put(key, oldEntries[i + 1]);
             }
         }
-    }
-
-    private int hash(final long key) {
-        int hash = (int) key ^ (int) (key >>> 32);
-        hash = (hash << 1) - (hash << 8);
-        return hash & mask;
     }
 
     /**
@@ -310,7 +306,7 @@ public class Long2LongHashMap implements Map<Long, Long> {
 
     public long remove(final long key) {
         final long[] entries = this.entries;
-        int index = hash(key);
+        int index = evenLongHash(key, mask);
         long candidateKey;
         while ((candidateKey = entries[index]) != missingValue) {
             if (candidateKey == key) {
@@ -348,7 +344,7 @@ public class Long2LongHashMap implements Map<Long, Long> {
             if (entries[index] == missingValue) {
                 return;
             }
-            final int hash = hash(entries[index]);
+            final int hash = evenLongHash(entries[index], mask);
             if ((index < hash && (hash <= deleteIndex || deleteIndex <= index))
                     || (hash <= deleteIndex && deleteIndex <= index)) {
                 entries[deleteIndex] = entries[index];

--- a/hazelcast/src/test/java/com/hazelcast/util/collection/BiInt2ObjectMapTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/collection/BiInt2ObjectMapTest.java
@@ -17,6 +17,8 @@
 
 package com.hazelcast.util.collection;
 
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.util.collection.BiInt2ObjectMap.EntryConsumer;
 import com.hazelcast.util.function.Consumer;
 import com.hazelcast.test.HazelcastSerialClassRunner;
@@ -36,8 +38,8 @@ import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 
-@RunWith(HazelcastSerialClassRunner.class)
-@Category(QuickTest.class)
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class BiInt2ObjectMapTest {
     private final BiInt2ObjectMap<String> map = new BiInt2ObjectMap<String>();
 

--- a/hazelcast/src/test/java/com/hazelcast/util/collection/Int2ObjectHashMapTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/collection/Int2ObjectHashMapTest.java
@@ -17,7 +17,9 @@
 
 package com.hazelcast.util.collection;
 
+import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Assert;
 import org.junit.Test;
@@ -37,8 +39,8 @@ import static org.hamcrest.number.OrderingComparison.lessThan;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
-@RunWith(HazelcastSerialClassRunner.class)
-@Category(QuickTest.class)
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class Int2ObjectHashMapTest {
     private final Int2ObjectHashMap<String> intToObjectMap = new Int2ObjectHashMap<String>();
 
@@ -286,7 +288,7 @@ public class Int2ObjectHashMapTest {
             intToObjectMap.put(testEntry, String.valueOf(testEntry));
         }
 
-        final String mapAsAString = "{7=7, 12=12, 19=19, 3=3, 11=11, 1=1}";
+        final String mapAsAString = "{12=12, 11=11, 7=7, 19=19, 3=3, 1=1}";
         assertThat(intToObjectMap.toString(), equalTo(mapAsAString));
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/util/collection/IntHashSetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/collection/IntHashSetTest.java
@@ -17,7 +17,9 @@
 
 package com.hazelcast.util.collection;
 
+import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Rule;
 import org.junit.Test;
@@ -28,6 +30,7 @@ import org.junit.runner.RunWith;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.Random;
 import java.util.Set;
 
 import static org.hamcrest.Matchers.contains;
@@ -38,12 +41,12 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
-@RunWith(HazelcastSerialClassRunner.class)
-@Category(QuickTest.class)
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class IntHashSetTest {
     @Rule public final ExpectedException rule = ExpectedException.none();
 
-    private final IntHashSet set = new IntHashSet(100, -1);
+    private final IntHashSet set = new IntHashSet(1000, -1);
 
     @Test public void initiallyContainsNoElements() throws Exception {
         for (int i = 0; i < 10000; i++) {
@@ -82,11 +85,20 @@ public class IntHashSetTest {
     }
 
     @Test public void removingAPresentElementRemovesIt() {
-        assertTrue(set.add(1));
-
-        assertTrue(set.remove(1));
-
-        assertFalse(set.contains(1));
+        final Set<Integer> jdkSet = new HashSet<Integer>();
+        final Random rnd = new Random();
+        for (int i = 0; i < 1000; i++) {
+            final int value = rnd.nextInt();
+            set.add(value);
+            jdkSet.add(value);
+        }
+        assertEquals(jdkSet, set);
+        for (Iterator<Integer> iter = jdkSet.iterator(); iter.hasNext();) {
+            final int value = iter.next();
+            assertTrue("Set suddenly doesn't contain " + value, set.contains(value));
+            assertTrue("Didn't remove " + value, set.remove(value));
+            iter.remove();
+        }
     }
 
     @Test public void sizeIsInitiallyZero() {
@@ -158,7 +170,7 @@ public class IntHashSetTest {
         set.add(1);
         set.add(2);
 
-        final IntHashSet other = new IntHashSet(100, -1);
+        final IntHashSet other = new IntHashSet(1000, -1);
         other.copy(set);
 
         assertThat(other, contains(1, 2));

--- a/hazelcast/src/test/java/com/hazelcast/util/collection/Long2LongHashMapTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/collection/Long2LongHashMapTest.java
@@ -17,7 +17,9 @@
 
 package com.hazelcast.util.collection;
 
+import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.util.collection.Long2LongHashMap.LongLongCursor;
 import com.hazelcast.util.function.LongLongConsumer;
@@ -42,8 +44,8 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 
-@RunWith(HazelcastSerialClassRunner.class)
-@Category(QuickTest.class)
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class Long2LongHashMapTest {
     public static final long MISSING_VALUE = -1L;
 

--- a/hazelcast/src/test/java/com/hazelcast/util/collection/Long2ObjectHashMapTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/collection/Long2ObjectHashMapTest.java
@@ -18,7 +18,9 @@
 package com.hazelcast.util.collection;
 
 
+import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Assert;
 import org.junit.Test;
@@ -38,8 +40,8 @@ import static org.hamcrest.number.OrderingComparison.lessThan;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
-@RunWith(HazelcastSerialClassRunner.class)
-@Category(QuickTest.class)
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class Long2ObjectHashMapTest {
     private final Long2ObjectHashMap<String> longToObjectMap = new Long2ObjectHashMap<String>();
 
@@ -280,7 +282,7 @@ public class Long2ObjectHashMapTest {
             longToObjectMap.put(testEntry, String.valueOf(testEntry));
         }
 
-        final String mapAsAString = "{7=7, 12=12, 19=19, 3=3, 11=11, 1=1}";
+        final String mapAsAString = "{12=12, 11=11, 7=7, 19=19, 3=3, 1=1}";
         assertThat(longToObjectMap.toString(), equalTo(mapAsAString));
     }
 


### PR DESCRIPTION
1. Int/LongHashSet.compactChain was broken.
2. Hash function producing strictly even hashcodes was overused. It only makes sense in structures which store key/value pairs inline in a single array (we only have Long2LongHashSet with that property).
3. Minor cleanup of InflatableSet javadoc.