### PR TITLE
Increased code coverage of UnsafeHelper

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/nio/UnsafeHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/UnsafeHelper.java
@@ -72,7 +72,6 @@ public final class UnsafeHelper {
             + "seem to support unaligned access to memory. Unsafe usage has been enforced via System Property "
             + UNSAFE_MODE_PROPERTY_NAME + " This is not a supported configuration and it can crash JVM or corrupt your data!";
 
-
     static {
         Unsafe unsafe;
         try {
@@ -134,7 +133,7 @@ public final class UnsafeHelper {
         return unsafe == null ? -1 : unsafe.arrayIndexScale(type);
     }
 
-    private static Unsafe findUnsafeIfAllowed() {
+    static Unsafe findUnsafeIfAllowed() {
         if (isUnsafeExplicitlyDisabled()) {
             Logger.getLogger(UnsafeHelper.class).warning(UNSAFE_WARNING_WHEN_EXPLICTLY_DISABLED);
             return null;
@@ -165,13 +164,11 @@ public final class UnsafeHelper {
     }
 
     private static boolean isUnalignedAccessAllowed() {
-        //we can't use Unsafe to access memory on platforms where unaligned access is not allowed
-        //see https://github.com/hazelcast/hazelcast/issues/5518 for details.
+        // we can't use Unsafe to access memory on platforms where unaligned access is not allowed
+        // see https://github.com/hazelcast/hazelcast/issues/5518 for details.
         String arch = System.getProperty("os.arch");
-        //list of architectures copied from OpenJDK - java.nio.Bits::unaligned
-        boolean unalignedAllowed = arch.equals("i386") || arch.equals("x86")
-                || arch.equals("amd64") || arch.equals("x86_64");
-        return unalignedAllowed;
+        // list of architectures copied from OpenJDK - java.nio.Bits::unaligned
+        return arch.equals("i386") || arch.equals("x86") || arch.equals("amd64") || arch.equals("x86_64");
     }
 
     private static Unsafe findUnsafe() {

--- a/hazelcast/src/test/java/com/hazelcast/nio/UnsafeHelperTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/UnsafeHelperTest.java
@@ -1,0 +1,67 @@
+package com.hazelcast.nio;
+
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static com.hazelcast.nio.UnsafeHelper.findUnsafeIfAllowed;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class UnsafeHelperTest extends HazelcastTestSupport {
+
+    String unsafeMode;
+    String arch;
+
+    @Before
+    public void setUp() throws Exception {
+        unsafeMode = System.getProperty("hazelcast.unsafe.mode");
+        arch = System.getProperty("os.arch");
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        if (unsafeMode != null) {
+            System.setProperty("hazelcast.unsafe.mode", unsafeMode);
+        }
+        if (arch != null) {
+            System.setProperty("os.arch", arch);
+        }
+    }
+
+    @Test
+    public void testConstructor() {
+        assertUtilityConstructor(UnsafeHelper.class);
+    }
+
+    @Test
+    public void testFindUnsafeIfAllowed() {
+        assertNotNull(findUnsafeIfAllowed());
+    }
+
+    @Test
+    public void testFindUnsafeIfAllowed_disabled() {
+        System.setProperty("hazelcast.unsafe.mode", "disabled");
+        assertNull(findUnsafeIfAllowed());
+    }
+
+    @Test
+    public void testFindUnsafeIfAllowed_unalignedOS() {
+        System.setProperty("os.arch", "unaligned");
+        assertNull(findUnsafeIfAllowed());
+    }
+
+    @Test
+    public void testFindUnsafeIfAllowed_unalignedOS_forced() {
+        System.setProperty("os.arch", "unaligned");
+        System.setProperty("hazelcast.unsafe.mode", "enforced");
+        assertNotNull(findUnsafeIfAllowed());
+    }
+}


### PR DESCRIPTION
File is missing code coverage in at least one feature.

Do you think it's safe to assume that `sun.misc.Unsafe` is available on our build machines? Otherwise two of these tests may fail.