### PR TITLE
Partition Identifier added to protocol code generation

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientRingbufferProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientRingbufferProxy.java
@@ -158,10 +158,9 @@ public class ClientRingbufferProxy<E> extends ClientProxy implements Ringbuffer<
 
         Data element = toData(item);
         ClientMessage request = RingbufferAddCodec.encodeRequest(name, overflowPolicy.getId(), element);
-        request.setPartitionId(partitionId);
 
         try {
-            ClientInvocationFuture invocationFuture = new ClientInvocation(getClient(), request).invoke();
+            ClientInvocationFuture invocationFuture = new ClientInvocation(getClient(), request, partitionId).invoke();
             return new ClientDelegatingFuture<Long>(
                     invocationFuture,
                     getContext().getSerializationService(),
@@ -195,10 +194,9 @@ public class ClientRingbufferProxy<E> extends ClientProxy implements Ringbuffer<
         }
 
         ClientMessage request = RingbufferAddAllCodec.encodeRequest(name, valueList, overflowPolicy.getId());
-        request.setPartitionId(partitionId);
 
         try {
-            ClientInvocationFuture invocationFuture = new ClientInvocation(getClient(), request).invoke();
+            ClientInvocationFuture invocationFuture = new ClientInvocation(getClient(), request, partitionId).invoke();
             return new ClientDelegatingFuture<Long>(
                     invocationFuture,
                     getContext().getSerializationService(),
@@ -224,10 +222,9 @@ public class ClientRingbufferProxy<E> extends ClientProxy implements Ringbuffer<
                 minCount,
                 maxCount,
                 toData(filter));
-        request.setPartitionId(partitionId);
 
         try {
-            ClientInvocationFuture invocationFuture = new ClientInvocation(getClient(), request).invoke();
+            ClientInvocationFuture invocationFuture = new ClientInvocation(getClient(), request, partitionId).invoke();
             return new ClientDelegatingFuture<ReadResultSet<E>>(
                     invocationFuture,
                     getContext().getSerializationService(),

--- a/hazelcast-code-generator/src/main/java/com/hazelcast/annotation/Request.java
+++ b/hazelcast-code-generator/src/main/java/com/hazelcast/annotation/Request.java
@@ -30,6 +30,7 @@ public @interface Request {
     short id();
     boolean retryable();
     int response();
+    String partitionIdentifier() default "-1";
     int[] event() default -1;
 }
 

--- a/hazelcast-code-generator/src/main/java/com/hazelcast/client/protocol/generator/CodeGenerationUtils.java
+++ b/hazelcast-code-generator/src/main/java/com/hazelcast/client/protocol/generator/CodeGenerationUtils.java
@@ -64,7 +64,17 @@ public final class CodeGenerationUtils {
     }
 
     public static String addHexPrefix(String s) {
-        return s.length() == 3 ? "0x0" + s : "0x" + s;
+        switch (s.length()) {
+            case 3:
+                return "0x0" + s;
+            case 2:
+                return "0x00" + s;
+            case 1:
+                return "0x000" + s;
+            default:
+                return "0x" + s;
+        }
+
     }
 
     public static String getArrayType(String type) {
@@ -132,9 +142,9 @@ public final class CodeGenerationUtils {
         }
         return type;
     }
-    
+
     public static String getDescription(String parameterName, String commentString) {
-        String result  = "";
+        String result = "";
         if (null != parameterName && null != commentString) {
             int start = commentString.indexOf("@param");
             if (start >= 0) {
@@ -167,7 +177,7 @@ public final class CodeGenerationUtils {
     }
 
     public static String getReturnDescription(String commentString) {
-        String result  = "";
+        String result = "";
         final String RETURN_TAG = "@return";
         int returnTagStartIndex = commentString.indexOf(RETURN_TAG);
         if (returnTagStartIndex >= 0) {
@@ -186,16 +196,16 @@ public final class CodeGenerationUtils {
         return result;
     }
 
-    public static String getOperationDescription(String commentString){
-        String result="";
+    public static String getOperationDescription(String commentString) {
+        String result = "";
         int nextTagIndex = commentString.indexOf("@");
         if (nextTagIndex >= 0) {
-            result = commentString.substring(0,nextTagIndex);
+            result = commentString.substring(0, nextTagIndex);
 
             result = result.trim();
         }
 
-            result = result.replace("\n", "<br>");
+        result = result.replace("\n", "<br>");
 
         return result;
 
@@ -203,7 +213,9 @@ public final class CodeGenerationUtils {
 
     public static String getDistributedObjectName(String templateClassName) {
         String result = templateClassName;
-
+        if (templateClassName.equals("com.hazelcast.client.impl.protocol.template.ClientMessageTemplate")) {
+            return "Generic";
+        }
         int startIndex = templateClassName.lastIndexOf('.');
         if (startIndex >= 0) {
             int endIndex = templateClassName.indexOf("CodecTemplate", startIndex);
@@ -226,8 +238,7 @@ public final class CodeGenerationUtils {
                 paramList.add(current.toString().trim());
                 current = new StringBuilder();
                 continue;
-            }
-            else if (c == '<') {
+            } else if (c == '<') {
                 balanced++;
             } else if (c == '>') {
                 balanced--;

--- a/hazelcast-code-generator/src/main/java/com/hazelcast/client/protocol/generator/CodecModel.java
+++ b/hazelcast-code-generator/src/main/java/com/hazelcast/client/protocol/generator/CodecModel.java
@@ -16,23 +16,22 @@
 
 package com.hazelcast.client.protocol.generator;
 
+import com.hazelcast.annotation.EventResponse;
+import com.hazelcast.annotation.GenerateCodec;
+import com.hazelcast.annotation.Nullable;
+import com.hazelcast.annotation.Request;
+
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.VariableElement;
+import javax.lang.model.util.Elements;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
-import javax.lang.model.element.ExecutableElement;
-import javax.lang.model.element.TypeElement;
-import javax.lang.model.element.VariableElement;
-import javax.lang.model.util.Elements;
-
-import com.hazelcast.annotation.EventResponse;
-import com.hazelcast.annotation.GenerateCodec;
-import com.hazelcast.annotation.Nullable;
-import com.hazelcast.annotation.Request;
-
-public class CodecModel implements Model{
+public class CodecModel implements Model {
 
     static final Map<String, TypeElement> CUSTOM_CODEC_MAP = new HashMap<String, TypeElement>();
 
@@ -43,6 +42,7 @@ public class CodecModel implements Model{
     private String className;
     private String parentName;
     private String packageName;
+    private String partitionIdentifier;
     private String comment = "";
 
     private int retryable;
@@ -156,6 +156,7 @@ public class CodecModel implements Model{
 
         name = methodElement.getSimpleName().toString();
         requestId = methodElement.getAnnotation(Request.class).id();
+        partitionIdentifier = methodElement.getAnnotation(Request.class).partitionIdentifier();
         short masterId = parent.getAnnotation(GenerateCodec.class).id();
         id = CodeGenerationUtils.addHexPrefix(CodeGenerationUtils.mergeIds(masterId, requestId));
         parentName = parent.getAnnotation(GenerateCodec.class).name();
@@ -240,6 +241,10 @@ public class CodecModel implements Model{
         return id;
     }
 
+    public String getPartitionIdentifier() {
+        return partitionIdentifier;
+    }
+
     public String getComment() {
         return comment;
     }
@@ -263,6 +268,10 @@ public class CodecModel implements Model{
 
     public int getResponse() {
         return response;
+    }
+
+    public String getHexadecimalResponseId(){
+        return CodeGenerationUtils.addHexPrefix(Integer.toHexString(response));
     }
 
     public List<ParameterModel> getRequestParams() {
@@ -293,6 +302,10 @@ public class CodecModel implements Model{
 
         public int getType() {
             return type;
+        }
+
+        public String getHexadecimalTypeId(){
+            return CodeGenerationUtils.addHexPrefix(Integer.toHexString(type));
         }
 
         public String getName() {

--- a/hazelcast-code-generator/src/main/resources/codec-template-md.ftl
+++ b/hazelcast-code-generator/src/main/resources/codec-template-md.ftl
@@ -1,4 +1,4 @@
-#Protocol Messages
+# Protocol Messages
 
 ## Compound Data Types Used In The Protocol Specification
 Some common compound data structures used in the protocol message specification are defined in this section.
@@ -123,11 +123,9 @@ The following error codes are defined in the system:
 |AUTHENTICATION|3|The authentication failed.|
 |CACHE|4||
 |CACHE_LOADER|5||
-|CACHE_NOT_EXISTS|6|This exception class is thrown while creating com.hazelcast.cache.impl.CacheRecordStore instances but the cache config does not exist on the node to create the instance on. This can happen in either of two cases:<br>the cache's config is not yet distributed to the node, or <br>the cache has been already destroyed.<br> For the first option, the caller can decide to just retry the operation a couple of times since distribution is executed in a asynchronous way.
-|
+|CACHE_NOT_EXISTS|6|This exception class is thrown while creating com.hazelcast.cache.impl.CacheRecordStore instances but the cache config does not exist on the node to create the instance on. This can happen in either of two cases:<br>the cache's config is not yet distributed to the node, or <br>the cache has been already destroyed.<br> For the first option, the caller can decide to just retry the operation a couple of times since distribution is executed in a asynchronous way.|
 |CACHE_WRITER|7||
-|CALLER_NOT_MEMBER|8|A Retryable Hazelcast Exception that indicates that an operation was sent by a machine which isn't member in the cluster when the operation is executed.
-|
+|CALLER_NOT_MEMBER|8|A Retryable Hazelcast Exception that indicates that an operation was sent by a machine which isn't member in the cluster when the operation is executed.|
 |CANCELLATION|9|Exception indicating that the result of a value-producing task, such as a FutureTask, cannot be retrieved because the task was cancelled.|
 |CLASS_CAST|10|The class conversion (cast) failed.|
 |CLASS_NOT_FOUND|11|The class does not exists in the loaded jars at the server member.|
@@ -159,8 +157,7 @@ The following error codes are defined in the system:
 |NO_SUCH_ELEMENT|37|The requested element does not exist in the distributed object.|
 |NOT_SERIALIZABLE|38|The object could not be serialized|
 |NULL_POINTER|39|The server faced a null pointer exception during the operation.|
-|OPERATION_TIMEOUT|40| An unchecked version of java.util.concurrent.TimeoutException. <p>Some of the Hazelcast operations may throw an <tt>OperationTimeoutException</tt>. Hazelcast uses OperationTimeoutException to pass TimeoutException up through interfaces that don't have TimeoutException in their signatures.</p>
-|
+|OPERATION_TIMEOUT|40| An unchecked version of java.util.concurrent.TimeoutException. <p>Some of the Hazelcast operations may throw an *OperationTimeoutException*. Hazelcast uses OperationTimeoutException to pass TimeoutException up through interfaces that don't have TimeoutException in their signatures.</p>|
 |PARTITION_MIGRATING|41|Thrown when an operation is executed on a partition, but that partition is currently being moved around.|
 |QUERY|42|Error during query.|
 |QUERY_RESULT_SIZE_EXCEEDED|43|Thrown when a query exceeds a configurable result size limit.|
@@ -196,17 +193,23 @@ The following error codes are defined in the system:
 <#assign map=model?values[key_index]?values/>
 <#if map?has_content>
 
+<br><hr><br>
 <#if key == "com.hazelcast.client.impl.protocol.template.ClientMessageTemplate">
-##General Protocol Operations (No Specific Object)
+## General Protocol Operations
 <#else>
-##${util.getDistributedObjectName(key)} Object
+## ${util.getDistributedObjectName(key)}
 </#if>
 
 <#list map as cm>
-###"${cm.name?cap_first}" Operation
+<br>
+### ${util.getDistributedObjectName(key)}.${cm.name?cap_first}
 
-Request Message Type Id:${cm.id}, Retryable:<#if cm.retryable == 1 >Yes<#else>No</#if>
-<p>${util.getOperationDescription(cm.comment)}
+${util.getOperationDescription(cm.comment)}
+<#if cm.retryable == 1 >This message is idempotent.</#if>
+
+#### Request Message
+**Type Id**      : ${cm.id}<br>
+**Partition Id** : ${resolvePartitionIdentifier(cm.partitionIdentifier)}
 
     <#if cm.requestParams?has_content>
 
@@ -219,7 +222,8 @@ Request Message Type Id:${cm.id}, Retryable:<#if cm.retryable == 1 >Yes<#else>No
 Header only request message, no message body exist.
     </#if>
 
-Response Message Type Id:${cm.response}
+#### Response Message
+**Type Id** : ${cm.hexadecimalResponseId}
 
 ${util.getReturnDescription(cm.comment)}
 
@@ -230,18 +234,16 @@ ${util.getReturnDescription(cm.comment)}
         <#list cm.responseParams as param>
 |${param.name}| ${convertTypeToDocumentType(param.type)}| <#if param.nullable >Yes<#else>No</#if>|
         </#list>
-
     <#else>
-
 Header only response message, no message body exist.
     </#if>
 
     <#if cm.events?has_content>
 
 <#list cm.events as event >
-<br>"${event.name}" Event Message
 
-Message Type Id:${event.type}
+#### Event Message
+**Type Id** : ${event.hexadecimalTypeId}
 
     <#if event.eventParams?has_content>
 
@@ -292,19 +294,19 @@ Header only event message, no message body exist.
             <#return "boolean">
         <#case "java.util.List<" + util.DATA_FULL_NAME + ">">
             <#return "array of byte-array">
-        <#case "java.util.Set<" + util.DATA_FULL_NAME + ">">
+        <#case "java.util.List<" + util.DATA_FULL_NAME + ">">
             <#return "array of byte-array">
-        <#case "java.util.Set<com.hazelcast.core.Member>">
+        <#case "java.util.List<com.hazelcast.core.Member>">
             <#return "array of Member">
-        <#case "java.util.Set<com.hazelcast.client.impl.client.DistributedObjectInfo>">
+        <#case "java.util.List<com.hazelcast.client.impl.client.DistributedObjectInfo>">
             <#return "array of Distributed Object Info">
-        <#case "java.util.Map<com.hazelcast.nio.Address,java.util.Set<java.lang.Integer>>">
+        <#case "java.util.Map<com.hazelcast.nio.Address,java.util.List<java.lang.Integer>>">
             <#return "array of Address-Partition Id pair">
         <#case "java.util.Collection<" + util.DATA_FULL_NAME + ">">
             <#return "array of byte-array">
         <#case "java.util.Map<" + util.DATA_FULL_NAME + "," + util.DATA_FULL_NAME + ">">
             <#return "array of key-value byte array pair">
-        <#case "java.util.Set<java.util.Map.Entry<"+ util.DATA_FULL_NAME + "," + util.DATA_FULL_NAME + ">>">
+        <#case "java.util.List<java.util.Map.Entry<"+ util.DATA_FULL_NAME + "," + util.DATA_FULL_NAME + ">>">
             <#return "array of key-value byte array pair">
         <#case "java.util.List<java.util.Map.Entry<"+ util.DATA_FULL_NAME + "," + util.DATA_FULL_NAME + ">>">
             <#return "array of key-value byte array pair">
@@ -322,7 +324,7 @@ Header only event message, no message body exist.
             <#return "Query Cache Event Data">
         <#case "java.util.List<com.hazelcast.mapreduce.JobPartitionState>">
             <#return "array of Job Partition State">
-        <#case "java.util.Set<com.hazelcast.cache.impl.CacheEventData>">
+        <#case "java.util.List<com.hazelcast.cache.impl.CacheEventData>">
             <#return "array of Cache Event Data">
         <#case "java.util.List<com.hazelcast.map.impl.querycache.event.QueryCacheEventData>">
             <#return "array of Query Cache Event Data">
@@ -333,3 +335,16 @@ Header only event message, no message body exist.
     </#switch>
 </#function>
 
+
+<#function resolvePartitionIdentifier partitionIdentifier>
+    <#switch partitionIdentifier?trim>
+        <#case "random">
+            <#return "a random partition id from 0 to PARTITION_COUNT(inclusive)">
+        <#case "-1">
+            <#return "-1">
+        <#case "partitionId">
+            <#return "the value passed in partitionId field">
+        <#default>
+            <#return "Murmur hash of " + partitionIdentifier + " % partition count">
+    </#switch>
+</#function>

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/EventMessageConst.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/EventMessageConst.java
@@ -23,7 +23,7 @@ package com.hazelcast.client.impl.protocol;
  * <p/>
  * Event response classes are defined    {@link com.hazelcast.client.impl.protocol.template.EventResponseTemplate}
  * <p/>
- * see {@link   com.hazelcast.client.impl.protocol.template.ClientMessageTemplate#membershipListener()}
+ * see {@link   com.hazelcast.client.impl.protocol.template.ClientMessageTemplate#addMembershipListener(boolean)} ()}
  * for  a sample usage of events in a request.
  */
 public final class EventMessageConst {

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/AtomicLongCodecTemplate.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/AtomicLongCodecTemplate.java
@@ -29,62 +29,62 @@ public interface AtomicLongCodecTemplate {
     /**
      * Applies a function on the value, the actual stored value will not change.
      *
-     * @param name The name of this IAtomicLong instance.
+     * @param name     The name of this IAtomicLong instance.
      * @param function The function applied to the value, the value is not changed.
      * @return The result of the function application.
      */
-    @Request(id = 1, retryable = false, response = ResponseMessageConst.DATA)
+    @Request(id = 1, retryable = false, response = ResponseMessageConst.DATA, partitionIdentifier = "name")
     Object apply(String name, Data function);
 
     /**
      * Alters the currently stored value by applying a function on it.
      *
-     * @param name The name of this IAtomicLong instance.
+     * @param name     The name of this IAtomicLong instance.
      * @param function The function applied to the currently stored value.
      */
-    @Request(id = 2, retryable = false, response = ResponseMessageConst.VOID)
+    @Request(id = 2, retryable = false, response = ResponseMessageConst.VOID, partitionIdentifier = "name")
     void alter(String name, Data function);
 
     /**
      * Alters the currently stored value by applying a function on it and gets the result.
      *
-     * @param name The name of this IAtomicLong instance.
+     * @param name     The name of this IAtomicLong instance.
      * @param function The function applied to the currently stored value.
      * @return The result of the function application.
      */
-    @Request(id = 3, retryable = false, response = ResponseMessageConst.LONG)
+    @Request(id = 3, retryable = false, response = ResponseMessageConst.LONG, partitionIdentifier = "name")
     Object alterAndGet(String name, Data function);
 
     /**
      * Alters the currently stored value by applying a function on it on and gets the old value.
      *
-     * @param name The name of this IAtomicLong instance.
+     * @param name     The name of this IAtomicLong instance.
      * @param function The function applied to the currently stored value.
      * @return The old value before the function application.
      */
-    @Request(id = 4, retryable = false, response = ResponseMessageConst.LONG)
+    @Request(id = 4, retryable = false, response = ResponseMessageConst.LONG, partitionIdentifier = "name")
     Object getAndAlter(String name, Data function);
 
     /**
      * Atomically adds the given value to the current value.
      *
-     * @param name The name of this IAtomicLong instance.
+     * @param name  The name of this IAtomicLong instance.
      * @param delta the value to add to the current value
      * @return the updated value, the given value added to the current value
      */
-    @Request(id = 5, retryable = false, response = ResponseMessageConst.LONG)
+    @Request(id = 5, retryable = false, response = ResponseMessageConst.LONG, partitionIdentifier = "name")
     Object addAndGet(String name, long delta);
 
     /**
      * Atomically sets the value to the given updated value only if the current value the expected value.
      *
-     * @param name The name of this IAtomicLong instance.
+     * @param name     The name of this IAtomicLong instance.
      * @param expected the expected value
-     * @param updated the new value
+     * @param updated  the new value
      * @return true if successful; or false if the actual value
-     *         was not equal to the expected value.
+     * was not equal to the expected value.
      */
-    @Request(id = 6, retryable = false, response = ResponseMessageConst.BOOLEAN)
+    @Request(id = 6, retryable = false, response = ResponseMessageConst.BOOLEAN, partitionIdentifier = "name")
     Object compareAndSet(String name, long expected, long updated);
 
     /**
@@ -93,7 +93,7 @@ public interface AtomicLongCodecTemplate {
      * @param name The name of this IAtomicLong instance.
      * @return the updated value, the current value decremented by one
      */
-    @Request(id = 7, retryable = false, response = ResponseMessageConst.LONG)
+    @Request(id = 7, retryable = false, response = ResponseMessageConst.LONG, partitionIdentifier = "name")
     Object decrementAndGet(String name);
 
     /**
@@ -102,27 +102,27 @@ public interface AtomicLongCodecTemplate {
      * @param name The name of this IAtomicLong instance.
      * @return the current value
      */
-    @Request(id = 8, retryable = false, response = ResponseMessageConst.LONG)
+    @Request(id = 8, retryable = false, response = ResponseMessageConst.LONG, partitionIdentifier = "name")
     Object get(String name);
 
     /**
      * Atomically adds the given value to the current value.
      *
-     * @param name The name of this IAtomicLong instance.
+     * @param name  The name of this IAtomicLong instance.
      * @param delta the value to add to the current value
      * @return the old value before the add
      */
-    @Request(id = 9, retryable = false, response = ResponseMessageConst.LONG)
+    @Request(id = 9, retryable = false, response = ResponseMessageConst.LONG, partitionIdentifier = "name")
     Object getAndAdd(String name, long delta);
 
     /**
      * Atomically sets the given value and returns the old value.
      *
-     * @param name The name of this IAtomicLong instance.
+     * @param name     The name of this IAtomicLong instance.
      * @param newValue the new value
      * @return the old value
      */
-    @Request(id = 10, retryable = false, response = ResponseMessageConst.LONG)
+    @Request(id = 10, retryable = false, response = ResponseMessageConst.LONG, partitionIdentifier = "name")
     Object getAndSet(String name, long newValue);
 
     /**
@@ -131,7 +131,7 @@ public interface AtomicLongCodecTemplate {
      * @param name The name of this IAtomicLong instance.
      * @return The updated value, the current value incremented by one
      */
-    @Request(id = 11, retryable = false, response = ResponseMessageConst.LONG)
+    @Request(id = 11, retryable = false, response = ResponseMessageConst.LONG, partitionIdentifier = "name")
     Object incrementAndGet(String name);
 
     /**
@@ -140,15 +140,15 @@ public interface AtomicLongCodecTemplate {
      * @param name The name of this IAtomicLong instance.
      * @return the old value
      */
-    @Request(id = 12, retryable = false, response = ResponseMessageConst.LONG)
+    @Request(id = 12, retryable = false, response = ResponseMessageConst.LONG, partitionIdentifier = "name")
     Object getAndIncrement(String name);
 
     /**
      * Atomically sets the given value.
      *
-     * @param name The name of this IAtomicLong instance.
+     * @param name     The name of this IAtomicLong instance.
      * @param newValue The new value
      */
-    @Request(id = 13, retryable = false, response = ResponseMessageConst.VOID)
+    @Request(id = 13, retryable = false, response = ResponseMessageConst.VOID, partitionIdentifier = "name")
     void set(String name, long newValue);
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/AtomicReferenceCodecTemplate.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/AtomicReferenceCodecTemplate.java
@@ -29,62 +29,62 @@ public interface AtomicReferenceCodecTemplate {
     /**
      * Applies a function on the value, the actual stored value will not change.
      *
-     * @param name Name of the AtomicReference distributed object instance.
+     * @param name     Name of the AtomicReference distributed object instance.
      * @param function the function applied on the value, the stored value does not change
-     * @return  the result of the function application
+     * @return the result of the function application
      */
-    @Request(id = 1, retryable = false, response = ResponseMessageConst.DATA)
+    @Request(id = 1, retryable = false, response = ResponseMessageConst.DATA, partitionIdentifier = "name")
     Object apply(String name, Data function);
 
     /**
      * Alters the currently stored reference by applying a function on it.
      *
-     * @param name Name of the AtomicReference distributed object instance.
+     * @param name     Name of the AtomicReference distributed object instance.
      * @param function the function that alters the currently stored reference
      */
-    @Request(id = 2, retryable = false, response = ResponseMessageConst.VOID)
+    @Request(id = 2, retryable = false, response = ResponseMessageConst.VOID, partitionIdentifier = "name")
     void alter(String name, Data function);
 
     /**
      * Alters the currently stored reference by applying a function on it and gets the result.
      *
-     * @param name Name of the AtomicReference distributed object instance.
+     * @param name     Name of the AtomicReference distributed object instance.
      * @param function the function that alters the currently stored reference
      * @return the new value, the result of the applied function.
      */
-    @Request(id = 3, retryable = false, response = ResponseMessageConst.DATA)
+    @Request(id = 3, retryable = false, response = ResponseMessageConst.DATA, partitionIdentifier = "name")
     Object alterAndGet(String name, Data function);
 
     /**
      * Alters the currently stored reference by applying a function on it on and gets the old value.
      *
-     * @param name Name of the AtomicReference distributed object instance.
+     * @param name     Name of the AtomicReference distributed object instance.
      * @param function the function that alters the currently stored reference
-     * @return  the old value, the value before the function is applied
+     * @return the old value, the value before the function is applied
      */
-    @Request(id = 4, retryable = false, response = ResponseMessageConst.DATA)
+    @Request(id = 4, retryable = false, response = ResponseMessageConst.DATA, partitionIdentifier = "name")
     Object getAndAlter(String name, Data function);
 
     /**
      * Checks if the reference contains the value.
      *
-     * @param name Name of the AtomicReference distributed object instance.
+     * @param name     Name of the AtomicReference distributed object instance.
      * @param expected the value to check (is allowed to be null).
      * @return true if the value is found, false otherwise.
      */
-    @Request(id = 5, retryable = true, response = ResponseMessageConst.BOOLEAN)
+    @Request(id = 5, retryable = true, response = ResponseMessageConst.BOOLEAN, partitionIdentifier = "name")
     Object contains(String name, @Nullable Data expected);
 
     /**
      * Atomically sets the value to the given updated value only if the current value the expected value.
      *
-     * @param name Name of the AtomicReference distributed object instance.
+     * @param name     Name of the AtomicReference distributed object instance.
      * @param expected the expected value
-     * @param updated the new value
+     * @param updated  the new value
      * @return true if successful; or false if the actual value
-     *         was not equal to the expected value.
+     * was not equal to the expected value.
      */
-    @Request(id = 6, retryable = false, response = ResponseMessageConst.BOOLEAN)
+    @Request(id = 6, retryable = false, response = ResponseMessageConst.BOOLEAN, partitionIdentifier = "name")
     Object compareAndSet(String name, @Nullable Data expected, @Nullable Data updated);
 
     /**
@@ -93,16 +93,16 @@ public interface AtomicReferenceCodecTemplate {
      * @param name Name of the AtomicReference distributed object instance.
      * @return the current value
      */
-    @Request(id = 8, retryable = true, response = ResponseMessageConst.DATA)
+    @Request(id = 8, retryable = true, response = ResponseMessageConst.DATA, partitionIdentifier = "name")
     Object get(String name);
 
     /**
      * Atomically sets the given value.
      *
-     * @param name Name of the AtomicReference distributed object instance.
+     * @param name     Name of the AtomicReference distributed object instance.
      * @param newValue the new value
      */
-    @Request(id = 9, retryable = false, response = ResponseMessageConst.VOID)
+    @Request(id = 9, retryable = false, response = ResponseMessageConst.VOID, partitionIdentifier = "name")
     void set(String name, @Nullable Data newValue);
 
     /**
@@ -110,27 +110,27 @@ public interface AtomicReferenceCodecTemplate {
      *
      * @param name Name of the AtomicReference distributed object instance.
      */
-    @Request(id = 10, retryable = false, response = ResponseMessageConst.VOID)
+    @Request(id = 10, retryable = false, response = ResponseMessageConst.VOID, partitionIdentifier = "name")
     void clear(String name);
 
     /**
      * Gets the old value and sets the new value.
      *
-     * @param name Name of the AtomicReference distributed object instance.
+     * @param name     Name of the AtomicReference distributed object instance.
      * @param newValue the new value.
      * @return the old value.
      */
-    @Request(id = 11, retryable = false, response = ResponseMessageConst.DATA)
+    @Request(id = 11, retryable = false, response = ResponseMessageConst.DATA, partitionIdentifier = "name")
     Object getAndSet(String name, @Nullable Data newValue);
 
     /**
      * Sets and gets the value.
      *
-     * @param name Name of the AtomicReference distributed object instance.
+     * @param name     Name of the AtomicReference distributed object instance.
      * @param newValue the new value
-     * @return  the new value
+     * @return the new value
      */
-    @Request(id = 12, retryable = false, response = ResponseMessageConst.DATA)
+    @Request(id = 12, retryable = false, response = ResponseMessageConst.DATA, partitionIdentifier = "name")
     Object setAndGet(String name, @Nullable Data newValue);
 
     /**
@@ -139,6 +139,6 @@ public interface AtomicReferenceCodecTemplate {
      * @param name Name of the AtomicReference distributed object instance.
      * @return true if null, false otherwise.
      */
-    @Request(id = 13, retryable = true, response = ResponseMessageConst.BOOLEAN)
+    @Request(id = 13, retryable = true, response = ResponseMessageConst.BOOLEAN, partitionIdentifier = "name")
     Object isNull(String name);
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/CacheCodecTemplate.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/CacheCodecTemplate.java
@@ -26,25 +26,24 @@ import com.hazelcast.nio.serialization.Data;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 @GenerateCodec(id = TemplateConstants.JCACHE_TEMPLATE_ID, name = "Cache", ns = "Hazelcast.Client.Protocol.Codec")
 public interface CacheCodecTemplate {
 
     /**
-     * @param name Name of the cache.
+     * @param name      Name of the cache.
      * @param localOnly if true fires events that originated from this node only, otherwise fires all events
      * @return Registration id for the registered listener.
      */
-    @Request(id = 1, retryable = true, response = ResponseMessageConst.STRING, event = {EventMessageConst.EVENT_CACHE})
+    @Request(id = 1, retryable = false, response = ResponseMessageConst.STRING, event = {EventMessageConst.EVENT_CACHE})
     Object addEntryListener(String name, boolean localOnly);
 
     /**
-     * @param name Name of the cache.
+     * @param name      Name of the cache.
      * @param localOnly if true fires events that originated from this node only, otherwise fires all events
      * @return Registration id for the registered listener.
      */
-    @Request(id = 2, retryable = true, response = ResponseMessageConst.STRING,
+    @Request(id = 2, retryable = false, response = ResponseMessageConst.STRING,
             event = {EventMessageConst.EVENT_CACHEINVALIDATION, EventMessageConst.EVENT_CACHEBATCHINVALIDATION})
     Object addInvalidationListener(String name, boolean localOnly);
 
@@ -90,7 +89,7 @@ public interface CacheCodecTemplate {
      * @param key  The key whose presence in this cache is to be tested.
      * @return Returns true if cache value for the key exists, false otherwise.
      */
-    @Request(id = 6, retryable = true, response = ResponseMessageConst.BOOLEAN)
+    @Request(id = 6, retryable = true, response = ResponseMessageConst.BOOLEAN, partitionIdentifier = "key")
     Object containsKey(String name, Data key);
 
     /**
@@ -100,7 +99,7 @@ public interface CacheCodecTemplate {
      * @return The created configuration object. Byte-array which is serialized from an object implementing
      * javax.cache.configuration.Configuration interface.
      */
-    @Request(id = 7, retryable = true, response = ResponseMessageConst.DATA)
+    @Request(id = 7, retryable = true, response = ResponseMessageConst.DATA, partitionIdentifier = "name")
     Object createConfig(Data cacheConfig, boolean createAlsoOnOthers);
 
     /**
@@ -108,7 +107,7 @@ public interface CacheCodecTemplate {
      *
      * @param name Name of the cache.
      */
-    @Request(id = 8, retryable = false, response = ResponseMessageConst.VOID)
+    @Request(id = 8, retryable = false, response = ResponseMessageConst.VOID, partitionIdentifier = "name")
     void destroy(String name);
 
     /**
@@ -121,7 +120,7 @@ public interface CacheCodecTemplate {
      *                       the request in the cluster.
      * @return the result of the processing, if any, defined by the EntryProcessor implementation
      */
-    @Request(id = 9, retryable = false, response = ResponseMessageConst.DATA)
+    @Request(id = 9, retryable = false, response = ResponseMessageConst.DATA, partitionIdentifier = "key")
     Object entryProcessor(String name, Data key, Data entryProcessor, List<Data> arguments, int completionId);
 
     /**
@@ -149,7 +148,7 @@ public interface CacheCodecTemplate {
      *                     the request in the cluster.
      * @return the value if one existed or null if no mapping existed for this key
      */
-    @Request(id = 11, retryable = false, response = ResponseMessageConst.DATA)
+    @Request(id = 11, retryable = false, response = ResponseMessageConst.DATA, partitionIdentifier = "key")
     Object getAndRemove(String name, Data key, int completionId);
 
     /**
@@ -167,7 +166,7 @@ public interface CacheCodecTemplate {
      *                     the request in the cluster.
      * @return The old value previously assigned to the given key.
      */
-    @Request(id = 12, retryable = false, response = ResponseMessageConst.DATA)
+    @Request(id = 12, retryable = false, response = ResponseMessageConst.DATA, partitionIdentifier = "key")
     Object getAndReplace(String name, Data key, Data value, @Nullable Data expiryPolicy, int completionId);
 
     /**
@@ -176,7 +175,7 @@ public interface CacheCodecTemplate {
      * @return The cache configuration. Byte-array which is serialized from an object implementing
      * javax.cache.configuration.Configuration interface.
      */
-    @Request(id = 13, retryable = true, response = ResponseMessageConst.DATA)
+    @Request(id = 13, retryable = true, response = ResponseMessageConst.DATA, partitionIdentifier = "name")
     Object getConfig(String name, String simpleName);
 
     /**
@@ -190,7 +189,7 @@ public interface CacheCodecTemplate {
      *                     javax.cache.expiry.ExpiryPolicy interface.
      * @return The value assigned to the given key, or null if not assigned.
      */
-    @Request(id = 14, retryable = true, response = ResponseMessageConst.DATA)
+    @Request(id = 14, retryable = true, response = ResponseMessageConst.DATA, partitionIdentifier = "key")
     Object get(String name, Data key, @Nullable Data expiryPolicy);
 
     /**
@@ -205,7 +204,7 @@ public interface CacheCodecTemplate {
      * @param batch       The number of items to be batched
      * @return last index processed and list of data
      */
-    @Request(id = 15, retryable = false, response = ResponseMessageConst.CACHE_KEY_ITERATOR_RESULT)
+    @Request(id = 15, retryable = false, response = ResponseMessageConst.CACHE_KEY_ITERATOR_RESULT, partitionIdentifier = "partitionId")
     Object iterate(String name, int partitionId, int tableIndex, int batch);
 
     /**
@@ -250,7 +249,7 @@ public interface CacheCodecTemplate {
      *                     the request in the cluster.
      * @return true if a value was set, false otherwise.
      */
-    @Request(id = 19, retryable = false, response = ResponseMessageConst.BOOLEAN)
+    @Request(id = 19, retryable = false, response = ResponseMessageConst.BOOLEAN, partitionIdentifier = "key")
     Object putIfAbsent(String name, Data key, Data value, @Nullable Data expiryPolicy, int completionId);
 
     /**
@@ -264,7 +263,7 @@ public interface CacheCodecTemplate {
      *                     the request in the cluster.
      * @return The value previously assigned to the given key, or null if not assigned.
      */
-    @Request(id = 20, retryable = false, response = ResponseMessageConst.DATA)
+    @Request(id = 20, retryable = false, response = ResponseMessageConst.DATA, partitionIdentifier = "key")
     Object put(String name, Data key, Data value, @Nullable Data expiryPolicy, boolean get, int completionId);
 
     /**
@@ -293,7 +292,7 @@ public interface CacheCodecTemplate {
      *                     the request in the cluster.
      * @return returns false if there was no matching key
      */
-    @Request(id = 23, retryable = false, response = ResponseMessageConst.BOOLEAN)
+    @Request(id = 23, retryable = false, response = ResponseMessageConst.BOOLEAN, partitionIdentifier = "key")
     Object remove(String name, Data key, @Nullable Data currentValue, int completionId);
 
     /**
@@ -312,7 +311,7 @@ public interface CacheCodecTemplate {
      *                     the request in the cluster.
      * @return The replaced value.
      */
-    @Request(id = 24, retryable = false, response = ResponseMessageConst.DATA)
+    @Request(id = 24, retryable = false, response = ResponseMessageConst.DATA, partitionIdentifier = "key")
     Object replace(String name, Data key, @Nullable Data oldValue, Data newValue, @Nullable Data expiryPolicy, int completionId);
 
     /**
@@ -335,7 +334,7 @@ public interface CacheCodecTemplate {
      *                  sends all partition lost events.
      * @return returns the registration id for the CachePartitionLostListener.
      */
-    @Request(id = 26, retryable = true, response = ResponseMessageConst.STRING,
+    @Request(id = 26, retryable = false, response = ResponseMessageConst.STRING,
             event = EventMessageConst.EVENT_CACHEPARTITIONLOST)
     Object addPartitionLostListener(String name, boolean localOnly);
 
@@ -350,13 +349,12 @@ public interface CacheCodecTemplate {
     Object removePartitionLostListener(String name, String registrationId);
 
     /**
-     *
-     * @param name          name of the cache
-     * @param entries       entries to be put as batch
-     * @param expiryPolicy  expiry policy for the entry. Byte-array which is serialized from an object implementing
-     *                      {@link javax.cache.expiry.ExpiryPolicy} interface.
-     * @param completionId  user generated id which shall be received as a field of the cache event upon completion of
-     *                      the request in the cluster.
+     * @param name         name of the cache
+     * @param entries      entries to be put as batch
+     * @param expiryPolicy expiry policy for the entry. Byte-array which is serialized from an object implementing
+     *                     {@link javax.cache.expiry.ExpiryPolicy} interface.
+     * @param completionId user generated id which shall be received as a field of the cache event upon completion of
+     *                     the request in the cluster.
      */
     @Request(id = 28, retryable = false, response = ResponseMessageConst.VOID)
     void putAll(String name, List<Map.Entry<Data, Data>> entries, @Nullable Data expiryPolicy, int completionId);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/ClientMessageTemplate.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/ClientMessageTemplate.java
@@ -134,7 +134,7 @@ public interface ClientMessageTemplate {
      *                  sends all partition lost events.
      * @return The listener registration id.
      */
-    @Request(id = 10, retryable = true, response = ResponseMessageConst.STRING, event = {EventMessageConst.EVENT_PARTITIONLOST})
+    @Request(id = 10, retryable = false, response = ResponseMessageConst.STRING, event = {EventMessageConst.EVENT_PARTITIONLOST})
     Object addPartitionLostListener(boolean localOnly);
 
     /**
@@ -153,7 +153,7 @@ public interface ClientMessageTemplate {
     /**
      * @return The registration id for the distributed object listener.
      */
-    @Request(id = 13, retryable = true, response = ResponseMessageConst.STRING, event = {EventMessageConst.EVENT_DISTRIBUTEDOBJECT})
+    @Request(id = 13, retryable = false, response = ResponseMessageConst.STRING, event = {EventMessageConst.EVENT_DISTRIBUTEDOBJECT})
     Object addDistributedObjectListener(boolean localOnly);
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/ConditionCodecTemplate.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/ConditionCodecTemplate.java
@@ -26,13 +26,13 @@ public interface ConditionCodecTemplate {
     /**
      * Causes the current thread to wait until it is signalled or interrupted, or the specified waiting time elapses.
      *
-     * @param name Name of the Condition
+     * @param name     Name of the Condition
      * @param threadId The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
-     * @param timeout The maximum time to wait
+     * @param timeout  The maximum time to wait
      * @param lockName Name of the lock to wait on.
      * @return False if the waiting time detectably elapsed before return from the method, else true
      */
-    @Request(id = 1, retryable = false, response = ResponseMessageConst.BOOLEAN)
+    @Request(id = 1, retryable = false, response = ResponseMessageConst.BOOLEAN, partitionIdentifier = "lockName")
     Object await(String name, long threadId, long timeout, String lockName);
 
     /**
@@ -53,11 +53,11 @@ public interface ConditionCodecTemplate {
      * An implementation can favor responding to an interrupt over normal method return in response to a signal. In that
      * case the implementation must ensure that the signal is redirected to another waiting thread, if there is one.
      *
-     * @param name Name of the Condition
+     * @param name     Name of the Condition
      * @param threadId The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
      * @param lockName Name of the lock to wait on.
      */
-    @Request(id = 2, retryable = false, response = ResponseMessageConst.VOID)
+    @Request(id = 2, retryable = false, response = ResponseMessageConst.VOID, partitionIdentifier = "lockName")
     void beforeAwait(String name, long threadId, String lockName);
 
     /**
@@ -67,23 +67,23 @@ public interface ConditionCodecTemplate {
      * document this precondition and any actions taken if the lock is not held. Typically, an exception such as
      * ILLEGAL_MONITOR_STATE will be thrown.
      *
-     * @param name Name of the Condition
+     * @param name     Name of the Condition
      * @param threadId The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
      * @param lockName Name of the lock to wait on.
      */
 
-    @Request(id = 3, retryable = false, response = ResponseMessageConst.VOID)
+    @Request(id = 3, retryable = false, response = ResponseMessageConst.VOID, partitionIdentifier = "lockName")
     void signal(String name, long threadId, String lockName);
 
     /**
      * If any threads are waiting on this condition then they are all woken up. Each thread must re-acquire the lock
      * before it can return from
      *
-     * @param name Name of the Condition
+     * @param name     Name of the Condition
      * @param threadId The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
      * @param lockName Name of the lock to wait on.
      */
-    @Request(id = 4, retryable = false, response = ResponseMessageConst.VOID)
+    @Request(id = 4, retryable = false, response = ResponseMessageConst.VOID, partitionIdentifier = "lockName")
     void signalAll(String name, long threadId, String lockName);
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/CountdownLatchCodecTemplate.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/CountdownLatchCodecTemplate.java
@@ -35,11 +35,11 @@ public interface CountdownLatchCodecTemplate {
      * and the current thread's interrupted status is cleared. If the specified waiting time elapses then the value false
      * is returned.  If the time is less than or equal to zero, the method will not wait at all.
      *
-     * @param name Name of the CountDownLatch
+     * @param name    Name of the CountDownLatch
      * @param timeout The maximum time in milliseconds to wait
      * @return True if the count reached zero, false if the waiting time elapsed before the count reached zero
      */
-    @Request(id = 1, retryable = false, response = ResponseMessageConst.BOOLEAN)
+    @Request(id = 1, retryable = false, response = ResponseMessageConst.BOOLEAN, partitionIdentifier = "name")
     Object await(String name, long timeout);
 
     /**
@@ -49,7 +49,7 @@ public interface CountdownLatchCodecTemplate {
      *
      * @param name Name of the CountDownLatch
      */
-    @Request(id = 2, retryable = false, response = ResponseMessageConst.VOID)
+    @Request(id = 2, retryable = false, response = ResponseMessageConst.VOID, partitionIdentifier = "name")
     void countDown(String name);
 
     /**
@@ -58,18 +58,18 @@ public interface CountdownLatchCodecTemplate {
      * @param name Name of the CountDownLatch
      * @return The current count for the latch.
      */
-    @Request(id = 3, retryable = true, response = ResponseMessageConst.INTEGER)
+    @Request(id = 3, retryable = true, response = ResponseMessageConst.INTEGER, partitionIdentifier = "name")
     Object getCount(String name);
 
     /**
      * Sets the count to the given value if the current count is zero. If the count is not zero, then this method does
      * nothing and returns false
      *
-     * @param name Name of the CountDownLatch
+     * @param name  Name of the CountDownLatch
      * @param count The number of times countDown must be invoked before threads can pass through await
      * @return True if the new count was set, false if the current count is not zero.
      */
-    @Request(id = 4, retryable = false, response = ResponseMessageConst.BOOLEAN)
+    @Request(id = 4, retryable = false, response = ResponseMessageConst.BOOLEAN, partitionIdentifier = "name")
     Object trySetCount(String name, int count);
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/ExecutorServiceCodecTemplate.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/ExecutorServiceCodecTemplate.java
@@ -51,7 +51,7 @@ public interface ExecutorServiceCodecTemplate {
      * @param interrupt If true, then the thread interrupt call can be used to cancel the thread, otherwise interrupt can not be used.
      * @return True if cancelled successfully, false otherwise.
      */
-    @Request(id = 3, retryable = false, response = ResponseMessageConst.BOOLEAN)
+    @Request(id = 3, retryable = false, response = ResponseMessageConst.BOOLEAN, partitionIdentifier = "partitionId")
     Object cancelOnPartition(String uuid, int partitionId, boolean interrupt);
 
     /**
@@ -72,7 +72,7 @@ public interface ExecutorServiceCodecTemplate {
      * @param partitionId The id of the partition to execute this cancellation request.
      * @return The result of the callable execution.
      */
-    @Request(id = 5, retryable = false, response = ResponseMessageConst.DATA)
+    @Request(id = 5, retryable = false, response = ResponseMessageConst.DATA, partitionIdentifier = "partitionId")
     Object submitToPartition(String name, String uuid, Data callable, int partitionId);
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/ListCodecTemplate.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/ListCodecTemplate.java
@@ -33,7 +33,7 @@ public interface ListCodecTemplate {
      * @param name Name of List
      * @return The number of elements in this list
      */
-    @Request(id = 1, retryable = true, response = ResponseMessageConst.INTEGER)
+    @Request(id = 1, retryable = true, response = ResponseMessageConst.INTEGER, partitionIdentifier = "name")
     Object size(String name);
 
     /**
@@ -43,18 +43,18 @@ public interface ListCodecTemplate {
      * @param value Element whose presence in this list is to be tested
      * @return True if this list contains the specified element, false otherwise
      */
-    @Request(id = 2, retryable = true, response = ResponseMessageConst.BOOLEAN)
+    @Request(id = 2, retryable = true, response = ResponseMessageConst.BOOLEAN, partitionIdentifier = "name")
     Object contains(String name, Data value);
 
     /**
      * Returns true if this list contains all of the elements of the specified collection.
      *
-     * @param name     Name of the List
+     * @param name   Name of the List
      * @param values Collection to be checked for containment in this list
      * @return True if this list contains all of the elements of the
      * specified collection
      */
-    @Request(id = 3, retryable = true, response = ResponseMessageConst.BOOLEAN)
+    @Request(id = 3, retryable = true, response = ResponseMessageConst.BOOLEAN, partitionIdentifier = "name")
     Object containsAll(String name, List<Data> values);
 
     /**
@@ -67,7 +67,7 @@ public interface ListCodecTemplate {
      * @param value Element to be appended to this list
      * @return true if this list changed as a result of the call, false otherwise
      */
-    @Request(id = 4, retryable = false, response = ResponseMessageConst.BOOLEAN)
+    @Request(id = 4, retryable = false, response = ResponseMessageConst.BOOLEAN, partitionIdentifier = "name")
     Object add(String name, Data value);
 
     /**
@@ -80,7 +80,7 @@ public interface ListCodecTemplate {
      * @return True if this list contained the specified element, false otherwise
      */
 
-    @Request(id = 5, retryable = false, response = ResponseMessageConst.BOOLEAN)
+    @Request(id = 5, retryable = false, response = ResponseMessageConst.BOOLEAN, partitionIdentifier = "name")
     Object remove(String name, Data value);
 
     /**
@@ -93,28 +93,28 @@ public interface ListCodecTemplate {
      * @param valueList Collection containing elements to be added to this list
      * @return True if this list changed as a result of the call, false otherwise
      */
-    @Request(id = 6, retryable = false, response = ResponseMessageConst.BOOLEAN)
+    @Request(id = 6, retryable = false, response = ResponseMessageConst.BOOLEAN, partitionIdentifier = "name")
     Object addAll(String name, List<Data> valueList);
 
     /**
      * Removes from this list all of its elements that are contained in the specified collection (optional operation).
      *
-     * @param name     Name of the List
+     * @param name   Name of the List
      * @param values The list of values to compare for removal.
      * @return True if removed at least one of the items, false otherwise.
      */
-    @Request(id = 7, retryable = false, response = ResponseMessageConst.BOOLEAN)
+    @Request(id = 7, retryable = false, response = ResponseMessageConst.BOOLEAN, partitionIdentifier = "name")
     Object compareAndRemoveAll(String name, List<Data> values);
 
     /**
      * Retains only the elements in this list that are contained in the specified collection (optional operation).
      * In other words, removes from this list all of its elements that are not contained in the specified collection.
      *
-     * @param name     Name of the List
+     * @param name   Name of the List
      * @param values The list of values to compare for retaining.
      * @return True if this list changed as a result of the call, false otherwise.
      */
-    @Request(id = 8, retryable = false, response = ResponseMessageConst.BOOLEAN)
+    @Request(id = 8, retryable = false, response = ResponseMessageConst.BOOLEAN, partitionIdentifier = "name")
     Object compareAndRetainAll(String name, List<Data> values);
 
     /**
@@ -122,7 +122,7 @@ public interface ListCodecTemplate {
      *
      * @param name Name of the List
      */
-    @Request(id = 9, retryable = false, response = ResponseMessageConst.VOID)
+    @Request(id = 9, retryable = false, response = ResponseMessageConst.VOID, partitionIdentifier = "name")
     void clear(String name);
 
     /**
@@ -131,7 +131,7 @@ public interface ListCodecTemplate {
      * @param name Name of the List
      * @return An array of all item values in the list.
      */
-    @Request(id = 10, retryable = true, response = ResponseMessageConst.LIST_DATA)
+    @Request(id = 10, retryable = true, response = ResponseMessageConst.LIST_DATA, partitionIdentifier = "name")
     Object getAll(String name);
 
     /**
@@ -142,7 +142,7 @@ public interface ListCodecTemplate {
      * @param localOnly    if true fires events that originated from this node only, otherwise fires all events
      * @return Registration id for the listener.
      */
-    @Request(id = 11, retryable = true, response = ResponseMessageConst.STRING, event = {EventMessageConst.EVENT_ITEM})
+    @Request(id = 11, retryable = false, response = ResponseMessageConst.STRING, event = {EventMessageConst.EVENT_ITEM}, partitionIdentifier = "name")
     Object addListener(String name, boolean includeValue, boolean localOnly);
 
     /**
@@ -152,7 +152,7 @@ public interface ListCodecTemplate {
      * @param registrationId The id of the listener which was provided during registration.
      * @return True if unregistered, false otherwise.
      */
-    @Request(id = 12, retryable = true, response = ResponseMessageConst.BOOLEAN)
+    @Request(id = 12, retryable = true, response = ResponseMessageConst.BOOLEAN, partitionIdentifier = "name")
     Object removeListener(String name, String registrationId);
 
     /**
@@ -161,7 +161,7 @@ public interface ListCodecTemplate {
      * @param name Name of the List
      * @return True if this list contains no elements
      */
-    @Request(id = 13, retryable = true, response = ResponseMessageConst.BOOLEAN)
+    @Request(id = 13, retryable = true, response = ResponseMessageConst.BOOLEAN, partitionIdentifier = "name")
     Object isEmpty(String name);
 
     /**
@@ -176,7 +176,7 @@ public interface ListCodecTemplate {
      * @param valueList The list of value to insert into the list.
      * @return True if this list changed as a result of the call, false otherwise.
      */
-    @Request(id = 14, retryable = false, response = ResponseMessageConst.BOOLEAN)
+    @Request(id = 14, retryable = false, response = ResponseMessageConst.BOOLEAN, partitionIdentifier = "name")
     Object addAllWithIndex(String name, int index, List<Data> valueList);
 
     /**
@@ -186,7 +186,7 @@ public interface ListCodecTemplate {
      * @param index Index of the element to return
      * @return The element at the specified position in this list
      */
-    @Request(id = 15, retryable = true, response = ResponseMessageConst.DATA)
+    @Request(id = 15, retryable = true, response = ResponseMessageConst.DATA, partitionIdentifier = "name")
     Object get(String name, int index);
 
     /**
@@ -197,7 +197,7 @@ public interface ListCodecTemplate {
      * @param value Element to be stored at the specified position
      * @return The element previously at the specified position
      */
-    @Request(id = 16, retryable = false, response = ResponseMessageConst.DATA)
+    @Request(id = 16, retryable = false, response = ResponseMessageConst.DATA, partitionIdentifier = "name")
     Object set(String name, int index, Data value);
 
     /**
@@ -208,7 +208,7 @@ public interface ListCodecTemplate {
      * @param index index at which the specified element is to be inserted
      * @param value Value to be inserted.
      */
-    @Request(id = 17, retryable = false, response = ResponseMessageConst.VOID)
+    @Request(id = 17, retryable = false, response = ResponseMessageConst.VOID, partitionIdentifier = "name")
     void addWithIndex(String name, int index, Data value);
 
     /**
@@ -219,7 +219,7 @@ public interface ListCodecTemplate {
      * @param index The index of the element to be removed
      * @return The element previously at the specified position
      */
-    @Request(id = 18, retryable = false, response = ResponseMessageConst.DATA)
+    @Request(id = 18, retryable = false, response = ResponseMessageConst.DATA, partitionIdentifier = "name")
     Object removeWithIndex(String name, int index);
 
     /**
@@ -231,7 +231,7 @@ public interface ListCodecTemplate {
      * @return the index of the last occurrence of the specified element in
      * this list, or -1 if this list does not contain the element
      */
-    @Request(id = 19, retryable = true, response = ResponseMessageConst.INTEGER)
+    @Request(id = 19, retryable = true, response = ResponseMessageConst.INTEGER, partitionIdentifier = "name")
     Object lastIndexOf(String name, Data value);
 
     /**
@@ -243,7 +243,7 @@ public interface ListCodecTemplate {
      * @return The index of the first occurrence of the specified element in
      * this list, or -1 if this list does not contain the element
      */
-    @Request(id = 20, retryable = true, response = ResponseMessageConst.INTEGER)
+    @Request(id = 20, retryable = true, response = ResponseMessageConst.INTEGER, partitionIdentifier = "name")
     Object indexOf(String name, Data value);
 
     /**
@@ -265,7 +265,7 @@ public interface ListCodecTemplate {
      * @return A view of the specified range within this list
      */
 
-    @Request(id = 21, retryable = true, response = ResponseMessageConst.LIST_DATA)
+    @Request(id = 21, retryable = true, response = ResponseMessageConst.LIST_DATA, partitionIdentifier = "name")
     Object sub(String name, int from, int to);
 
     /**
@@ -274,7 +274,7 @@ public interface ListCodecTemplate {
      * @param name Name of the List
      * @return An iterator over the elements in this list in proper sequence
      */
-    @Request(id = 22, retryable = true, response = ResponseMessageConst.LIST_DATA)
+    @Request(id = 22, retryable = true, response = ResponseMessageConst.LIST_DATA, partitionIdentifier = "name")
     Object iterator(String name);
 
     /**
@@ -288,6 +288,6 @@ public interface ListCodecTemplate {
      * @return a list iterator over the elements in this list (in proper
      * sequence), starting at the specified position in the list
      */
-    @Request(id = 23, retryable = true, response = ResponseMessageConst.LIST_DATA)
+    @Request(id = 23, retryable = true, response = ResponseMessageConst.LIST_DATA, partitionIdentifier = "name")
     Object listIterator(String name, int index);
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/LockCodecTemplate.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/LockCodecTemplate.java
@@ -29,7 +29,7 @@ public interface LockCodecTemplate {
      * @param name Name of the Lock
      * @return True if this lock is locked, false otherwise.
      */
-    @Request(id = 1, retryable = true, response = ResponseMessageConst.BOOLEAN)
+    @Request(id = 1, retryable = true, response = ResponseMessageConst.BOOLEAN, partitionIdentifier = "name")
     Object isLocked(String name);
 
     /**
@@ -39,7 +39,7 @@ public interface LockCodecTemplate {
      * @param threadId The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
      * @return True if this lock is locked by current thread, false otherwise.
      */
-    @Request(id = 2, retryable = true, response = ResponseMessageConst.BOOLEAN)
+    @Request(id = 2, retryable = true, response = ResponseMessageConst.BOOLEAN, partitionIdentifier = "name")
     Object isLockedByCurrentThread(String name, long threadId);
 
     /**
@@ -48,7 +48,7 @@ public interface LockCodecTemplate {
      * @param name Name of the Lock
      * @return The lock hold count.
      */
-    @Request(id = 3, retryable = true, response = ResponseMessageConst.INTEGER)
+    @Request(id = 3, retryable = true, response = ResponseMessageConst.INTEGER, partitionIdentifier = "name")
     Object getLockCount(String name);
 
     /**
@@ -57,7 +57,7 @@ public interface LockCodecTemplate {
      * @param name Name of the Lock
      * @return Remaining lease time in milliseconds.
      */
-    @Request(id = 4, retryable = true, response = ResponseMessageConst.LONG)
+    @Request(id = 4, retryable = true, response = ResponseMessageConst.LONG, partitionIdentifier = "name")
     Object getRemainingLeaseTime(String name);
 
     /**
@@ -69,7 +69,7 @@ public interface LockCodecTemplate {
      * @param leaseTime Time to wait before releasing to lock
      * @param threadId The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
      */
-    @Request(id = 5, retryable = false, response = ResponseMessageConst.VOID)
+    @Request(id = 5, retryable = false, response = ResponseMessageConst.VOID, partitionIdentifier = "name")
     void lock(String name, long leaseTime, long threadId);
 
     /**
@@ -78,7 +78,7 @@ public interface LockCodecTemplate {
      * @param name Name of the Lock
      * @param threadId The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
      */
-    @Request(id = 6, retryable = false, response = ResponseMessageConst.VOID)
+    @Request(id = 6, retryable = false, response = ResponseMessageConst.VOID, partitionIdentifier = "name")
     void unlock(String name, long threadId);
 
     /**
@@ -87,7 +87,7 @@ public interface LockCodecTemplate {
      *
      * @param name Name of the Lock
      */
-    @Request(id = 7, retryable = false, response = ResponseMessageConst.VOID)
+    @Request(id = 7, retryable = false, response = ResponseMessageConst.VOID, partitionIdentifier = "name")
     void forceUnlock(String name);
 
     /**
@@ -102,7 +102,7 @@ public interface LockCodecTemplate {
      * @param timeout Maximum time to wait for the lock.
      * @return true if the lock was acquired and false if the waiting time elapsed before the lock was acquired.
      */
-    @Request(id = 8, retryable = false, response = ResponseMessageConst.BOOLEAN)
+    @Request(id = 8, retryable = false, response = ResponseMessageConst.BOOLEAN, partitionIdentifier = "name")
     Object tryLock(String name, long threadId, long lease, long timeout);
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/MapCodecTemplate.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/MapCodecTemplate.java
@@ -25,7 +25,6 @@ import com.hazelcast.nio.serialization.Data;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 @GenerateCodec(id = TemplateConstants.MAP_TEMPLATE_ID, name = "Map", ns = "Hazelcast.Client.Protocol.Codec")
 public interface MapCodecTemplate {
@@ -42,7 +41,7 @@ public interface MapCodecTemplate {
      * @param ttl      The duration in milliseconds after which this entry shall be deleted. O means infinite.
      * @return old value of the entry
      */
-    @Request(id = 1, retryable = false, response = ResponseMessageConst.DATA)
+    @Request(id = 1, retryable = false, response = ResponseMessageConst.DATA, partitionIdentifier = "key")
     Object put(String name, Data key, Data value, long threadId, long ttl);
 
     /**
@@ -54,7 +53,7 @@ public interface MapCodecTemplate {
      * @param threadId The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
      * @return The value for the key if exists
      */
-    @Request(id = 2, retryable = true, response = ResponseMessageConst.DATA)
+    @Request(id = 2, retryable = true, response = ResponseMessageConst.DATA, partitionIdentifier = "key")
     Object get(String name, Data key, long threadId);
 
     /**
@@ -69,7 +68,7 @@ public interface MapCodecTemplate {
      * @param threadId The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
      * @return Clone of the removed value, not the original (identically equal) value previously put into the map.
      */
-    @Request(id = 3, retryable = false, response = ResponseMessageConst.DATA)
+    @Request(id = 3, retryable = false, response = ResponseMessageConst.DATA, partitionIdentifier = "key")
     Object remove(String name, Data key, long threadId);
 
     /**
@@ -81,7 +80,7 @@ public interface MapCodecTemplate {
      * @param threadId The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
      * @return Clone of the previous value, not the original (identically equal) value previously put into the map.
      */
-    @Request(id = 4, retryable = false, response = ResponseMessageConst.DATA)
+    @Request(id = 4, retryable = false, response = ResponseMessageConst.DATA, partitionIdentifier = "key")
     Object replace(String name, Data key, Data value, long threadId);
 
     /**
@@ -94,7 +93,7 @@ public interface MapCodecTemplate {
      * @param threadId  The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
      * @return true if value is replaced with new one, false otherwise
      */
-    @Request(id = 5, retryable = false, response = ResponseMessageConst.BOOLEAN)
+    @Request(id = 5, retryable = false, response = ResponseMessageConst.BOOLEAN, partitionIdentifier = "key")
     Object replaceIfSame(String name, Data key, Data testValue, Data value, long threadId);
 
     /**
@@ -105,7 +104,7 @@ public interface MapCodecTemplate {
      * @param threadId The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
      * @return Returns true if the key exists, otherwise returns false.
      */
-    @Request(id = 9, retryable = true, response = ResponseMessageConst.BOOLEAN)
+    @Request(id = 9, retryable = true, response = ResponseMessageConst.BOOLEAN, partitionIdentifier = "key")
     Object containsKey(String name, Data key, long threadId);
 
     /**
@@ -128,7 +127,7 @@ public interface MapCodecTemplate {
      * @param threadId The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
      * @return Returns true if the key exists and removed, otherwise returns false.
      */
-    @Request(id = 11, retryable = false, response = ResponseMessageConst.BOOLEAN)
+    @Request(id = 11, retryable = false, response = ResponseMessageConst.BOOLEAN, partitionIdentifier = "key")
     Object removeIfSame(String name, Data key, Data value, long threadId);
 
     /**
@@ -143,7 +142,7 @@ public interface MapCodecTemplate {
      * @param key      Key for the map entry.
      * @param threadId The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
      */
-    @Request(id = 12, retryable = false, response = ResponseMessageConst.VOID)
+    @Request(id = 12, retryable = false, response = ResponseMessageConst.VOID, partitionIdentifier = "key")
     void delete(String name, Data key, long threadId);
 
     /**
@@ -166,7 +165,7 @@ public interface MapCodecTemplate {
      * @param timeout  maximum time in milliseconds to wait for acquiring the lock for the key.
      * @return Returns true if successful, otherwise returns false
      */
-    @Request(id = 14, retryable = false, response = ResponseMessageConst.BOOLEAN)
+    @Request(id = 14, retryable = false, response = ResponseMessageConst.BOOLEAN, partitionIdentifier = "key")
     Object tryRemove(String name, Data key, long threadId, long timeout);
 
     /**
@@ -181,7 +180,7 @@ public interface MapCodecTemplate {
      * @param timeout  maximum time in milliseconds to wait for acquiring the lock for the key.
      * @return Returns true if successful, otherwise returns false
      */
-    @Request(id = 15, retryable = false, response = ResponseMessageConst.BOOLEAN)
+    @Request(id = 15, retryable = false, response = ResponseMessageConst.BOOLEAN, partitionIdentifier = "key")
     Object tryPut(String name, Data key, Data value, long threadId, long timeout);
 
     /**
@@ -194,7 +193,7 @@ public interface MapCodecTemplate {
      * @param threadId The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
      * @param ttl      The duration in milliseconds after which this entry shall be deleted. O means infinite.
      */
-    @Request(id = 16, retryable = false, response = ResponseMessageConst.VOID)
+    @Request(id = 16, retryable = false, response = ResponseMessageConst.VOID, partitionIdentifier = "key")
     void putTransient(String name, Data key, Data value, long threadId, long ttl);
 
     /**
@@ -208,7 +207,7 @@ public interface MapCodecTemplate {
      * @param ttl      The duration in milliseconds after which this entry shall be deleted. O means infinite.
      * @return returns a clone of the previous value, not the original (identically equal) value previously put into the map.
      */
-    @Request(id = 17, retryable = false, response = ResponseMessageConst.DATA)
+    @Request(id = 17, retryable = false, response = ResponseMessageConst.DATA, partitionIdentifier = "key")
     Object putIfAbsent(String name, Data key, Data value, long threadId, long ttl);
 
     /**
@@ -222,7 +221,7 @@ public interface MapCodecTemplate {
      * @param threadId The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
      * @param ttl      The duration in milliseconds after which this entry shall be deleted. O means infinite.
      */
-    @Request(id = 18, retryable = false, response = ResponseMessageConst.VOID)
+    @Request(id = 18, retryable = false, response = ResponseMessageConst.VOID, partitionIdentifier = "key")
     void set(String name, Data key, Data value, long threadId, long ttl);
 
     /**
@@ -237,7 +236,7 @@ public interface MapCodecTemplate {
      * @param threadId The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
      * @param ttl      The duration in milliseconds after which this entry shall be deleted. O means infinite.
      */
-    @Request(id = 19, retryable = false, response = ResponseMessageConst.VOID)
+    @Request(id = 19, retryable = false, response = ResponseMessageConst.VOID, partitionIdentifier = "key")
     void lock(String name, Data key, long threadId, long ttl);
 
     /**
@@ -253,7 +252,7 @@ public interface MapCodecTemplate {
      * @param timeout  maximum time to wait for getting the lock.
      * @return Returns true if successful, otherwise returns false
      */
-    @Request(id = 20, retryable = false, response = ResponseMessageConst.BOOLEAN)
+    @Request(id = 20, retryable = false, response = ResponseMessageConst.BOOLEAN, partitionIdentifier = "key")
     Object tryLock(String name, Data key, long threadId, long lease, long timeout);
 
     /**
@@ -263,7 +262,7 @@ public interface MapCodecTemplate {
      * @param key  Key for the map entry to check if it is locked.
      * @return Returns true if the entry is locked, otherwise returns false
      */
-    @Request(id = 21, retryable = true, response = ResponseMessageConst.BOOLEAN)
+    @Request(id = 21, retryable = true, response = ResponseMessageConst.BOOLEAN, partitionIdentifier = "key")
     Object isLocked(String name, Data key);
 
     /**
@@ -276,7 +275,7 @@ public interface MapCodecTemplate {
      * @param key      Key for the map entry to unlock
      * @param threadId The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
      */
-    @Request(id = 22, retryable = false, response = ResponseMessageConst.VOID)
+    @Request(id = 22, retryable = false, response = ResponseMessageConst.VOID, partitionIdentifier = "key")
     void unlock(String name, Data key, long threadId);
 
     /**
@@ -307,13 +306,13 @@ public interface MapCodecTemplate {
      * @param name          name of map
      * @param key           Key for the map entry.
      * @param predicate     predicate for filtering entries.
-     * @param includeValue  <tt>true</tt> if <tt>EntryEvent</tt> should
+     * @param includeValue  true if EntryEvent should
      *                      contain the value.
      * @param listenerFlags flags of enabled listeners.
      * @param localOnly     if true fires events that originated from this node only, otherwise fires all events
      * @return A unique string which is used as a key to remove the listener.
      */
-    @Request(id = 25, retryable = true, response = ResponseMessageConst.STRING, event = EventMessageConst.EVENT_ENTRY)
+    @Request(id = 25, retryable = false, response = ResponseMessageConst.STRING, event = EventMessageConst.EVENT_ENTRY)
     Object addEntryListenerToKeyWithPredicate(String name, Data key, Data predicate,
                                               boolean includeValue, int listenerFlags, boolean localOnly);
 
@@ -323,13 +322,13 @@ public interface MapCodecTemplate {
      *
      * @param name          name of map
      * @param predicate     predicate for filtering entries.
-     * @param includeValue  <tt>true</tt> if <tt>EntryEvent</tt> should
+     * @param includeValue  true if EntryEvent should
      *                      contain the value.
      * @param listenerFlags flags of enabled listeners.
      * @param localOnly     if true fires events that originated from this node only, otherwise fires all events
      * @return A unique string which is used as a key to remove the listener.
      */
-    @Request(id = 26, retryable = true, response = ResponseMessageConst.STRING, event = EventMessageConst.EVENT_ENTRY)
+    @Request(id = 26, retryable = false, response = ResponseMessageConst.STRING, event = EventMessageConst.EVENT_ENTRY)
     Object addEntryListenerWithPredicate(String name, Data predicate, boolean includeValue,
                                          int listenerFlags, boolean localOnly);
 
@@ -339,12 +338,12 @@ public interface MapCodecTemplate {
      *
      * @param name          name of map
      * @param key           Key for the map entry.
-     * @param includeValue  <tt>true</tt> if <tt>EntryEvent</tt> should contain the value.
+     * @param includeValue  true if EntryEvent should contain the value.
      * @param listenerFlags flags of enabled listeners.
      * @param localOnly     if true fires events that originated from this node only, otherwise fires all events
      * @return A unique string which is used as a key to remove the listener.
      */
-    @Request(id = 27, retryable = true, response = ResponseMessageConst.STRING, event = EventMessageConst.EVENT_ENTRY)
+    @Request(id = 27, retryable = false, response = ResponseMessageConst.STRING, event = EventMessageConst.EVENT_ENTRY)
     Object addEntryListenerToKey(String name, Data key, boolean includeValue, int listenerFlags, boolean localOnly);
 
     /**
@@ -352,12 +351,12 @@ public interface MapCodecTemplate {
      * sub-interface for that event.
      *
      * @param name          name of map
-     * @param includeValue  <tt>true</tt> if <tt>EntryEvent</tt> should contain the value.
+     * @param includeValue  true if EntryEvent should contain the value.
      * @param listenerFlags flags of enabled listeners.
      * @param localOnly     if true fires events that originated from this node only, otherwise fires all events
      * @return A unique string which is used as a key to remove the listener.
      */
-    @Request(id = 28, retryable = true, response = ResponseMessageConst.STRING, event = EventMessageConst.EVENT_ENTRY)
+    @Request(id = 28, retryable = false, response = ResponseMessageConst.STRING, event = EventMessageConst.EVENT_ENTRY)
     Object addEntryListener(String name, boolean includeValue, int listenerFlags, boolean localOnly);
 
     /**
@@ -368,7 +367,7 @@ public interface MapCodecTemplate {
      * @param localOnly     if true fires events that originated from this node only, otherwise fires all events
      * @return A unique string which is used as a key to remove the listener.
      */
-    @Request(id = 29, retryable = true, response = ResponseMessageConst.STRING,
+    @Request(id = 29, retryable = false, response = ResponseMessageConst.STRING,
             event = {EventMessageConst.EVENT_IMAPINVALIDATION, EventMessageConst.EVENT_IMAPBATCHINVALIDATION})
     Object addNearCacheEntryListener(String name, int listenerFlags, boolean localOnly);
 
@@ -394,7 +393,7 @@ public interface MapCodecTemplate {
      * @param localOnly if true fires events that originated from this node only, otherwise fires all events
      * @return returns the registration id for the MapPartitionLostListener.
      */
-    @Request(id = 31, retryable = true, response = ResponseMessageConst.STRING,
+    @Request(id = 31, retryable = false, response = ResponseMessageConst.STRING,
             event = EventMessageConst.EVENT_MAPPARTITIONLOST)
     Object addPartitionLostListener(String name, boolean localOnly);
 
@@ -416,9 +415,9 @@ public interface MapCodecTemplate {
      * @param name     name of map
      * @param key      the key of the entry.
      * @param threadId The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
-     * @return <tt>EntryView</tt> of the specified key.
+     * @return EntryView of the specified key.
      */
-    @Request(id = 33, retryable = true, response = ResponseMessageConst.ENTRY_VIEW)
+    @Request(id = 33, retryable = true, response = ResponseMessageConst.ENTRY_VIEW, partitionIdentifier = "key")
     Object getEntryView(String name, Data key, long threadId);
 
     /**
@@ -428,9 +427,9 @@ public interface MapCodecTemplate {
      * @param name     name of map
      * @param key      the specified key to evict from this map.
      * @param threadId The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
-     * @return <tt>true</tt> if the key is evicted, <tt>false</tt> otherwise.
+     * @return true if the key is evicted, false otherwise.
      */
-    @Request(id = 34, retryable = false, response = ResponseMessageConst.BOOLEAN)
+    @Request(id = 34, retryable = false, response = ResponseMessageConst.BOOLEAN, partitionIdentifier = "key")
     Object evict(String name, Data key, long threadId);
 
     /**
@@ -486,7 +485,7 @@ public interface MapCodecTemplate {
      * @param keys keys to get
      * @return values for the provided keys.
      */
-    @Request(id = 39, retryable = false, response = ResponseMessageConst.LIST_ENTRY)
+    @Request(id = 39, retryable = false, response = ResponseMessageConst.LIST_ENTRY, partitionIdentifier = "any key belongs to target partition")
     Object getAll(String name, List<Data> keys);
 
     /**
@@ -569,7 +568,7 @@ public interface MapCodecTemplate {
      *
      * @param name      name of map
      * @param attribute index attribute of value
-     * @param ordered   <tt>true</tt> if index should be ordered, <tt>false</tt> otherwise.
+     * @param ordered   true if index should be ordered, false otherwise.
      */
     @Request(id = 45, retryable = false, response = ResponseMessageConst.VOID)
     void addIndex(String name, String attribute, boolean ordered);
@@ -588,7 +587,7 @@ public interface MapCodecTemplate {
      * Returns true if this map contains no key-value mappings.
      *
      * @param name name of map
-     * @return <tt>true</tt> if this map contains no key-value mappings
+     * @return true if this map contains no key-value mappings
      */
     @Request(id = 47, retryable = true, response = ResponseMessageConst.BOOLEAN)
     Object isEmpty(String name);
@@ -605,7 +604,7 @@ public interface MapCodecTemplate {
      * @param name    name of map
      * @param entries mappings to be stored in this map
      */
-    @Request(id = 48, retryable = false, response = ResponseMessageConst.VOID)
+    @Request(id = 48, retryable = false, response = ResponseMessageConst.VOID, partitionIdentifier = "any key belongs to target partition")
     void putAll(String name, Map<Data, Data> entries);
 
     /**
@@ -627,7 +626,7 @@ public interface MapCodecTemplate {
      * @param key            the key of the map entry.
      * @return result of entry process.
      */
-    @Request(id = 50, retryable = false, response = ResponseMessageConst.DATA)
+    @Request(id = 50, retryable = false, response = ResponseMessageConst.DATA, partitionIdentifier = "key")
     Object executeOnKey(String name, Data entryProcessor, Data key, long threadId);
 
     /**
@@ -640,7 +639,7 @@ public interface MapCodecTemplate {
      * @param key            the key of the map entry.
      * @return result of entry process.
      */
-    @Request(id = 51, retryable = false, response = ResponseMessageConst.DATA)
+    @Request(id = 51, retryable = false, response = ResponseMessageConst.DATA, partitionIdentifier = "key")
     Object submitToKey(String name, Data entryProcessor, Data key, long threadId);
 
     /**
@@ -684,7 +683,7 @@ public interface MapCodecTemplate {
      * @param name name of map
      * @param key  the key of the map entry.
      */
-    @Request(id = 55, retryable = false, response = ResponseMessageConst.VOID)
+    @Request(id = 55, retryable = false, response = ResponseMessageConst.VOID, partitionIdentifier = "key")
     void forceUnlock(String name, Data key);
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/MultiMapCodecTemplate.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/MultiMapCodecTemplate.java
@@ -27,36 +27,36 @@ public interface MultiMapCodecTemplate {
     /**
      * Stores a key-value pair in the multimap.
      *
-     * @param name Name of the MultiMap
-     * @param key The key to be stored
-     * @param value The value to be stored
+     * @param name     Name of the MultiMap
+     * @param key      The key to be stored
+     * @param value    The value to be stored
      * @param threadId The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
      * @return True if size of the multimap is increased, false if the multimap already contains the key-value pair.
      */
-    @Request(id = 1, retryable = false, response = ResponseMessageConst.BOOLEAN)
+    @Request(id = 1, retryable = false, response = ResponseMessageConst.BOOLEAN, partitionIdentifier = "key")
     Object put(String name, Data key, Data value, long threadId);
 
     /**
      * Returns the collection of values associated with the key. The collection is NOT backed by the map, so changes to
      * the map are NOT reflected in the collection, and vice-versa.
      *
-     * @param name Name of the MultiMap
-     * @param key The key whose associated values are to be returned
+     * @param name     Name of the MultiMap
+     * @param key      The key whose associated values are to be returned
      * @param threadId The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
      * @return The collection of the values associated with the key.
      */
-    @Request(id = 2, retryable = true, response = ResponseMessageConst.LIST_DATA)
+    @Request(id = 2, retryable = true, response = ResponseMessageConst.LIST_DATA, partitionIdentifier = "key")
     Object get(String name, Data key, long threadId);
 
     /**
      * Removes the given key value pair from the multimap.
      *
-     * @param name Name of the MultiMap
-     * @param key  The key of the entry to remove
+     * @param name     Name of the MultiMap
+     * @param key      The key of the entry to remove
      * @param threadId The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
      * @return True if the size of the multimap changed after the remove operation, false otherwise.
      */
-    @Request(id = 3, retryable = false, response = ResponseMessageConst.LIST_DATA)
+    @Request(id = 3, retryable = false, response = ResponseMessageConst.LIST_DATA, partitionIdentifier = "key")
     Object remove(String name, Data key, long threadId);
 
     /**
@@ -92,18 +92,18 @@ public interface MultiMapCodecTemplate {
     /**
      * Returns whether the multimap contains an entry with the key.
      *
-     * @param name Name of the MultiMap
-     * @param key The key whose existence is checked.
+     * @param name     Name of the MultiMap
+     * @param key      The key whose existence is checked.
      * @param threadId The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
      * @return True if the multimap contains an entry with the key, false otherwise.
      */
-    @Request(id = 7, retryable = true, response = ResponseMessageConst.BOOLEAN)
+    @Request(id = 7, retryable = true, response = ResponseMessageConst.BOOLEAN, partitionIdentifier = "key")
     Object containsKey(String name, Data key, long threadId);
 
     /**
      * Returns whether the multimap contains an entry with the value.
      *
-     * @param name Name of the MultiMap
+     * @param name  Name of the MultiMap
      * @param value The value whose existence is checked.
      * @return True if the multimap contains an entry with the value, false otherwise.
      */
@@ -113,13 +113,13 @@ public interface MultiMapCodecTemplate {
     /**
      * Returns whether the multimap contains the given key-value pair.
      *
-     * @param name Name of the MultiMap
-     * @param key The key whose existence is checked.
-     * @param value The value whose existence is checked.
+     * @param name     Name of the MultiMap
+     * @param key      The key whose existence is checked.
+     * @param value    The value whose existence is checked.
      * @param threadId The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation
      * @return True if the multimap contains the key-value pair, false otherwise.
      */
-    @Request(id = 9, retryable = true, response = ResponseMessageConst.BOOLEAN)
+    @Request(id = 9, retryable = true, response = ResponseMessageConst.BOOLEAN, partitionIdentifier = "key")
     Object containsEntry(String name, Data key, Data value, long threadId);
 
     /**
@@ -142,8 +142,8 @@ public interface MultiMapCodecTemplate {
     /**
      * Returns the number of values that match the given key in the multimap.
      *
-     * @param name Name of the MultiMap
-     * @param key The key whose values count is to be returned
+     * @param name     Name of the MultiMap
+     * @param key      The key whose values count is to be returned
      * @param threadId The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation
      * @return The number of values that match the given key in the multimap
      */
@@ -154,32 +154,32 @@ public interface MultiMapCodecTemplate {
      * Adds the specified entry listener for the specified key.The listener will be notified for all
      * add/remove/update/evict events for the specified key only.
      *
-     * @param name Name of the MultiMap
-     * @param key The key to listen to
+     * @param name         Name of the MultiMap
+     * @param key          The key to listen to
      * @param includeValue True if EntryEvent should contain the value,false otherwise
-     * @param localOnly if true fires events that originated from this node only, otherwise fires all events
+     * @param localOnly    if true fires events that originated from this node only, otherwise fires all events
      * @return Returns registration id for the entry listener
      */
-    @Request(id = 13, retryable = true, response = ResponseMessageConst.STRING,
+    @Request(id = 13, retryable = false, response = ResponseMessageConst.STRING,
             event = {EventMessageConst.EVENT_ENTRY})
     Object addEntryListenerToKey(String name, Data key, boolean includeValue, boolean localOnly);
 
     /**
      * Adds an entry listener for this multimap. The listener will be notified for all multimap add/remove/update/evict events.
      *
-     * @param name Name of the MultiMap
+     * @param name         Name of the MultiMap
      * @param includeValue True if EntryEvent should contain the value,false otherwise
-     * @param localOnly if true fires events that originated from this node only, otherwise fires all events
+     * @param localOnly    if true fires events that originated from this node only, otherwise fires all events
      * @return Returns registration id for the entry listener
      */
-    @Request(id = 14, retryable = true, response = ResponseMessageConst.STRING,
-             event = {EventMessageConst.EVENT_ENTRY})
+    @Request(id = 14, retryable = false, response = ResponseMessageConst.STRING,
+            event = {EventMessageConst.EVENT_ENTRY})
     Object addEntryListener(String name, boolean includeValue, boolean localOnly);
 
     /**
      * Removes the specified entry listener. Returns silently if no such listener was added before.
      *
-     * @param name Name of the MultiMap
+     * @param name           Name of the MultiMap
      * @param registrationId Registration id of listener
      * @return True if registration is removed, false otherwise
      */
@@ -193,12 +193,12 @@ public interface MultiMapCodecTemplate {
      * lock is only for the key in this map.Locks are re-entrant, so if the key is locked N times, then it should be
      * unlocked N times before another thread can acquire it.
      *
-     * @param name Name of the MultiMap
-     * @param key The key the Lock
+     * @param name     Name of the MultiMap
+     * @param key      The key the Lock
      * @param threadId The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation
-     * @param ttl The duration in milliseconds after which this entry shall be deleted. O means infinite.
+     * @param ttl      The duration in milliseconds after which this entry shall be deleted. O means infinite.
      */
-    @Request(id = 16, retryable = false, response = ResponseMessageConst.VOID)
+    @Request(id = 16, retryable = false, response = ResponseMessageConst.VOID, partitionIdentifier = "key")
     void lock(String name, Data key, long threadId, long ttl);
 
     /**
@@ -207,35 +207,35 @@ public interface MultiMapCodecTemplate {
      * and lies dormant until one of two things happens:the lock is acquired by the current thread, or the specified
      * waiting time elapses.
      *
-     * @param name Name of the MultiMap
-     * @param key Key to lock in this map.
+     * @param name     Name of the MultiMap
+     * @param key      Key to lock in this map.
      * @param threadId The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation
-     * @param lease Time in milliseconds to wait before releasing the lock.
-     * @param timeout Maximum time to wait for the lock.
+     * @param lease    Time in milliseconds to wait before releasing the lock.
+     * @param timeout  Maximum time to wait for the lock.
      * @return True if the lock was acquired and false if the waiting time elapsed before the lock acquired
      */
-    @Request(id = 17, retryable = false, response = ResponseMessageConst.BOOLEAN)
+    @Request(id = 17, retryable = false, response = ResponseMessageConst.BOOLEAN, partitionIdentifier = "key")
     Object tryLock(String name, Data key, long threadId, long lease, long timeout);
 
     /**
      * Checks the lock for the specified key. If the lock is acquired, this method returns true, else it returns false.
      *
      * @param name Name of the MultiMap
-     * @param key Key to lock to be checked.
+     * @param key  Key to lock to be checked.
      * @return True if the lock acquired,false otherwise
      */
-    @Request(id = 18, retryable = true, response = ResponseMessageConst.BOOLEAN)
+    @Request(id = 18, retryable = true, response = ResponseMessageConst.BOOLEAN, partitionIdentifier = "key")
     Object isLocked(String name, Data key);
 
     /**
      * Releases the lock for the specified key regardless of the lock owner. It always successfully unlocks the key,
      * never blocks and returns immediately.
      *
-     * @param name Name of the MultiMap
-     * @param key The key to Lock
+     * @param name     Name of the MultiMap
+     * @param key      The key to Lock
      * @param threadId The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation
      */
-    @Request(id = 19, retryable = false, response = ResponseMessageConst.VOID)
+    @Request(id = 19, retryable = false, response = ResponseMessageConst.VOID, partitionIdentifier = "key")
     void unlock(String name, Data key, long threadId);
 
     /**
@@ -243,22 +243,22 @@ public interface MultiMapCodecTemplate {
      * never blocks and returns immediately.
      *
      * @param name Name of the MultiMap
-     * @param key The key to Lock
+     * @param key  The key to Lock
      */
-    @Request(id = 20, retryable = false, response = ResponseMessageConst.VOID)
+    @Request(id = 20, retryable = false, response = ResponseMessageConst.VOID, partitionIdentifier = "key")
     void forceUnlock(String name, Data key);
 
     /**
      * Removes all the entries with the given key. The collection is NOT backed by the map, so changes to the map are
      * NOT reflected in the collection, and vice-versa.
      *
-     * @param name Name of the MultiMap
-     * @param key The key of the entry to remove
-     * @param value The value of the entry to remove
+     * @param name     Name of the MultiMap
+     * @param key      The key of the entry to remove
+     * @param value    The value of the entry to remove
      * @param threadId The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation
      * @return True if the size of the multimap changed after the remove operation, false otherwise.
      */
-    @Request(id = 21, retryable = false, response = ResponseMessageConst.BOOLEAN)
+    @Request(id = 21, retryable = false, response = ResponseMessageConst.BOOLEAN, partitionIdentifier = "key")
     Object removeEntry(String name, Data key, Data value, long threadId);
 }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/QueueCodecTemplate.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/QueueCodecTemplate.java
@@ -23,7 +23,6 @@ import com.hazelcast.client.impl.protocol.ResponseMessageConst;
 import com.hazelcast.nio.serialization.Data;
 
 import java.util.List;
-import java.util.Set;
 
 @GenerateCodec(id = TemplateConstants.QUEUE_TEMPLATE_ID, name = "Queue", ns = "Hazelcast.Client.Protocol.Codec")
 public interface QueueCodecTemplate {
@@ -31,21 +30,21 @@ public interface QueueCodecTemplate {
      * Inserts the specified element into this queue, waiting up to the specified wait time if necessary for space to
      * become available.
      *
-     * @param name Name of the Queue
-     * @param value The element to add
+     * @param name          Name of the Queue
+     * @param value         The element to add
      * @param timeoutMillis Maximum time in milliseconds to wait for acquiring the lock for the key.
      * @return <tt>True</tt> if the element was added to this queue, else <tt>false</tt>
      */
-    @Request(id = 1, retryable = false, response = ResponseMessageConst.BOOLEAN)
+    @Request(id = 1, retryable = false, response = ResponseMessageConst.BOOLEAN, partitionIdentifier = "name")
     Object offer(String name, Data value, long timeoutMillis);
 
     /**
      * Inserts the specified element into this queue, waiting if necessary for space to become available.
      *
-     * @param name Name of the Queue
+     * @param name  Name of the Queue
      * @param value The element to add
      */
-    @Request(id = 2, retryable = false, response = ResponseMessageConst.VOID)
+    @Request(id = 2, retryable = false, response = ResponseMessageConst.VOID, partitionIdentifier = "name")
     void put(String name, Data value);
 
     /**
@@ -55,29 +54,29 @@ public interface QueueCodecTemplate {
      * @param name Name of the Queue
      * @return The number of elements in this collection
      */
-    @Request(id = 3, retryable = false, response = ResponseMessageConst.INTEGER)
+    @Request(id = 3, retryable = false, response = ResponseMessageConst.INTEGER, partitionIdentifier = "name")
     Object size(String name);
 
     /**
      * Retrieves and removes the head of this queue.  This method differs from poll only in that it throws an exception
      * if this queue is empty.
      *
-     * @param name Name of the Queue
+     * @param name  Name of the Queue
      * @param value Element to be removed from this queue, if present
      * @return <tt>true</tt> if this queue changed as a result of the call
      */
-    @Request(id = 4, retryable = false, response = ResponseMessageConst.BOOLEAN)
+    @Request(id = 4, retryable = false, response = ResponseMessageConst.BOOLEAN, partitionIdentifier = "name")
     Object remove(String name, Data value);
 
     /**
      * Retrieves and removes the head of this queue, waiting up to the specified wait time if necessary for an element
      * to become available.
      *
-     * @param name Name of the Queue
+     * @param name          Name of the Queue
      * @param timeoutMillis Maximum time in milliseconds to wait for acquiring the lock for the key.
      * @return The head of this queue, or <tt>null</tt> if this queue is empty
      */
-    @Request(id = 5, retryable = false, response = ResponseMessageConst.DATA)
+    @Request(id = 5, retryable = false, response = ResponseMessageConst.DATA, partitionIdentifier = "name")
     Object poll(String name, long timeoutMillis);
 
     /**
@@ -86,7 +85,7 @@ public interface QueueCodecTemplate {
      * @param name Name of the Queue
      * @return The head of this queue
      */
-    @Request(id = 6, retryable = false, response = ResponseMessageConst.DATA)
+    @Request(id = 6, retryable = false, response = ResponseMessageConst.DATA, partitionIdentifier = "name")
     Object take(String name);
 
     /**
@@ -95,7 +94,7 @@ public interface QueueCodecTemplate {
      * @param name Name of the Queue
      * @return The head of this queue, or <tt>null</tt> if this queue is empty
      */
-    @Request(id = 7, retryable = false, response = ResponseMessageConst.DATA)
+    @Request(id = 7, retryable = false, response = ResponseMessageConst.DATA, partitionIdentifier = "name")
     Object peek(String name);
 
     /**
@@ -106,7 +105,7 @@ public interface QueueCodecTemplate {
      * @return list of all data in queue
      */
 
-    @Request(id = 8, retryable = false, response = ResponseMessageConst.LIST_DATA)
+    @Request(id = 8, retryable = false, response = ResponseMessageConst.LIST_DATA, partitionIdentifier = "name")
     Object iterator(String name);
 
     /**
@@ -119,7 +118,7 @@ public interface QueueCodecTemplate {
      * @param name Name of the Queue
      * @return list of all removed data in queue
      */
-    @Request(id = 9, retryable = false, response = ResponseMessageConst.LIST_DATA)
+    @Request(id = 9, retryable = false, response = ResponseMessageConst.LIST_DATA, partitionIdentifier = "name")
     Object drainTo(String name);
 
     /**
@@ -129,54 +128,54 @@ public interface QueueCodecTemplate {
      * ILLEGAL_ARGUMENT. Further, the behavior of this operation is undefined if the specified collection is
      * modified while the operation is in progress.
      *
-     * @param name Name of the Queue
+     * @param name    Name of the Queue
      * @param maxSize The maximum number of elements to transfer
      * @return list of all removed data in result of this method
      */
-    @Request(id = 10, retryable = false, response = ResponseMessageConst.LIST_DATA)
+    @Request(id = 10, retryable = false, response = ResponseMessageConst.LIST_DATA, partitionIdentifier = "name")
     Object drainToMaxSize(String name, int maxSize);
 
     /**
      * Returns true if this queue contains the specified element. More formally, returns true if and only if this queue
      * contains at least one element e such that value.equals(e)
      *
-     * @param name Name of the Queue
+     * @param name  Name of the Queue
      * @param value Element whose presence in this collection is to be tested
      * @return <tt>true</tt> if this collection contains the specified element
      */
-    @Request(id = 11, retryable = false, response = ResponseMessageConst.BOOLEAN)
+    @Request(id = 11, retryable = false, response = ResponseMessageConst.BOOLEAN, partitionIdentifier = "name")
     Object contains(String name, Data value);
 
     /**
      * Return true if this collection contains all of the elements in the specified collection.
      *
-     * @param name Name of the Queue
+     * @param name     Name of the Queue
      * @param dataList Collection to be checked for containment in this collection
      * @return <tt>true</tt> if this collection contains all of the elements in the specified collection
      */
-    @Request(id = 12, retryable = false, response = ResponseMessageConst.BOOLEAN)
+    @Request(id = 12, retryable = false, response = ResponseMessageConst.BOOLEAN, partitionIdentifier = "name")
     Object containsAll(String name, List<Data> dataList);
 
     /**
      * Removes all of this collection's elements that are also contained in the specified collection (optional operation).
      * After this call returns, this collection will contain no elements in common with the specified collection.
      *
-     * @param name Name of the Queue
+     * @param name     Name of the Queue
      * @param dataList Collection containing elements to be removed from this collection
      * @return <tt>true</tt> if this collection changed as a result of the call
      */
-    @Request(id = 13, retryable = false, response = ResponseMessageConst.BOOLEAN)
+    @Request(id = 13, retryable = false, response = ResponseMessageConst.BOOLEAN, partitionIdentifier = "name")
     Object compareAndRemoveAll(String name, List<Data> dataList);
 
     /**
      * Retains only the elements in this collection that are contained in the specified collection (optional operation).
      * In other words, removes from this collection all of its elements that are not contained in the specified collection.
      *
-     * @param name Name of the Queue
+     * @param name     Name of the Queue
      * @param dataList collection containing elements to be retained in this collection
      * @return <tt>true</tt> if this collection changed as a result of the call
      */
-    @Request(id = 14, retryable = false, response = ResponseMessageConst.BOOLEAN)
+    @Request(id = 14, retryable = false, response = ResponseMessageConst.BOOLEAN, partitionIdentifier = "name")
     Object compareAndRetainAll(String name, List<Data> dataList);
 
     /**
@@ -185,7 +184,7 @@ public interface QueueCodecTemplate {
      *
      * @param name Name of the Queue
      */
-    @Request(id = 15, retryable = false, response = ResponseMessageConst.VOID)
+    @Request(id = 15, retryable = false, response = ResponseMessageConst.VOID, partitionIdentifier = "name")
     void clear(String name);
 
     /**
@@ -194,29 +193,29 @@ public interface QueueCodecTemplate {
      * (This implies that the behavior of this call is undefined if the specified collection is this collection,
      * and this collection is nonempty.)
      *
-     * @param name Name of the Queue
+     * @param name     Name of the Queue
      * @param dataList Collection containing elements to be added to this collection
      * @return <tt>true</tt> if this collection changed as a result of the call
      */
-    @Request(id = 16, retryable = false, response = ResponseMessageConst.BOOLEAN)
+    @Request(id = 16, retryable = false, response = ResponseMessageConst.BOOLEAN, partitionIdentifier = "name")
     Object addAll(String name, List<Data> dataList);
 
     /**
      * Adds an listener for this collection. Listener will be notified or all collection add/remove events.
      *
-     * @param name Name of the Queue
+     * @param name         Name of the Queue
      * @param includeValue <tt>true</tt> if the updated item should be passed to the item listener, <tt>false</tt> otherwise.
-     * @param localOnly if true fires events that originated from this node only, otherwise fires all events
-     * @return  The registration id
+     * @param localOnly    if true fires events that originated from this node only, otherwise fires all events
+     * @return The registration id
      */
-    @Request(id = 17, retryable = true, response = ResponseMessageConst.STRING,
-             event = {EventMessageConst.EVENT_ITEM})
+    @Request(id = 17, retryable = false, response = ResponseMessageConst.STRING,
+            event = {EventMessageConst.EVENT_ITEM})
     Object addListener(String name, boolean includeValue, boolean localOnly);
 
     /**
      * Removes the specified item listener.Returns silently if the specified listener was not added before.
      *
-     * @param name Name of the Queue
+     * @param name           Name of the Queue
      * @param registrationId Id of the listener registration.
      * @return True if the item listener is removed, false otherwise
      */
@@ -232,7 +231,7 @@ public interface QueueCodecTemplate {
      * @param name Name of the Queue
      * @return The remaining capacity
      */
-    @Request(id = 19, retryable = false, response = ResponseMessageConst.INTEGER)
+    @Request(id = 19, retryable = false, response = ResponseMessageConst.INTEGER, partitionIdentifier = "name")
     Object remainingCapacity(String name);
 
     /**
@@ -241,7 +240,7 @@ public interface QueueCodecTemplate {
      * @param name Name of the Queue
      * @return <tt>True</tt> if this collection contains no elements
      */
-    @Request(id = 20, retryable = false, response = ResponseMessageConst.BOOLEAN)
+    @Request(id = 20, retryable = false, response = ResponseMessageConst.BOOLEAN, partitionIdentifier = "name")
     Object isEmpty(String name);
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/ReplicatedMapCodecTemplate.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/ReplicatedMapCodecTemplate.java
@@ -39,7 +39,7 @@ public interface ReplicatedMapCodecTemplate {
      * @param ttl ttl in milliseconds to be associated with the specified key-value pair
      * @return The old value if existed for the key.
      */
-    @Request(id = 1, retryable = false, response = ResponseMessageConst.DATA)
+    @Request(id = 1, retryable = false, response = ResponseMessageConst.DATA, partitionIdentifier = "key")
     Object put(String name, Data key, Data value, long ttl);
 
     /**
@@ -49,7 +49,7 @@ public interface ReplicatedMapCodecTemplate {
      * @param name Name of the ReplicatedMap
      * @return the number of key-value mappings in this map.
      */
-    @Request(id = 2, retryable = true, response = ResponseMessageConst.INTEGER)
+    @Request(id = 2, retryable = true, response = ResponseMessageConst.INTEGER, partitionIdentifier = "random")
     Object size(String name);
 
     /**
@@ -58,7 +58,7 @@ public interface ReplicatedMapCodecTemplate {
      * @param name Name of the ReplicatedMap
      * @return <tt>True</tt> if this map contains no key-value mappings
      */
-    @Request(id = 3, retryable = true, response = ResponseMessageConst.BOOLEAN)
+    @Request(id = 3, retryable = true, response = ResponseMessageConst.BOOLEAN, partitionIdentifier = "random")
     Object isEmpty(String name);
 
     /**
@@ -69,7 +69,7 @@ public interface ReplicatedMapCodecTemplate {
      * @return <tt>True</tt> if this map contains a mapping for the specified key
      *
      */
-    @Request(id = 4, retryable = true, response = ResponseMessageConst.BOOLEAN)
+    @Request(id = 4, retryable = true, response = ResponseMessageConst.BOOLEAN, partitionIdentifier = "key")
     Object containsKey(String name, Data key);
 
     /**
@@ -80,7 +80,7 @@ public interface ReplicatedMapCodecTemplate {
      * @param value value whose presence in this map is to be tested
      * @return <tt>true</tt> if this map maps one or more keys to the specified value
      */
-    @Request(id = 5, retryable = true, response = ResponseMessageConst.BOOLEAN)
+    @Request(id = 5, retryable = true, response = ResponseMessageConst.BOOLEAN, partitionIdentifier = "random")
     Object containsValue(String name, Data value);
 
     /**
@@ -93,7 +93,7 @@ public interface ReplicatedMapCodecTemplate {
      * @param key The key whose associated value is to be returned
      * @return The value to which the specified key is mapped, or null if this map contains no mapping for the key
      */
-    @Request(id = 6, retryable = true, response = ResponseMessageConst.DATA)
+    @Request(id = 6, retryable = true, response = ResponseMessageConst.DATA, partitionIdentifier = "key")
     Object get(String name, Data key);
 
     /**
@@ -106,7 +106,7 @@ public interface ReplicatedMapCodecTemplate {
      * @param key Key with which the specified value is to be associated.
      * @return the previous value associated with <tt>key</tt>, or <tt>null</tt> if there was no mapping for <tt>key</tt>.
      */
-    @Request(id = 7, retryable = false, response = ResponseMessageConst.DATA)
+    @Request(id = 7, retryable = false, response = ResponseMessageConst.DATA, partitionIdentifier = "key")
     Object remove(String name, Data key);
 
     /**
@@ -142,7 +142,7 @@ public interface ReplicatedMapCodecTemplate {
      * @param localOnly if true fires events that originated from this node only, otherwise fires all events
      * @return A unique string  which is used as a key to remove the listener.
      */
-    @Request(id = 10, retryable = true, response = ResponseMessageConst.STRING
+    @Request(id = 10, retryable = false, response = ResponseMessageConst.STRING
             , event = {EventMessageConst.EVENT_ENTRY})
     Object addEntryListenerToKeyWithPredicate(String name, Data key, Data predicate, boolean localOnly);
 
@@ -155,7 +155,7 @@ public interface ReplicatedMapCodecTemplate {
      * @param localOnly if true fires events that originated from this node only, otherwise fires all events
      * @return A unique string  which is used as a key to remove the listener.
      */
-    @Request(id = 11, retryable = true, response = ResponseMessageConst.STRING
+    @Request(id = 11, retryable = false, response = ResponseMessageConst.STRING
             , event = {EventMessageConst.EVENT_ENTRY})
     Object addEntryListenerWithPredicate(String name, Data predicate, boolean localOnly);
 
@@ -168,7 +168,7 @@ public interface ReplicatedMapCodecTemplate {
      * @param localOnly if true fires events that originated from this node only, otherwise fires all events
      * @return A unique string  which is used as a key to remove the listener.
      */
-    @Request(id = 12, retryable = true, response = ResponseMessageConst.STRING
+    @Request(id = 12, retryable = false, response = ResponseMessageConst.STRING
             , event = {EventMessageConst.EVENT_ENTRY})
     Object addEntryListenerToKey(String name, Data key, boolean localOnly);
 
@@ -179,7 +179,7 @@ public interface ReplicatedMapCodecTemplate {
      * @param localOnly if true fires events that originated from this node only, otherwise fires all events
      * @return A unique string  which is used as a key to remove the listener.
      */
-    @Request(id = 13, retryable = true, response = ResponseMessageConst.STRING
+    @Request(id = 13, retryable = false, response = ResponseMessageConst.STRING
             , event = {EventMessageConst.EVENT_ENTRY})
     Object addEntryListener(String name, boolean localOnly);
 
@@ -204,7 +204,7 @@ public interface ReplicatedMapCodecTemplate {
      * @param name Name of the ReplicatedMap
      * @return A lazy set view of the keys contained in this map.
      */
-    @Request(id = 15, retryable = true, response = ResponseMessageConst.LIST_DATA)
+    @Request(id = 15, retryable = true, response = ResponseMessageConst.LIST_DATA, partitionIdentifier = "random")
     Object keySet(String name);
 
     /**
@@ -212,7 +212,7 @@ public interface ReplicatedMapCodecTemplate {
      * @param name Name of the ReplicatedMap
      * @return A collection view of the values contained in this map.
      */
-    @Request(id = 16, retryable = true, response = ResponseMessageConst.LIST_DATA)
+    @Request(id = 16, retryable = true, response = ResponseMessageConst.LIST_DATA, partitionIdentifier = "random")
     Object values(String name);
 
     /**
@@ -220,7 +220,7 @@ public interface ReplicatedMapCodecTemplate {
      * @param name Name of the ReplicatedMap
      * @return A lazy set view of the mappings contained in this map.
      */
-    @Request(id = 17, retryable = true, response = ResponseMessageConst.LIST_ENTRY)
+    @Request(id = 17, retryable = true, response = ResponseMessageConst.LIST_ENTRY, partitionIdentifier = "random")
     Object entrySet(String name);
 
     /**
@@ -230,7 +230,7 @@ public interface ReplicatedMapCodecTemplate {
      * @param localOnly if true fires events that originated from this node only, otherwise fires all events
      * @return A unique string  which is used as a key to remove the listener.
      */
-    @Request(id = 18, retryable = true, response = ResponseMessageConst.STRING, event = EventMessageConst.EVENT_ENTRY)
+    @Request(id = 18, retryable = false, response = ResponseMessageConst.STRING, event = EventMessageConst.EVENT_ENTRY)
     Object addNearCacheEntryListener(String name, boolean includeValue, boolean localOnly);
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/RingbufferCodecTemplate.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/RingbufferCodecTemplate.java
@@ -17,7 +17,7 @@ public interface RingbufferCodecTemplate {
      * @param name Name of the Ringbuffer
      * @return the size
      */
-    @Request(id = 1, retryable = false, response = ResponseMessageConst.LONG)
+    @Request(id = 1, retryable = false, response = ResponseMessageConst.LONG, partitionIdentifier = "name")
     Object size(String name);
 
     /**
@@ -27,8 +27,9 @@ public interface RingbufferCodecTemplate {
      * @param name Name of the Ringbuffer
      * @return the sequence of the tail
      */
-    @Request(id = 2, retryable = false, response = ResponseMessageConst.LONG)
+    @Request(id = 2, retryable = false, response = ResponseMessageConst.LONG, partitionIdentifier = "name")
     Object tailSequence(String name);
+
     /**
      * Returns the sequence of the head. The head is the side of the ringbuffer where the oldest items in the ringbuffer
      * are found. If the RingBuffer is empty, the head will be one more than the tail.
@@ -37,15 +38,16 @@ public interface RingbufferCodecTemplate {
      * @param name Name of the Ringbuffer
      * @return the sequence of the head
      */
-    @Request(id = 3, retryable = false, response = ResponseMessageConst.LONG)
+    @Request(id = 3, retryable = false, response = ResponseMessageConst.LONG, partitionIdentifier = "name")
     Object headSequence(String name);
+
     /**
      * Returns the capacity of this Ringbuffer.
      *
      * @param name Name of the Ringbuffer
      * @return the capacity
      */
-    @Request(id = 4, retryable = false, response = ResponseMessageConst.LONG)
+    @Request(id = 4, retryable = false, response = ResponseMessageConst.LONG, partitionIdentifier = "name")
     Object capacity(String name);
 
     /**
@@ -55,7 +57,7 @@ public interface RingbufferCodecTemplate {
      * @param name Name of the Ringbuffer
      * @return the remaining capacity
      */
-    @Request(id = 5, retryable = false, response = ResponseMessageConst.LONG)
+    @Request(id = 5, retryable = false, response = ResponseMessageConst.LONG, partitionIdentifier = "name")
     Object remainingCapacity(String name);
 
     /**
@@ -63,7 +65,7 @@ public interface RingbufferCodecTemplate {
      * will return the sequence of the written item. If there is no space, it depends on the overflow policy what happens:
      * OverflowPolicy OVERWRITE we just overwrite the oldest item in the ringbuffer and we violate the ttl
      * OverflowPolicy FAIL we return -1. The reason that FAIL exist is to give the opportunity to obey the ttl.
-     *
+     * <p/>
      * This sequence will always be unique for this Ringbuffer instance so it can be used as a unique id generator if you are
      * publishing items on this Ringbuffer. However you need to take care of correctly determining an initial id when any node
      * uses the ringbuffer for the first time. The most reliable way to do that is to write a dummy item into the ringbuffer and
@@ -71,12 +73,12 @@ public interface RingbufferCodecTemplate {
      * this id is not the sequence of the item you are about to publish but from a previously published item. So it can't be used
      * to find that item.
      *
-     * @param name Name of the Ringbuffer
+     * @param name           Name of the Ringbuffer
      * @param overflowPolicy the OverflowPolicy to use.
-     * @param value to item to add
+     * @param value          to item to add
      * @return the sequence of the added item, or -1 if the add failed.
      */
-    @Request(id = 6, retryable = false, response = ResponseMessageConst.LONG)
+    @Request(id = 6, retryable = false, response = ResponseMessageConst.LONG, partitionIdentifier = "name")
     Object add(String name, int overflowPolicy, Data value);
 
     /**
@@ -85,11 +87,11 @@ public interface RingbufferCodecTemplate {
      * readers or it can be read multiple times by the same reader. Currently it isn't possible to control how long this
      * call is going to block. In the future we could add e.g. tryReadOne(long sequence, long timeout, TimeUnit unit).
      *
-     * @param name Name of the Ringbuffer
+     * @param name     Name of the Ringbuffer
      * @param sequence the sequence of the item to read.
      * @return the read item
      */
-    @Request(id = 8, retryable = false, response = ResponseMessageConst.DATA)
+    @Request(id = 8, retryable = false, response = ResponseMessageConst.DATA, partitionIdentifier = "name")
     Object readOne(String name, long sequence);
 
     /**
@@ -102,12 +104,12 @@ public interface RingbufferCodecTemplate {
      * If an addAll is executed concurrently with an add or addAll, no guarantee is given that items are contiguous.
      * The result of the future contains the sequenceId of the last written item
      *
-     * @param name Name of the Ringbuffer
-     * @param valueList the batch of items to add
+     * @param name           Name of the Ringbuffer
+     * @param valueList      the batch of items to add
      * @param overflowPolicy the overflowPolicy to use
      * @return the ICompletableFuture to synchronize on completion.
      */
-    @Request(id = 9, retryable = false, response = ResponseMessageConst.LONG)
+    @Request(id = 9, retryable = false, response = ResponseMessageConst.LONG, partitionIdentifier = "name")
     Object addAll(String name, List<Data> valueList, int overflowPolicy);
 
     /**
@@ -119,13 +121,13 @@ public interface RingbufferCodecTemplate {
      * true are returned. Using filters is a good way to prevent getting items that are of no value to the receiver.
      * This reduces the amount of IO and the number of operations being executed, and can result in a significant performance improvement.
      *
-     * @param name Name of the Ringbuffer
+     * @param name          Name of the Ringbuffer
      * @param startSequence the startSequence of the first item to read
-     * @param minCount the minimum number of items to read.
-     * @param maxCount the maximum number of items to read.
-     * @param filter Filter is allowed to be null, indicating there is no filter.
-     * @return  a future containing the items read.
+     * @param minCount      the minimum number of items to read.
+     * @param maxCount      the maximum number of items to read.
+     * @param filter        Filter is allowed to be null, indicating there is no filter.
+     * @return a future containing the items read.
      */
-    @Request(id = 10, retryable = false, response = ResponseMessageConst.READ_RESULT_SET)
+    @Request(id = 10, retryable = false, response = ResponseMessageConst.READ_RESULT_SET, partitionIdentifier = "name")
     Object readMany(String name, long startSequence, int minCount, int maxCount, @Nullable Data filter);
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/SemaphoreCodecTemplate.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/SemaphoreCodecTemplate.java
@@ -26,11 +26,11 @@ public interface SemaphoreCodecTemplate {
     /**
      * Try to initialize this ISemaphore instance with the given permit count
      *
-     * @param name Name of the Semaphore
+     * @param name    Name of the Semaphore
      * @param permits The given permit count
      * @return True if initialization succeeds, false otherwise.
      */
-    @Request(id = 1, retryable = false, response = ResponseMessageConst.BOOLEAN)
+    @Request(id = 1, retryable = false, response = ResponseMessageConst.BOOLEAN, partitionIdentifier = "name")
     Object init(String name, int permits);
 
     /**
@@ -42,11 +42,10 @@ public interface SemaphoreCodecTemplate {
      * the current thread. If the current thread has its interrupted status set on entry to this method, or is  while
      * waiting for a permit, then  is thrown and the current thread's interrupted status is cleared.
      *
-     * @param name Name of the Semaphore
+     * @param name    Name of the Semaphore
      * @param permits The given permit count
-     *
      */
-    @Request(id = 2, retryable = false, response = ResponseMessageConst.VOID)
+    @Request(id = 2, retryable = false, response = ResponseMessageConst.VOID, partitionIdentifier = "name")
     void acquire(String name, int permits);
 
     /**
@@ -56,7 +55,7 @@ public interface SemaphoreCodecTemplate {
      * @param name Name of the Semaphore
      * @return The number of permits available in this semaphore.
      */
-    @Request(id = 3, retryable = true, response = ResponseMessageConst.INTEGER)
+    @Request(id = 3, retryable = true, response = ResponseMessageConst.INTEGER, partitionIdentifier = "name")
     Object availablePermits(String name);
 
     /**
@@ -65,18 +64,17 @@ public interface SemaphoreCodecTemplate {
      * @param name Name of the Semaphore
      * @return The number of permits drained
      */
-    @Request(id = 4, retryable = false, response = ResponseMessageConst.INTEGER)
+    @Request(id = 4, retryable = false, response = ResponseMessageConst.INTEGER, partitionIdentifier = "name")
     Object drainPermits(String name);
 
     /**
      * Shrinks the number of available permits by the indicated reduction. This method differs from  acquire in that it
      * does not block waiting for permits to become available.
      *
-     * @param name Name of the Semaphore
+     * @param name      Name of the Semaphore
      * @param reduction The number of permits to remove
-     *
      */
-    @Request(id = 5, retryable = false, response = ResponseMessageConst.VOID)
+    @Request(id = 5, retryable = false, response = ResponseMessageConst.VOID, partitionIdentifier = "name")
     void reducePermits(String name, int reduction);
 
     /**
@@ -84,10 +82,10 @@ public interface SemaphoreCodecTemplate {
      * requirement that a thread that releases a permit must have acquired that permit by calling one of the
      * acquire()acquire methods. Correct usage of a semaphore is established by programming convention in the application.
      *
-     * @param name Name of the Semaphore
+     * @param name    Name of the Semaphore
      * @param permits The number of permits to remove
      */
-    @Request(id = 6, retryable = false, response = ResponseMessageConst.VOID)
+    @Request(id = 6, retryable = false, response = ResponseMessageConst.VOID, partitionIdentifier = "name")
     void release(String name, int permits);
 
     /**
@@ -95,12 +93,12 @@ public interface SemaphoreCodecTemplate {
      * reducing the number of available permits by the given amount. If insufficient permits are available then this
      * method will return immediately with the value false and the number of available permits is unchanged.
      *
-     * @param name Name of the Semaphore
+     * @param name    Name of the Semaphore
      * @param permits The number of permits to remove
      * @param timeout The maximum time to wait for a permit
      * @return true if all permits were acquired,  false if the waiting time elapsed before all permits could be acquired
      */
-    @Request(id = 7, retryable = false, response = ResponseMessageConst.BOOLEAN)
+    @Request(id = 7, retryable = false, response = ResponseMessageConst.BOOLEAN, partitionIdentifier = "name")
     Object tryAcquire(String name, int permits, long timeout);
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/SetCodecTemplate.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/SetCodecTemplate.java
@@ -33,7 +33,7 @@ public interface SetCodecTemplate {
      * @param name Name of the Set
      * @return The number of elements in this set (its cardinality)
      */
-    @Request(id = 1, retryable = false, response = ResponseMessageConst.INTEGER)
+    @Request(id = 1, retryable = false, response = ResponseMessageConst.INTEGER, partitionIdentifier = "name")
     Object size(String name);
 
     /**
@@ -43,19 +43,19 @@ public interface SetCodecTemplate {
      * @param value Element whose presence in this set is to be tested
      * @return True if this set contains the specified element, false otherwise
      */
-    @Request(id = 2, retryable = false, response = ResponseMessageConst.BOOLEAN)
+    @Request(id = 2, retryable = false, response = ResponseMessageConst.BOOLEAN, partitionIdentifier = "name")
     Object contains(String name, Data value);
 
     /**
      * Returns true if this set contains all of the elements of the specified collection. If the specified collection is
      * also a set, this method returns true if it is a subset of this set.
      *
-     * @param name     Name of the Set
+     * @param name  Name of the Set
      * @param items Collection to be checked for containment in this list
      * @return true if this set contains all of the elements of the
      * specified collection
      */
-    @Request(id = 3, retryable = false, response = ResponseMessageConst.BOOLEAN)
+    @Request(id = 3, retryable = false, response = ResponseMessageConst.BOOLEAN, partitionIdentifier = "name")
     Object containsAll(String name, List<Data> items);
 
     /**
@@ -71,7 +71,7 @@ public interface SetCodecTemplate {
      * @return True if this set did not already contain the specified
      * element and the element is added, returns false otherwise.
      */
-    @Request(id = 4, retryable = false, response = ResponseMessageConst.BOOLEAN)
+    @Request(id = 4, retryable = false, response = ResponseMessageConst.BOOLEAN, partitionIdentifier = "name")
     Object add(String name, Data value);
 
     /**
@@ -83,7 +83,7 @@ public interface SetCodecTemplate {
      * @param value Object to be removed from this set, if present
      * @return True if this set contained the specified element and it is removed successfully
      */
-    @Request(id = 5, retryable = false, response = ResponseMessageConst.BOOLEAN)
+    @Request(id = 5, retryable = false, response = ResponseMessageConst.BOOLEAN, partitionIdentifier = "name")
     Object remove(String name, Data value);
 
     /**
@@ -96,7 +96,7 @@ public interface SetCodecTemplate {
      * @param valueList Collection containing elements to be added to this set
      * @return True if this set changed as a result of the call
      */
-    @Request(id = 6, retryable = false, response = ResponseMessageConst.BOOLEAN)
+    @Request(id = 6, retryable = false, response = ResponseMessageConst.BOOLEAN, partitionIdentifier = "name")
     Object addAll(String name, List<Data> valueList);
 
     /**
@@ -104,11 +104,11 @@ public interface SetCodecTemplate {
      * If the specified collection is also a set, this operation effectively modifies this set so that its value is the
      * asymmetric set difference of the two sets.
      *
-     * @param name     Name of the Set
+     * @param name   Name of the Set
      * @param values The list of values to test for matching the item to remove.
      * @return true if at least one item in values existed and removed, false otherwise.
      */
-    @Request(id = 7, retryable = false, response = ResponseMessageConst.BOOLEAN)
+    @Request(id = 7, retryable = false, response = ResponseMessageConst.BOOLEAN, partitionIdentifier = "name")
     Object compareAndRemoveAll(String name, List<Data> values);
 
     /**
@@ -122,7 +122,7 @@ public interface SetCodecTemplate {
      * @return true if at least one item in values existed and it is retained, false otherwise. All items not in valueSet but
      * in the Set are removed.
      */
-    @Request(id = 8, retryable = false, response = ResponseMessageConst.BOOLEAN)
+    @Request(id = 8, retryable = false, response = ResponseMessageConst.BOOLEAN, partitionIdentifier = "name")
     Object compareAndRetainAll(String name, List<Data> values);
 
     /**
@@ -130,7 +130,7 @@ public interface SetCodecTemplate {
      *
      * @param name Name of the Set
      */
-    @Request(id = 9, retryable = false, response = ResponseMessageConst.VOID)
+    @Request(id = 9, retryable = false, response = ResponseMessageConst.VOID, partitionIdentifier = "name")
     Object clear(String name);
 
     /**
@@ -139,7 +139,7 @@ public interface SetCodecTemplate {
      * @param name Name of the Set
      * @return Array of all values in the Set
      */
-    @Request(id = 10, retryable = false, response = ResponseMessageConst.LIST_DATA)
+    @Request(id = 10, retryable = false, response = ResponseMessageConst.LIST_DATA, partitionIdentifier = "name")
     Object getAll(String name);
 
     /**
@@ -150,7 +150,7 @@ public interface SetCodecTemplate {
      * @param localOnly    if true fires events that originated from this node only, otherwise fires all events
      * @return The registration id.
      */
-    @Request(id = 11, retryable = true, response = ResponseMessageConst.STRING,
+    @Request(id = 11, retryable = false, response = ResponseMessageConst.STRING,
             event = {EventMessageConst.EVENT_ITEM})
     Object addListener(String name, boolean includeValue, boolean localOnly);
 
@@ -170,7 +170,7 @@ public interface SetCodecTemplate {
      * @param name Name of the Set
      * @return True if this set contains no elements
      */
-    @Request(id = 13, retryable = false, response = ResponseMessageConst.BOOLEAN)
+    @Request(id = 13, retryable = false, response = ResponseMessageConst.BOOLEAN, partitionIdentifier = "name")
     Object isEmpty(String name);
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/TopicCodecTemplate.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/TopicCodecTemplate.java
@@ -31,7 +31,7 @@ public interface TopicCodecTemplate {
      * @param message The message to publish to all subscribers of this topic
      *
      */
-    @Request(id = 1, retryable = false, response = ResponseMessageConst.VOID)
+    @Request(id = 1, retryable = false, response = ResponseMessageConst.VOID, partitionIdentifier = "name")
     void publish(String name, Data message);
 
     /**
@@ -42,7 +42,7 @@ public interface TopicCodecTemplate {
      * @param localOnly if true listens only local events on registered member
      * @return returns the registration id
      */
-    @Request(id = 2, retryable = true, response = ResponseMessageConst.STRING
+    @Request(id = 2, retryable = false, response = ResponseMessageConst.STRING
             , event = {EventMessageConst.EVENT_TOPIC})
     Object addMessageListener(String name, boolean localOnly);
     /**

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/XATransactionalCodecTemplate.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/XATransactionalCodecTemplate.java
@@ -30,7 +30,7 @@ public interface XATransactionalCodecTemplate {
      *
      * @param xid Java XA transaction id as defined in interface javax.transaction.xa.Xid.
      */
-    @Request(id = 1, retryable = false, response = ResponseMessageConst.VOID)
+    @Request(id = 1, retryable = false, response = ResponseMessageConst.VOID, partitionIdentifier = "xid")
     void clearRemote(Xid xid);
 
     /**
@@ -45,7 +45,7 @@ public interface XATransactionalCodecTemplate {
      * @param xid Java XA transaction id as defined in interface javax.transaction.xa.Xid.
      * @param isCommit If true, the transaction is committed else transaction is rolled back.
      */
-    @Request(id = 3, retryable = false, response = ResponseMessageConst.VOID)
+    @Request(id = 3, retryable = false, response = ResponseMessageConst.VOID, partitionIdentifier = "xid")
     void finalize(Xid xid, boolean isCommit);
 
     /**


### PR DESCRIPTION
How a partition id calculated was missing in protocol documentation.
Introduced partitionIdentifier in protocol code generation for this
purpose. All types are converted to hexadecimal. And made further
cleanup on protocol documentation template file to increase
readability of document.

For this changes output refer to 
https://hazelcast.atlassian.net/wiki/display/HZC/Hazelcast+Open+Binary+Client+Protocol+-+Version+1.0