### PR TITLE
Remove unused constructors in lite-member related exceptions

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/partition/NoDataMemberInClusterException.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/NoDataMemberInClusterException.java
@@ -23,9 +23,6 @@ import com.hazelcast.core.HazelcastException;
  */
 public class NoDataMemberInClusterException
         extends HazelcastException {
-    public NoDataMemberInClusterException() {
-        super();
-    }
 
     public NoDataMemberInClusterException(String message) {
         super(message);

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/ReplicatedMapCantBeCreatedOnLiteMemberException.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/ReplicatedMapCantBeCreatedOnLiteMemberException.java
@@ -25,9 +25,6 @@ import com.hazelcast.nio.Address;
 public class ReplicatedMapCantBeCreatedOnLiteMemberException
         extends HazelcastException {
 
-    public ReplicatedMapCantBeCreatedOnLiteMemberException() {
-    }
-
     public ReplicatedMapCantBeCreatedOnLiteMemberException(Address address) {
         this("Can't create replicated map instance on " + address);
     }


### PR DESCRIPTION
This is a very trivial change but I am sending it as a PR to make sure that it doesn't break anything.