### PR TITLE
Small fixes for issues found during hot-restart test

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/ClusterServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/ClusterServiceImpl.java
@@ -845,6 +845,9 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
                     = new LinkedHashMap<Address, MemberImpl>(membersRemovedInNotActiveStateRef.get());
 
             for (Address address : addresses) {
+                if (thisAddress.equals(address)) {
+                    continue;
+                }
                 membersRemovedInNotActiveState.put(address, new MemberImpl(address, false));
             }
 

--- a/hazelcast/src/main/java/com/hazelcast/partition/impl/InternalPartitionServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/impl/InternalPartitionServiceImpl.java
@@ -435,12 +435,18 @@ public class InternalPartitionServiceImpl implements InternalPartitionService, M
                 throw new IllegalStateException("Partition table is already initialized!");
             }
             logger.info("Setting cluster partition table ...");
+            boolean foundReplica = false;
             for (int partitionId = 0; partitionId < partitionCount; partitionId++) {
                 InternalPartitionImpl partition = partitions[partitionId];
                 Address[] replicas = newState[partitionId];
+                if (!foundReplica && replicas != null) {
+                    for (int i = 0; i < InternalPartition.MAX_REPLICA_COUNT; i++) {
+                        foundReplica |= replicas[i] != null;
+                    }
+                }
                 partition.setInitialReplicaAddresses(replicas);
             }
-            initialized = true;
+            initialized = foundReplica;
         } finally {
             lock.unlock();
         }


### PR DESCRIPTION
-  `InternalPartitionService.setInitialState()` should not set initialized flag if all replicas are empty
- `ClusterServiceImpl.addMembersRemovedInNotActiveState()` should skip local address