### PR TITLE
Server should respond to authentication message when node is not active

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractMessageTask.java
@@ -156,7 +156,7 @@ public abstract class AbstractMessageTask<P>
     }
 
     private void handleProcessingFailure(Throwable throwable) {
-        if (parameters != null && endpoint != null) {
+        if (endpoint != null) {
             sendClientMessage(throwable);
         }
     }


### PR DESCRIPTION
This seems to be a regression after the message decoding was moved to partition thread. When the node is not active, the error message is not sent back to the client