### PR TITLE
Set lastAccessTime and lastUpdateTime to zero at record creation

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/record/AbstractRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/record/AbstractRecord.java
@@ -17,6 +17,7 @@
 package com.hazelcast.map.impl.record;
 
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.util.Clock;
 
 import static com.hazelcast.map.impl.record.RecordStatistics.EMPTY_STATS;
 
@@ -40,6 +41,7 @@ public abstract class AbstractRecord<V> implements Record<V> {
 
     AbstractRecord() {
         version = 0L;
+        creationTime = Clock.currentTimeMillis();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/AbstractRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/AbstractRecordStore.java
@@ -88,11 +88,7 @@ abstract class AbstractRecordStore implements RecordStore<Record> {
     @Override
     public Record createRecord(Object value, long ttlMillis, long now) {
         MapConfig mapConfig = mapContainer.getMapConfig();
-
         Record record = recordFactory.newRecord(value);
-        record.setCreationTime(now);
-        record.setLastAccessTime(now);
-        record.setLastUpdateTime(now);
 
         final long ttlMillisFromConfig = calculateTTLMillis(mapConfig);
         final long ttl = pickTTL(ttlMillis, ttlMillisFromConfig);

--- a/hazelcast/src/test/java/com/hazelcast/map/BasicMapTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/BasicMapTest.java
@@ -628,7 +628,12 @@ public class BasicMapTest extends HazelcastTestSupport {
         final IMap<Integer, Integer> map = instance.getMap("testEntryView");
         long time1 = Clock.currentTimeMillis();
         map.put(1, 1);
+        map.put(1, 1);
+        map.get(1);
         map.put(2, 2);
+        map.put(2, 2);
+        map.get(2);
+        map.put(3, 3);
         map.put(3, 3);
         long time2 = Clock.currentTimeMillis();
         map.get(3);
@@ -649,13 +654,13 @@ public class BasicMapTest extends HazelcastTestSupport {
         assertEquals((Integer) 22, entryView2.getValue());
         assertEquals((Integer) 3, entryView3.getValue());
 
-        assertEquals(0, entryView1.getHits());
-        assertEquals(1, entryView2.getHits());
-        assertEquals(2, entryView3.getHits());
+        assertEquals(2, entryView1.getHits());
+        assertEquals(3, entryView2.getHits());
+        assertEquals(3, entryView3.getHits());
 
-        assertEquals(0, entryView1.getVersion());
-        assertEquals(1, entryView2.getVersion());
-        assertEquals(0, entryView3.getVersion());
+        assertEquals(1, entryView1.getVersion());
+        assertEquals(2, entryView2.getVersion());
+        assertEquals(1, entryView3.getVersion());
 
         assertTrue(entryView1.getCreationTime() >= time1 && entryView1.getCreationTime() <= time2);
         assertTrue(entryView2.getCreationTime() >= time1 && entryView2.getCreationTime() <= time2);

--- a/hazelcast/src/test/java/com/hazelcast/map/ExpirationTimeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/ExpirationTimeTest.java
@@ -130,8 +130,10 @@ public class ExpirationTimeTest extends HazelcastTestSupport {
         EntryView<Integer, Integer> entryView = map.getEntryView(1);
 
         long lastAccessTime = entryView.getLastAccessTime();
-        long expectedExpirationTime = lastAccessTime + TimeUnit.SECONDS.toMillis(10);
+        long delayToExpiration = lastAccessTime + TimeUnit.SECONDS.toMillis(10);
 
+        // lastAccessTime is zero after put, we can find expiration by this calculation.
+        long expectedExpirationTime = delayToExpiration + entryView.getCreationTime();
         assertEquals(expectedExpirationTime, entryView.getExpirationTime());
 
     }
@@ -151,7 +153,25 @@ public class ExpirationTimeTest extends HazelcastTestSupport {
         long expectedExpirationTime = creationTime + TimeUnit.SECONDS.toMillis(5);
 
         assertEquals(expectedExpirationTime, expirationTime);
+    }
 
+
+    @Test
+    public void testLastAccessTime_isZero_afterFirstPut() throws Exception {
+        IMap<Integer, Integer> map = createMap();
+        map.put(1, 1);
+        EntryView<Integer, Integer> entryView = map.getEntryView(1);
+
+        assertEquals(0L, entryView.getLastAccessTime());
+    }
+
+    @Test
+    public void testLastUpdateTime_isZero_afterFirstPut() throws Exception {
+        IMap<Integer, Integer> map = createMap();
+        map.put(1, 1);
+        EntryView<Integer, Integer> entryView = map.getEntryView(1);
+
+        assertEquals(0L, entryView.getLastUpdateTime());
     }
 
     private IMap<Integer, Integer> createMap() {

--- a/hazelcast/src/test/java/com/hazelcast/map/LocalMapStatsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/LocalMapStatsTest.java
@@ -15,7 +15,6 @@ import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
-import com.hazelcast.test.annotation.Repeat;
 import com.hazelcast.util.Clock;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -169,14 +168,15 @@ public class LocalMapStatsTest extends HazelcastTestSupport {
 
         String key = "key";
         map.put(key, "value");
+        map.get(key);
 
-        long lastUpdateTime = map.getLocalMapStats().getLastUpdateTime();
-        assertTrue(lastUpdateTime >= startTime);
+        long lastAccessTime = map.getLocalMapStats().getLastAccessTime();
+        assertTrue(lastAccessTime >= startTime);
 
         Thread.sleep(5);
         map.put(key, "value2");
-        long lastUpdateTime2 = map.getLocalMapStats().getLastUpdateTime();
-        assertTrue(lastUpdateTime2 > lastUpdateTime);
+        long lastAccessTime2 = map.getLocalMapStats().getLastAccessTime();
+        assertTrue(lastAccessTime2 > lastAccessTime);
     }
 
     @Test
@@ -185,6 +185,7 @@ public class LocalMapStatsTest extends HazelcastTestSupport {
         final IMap<String, String> map = getMap();
 
         final String key = "key";
+        map.put(key, "value");
         map.put(key, "value");
 
         final LocalMapStats localMapStats = map.getLocalMapStats();


### PR DESCRIPTION
This is required to truly find the least recently used entry for LRU eviction by using last-access-time.