### PR TITLE
[BACKPORT] Mark stats-related record fields as volatile

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/record/AbstractBaseRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/record/AbstractBaseRecord.java
@@ -28,8 +28,8 @@ abstract class AbstractBaseRecord<V> implements Record<V> {
      */
     protected long evictionCriteriaNumber;
     protected long ttl;
-    protected long lastAccessTime;
-    protected long lastUpdateTime;
+    protected volatile long lastAccessTime;
+    protected volatile long lastUpdateTime;
     protected long creationTime;
 
     public AbstractBaseRecord() {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/record/RecordStatistics.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/record/RecordStatistics.java
@@ -28,8 +28,7 @@ import java.io.IOException;
  */
 public class RecordStatistics implements DataSerializable {
 
-    // TODO is volatile needed? if yes then hits should be atomicnumber
-    protected int hits;
+    protected volatile int hits;
     protected long lastStoredTime;
     protected long expirationTime;
 
@@ -53,6 +52,8 @@ public class RecordStatistics implements DataSerializable {
         this.expirationTime = expirationTime;
     }
 
+    @edu.umd.cs.findbugs.annotations.SuppressWarnings(value = "VO_VOLATILE_INCREMENT",
+            justification = "We have the guarantee that only the partition thread will call this method")
     public void access() {
         hits++;
     }

--- a/hazelcast/src/test/java/com/hazelcast/map/LocalMapStatsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/LocalMapStatsTest.java
@@ -86,16 +86,17 @@ public class LocalMapStatsTest extends HazelcastTestSupport {
     @Test
     public void testGetAsyncAndHitsGenerated() throws Exception {
         HazelcastInstance h1 = createHazelcastInstance();
-        IMap<Integer, Integer> map = h1.getMap(randomMapName());
+        final IMap<Integer, Integer> map = h1.getMap(randomMapName());
         for (int i = 0; i < 100; i++) {
             map.put(i, i);
             map.getAsync(i);
         }
-        final LocalMapStats localMapStats = map.getLocalMapStats();
+
         assertTrueEventually(new AssertTask() {
             @Override
             public void run()
                     throws Exception {
+                final LocalMapStats localMapStats = map.getLocalMapStats();
                 assertEquals(100, localMapStats.getGetOperationCount());
                 assertEquals(100, localMapStats.getHits());
             }


### PR DESCRIPTION
* Stats related fields are updated from partition thread and being read from user thread.

Backport of #6899 