### PR TITLE
Changed predicate implementations to implement IdentifiedDataSerializable

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/FactoryIdHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/FactoryIdHelper.java
@@ -98,6 +98,9 @@ public final class FactoryIdHelper {
     public static final String WAN_REPLICATION_DS_FACTORY = "hazelcast.serialization.ds.wan_replication";
     public static final int WAN_REPLICATION_DS_FACTORY_ID = -31;
 
+    public static final String PREDICATE_DS_FACTORY = "hazelcast.serialization.ds.predicate";
+    public static final int PREDICATE_DS_FACTORY_ID = -32;
+
     // =========================== portables =============================================
 
     public static final String SPI_PORTABLE_FACTORY = "hazelcast.serialization.portable.spi";

--- a/hazelcast/src/main/java/com/hazelcast/query/PagingPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/PagingPredicate.java
@@ -18,9 +18,10 @@ package com.hazelcast.query;
 
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.DataSerializable;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.query.impl.QueryContext;
 import com.hazelcast.query.impl.QueryableEntry;
+import com.hazelcast.query.impl.predicates.PredicateDataSerializerHook;
 import com.hazelcast.util.IterationType;
 import com.hazelcast.util.SortingUtil;
 
@@ -32,6 +33,8 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
+import static com.hazelcast.internal.serialization.impl.FactoryIdHelper.PREDICATE_DS_FACTORY_ID;
 
 /**
  * This class is a special Predicate which helps to get a page-by-page result of a query.
@@ -67,7 +70,7 @@ import java.util.Set;
  * System.out.println("values = " + values) // will print 'values = [0, 1]'
  * </pre>
  */
-public class PagingPredicate implements IndexAwarePredicate, DataSerializable {
+public class PagingPredicate implements IndexAwarePredicate, IdentifiedDataSerializable {
 
     private static final Map.Entry<Integer, Map.Entry> NULL_ANCHOR = new SimpleImmutableEntry(-1, null);
 
@@ -359,4 +362,13 @@ public class PagingPredicate implements IndexAwarePredicate, DataSerializable {
         }
     }
 
+    @Override
+    public int getFactoryId() {
+        return PREDICATE_DS_FACTORY_ID;
+    }
+
+    @Override
+    public int getId() {
+        return PredicateDataSerializerHook.PAGING_PREDICATE;
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/query/SqlPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/SqlPredicate.java
@@ -18,10 +18,11 @@ package com.hazelcast.query;
 
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.DataSerializable;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.query.impl.Indexes;
 import com.hazelcast.query.impl.QueryContext;
 import com.hazelcast.query.impl.QueryableEntry;
+import com.hazelcast.query.impl.predicates.PredicateDataSerializerHook;
 import com.hazelcast.query.impl.predicates.Visitor;
 
 import java.io.IOException;
@@ -31,6 +32,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static com.hazelcast.internal.serialization.impl.FactoryIdHelper.PREDICATE_DS_FACTORY_ID;
 import static com.hazelcast.query.Predicates.and;
 import static com.hazelcast.query.Predicates.between;
 import static com.hazelcast.query.Predicates.equal;
@@ -47,7 +49,8 @@ import static com.hazelcast.query.Predicates.regex;
 /**
  * This class contains methods related to conversion of sql query to predicate.
  */
-public class SqlPredicate implements IndexAwarePredicate, VisitablePredicate, DataSerializable {
+public class SqlPredicate
+        implements IndexAwarePredicate, VisitablePredicate, IdentifiedDataSerializable {
 
     private static final long serialVersionUID = 1;
 
@@ -333,5 +336,15 @@ public class SqlPredicate implements IndexAwarePredicate, VisitablePredicate, Da
 
     public Predicate getPredicate() {
         return predicate;
+    }
+
+    @Override
+    public int getFactoryId() {
+        return PREDICATE_DS_FACTORY_ID;
+    }
+
+    @Override
+    public int getId() {
+        return PredicateDataSerializerHook.SQL_PREDICATE;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/query/TruePredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/TruePredicate.java
@@ -18,15 +18,18 @@ package com.hazelcast.query;
 
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.DataSerializable;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.query.impl.predicates.PredicateDataSerializerHook;
 
 import java.io.IOException;
 import java.util.Map;
 
+import static com.hazelcast.internal.serialization.impl.FactoryIdHelper.PREDICATE_DS_FACTORY_ID;
+
 /**
  * A {@link com.hazelcast.query.Predicate} which always returns true.
  */
-public class TruePredicate implements DataSerializable, Predicate {
+public class TruePredicate implements IdentifiedDataSerializable, Predicate {
 
     //reminder:
     //when TruePredicate is going to implement IdentifiedDataSerializable, make sure no new instance
@@ -53,5 +56,15 @@ public class TruePredicate implements DataSerializable, Predicate {
     @Override
     public String toString() {
         return "TruePredicate{}";
+    }
+
+    @Override
+    public int getFactoryId() {
+        return PREDICATE_DS_FACTORY_ID;
+    }
+
+    @Override
+    public int getId() {
+        return PredicateDataSerializerHook.TRUE_PREDICATE;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/FalsePredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/FalsePredicate.java
@@ -18,21 +18,24 @@ package com.hazelcast.query.impl;
 
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.DataSerializable;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.query.IndexAwarePredicate;
 import com.hazelcast.query.Predicate;
+import com.hazelcast.query.impl.predicates.PredicateDataSerializerHook;
 
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 
+import static com.hazelcast.internal.serialization.impl.FactoryIdHelper.PREDICATE_DS_FACTORY_ID;
+
 /**
  * reminder:
  * when FalsePredicate is going to implement IdentifiedDataSerializable, make sure no new instance
  * is created, but the INSTANCE is returned. No need to create new objects.
  */
-public class FalsePredicate implements DataSerializable, Predicate, IndexAwarePredicate {
+public class FalsePredicate implements IdentifiedDataSerializable, Predicate, IndexAwarePredicate {
     /**
      * An instance of the FalsePredicate.
      */
@@ -64,5 +67,15 @@ public class FalsePredicate implements DataSerializable, Predicate, IndexAwarePr
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
+    }
+
+    @Override
+    public int getFactoryId() {
+        return PREDICATE_DS_FACTORY_ID;
+    }
+
+    @Override
+    public int getId() {
+        return PredicateDataSerializerHook.FALSE_PREDICATE;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/AbstractPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/AbstractPredicate.java
@@ -18,7 +18,7 @@ package com.hazelcast.query.impl.predicates;
 
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.DataSerializable;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.QueryException;
 import com.hazelcast.query.impl.AttributeType;
@@ -31,11 +31,14 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
+import static com.hazelcast.internal.serialization.impl.FactoryIdHelper.PREDICATE_DS_FACTORY_ID;
+
 /**
  * Provides base features for predicates, such as extraction and convertion of the attribute's value.
  * It also handles apply() on MultiResult.
  */
-public abstract class AbstractPredicate implements Predicate, DataSerializable {
+public abstract class AbstractPredicate
+        implements Predicate, IdentifiedDataSerializable {
 
     String attributeName;
     private transient volatile AttributeType attributeType;
@@ -143,5 +146,10 @@ public abstract class AbstractPredicate implements Predicate, DataSerializable {
     @Override
     public void readData(ObjectDataInput in) throws IOException {
         attributeName = in.readUTF();
+    }
+
+    @Override
+    public int getFactoryId() {
+        return PREDICATE_DS_FACTORY_ID;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/AndPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/AndPredicate.java
@@ -18,7 +18,7 @@ package com.hazelcast.query.impl.predicates;
 
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.DataSerializable;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.query.IndexAwarePredicate;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.VisitablePredicate;
@@ -33,10 +33,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static com.hazelcast.internal.serialization.impl.FactoryIdHelper.PREDICATE_DS_FACTORY_ID;
+
 /**
  * And Predicate
  */
-public final class AndPredicate implements IndexAwarePredicate, DataSerializable, VisitablePredicate, NegatablePredicate {
+public final class AndPredicate
+        implements IndexAwarePredicate, IdentifiedDataSerializable, VisitablePredicate, NegatablePredicate {
 
     protected Predicate[] predicates;
 
@@ -164,5 +167,15 @@ public final class AndPredicate implements IndexAwarePredicate, DataSerializable
         }
         OrPredicate orPredicate = new OrPredicate(inners);
         return orPredicate;
+    }
+
+    @Override
+    public int getFactoryId() {
+        return PREDICATE_DS_FACTORY_ID;
+    }
+
+    @Override
+    public int getId() {
+        return PredicateDataSerializerHook.AND_PREDICATE;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/BetweenPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/BetweenPredicate.java
@@ -83,4 +83,9 @@ public class BetweenPredicate extends AbstractIndexAwarePredicate {
     public String toString() {
         return attributeName + " BETWEEN " + from + " AND " + to;
     }
+
+    @Override
+    public int getId() {
+        return PredicateDataSerializerHook.BETWEEN_PREDICATE;
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/EqualPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/EqualPredicate.java
@@ -82,4 +82,9 @@ public class EqualPredicate extends AbstractIndexAwarePredicate implements Negat
     public Predicate negate() {
         return new NotEqualPredicate(attributeName, value);
     }
+
+    @Override
+    public int getId() {
+        return PredicateDataSerializerHook.EQUAL_PREDICATE;
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/GreaterLessPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/GreaterLessPredicate.java
@@ -106,4 +106,9 @@ public final class GreaterLessPredicate extends AbstractIndexAwarePredicate impl
     public Predicate negate() {
         return new GreaterLessPredicate(attributeName, value, !equal, !less);
     }
+
+    @Override
+    public int getId() {
+        return PredicateDataSerializerHook.GREATERLESS_PREDICATE;
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/ILikePredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/ILikePredicate.java
@@ -39,4 +39,9 @@ public class ILikePredicate extends LikePredicate {
     protected int getFlags() {
         return Pattern.CASE_INSENSITIVE;
     }
+
+    @Override
+    public int getId() {
+        return PredicateDataSerializerHook.ILIKE_PREDICATE;
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/InPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/InPredicate.java
@@ -106,4 +106,9 @@ public class InPredicate extends AbstractIndexAwarePredicate {
         sb.append(")");
         return sb.toString();
     }
+
+    @Override
+    public int getId() {
+        return PredicateDataSerializerHook.IN_PREDICATE;
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/InstanceOfPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/InstanceOfPredicate.java
@@ -18,22 +18,28 @@ package com.hazelcast.query.impl.predicates;
 
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.DataSerializable;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.nio.serialization.HazelcastSerializationException;
 import com.hazelcast.query.Predicate;
 
 import java.io.IOException;
 import java.util.Map;
 
+import static com.hazelcast.internal.serialization.impl.FactoryIdHelper.PREDICATE_DS_FACTORY_ID;
+
 /**
  * Predicate version of `instaceof` operator from Java.
  *
  */
-public class InstanceOfPredicate implements Predicate, DataSerializable {
+public class InstanceOfPredicate
+        implements Predicate, IdentifiedDataSerializable {
     private Class klass;
 
     public InstanceOfPredicate(Class klass) {
         this.klass = klass;
+    }
+
+    public InstanceOfPredicate() {
     }
 
     @Override
@@ -63,5 +69,15 @@ public class InstanceOfPredicate implements Predicate, DataSerializable {
     @Override
     public String toString() {
         return " instanceOf (" + klass.getName() + ")";
+    }
+
+    @Override
+    public int getFactoryId() {
+        return PREDICATE_DS_FACTORY_ID;
+    }
+
+    @Override
+    public int getId() {
+        return PredicateDataSerializerHook.INSTANCEOF_PREDICATE;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/LikePredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/LikePredicate.java
@@ -91,4 +91,9 @@ public class LikePredicate extends AbstractPredicate {
     public String toString() {
         return attributeName + " LIKE '" + expression + "'";
     }
+
+    @Override
+    public int getId() {
+        return PredicateDataSerializerHook.LIKE_PREDICATE;
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/NotEqualPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/NotEqualPredicate.java
@@ -58,4 +58,9 @@ public final class NotEqualPredicate extends EqualPredicate {
     public Predicate negate() {
         return new EqualPredicate(attributeName, value);
     }
+
+    @Override
+    public int getId() {
+        return PredicateDataSerializerHook.NOTEQUAL_PREDICATE;
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/NotPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/NotPredicate.java
@@ -18,7 +18,7 @@ package com.hazelcast.query.impl.predicates;
 
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.DataSerializable;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.VisitablePredicate;
 import com.hazelcast.query.impl.Indexes;
@@ -26,10 +26,13 @@ import com.hazelcast.query.impl.Indexes;
 import java.io.IOException;
 import java.util.Map;
 
+import static com.hazelcast.internal.serialization.impl.FactoryIdHelper.PREDICATE_DS_FACTORY_ID;
+
 /**
  * Not Predicate
  */
-public final class NotPredicate implements Predicate, DataSerializable, VisitablePredicate, NegatablePredicate {
+public final class NotPredicate
+        implements Predicate, VisitablePredicate, NegatablePredicate, IdentifiedDataSerializable {
     protected Predicate predicate;
 
     public NotPredicate(Predicate predicate) {
@@ -79,5 +82,15 @@ public final class NotPredicate implements Predicate, DataSerializable, Visitabl
     @Override
     public Predicate negate() {
         return predicate;
+    }
+
+    @Override
+    public int getFactoryId() {
+        return PREDICATE_DS_FACTORY_ID;
+    }
+
+    @Override
+    public int getId() {
+        return PredicateDataSerializerHook.NOT_PREDICATE;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/OrPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/OrPredicate.java
@@ -18,7 +18,7 @@ package com.hazelcast.query.impl.predicates;
 
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.DataSerializable;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.query.IndexAwarePredicate;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.VisitablePredicate;
@@ -33,10 +33,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static com.hazelcast.internal.serialization.impl.FactoryIdHelper.PREDICATE_DS_FACTORY_ID;
+
 /**
  * Or Predicate
  */
-public final class OrPredicate implements IndexAwarePredicate, DataSerializable, VisitablePredicate, NegatablePredicate {
+public final class OrPredicate
+        implements IndexAwarePredicate, VisitablePredicate, NegatablePredicate, IdentifiedDataSerializable {
 
     protected Predicate[] predicates;
 
@@ -149,5 +152,15 @@ public final class OrPredicate implements IndexAwarePredicate, DataSerializable,
         }
         AndPredicate andPredicate = new AndPredicate(inners);
         return andPredicate;
+    }
+
+    @Override
+    public int getFactoryId() {
+        return PREDICATE_DS_FACTORY_ID;
+    }
+
+    @Override
+    public int getId() {
+        return PredicateDataSerializerHook.OR_PREDICATE;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/PredicateDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/PredicateDataSerializerHook.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.query.impl.predicates;
+
+import com.hazelcast.internal.serialization.DataSerializerHook;
+import com.hazelcast.internal.serialization.impl.ArrayDataSerializableFactory;
+import com.hazelcast.internal.serialization.impl.FactoryIdHelper;
+import com.hazelcast.nio.serialization.DataSerializableFactory;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.query.PagingPredicate;
+import com.hazelcast.query.SqlPredicate;
+import com.hazelcast.query.TruePredicate;
+import com.hazelcast.query.impl.FalsePredicate;
+import com.hazelcast.util.ConstructorFunction;
+
+import static com.hazelcast.internal.serialization.impl.FactoryIdHelper.PREDICATE_DS_FACTORY;
+import static com.hazelcast.internal.serialization.impl.FactoryIdHelper.PREDICATE_DS_FACTORY_ID;
+
+public class PredicateDataSerializerHook
+        implements DataSerializerHook {
+
+    public static final int F_ID = FactoryIdHelper.getFactoryId(PREDICATE_DS_FACTORY, PREDICATE_DS_FACTORY_ID);
+
+    public static final int SQL_PREDICATE = 0;
+
+    public static final int AND_PREDICATE = 1;
+
+    public static final int BETWEEN_PREDICATE = 2;
+
+    public static final int EQUAL_PREDICATE = 3;
+
+    public static final int GREATERLESS_PREDICATE = 4;
+
+    public static final int LIKE_PREDICATE = 5;
+
+    public static final int ILIKE_PREDICATE = 6;
+
+    public static final int IN_PREDICATE = 7;
+
+    public static final int INSTANCEOF_PREDICATE = 8;
+
+    public static final int NOTEQUAL_PREDICATE = 9;
+
+    public static final int NOT_PREDICATE = 10;
+
+    public static final int OR_PREDICATE = 11;
+
+    public static final int REGEX_PREDICATE = 12;
+
+    public static final int FALSE_PREDICATE = 13;
+
+    public static final int TRUE_PREDICATE = 14;
+
+    public static final int PAGING_PREDICATE = 15;
+
+    public static final int LEN = 16;
+
+    @Override
+    public int getFactoryId() {
+        return F_ID;
+    }
+
+    @Override
+    public DataSerializableFactory createFactory() {
+        ConstructorFunction<Integer, IdentifiedDataSerializable>[] constructors = new ConstructorFunction[LEN];
+
+        constructors[SQL_PREDICATE] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new SqlPredicate();
+            }
+        };
+        constructors[AND_PREDICATE] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new AndPredicate();
+            }
+        };
+        constructors[BETWEEN_PREDICATE] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new BetweenPredicate();
+            }
+        };
+        constructors[EQUAL_PREDICATE] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new EqualPredicate();
+            }
+        };
+        constructors[GREATERLESS_PREDICATE] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new GreaterLessPredicate();
+            }
+        };
+        constructors[LIKE_PREDICATE] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new LikePredicate();
+            }
+        };
+        constructors[ILIKE_PREDICATE] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new ILikePredicate();
+            }
+        };
+        constructors[IN_PREDICATE] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new InPredicate();
+            }
+        };
+        constructors[INSTANCEOF_PREDICATE] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new InstanceOfPredicate();
+            }
+        };
+        constructors[NOTEQUAL_PREDICATE] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new NotEqualPredicate();
+            }
+        };
+        constructors[NOT_PREDICATE] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new NotPredicate();
+            }
+        };
+        constructors[OR_PREDICATE] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new OrPredicate();
+            }
+        };
+        constructors[REGEX_PREDICATE] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new RegexPredicate();
+            }
+        };
+        constructors[FALSE_PREDICATE] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new FalsePredicate();
+            }
+        };
+        constructors[TRUE_PREDICATE] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new TruePredicate();
+            }
+        };
+        constructors[PAGING_PREDICATE] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new PagingPredicate();
+            }
+        };
+
+        return new ArrayDataSerializableFactory(constructors);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/RegexPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/RegexPredicate.java
@@ -72,4 +72,9 @@ public class RegexPredicate extends AbstractPredicate {
     public String toString() {
         return attributeName + " REGEX '" + regex + "'";
     }
+
+    @Override
+    public int getId() {
+        return PredicateDataSerializerHook.REGEX_PREDICATE;
+    }
 }

--- a/hazelcast/src/main/resources/META-INF/services/com.hazelcast.DataSerializerHook
+++ b/hazelcast/src/main/resources/META-INF/services/com.hazelcast.DataSerializerHook
@@ -20,4 +20,5 @@ com.hazelcast.mapreduce.aggregation.impl.AggregationsDataSerializerHook
 com.hazelcast.cache.impl.CacheDataSerializerHook
 com.hazelcast.ringbuffer.impl.RingbufferDataSerializerHook
 com.hazelcast.wan.impl.WanDataSerializerHook
+com.hazelcast.query.impl.predicates.PredicateDataSerializerHook
 


### PR DESCRIPTION
Changed the predicate implementations to implement IdentifiedDataSerializable rather than DataSerializable. The change is needed for non-java clients to work without class name information.