### PR TITLE
If value is null call inner future's get even if the future is marked as done

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -504,6 +504,8 @@
     <suppress checks="JavadocType" files="com/hazelcast/util/executor/"/>
     <suppress checks="JavadocMethod" files="com/hazelcast/util/executor/"/>
     <suppress checks="JavadocVariable" files="com/hazelcast/util/executor/"/>
+    <suppress checks="NPathComplexity" files="com.hazelcast.util.executor.DelegatingFuture"/>
+    <suppress checks="NPathComplexity|CyclomaticComplexity" files="com.hazelcast.client.util.ClientDelegatingFuture"/>
 
     <!-- Written by Doug Lea  -->
     <suppress checks="MagicNumber|FileLength|DeclarationOrder|RedundantModifier|InnerAssignment|NPath|Cyclomatic"

--- a/hazelcast-client/src/main/java/com/hazelcast/client/util/ClientDelegatingFuture.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/util/ClientDelegatingFuture.java
@@ -111,9 +111,9 @@ public class ClientDelegatingFuture<V> implements ICompletableFuture<V> {
     @Override
     public V get(long timeout, TimeUnit unit) throws InterruptedException,
             ExecutionException, TimeoutException {
-        if (!done) {
+        if (!done || response == null) {
             synchronized (mutex) {
-                if (!done) {
+                if (!done || response == null) {
                     try {
                         response = resolveMessageToValue(future.get(timeout, unit));
                         if (deserializedValue == null) {
@@ -129,11 +129,14 @@ public class ClientDelegatingFuture<V> implements ICompletableFuture<V> {
             }
         }
         if (error != null) {
-            if (error instanceof ExecutionException) {
-                throw (ExecutionException) error;
-            }
             if (error instanceof CancellationException) {
                 throw (CancellationException) error;
+            }
+            if (error.getCause() instanceof CancellationException) {
+                throw (CancellationException) error.getCause();
+            }
+            if (error instanceof ExecutionException) {
+                throw (ExecutionException) error;
             }
             if (error instanceof InterruptedException) {
                 throw (InterruptedException) error;


### PR DESCRIPTION
The reasoning behind this change is there is a race between `cancel` and `get` in`CancellableDelegatingFuture` which occurs while executing `IExecutorService.invokeAll(tasks, time, TimeUnit)`. race is in `CancellableDelegatingFuture.cancel` method:

```
@Override
    public boolean cancel(boolean mayInterruptIfRunning) {
        if (isDone() || cancelled) {
            return false;
        }

        Future f = invokeCancelOperation(mayInterruptIfRunning);
        try {
            Boolean b = (Boolean) f.get();
            if (b != null && b) {
                setError(new CancellationException());
                cancelled = true;
                return true;
            }
            return false;
        } catch (Exception e) {
            throw rethrow(e);
        } finally {
            setDone();
        }
    }
```
While executing cancel, it may happen that future was not done so we continue on sending cancel operation. But before cancel operation executed the inner future is completed which results returning false and setting the future as done (in finally block). Since the future is set as done `get` method in `DelegatingFuture` does not try to get the result from inner future but returns the `value` which is null.

With this change `get` method will try to get the inner future's result if the value is null, ignoring that the future is marked as done. 

fixes https://github.com/hazelcast/hazelcast/issues/5128
