### PR TITLE
[BACKPORT] allows omitting quorum-size, type or custom function in spring config

### DIFF
--- a/hazelcast-spring/src/main/resources/hazelcast-spring-3.5.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-3.5.xsd
@@ -2235,9 +2235,9 @@
 
     <xs:complexType name="quorum">
         <xs:all>
-            <xs:element name="quorum-size" type="quorum-size" maxOccurs="1"/>
-            <xs:element name="quorum-type" type="quorum-type" maxOccurs="1"/>
-            <xs:element name="quorum-function-class-name" type="xs:string" maxOccurs="1"/>
+            <xs:element name="quorum-size" type="quorum-size" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="quorum-type" type="quorum-type" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="quorum-function-class-name" type="xs:string" minOccurs="0" maxOccurs="1"/>
             <xs:element name="quorum-listeners" minOccurs="0" maxOccurs="1">
                 <xs:complexType>
                     <xs:sequence>
@@ -2264,7 +2264,7 @@
 
     <xs:simpleType name="quorum-size">
         <xs:restriction base="xs:int">
-            <xs:minInclusive value="0"/>
+            <xs:minInclusive value="2"/>
         </xs:restriction>
     </xs:simpleType>
 


### PR DESCRIPTION
backport of https://github.com/hazelcast/hazelcast/pull/6957