### PR TITLE
Additional unit tests for query-related code added

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryEventFilter.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryEventFilter.java
@@ -70,6 +70,9 @@ public class QueryEventFilter extends EntryEventFilter {
             return false;
         }
         QueryEventFilter that = (QueryEventFilter) o;
+        if (!super.equals(o)) {
+            return false;
+        }
         if (!predicate.equals(that.predicate)) {
             return false;
         }
@@ -78,6 +81,8 @@ public class QueryEventFilter extends EntryEventFilter {
 
     @Override
     public int hashCode() {
-        return predicate.hashCode();
+        int result = super.hashCode();
+        result = 31 * result + predicate.hashCode();
+        return result;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/CachedQueryEntry.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/CachedQueryEntry.java
@@ -74,9 +74,6 @@ public class CachedQueryEntry extends QueryableEntry {
 
     @Override
     public Data getKeyData() {
-        if (keyData == null) {
-            keyData = serializationService.toData(keyObject);
-        }
         return keyData;
     }
 
@@ -92,18 +89,11 @@ public class CachedQueryEntry extends QueryableEntry {
     protected Object getTargetObject(boolean key) {
         Object targetObject;
         if (key) {
-            if (keyObject == null) {
-                if (keyData.isPortable()) {
-                    targetObject = keyData;
-                } else {
-                    targetObject = getKey();
-                }
+            //keyData is never null
+            if (keyData.isPortable()) {
+                targetObject = keyData;
             } else {
-                if (keyObject instanceof Portable) {
-                    targetObject = getKeyData();
-                } else {
-                    targetObject = getKey();
-                }
+                targetObject = getKey();
             }
         } else {
             if (valueObject == null) {

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryEventFilterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryEventFilterTest.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.query;
+
+import com.hazelcast.internal.serialization.SerializationService;
+import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.query.Predicate;
+import com.hazelcast.query.TruePredicate;
+import com.hazelcast.query.impl.FalsePredicate;
+import com.hazelcast.query.impl.QueryableEntry;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class QueryEventFilterTest {
+
+
+    private SerializationService serializationService;
+
+    @Before
+    public void setUp() {
+        serializationService = new DefaultSerializationServiceBuilder().build();
+    }
+
+    @Test
+    public void testEval_givenFilterContainsKey_whenKeyOfEntryIsNotEqual_thenReturnFalse() {
+        //given
+        Data key1 = serializationService.toData("key1");
+        Predicate predicate = TruePredicate.INSTANCE;
+        QueryEventFilter filter = new QueryEventFilter(true, key1, predicate);
+
+        //when
+        Data key2 = serializationService.toData("key2");
+        QueryableEntry entry = mockEntryWithKeyData(key2);
+
+        //then
+        boolean result = filter.eval(entry);
+        assertFalse(result);
+    }
+
+    @Test
+    public void testEval_givenFilterContainsKey_whenKeyOfEntryIsEqualAndPredicacteIsMatching_thenReturnTrue() {
+        //given
+        Data key1 = serializationService.toData("key1");
+        Predicate predicate = TruePredicate.INSTANCE;
+        QueryEventFilter filter = new QueryEventFilter(true, key1, predicate);
+
+        //when
+        Data key2 = serializationService.toData("key1");
+        QueryableEntry entry = mockEntryWithKeyData(key2);
+
+        //then
+        boolean result = filter.eval(entry);
+        assertTrue(result);
+    }
+
+    @Test
+    public void testEval_givenFilterDoesNotContainKey_whenPredicateIsMatching_thenReturnTrue() {
+        //given
+        Predicate predicate = TruePredicate.INSTANCE;
+        QueryEventFilter filter = new QueryEventFilter(true, null, predicate);
+
+        //when
+        Data key2 = serializationService.toData("key");
+        QueryableEntry entry = mockEntryWithKeyData(key2);
+
+        //then
+        boolean result = filter.eval(entry);
+        assertTrue(result);
+    }
+
+    @Test
+    public void testEval_givenFilterDoesNotContainKey_whenPredicateIsNotMatching_thenReturnFalse() {
+        //given
+        Predicate predicate = FalsePredicate.INSTANCE;
+        QueryEventFilter filter = new QueryEventFilter(true, null, predicate);
+
+        //when
+        Data key2 = serializationService.toData("key");
+        QueryableEntry entry = mockEntryWithKeyData(key2);
+
+        //then
+        boolean result = filter.eval(entry);
+        assertFalse(result);
+    }
+
+    @Test
+    public void testEquals_givenSameInstance_thenReturnTrue() {
+        Data key = serializationService.toData("key");
+        QueryEventFilter filter1 = new QueryEventFilter(true, key, TruePredicate.INSTANCE);
+        QueryEventFilter filter2 = filter1;
+
+        assertTrue(filter1.equals(filter2));
+    }
+
+    @Test
+    public void testEquals_givenOtherIsNull_thenReturnFalse() {
+        Data key = serializationService.toData("key");
+        QueryEventFilter filter1 = new QueryEventFilter(true, key, TruePredicate.INSTANCE);
+        QueryEventFilter filter2 = null;
+
+        assertFalse(filter1.equals(filter2));
+    }
+
+    @Test
+    public void testEquals_givenOtherIsDifferentClass_thenReturnFalse() {
+        Data key = serializationService.toData("key");
+        QueryEventFilter filter1 = new QueryEventFilter(true, key, TruePredicate.INSTANCE);
+        Object filter2 = new Object();
+
+        assertFalse(filter1.equals(filter2));
+    }
+
+    @Test
+    public void testEquals_givenIncludeValueIsTrue_whenOtherHasIncludeValueFalse_thenReturnFalse() {
+        Data key = serializationService.toData("key");
+        QueryEventFilter filter1 = new QueryEventFilter(true, key, TruePredicate.INSTANCE);
+
+        QueryEventFilter filter2 = new QueryEventFilter(false, key, TruePredicate.INSTANCE);
+
+        assertFalse(filter1.equals(filter2));
+    }
+
+    @Test
+    public void testEquals_givenIncludeValueIsFalse_whenOtherHasIncludeValueTrue_thenReturnFalse() {
+        Data key = serializationService.toData("key");
+        QueryEventFilter filter1 = new QueryEventFilter(false, key, TruePredicate.INSTANCE);
+
+        QueryEventFilter filter2 = new QueryEventFilter(true, key, TruePredicate.INSTANCE);
+
+        assertFalse(filter1.equals(filter2));
+    }
+
+    @Test
+    public void testEquals_givenKeyIsNull_whenOtherHasKeyNonNull_thenReturnFalse() {
+        QueryEventFilter filter1 = new QueryEventFilter(true, null, TruePredicate.INSTANCE);
+
+        Data key = serializationService.toData("key");
+        QueryEventFilter filter2 = new QueryEventFilter(true, key, TruePredicate.INSTANCE);
+
+        assertFalse(filter1.equals(filter2));
+    }
+
+    @Test
+    public void testEquals_givenKeyIsNonNull_whenOtherHasNonEqualsKey_thenReturnFalse() {
+        Data key1 = serializationService.toData("key1");
+        QueryEventFilter filter1 = new QueryEventFilter(true, key1, TruePredicate.INSTANCE);
+
+        Data key2 = serializationService.toData("key2");
+        QueryEventFilter filter2 = new QueryEventFilter(true, key2, TruePredicate.INSTANCE);
+
+        assertFalse(filter1.equals(filter2));
+    }
+
+    @Test
+    public void testEquals_givenKeyIsNull_whenOtherHasKeyNull_thenReturnTrue() {
+        QueryEventFilter filter1 = new QueryEventFilter(true, null, TruePredicate.INSTANCE);
+        QueryEventFilter filter2 = new QueryEventFilter(true, null, TruePredicate.INSTANCE);
+
+        assertTrue(filter1.equals(filter2));
+    }
+
+    @Test
+    public void testEquals_whenPredicatesAreNotEquals_thenReturnFalse() {
+        QueryEventFilter filter1 = new QueryEventFilter(true, null, TruePredicate.INSTANCE);
+        QueryEventFilter filter2 = new QueryEventFilter(true, null, FalsePredicate.INSTANCE);
+
+        assertFalse(filter1.equals(filter2));
+    }
+
+    @Test
+    public void testEquals_whenPredicatesAreEquals_thenReturnTrue() {
+        QueryEventFilter filter1 = new QueryEventFilter(true, null, TruePredicate.INSTANCE);
+        QueryEventFilter filter2 = new QueryEventFilter(true, null, FalsePredicate.INSTANCE);
+
+        assertFalse(filter1.equals(filter2));
+    }
+
+
+
+    private QueryableEntry mockEntryWithKeyData(Data key) {
+        QueryableEntry entry = mock(QueryableEntry.class);
+        when(entry.getKeyData()).thenReturn(key);
+        return entry;
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/CachedQueryEntryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/CachedQueryEntryTest.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.query.impl;
+
+import com.hazelcast.internal.serialization.SerializationService;
+import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.query.impl.getters.Extractors;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class CachedQueryEntryTest {
+
+    private SerializationService serializationService;
+
+    @Before
+    public void before() {
+        serializationService = new DefaultSerializationServiceBuilder().build();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInit_whenKeyIsNull_thenThrowIllegalArgumentException() {
+        Data key = null;
+        new CachedQueryEntry(serializationService, key, new Object(), Extractors.empty());
+    }
+
+    @Test
+    public void testGetKey() {
+        String keyObject = "key";
+        Data keyData = serializationService.toData(keyObject);
+        CachedQueryEntry entry = new CachedQueryEntry(serializationService, keyData, new Object(), Extractors.empty());
+
+        Object key = entry.getKey();
+        assertEquals(keyObject, key);
+    }
+
+    @Test
+    public void testGetTargetObject_givenKeyDataIsPortable_whenKeyFlagIsTrue_thenReturnKeyData() {
+        //given
+        Data keyData = mockPortableData();
+        CachedQueryEntry entry = new CachedQueryEntry(serializationService, keyData, new Object(), Extractors.empty());
+
+        //when
+        Object targetObject = entry.getTargetObject(true);
+
+        //then
+        assertSame(keyData, targetObject);
+    }
+
+    @Test
+    public void testGetTargetObject_givenKeyDataIsNotPortable_whenKeyFlagIsTrue_thenReturnKeyObject() {
+        //given
+        Object keyObject = "key";
+        Data keyData = serializationService.toData(keyObject);
+        CachedQueryEntry entry = new CachedQueryEntry(serializationService, keyData, new Object(), Extractors.empty());
+
+        //when
+        Object targetObject = entry.getTargetObject(true);
+
+        //then
+        assertEquals(keyObject, targetObject);
+    }
+
+    @Test
+    public void testEquals_givenSameInstance_thenReturnTrue() {
+        CachedQueryEntry entry1 = newEntry("key");
+        CachedQueryEntry entry2 = entry1;
+
+        assertTrue(entry1.equals(entry2));
+    }
+
+    @Test
+    public void testEquals_givenOtherIsNull_thenReturnFalse() {
+        CachedQueryEntry entry1 = newEntry("key");
+        CachedQueryEntry entry2 = null;
+
+        assertFalse(entry1.equals(entry2));
+    }
+
+    @Test
+    public void testEquals_givenOtherIsDifferentClass_thenReturnFalse() {
+        CachedQueryEntry entry1 = newEntry("key");
+        Object entry2 = new Object();
+
+        assertFalse(entry1.equals(entry2));
+    }
+
+    @Test
+    public void testEquals_givenOtherHasDifferentKey_thenReturnFalse() {
+        CachedQueryEntry entry1 = newEntry("key1");
+        CachedQueryEntry entry2 = newEntry("key2");
+
+        assertFalse(entry1.equals(entry2));
+    }
+
+    @Test
+    public void testEquals_givenOtherHasEqualKey_thenReturnTrue() {
+        CachedQueryEntry entry1 = newEntry("key");
+        CachedQueryEntry entry2 = newEntry("key");
+
+        assertTrue(entry1.equals(entry2));
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void givenNewEntry_whenSetValue_thenThrowUnsupportedOperationException() {
+        //given
+        CachedQueryEntry entry = newEntry("key");
+
+        //when
+        entry.setValue(new Object());
+    }
+
+    private CachedQueryEntry newEntry(Object key) {
+        Data keyData = serializationService.toData(key);
+        return new CachedQueryEntry(serializationService, keyData, new Object(), Extractors.empty());
+    }
+
+    private Data mockPortableData() {
+        Data keyData = mock(Data.class);
+        when(keyData.isPortable()).thenReturn(true);
+        return keyData;
+    }
+
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/QueryEntryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/QueryEntryTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.query.impl;
 
 import com.hazelcast.internal.serialization.SerializationService;
@@ -23,6 +39,7 @@ import org.junit.runner.RunWith;
 import java.io.IOException;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
@@ -97,6 +114,61 @@ public class QueryEntryTest extends HazelcastTestSupport {
         assertEquals(0, value.serializationCount);
     }
 
+    @Test(expected = UnsupportedOperationException.class)
+    public void givenNewQueryEntry_whenSetValue_thenThrowUnsupportedOperationException() {
+        //given
+        QueryEntry entry = newEntry();
+
+        //when
+        entry.setValue(new Object());
+    }
+
+    @Test
+    public void testEquals_givenSameInstance_thenReturnTrue() {
+        QueryEntry entry1 = newEntry();
+        QueryEntry entry2 = entry1;
+
+        assertTrue(entry1.equals(entry2));
+    }
+
+    @Test
+    public void testEquals_givenOtherIsNull_thenReturnFalse() {
+        QueryEntry entry = newEntry();
+
+        assertFalse(entry.equals(null));
+    }
+
+    @Test
+    public void testEquals_givenOtherIsDifferentClass_thenReturnFalse() {
+        QueryEntry entry = newEntry();
+
+        assertFalse(entry.equals(new Object()));
+    }
+
+    @Test
+    public void testEquals_givenOtherHasDifferentKey_thenReturnFalse() {
+        SerializableObject value = new SerializableObject();
+        QueryEntry entry1 = newEntry("key1", value);
+        QueryEntry entry2 = newEntry("key2", value);
+
+        assertFalse(entry1.equals(entry2));
+    }
+
+    @Test
+    public void testEquals_givenOtherHasEqualsKey_thenReturnTrue() {
+        SerializableObject value = new SerializableObject();
+        QueryEntry entry1 = newEntry("key", value);
+        QueryEntry entry2 = newEntry("key", value);
+
+        assertTrue(entry1.equals(entry2));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInit_whenKeyIsNull_thenThrowIllegalArgumentException() {
+        Data key = null;
+        new QueryEntry(serializationService, key, new SerializableObject(), Extractors.empty());
+    }
+
     @Test
     public void test_init() throws Exception {
         Data dataKey = serializationService.toData("dataKey");
@@ -111,6 +183,17 @@ public class QueryEntryTest extends HazelcastTestSupport {
         // compare references of objects since they should be cloned after QueryEntry#init call.
         assertTrue("Old dataKey should not be here", dataKey != queryEntry.getKeyData());
         assertTrue("Old dataValue should not be here", dataValue != queryEntry.getValueData());
+    }
+
+    private QueryEntry newEntry() {
+        Data key = serializationService.toData(new SerializableObject());
+        SerializableObject value = new SerializableObject();
+        return new QueryEntry(serializationService, key, value, Extractors.empty());
+    }
+
+    private QueryEntry newEntry(Object key, Object value) {
+        key = serializationService.toData(key);
+        return new QueryEntry(serializationService, (Data)key, value, Extractors.empty());
     }
 
     @SuppressWarnings("unused")


### PR DESCRIPTION
- Additional unit tests for query-related code added
- Bug in equals()/hashCode in QueryEventFilter fixed - it didn't call its superclass