### PR TITLE
Fixes NPE on ClientExecutionPoolSizeLowTest

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngineImpl.java
@@ -506,12 +506,6 @@ public class ClientEngineImpl implements ClientEngine, CoreService, PostJoinAwar
             }
 
             Object service = nodeEngine.getService(serviceName);
-            if (service == null) {
-                if (nodeEngine.isActive()) {
-                    throw new IllegalArgumentException("No service registered with name: " + serviceName);
-                }
-                throw new HazelcastInstanceNotActiveException();
-            }
             request.setService(service);
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/instance/Node.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/Node.java
@@ -167,7 +167,6 @@ public class Node {
             textCommandService = new TextCommandServiceImpl(this);
             nodeExtension.printNodeInfo(this);
             this.multicastService = createMulticastService(addressPicker);
-            initializeListeners(config);
             joiner = nodeContext.createJoiner(this);
         } catch (Throwable e) {
             try {
@@ -328,6 +327,7 @@ public class Node {
         }
         if (completelyShutdown) return;
         nodeEngine.start();
+        initializeListeners(config);
         connectionManager.start();
         if (config.getNetworkConfig().getJoin().getMulticastConfig().isEnabled()) {
             final Thread multicastServiceThread = new Thread(

--- a/hazelcast/src/main/java/com/hazelcast/quorum/impl/QuorumServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/quorum/impl/QuorumServiceImpl.java
@@ -64,8 +64,11 @@ public class QuorumServiceImpl implements EventPublishingService<QuorumEvent, Qu
         this.nodeEngine = nodeEngine;
         this.eventService = nodeEngine.getEventService();
         initializeQuorums();
-        initializeListeners();
         this.inactive = quorums.isEmpty();
+    }
+
+    public void start() {
+        initializeListeners();
     }
 
     private void initializeQuorums() {

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/ReplicatedMapService.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/ReplicatedMapService.java
@@ -69,17 +69,16 @@ public class ReplicatedMapService
     private final Config config;
     private final NodeEngine nodeEngine;
     private final EventService eventService;
-    private final EventRegistration eventRegistration;
 
     public ReplicatedMapService(NodeEngine nodeEngine) {
         this.nodeEngine = nodeEngine;
         this.config = nodeEngine.getConfig();
         this.eventService = nodeEngine.getEventService();
-        this.eventRegistration = eventService.registerListener(SERVICE_NAME, EVENT_TOPIC_NAME, new ReplicationListener());
     }
 
     @Override
     public void init(NodeEngine nodeEngine, Properties properties) {
+        eventService.registerListener(SERVICE_NAME, EVENT_TOPIC_NAME, new ReplicationListener());
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/spi/Operation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/Operation.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.spi;
 
-import com.hazelcast.core.HazelcastException;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.nio.Address;
@@ -27,7 +26,6 @@ import com.hazelcast.nio.serialization.DataSerializable;
 import com.hazelcast.partition.InternalPartition;
 import com.hazelcast.quorum.QuorumException;
 import com.hazelcast.spi.exception.RetryableException;
-import com.hazelcast.spi.exception.RetryableHazelcastException;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 
 import java.io.IOException;
@@ -208,14 +206,6 @@ public abstract class Operation implements DataSerializable {
             // one might have overridden getServiceName() method...
             final String name = serviceName != null ? serviceName : getServiceName();
             service = ((NodeEngineImpl) nodeEngine).getService(name);
-            if (service == null) {
-                if (nodeEngine.isActive()) {
-                    throw new HazelcastException("Service with name '" + name + "' not found!");
-                } else {
-                    throw new RetryableHazelcastException("HazelcastInstance[" + nodeEngine.getThisAddress()
-                            + "] is not active!");
-                }
-            }
         }
         return (T) service;
     }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/EventPacketProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/EventPacketProcessor.java
@@ -42,9 +42,6 @@ public class EventPacketProcessor implements StripedRunnable {
         String serviceName = eventPacket.getServiceName();
 
         EventPublishingService<Object, Object> service = getPublishingService(serviceName);
-        if (service == null) {
-            return;
-        }
 
         Registration registration = getRegistration(eventPacket, serviceName);
         if (registration == null) {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/LocalEventDispatcher.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/LocalEventDispatcher.java
@@ -53,13 +53,6 @@ public final class LocalEventDispatcher implements StripedRunnable, TimeoutRunna
     @Override
     public void run() {
         final EventPublishingService<Object, Object> service = eventService.nodeEngine.getService(serviceName);
-        if (service == null) {
-            if (eventService.nodeEngine.isActive()) {
-                throw new IllegalArgumentException("Service[" + serviceName + "] could not be found!");
-            }
-            return;
-        }
-
         service.dispatchEvent(event, listener);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/IsStillRunningService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/IsStillRunningService.java
@@ -142,10 +142,6 @@ public class IsStillRunningService {
      */
     public boolean isOperationExecuting(Address callerAddress, String callerUuid, String serviceName, Object identifier) {
         Object service = nodeEngine.getService(serviceName);
-        if (service == null) {
-            logger.severe("Not able to find operation execution info. Invalid service: " + serviceName);
-            return false;
-        }
         if (service instanceof ExecutionTracingService) {
             return ((ExecutionTracingService) service).isOperationExecuting(callerAddress, callerUuid, identifier);
         }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/ProxyServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/ProxyServiceImpl.java
@@ -149,9 +149,7 @@ public class ProxyServiceImpl
             registry.destroyProxy(name, fireEvent);
         }
         final RemoteService service = nodeEngine.getService(serviceName);
-        if (service != null) {
-            service.destroyDistributedObject(name);
-        }
+        service.destroyDistributedObject(name);
         String message = "DistributedObject[" + service + " -> " + name + "] has been destroyed!";
         Throwable cause = new DistributedObjectDestroyedException(message);
         nodeEngine.getWaitNotifyService().cancelWaitingOps(serviceName, name, cause);

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionContextImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionContextImpl.java
@@ -19,7 +19,6 @@ package com.hazelcast.transaction.impl;
 import com.hazelcast.collection.impl.list.ListService;
 import com.hazelcast.collection.impl.queue.QueueService;
 import com.hazelcast.collection.impl.set.SetService;
-import com.hazelcast.core.HazelcastInstanceNotActiveException;
 import com.hazelcast.core.TransactionalList;
 import com.hazelcast.core.TransactionalMap;
 import com.hazelcast.core.TransactionalMultiMap;
@@ -127,12 +126,6 @@ final class TransactionContextImpl implements TransactionContext {
             obj = ((TransactionalService) service).createTransactionalObject(name, transaction);
             txnObjectMap.put(key, obj);
         } else {
-            if (service == null) {
-                if (!nodeEngine.isActive()) {
-                    throw new HazelcastInstanceNotActiveException();
-                }
-                throw new IllegalArgumentException("Unknown Service[" + serviceName + "]!");
-            }
             throw new IllegalArgumentException("Service[" + serviceName + "] is not transactional!");
         }
         return obj;

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/XATransactionContextImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/XATransactionContextImpl.java
@@ -19,7 +19,6 @@ package com.hazelcast.transaction.impl.xa;
 import com.hazelcast.collection.impl.list.ListService;
 import com.hazelcast.collection.impl.queue.QueueService;
 import com.hazelcast.collection.impl.set.SetService;
-import com.hazelcast.core.HazelcastInstanceNotActiveException;
 import com.hazelcast.core.TransactionalList;
 import com.hazelcast.core.TransactionalMap;
 import com.hazelcast.core.TransactionalMultiMap;
@@ -122,12 +121,6 @@ public class XATransactionContextImpl implements TransactionContext {
             obj = ((TransactionalService) service).createTransactionalObject(name, transaction);
             txnObjectMap.put(key, obj);
         } else {
-            if (service == null) {
-                if (!nodeEngine.isActive()) {
-                    throw new HazelcastInstanceNotActiveException();
-                }
-                throw new IllegalArgumentException("Unknown Service[" + serviceName + "]!");
-            }
             throw new IllegalArgumentException("Service[" + serviceName + "] is not transactional!");
         }
         return obj;


### PR DESCRIPTION
pulled service access logic to nodeEngine in order not to return
null from getService()

move listener initilization from node constructor to start. Add start
to quorum service and move listener registration there

Fixes #6853
Backport of https://github.com/hazelcast/hazelcast/pull/6936