### PR TITLE
Increased code coverage of ManagementCenterService

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/management/ManagementCenterServiceIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/ManagementCenterServiceIntegrationTest.java
@@ -1,0 +1,103 @@
+package com.hazelcast.internal.management;
+
+import com.eclipsesource.json.JsonObject;
+import com.hazelcast.config.Config;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.monitor.TimedMemberState;
+import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.SlowTest;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.util.EntityUtils;
+import org.apache.log4j.Level;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.net.URL;
+import java.net.URLDecoder;
+
+import static java.lang.String.format;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(SlowTest.class)
+public class ManagementCenterServiceIntegrationTest extends HazelcastTestSupport {
+
+    private JettyServer jettyServer;
+    private int portNum;
+
+    @Before
+    public void setUp() throws Exception {
+        setLoggingLog4j();
+        setLogLevel(Level.DEBUG);
+
+        URL root = new URL(MancenterServlet.class.getResource("/"), "../test-classes");
+        String baseDir = URLDecoder.decode(root.getFile(), "UTF-8");
+        String sourceDir = baseDir + "/../../src/test/webapp";
+        String sourceName = "server_config.xml";
+        portNum = availablePort();
+        jettyServer = new JettyServer(portNum, sourceDir, sourceName);
+
+        Hazelcast.newHazelcastInstance(getManagementCenterConfig());
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        resetLogLevel();
+
+        Hazelcast.shutdownAll();
+        jettyServer.stop();
+    }
+
+    @Test
+    public void testTimedMemberStateNotNull() {
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                CloseableHttpClient client = HttpClientBuilder.create().disableRedirectHandling().build();
+                HttpUriRequest request = new HttpGet("http://localhost:" + portNum + "/mancen/memberStateCheck");
+                HttpResponse response = client.execute(request);
+                HttpEntity entity = response.getEntity();
+                String responseString = EntityUtils.toString(entity);
+                assertNotEquals("", responseString);
+
+                JsonObject object = JsonObject.readFrom(responseString);
+                TimedMemberState memberState = new TimedMemberState();
+                memberState.fromJson(object);
+                assertEquals("dev", memberState.getClusterName());
+            }
+        });
+    }
+
+    private int availablePort() throws IOException {
+        while (true) {
+            int port = (int) (65536 * Math.random());
+            try {
+                ServerSocket socket = new ServerSocket(port);
+                socket.close();
+                return port;
+            } catch (Exception ignore) {
+                // try next port
+            }
+        }
+    }
+
+    private Config getManagementCenterConfig() {
+        Config config = new Config();
+        config.getManagementCenterConfig().setEnabled(true);
+        config.getManagementCenterConfig().setUrl(format("http://localhost:%d%s/", portNum, "/mancen"));
+        return config;
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/ManagementCenterServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/ManagementCenterServiceTest.java
@@ -1,103 +1,59 @@
 package com.hazelcast.internal.management;
 
-import com.eclipsesource.json.JsonObject;
-import com.hazelcast.config.Config;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.monitor.TimedMemberState;
-import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
-import com.hazelcast.test.annotation.NightlyTest;
 import com.hazelcast.test.annotation.QuickTest;
-import com.hazelcast.test.annotation.SlowTest;
-import org.apache.http.HttpEntity;
-import org.apache.http.HttpResponse;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpUriRequest;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClientBuilder;
-import org.apache.http.util.EntityUtils;
+import org.apache.log4j.Level;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
-import java.io.File;
-import java.io.IOException;
-import java.net.ServerSocket;
-import java.net.URL;
-import java.net.URLDecoder;
+import static com.hazelcast.internal.management.ManagementCenterService.cleanupUrl;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
-import static java.lang.String.format;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-
-@Category(SlowTest.class)
+@RunWith(HazelcastParallelClassRunner.class)
+@Category(QuickTest.class)
 public class ManagementCenterServiceTest extends HazelcastTestSupport {
-
-    private JettyServer jettyServer;
-    private HazelcastInstance hazelcastInstance;
-    private int portNum;
 
     @Before
     public void setUp() throws Exception {
-        URL root = new URL(MancenterServlet.class.getResource("/"), "../test-classes");
-        String baseDir = URLDecoder.decode(root.getFile(), "UTF-8");
-        String sourceDir = baseDir + "/../../src/test/webapp";
-        String sourceName = "server_config.xml";
-        portNum = availablePort();
-        jettyServer = new JettyServer(portNum, sourceDir, sourceName);
-
-        hazelcastInstance = Hazelcast.newHazelcastInstance(makeConfig());
-    }
-
-    @Test
-    public void testTimedMemberStateNotNull() throws Exception {
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run() throws Exception {
-                CloseableHttpClient client = HttpClientBuilder.create().disableRedirectHandling().build();
-                HttpUriRequest request;
-                request = new HttpGet("http://localhost:" + portNum + "/mancen/memberStateCheck");
-                HttpResponse response = client.execute(request);
-                HttpEntity entity = response.getEntity();
-                String responseString = EntityUtils.toString(entity);
-                assertNotEquals("", responseString);
-                JsonObject object = JsonObject.readFrom(responseString);
-                TimedMemberState memberState = new TimedMemberState();
-                memberState.fromJson(object);
-                assertEquals("dev", memberState.getClusterName());
-            }
-        });
+        setLoggingLog4j();
+        setLogLevel(Level.DEBUG);
     }
 
     @After
     public void tearDown() throws Exception {
-        hazelcastInstance.shutdown();
-        jettyServer.stop();
+        resetLogLevel();
+
+        Hazelcast.shutdownAll();
     }
 
-    private Config makeConfig() {
-        Config config = new Config();
-        return addManagementCenter(config);
+    @Test(expected = IllegalStateException.class)
+    public void testConstructor_withNullConfiguration() {
+        HazelcastInstance instance = Hazelcast.newHazelcastInstance();
+        instance.getConfig().setManagementCenterConfig(null);
+        new ManagementCenterService(getNode(instance).hazelcastInstance);
     }
 
-    private Config addManagementCenter(Config config) {
-        config.getManagementCenterConfig().setEnabled(true);
-        config.getManagementCenterConfig().setUrl(format("http://localhost:%d%s/", portNum, "/mancen"));
-        return config;
+    @Test
+    public void testCleanupUrl() {
+        String url = cleanupUrl("http://noCleanupNeeded/");
+        assertTrue(url.endsWith("/"));
     }
 
-    private int availablePort() throws IOException {
-        while (true) {
-            int port = (int) (65536 * Math.random());
-            try {
-                ServerSocket socket = new ServerSocket(port);
-                socket.close();
-                return port;
-            } catch (Exception ignore) {
-                // try next port
-            }
-        }
+    @Test
+    public void testCleanupUrl_needsCleanup() {
+        String url = cleanupUrl("http://needsCleanUp");
+        assertTrue(url.endsWith("/"));
+    }
+
+    @Test
+    public void testCleanupUrl_withNull() {
+        assertNull(cleanupUrl(null));
     }
 }


### PR DESCRIPTION
`ManagementCenterService` is missing code coverage to pass the QA verification.

Content of `ManagementCenterServiceTest` was moved to `ManagementCenterServiceIntegrationTest`. The new `ManagementCenterServiceTest` tests some low hanging fruits of `ManagementCenterService` to increase the coverage. I also added the missing `@RunWith` annotation to the `ManagementCenterServiceIntegrationTest`.