### PR TITLE
Unignore ClientRegressionWithMockNetwork tests

### DIFF
--- a/hazelcast-client-legacy/src/test/java/com/hazelcast/client/ClientRegressionWithMockNetworkTest.java
+++ b/hazelcast-client-legacy/src/test/java/com/hazelcast/client/ClientRegressionWithMockNetworkTest.java
@@ -77,7 +77,6 @@ import static org.junit.Assert.fail;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-@Ignore //https://github.com/hazelcast/hazelcast/issues/6153
 public class ClientRegressionWithMockNetworkTest extends HazelcastTestSupport {
 
     private final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();

--- a/hazelcast-client/src/test/java/com/hazelcast/client/ClientRegressionWithMockNetworkTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ClientRegressionWithMockNetworkTest.java
@@ -77,7 +77,6 @@ import static org.junit.Assert.fail;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-@Ignore //https://github.com/hazelcast/hazelcast/issues/6153
 public class ClientRegressionWithMockNetworkTest extends HazelcastTestSupport {
 
     private final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();


### PR DESCRIPTION
These tests are being unignored, because it's not clear if the specific
failure in issue #6153 is related to these tests. The tests can be ignored
again if they're still failing.