### PR TITLE
Wait for only cluster members in the same JVM during shutdown

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/instance/HazelcastInstanceFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/HazelcastInstanceFactory.java
@@ -26,14 +26,13 @@ import com.hazelcast.spi.annotation.PrivateApi;
 import com.hazelcast.util.EmptyStatement;
 import com.hazelcast.util.ExceptionUtil;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -255,20 +254,25 @@ public final class HazelcastInstanceFactory {
         }
     }
 
-    static Map<MemberImpl, HazelcastInstanceImpl> getInstanceImplMap() {
-        Map<MemberImpl, HazelcastInstanceImpl> map = new HashMap<MemberImpl, HazelcastInstanceImpl>();
+    static Set<HazelcastInstanceImpl> getInstanceImpls(Collection<Member> members) {
+        Set<HazelcastInstanceImpl> set = new HashSet<HazelcastInstanceImpl>();
         for (InstanceFuture future : INSTANCE_MAP.values()) {
             try {
-                HazelcastInstanceProxy instanceProxy = future.get();
-                HazelcastInstanceImpl impl = instanceProxy.original;
-                if (impl != null) {
-                    map.put(impl.node.getLocalMember(), impl);
+                if (future.isSet()) {
+                    HazelcastInstanceProxy instanceProxy = future.get();
+                    HazelcastInstanceImpl impl = instanceProxy.original;
+                    if (impl != null) {
+                        final MemberImpl localMember = impl.node.getLocalMember();
+                        if (members.contains(localMember)) {
+                            set.add(impl);
+                        }
+                    }
                 }
             } catch (RuntimeException ignored) {
                 EmptyStatement.ignore(ignored);
             }
         }
-        return map;
+        return set;
     }
 
     static void remove(HazelcastInstanceImpl instance) {

--- a/hazelcast/src/main/java/com/hazelcast/instance/NodeShutdownLatch.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/NodeShutdownLatch.java
@@ -17,6 +17,7 @@
 package com.hazelcast.instance;
 
 import com.hazelcast.cluster.impl.ClusterServiceImpl;
+import com.hazelcast.core.Member;
 import com.hazelcast.core.MemberAttributeEvent;
 import com.hazelcast.core.MembershipEvent;
 import com.hazelcast.core.MembershipListener;
@@ -39,24 +40,20 @@ final class NodeShutdownLatch {
 
     NodeShutdownLatch(final Node node) {
         localMember = node.localMember;
-        Collection<MemberImpl> memberList = node.clusterService.getMemberImpls();
+        Collection<Member> memberList = node.clusterService.getMembers();
         registrations = new HashMap<String, HazelcastInstanceImpl>(3);
-        Set<MemberImpl> members = new HashSet<MemberImpl>(memberList);
+        Set<Member> members = new HashSet<Member>(memberList);
         members.remove(localMember);
 
         if (!members.isEmpty()) {
-            final Map<MemberImpl, HazelcastInstanceImpl> map = HazelcastInstanceFactory.getInstanceImplMap();
-            for (Map.Entry<MemberImpl, HazelcastInstanceImpl> entry : map.entrySet()) {
-                final MemberImpl member = entry.getKey();
-                if (members.contains(member)) {
-                    HazelcastInstanceImpl instance = entry.getValue();
-                    if (instance.node.isRunning()) {
-                        try {
-                            ClusterServiceImpl clusterService = instance.node.clusterService;
-                            final String id = clusterService.addMembershipListener(new ShutdownMembershipListener());
-                            registrations.put(id, instance);
-                        } catch (Throwable ignored) {
-                        }
+            for (HazelcastInstanceImpl instance : HazelcastInstanceFactory.getInstanceImpls(members)) {
+                if (instance.node.isRunning()) {
+                    try {
+                        ClusterServiceImpl clusterService = instance.node.clusterService;
+                        final String id = clusterService.addMembershipListener(new ShutdownMembershipListener());
+                        registrations.put(id, instance);
+                    } catch (Throwable ignored) {
+
                     }
                 }
             }


### PR DESCRIPTION
 * NodeShutdownLatch waits until other hazelcast instances in the same JVM to notice the shutting down member. It retrieves all of the hazelcast instances in the same JVM even if they are in a different cluster. It also waits for the instances that have not completed the start process yet. Because of this, it slows down the shutdown since when a node tries to shutdown in a test method, it can wait for other Hazelcast instances starting in other test methods.

Fixes #6372