### PR TITLE
Remove unused transferRecordsFrom() method from cache record store

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheRecordStore.java
@@ -20,7 +20,6 @@ import com.hazelcast.cache.CacheNotExistsException;
 import com.hazelcast.cache.impl.maxsize.MaxSizeChecker;
 import com.hazelcast.cache.impl.maxsize.impl.EntryCountCacheMaxSizeChecker;
 import com.hazelcast.cache.impl.record.CacheRecord;
-import com.hazelcast.cache.impl.record.CacheRecordMap;
 import com.hazelcast.cache.impl.record.SampleableCacheRecordMap;
 import com.hazelcast.config.CacheConfig;
 import com.hazelcast.config.EvictionConfig;
@@ -34,7 +33,6 @@ import com.hazelcast.internal.eviction.EvictionPolicyEvaluatorProvider;
 import com.hazelcast.internal.eviction.EvictionStrategy;
 import com.hazelcast.internal.eviction.EvictionStrategyProvider;
 import com.hazelcast.map.impl.MapEntries;
-import com.hazelcast.nio.Disposable;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.partition.InternalPartitionService;
 import com.hazelcast.spi.EventRegistration;
@@ -1469,19 +1467,5 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
     @Override
     public boolean isWanReplicationEnabled() {
         return wanReplicationEnabled;
-    }
-
-    @Override
-    public void transferRecordsFrom(ICacheRecordStore src) {
-        if (!(src instanceof AbstractCacheRecordStore)) {
-            throw new IllegalArgumentException("Expecting AbstractCacheRecordStore!");
-        }
-
-        AbstractCacheRecordStore dest = this;
-        CacheRecordMap oldRecords = dest.records;
-        dest.records = ((AbstractCacheRecordStore) src).records;
-        if (oldRecords instanceof Disposable) {
-            ((Disposable) oldRecords).dispose();
-        }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/ICacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/ICacheRecordStore.java
@@ -432,14 +432,4 @@ public interface ICacheRecordStore {
      * @return <tt>true</tt> if wan replication is enabled for this record store, <tt>false</tt> otherwise
      */
     boolean isWanReplicationEnabled();
-
-    /**
-     * Transfers all records from source record store
-     * and drops previous records owned by this record store.
-     * Source record store should not be accessed anymore
-     * after transfer.
-     *
-     * @param src source record store whose records will be transferred
-     */
-    void transferRecordsFrom(ICacheRecordStore src);
 }


### PR DESCRIPTION
`transferRecordsFrom()` became obsolete after EE change: https://github.com/hazelcast/hazelcast-enterprise/pull/535