### PR TITLE
Moved deserialization into event-publisher to avoid unnecessary deserialization when includeValue=false

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/event/MapEventPublisher.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/event/MapEventPublisher.java
@@ -39,13 +39,13 @@ public interface MapEventPublisher {
     void publishMapEvent(Address caller, String mapName, EntryEventType eventType, int numberOfEntriesAffected);
 
     void publishEvent(Address caller, String mapName, EntryEventType eventType,
-                      Data dataKey, Data dataOldValue, Data dataValue);
+                      Data dataKey, Object dataOldValue, Object dataValue);
 
     void publishEvent(Address caller, String mapName, EntryEventType eventType, boolean synthetic,
-                      Data dataKey, Data dataOldValue, Data dataValue);
+                      Data dataKey, Object dataOldValue, Object dataValue);
 
     void publishEvent(Address caller, String mapName, EntryEventType eventType, boolean synthetic,
-                      Data dataKey, Data dataOldValue, Data dataValue, Data dataMergingValue);
+                      Data dataKey, Object dataOldValue, Object dataValue, Object dataMergingValue);
 
     void publishMapPartitionLostEvent(Address caller, String mapName, int partitionId);
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/BasePutOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/BasePutOperation.java
@@ -61,11 +61,12 @@ public abstract class BasePutOperation extends LockAwareOperation implements Bac
 
     private void publishEvent(MapEventPublisher mapEventPublisher) {
         eventType = getEventType();
+        Object value = dataValue;
         if (recordStore.getMapDataStore().isPostProcessingMapStore()) {
             final Record record = recordStore.getRecord(dataKey);
-            dataValue = mapServiceContext.toData(record.getValue());
+            value = record.getValue();
         }
-        mapEventPublisher.publishEvent(getCallerAddress(), name, eventType, dataKey, dataOldValue, dataValue);
+        mapEventPublisher.publishEvent(getCallerAddress(), name, eventType, dataKey, dataOldValue, value);
     }
 
     private void publishWANReplicationEvent(MapServiceContext mapServiceContext, MapEventPublisher mapEventPublisher) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOperation.java
@@ -250,9 +250,7 @@ public class EntryOperation extends LockAwareOperation implements BackupAwareOpe
         if (hasRegisteredListenerForThisMap()) {
             nullifyOldValueIfNecessary();
             final MapEventPublisher mapEventPublisher = getMapEventPublisher();
-            dataValue = toData(dataValue);
-            mapEventPublisher.
-                    publishEvent(getCallerAddress(), name, eventType, dataKey, toData(oldValue), (Data) dataValue);
+            mapEventPublisher.publishEvent(getCallerAddress(), name, eventType, dataKey, oldValue, dataValue);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutAllOperation.java
@@ -87,17 +87,17 @@ public class PutAllOperation extends MapOperation implements PartitionAwareOpera
         }
 
         Data dataValue = entry.getValue();
-        Data dataOldValue = null;
+        Object oldValue = null;
         if (initialLoad) {
             recordStore.putFromLoad(dataKey, dataValue, -1);
         } else {
-            dataOldValue = mapServiceContext.toData(recordStore.put(dataKey, dataValue, DEFAULT_TTL));
+            oldValue = recordStore.put(dataKey, dataValue, DEFAULT_TTL);
         }
         mapServiceContext.interceptAfterPut(name, dataValue);
-        EntryEventType eventType = dataOldValue == null ? ADDED : UPDATED;
+        EntryEventType eventType = oldValue == null ? ADDED : UPDATED;
         MapEventPublisher mapEventPublisher = mapServiceContext.getMapEventPublisher();
         dataValue = getValueOrPostProcessedValue(dataKey, dataValue);
-        mapEventPublisher.publishEvent(getCallerAddress(), name, eventType, dataKey, dataOldValue, dataValue);
+        mapEventPublisher.publishEvent(getCallerAddress(), name, eventType, dataKey, oldValue, dataValue);
 
         Record record = recordStore.getRecord(dataKey);
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutFromLoadAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutFromLoadAllOperation.java
@@ -64,15 +64,16 @@ public class PutFromLoadAllOperation extends MapOperation implements PartitionAw
         final MapService mapService = this.mapService;
         MapServiceContext mapServiceContext = mapService.getMapServiceContext();
         final RecordStore recordStore = mapServiceContext.getRecordStore(partitionId, name);
+        boolean hasInterceptor = mapServiceContext.hasInterceptor(name);
         for (int i = 0; i < keyValueSequence.size(); i += 2) {
-            final Data key = keyValueSequence.get(i);
-            final Data dataValue = keyValueSequence.get(i + 1);
+            Data key = keyValueSequence.get(i);
+            Data dataValue = keyValueSequence.get(i + 1);
             // here object conversion is for interceptors.
-            final Object objectValue = mapServiceContext.toObject(dataValue);
-            final Object previousValue = recordStore.putFromLoad(key, objectValue);
+            Object value = hasInterceptor ? mapServiceContext.toObject(dataValue) : dataValue;
+            Object previousValue = recordStore.putFromLoad(key, value);
 
-            callAfterPutInterceptors(objectValue);
-            publishEntryEvent(key, mapServiceContext.toData(previousValue), dataValue);
+            callAfterPutInterceptors(value);
+            publishEntryEvent(key, previousValue, dataValue);
             publishWanReplicationEvent(key, dataValue, recordStore.getRecord(key));
         }
     }
@@ -81,7 +82,7 @@ public class PutFromLoadAllOperation extends MapOperation implements PartitionAw
         mapService.getMapServiceContext().interceptAfterPut(name, value);
     }
 
-    private void publishEntryEvent(Data key, Data previousValue, Data newValue) {
+    private void publishEntryEvent(Data key, Object previousValue, Data newValue) {
         final EntryEventType eventType = previousValue == null ? EntryEventType.ADDED : EntryEventType.UPDATED;
         final MapServiceContext mapServiceContext = mapService.getMapServiceContext();
         final MapEventPublisher mapEventPublisher = mapServiceContext.getMapEventPublisher();

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/AbstractEvictableRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/AbstractEvictableRecordStore.java
@@ -326,12 +326,11 @@ abstract class AbstractEvictableRecordStore extends AbstractRecordStore {
         }
 
         Address thisAddress = nodeEngine.getThisAddress();
-        Data dataValue = mapServiceContext.toData(value);
 
         // Fire EVICTED event also in case of expiration because historically eviction-listener
         // listens all kind of eviction and expiration events and by firing EVICTED event we are preserving
         // this behavior.
-        mapEventPublisher.publishEvent(thisAddress, name, EVICTED, true, key, dataValue, null);
+        mapEventPublisher.publishEvent(thisAddress, name, EVICTED, true, key, value, null);
 
         if (isExpired) {
             // We will be in this if in two cases:
@@ -339,7 +338,7 @@ abstract class AbstractEvictableRecordStore extends AbstractRecordStore {
             // 2. When evicting due to the size-based eviction, we are also firing an EXPIRED event
             //    because there is a possibility that evicted entry may be also an expired one. Trying to catch
             //    as much as possible expired entries.
-            mapEventPublisher.publishEvent(thisAddress, name, EXPIRED, true, key, dataValue, null);
+            mapEventPublisher.publishEvent(thisAddress, name, EXPIRED, true, key, value, null);
         }
     }
 


### PR DESCRIPTION
changed MapEventPublisher interface so that it accepts value as `Object` not `Data`.
With this change, if the registered listener will not include the value, it will not get deserialized.
fixes https://github.com/hazelcast/hazelcast/issues/6866