### PR TITLE
Prevent OperationTimeoutException for long running user codes from client

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapIssueTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapIssueTest.java
@@ -19,10 +19,15 @@ package com.hazelcast.client.map;
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.config.ClientProperty;
 import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.config.Config;
+import com.hazelcast.config.XmlConfigBuilder;
 import com.hazelcast.core.EntryAdapter;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.instance.TestUtil;
+import com.hazelcast.map.EntryBackupProcessor;
+import com.hazelcast.map.EntryProcessor;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.query.PagingPredicate;
 import com.hazelcast.spi.EventRegistration;
@@ -38,6 +43,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import java.io.Serializable;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
@@ -220,5 +226,45 @@ public class ClientMapIssueTest extends HazelcastTestSupport {
 
         final Set<Integer> values = map.keySet(predicate);
         assertEquals(pageSize, values.size());
+    }
+
+
+    @Test
+    public void testNoOperationTimeoutException_whenUserCodeLongRunning() {
+        Config config = new XmlConfigBuilder().build();
+        config.setProperty(GroupProperty.OPERATION_CALL_TIMEOUT_MILLIS.getName(), "100");
+        hazelcastFactory.newHazelcastInstance(config);
+
+        HazelcastInstance client = hazelcastFactory.newHazelcastClient();
+        IMap<Object, Object> map = client.getMap(randomMapName());
+        SleepyProcessor sleepyProcessor = new SleepyProcessor(2000);
+        String key = randomString();
+        String value = randomString();
+        map.put(key, value);
+        assertEquals(value, map.executeOnKey(key, sleepyProcessor));
+    }
+
+    static class SleepyProcessor implements EntryProcessor, Serializable {
+
+        private long millis;
+
+        SleepyProcessor(long millis) {
+            this.millis = millis;
+        }
+
+        public Object process(Map.Entry entry) {
+            try {
+
+                Thread.sleep(millis);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+            return entry.getValue();
+        }
+
+        public EntryBackupProcessor getBackupProcessor() {
+            return null;
+        }
+
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngineImpl.java
@@ -366,7 +366,7 @@ public class ClientEngineImpl implements ClientEngine, CoreService, PostJoinAwar
         return node.nodeEngine.getTransactionManagerService();
     }
 
-    private final class ClientPacketProcessor implements PartitionSpecificRunnable {
+    public final class ClientPacketProcessor implements PartitionSpecificRunnable {
         final Packet packet;
 
         private ClientPacketProcessor(Packet packet) {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/IsStillRunningService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/IsStillRunningService.java
@@ -268,7 +268,7 @@ public class IsStillRunningService {
                     invocation.nodeEngine, invocation.serviceName, isStillRunningOperation,
                     invocation.getTarget(), 0, 0, IS_EXECUTING_CALL_TIMEOUT, callback, true);
 
-            invocation.logger.warning("Asking if operation execution has been started: " + isStillRunningOperation);
+            invocation.logger.warning("Asking if operation execution has been started: " + invocation);
             inv.invoke();
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImpl.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.spi.impl.operationservice.impl;
 
+import com.hazelcast.client.impl.ClientEngineImpl;
+import com.hazelcast.client.impl.protocol.task.MessageTask;
 import com.hazelcast.cluster.ClusterState;
 import com.hazelcast.core.HazelcastException;
 import com.hazelcast.core.HazelcastInstanceNotActiveException;
@@ -131,7 +133,9 @@ class OperationRunnerImpl extends OperationRunner {
     }
 
     private boolean publishCurrentTask() {
-        return (getPartitionId() != AD_HOC_PARTITION_ID && currentTask == null);
+        boolean isClientRunnable = currentTask instanceof MessageTask
+                || currentTask instanceof ClientEngineImpl.ClientPacketProcessor;
+        return (getPartitionId() != AD_HOC_PARTITION_ID && (currentTask == null || isClientRunnable));
     }
 
     @Override


### PR DESCRIPTION
When client runnables get into operation thread, they publish
themselves as currentTask. Then, when they do invocation on same
thread with same partition id, they were not able to update current
task with new operation. Since InvocationStillRunning is checked
by published current task, the user code looked like finished
at the moment and gets operation timeout exception.
Fix enables client runnables to change currentTask with new
invocation operation.

Fixes #5555