### PR TITLE
Fix hasOnGoingMigration 

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/ClusterStateManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/ClusterStateManager.java
@@ -160,19 +160,16 @@ public class ClusterStateManager {
     }
 
     private void checkMigrationsAndPartitionStateVersion(ClusterState newState, int partitionStateVersion) {
-        if (newState != ClusterState.ACTIVE) {
-            final InternalPartitionService partitionService = node.getPartitionService();
-            final int thisPartitionStateVersion = partitionService.getPartitionStateVersion();
+        final InternalPartitionService partitionService = node.getPartitionService();
+        final int thisPartitionStateVersion = partitionService.getPartitionStateVersion();
 
-            if (partitionService.hasOnGoingMigrationLocal()) {
-                throw new IllegalStateException("Still have pending migration/replication tasks, "
-                        + "cannot lock cluster state! New state: " + newState
-                        + ", current state: " + getState());
-            } else  if (partitionStateVersion != thisPartitionStateVersion) {
-                throw new IllegalStateException("Can not lock cluster state! Partition tables have different versions! "
-                        + "Expected version: " + partitionStateVersion + " Current version: " + thisPartitionStateVersion);
-            }
-
+        if (partitionService.hasOnGoingMigrationLocal()) {
+            throw new IllegalStateException("Still have pending migration tasks, "
+                    + "cannot lock cluster state! New state: " + newState
+                    + ", current state: " + getState());
+        } else  if (partitionStateVersion != thisPartitionStateVersion) {
+            throw new IllegalStateException("Can not lock cluster state! Partition tables have different versions! "
+                    + "Expected version: " + partitionStateVersion + " Current version: " + thisPartitionStateVersion);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/partition/InternalPartitionService.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/InternalPartitionService.java
@@ -112,13 +112,6 @@ public interface InternalPartitionService extends CoreService {
      */
     int getPartitionCount();
 
-    /**
-     * Checks if there currently are any migrations.
-     *
-     * @return true if there are migrations, false otherwise.
-     */
-    boolean hasOnGoingMigration();
-
     List<Integer> getMemberPartitions(Address target);
 
     /**
@@ -183,6 +176,18 @@ public interface InternalPartitionService extends CoreService {
 
     int getPartitionStateVersion();
 
+    /**
+     * Checks if there are any cluster-wide migrations.
+     *
+     * @return true if there are migrations, false otherwise.
+     */
+    boolean hasOnGoingMigration();
+
+    /**
+     * Checks if there are any local migrations.
+     *
+     * @return true if there are migrations, false otherwise.
+     */
     boolean hasOnGoingMigrationLocal();
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/partition/impl/InternalPartitionServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/impl/InternalPartitionServiceImpl.java
@@ -1242,8 +1242,7 @@ public class InternalPartitionServiceImpl implements InternalPartitionService, M
     @Override
     public boolean hasOnGoingMigrationLocal() {
         return !activeMigrations.isEmpty() || !migrationQueue.isEmpty()
-                || migrationThread.isMigrating()
-                || shouldWaitMigrationOrBackups(Level.OFF);
+                || migrationThread.isMigrating();
     }
 
     private boolean isReplicaInSyncState() {

--- a/hazelcast/src/test/java/com/hazelcast/cluster/impl/BasicClusterStateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/impl/BasicClusterStateTest.java
@@ -20,7 +20,7 @@ import com.hazelcast.cluster.ClusterState;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
-import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.instance.Node;
 import com.hazelcast.instance.NodeState;
 import com.hazelcast.nio.Address;
@@ -205,7 +205,7 @@ public class BasicClusterStateTest
     @Test(expected = IllegalStateException.class)
     public void changeClusterState_toFrozen_shouldFail_whilePartitionsMigrating() {
         Config config = new Config();
-        config.setProperty(GroupProperties.PROP_PARTITION_MIGRATION_INTERVAL, "10");
+        config.setProperty(GroupProperty.PARTITION_MIGRATION_INTERVAL, "10");
 
         TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
         HazelcastInstance hz = factory.newHazelcastInstance(config);
@@ -218,7 +218,7 @@ public class BasicClusterStateTest
     @Test(expected = IllegalStateException.class)
     public void changeClusterState_toPassive_shouldFail_whilePartitionsMigrating() {
         Config config = new Config();
-        config.setProperty(GroupProperties.PROP_PARTITION_MIGRATION_INTERVAL, "10");
+        config.setProperty(GroupProperty.PARTITION_MIGRATION_INTERVAL, "10");
 
         TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
         HazelcastInstance hz = factory.newHazelcastInstance(config);
@@ -232,8 +232,8 @@ public class BasicClusterStateTest
     @Test
     public void changeClusterState_toActive_isAllowed_whileReplicationInProgress() {
         Config config = new Config();
-        config.setProperty(GroupProperties.PROP_PARTITION_MIGRATION_INTERVAL, "10");
-        config.setProperty(GroupProperties.PROP_PARTITION_MAX_PARALLEL_REPLICATIONS, "1");
+        config.setProperty(GroupProperty.PARTITION_MIGRATION_INTERVAL, "10");
+        config.setProperty(GroupProperty.PARTITION_MAX_PARALLEL_REPLICATIONS, "1");
 
         TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(3);
         HazelcastInstance[] instances = factory.newInstances(config);
@@ -255,8 +255,8 @@ public class BasicClusterStateTest
     @Test
     public void changeClusterState_toPassive_isAllowed_whileReplicationInProgress() {
         Config config = new Config();
-        config.setProperty(GroupProperties.PROP_PARTITION_MIGRATION_INTERVAL, "10");
-        config.setProperty(GroupProperties.PROP_PARTITION_MAX_PARALLEL_REPLICATIONS, "1");
+        config.setProperty(GroupProperty.PARTITION_MIGRATION_INTERVAL, "10");
+        config.setProperty(GroupProperty.PARTITION_MAX_PARALLEL_REPLICATIONS, "1");
 
         TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(3);
         HazelcastInstance[] instances = factory.newInstances(config);

--- a/hazelcast/src/test/java/com/hazelcast/cluster/impl/ClusterStateManagerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/impl/ClusterStateManagerTest.java
@@ -156,13 +156,25 @@ public class ClusterStateManagerTest {
         clusterStateManager.lockClusterState(newState, initiator, TXN, 1000, 0);
     }
 
-    @Test
+    @Test(expected = IllegalStateException.class)
     public void test_lockClusterState_forActiveState_whenHasOnGoingMigration() throws Exception {
         when(partitionService.hasOnGoingMigrationLocal()).thenReturn(true);
         clusterStateManager.initialClusterState(FROZEN);
 
         Address initiator = newAddress();
         final ClusterState newState = ACTIVE;
+        clusterStateManager.lockClusterState(newState, initiator, TXN, 1000, 0);
+
+        assertLockedBy(initiator);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void test_lockClusterState_forPassiveState_whenHasOnGoingMigration() throws Exception {
+        when(partitionService.hasOnGoingMigrationLocal()).thenReturn(true);
+        clusterStateManager.initialClusterState(FROZEN);
+
+        Address initiator = newAddress();
+        final ClusterState newState = PASSIVE;
         clusterStateManager.lockClusterState(newState, initiator, TXN, 1000, 0);
 
         assertLockedBy(initiator);


### PR DESCRIPTION
- During cluster state change migration is always forbidden, replication is allowed
- InternalPartitionService.hasOnGoingMigrationLocal should only check local migrations. 
Before it was checking for missing backups too which makes the method more strict
but also causes wrong a perception.

Fixes #6479