### PR TITLE
Better error message when NATIVE format is selected, but Hazelcast Enterprise is not on classpath

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheService.java
@@ -435,7 +435,8 @@ public abstract class AbstractCacheService
     @Override
     public CacheOperationProvider getCacheOperationProvider(String nameWithPrefix, InMemoryFormat inMemoryFormat) {
         if (InMemoryFormat.NATIVE.equals(inMemoryFormat)) {
-            throw new IllegalArgumentException("Native memory is available only in Enterprise!");
+            throw new IllegalArgumentException("Native memory is available only in Hazelcast Enterprise."
+                    + "Make sure you have Hazelcast Enterprise JARs on your classpath!");
         }
         CacheOperationProvider cacheOperationProvider = operationProviderCache.get(nameWithPrefix);
         if (cacheOperationProvider != null) {

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/record/CacheRecordFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/record/CacheRecordFactory.java
@@ -52,6 +52,9 @@ public class CacheRecordFactory<R extends CacheRecord> {
                 Object objectValue = serializationService.toObject(value);
                 record = (R) createCacheObjectRecord(objectValue, creationTime, expiryTime);
                 break;
+            case NATIVE:
+                throw new IllegalArgumentException("Native storage format is supported in Hazelcast Enterprise only. "
+                        + "Make sure you have Hazelcast Enterprise JARs on your classpath!");
             default:
                 throw new IllegalArgumentException("Invalid storage format: " + inMemoryFormat);
         }

--- a/hazelcast/src/main/java/com/hazelcast/config/QueryCacheConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/QueryCacheConfig.java
@@ -284,7 +284,7 @@ public class QueryCacheConfig {
      */
     public QueryCacheConfig setInMemoryFormat(InMemoryFormat inMemoryFormat) {
         checkNotNull(inMemoryFormat, "inMemoryFormat cannot be null");
-        checkFalse(inMemoryFormat == InMemoryFormat.NATIVE, "InMemoryFormat." + inMemoryFormat + " is not supported");
+        checkFalse(inMemoryFormat == InMemoryFormat.NATIVE, "InMemoryFormat." + inMemoryFormat + " is not supported.");
 
         this.inMemoryFormat = inMemoryFormat;
         return this;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapContainer.java
@@ -129,6 +129,9 @@ public class MapContainer {
                     case OBJECT:
                         recordFactory = new ObjectRecordFactory(mapConfig, serializationService);
                         break;
+                    case NATIVE:
+                        throw new IllegalArgumentException("Native storage format is supported in Hazelcast Enterprise only. "
+                                + "Make sure you have Hazelcast Enterprise JARs on your classpath!");
                     default:
                         throw new IllegalArgumentException("Invalid storage format: " + mapConfig.getInMemoryFormat());
                 }


### PR DESCRIPTION
Better error message when NATIVE format is selected, but Hazelcast Enterprise is not on classpath