### PR TITLE
[BACKPORT] Wait for only cluster members in the same JVM during shutdown

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/instance/HazelcastInstanceFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/HazelcastInstanceFactory.java
@@ -25,14 +25,13 @@ import com.hazelcast.jmx.ManagementService;
 import com.hazelcast.spi.annotation.PrivateApi;
 import com.hazelcast.util.ExceptionUtil;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -243,19 +242,24 @@ public final class HazelcastInstanceFactory {
         }
     }
 
-    static Map<MemberImpl, HazelcastInstanceImpl> getInstanceImplMap() {
-        final Map<MemberImpl, HazelcastInstanceImpl> map = new HashMap<MemberImpl, HazelcastInstanceImpl>();
+    static Set<HazelcastInstanceImpl> getInstanceImpls(Collection<Member> members) {
+        final Set<HazelcastInstanceImpl> set = new HashSet<HazelcastInstanceImpl>();
         for (InstanceFuture f : INSTANCE_MAP.values()) {
             try {
-                HazelcastInstanceProxy instanceProxy = f.get();
-                final HazelcastInstanceImpl impl = instanceProxy.original;
-                if (impl != null) {
-                    map.put(impl.node.getLocalMember(), impl);
+                if (f.isSet()) {
+                    HazelcastInstanceProxy instanceProxy = f.get();
+                    final HazelcastInstanceImpl impl = instanceProxy.original;
+                    if (impl != null) {
+                        final MemberImpl localMember = impl.node.getLocalMember();
+                        if (members.contains(localMember)) {
+                            set.add(impl);
+                        }
+                    }
                 }
             } catch (RuntimeException ignore) {
             }
         }
-        return map;
+        return set;
     }
 
     static void remove(HazelcastInstanceImpl instance) {
@@ -312,6 +316,10 @@ public final class HazelcastInstanceFactory {
                 this.throwable = throwable;
                 notifyAll();
             }
+        }
+
+        boolean isSet() {
+            return hz != null;
         }
     }
 }


### PR DESCRIPTION
 * NodeShutdownLatch waits until other hazelcast instances in the same JVM to notice the shutting down member. It retrieves all of the hazelcast instances in the same JVM even if they are in a different cluster. It also waits for the instances that have not completed the start process yet. Because of this, it slows down the shutdown since when a node tries to shutdown in a test method, it can wait for other Hazelcast instances starting in other test methods.

Backport of #6939 