### PR TITLE
Changed backup preparation of queue, so that it ensures reserve, not just checks

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueContainer.java
@@ -106,11 +106,21 @@ public class QueueContainer implements IdentifiedDataSerializable {
 
     //TX Methods
 
-    public boolean txnEnsureReserve(long itemId) {
+    public boolean txnCheckReserve(long itemId) {
         if (txMap.get(itemId) == null) {
             throw new TransactionException("No reserve for itemId: " + itemId);
         }
         return true;
+    }
+
+    public void txnEnsureBackupReserve(long itemId, String transactionId, boolean pollOperation) {
+        if (txMap.get(itemId) == null) {
+            if (pollOperation) {
+                txnPollBackupReserve(itemId, transactionId);
+            } else {
+                txnOfferBackupReserve(itemId, transactionId);
+            }
+        }
     }
 
     //TX Poll

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/operations/TxnPrepareBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/operations/TxnPrepareBackupOperation.java
@@ -47,7 +47,7 @@ public class TxnPrepareBackupOperation extends QueueOperation implements BackupO
     @Override
     public void run() throws Exception {
         QueueContainer queueContainer = getOrCreateContainer();
-        response = queueContainer.txnEnsureReserve(itemId);
+        queueContainer.txnEnsureBackupReserve(itemId, transactionId, pollOperation);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/operations/TxnPrepareOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/operations/TxnPrepareOperation.java
@@ -48,7 +48,7 @@ public class TxnPrepareOperation extends QueueBackupAwareOperation {
     @Override
     public void run() throws Exception {
         QueueContainer queueContainer = getOrCreateContainer();
-        response = queueContainer.txnEnsureReserve(itemId);
+        response = queueContainer.txnCheckReserve(itemId);
     }
 
     @Override


### PR DESCRIPTION
Prepare-backup operation of queue was checking if backup has the reserved item and throwing exception if not. Since we don't retry backup operations this exception throwing was not adding much value other than noise. 
I've changed the prepare-backup logic so that it ensures that there is a reserve. So on normal setup this reserve should be taken with the first invocation of the method (`offer` / `poll`). But for some reasons this may not be the case:
- backup operation of `offer` / `poll` may get lost due to network
- While executing `offer` / `poll` it may be that there was no backup node but added later, just before prepare-backup get executed.

fixes https://github.com/hazelcast/hazelcast/issues/2838