### PR TITLE
MulticastJoiner try count should be bounded

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/MulticastJoiner.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/MulticastJoiner.java
@@ -31,7 +31,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 public class MulticastJoiner extends AbstractJoiner {
 
-    private static final int PUBLISH_INTERVAL = 100;
+    private static final int PUBLISH_INTERVAL_MIN = 50;
+    private static final int PUBLISH_INTERVAL_MAX = 200;
     private static final long JOIN_RETRY_INTERVAL = 1000L;
 
     private final AtomicInteger currentTryCount = new AtomicInteger(0);
@@ -164,7 +165,7 @@ public class MulticastJoiner extends AbstractJoiner {
                 node.multicastService.send(joinRequest);
                 if (node.getMasterAddress() == null) {
                     //noinspection BusyWait
-                    Thread.sleep(PUBLISH_INTERVAL);
+                    Thread.sleep(getPublishInterval());
                 } else {
                     return node.getMasterAddress();
                 }
@@ -182,8 +183,8 @@ public class MulticastJoiner extends AbstractJoiner {
     private int calculateTryCount() {
         final NetworkConfig networkConfig = config.getNetworkConfig();
         int timeoutSeconds = networkConfig.getJoin().getMulticastConfig().getMulticastTimeoutSeconds();
-        int tryCountCoefficient = 1000 / PUBLISH_INTERVAL;
-        int tryCount = timeoutSeconds * tryCountCoefficient;
+        int avgPublishInterval = (PUBLISH_INTERVAL_MAX + PUBLISH_INTERVAL_MIN) / 2;
+        int tryCount = timeoutSeconds * 1000 / avgPublishInterval;
         String host = node.getThisAddress().getHost();
         int lastDigits;
         try {
@@ -191,10 +192,13 @@ public class MulticastJoiner extends AbstractJoiner {
         } catch (NumberFormatException e) {
             lastDigits = RandomPicker.getInt(512);
         }
-        lastDigits = lastDigits % 100;
         int portDiff = node.getThisAddress().getPort() - networkConfig.getPort();
-        tryCount += lastDigits + portDiff * timeoutSeconds * 3;
+        tryCount += (lastDigits + portDiff) % 10;
         return tryCount;
+    }
+
+    private int getPublishInterval() {
+        return RandomPicker.getInt(PUBLISH_INTERVAL_MIN, PUBLISH_INTERVAL_MAX);
     }
 
     public void onReceivedJoinRequest(JoinRequest joinRequest) {

--- a/hazelcast/src/main/java/com/hazelcast/util/RandomPicker.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/RandomPicker.java
@@ -51,4 +51,18 @@ public final class RandomPicker {
         return randomNumberGenerator.nextInt(n);
     }
 
+
+    /**
+     * Return a pseudorandom, uniformly distributed in value between the low value (inclusive) and
+     * the high value (exclusive), drawn from this random number generator's sequence.
+     * Starts the random number generator sequence if it has not been initialized.
+     *
+     * @param low lowest value of the range (inclusive)
+     * @param high highest value of the range (exclusive)
+     * @return a value between the specified low (inclusive) and high value (exclusive).
+     */
+    public static int getInt(int low, int high) {
+        return getInt(high - low) + low;
+    }
+
 }

--- a/hazelcast/src/test/java/com/hazelcast/cluster/PublicAddressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/PublicAddressTest.java
@@ -24,6 +24,7 @@ import com.hazelcast.nio.Address;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
+import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -33,12 +34,19 @@ import java.net.UnknownHostException;
 
 import static org.junit.Assert.assertEquals;
 
-@Ignore
 @RunWith(HazelcastSerialClassRunner.class)
 @Category({QuickTest.class})
 public class PublicAddressTest {
 
     public static final int DEFAULT_PORT = 5701;
+
+    private Config config;
+
+    @Before
+    public void createConfig() {
+        config = new Config();
+        config.getNetworkConfig().getJoin().getMulticastConfig().setMulticastTimeoutSeconds(1);
+    }
 
     @After
     public void cleanup() {
@@ -47,7 +55,6 @@ public class PublicAddressTest {
 
     @Test
     public void testUseDefaultPortWhenLoopback() throws UnknownHostException {
-        Config config = new Config();
         config.getNetworkConfig().setPublicAddress("127.0.0.1");
         HazelcastInstance instance = Hazelcast.newHazelcastInstance(config);
 
@@ -56,7 +63,6 @@ public class PublicAddressTest {
 
     @Test
     public void testUseDefaultPortWhenLocalhost() throws UnknownHostException {
-        Config config = new Config();
         config.getNetworkConfig().setPublicAddress("localhost");
         HazelcastInstance instance = Hazelcast.newHazelcastInstance(config);
 
@@ -65,7 +71,6 @@ public class PublicAddressTest {
 
     @Test
     public void testUseSpecifiedHost() throws UnknownHostException {
-        Config config = new Config();
         config.getNetworkConfig().setPublicAddress("www.example.org");
         HazelcastInstance instance = Hazelcast.newHazelcastInstance(config);
 
@@ -74,7 +79,6 @@ public class PublicAddressTest {
 
     @Test
     public void testUseSpecifiedHostAndPort() throws UnknownHostException {
-        Config config = new Config();
         config.getNetworkConfig().setPublicAddress("www.example.org:6789");
         HazelcastInstance instance = Hazelcast.newHazelcastInstance(config);
 
@@ -83,7 +87,6 @@ public class PublicAddressTest {
 
     @Test
     public void testUseSpecifiedHostAndPortViaProperty() throws UnknownHostException {
-        Config config = new Config();
         config.setProperty("hazelcast.local.publicAddress", "192.168.1.1:6789");
         HazelcastInstance instance = Hazelcast.newHazelcastInstance(config);
 


### PR DESCRIPTION
Currently MulticastJoiner has no bounds, especially when portDiff is large
it can result in a very large try count (>10000)

Removing ignore from tests which were ignored because of slowness with this issue.

Fixes #5598 and #6858