### PR TITLE
Fix SecondsBasedEntryTaskScheduler issues

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/util/scheduler/CompositeKey.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/scheduler/CompositeKey.java
@@ -19,16 +19,16 @@ package com.hazelcast.util.scheduler;
 /**
  * This object is first needed for having different key objects that are created for the same key updated in
  * different times so should be persisted consequently.
- * So using ScheduleType.FOR_EACH, all the updates will be scheduled seperately.
+ * So using ScheduleType.FOR_EACH, all the updates will be scheduled separately.
  */
-final class TimeKey {
+final class CompositeKey {
 
-    private Object key;
-    private long time;
+    private final Object key;
+    private final long id;
 
-    public TimeKey(Object key, long time) {
+    public CompositeKey(Object key, long id) {
         this.key = key;
-        this.time = time;
+        this.id = id;
     }
 
     public Object getKey() {
@@ -44,9 +44,9 @@ final class TimeKey {
             return false;
         }
 
-        TimeKey that = (TimeKey) o;
+        CompositeKey that = (CompositeKey) o;
 
-        if (time != that.time) {
+        if (id != that.id) {
             return false;
         }
         if (key != null ? !key.equals(that.key) : that.key != null) {
@@ -59,12 +59,12 @@ final class TimeKey {
     @Override
     public int hashCode() {
         int result = key != null ? key.hashCode() : 0;
-        result = 31 * result + (int) (time ^ (time >>> 32));
+        result = 31 * result + (int) (id ^ (id >>> 32));
         return result;
     }
 
     @Override
     public String toString() {
-        return "TimeKey{" + "key=" + key + ",time=" + time + '}';
+        return "Key{" + "key=" + key + ", id=" + id + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/util/scheduler/ScheduledEntry.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/scheduler/ScheduledEntry.java
@@ -36,22 +36,14 @@ public final class ScheduledEntry<K, V> implements Map.Entry<K, V> {
 
     private final int actualDelaySeconds;
 
-    private final long scheduleStartTimeInNanos;
+    private final long scheduleId;
 
-    public ScheduledEntry(K key, V value, long scheduledDelayMillis, int actualDelaySeconds) {
+    public ScheduledEntry(K key, V value, long scheduledDelayMillis, int actualDelaySeconds, long scheduleId) {
         this.key = key;
         this.value = value;
         this.scheduledDelayMillis = scheduledDelayMillis;
         this.actualDelaySeconds = actualDelaySeconds;
-        this.scheduleStartTimeInNanos = System.nanoTime();
-    }
-
-    public ScheduledEntry(K key, V value, long scheduledDelayMillis, int actualDelaySeconds, long scheduleStartTimeInNanos) {
-        this.key = key;
-        this.value = value;
-        this.scheduledDelayMillis = scheduledDelayMillis;
-        this.actualDelaySeconds = actualDelaySeconds;
-        this.scheduleStartTimeInNanos = scheduleStartTimeInNanos;
+        this.scheduleId = scheduleId;
     }
 
     @Override
@@ -77,8 +69,8 @@ public final class ScheduledEntry<K, V> implements Map.Entry<K, V> {
         return actualDelaySeconds;
     }
 
-    public long getScheduleStartTimeInNanos() {
-        return scheduleStartTimeInNanos;
+    public long getScheduleId() {
+        return scheduleId;
     }
 
     public long getActualDelayMillis() {
@@ -124,8 +116,8 @@ public final class ScheduledEntry<K, V> implements Map.Entry<K, V> {
                 + scheduledDelayMillis
                 + ", actualDelaySeconds="
                 + actualDelaySeconds
-                + ", scheduleStartTimeInNanos="
-                + scheduleStartTimeInNanos
+                + ", scheduleId="
+                + scheduleId
                 + '}';
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/util/scheduler/SecondsBasedEntryTaskSchedulerStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/scheduler/SecondsBasedEntryTaskSchedulerStressTest.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.util.scheduler;
+
+import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static com.hazelcast.test.HazelcastTestSupport.assertTrueEventually;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class SecondsBasedEntryTaskSchedulerStressTest {
+
+    private static final int NUMBER_OF_THREADS = 4;
+    private static final int NUMBER_OF_EVENTS_PER_THREAD = 10000;
+
+    // scheduler is single threaded
+    private final ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExecutor();
+
+    @After
+    public void tearDown() {
+        executorService.shutdownNow();
+    }
+
+    @Test
+    public void test_ifNew() {
+        test_forScheduleType(ScheduleType.SCHEDULE_IF_NEW);
+    }
+
+    @Test
+    public void test_forEach() {
+        test_forScheduleType(ScheduleType.FOR_EACH);
+    }
+
+    @SuppressWarnings("unchecked")
+    private void test_forScheduleType(ScheduleType scheduleType) {
+        final EventCountingEntryProcessor processor = new EventCountingEntryProcessor();
+        final SecondsBasedEntryTaskScheduler scheduler = new SecondsBasedEntryTaskScheduler(executorService, processor,
+                scheduleType);
+
+        for (int i = 0; i < NUMBER_OF_THREADS; i++) {
+            final Thread thread = new Thread() {
+                final Random random = new Random();
+                @Override
+                public void run() {
+                    for (int j = 0; j < NUMBER_OF_EVENTS_PER_THREAD; j++) {
+                        scheduler.schedule(getDelayMillis(), j, null);
+                    }
+                }
+
+                private int getDelayMillis() {
+                    return random.nextInt(5000) + 1;
+                }
+            };
+            thread.start();
+        }
+
+        final long numberOfExpectedEvents = getExpectedEventCount(scheduleType, NUMBER_OF_THREADS,
+                NUMBER_OF_EVENTS_PER_THREAD);
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertEquals(numberOfExpectedEvents, processor.getNumberOfEvents());
+            }
+        });
+    }
+
+    @Test
+    public void test_postpone() {
+        final EntryStoringProcessor processor = new EntryStoringProcessor();
+        final SecondsBasedEntryTaskScheduler<Integer, Integer> scheduler
+                = new SecondsBasedEntryTaskScheduler<Integer, Integer>(executorService, processor, ScheduleType.POSTPONE);
+
+        final int numberOfKeys = NUMBER_OF_THREADS;
+        final Object[] locks = new Object[numberOfKeys];
+        Arrays.fill(locks, new Object());
+
+        final Map<Integer, Integer> latestValues = new ConcurrentHashMap<Integer, Integer>();
+
+        for (int i = 0; i < NUMBER_OF_THREADS; i++) {
+            final Thread thread = new Thread() {
+                final Random random = new Random();
+                @Override
+                public void run() {
+                    for (int j = 0; j < NUMBER_OF_EVENTS_PER_THREAD; j++) {
+                        int key = random.nextInt(numberOfKeys);
+
+                        synchronized (locks[key]) {
+                            if (scheduler.schedule(getDelayMillis(), key, j)) {
+                                latestValues.put(key, j);
+                            }
+                        }
+                    }
+                }
+
+                private int getDelayMillis() {
+                    return random.nextInt(5000) + 1;
+                }
+            };
+            thread.start();
+        }
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertEquals(latestValues.size(), processor.values.size());
+
+                for (int key = 0; key < numberOfKeys; key++) {
+                    Integer expected = latestValues.get(key);
+                    Integer actual = processor.get(key);
+
+                    if (expected == null) {
+                        assertNull(actual);
+                    } else {
+                        assertEquals(expected, actual);
+                    }
+                }
+            }
+        });
+    }
+
+    private long getExpectedEventCount(ScheduleType scheduleType, int numberOfThreads, long numberOfPerThreadExpectedEvents) {
+        if (scheduleType == ScheduleType.FOR_EACH) {
+            return numberOfThreads * numberOfPerThreadExpectedEvents;
+        } else if (scheduleType == ScheduleType.SCHEDULE_IF_NEW) {
+            return numberOfPerThreadExpectedEvents;
+        }
+        throw new IllegalArgumentException();
+    }
+
+    private static class EventCountingEntryProcessor implements ScheduledEntryProcessor {
+        final AtomicInteger numberOfEvents = new AtomicInteger();
+
+        @Override
+        public void process(EntryTaskScheduler scheduler, Collection collection) {
+            numberOfEvents.addAndGet(collection.size());
+        }
+
+        long getNumberOfEvents() {
+            return numberOfEvents.get();
+        }
+    }
+
+    private static class EntryStoringProcessor implements ScheduledEntryProcessor<Integer, Integer> {
+        final Map<Integer, Integer> values = new ConcurrentHashMap<Integer, Integer>();
+
+        @Override
+        public void process(EntryTaskScheduler<Integer, Integer> scheduler,
+                Collection<ScheduledEntry<Integer, Integer>> entries) {
+
+            // scheduler is single threaded
+            for (ScheduledEntry<Integer, Integer> entry : entries) {
+                values.put(entry.getKey(), entry.getValue());
+            }
+        }
+
+        Integer get(int key) {
+            return values.get(key);
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/util/scheduler/SecondsBasedEntryTaskSchedulerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/scheduler/SecondsBasedEntryTaskSchedulerTest.java
@@ -3,7 +3,8 @@ package com.hazelcast.util.scheduler;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
-import org.junit.After;
+import com.hazelcast.util.Clock;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -37,21 +38,14 @@ public class SecondsBasedEntryTaskSchedulerTest {
     @Mock
     private ScheduledEntryProcessor<Integer, Integer> entryProcessor = mock(ScheduledEntryProcessor.class);
 
-
-    private void mockScheduleMethod() {
+    @Before
+    public void mockScheduleMethod() {
         when(executorService.schedule(any(Runnable.class), anyLong(), any(TimeUnit.class))).thenReturn(
                 mock(ScheduledFuture.class));
     }
 
-    @After
-    public void after() {
-        System.clearProperty("com.hazelcast.clock.impl");
-    }
-
     @Test
     public void test_scheduleEntry_scheduleIfNew() {
-        mockScheduleMethod();
-
         final SecondsBasedEntryTaskScheduler<Integer, Integer> scheduler =
                 new SecondsBasedEntryTaskScheduler<Integer, Integer>(executorService, entryProcessor, SCHEDULE_IF_NEW);
 
@@ -62,8 +56,6 @@ public class SecondsBasedEntryTaskSchedulerTest {
 
     @Test
     public void test_scheduleEntryOnlyOnce_scheduleIfNew() {
-        mockScheduleMethod();
-
         final SecondsBasedEntryTaskScheduler<Integer, Integer> scheduler =
                 new SecondsBasedEntryTaskScheduler<Integer, Integer>(executorService, entryProcessor, SCHEDULE_IF_NEW);
 
@@ -75,8 +67,6 @@ public class SecondsBasedEntryTaskSchedulerTest {
 
     @Test
     public void test_cancelEntry_scheduleIfNew() {
-        mockScheduleMethod();
-
         final SecondsBasedEntryTaskScheduler<Integer, Integer> scheduler =
                 new SecondsBasedEntryTaskScheduler<Integer, Integer>(executorService, entryProcessor, SCHEDULE_IF_NEW);
 
@@ -96,8 +86,6 @@ public class SecondsBasedEntryTaskSchedulerTest {
 
     @Test
     public void test_scheduleEntry_postpone() {
-        mockScheduleMethod();
-
         final SecondsBasedEntryTaskScheduler<Integer, Integer> scheduler =
                 new SecondsBasedEntryTaskScheduler<Integer, Integer>(executorService, entryProcessor, POSTPONE);
 
@@ -108,8 +96,6 @@ public class SecondsBasedEntryTaskSchedulerTest {
 
     @Test
     public void test_rescheduleEntry_postpone() {
-        mockScheduleMethod();
-
         final SecondsBasedEntryTaskScheduler<Integer, Integer> scheduler =
                 new SecondsBasedEntryTaskScheduler<Integer, Integer>(executorService, entryProcessor, POSTPONE);
 
@@ -121,22 +107,22 @@ public class SecondsBasedEntryTaskSchedulerTest {
 
     @Test
     public void test_dontRescheduleEntryWithinSameSecond_postpone() {
-        System.setProperty("com.hazelcast.clock.impl", "com.hazelcast.util.StaticClock");
-        mockScheduleMethod();
+        System.setProperty(Clock.HAZELCAST_CLOCK_IMPL, StaticClock.class.getName());
+        try {
+            final SecondsBasedEntryTaskScheduler<Integer, Integer> scheduler =
+                    new SecondsBasedEntryTaskScheduler<Integer, Integer>(executorService, entryProcessor, POSTPONE);
 
-        final SecondsBasedEntryTaskScheduler<Integer, Integer> scheduler =
-                new SecondsBasedEntryTaskScheduler<Integer, Integer>(executorService, entryProcessor, POSTPONE);
-
-        assertTrue(scheduler.schedule(0, 1, 1));
-        assertFalse(scheduler.schedule(0, 1, 1));
-        assertNotNull(scheduler.get(1));
-        assertEquals(1, scheduler.size());
+            assertTrue(scheduler.schedule(0, 1, 1));
+            assertFalse(scheduler.schedule(0, 1, 1));
+            assertNotNull(scheduler.get(1));
+            assertEquals(1, scheduler.size());
+        } finally {
+            System.clearProperty(Clock.HAZELCAST_CLOCK_IMPL);
+        }
     }
 
     @Test
     public void test_cancelEntry_postpone() {
-        mockScheduleMethod();
-
         final SecondsBasedEntryTaskScheduler<Integer, Integer> scheduler =
                 new SecondsBasedEntryTaskScheduler<Integer, Integer>(executorService, entryProcessor, POSTPONE);
 
@@ -148,8 +134,6 @@ public class SecondsBasedEntryTaskSchedulerTest {
 
     @Test
     public void test_scheduleEntry_foreach() {
-        mockScheduleMethod();
-
         final SecondsBasedEntryTaskScheduler<Integer, Integer> scheduler =
                 new SecondsBasedEntryTaskScheduler<Integer, Integer>(executorService, entryProcessor, FOR_EACH);
 
@@ -160,8 +144,6 @@ public class SecondsBasedEntryTaskSchedulerTest {
 
     @Test
     public void test_scheduleEntryMultipleTimes_foreach() {
-        mockScheduleMethod();
-
         final SecondsBasedEntryTaskScheduler<Integer, Integer> scheduler =
                 new SecondsBasedEntryTaskScheduler<Integer, Integer>(executorService, entryProcessor, FOR_EACH);
 
@@ -173,8 +155,6 @@ public class SecondsBasedEntryTaskSchedulerTest {
 
     @Test
     public void test_cancelIfExists_scheduleIfNew() {
-        mockScheduleMethod();
-
         final SecondsBasedEntryTaskScheduler<Integer, Integer> scheduler =
                 new SecondsBasedEntryTaskScheduler<Integer, Integer>(executorService, entryProcessor, SCHEDULE_IF_NEW);
 
@@ -184,8 +164,6 @@ public class SecondsBasedEntryTaskSchedulerTest {
 
     @Test
     public void test_cancelIfExists_postpone() {
-        mockScheduleMethod();
-
         final SecondsBasedEntryTaskScheduler<Integer, Integer> scheduler =
                 new SecondsBasedEntryTaskScheduler<Integer, Integer>(executorService, entryProcessor, POSTPONE);
 
@@ -195,8 +173,6 @@ public class SecondsBasedEntryTaskSchedulerTest {
 
     @Test
     public void test_cancelIfExists_foreach() {
-        mockScheduleMethod();
-
         final SecondsBasedEntryTaskScheduler<Integer, Integer> scheduler =
                 new SecondsBasedEntryTaskScheduler<Integer, Integer>(executorService, entryProcessor, FOR_EACH);
 
@@ -206,8 +182,6 @@ public class SecondsBasedEntryTaskSchedulerTest {
 
     @Test
     public void test_cancelIfExistsWithInvalidValue_foreach() {
-        mockScheduleMethod();
-
         final SecondsBasedEntryTaskScheduler<Integer, Integer> scheduler =
                 new SecondsBasedEntryTaskScheduler<Integer, Integer>(executorService, entryProcessor, FOR_EACH);
 
@@ -217,8 +191,6 @@ public class SecondsBasedEntryTaskSchedulerTest {
 
     @Test
     public void test_cancelIfExistsMultiple_foreach() {
-        mockScheduleMethod();
-
         final SecondsBasedEntryTaskScheduler<Integer, Integer> scheduler =
                 new SecondsBasedEntryTaskScheduler<Integer, Integer>(executorService, entryProcessor, FOR_EACH);
 
@@ -237,8 +209,6 @@ public class SecondsBasedEntryTaskSchedulerTest {
 
     @Test
     public void test_cancelAll() {
-        mockScheduleMethod();
-
         final SecondsBasedEntryTaskScheduler<Integer, Integer> scheduler =
                 new SecondsBasedEntryTaskScheduler<Integer, Integer>(executorService, entryProcessor, FOR_EACH);
 

--- a/hazelcast/src/test/java/com/hazelcast/util/scheduler/StaticClock.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/scheduler/StaticClock.java
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
-package com.hazelcast.util;
+package com.hazelcast.util.scheduler;
 
-// for testing purposes
+import com.hazelcast.util.Clock;
+
 class StaticClock extends Clock.ClockImpl {
 
     private static final long TIME = System.currentTimeMillis();


### PR DESCRIPTION
- SecondsBasedEntryTaskScheduler was using System.nanoTime() as unique
identifier and order key for scheduled entries. But it's known that
System.nanoTime() can return the same value on consecutive calls.

- While preparing entries to process, scheduled entries was being stored
in a set and then copied to a list to sort.
There are two problems with this approach:
	* Extra copy, which is obvious
	* When key/value pair is scheduled more than once (FOR_EACH)
	then only one instance of entry is used for processing.
	But every entry must be processed regardless of their values,
	once they are scheduled (when schedule() method returns true).

_Lock lease uses this scheduler, probably fixes https://github.com/hazelcast/hazelcast/issues/6141_