### PR TITLE
Mark stats-related record fields as volatile

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/record/AbstractRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/record/AbstractRecord.java
@@ -33,8 +33,8 @@ public abstract class AbstractRecord<V> implements Record<V> {
      */
     protected long evictionCriteriaNumber;
     protected long ttl;
-    protected long lastAccessTime;
-    protected long lastUpdateTime;
+    protected volatile long lastAccessTime;
+    protected volatile long lastUpdateTime;
     protected long creationTime;
     protected long tombstoneSequence;
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/record/RecordStatisticsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/record/RecordStatisticsImpl.java
@@ -19,6 +19,7 @@ package com.hazelcast.map.impl.record;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.util.Clock;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.IOException;
 
@@ -27,8 +28,7 @@ import java.io.IOException;
  */
 public class RecordStatisticsImpl implements RecordStatistics {
 
-    // TODO is volatile needed? if yes then hits should be atomicnumber
-    protected int hits;
+    protected volatile int hits;
     protected long lastStoredTime;
     protected long expirationTime;
 
@@ -56,6 +56,8 @@ public class RecordStatisticsImpl implements RecordStatistics {
         this.expirationTime = expirationTime;
     }
 
+    @SuppressFBWarnings(value = "VO_VOLATILE_INCREMENT",
+            justification = "We have the guarantee that only the partition thread will call this method")
     @Override
     public void access() {
         hits++;

--- a/hazelcast/src/test/java/com/hazelcast/map/LocalMapStatsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/LocalMapStatsTest.java
@@ -15,6 +15,7 @@ import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.test.annotation.Repeat;
 import com.hazelcast.util.Clock;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -84,16 +85,17 @@ public class LocalMapStatsTest extends HazelcastTestSupport {
 
     @Test
     public void testGetAsyncAndHitsGenerated() throws Exception {
-        IMap<Integer, Integer> map = getMap();
+        final IMap<Integer, Integer> map = getMap();
         for (int i = 0; i < 100; i++) {
             map.put(i, i);
             map.getAsync(i).get();
         }
-        final LocalMapStats localMapStats = map.getLocalMapStats();
+
         assertTrueEventually(new AssertTask() {
             @Override
             public void run()
                     throws Exception {
+                final LocalMapStats localMapStats = map.getLocalMapStats();
                 assertEquals(100, localMapStats.getGetOperationCount());
                 assertEquals(100, localMapStats.getHits());
             }


### PR DESCRIPTION
* Stats related fields are updated from partition thread and being read from user thread.

Fixes #6885