### PR TITLE
Client proxy initialization should take care of any failure

### DIFF
--- a/hazelcast-client-legacy/src/main/java/com/hazelcast/client/spi/ProxyManager.java
+++ b/hazelcast-client-legacy/src/main/java/com/hazelcast/client/spi/ProxyManager.java
@@ -218,7 +218,7 @@ public final class ProxyManager {
         }
         try {
             initializeWithRetry(clientProxy);
-        } catch (Exception e) {
+        } catch (Throwable e) {
             proxies.remove(ns);
             proxyFuture.set(e);
             throw ExceptionUtil.rethrow(e);

--- a/hazelcast-client-legacy/src/test/java/com/hazelcast/client/spi/ProxyFactoryTest.java
+++ b/hazelcast-client-legacy/src/test/java/com/hazelcast/client/spi/ProxyFactoryTest.java
@@ -18,6 +18,8 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import static org.junit.Assert.fail;
+
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class ProxyFactoryTest {
@@ -70,6 +72,37 @@ public class ProxyFactoryTest {
         Assert.assertEquals(SERVICE_NAME, proxy.getServiceName());
         Assert.assertEquals(objectName, proxy.getName());
     }
+
+    @Test
+    public void testProxy_whenInitThrowsError() {
+        ClientConfig clientConfig = new ClientConfig();
+        ProxyFactoryConfig proxyFactoryConfig = new ProxyFactoryConfig();
+        proxyFactoryConfig.setService(SERVICE_NAME);
+        proxyFactoryConfig.setFactoryImpl(new ClientProxyFactory() {
+            @Override
+            public ClientProxy create(String id) {
+                return new ClientProxy(SERVICE_NAME, id) {
+                    @Override
+                    protected void onInitialize() {
+                        super.onInitialize();
+                        throw new ExpectedError();
+                    }
+                };
+            }
+        });
+
+        clientConfig.addProxyFactoryConfig(proxyFactoryConfig);
+
+        HazelcastInstance client = hazelcastFactory.newHazelcastClient(clientConfig);
+        String objectName = "custom-object";
+        try {
+            client.getDistributedObject(SERVICE_NAME, objectName);
+            fail("Client proxy initialization should fail!");
+        } catch (ExpectedError expected) {
+        }
+    }
+
+    private static class ExpectedError extends Error {}
 
     private static class CustomService implements RemoteService {
         @Override

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/ProxyManager.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/ProxyManager.java
@@ -236,7 +236,7 @@ public final class ProxyManager {
         }
         try {
             initializeWithRetry(clientProxy);
-        } catch (Exception e) {
+        } catch (Throwable e) {
             proxies.remove(ns);
             proxyFuture.set(e);
             throw ExceptionUtil.rethrow(e);

--- a/hazelcast-client/src/test/java/com/hazelcast/client/spi/ProxyFactoryTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/spi/ProxyFactoryTest.java
@@ -18,6 +18,8 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import static org.junit.Assert.fail;
+
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class ProxyFactoryTest {
@@ -70,6 +72,37 @@ public class ProxyFactoryTest {
         Assert.assertEquals(SERVICE_NAME, proxy.getServiceName());
         Assert.assertEquals(objectName, proxy.getName());
     }
+
+    @Test
+    public void testProxy_whenInitThrowsError() {
+        ClientConfig clientConfig = new ClientConfig();
+        ProxyFactoryConfig proxyFactoryConfig = new ProxyFactoryConfig();
+        proxyFactoryConfig.setService(SERVICE_NAME);
+        proxyFactoryConfig.setFactoryImpl(new ClientProxyFactory() {
+            @Override
+            public ClientProxy create(String id) {
+                return new ClientProxy(SERVICE_NAME, id) {
+                    @Override
+                    protected void onInitialize() {
+                        super.onInitialize();
+                        throw new ExpectedError();
+                    }
+                };
+            }
+        });
+
+        clientConfig.addProxyFactoryConfig(proxyFactoryConfig);
+
+        HazelcastInstance client = hazelcastFactory.newHazelcastClient(clientConfig);
+        String objectName = "custom-object";
+        try {
+            client.getDistributedObject(SERVICE_NAME, objectName);
+            fail("Client proxy initialization should fail!");
+        } catch (ExpectedError expected) {
+        }
+    }
+
+    private static class ExpectedError extends Error {}
 
     private static class CustomService implements RemoteService {
         @Override


### PR DESCRIPTION
Currently proxy creation/initialization only handles `Exception`
but when it fails with an `Error`, `ClientProxyFuture` is remains unset
and client shutdown and a subsequent getProxy call will hang forever.