### PR TITLE
Fix deadlock issues during shutdown when instance failed to start

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/instance/HazelcastInstanceFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/HazelcastInstanceFactory.java
@@ -274,7 +274,7 @@ public final class HazelcastInstanceFactory {
     static void remove(HazelcastInstanceImpl instance) {
         OutOfMemoryErrorDispatcher.deregisterServer(instance);
         InstanceFuture future = INSTANCE_MAP.remove(instance.getName());
-        if (future != null) {
+        if (future != null && future.isSet()) {
             future.get().original = null;
         }
         if (INSTANCE_MAP.size() == 0) {
@@ -326,6 +326,10 @@ public final class HazelcastInstanceFactory {
                 this.throwable = throwable;
                 notifyAll();
             }
+        }
+
+        boolean isSet() {
+            return hz != null;
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/instance/Node.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/Node.java
@@ -393,6 +393,18 @@ public class Node {
         } catch (Throwable ignored) {
         }
 
+        try {
+            shutdownServices(terminate);
+            state = NodeState.SHUT_DOWN;
+            logger.info("Hazelcast Shutdown is completed in " + (Clock.currentTimeMillis() - start) + " ms.");
+        } finally {
+            if (state != NodeState.SHUT_DOWN) {
+                shuttingDown.compareAndSet(true, false);
+            }
+        }
+    }
+
+    private void shutdownServices(boolean terminate) {
         nodeExtension.beforeShutdown();
         phoneHome.shutdown();
         if (managementCenterService != null) {
@@ -418,8 +430,6 @@ public class Node {
 
         hazelcastThreadGroup.destroy();
         nodeExtension.shutdown();
-        logger.info("Hazelcast Shutdown is completed in " + (Clock.currentTimeMillis() - start) + " ms.");
-        state = NodeState.SHUT_DOWN;
     }
 
     private boolean setShuttingDown() {

--- a/hazelcast/src/main/java/com/hazelcast/partition/impl/InternalPartitionServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/impl/InternalPartitionServiceImpl.java
@@ -1222,7 +1222,7 @@ public class InternalPartitionServiceImpl implements InternalPartitionService, M
     private boolean hasOnGoingMigrationMaster(Level level) {
         Address masterAddress = node.getMasterAddress();
         if (masterAddress == null) {
-            return true;
+            return node.joined();
         }
         Operation operation = new HasOngoingMigration();
         OperationService operationService = nodeEngine.getOperationService();

--- a/hazelcast/src/test/java/com/hazelcast/util/HazelcastInstanceFactoryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/HazelcastInstanceFactoryTest.java
@@ -16,8 +16,15 @@
 
 package com.hazelcast.util;
 
+import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.instance.HazelcastInstanceFactory;
+import com.hazelcast.instance.Node;
+import com.hazelcast.instance.NodeContext;
+import com.hazelcast.instance.NodeExtension;
+import com.hazelcast.instance.NodeExtensionTest;
 import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.ExpectedRuntimeException;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
@@ -26,8 +33,14 @@ import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
@@ -86,5 +99,131 @@ public class HazelcastInstanceFactoryTest extends HazelcastTestSupport {
         instanceFactory.terminateAll();
         instanceFactory2.terminateAll();
 
+    }
+
+    @Test(expected = ExpectedRuntimeException.class)
+    public void test_NewInstance_failed_beforeNodeStart() throws Exception {
+        NodeContext context = new NodeExtensionTest.DummyNodeContext() {
+            @Override
+            public NodeExtension createNodeExtension(Node node) {
+                NodeExtension nodeExtension = super.createNodeExtension(node);
+                doThrow(new ExpectedRuntimeException()).when(nodeExtension).beforeStart();
+                return nodeExtension;
+            }
+        };
+
+        Config config = new Config();
+        config.getNetworkConfig().getJoin().getMulticastConfig().setEnabled(false);
+
+        HazelcastInstanceFactory.newHazelcastInstance(config, randomString(), context);
+    }
+
+    @Test(expected = ExpectedRuntimeException.class)
+    public void test_NewInstance_failed_beforeJoin() throws Exception {
+        NodeContext context = new NodeExtensionTest.DummyNodeContext() {
+            @Override
+            public NodeExtension createNodeExtension(Node node) {
+                NodeExtension nodeExtension = super.createNodeExtension(node);
+                doThrow(new ExpectedRuntimeException()).when(nodeExtension).beforeJoin();
+                return nodeExtension;
+            }
+        };
+
+        Config config = new Config();
+        config.getNetworkConfig().getJoin().getMulticastConfig().setEnabled(false);
+
+        HazelcastInstanceFactory.newHazelcastInstance(config, randomString(), context);
+    }
+
+    @Test(expected = ExpectedRuntimeException.class)
+    public void test_NewInstance_failed_afterNodeStart() throws Exception {
+        NodeContext context = new NodeExtensionTest.DummyNodeContext() {
+            @Override
+            public NodeExtension createNodeExtension(Node node) {
+                NodeExtension nodeExtension = super.createNodeExtension(node);
+                doThrow(new ExpectedRuntimeException()).when(nodeExtension).afterStart();
+                return nodeExtension;
+            }
+        };
+
+        Config config = new Config();
+        config.getNetworkConfig().getJoin().getMulticastConfig().setEnabled(false);
+
+        HazelcastInstanceFactory.newHazelcastInstance(config, randomString(), context);
+    }
+
+    @Test(expected = ExpectedRuntimeException.class)
+    public void test_NewInstance_failed_beforeNodeShutdown() throws Exception {
+        NodeContext context = new NodeExtensionTest.DummyNodeContext() {
+            @Override
+            public NodeExtension createNodeExtension(Node node) {
+                NodeExtension nodeExtension = super.createNodeExtension(node);
+                doAnswer(new Answer() {
+                    final AtomicBoolean throwException = new AtomicBoolean(false);
+                    @Override
+                    public Object answer(InvocationOnMock invocation) throws Throwable {
+                        if (throwException.compareAndSet(false, true)) {
+                            throw new ExpectedRuntimeException();
+                        }
+                        return null;
+                    }
+                }).when(nodeExtension).beforeShutdown();
+                return nodeExtension;
+            }
+        };
+
+        Config config = new Config();
+        config.getNetworkConfig().getJoin().getMulticastConfig().setEnabled(false);
+
+        HazelcastInstance instance = HazelcastInstanceFactory.newHazelcastInstance(config, randomString(), context);
+        try {
+            instance.getLifecycleService().terminate();
+        } catch (ExpectedRuntimeException expected) {
+            instance.getLifecycleService().terminate();
+            throw expected;
+        }
+    }
+
+    @Test(expected = ExpectedRuntimeException.class)
+    public void test_NewInstance_failedAfterStartAndBeforeShutdown() throws Exception {
+        NodeContext context = new NodeExtensionTest.DummyNodeContext() {
+            @Override
+            public NodeExtension createNodeExtension(Node node) {
+                NodeExtension nodeExtension = super.createNodeExtension(node);
+                doThrow(new ExpectedRuntimeException()).when(nodeExtension).afterStart();
+                doThrow(new ExpectedRuntimeException()).when(nodeExtension).beforeShutdown();
+                return nodeExtension;
+            }
+        };
+
+        Config config = new Config();
+        config.getNetworkConfig().getJoin().getMulticastConfig().setEnabled(false);
+
+        HazelcastInstanceFactory.newHazelcastInstance(config, randomString(), context);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void test_NewInstance_terminateInstance_afterNodeStart() throws Exception {
+        NodeContext context = new NodeExtensionTest.DummyNodeContext() {
+            @Override
+            public NodeExtension createNodeExtension(final Node node) {
+                NodeExtension nodeExtension = super.createNodeExtension(node);
+
+                doAnswer(new Answer() {
+                    @Override
+                    public Object answer(InvocationOnMock invocation) throws Throwable {
+                        node.hazelcastInstance.shutdown();
+                        return null;
+                    }
+                }).when(nodeExtension).afterStart();
+
+                return nodeExtension;
+            }
+        };
+
+        Config config = new Config();
+        config.getNetworkConfig().getJoin().getMulticastConfig().setEnabled(false);
+
+        HazelcastInstanceFactory.newHazelcastInstance(config, randomString(), context);
     }
 }


### PR DESCRIPTION
- HazelcastInstanceFactory should check if future is set before
retrieving the instance proxy. Otherwise it can cause infinite hang 
when node fails to start and terminated.
- Node.shutdown() should rollback the shutting down flag if shutdown
is failed.
- InternalPartitionService.hasOnGoingMigrationMaster() should check
Node's join state.

_PS: These bug are found during hot-restart tests. See https://github.com/hazelcast/hazelcast-enterprise/pull/507_