### PR TITLE
Check the taken session id and ignore its invalidation if it is already invalidated inside Hazelcast's session inside `WebFilter::readSessionFromLocal`

### DIFF
--- a/hazelcast-wm/src/main/java/com/hazelcast/web/HazelcastHttpSession.java
+++ b/hazelcast-wm/src/main/java/com/hazelcast/web/HazelcastHttpSession.java
@@ -33,6 +33,8 @@ import java.util.concurrent.ConcurrentHashMap;
 
 public class HazelcastHttpSession implements HttpSession {
 
+    volatile String invalidatedOriginalSessionId;
+
     private WebFilter webFilter;
     private volatile boolean valid = true;
     private final String id;
@@ -175,6 +177,7 @@ public class HazelcastHttpSession implements HttpSession {
         // invalidation as our SessionListener will be triggered.
         webFilter.destroySession(this, true);
         originalSession.invalidate();
+        invalidatedOriginalSessionId = originalSession.getId();
     }
 
     public boolean isNew() {


### PR DESCRIPTION
Even though session can be taken from request, it might be already invalidated.

For example, in Wildfly (uses Undertow), taken wrapper session might be valid but its underlying real session might be already invalidated after redirection due to its request/url based wrapper session (points to same original session) design. Therefore, we check the taken session id and ignore its invalidation if it is already invalidated inside Hazelcast's session.

Fixes #6335 