### PR TITLE
[Backport] On server shutdown, the client should shutdown without temporary deadlock

### DIFF
--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/spi/impl/ClusterListenerSupport.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/spi/impl/ClusterListenerSupport.java
@@ -56,7 +56,6 @@ import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 
 public abstract class ClusterListenerSupport implements ConnectionListener, ConnectionHeartbeatListener,
@@ -108,15 +107,6 @@ public abstract class ClusterListenerSupport implements ConnectionListener, Conn
 
     public void shutdown() {
         clusterExecutor.shutdown();
-        try {
-            boolean success = clusterExecutor.awaitTermination(TERMINATE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
-            if (!success) {
-                LOGGER.warning("ClientClusterService shutdown could not completed in "
-                        + TERMINATE_TIMEOUT_SECONDS + " seconds");
-            }
-        } catch (InterruptedException e) {
-            LOGGER.warning("ClientClusterService shutdown is interrupted", e);
-        }
     }
 
     private class ManagerAuthenticator implements Authenticator {

--- a/hazelcast-client-new/src/test/java/com/hazelcast/client/ClientReconnectTest.java
+++ b/hazelcast-client-new/src/test/java/com/hazelcast/client/ClientReconnectTest.java
@@ -105,4 +105,37 @@ public class ClientReconnectTest extends HazelcastTestSupport {
         });
     }
 
+    @Test
+    public void testClientShutdownIfReconnectionNotPossible() {
+        HazelcastInstance server = hazelcastFactory.newHazelcastInstance();
+        ClientConfig clientConfig = new ClientConfig();
+        clientConfig.getNetworkConfig().setConnectionAttemptLimit(1);
+        HazelcastInstance client = hazelcastFactory.newHazelcastClient(clientConfig);
+
+        final CountDownLatch shutdownLatch = new CountDownLatch(1);
+        client.getLifecycleService().addLifecycleListener(new LifecycleListener() {
+            @Override
+            public void stateChanged(LifecycleEvent event) {
+                if (event.getState() == LifecycleEvent.LifecycleState.SHUTDOWN) {
+                    shutdownLatch.countDown();
+                }
+            }
+        });
+        server.shutdown();
+
+        assertOpenEventually(shutdownLatch, 10);
+    }
+
+    @Test(expected = HazelcastClientNotActiveException.class, timeout = 30000)
+    public void testRequestShouldFailOnShutdown() {
+        final HazelcastInstance server = hazelcastFactory.newHazelcastInstance();
+        ClientConfig clientConfig = new ClientConfig();
+        clientConfig.getNetworkConfig().setConnectionAttemptLimit(1);
+        HazelcastInstance client = hazelcastFactory.newHazelcastClient(clientConfig);
+
+        IMap<Object, Object> test = client.getMap("test");
+        test.put("key", "value");
+        server.shutdown();
+        test.get("key");
+    }
 }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocation.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocation.java
@@ -232,7 +232,7 @@ public class ClientInvocation implements Runnable {
             if (LOGGER.isFinestEnabled()) {
                 LOGGER.finest("Retry could not be scheduled ", e);
             }
-            clientInvocationFuture.setResponse(e);
+            notifyException(e);
         }
         return true;
     }
@@ -241,21 +241,28 @@ public class ClientInvocation implements Runnable {
         executionService.schedule(new Runnable() {
             @Override
             public void run() {
-                ICompletableFuture<?> future = ((ClientExecutionServiceImpl) executionService)
-                        .submitInternal(ClientInvocation.this);
-                future.andThen(new ExecutionCallback() {
-                    @Override
-                    public void onResponse(Object response) {
-                    }
-
-                    @Override
-                    public void onFailure(Throwable t) {
-                        if (LOGGER.isFinestEnabled()) {
-                            LOGGER.finest("Failure during retry ", t);
+                try {
+                    ICompletableFuture<?> future = ((ClientExecutionServiceImpl) executionService)
+                            .submitInternal(ClientInvocation.this);
+                    future.andThen(new ExecutionCallback() {
+                        @Override
+                        public void onResponse(Object response) {
                         }
-                        clientInvocationFuture.setResponse(t);
+
+                        @Override
+                        public void onFailure(Throwable t) {
+                            if (LOGGER.isFinestEnabled()) {
+                                LOGGER.finest("Failure during retry ", t);
+                            }
+                            clientInvocationFuture.setResponse(t);
+                        }
+                    });
+                } catch (RejectedExecutionException e) {
+                    if (LOGGER.isFinestEnabled()) {
+                        LOGGER.finest("Could not reschedule invocation.", e);
                     }
-                });
+                    notifyException(e);
+                }
             }
         }, RETRY_WAIT_TIME_IN_SECONDS, TimeUnit.SECONDS);
     }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClusterListenerSupport.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClusterListenerSupport.java
@@ -55,7 +55,6 @@ import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 
 public abstract class ClusterListenerSupport implements ConnectionListener, ConnectionHeartbeatListener,
@@ -107,15 +106,6 @@ public abstract class ClusterListenerSupport implements ConnectionListener, Conn
 
     public void shutdown() {
         clusterExecutor.shutdown();
-        try {
-            boolean success = clusterExecutor.awaitTermination(TERMINATE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
-            if (!success) {
-                LOGGER.warning("ClientClusterService shutdown could not completed in "
-                        + TERMINATE_TIMEOUT_SECONDS + " seconds");
-            }
-        } catch (InterruptedException e) {
-            LOGGER.warning("ClientClusterService shutdown is interrupted", e);
-        }
     }
 
     private class ManagerAuthenticator implements Authenticator {


### PR DESCRIPTION
After server shutdown, the client will shutdown after connection attempts
have failed. However there was a deadlock preventing the ClusterService
from being shutdown. Fixes #6829

Another related issue was that on shutdown, the pending requests would not
cancelled due to executor shutdown order.