### PR TITLE
Tiny addition: Fetched near-cache config dynamically

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/NearCacheProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/NearCacheProvider.java
@@ -41,7 +41,7 @@ public class NearCacheProvider {
         public NearCache createNew(String mapName) {
             MapContainer mapContainer = mapServiceContext.getMapContainer(mapName);
             SizeEstimator nearCacheSizeEstimator = mapContainer.getNearCacheSizeEstimator();
-            NearCacheImpl nearCache = new NearCacheImpl(mapName, nodeEngine);
+            NearCacheImpl nearCache = new NearCacheImpl(mapContainer, nodeEngine);
             nearCache.setNearCacheSizeEstimator(nearCacheSizeEstimator);
             return nearCache;
         }


### PR DESCRIPTION
Closes https://github.com/hazelcast/hazelcast/issues/5485. Btw dynamic configuration of near-cache is not an officially supported feature. This PR only makes the config dynamically reachable. Current near-cache tests should be enough to prove this. 

PS: There is also a PR from the requester https://github.com/hazelcast/hazelcast/pull/5547