### PR TITLE
Misleading method name in Discovery SPI config object fixed

### DIFF
--- a/hazelcast-client-legacy/src/main/java/com/hazelcast/client/config/XmlClientConfigBuilder.java
+++ b/hazelcast-client-legacy/src/main/java/com/hazelcast/client/config/XmlClientConfigBuilder.java
@@ -385,7 +385,7 @@ public class XmlClientConfigBuilder extends AbstractConfigBuilder {
             }
         }
 
-        discoveryConfig.addDiscoveryProviderConfig(new DiscoveryStrategyConfig(clazz, properties));
+        discoveryConfig.addDiscoveryStrategyConfig(new DiscoveryStrategyConfig(clazz, properties));
     }
 
     private void handleAWS(Node node, ClientNetworkConfig clientNetworkConfig) {

--- a/hazelcast-client-legacy/src/test/java/com/hazelcast/client/spi/impl/discovery/ClientDiscoverySpiTest.java
+++ b/hazelcast-client-legacy/src/test/java/com/hazelcast/client/spi/impl/discovery/ClientDiscoverySpiTest.java
@@ -141,7 +141,7 @@ public class ClientDiscoverySpiTest extends HazelcastTestSupport {
         discoveryConfig.getDiscoveryStrategyConfigs().clear();
 
         DiscoveryStrategyConfig strategyConfig = new DiscoveryStrategyConfig(factory, Collections.<String, Comparable>emptyMap());
-        discoveryConfig.addDiscoveryProviderConfig(strategyConfig);
+        discoveryConfig.addDiscoveryStrategyConfig(strategyConfig);
 
         final HazelcastInstance hazelcastInstance1 = Hazelcast.newHazelcastInstance(config);
         final HazelcastInstance hazelcastInstance2 = Hazelcast.newHazelcastInstance(config);
@@ -153,7 +153,7 @@ public class ClientDiscoverySpiTest extends HazelcastTestSupport {
             discoveryConfig.getDiscoveryStrategyConfigs().clear();
 
             strategyConfig = new DiscoveryStrategyConfig(factory, Collections.<String, Comparable>emptyMap());
-            discoveryConfig.addDiscoveryProviderConfig(strategyConfig);
+            discoveryConfig.addDiscoveryStrategyConfig(strategyConfig);
 
             final HazelcastInstance client = HazelcastClient.newHazelcastClient(clientConfig);
 

--- a/hazelcast-client/src/main/java/com/hazelcast/client/config/XmlClientConfigBuilder.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/config/XmlClientConfigBuilder.java
@@ -384,7 +384,7 @@ public class XmlClientConfigBuilder extends AbstractConfigBuilder {
             }
         }
 
-        discoveryConfig.addDiscoveryProviderConfig(new DiscoveryStrategyConfig(clazz, properties));
+        discoveryConfig.addDiscoveryStrategyConfig(new DiscoveryStrategyConfig(clazz, properties));
     }
 
     private void handleAWS(Node node, ClientNetworkConfig clientNetworkConfig) {

--- a/hazelcast-client/src/test/java/com/hazelcast/client/spi/impl/discovery/ClientDiscoverySpiTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/spi/impl/discovery/ClientDiscoverySpiTest.java
@@ -141,7 +141,7 @@ public class ClientDiscoverySpiTest extends HazelcastTestSupport {
         discoveryConfig.getDiscoveryStrategyConfigs().clear();
 
         DiscoveryStrategyConfig strategyConfig = new DiscoveryStrategyConfig(factory, Collections.<String, Comparable>emptyMap());
-        discoveryConfig.addDiscoveryProviderConfig(strategyConfig);
+        discoveryConfig.addDiscoveryStrategyConfig(strategyConfig);
 
         final HazelcastInstance hazelcastInstance1 = Hazelcast.newHazelcastInstance(config);
         final HazelcastInstance hazelcastInstance2 = Hazelcast.newHazelcastInstance(config);
@@ -153,7 +153,7 @@ public class ClientDiscoverySpiTest extends HazelcastTestSupport {
             discoveryConfig.getDiscoveryStrategyConfigs().clear();
 
             strategyConfig = new DiscoveryStrategyConfig(factory, Collections.<String, Comparable>emptyMap());
-            discoveryConfig.addDiscoveryProviderConfig(strategyConfig);
+            discoveryConfig.addDiscoveryStrategyConfig(strategyConfig);
 
             final HazelcastInstance client = HazelcastClient.newHazelcastClient(clientConfig);
 

--- a/hazelcast/src/main/java/com/hazelcast/config/DiscoveryConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/DiscoveryConfig.java
@@ -107,7 +107,7 @@ public class DiscoveryConfig {
      *
      * @param discoveryStrategyConfig
      */
-    public void addDiscoveryProviderConfig(DiscoveryStrategyConfig discoveryStrategyConfig) {
+    public void addDiscoveryStrategyConfig(DiscoveryStrategyConfig discoveryStrategyConfig) {
         discoveryStrategyConfigs.add(discoveryStrategyConfig);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/config/DiscoveryConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/DiscoveryConfigReadOnly.java
@@ -46,7 +46,7 @@ public class DiscoveryConfigReadOnly
     }
 
     @Override
-    public void addDiscoveryProviderConfig(DiscoveryStrategyConfig discoveryStrategyConfig) {
+    public void addDiscoveryStrategyConfig(DiscoveryStrategyConfig discoveryStrategyConfig) {
         throw new UnsupportedOperationException("Configuration is readonly");
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
@@ -719,7 +719,7 @@ public class XmlConfigBuilder extends AbstractConfigBuilder implements ConfigBui
             }
         }
 
-        discoveryConfig.addDiscoveryProviderConfig(new DiscoveryStrategyConfig(clazz, properties));
+        discoveryConfig.addDiscoveryStrategyConfig(new DiscoveryStrategyConfig(clazz, properties));
     }
 
     private void handleAWS(Node node) {

--- a/hazelcast/src/test/java/com/hazelcast/config/DiscoveryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/DiscoveryTest.java
@@ -88,24 +88,24 @@ public class DiscoveryTest {
     }
 
     @Test
-    public void test_DiscoveryConfigReadOnly_addDiscoveryProviderConfig() {
+    public void test_DiscoveryConfigReadOnly_addDiscoveryStrategyConfig() {
         DiscoveryConfig discoveryConfig = new DiscoveryConfig();
 
         DiscoveryStrategyFactory discoveryStrategyFactory = new TestDiscoveryStrategyFactory();
         DiscoveryStrategyConfig discoveryStrategyConfig = new DiscoveryStrategyConfig(discoveryStrategyFactory);
-        discoveryConfig.addDiscoveryProviderConfig(discoveryStrategyConfig);
+        discoveryConfig.addDiscoveryStrategyConfig(discoveryStrategyConfig);
 
         assertSame(discoveryStrategyConfig, discoveryConfig.getDiscoveryStrategyConfigs().iterator().next());
     }
 
     @Test(expected = UnsupportedOperationException.class)
-    public void test_DiscoveryConfigReadOnly_addDiscoveryProviderConfig_thenUnsupportedOperationException() {
+    public void test_DiscoveryConfigReadOnly_addDiscoveryStrategyConfig_thenUnsupportedOperationException() {
         DiscoveryConfig discoveryConfig = new DiscoveryConfig();
         DiscoveryConfig readOnly = discoveryConfig.getAsReadOnly();
 
         DiscoveryStrategyFactory discoveryStrategyFactory = new TestDiscoveryStrategyFactory();
         DiscoveryStrategyConfig discoveryStrategyConfig = new DiscoveryStrategyConfig(discoveryStrategyFactory);
-        readOnly.addDiscoveryProviderConfig(discoveryStrategyConfig);
+        readOnly.addDiscoveryStrategyConfig(discoveryStrategyConfig);
     }
 
     private static class TestDiscoveryServiceProvider implements DiscoveryServiceProvider {

--- a/hazelcast/src/test/java/com/hazelcast/spi/discovery/DiscoverySpiTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/discovery/DiscoverySpiTest.java
@@ -139,7 +139,7 @@ public class DiscoverySpiTest
         discoveryConfig.getDiscoveryStrategyConfigs().clear();
 
         DiscoveryStrategyConfig strategyConfig = new DiscoveryStrategyConfig(factory, Collections.<String, Comparable>emptyMap());
-        discoveryConfig.addDiscoveryProviderConfig(strategyConfig);
+        discoveryConfig.addDiscoveryStrategyConfig(strategyConfig);
 
         try {
             final HazelcastInstance hazelcastInstance1 = Hazelcast.newHazelcastInstance(config);


### PR DESCRIPTION
It's a left-over from old Discovery SPI implementation. I am not deprecating the old method as it has never been released as a Final.
Fixing #6911