### PR TITLE
[BACKPORT] Return true from task cancellation only if cancellation is sent to original invocation

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/executor/impl/DistributedExecutorService.java
+++ b/hazelcast/src/main/java/com/hazelcast/executor/impl/DistributedExecutorService.java
@@ -111,9 +111,10 @@ public class DistributedExecutorService implements ManagedService, RemoteService
     public boolean cancel(String uuid, boolean interrupt) {
         CallableProcessor processor = submittedTasks.remove(uuid);
         if (processor != null && processor.cancel(interrupt)) {
-            processor.sendResponse(new CancellationException());
-            getLocalExecutorStats(processor.name).cancelExecution();
-            return true;
+            if (processor.sendResponse(new CancellationException())) {
+                getLocalExecutorStats(processor.name).cancelExecution();
+                return true;
+            }
         }
         return false;
     }
@@ -223,10 +224,13 @@ public class DistributedExecutorService implements ManagedService, RemoteService
             }
         }
 
-        private void sendResponse(Object result) {
+        private boolean sendResponse(Object result) {
             if (RESPONSE_FLAG_FIELD_UPDATER.compareAndSet(this, Boolean.FALSE, Boolean.TRUE)) {
                 responseHandler.sendResponse(result);
+                return true;
             }
+
+            return false;
         }
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/util/executor/CancellableDelegatingFutureTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/executor/CancellableDelegatingFutureTest.java
@@ -1,0 +1,60 @@
+package com.hazelcast.util.executor;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IExecutorService;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.io.Serializable;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ExecutionException;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class CancellableDelegatingFutureTest extends HazelcastTestSupport {
+
+    @Test
+    public void testInnerFutureThrowsCancellationExceptionWhenOuterFutureIsCancelled()
+            throws InterruptedException {
+        final TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(1);
+        final HazelcastInstance instance = factory.newHazelcastInstance();
+        IExecutorService executorService = instance.getExecutorService(randomString());
+        final CompletesOnInterruptionCallable callable = new CompletesOnInterruptionCallable();
+        final DelegatingFuture<Boolean> future = (DelegatingFuture<Boolean>) executorService.submit(callable);
+
+        if (future.cancel(true)) {
+            try {
+                future.getFuture().get();
+                fail();
+            } catch (ExecutionException expected) {
+                assertTrue(expected.getCause() instanceof CancellationException);
+            }
+        }
+    }
+
+    static class CompletesOnInterruptionCallable implements Callable<Boolean>, Serializable {
+
+        @Override
+        public Boolean call()
+                throws Exception {
+            while (true) {
+                try {
+                    Thread.sleep(1);
+                } catch (InterruptedException e) {
+                    return Boolean.TRUE;
+                }
+            }
+        }
+    }
+
+
+}


### PR DESCRIPTION
Fixes #6283
Backport of #6962