### PR TITLE
Improve hash functions for primitive hashtables

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -4,3 +4,6 @@ com.hazelcast.client.impl.protocol.util.UnsafeBuffer
 com.hazelcast.client.impl.protocol.util.BufferBuilder
 contain code originating from the Agrona project
 (https://github.com/real-logic/Agrona).
+
+The class com.hazelcast.util.HashUtil contains code originating
+from the Koloboke project (https://github.com/OpenHFT/Koloboke).

--- a/hazelcast/src/main/java/com/hazelcast/util/HashUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/HashUtil.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ * Portions Copyright 2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -408,6 +409,21 @@ public final class HashUtil {
         k *= 0xc4ceb9fe1a85ec53L;
         k ^= k >>> 33;
         return k;
+    }
+
+    public static long fastLongMix(long k) {
+        // phi = 2^64 / goldenRatio
+        final long phi = 0x9E3779B97F4A7C15L;
+        long h = k * phi;
+        h ^= h >>> 32;
+        return h ^ (h >>> 16);
+    }
+
+    public static int fastIntMix(int k) {
+        // phi = 2^32 / goldenRatio
+        final int phi = 0x9E3779B9;
+        final int h = k * phi;
+        return h ^ (h >>> 16);
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/util/collection/Hashing.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/collection/Hashing.java
@@ -17,26 +17,25 @@
 
 package com.hazelcast.util.collection;
 
+import static com.hazelcast.util.HashUtil.fastIntMix;
+import static com.hazelcast.util.HashUtil.fastLongMix;
+
 /**
- * Hashcode calculation.
+ * Hashcode functions for classes in this package.
  */
 public final class Hashing {
     private Hashing() { }
 
-    public static int intHash(final int value, final int mask) {
-        final int hash = value ^ (value >>> 16);
-        return hash & mask;
+    static int intHash(final int value, final int mask) {
+        return fastIntMix(value) & mask;
     }
 
-    public static int longHash(final long value, final int mask) {
-        int hash = (int) value ^ (int) (value >>> 32);
-        hash ^= (hash >>> 16);
-        return hash & mask;
+    static int longHash(final long value, final int mask) {
+        return ((int) fastLongMix(value)) & mask;
     }
 
-    public static int evenLongHash(final long value, final int mask) {
-        int hash = (int) value ^ (int) (value >>> 32);
-        hash = (hash << 1) - (hash << 8);
-        return hash & mask;
+    static int evenLongHash(final long value, final int mask) {
+        final int h = (int) fastLongMix(value);
+        return h & mask & ~1;
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/util/collection/Int2ObjectHashMapTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/collection/Int2ObjectHashMapTest.java
@@ -288,7 +288,7 @@ public class Int2ObjectHashMapTest {
             intToObjectMap.put(testEntry, String.valueOf(testEntry));
         }
 
-        final String mapAsAString = "{12=12, 11=11, 7=7, 19=19, 3=3, 1=1}";
+        final String mapAsAString = "{1=1, 3=3, 7=7, 12=12, 19=19, 11=11}";
         assertThat(intToObjectMap.toString(), equalTo(mapAsAString));
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/util/collection/IntHashSetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/collection/IntHashSetTest.java
@@ -173,7 +173,7 @@ public class IntHashSetTest {
         final IntHashSet other = new IntHashSet(1000, -1);
         other.copy(set);
 
-        assertThat(other, contains(1, 2));
+        assertThat(other, contains(2, 1));
     }
 
     @Test public void twoEmptySetsAreEqual() {
@@ -275,9 +275,9 @@ public class IntHashSetTest {
         final Iterator<Integer> iter = set.iterator();
 
         assertTrue(iter.hasNext());
-        assertEquals(Integer.valueOf(1), iter.next());
-        assertTrue(iter.hasNext());
         assertEquals(Integer.valueOf(2), iter.next());
+        assertTrue(iter.hasNext());
+        assertEquals(Integer.valueOf(1), iter.next());
         assertFalse(iter.hasNext());
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/util/collection/Long2LongHashMapTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/collection/Long2LongHashMapTest.java
@@ -184,9 +184,9 @@ public class Long2LongHashMapTest {
 
         final Iterator<Entry<Long, Long>> it = entrySet.iterator();
         assertTrue(it.hasNext());
-        assertEntryIs(it.next(), 1L, 1L);
-        assertTrue(it.hasNext());
         assertEntryIs(it.next(), 2L, 3L);
+        assertTrue(it.hasNext());
+        assertEntryIs(it.next(), 1L, 1L);
         assertFalse(it.hasNext());
     }
 
@@ -236,7 +236,7 @@ public class Long2LongHashMapTest {
     @Test public void toStringShouldReportAllEntries() {
         map.put(1, 2);
         map.put(3, 4);
-        assertEquals("{1->2 3->4}", map.toString());
+        assertEquals("{3->4 1->2}", map.toString());
     }
 
     private static void assertEntryIs(final Entry<Long, Long> entry, final long expectedKey, final long expectedValue) {

--- a/hazelcast/src/test/java/com/hazelcast/util/collection/Long2ObjectHashMapTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/collection/Long2ObjectHashMapTest.java
@@ -282,7 +282,7 @@ public class Long2ObjectHashMapTest {
             longToObjectMap.put(testEntry, String.valueOf(testEntry));
         }
 
-        final String mapAsAString = "{12=12, 11=11, 7=7, 19=19, 3=3, 1=1}";
+        final String mapAsAString = "{11=11, 7=7, 3=3, 12=12, 19=19, 1=1}";
         assertThat(longToObjectMap.toString(), equalTo(mapAsAString));
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/util/collection/LongHashSetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/collection/LongHashSetTest.java
@@ -173,7 +173,7 @@ public class LongHashSetTest {
         final LongHashSet other = new LongHashSet(1000, -1);
         other.copy(set);
 
-        assertThat(other, contains(1L, 2L));
+        assertThat(other, contains(2L, 1L));
     }
 
     @Test public void twoEmptySetsAreEqual() {
@@ -275,9 +275,9 @@ public class LongHashSetTest {
         final Iterator<Long> iter = set.iterator();
 
         assertTrue(iter.hasNext());
-        assertEquals(Long.valueOf(1), iter.next());
-        assertTrue(iter.hasNext());
         assertEquals(Long.valueOf(2), iter.next());
+        assertTrue(iter.hasNext());
+        assertEquals(Long.valueOf(1), iter.next());
         assertFalse(iter.hasNext());
     }
 }


### PR DESCRIPTION
Existing hashcodes from Agrona were very fast, but overly simple. In some cases they caused too long probing chains. The new hash functions come from Koloboke and provide better bit avalanching.