### PR TITLE
[BACKPORT] Client proxy initialization should take care of any failure

### DIFF
--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/spi/ProxyManager.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/spi/ProxyManager.java
@@ -193,7 +193,7 @@ public final class ProxyManager {
         }
         try {
             initialize(clientProxy);
-        } catch (Exception e) {
+        } catch (Throwable e) {
             proxies.remove(ns);
             proxyFuture.set(e);
             throw ExceptionUtil.rethrow(e);

--- a/hazelcast-client-new/src/test/java/com/hazelcast/client/spi/ProxyFactoryTest.java
+++ b/hazelcast-client-new/src/test/java/com/hazelcast/client/spi/ProxyFactoryTest.java
@@ -6,7 +6,6 @@ import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.ServiceConfig;
 import com.hazelcast.core.DistributedObject;
-import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.spi.RemoteService;
 import com.hazelcast.test.HazelcastParallelClassRunner;
@@ -18,6 +17,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import static org.junit.Assert.fail;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category(QuickTest.class)
@@ -70,6 +70,37 @@ public class ProxyFactoryTest {
         Assert.assertEquals(SERVICE_NAME, proxy.getServiceName());
         Assert.assertEquals(objectName, proxy.getName());
     }
+
+    @Test
+    public void testProxy_whenInitThrowsError() {
+        ClientConfig clientConfig = new ClientConfig();
+        ProxyFactoryConfig proxyFactoryConfig = new ProxyFactoryConfig();
+        proxyFactoryConfig.setService(SERVICE_NAME);
+        proxyFactoryConfig.setFactoryImpl(new ClientProxyFactory() {
+            @Override
+            public ClientProxy create(String id) {
+                return new ClientProxy(SERVICE_NAME, id) {
+                    @Override
+                    protected void onInitialize() {
+                        super.onInitialize();
+                        throw new ExpectedError();
+                    }
+                };
+            }
+        });
+
+        clientConfig.addProxyFactoryConfig(proxyFactoryConfig);
+
+        HazelcastInstance client = hazelcastFactory.newHazelcastClient(clientConfig);
+        String objectName = "custom-object";
+        try {
+            client.getDistributedObject(SERVICE_NAME, objectName);
+            fail("Client proxy initialization should fail!");
+        } catch (ExpectedError expected) {
+        }
+    }
+
+    private static class ExpectedError extends Error {}
 
     private static class CustomService implements RemoteService {
         @Override

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/ProxyManager.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/ProxyManager.java
@@ -195,7 +195,7 @@ public final class ProxyManager {
         }
         try {
             initialize(clientProxy);
-        } catch (Exception e) {
+        } catch (Throwable e) {
             proxies.remove(ns);
             proxyFuture.set(e);
             throw ExceptionUtil.rethrow(e);

--- a/hazelcast-client/src/test/java/com/hazelcast/client/spi/ProxyFactoryTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/spi/ProxyFactoryTest.java
@@ -6,7 +6,6 @@ import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.ServiceConfig;
 import com.hazelcast.core.DistributedObject;
-import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.spi.RemoteService;
 import com.hazelcast.test.HazelcastParallelClassRunner;
@@ -18,6 +17,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import static org.junit.Assert.fail;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category(QuickTest.class)
@@ -70,6 +70,37 @@ public class ProxyFactoryTest {
         Assert.assertEquals(SERVICE_NAME, proxy.getServiceName());
         Assert.assertEquals(objectName, proxy.getName());
     }
+
+    @Test
+    public void testProxy_whenInitThrowsError() {
+        ClientConfig clientConfig = new ClientConfig();
+        ProxyFactoryConfig proxyFactoryConfig = new ProxyFactoryConfig();
+        proxyFactoryConfig.setService(SERVICE_NAME);
+        proxyFactoryConfig.setFactoryImpl(new ClientProxyFactory() {
+            @Override
+            public ClientProxy create(String id) {
+                return new ClientProxy(SERVICE_NAME, id) {
+                    @Override
+                    protected void onInitialize() {
+                        super.onInitialize();
+                        throw new ExpectedError();
+                    }
+                };
+            }
+        });
+
+        clientConfig.addProxyFactoryConfig(proxyFactoryConfig);
+
+        HazelcastInstance client = hazelcastFactory.newHazelcastClient(clientConfig);
+        String objectName = "custom-object";
+        try {
+            client.getDistributedObject(SERVICE_NAME, objectName);
+            fail("Client proxy initialization should fail!");
+        } catch (ExpectedError expected) {
+        }
+    }
+
+    private static class ExpectedError extends Error {}
 
     private static class CustomService implements RemoteService {
         @Override


### PR DESCRIPTION
Currently proxy creation/initialization only handles `Exception`
but when it fails with an `Error`, `ClientProxyFuture` is remains unset
and client shutdown and a subsequent getProxy call will hang forever.

Backport of https://github.com/hazelcast/hazelcast/pull/6940