### PR TITLE
Atomicity supported between cache record store and `CacheWriter` while adding (not for update) new entry

### DIFF
--- a/hazelcast-client-legacy/src/test/java/com/hazelcast/client/cache/CacheClientListenerTest.java
+++ b/hazelcast-client-legacy/src/test/java/com/hazelcast/client/cache/CacheClientListenerTest.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.client.cache;
 
-import com.hazelcast.cache.JCacheListenerTest;
+import com.hazelcast.cache.CacheListenerTest;
 import com.hazelcast.client.HazelcastClient;
 import com.hazelcast.client.cache.impl.HazelcastClientCachingProvider;
 import com.hazelcast.client.config.ClientConfig;
@@ -35,7 +35,7 @@ import javax.cache.spi.CachingProvider;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class JCacheClientListenerTest extends JCacheListenerTest {
+public class CacheClientListenerTest extends CacheListenerTest {
 
     @Before
     @After

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/CacheClientListenerTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/CacheClientListenerTest.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.client.cache;
 
-import com.hazelcast.cache.JCacheListenerTest;
+import com.hazelcast.cache.CacheListenerTest;
 import com.hazelcast.client.HazelcastClient;
 import com.hazelcast.client.cache.impl.HazelcastClientCachingProvider;
 import com.hazelcast.client.config.ClientConfig;
@@ -35,7 +35,7 @@ import javax.cache.spi.CachingProvider;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class JCacheClientListenerTest extends JCacheListenerTest {
+public class CacheClientListenerTest extends CacheListenerTest {
 
     @Before
     @After

--- a/hazelcast/src/test/java/com/hazelcast/cache/CacheListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CacheListenerTest.java
@@ -53,7 +53,7 @@ import static org.junit.Assert.fail;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class JCacheListenerTest extends HazelcastTestSupport {
+public class CacheListenerTest extends HazelcastTestSupport {
 
     protected HazelcastInstance hazelcastInstance;
 

--- a/hazelcast/src/test/java/com/hazelcast/cache/CacheReadWriteThroughTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CacheReadWriteThroughTest.java
@@ -18,9 +18,9 @@ package com.hazelcast.cache;
 
 import com.hazelcast.cache.impl.HazelcastServerCachingProvider;
 import com.hazelcast.config.CacheConfig;
+import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.test.AssertTask;
-import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelTest;
@@ -33,14 +33,18 @@ import org.junit.runner.RunWith;
 
 import javax.cache.Cache;
 import javax.cache.CacheManager;
-import javax.cache.configuration.CompleteConfiguration;
 import javax.cache.configuration.FactoryBuilder;
 import javax.cache.integration.CacheLoader;
 import javax.cache.integration.CacheLoaderException;
+import javax.cache.integration.CacheWriter;
+import javax.cache.integration.CacheWriterException;
 import javax.cache.integration.CompletionListener;
 import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
@@ -49,9 +53,9 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
-@RunWith(HazelcastSerialClassRunner.class)
+@RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class ReadWriteThroughJCacheTests extends HazelcastTestSupport {
+public class CacheReadWriteThroughTest extends HazelcastTestSupport {
 
     private TestHazelcastInstanceFactory factory;
     private HazelcastInstance hz1;
@@ -60,46 +64,47 @@ public class ReadWriteThroughJCacheTests extends HazelcastTestSupport {
     private HazelcastServerCachingProvider cachingProvider1;
     private HazelcastServerCachingProvider cachingProvider2;
 
+    protected Config createConfig() {
+        return new Config();
+    }
+
     @Before
-    public void init() {
+    public void setup() {
         factory = new TestHazelcastInstanceFactory(2);
-        hz1 = factory.newHazelcastInstance();
-        hz2 = factory.newHazelcastInstance();
+        hz1 = factory.newHazelcastInstance(createConfig());
+        hz2 = factory.newHazelcastInstance(createConfig());
         cachingProvider1 = HazelcastServerCachingProvider.createCachingProvider(hz1);
         cachingProvider2 = HazelcastServerCachingProvider.createCachingProvider(hz2);
     }
 
     @After
-    public void tear() {
+    public void tearDown() {
         cachingProvider1.close();
         cachingProvider2.close();
         factory.shutdownAll();
     }
 
+    protected CacheConfig<Integer, Integer> createCacheConfig() {
+        CacheConfig cacheConfig = new CacheConfig<Integer, Integer>();
+        cacheConfig.setTypes(Integer.class, Integer.class);
+        return cacheConfig;
+    }
+
     @Test
-    public void test_getall_readthrough() throws Exception {
-        final String cacheName = randomMapName();
+    public void test_getAll_readThrough() throws Exception {
+        final String cacheName = randomName();
 
         CacheManager cacheManager = cachingProvider1.getCacheManager();
         assertNotNull(cacheManager);
 
         assertNull(cacheManager.getCache(cacheName));
 
-        CompleteConfiguration<Integer, Integer> config = new CacheConfig<Integer, Integer>()
-                .setTypes(Integer.class, Integer.class)
-                .setReadThrough(true)
-                .setCacheLoaderFactory(FactoryBuilder.factoryOf(new GetAllAsyncCacheLoader()));
+        CacheConfig<Integer, Integer> config = createCacheConfig();
+        config.setReadThrough(true);
+        config.setCacheLoaderFactory(FactoryBuilder.factoryOf(new GetAllAsyncCacheLoader()));
 
         Cache<Integer, Integer> cache = cacheManager.createCache(cacheName, config);
         assertNotNull(cache);
-
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run() throws Exception {
-                CacheManager cm2 = cachingProvider2.getCacheManager();
-                assertNotNull(cm2.getCache(cacheName, Integer.class, Integer.class));
-            }
-        });
 
         Set<Integer> keys = new HashSet<Integer>();
         for (int i = 0; i < 150; i++) {
@@ -111,29 +116,20 @@ public class ReadWriteThroughJCacheTests extends HazelcastTestSupport {
     }
 
     @Test
-    public void test_loadall_readthrough() throws Exception {
-        final String cacheName = randomMapName();
+    public void test_loadAll_readThrough() throws Exception {
+        final String cacheName = randomName();
 
         CacheManager cacheManager = cachingProvider1.getCacheManager();
         assertNotNull(cacheManager);
 
         assertNull(cacheManager.getCache(cacheName));
 
-        CompleteConfiguration<Integer, Integer> config = new CacheConfig<Integer, Integer>()
-                .setTypes(Integer.class, Integer.class)
-                .setReadThrough(true)
-                .setCacheLoaderFactory(FactoryBuilder.factoryOf(new GetAllAsyncCacheLoader()));
+        CacheConfig<Integer, Integer> config = createCacheConfig();
+        config.setReadThrough(true);
+        config.setCacheLoaderFactory(FactoryBuilder.factoryOf(new GetAllAsyncCacheLoader()));
 
         Cache<Integer, Integer> cache = cacheManager.createCache(cacheName, config);
         assertNotNull(cache);
-
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run() throws Exception {
-                CacheManager cm2 = cachingProvider2.getCacheManager();
-                assertNotNull(cm2.getCache(cacheName, Integer.class, Integer.class));
-            }
-        });
 
         Set<Integer> keys = new HashSet<Integer>();
         for (int i = 0; i < 150; i++) {
@@ -175,6 +171,88 @@ public class ReadWriteThroughJCacheTests extends HazelcastTestSupport {
                 }
             }
             return result;
+        }
+    }
+
+    private void do_put_writeThrough(boolean acceptAll) {
+        final int ENTRY_COUNT = 100;
+        final String cacheName = randomName();
+
+        CacheManager cacheManager = cachingProvider1.getCacheManager();
+        assertNotNull(cacheManager);
+
+        assertNull(cacheManager.getCache(cacheName));
+
+        PutCacheWriter putCacheWriter = new PutCacheWriter(acceptAll);
+        CacheConfig<Integer, Integer> config = createCacheConfig();
+        config.setWriteThrough(true);
+        config.setCacheWriterFactory(FactoryBuilder.factoryOf(putCacheWriter));
+
+        ICache<Integer, Integer> cache = cacheManager.createCache(cacheName, config).unwrap(ICache.class);
+        assertNotNull(cache);
+
+        List<Integer> bannedKeys = new ArrayList<Integer>();
+        for (int i = 0; i < ENTRY_COUNT; i++) {
+            try {
+                cache.put(i, i);
+            } catch (CacheWriterException e) {
+                bannedKeys.add(i);
+            }
+        }
+
+        assertEquals(ENTRY_COUNT - bannedKeys.size(), cache.size());
+        for (Integer bannedKey : bannedKeys) {
+            assertNull(cache.get(bannedKey));
+        }
+    }
+
+    @Test
+    public void test_put_writeThrough_allKeysAccepted() {
+        do_put_writeThrough(true);
+    }
+
+    @Test
+    public void test_put_writeThrough_someKeysBanned() {
+        do_put_writeThrough(false);
+    }
+
+    public static class PutCacheWriter implements CacheWriter<Integer, Integer>, Serializable {
+
+        private final boolean acceptAll;
+
+        private PutCacheWriter(boolean acceptAll) {
+            this.acceptAll = acceptAll;
+        }
+
+        private boolean isAcceptableKey(int key) {
+            if (acceptAll) {
+                return true;
+            }
+            return key % 10 != 0;
+        }
+
+        @Override
+        public void write(Cache.Entry<? extends Integer, ? extends Integer> entry)
+                throws CacheWriterException {
+            Integer keyValue = entry.getKey().intValue();
+            if (!isAcceptableKey(keyValue)) {
+                throw new CacheWriterException("Key value is invalid: " + keyValue);
+            }
+        }
+
+        @Override
+        public void writeAll(Collection<Cache.Entry<? extends Integer, ? extends Integer>> entries)
+                throws CacheWriterException {
+        }
+
+        @Override
+        public void delete(Object key)
+                throws CacheWriterException {
+        }
+
+        @Override
+        public void deleteAll(Collection<?> keys)
+                throws CacheWriterException {
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/cache/entryprocessor/CacheEntryProcessorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/entryprocessor/CacheEntryProcessorTest.java
@@ -57,7 +57,7 @@ import static org.junit.Assert.fail;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class JCacheEntryProcessorTest extends HazelcastTestSupport {
+public class CacheEntryProcessorTest extends HazelcastTestSupport {
 
     private static final int ASSERTION_TIMEOUT_SECONDS = 300;
 


### PR DESCRIPTION
Currently, writing to `CacheWriter` is done before record is added to cache record store. But in case of failure while adding to record store (such as native OOME at EE),  record is written to `CacheWriter` more than once while trying to adding to record store.

With this PR, writing to `CacheWriter` is done after record is added to cache record store successfully. Also to be consistent if writing to `CacheWriter` fails, new added records are reverted (removed from record store).

**P.S:** Note that this PR is only for add (new put) not for update. Update case will be handled in another PR.