### PR TITLE
Introduces CacheDeserializedValues into MapConfig

### DIFF
--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastConfigBeanDefinitionParser.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastConfigBeanDefinitionParser.java
@@ -75,6 +75,7 @@ import com.hazelcast.config.SetConfig;
 import com.hazelcast.config.SymmetricEncryptionConfig;
 import com.hazelcast.config.TcpIpConfig;
 import com.hazelcast.config.TopicConfig;
+import com.hazelcast.config.CacheDeserializedValues;
 import com.hazelcast.config.WanReplicationConfig;
 import com.hazelcast.config.WanReplicationRef;
 import com.hazelcast.config.WanTargetClusterConfig;
@@ -596,6 +597,13 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
                         .addPropertyValue(xmlToJavaName(cleanNodeName(maxSizePolicyNode))
                                 , MaxSizeConfig.MaxSizePolicy.valueOf(getTextContent(maxSizePolicyNode)));
             }
+            final Node cacheDeserializedValueNode = node.getAttributes().getNamedItem("cache-deserialized-values");
+            if (cacheDeserializedValueNode != null) {
+                String cacheDeserializedValueContent = getTextContent(cacheDeserializedValueNode);
+                CacheDeserializedValues value = CacheDeserializedValues.parseString(cacheDeserializedValueContent);
+                mapConfigBuilder.addPropertyValue("cacheDeserializedValues", value);
+            }
+
             for (Node childNode : childElements(node)) {
                 final String nodeName = cleanNodeName(childNode);
                 if ("map-store".equals(nodeName)) {

--- a/hazelcast-spring/src/main/resources/hazelcast-spring-3.6.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-3.6.xsd
@@ -275,13 +275,30 @@
                                         </xs:documentation>
                                     </xs:annotation>
                                 </xs:attribute>
-                                <xs:attribute name="optimize-queries" use="optional" type="parameterized-boolean"
-                                              default="false">
+                                <xs:attribute name="optimize-queries" use="optional" type="parameterized-boolean">
                                     <xs:annotation>
                                         <xs:documentation>
+                                            This parameter is deprecated as of Hazelcast 3.6
+                                            Use cache-deserialized-values attribute instead.
+
+                                            When both optimize-query and cache-deserialized-values are used at the same time
+                                            Hazelcast will do its best to detect possible conflicts. Conflict detection
+                                            is done on best-effort basis and you should not rely on it. 
+
                                             This parameter is used to increase the speed of query processes in the map.
                                             It only works when `in-memory-format` is set as `BINARY` and performs
                                             a pre-caching on the entries queried.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:attribute name="cache-deserialized-values" use="optional" type="cache-deserialized">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            Control caching of de-serialized values. Caching makes query evaluation faster, but it cost memory.
+                                            Possible Values:
+                                            NEVER: Never cache de-serialized object
+                                            INDEX-ONLY: Cache values only when they are inserted into an index.
+                                            ALWAYS: Always cache de-serialized values.
                                         </xs:documentation>
                                     </xs:annotation>
                                 </xs:attribute>
@@ -1487,6 +1504,14 @@
 
     <xs:simpleType name="interface">
         <xs:restriction base="xs:string"/>
+    </xs:simpleType>
+
+    <xs:simpleType name="cache-deserialized">
+        <xs:restriction base="non-space-string">
+            <xs:enumeration value="NEVER"/>
+            <xs:enumeration value="ALWAYS"/>
+            <xs:enumeration value="INDEX-ONLY"/>
+        </xs:restriction>
     </xs:simpleType>
 
     <xs:simpleType name="member">

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
@@ -54,6 +54,7 @@ import com.hazelcast.config.ServiceConfig;
 import com.hazelcast.config.SocketInterceptorConfig;
 import com.hazelcast.config.TcpIpConfig;
 import com.hazelcast.config.TopicConfig;
+import com.hazelcast.config.CacheDeserializedValues;
 import com.hazelcast.config.WanAcknowledgeType;
 import com.hazelcast.config.WanReplicationConfig;
 import com.hazelcast.config.WanReplicationRef;
@@ -228,7 +229,7 @@ public class TestFullApplicationContext {
     @Test
     public void testMapConfig() {
         assertNotNull(config);
-        assertEquals(12, config.getMapConfigs().size());
+        assertEquals(14, config.getMapConfigs().size());
 
         MapConfig testMapConfig = config.getMapConfig("testMap");
         assertNotNull(testMapConfig);
@@ -333,13 +334,19 @@ public class TestFullApplicationContext {
         assertEquals(dummyMapStoreFactory, testMapConfig4.getMapStoreConfig().getFactoryImplementation());
 
         MapConfig mapWithOptimizedQueriesConfig = config.getMapConfig("mapWithOptimizedQueries");
-        assertTrue(mapWithOptimizedQueriesConfig.isOptimizeQueries());
+        assertEquals(CacheDeserializedValues.ALWAYS, mapWithOptimizedQueriesConfig.getCacheDeserializedValues());
+
+        MapConfig mapWithValueCachingSetToNever = config.getMapConfig("mapWithValueCachingSetToNever");
+        assertEquals(CacheDeserializedValues.NEVER, mapWithValueCachingSetToNever.getCacheDeserializedValues());
+
+        MapConfig mapWithValueCachingSetToAlways = config.getMapConfig("mapWithValueCachingSetToAlways");
+        assertEquals(CacheDeserializedValues.ALWAYS, mapWithValueCachingSetToAlways.getCacheDeserializedValues());
 
         MapConfig mapWithNotOptimizedQueriesConfig = config.getMapConfig("mapWithNotOptimizedQueries");
-        assertFalse(mapWithNotOptimizedQueriesConfig.isOptimizeQueries());
+        assertEquals(CacheDeserializedValues.INDEX_ONLY, mapWithNotOptimizedQueriesConfig.getCacheDeserializedValues());
 
         MapConfig mapWithDefaultOptimizedQueriesConfig = config.getMapConfig("mapWithDefaultOptimizedQueries");
-        assertFalse(mapWithDefaultOptimizedQueriesConfig.isOptimizeQueries());
+        assertEquals(CacheDeserializedValues.INDEX_ONLY, mapWithDefaultOptimizedQueriesConfig.getCacheDeserializedValues());
 
         MapConfig testMapWithPartitionLostListenerConfig = config.getMapConfig("mapWithPartitionLostListener");
         List<MapPartitionLostListenerConfig> partitionLostListenerConfigs = testMapWithPartitionLostListenerConfig.getPartitionLostListenerConfigs();

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullcacheconfig-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullcacheconfig-applicationContext-hazelcast.xml
@@ -232,6 +232,8 @@
 
             <hz:map name="mapWithOptimizedQueries" optimize-queries="true"/>
             <hz:map name="mapWithNotOptimizedQueries" optimize-queries="false"/>
+            <hz:map name="mapWithValueCachingSetToNever" cache-deserialized-values="NEVER"/>
+            <hz:map name="mapWithValueCachingSetToAlways" cache-deserialized-values="ALWAYS"/>
             <hz:map name="mapWithDefaultOptimizedQueries"/>
             <hz:map name="map-with-native-max-size-policy" max-size-policy="USED_NATIVE_MEMORY_PERCENTAGE" in-memory-format="NATIVE"/>
 

--- a/hazelcast/src/main/java/com/hazelcast/config/CacheDeserializedValues.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CacheDeserializedValues.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+import com.hazelcast.util.StringUtil;
+
+import java.util.Arrays;
+
+/**
+ *
+ * Control caching of de-serialized values. Caching makes query evaluation faster but it cost memory.
+ *
+ * To maintain reusability cached values are used by read-only operations only and they are never
+ * passed to user-code where they could be accidentally mutated. Users will always get a fresh object,
+ * which they are free to mutate.
+ *
+ * It does not have any effect when {@link com.hazelcast.nio.serialization.Portable} serialization or
+ * {@link InMemoryFormat#OBJECT} format is used.
+ *
+ * @since 3.6
+ */
+public enum CacheDeserializedValues {
+
+    /**
+     * Never cache de-serialized value
+     *
+     */
+    NEVER,
+
+    /**
+     * Cache values only when using search indexes.
+     *
+     */
+    INDEX_ONLY,
+
+    /**
+     * Always cache de-serialized values
+     *
+     */
+    ALWAYS;
+
+    /**
+     * Create instance from String
+     *
+     * @param string
+     * @return instance of {@link CacheDeserializedValues}
+     * @throws IllegalArgumentException when unknown value is passed
+     */
+    public static CacheDeserializedValues parseString(String string) {
+        String upperCase = StringUtil.upperCaseInternal(string);
+        if ("NEVER".equals(upperCase)) {
+            return NEVER;
+        } else if ("INDEX_ONLY".equals(upperCase) || "INDEX-ONLY".equals(upperCase)) {
+            return INDEX_ONLY;
+        } else if ("ALWAYS".equals(upperCase)) {
+            return ALWAYS;
+        } else {
+            throw new IllegalArgumentException("Unknown CacheDeserializedValues option '" + string + ". "
+                    + "Possible options: " + Arrays.toString(CacheDeserializedValues.values()) + " .");
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
@@ -1084,6 +1084,9 @@ public class XmlConfigBuilder extends AbstractConfigBuilder implements ConfigBui
                 mapConfig.setStatisticsEnabled(getBooleanValue(value));
             } else if ("optimize-queries".equals(nodeName)) {
                 mapConfig.setOptimizeQueries(getBooleanValue(value));
+            } else if ("cache-deserialized-values".equals(nodeName)) {
+                CacheDeserializedValues cacheDeserializedValues = CacheDeserializedValues.parseString(value);
+                mapConfig.setCacheDeserializedValues(cacheDeserializedValues);
             } else if ("wan-replication-ref".equals(nodeName)) {
                 mapWanReplicationRefHandle(node, mapConfig);
             } else if ("indexes".equals(nodeName)) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapContainer.java
@@ -105,7 +105,7 @@ public class MapContainer {
         this.quorumName = mapConfig.getQuorumName();
         this.serializationService = nodeEngine.getSerializationService();
         this.recordFactoryConstructor = createRecordFactoryConstructor(serializationService);
-        this.queryEntryFactory = new QueryEntryFactory(mapConfig.isOptimizeQueries());
+        this.queryEntryFactory = new QueryEntryFactory(mapConfig.getCacheDeserializedValues());
         initWanReplication(nodeEngine);
         this.interceptors = new CopyOnWriteArrayList<MapInterceptor>();
         this.interceptorMap = new ConcurrentHashMap<String, MapInterceptor>();

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryEntryFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryEntryFactory.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.map.impl.query;
 
+import com.hazelcast.config.CacheDeserializedValues;
 import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.query.impl.CachedQueryEntry;
@@ -24,18 +25,18 @@ import com.hazelcast.query.impl.QueryEntry;
 import com.hazelcast.query.impl.QueryableEntry;
 
 public final class QueryEntryFactory {
+    private final CacheDeserializedValues cacheDeserializedValues;
 
-    private final boolean useCache;
-
-    public QueryEntryFactory(boolean optimizeQueries) {
-        useCache = optimizeQueries;
+    public QueryEntryFactory(CacheDeserializedValues cacheDeserializedValues) {
+        this.cacheDeserializedValues = cacheDeserializedValues;
     }
 
     public QueryableEntry newEntry(SerializationService serializationService, Data key, Object value, Extractors extractors) {
-        if (useCache) {
-            return new CachedQueryEntry(serializationService, key, value, extractors);
-        } else {
-            return new QueryEntry(serializationService, key, value, extractors);
+        switch (cacheDeserializedValues) {
+            case NEVER:
+                return new QueryEntry(serializationService, key, value, extractors);
+            default:
+                return new CachedQueryEntry(serializationService, key, value, extractors);
         }
     }
 }

--- a/hazelcast/src/main/resources/hazelcast-config-3.6.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-3.6.xsd
@@ -98,8 +98,26 @@
             <xs:element name="optimize-queries" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false">
                 <xs:annotation>
                     <xs:documentation>
+                        This parameter is deprecated as of Hazelcast 3.6
+                        Use cache-deserialized-values attribute instead.
+
+                        When both optimize-query and cache-deserialized-values are used at the same time
+                        Hazelcast will do its best to detect possible conflicts. Conflict detection
+                        is done on best-effort basis and you should not rely on it.
+
                         If true, increases the speed of query processes in the map. It only works when in-memory-format
                         is set as BINARY and performs a pre-caching on the entries queried. Default value is false.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="cache-deserialized-values" type="cache-deserialized-values" minOccurs="0" maxOccurs="1" default="INDEX-ONLY">
+                <xs:annotation>
+                    <xs:documentation>
+                        Control caching of de-serialized values. Caching makes query evaluation faster, but it cost memory.
+                        Possible Values:
+                        NEVER: Never cache de-serialized object
+                        INDEX-ONLY: Cache values only when they are inserted into an index.
+                        ALWAYS: Always cache de-serialized values.
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
@@ -2276,6 +2294,14 @@
             <xs:enumeration value="BINARY"/>
             <xs:enumeration value="OBJECT"/>
             <xs:enumeration value="NATIVE"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="cache-deserialized-values">
+        <xs:restriction base="non-space-string">
+            <xs:enumeration value="NEVER"/>
+            <xs:enumeration value="ALWAYS"/>
+            <xs:enumeration value="INDEX-ONLY"/>
         </xs:restriction>
     </xs:simpleType>
 

--- a/hazelcast/src/main/resources/hazelcast-default.xml
+++ b/hazelcast/src/main/resources/hazelcast-default.xml
@@ -195,6 +195,15 @@
         -->
         <merge-policy>com.hazelcast.map.merge.PutIfAbsentMapMergePolicy</merge-policy>
 
+        <!--
+           Control caching of de-serialized values. Caching makes query evaluation faster, but it cost memory.
+           Possible Values:
+                        NEVER: Never cache deserialized object
+                        INDEX-ONLY: Caches values only when they are inserted into an index.
+                        ALWAYS: Always cache deserialized values.
+        -->
+        <cache-deserialized-values>INDEX-ONLY</cache-deserialized-values>
+
     </map>
 
     <multimap name="default">

--- a/hazelcast/src/test/java/com/hazelcast/config/CacheDeserializedValuesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/CacheDeserializedValuesTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class CacheDeserializedValuesTest extends HazelcastTestSupport {
+
+    @Test
+    public void parseString_whenNEVER() {
+        CacheDeserializedValues cacheDeserializedValues = CacheDeserializedValues.parseString("NEVER");
+        assertEquals(CacheDeserializedValues.NEVER, cacheDeserializedValues);
+    }
+
+    @Test
+    public void parseString_whenNever() {
+        CacheDeserializedValues cacheDeserializedValues = CacheDeserializedValues.parseString("never");
+        assertEquals(CacheDeserializedValues.NEVER, cacheDeserializedValues);
+    }
+
+    @Test
+    public void parseString_whenINDEX_ONLY() {
+        CacheDeserializedValues cacheDeserializedValues = CacheDeserializedValues.parseString("INDEX_ONLY");
+        assertEquals(CacheDeserializedValues.INDEX_ONLY, cacheDeserializedValues);
+    }
+
+    @Test
+    public void parseString_whenINDEX_ONLY_withDash() {
+        CacheDeserializedValues cacheDeserializedValues = CacheDeserializedValues.parseString("INDEX-ONLY");
+        assertEquals(CacheDeserializedValues.INDEX_ONLY, cacheDeserializedValues);
+    }
+
+    @Test
+    public void parseString_whenIndex_only() {
+        CacheDeserializedValues cacheDeserializedValues = CacheDeserializedValues.parseString("index_only");
+        assertEquals(CacheDeserializedValues.INDEX_ONLY, cacheDeserializedValues);
+    }
+
+    @Test
+    public void parseString_whenIndex_only_withDash() {
+        CacheDeserializedValues cacheDeserializedValues = CacheDeserializedValues.parseString("index-only");
+        assertEquals(CacheDeserializedValues.INDEX_ONLY, cacheDeserializedValues);
+    }
+
+    @Test
+    public void parseString_whenALWAYS() {
+        CacheDeserializedValues cacheDeserializedValues = CacheDeserializedValues.parseString("ALWAYS");
+        assertEquals(CacheDeserializedValues.ALWAYS, cacheDeserializedValues);
+    }
+
+    @Test
+    public void parseString_whenAlways() {
+        CacheDeserializedValues cacheDeserializedValues = CacheDeserializedValues.parseString("always");
+        assertEquals(CacheDeserializedValues.ALWAYS, cacheDeserializedValues);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void parseString_whenUnknownString() {
+        CacheDeserializedValues cacheDeserializedValues = CacheDeserializedValues.parseString("does no exist");
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/config/MapConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/MapConfigTest.java
@@ -20,6 +20,7 @@ import com.hazelcast.map.listener.MapPartitionLostListener;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -288,5 +289,121 @@ public class MapConfigTest {
         assertNotEquals(config1, config3);
         assertNotEquals(config2, config3);
     }
+
+    @Test(expected = ConfigurationException.class)
+    public void givenCacheDeserializedValuesSetToALWAYS_whenSetOptimizeQueriesToFalse_thenThrowConfigurationException() {
+        //given
+        MapConfig mapConfig = new MapConfig();
+        mapConfig.setCacheDeserializedValues(CacheDeserializedValues.ALWAYS);
+
+        //when
+        mapConfig.setOptimizeQueries(false);
+    }
+
+    @Test(expected = ConfigurationException.class)
+    public void givenCacheDeserializedValuesSetToNEVER_whenSetOptimizeQueriesToTrue_thenThrowConfigurationException() {
+        //given
+        MapConfig mapConfig = new MapConfig();
+        mapConfig.setCacheDeserializedValues(CacheDeserializedValues.NEVER);
+
+        //when
+        mapConfig.setOptimizeQueries(true);
+    }
+
+    @Test
+    public void givenCacheDeserializedValuesIsDefault_whenSetOptimizeQueriesToTrue_thenSetCacheDeserializedValuesToALWAYS() {
+        //given
+        MapConfig mapConfig = new MapConfig();
+
+        //when
+        mapConfig.setOptimizeQueries(true);
+
+        //then
+        CacheDeserializedValues cacheDeserializedValues = mapConfig.getCacheDeserializedValues();
+        assertEquals(CacheDeserializedValues.ALWAYS, cacheDeserializedValues);
+    }
+
+    @Test
+    public void givenCacheDeserializedValuesIsDefault_thenIsOptimizeQueriesReturnFalse() {
+        //given
+        MapConfig mapConfig = new MapConfig();
+
+        //then
+        boolean optimizeQueries = mapConfig.isOptimizeQueries();
+        assertFalse(optimizeQueries);
+    }
+
+    @Test
+    public void givenCacheDeserializedValuesIsDefault_whenSetCacheDeserializedValuesToALWAYS_thenIsOptimizeQueriesReturnTrue() {
+        //given
+        MapConfig mapConfig = new MapConfig();
+
+        //when
+        mapConfig.setCacheDeserializedValues(CacheDeserializedValues.ALWAYS);
+
+        //then
+        boolean optimizeQueries = mapConfig.isOptimizeQueries();
+        assertTrue(optimizeQueries);
+    }
+
+    @Test
+    public void givenCacheDeserializedValuesIsDefault_whenSetCacheDeserializedValuesToNEVER_thenIsOptimizeQueriesReturnFalse() {
+        //given
+        MapConfig mapConfig = new MapConfig();
+
+        //when
+        mapConfig.setCacheDeserializedValues(CacheDeserializedValues.NEVER);
+
+        //then
+        boolean optimizeQueries = mapConfig.isOptimizeQueries();
+        assertFalse(optimizeQueries);
+    }
+
+    @Test(expected = ConfigurationException.class)
+    public void givenSetOptimizeQueryIsTrue_whenSetCacheDeserializedValuesToNEVER_thenThrowConfigurationException() {
+        //given
+        MapConfig mapConfig = new MapConfig();
+        mapConfig.setOptimizeQueries(true);
+
+        //when
+        mapConfig.setCacheDeserializedValues(CacheDeserializedValues.NEVER);
+    }
+
+    @Test(expected = ConfigurationException.class)
+    public void givenSetOptimizeQueryIsFalse_whenSetCacheDeserializedValuesToALWAYS_thenThrowConfigurationException() {
+        //given
+        MapConfig mapConfig = new MapConfig();
+        mapConfig.setOptimizeQueries(false);
+
+        //when
+        mapConfig.setCacheDeserializedValues(CacheDeserializedValues.ALWAYS);
+    }
+
+    @Test(expected = ConfigurationException.class)
+    public void givenSetOptimizeQueryIsTrue_whenSetCacheDeserializedValuesToINDEX_ONLY_thenThrowConfigurationException() {
+        //given
+        MapConfig mapConfig = new MapConfig();
+        mapConfig.setOptimizeQueries(true);
+
+        //when
+        mapConfig.setCacheDeserializedValues(CacheDeserializedValues.INDEX_ONLY);
+    }
+
+    @Test
+    @Ignore //this MapStoreConfig does not override equals/hashcode -> this cannot pass right now
+    public void givenSetCacheDeserializedValuesIsINDEX_ONLY_whenComparedWithOtherConfigWhereCacheIsINDEX_ONLY_thenReturnTrue() {
+        //given
+        MapConfig mapConfig = new MapConfig();
+        mapConfig.setCacheDeserializedValues(CacheDeserializedValues.INDEX_ONLY);
+
+        //when
+        MapConfig otherMapConfig = new MapConfig();
+        otherMapConfig.setCacheDeserializedValues(CacheDeserializedValues.INDEX_ONLY);
+
+        //then
+        assertEquals(mapConfig, otherMapConfig);
+    }
+
+
 
 }

--- a/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
@@ -442,7 +442,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
                         "</hazelcast>";
         final Config config1 = buildConfig(xml1);
         final MapConfig mapConfig1 = config1.getMapConfig("mymap1");
-        assertTrue(mapConfig1.isOptimizeQueries());
+        assertEquals(CacheDeserializedValues.ALWAYS, mapConfig1.getCacheDeserializedValues());
 
         String xml2 =
                 HAZELCAST_START_TAG +
@@ -452,11 +452,11 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
                         "</hazelcast>";
         final Config config2 = buildConfig(xml2);
         final MapConfig mapConfig2 = config2.getMapConfig("mymap2");
-        assertFalse(mapConfig2.isOptimizeQueries());
+        assertEquals(CacheDeserializedValues.INDEX_ONLY, mapConfig2.getCacheDeserializedValues());
     }
 
     @Test
-    public void testMapConfig_optimizeQueries_defaultValue() {
+    public void testMapConfig_cacheValueConfig_defaultValue() {
         String xml =
                 "<hazelcast xmlns=\"http://www.hazelcast.com/schema/config\">" +
                         "<map name=\"mymap\">" +
@@ -464,7 +464,46 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
                         "</hazelcast>";
         final Config config = buildConfig(xml);
         final MapConfig mapConfig = config.getMapConfig("mymap");
-        assertFalse(mapConfig.isOptimizeQueries());
+        assertEquals(CacheDeserializedValues.INDEX_ONLY, mapConfig.getCacheDeserializedValues());
+    }
+
+    @Test
+    public void testMapConfig_cacheValueConfig_never() {
+        String xml =
+                "<hazelcast xmlns=\"http://www.hazelcast.com/schema/config\">" +
+                        "<map name=\"mymap\">" +
+                        "<cache-deserialized-values>NEVER</cache-deserialized-values>" +
+                        "</map>" +
+                        "</hazelcast>";
+        final Config config = buildConfig(xml);
+        final MapConfig mapConfig = config.getMapConfig("mymap");
+        assertEquals(CacheDeserializedValues.NEVER, mapConfig.getCacheDeserializedValues());
+    }
+
+    @Test
+    public void testMapConfig_cacheValueConfig_always() {
+        String xml =
+                "<hazelcast xmlns=\"http://www.hazelcast.com/schema/config\">" +
+                        "<map name=\"mymap\">" +
+                        "<cache-deserialized-values>ALWAYS</cache-deserialized-values>" +
+                        "</map>" +
+                        "</hazelcast>";
+        final Config config = buildConfig(xml);
+        final MapConfig mapConfig = config.getMapConfig("mymap");
+        assertEquals(CacheDeserializedValues.ALWAYS, mapConfig.getCacheDeserializedValues());
+    }
+
+    @Test
+    public void testMapConfig_cacheValueConfig_indexOnly() {
+        String xml =
+                "<hazelcast xmlns=\"http://www.hazelcast.com/schema/config\">" +
+                        "<map name=\"mymap\">" +
+                        "<cache-deserialized-values>INDEX-ONLY</cache-deserialized-values>" +
+                        "</map>" +
+                        "</hazelcast>";
+        final Config config = buildConfig(xml);
+        final MapConfig mapConfig = config.getMapConfig("mymap");
+        assertEquals(CacheDeserializedValues.INDEX_ONLY, mapConfig.getCacheDeserializedValues());
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryBasicTest.java
@@ -3,6 +3,7 @@ package com.hazelcast.map.impl.query;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.config.MapIndexConfig;
+import com.hazelcast.config.CacheDeserializedValues;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.instance.GroupProperties;
@@ -767,10 +768,10 @@ public class QueryBasicTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void testQueryPortableObjectAndOptimizeQueries() {
+    public void testQueryPortableObjectAndAlwaysCacheValues() {
         String name = randomMapName();
         Config config = getConfig();
-        config.addMapConfig(new MapConfig(name).setOptimizeQueries(true));
+        config.addMapConfig(new MapConfig(name).setCacheDeserializedValues(CacheDeserializedValues.ALWAYS));
 
         testQueryUsingPortableObject(config, name);
     }
@@ -851,11 +852,11 @@ public class QueryBasicTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void testQueryPortableObjectWithIndexAndOptimizeQueries() {
+    public void testQueryPortableObjectWithIndexAndAlwaysCacheValues() {
         String name = randomMapName();
         Config config = getConfig();
         config.addMapConfig(new MapConfig(name)
-                .setOptimizeQueries(true)
+                .setCacheDeserializedValues(CacheDeserializedValues.ALWAYS)
                 .addMapIndexConfig(new MapIndexConfig("timestamp", true)));
 
         testQueryUsingPortableObject(config, name);

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/record/DataRecordFactoryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/record/DataRecordFactoryTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.record;
+
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.config.CacheDeserializedValues;
+import com.hazelcast.core.PartitioningStrategy;
+import com.hazelcast.internal.serialization.SerializationService;
+import com.hazelcast.internal.serialization.impl.HeapData;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class DataRecordFactoryTest extends HazelcastTestSupport {
+
+    private SerializationService mockSerializationService;
+    private PartitioningStrategy mockPartitioningStrategy;
+
+    private Object object = new Object();
+    private Data data = new HeapData();
+
+
+    @Before
+    public void setUp() {
+        mockSerializationService = mock(SerializationService.class);
+        mockPartitioningStrategy = mock(PartitioningStrategy.class);
+        object = new Object();
+        data = new HeapData();
+        when(mockSerializationService.toData(object, mockPartitioningStrategy)).thenReturn(data);
+
+    }
+
+    @Test
+    public void givenStatisticsEnabledAndCacheDeserializedValuesIsNEVER_thenCreateDataRecordWithStats() {
+        MapConfig mapConfig = new MapConfig().setStatisticsEnabled(true).setCacheDeserializedValues(CacheDeserializedValues.NEVER);
+        DataRecordFactory dataRecordFactory = new DataRecordFactory(mapConfig, mockSerializationService, mockPartitioningStrategy);
+
+        Record<Data> dataRecord = dataRecordFactory.newRecord(object);
+
+        assertInstanceOf(DataRecordWithStats.class, dataRecord);
+    }
+
+    @Test
+    public void givenStatisticsDisabledAndCacheDeserializedValuesIsNEVER_thenCreateDataRecordWithStats() {
+        MapConfig mapConfig = new MapConfig().setStatisticsEnabled(false).setCacheDeserializedValues(CacheDeserializedValues.NEVER);
+        DataRecordFactory dataRecordFactory = new DataRecordFactory(mapConfig, mockSerializationService, mockPartitioningStrategy);
+
+        Record<Data> dataRecord = dataRecordFactory.newRecord(object);
+
+        assertInstanceOf(DataRecord.class, dataRecord);
+    }
+
+    @Test
+    public void givenStatisticsEnabledAndCacheDeserializedValuesIsDefault_thenCreateCachedDataRecordWithStats() {
+        MapConfig mapConfig = new MapConfig().setStatisticsEnabled(true);
+        DataRecordFactory dataRecordFactory = new DataRecordFactory(mapConfig, mockSerializationService, mockPartitioningStrategy);
+
+        Record<Data> dataRecord = dataRecordFactory.newRecord(object);
+
+        assertInstanceOf(CachedDataRecordWithStats.class, dataRecord);
+    }
+
+    @Test
+    public void givenStatisticsDisabledAndCacheDeserializedValuesIsDefault_thenCreateCachedDataRecord() {
+        MapConfig mapConfig = new MapConfig().setStatisticsEnabled(false);
+        DataRecordFactory dataRecordFactory = new DataRecordFactory(mapConfig, mockSerializationService, mockPartitioningStrategy);
+
+        Record<Data> dataRecord = dataRecordFactory.newRecord(object);
+
+        assertInstanceOf(CachedDataRecord.class, dataRecord);
+    }
+}


### PR DESCRIPTION
Allows to configure caching with finer granularity
than (now deprecated) optimizeQueries boolean flag.