### PR TITLE
Adds cluster state list and change REST APIS.

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpCommandProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpCommandProcessor.java
@@ -23,7 +23,10 @@ public abstract class HttpCommandProcessor<T> extends AbstractTextCommandProcess
     public static final String URI_MAPS = "/hazelcast/rest/maps/";
     public static final String URI_QUEUES = "/hazelcast/rest/queues/";
     public static final String URI_CLUSTER = "/hazelcast/rest/cluster";
-    public static final String URI_SHUTDOWN_CLUSTER_URL = "/hazelcast/rest/management/cluster/shutdown";
+    public static final String URI_CLUSTER_MANAGEMENT_BASE_URL = "/hazelcast/rest/management/cluster";
+    public static final String URI_CLUSTER_STATE_URL = URI_CLUSTER_MANAGEMENT_BASE_URL + "/state";
+    public static final String URI_CHANGE_CLUSTER_STATE_URL = URI_CLUSTER_MANAGEMENT_BASE_URL + "/changeState";
+    public static final String URI_SHUTDOWN_CLUSTER_URL =  URI_CLUSTER_MANAGEMENT_BASE_URL + "/shutdown";
     public static final String URI_MANCENTER_CHANGE_URL = "/hazelcast/rest/mancenter/changeurl";
 
     protected HttpCommandProcessor(TextCommandService textCommandService) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpPostCommandProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpPostCommandProcessor.java
@@ -17,6 +17,7 @@
 package com.hazelcast.internal.ascii.rest;
 
 import com.hazelcast.cluster.ClusterService;
+import com.hazelcast.cluster.ClusterState;
 import com.hazelcast.config.GroupConfig;
 import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.instance.Node;
@@ -48,6 +49,10 @@ public class HttpPostCommandProcessor extends HttpCommandProcessor<HttpPostComma
                 handleManagementCenterUrlChange(command);
             } else if (uri.startsWith(URI_QUEUES)) {
                 handleQueue(command, uri);
+            } else if (uri.startsWith(URI_CLUSTER_STATE_URL)) {
+                handleGetClusterState(command);
+            } else if (uri.startsWith(URI_CHANGE_CLUSTER_STATE_URL)) {
+                handleChangeClusterState(command);
             } else if (uri.startsWith(URI_SHUTDOWN_CLUSTER_URL)) {
                 handleClusterShutdown(command);
                 return;
@@ -60,12 +65,78 @@ public class HttpPostCommandProcessor extends HttpCommandProcessor<HttpPostComma
         textCommandService.sendResponse(command);
     }
 
+    private void handleChangeClusterState(HttpPostCommand command) throws UnsupportedEncodingException  {
+        byte[] data = command.getData();
+        String[] strList = bytesToString(data).split("&");
+        String groupName = URLDecoder.decode(strList[0], "UTF-8");
+        String groupPass = URLDecoder.decode(strList[1], "UTF-8");
+        String stateParam = URLDecoder.decode(strList[2], "UTF-8");
+        String res = "{\"status\":\"${STATUS}\",\"state\":\"${STATE}\"}";
+        try {
+            Node node = textCommandService.getNode();
+            ClusterService clusterService = node.getClusterService();
+            GroupConfig groupConfig = node.getConfig().getGroupConfig();
+            if (!(groupConfig.getName().equals(groupName) && groupConfig.getPassword().equals(groupPass))) {
+                res = res.replace("${STATUS}", "forbidden");
+                res = res.replace("${STATE}", "null");
+            } else {
+                ClusterState state = clusterService.getClusterState();
+                if (stateParam.equals("frozen")) {
+                    state = ClusterState.FROZEN;
+                }
+                if (stateParam.equals("active")) {
+                    state = ClusterState.ACTIVE;
+                }
+                if (stateParam.equals("passive")) {
+                    state = ClusterState.PASSIVE;
+                }
+                if (!state.equals(clusterService.getClusterState())) {
+                    clusterService.changeClusterState(state);
+                    res = res.replace("${STATUS}", "success");
+                    res = res.replace("${STATE}", state.toString().toLowerCase());
+                } else {
+                    res = res.replace("${STATUS}", "fail");
+                    res = res.replace("${STATE}", state.toString().toLowerCase());
+                }
+            }
+        } catch (Throwable throwable) {
+            res = res.replace("${STATUS}", "fail");
+            res = res.replace("${STATE}", "null");
+        }
+        command.setResponse(HttpCommand.CONTENT_TYPE_JSON , stringToBytes(res));
+    }
+
+    private void handleGetClusterState(HttpPostCommand command) throws UnsupportedEncodingException {
+        byte[] data = command.getData();
+        String[] strList = bytesToString(data).split("&");
+        String groupName = URLDecoder.decode(strList[0], "UTF-8");
+        String groupPass = URLDecoder.decode(strList[1], "UTF-8");
+        String res = "{\"status\":\"${STATUS}\",\"state\":\"${STATE}\"}";
+        try {
+            Node node = textCommandService.getNode();
+            ClusterService clusterService = node.getClusterService();
+            GroupConfig groupConfig = node.getConfig().getGroupConfig();
+            if (!(groupConfig.getName().equals(groupName) && groupConfig.getPassword().equals(groupPass))) {
+                res = res.replace("${STATUS}", "forbidden");
+                res = res.replace("${STATE}", "null");
+            } else {
+                res = res.replace("${STATUS}", "success");
+                res = res.replace("${STATE}", clusterService.getClusterState().toString().toLowerCase());
+            }
+        } catch (Throwable throwable) {
+            res = res.replace("${STATUS}", "fail");
+            res = res.replace("${STATE}", "null");
+        }
+        command.setResponse(HttpCommand.CONTENT_TYPE_JSON , stringToBytes(res));
+    }
+
+
     private void handleClusterShutdown(HttpPostCommand command)  throws UnsupportedEncodingException {
         byte[] data = command.getData();
         String[] strList = bytesToString(data).split("&");
         String groupName = URLDecoder.decode(strList[0], "UTF-8");
         String groupPass = URLDecoder.decode(strList[1], "UTF-8");
-        String res = "{status : \"${STATUS}\"}";
+        String res = "{\"status\":\"${STATUS}\"}";
         try {
             Node node = textCommandService.getNode();
             ClusterService clusterService = node.getClusterService();

--- a/hazelcast/src/main/java/com/hazelcast/nio/ascii/TextReadHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/ascii/TextReadHandler.java
@@ -167,9 +167,9 @@ public class TextReadHandler implements ReadHandler {
             if (command instanceof HttpCommand) {
                 boolean isMancenterRequest = ((HttpCommand) command).getURI().
                         startsWith(HttpCommandProcessor.URI_MANCENTER_CHANGE_URL);
-                boolean isShutdownClusterRequest = ((HttpCommand) command).getURI().
-                        startsWith(HttpCommandProcessor.URI_SHUTDOWN_CLUSTER_URL);
-                if (!restEnabled && !isMancenterRequest && !isShutdownClusterRequest) {
+                boolean isClusterManagementRequest = ((HttpCommand) command).getURI().
+                        startsWith(HttpCommandProcessor.URI_CLUSTER_MANAGEMENT_BASE_URL);
+                if (!restEnabled && (!isMancenterRequest && !isClusterManagementRequest)) {
                     connection.close();
                     return;
                 }

--- a/hazelcast/src/main/resources/cluster.sh
+++ b/hazelcast/src/main/resources/cluster.sh
@@ -1,0 +1,157 @@
+#!/bin/sh
+if [[ ( $1 == "--help") ||  ($1 == "-h") ]]; then 
+   	echo "parameters : "
+   	echo "	-o, --operation 	: Defines state operation of the script. Operation can be 'get' or 'change'."
+    echo "	-s, --state 	    : Defines new state of the cluster. State can be 'active', 'frozen', 'passive'"
+   	echo "	-p, --port  	    : Defines which port hazelcast is running. Default value is '5701'."
+   	echo "	-g, --groupname     : Defines groupname of the cluster. Default value is 'dev'."
+   	echo "	-P, --password      : Defines password of the cluster. Default value is 'dev-pass'."
+   	exit 0
+fi
+
+while [[ $# > 1 ]]
+do
+key="$1"
+case $key in
+  	-o|--operation)
+    OPERATION="$2"
+    shift # past argument
+    ;;
+    -s|--state)
+    STATE="$2"
+    shift # past argument
+    ;;
+    -p|--port)
+    PORT="$2"
+    shift # past argument
+    ;;
+    -g|--groupname)
+    GROUPNAME="$2"
+    shift # past argument
+    ;;
+    -P|--password)
+    PASSWORD="$2"
+    shift # past argument
+    ;;
+    *)
+esac
+shift # past argument or value
+done
+
+if [[ -z "$OPERATION" ]]; then
+ 	echo "No operation is defined, running script with default operation : 'get'."
+ 	OPERATION="get"
+fi
+
+if [[ -z "$PORT" ]]; then
+    echo "No port is defined, running script with default port : '5701'."
+    PORT="5701"
+fi
+
+if [[ -z "$GROUPNAME" ]]; then
+    echo "No groupname is defined, running script with default groupname : 'dev'."
+    GROUPNAME="dev"
+fi
+
+if [[ -z "$PASSWORD" ]]; then
+    echo "No password is defined, running script with default password : 'dev-pass'."
+    PASSWORD="dev-pass"
+fi
+
+command -v curl >/dev/null 2>&1 || { echo >&2 "Cluster state script requires curl but it's not installed. Aborting."; exit -1; }
+
+if [ "$OPERATION" != "get" ] && [ "$OPERATION" != "change" ] && [ "$OPERATION" != "shutdown" ]; then
+    echo "Not a valid cluster operation, valid operations  are 'get' || 'change' || 'shutdown'"
+    exit -1
+fi
+
+if [ $OPERATION = "get" ]; then
+	echo "Getting cluster state from member on this machine on port ${PORT}"
+	request="http://127.0.0.1:${PORT}/hazelcast/rest/management/cluster/state"
+ 	response=$(curl --data "${GROUPNAME}&${PASSWORD}" --silent "${request}");
+
+ 	if [[ $response == *"fail"* ]];then
+        echo "An error occured while listing !";
+    	exit -1
+    fi
+	if [[ $response == *"forbidden"* ]];then
+        echo "Please make sure you provide valid user/pass.";
+        exit -1
+    fi
+	if [[ $response == *"success"* ]];then
+	    CURRSTATE=$(echo "${response}" | sed -e 's/^.*"state"[ ]*:[ ]*"//' -e 's/".*//');
+	    echo "Cluster is in ${CURRSTATE} state."
+    	exit 0
+    fi
+    echo "No hazelcast cluster is running."
+    exit -1
+fi
+
+if [ $OPERATION = "change" ]; then
+
+    if [[ -z "STATE" ]]; then
+        echo "No new state is defined, Please define new state with --state 'active', 'frozen', 'passive' "
+        exit -1
+    fi
+
+    if [ "$STATE" != "frozen" ] && [ "$STATE" != "active" ] && [ "$STATE" != "passive" ]; then
+        echo "Not a valid cluster state, valid states  are 'active' || 'frozen' || 'passive'"
+        exit -1
+    fi
+
+    echo "Changing cluster state to ${STATE} from member on this machine on port ${PORT}"
+    request="http://127.0.0.1:${PORT}/hazelcast/rest/management/cluster/changeState"
+    response=$(curl --data "${GROUPNAME}&${PASSWORD}&${STATE}" --silent "${request}");
+
+    if [[ $response == *"fail"* ]];then
+       NEWSTATE=$(echo "${response}" | sed -e 's/^.*"state"[ ]*:[ ]*"//' -e 's/".*//');
+       if [ $NEWSTATE != "null"]; then
+           echo "Cluster is already in ${STATE} state}"
+       else
+            echo "An error occured while changing cluster state!";
+       fi
+       exit -1
+    fi
+
+    if [[ $response == *"forbidden"* ]];then
+        echo "Please make sure you provide valid user/pass.";
+        exit -1
+    fi
+
+    if [[ $response == *"success"* ]];then
+        NEWSTATE=$(echo "${response}" | sed -e 's/^.*"state"[ ]*:[ ]*"//' -e 's/".*//');
+        STATUS=$(echo "${response}" | sed -e 's/^.*"state"[ ]*:[ ]*"//' -e 's/".*//');
+        echo "State of the cluster changed to ${NEWSTATE} state"
+        exit 0
+    fi
+
+    echo "No hazelcast cluster is running."
+    exit -1
+fi
+
+if [ $OPERATION = "shutdown" ]; then
+
+    echo "You are shutting down the cluster. Please make sure you provide valid user/pass."
+    echo "Shutting down cluster from member on this machine on port ${PORT}"
+
+    request="http://127.0.0.1:${PORT}/hazelcast/rest/management/cluster/shutdown"
+    response=$(curl --data "${GROUPNAME}&${PASSWORD}" --silent "${request}");
+
+    if [[ $response == *"fail"* ]];then
+        echo "An error occured while shutting down cluster!";
+        exit -1
+    fi
+
+    if [[ $response == *"forbidden"* ]];then
+        echo "Wrong user/pass!";
+        exit -1
+    fi
+
+    if [[ $response == *"success"* ]];then
+        echo "Cluster shutdown completed!"
+        exit 0
+    fi
+
+    echo "No hazelcast cluster is running."
+    exit -1
+fi

--- a/hazelcast/src/main/resources/stop.sh
+++ b/hazelcast/src/main/resources/stop.sh
@@ -4,103 +4,18 @@ PRGDIR=`dirname "$PRG"`
 HAZELCAST_HOME=`cd "$PRGDIR/.." >/dev/null; pwd`
 PID_FILE=$HAZELCAST_HOME/bin/hazelcast_instance.pid
 
-if [[ ( $1 == "--help") ||  ($1 == "-h") ]]; then 
-   	echo "parameters : "
-   	echo "	-s, --scope 	: Defines scope of the script. Scope can be 'member' or 'cluster'."
-   	echo "	-p, --port  	: Defines which port hazelcast is running. Default value is '5701'."
-   	echo "	-g, --groupname : Defines groupname of the cluster. Default value is 'dev'."
-   	echo "	-P, --password  : Defines password of the cluster. Default value is 'dev-pass'."
-   	exit 0
-fi 
-
-while [[ $# > 1 ]]
-do
-key="$1"
-case $key in
-  	-s|--scope)
-    SCOPE="$2"
-    shift # past argument
-    ;;
-    -p|--port)
-    PORT="$2"
-    shift # past argument
-    ;;
-    -g|--groupname)
-    GROUPNAME="$2"
-    shift # past argument
-    ;;
-    -P|--password)
-    PASSWORD="$2"
-    shift # past argument
-    ;;
-    *)
-esac
-shift # past argument or value
-done
-
-if [[ -z "$SCOPE" ]]; then
- 	echo "No scope is defined, running script with default scope : 'member'"
- 	SCOPE="member"
-fi
-	
-if [ $SCOPE = "cluster" ]; then
-
-	command -v curl >/dev/null 2>&1 || { echo >&2 "Cluster shutdown requires curl but it's not installed. Aborting."; exit -1; }
-	if [[ -z "$PORT" ]]; then
-		echo "No port is defined, running script with default port : '5701'"
-		PORT="5701"
-	fi
-
-	if [[ -z "$GROUPNAME" ]]; then
-		echo "No groupname is defined, running script with default groupname : 'dev'"
-		GROUPNAME="dev"
-	fi
-
-	if [[ -z "$PASSWORD" ]]; then
-		echo "No password is defined, running script with default password : 'dev-pass'"
-		PASSWORD="dev-pass"
-	fi
-	echo "You are shutting down the cluster. Please make sure you provide valid user/pass."
-	echo "Shutting down cluster from member on this machine on port ${PORT}"
-
-	request="http://127.0.0.1:${PORT}/hazelcast/rest/management/cluster/shutdown"
- 	response=$(curl --data "${GROUPNAME}&${PASSWORD}" --silent "${request}");
-
- 	if [[ $response == *"fail"* ]];then
-        echo "An error occured while shutting down cluster!";
-    	exit -1
-    fi
-
-	if [[ $response == *"forbidden"* ]];then
-        echo "Wrong user/pass!";
-        exit -1
-    fi
-	if [[ $response == *"success"* ]];then
-      	echo "Cluster shutdown completed!"
-    	exit 0
-    fi
-
-    echo "No hazelcast cluster is running."
+if [ ! -f ${PID_FILE} ]; then
+    echo "No hazelcast instance is running."
     exit -1
-else 
+fi
 
-	if [ $SCOPE = "member" ]; then 
-		if [ ! -f ${PID_FILE} ]; then
-			echo "No hazelcast instance is running."
-	  		exit -1
-		fi
-		PID=$(cat ${PID_FILE});
-		if [[ -z "${PID}" ]]; then
-		    echo "No hazelcast instance is running."
-		    exit -1
-		else
-		   kill ${PID}
-		   rm ${PID_FILE}
-		   echo "Hazelcast Instance with PID ${PID} shutdown."
-		   exit 0
-		fi
-	else
-		echo "Unknown scope. Please define scope with --scope member || cluster"
-	fi
-
+PID=$(cat ${PID_FILE});
+if [[ -z "${PID}" ]]; then
+    echo "No hazelcast instance is running."
+    exit -1
+else
+   kill ${PID}
+   rm ${PID_FILE}
+   echo "Hazelcast Instance with PID ${PID} shutdown."
+   exit 0
 fi

--- a/hazelcast/src/test/java/com/hazelcast/internal/ascii/HTTPCommunicator.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/ascii/HTTPCommunicator.java
@@ -159,6 +159,37 @@ public class HTTPCommunicator {
         return urlConnection.getResponseCode();
     }
 
+    public String getClusterState(String groupName, String groupPassword) throws IOException {
+
+        String url = address + "management/cluster/state";
+        return doPost(url, groupName, groupPassword);
+
+    }
+
+    public int changeClusterState(String groupName, String groupPassword, String newState) throws IOException {
+
+        String url = address + "management/cluster/changeState";
+        /** set up the http connection parameters */
+        HttpURLConnection urlConnection = (HttpURLConnection) (new URL(url)).openConnection();
+        urlConnection.setRequestMethod("POST");
+        urlConnection.setDoOutput(true);
+        urlConnection.setDoInput(true);
+        urlConnection.setUseCaches(false);
+        urlConnection.setAllowUserInteraction(false);
+        urlConnection.setRequestProperty("Content-type", "text/xml; charset=" + "UTF-8");
+
+        /** post the data */
+        OutputStream out = urlConnection.getOutputStream();
+        Writer writer = new OutputStreamWriter(out, "UTF-8");
+        String data = URLEncoder.encode(groupName, "UTF-8") + "&" + URLEncoder.encode(groupPassword, "UTF-8")+
+                "&" + URLEncoder.encode(newState, "UTF-8");
+        writer.write(data);
+        writer.close();
+        out.close();
+
+        return urlConnection.getResponseCode();
+    }
+
     private String doGet(final String url) throws IOException {
         HttpURLConnection httpUrlConnection = (HttpURLConnection) (new URL(url)).openConnection();
         try {
@@ -168,6 +199,35 @@ public class HTTPCommunicator {
             return readBytes == -1 ? "" : new String(buffer, 0, readBytes);
         } finally {
             httpUrlConnection.disconnect();
+        }
+    }
+
+    private String doPost(final String url, String ... params) throws IOException {
+        /** set up the http connection parameters */
+        HttpURLConnection urlConnection = (HttpURLConnection) (new URL(url)).openConnection();
+        urlConnection.setRequestMethod("POST");
+        urlConnection.setDoOutput(true);
+        urlConnection.setDoInput(true);
+        urlConnection.setUseCaches(false);
+        urlConnection.setAllowUserInteraction(false);
+        urlConnection.setRequestProperty("Content-type", "text/xml; charset=" + "UTF-8");
+        /** post the data */
+        OutputStream out = urlConnection.getOutputStream();
+        Writer writer = new OutputStreamWriter(out, "UTF-8");
+        String data = "";
+        for ( String param : params){
+            data +=  URLEncoder.encode(param, "UTF-8") + "&";
+        }
+        writer.write(data);
+        writer.close();
+        out.close();
+        try {
+            InputStream inputStream = urlConnection.getInputStream();
+            byte[] buffer = new byte[4096];
+            int readBytes = inputStream.read(buffer);
+            return readBytes == -1 ? "" : new String(buffer, 0, readBytes);
+        } finally {
+            urlConnection.disconnect();
         }
     }
 }


### PR DESCRIPTION
Also wrote a newclusterState.sh script which uses this API. Scripts must run on a machine at least one hazelcast member is running.

Sample usage : 

For getting cluster state : 
`./clusterState.sh -- operation get -port 5701 --groupname dev --password devpass`

For changing cluster state : 
`./clusterState.sh --operation change --state passive --port 5701 --groupname dev --password devpass`
