### PR TITLE
added isCanceled check before sending response

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/executor/impl/DistributedExecutorService.java
+++ b/hazelcast/src/main/java/com/hazelcast/executor/impl/DistributedExecutorService.java
@@ -211,8 +211,8 @@ public class DistributedExecutorService implements ManagedService, RemoteService
                 if (uuid != null) {
                     submittedTasks.remove(uuid);
                 }
-                sendResponse(result);
                 if (!isCancelled()) {
+                    sendResponse(result);
                     finishExecution(name, Clock.currentTimeMillis() - start);
                 }
             }


### PR DESCRIPTION
Reasoning behind this change:
When a task is canceled, it tries to send the response (which maybe null) without checking `isCanceled`
If the task is cancelled (`task.cancel()` returns true) the canceller part should be responsible sending the response (`CancellationException`)

fixes #6969 and #6966 