### PR TITLE
New option on map that allows to configure if wants a defensive copy of object contained

### DIFF
--- a/hazelcast-client-new/src/test/java/com/hazelcast/client/lock/ClientConditionTest.java
+++ b/hazelcast-client-new/src/test/java/com/hazelcast/client/lock/ClientConditionTest.java
@@ -23,7 +23,7 @@ import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category(QuickTest.class)
-public class ClientConditionTest extends HazelcastTestSupport{
+public class ClientConditionTest extends HazelcastTestSupport {
 
     private final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
     private HazelcastInstance client;
@@ -44,14 +44,16 @@ public class ClientConditionTest extends HazelcastTestSupport{
 
     @Test
     public void testLockConditionSimpleUsage() throws InterruptedException {
-        final String name = "testLockConditionSimpleUsage";
+        final String name = randomString();
         final ILock lock = client.getLock(name);
-        final ICondition condition = lock.newCondition(name + "c");
+        final ICondition condition = lock.newCondition(randomString());
         final AtomicInteger count = new AtomicInteger(0);
+        final CountDownLatch threadGetTheLock = new CountDownLatch(1);
 
         Thread t = new Thread(new Runnable() {
             public void run() {
                 lock.lock();
+                threadGetTheLock.countDown();
                 try {
                     if (lock.isLockedByCurrentThread()) {
                         count.incrementAndGet();
@@ -67,9 +69,8 @@ public class ClientConditionTest extends HazelcastTestSupport{
             }
         });
         t.start();
-        Thread.sleep(1000);
+        assertOpenEventually(threadGetTheLock);
 
-        assertEquals(false, lock.isLocked());
         lock.lock();
         assertEquals(true, lock.isLocked());
         condition.signal();

--- a/hazelcast/src/main/java/com/hazelcast/config/MapConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MapConfig.java
@@ -117,6 +117,8 @@ public class MapConfig {
 
     private InMemoryFormat inMemoryFormat = DEFAULT_IN_MEMORY_FORMAT;
 
+    private boolean defensiveCopyObjectMemoryFormat = true;
+
     private WanReplicationRef wanReplicationRef;
 
     private List<EntryListenerConfig> entryListenerConfigs;
@@ -154,6 +156,7 @@ public class MapConfig {
         this.maxSizeConfig = config.maxSizeConfig != null ? new MaxSizeConfig(config.maxSizeConfig) : null;
         this.evictionPolicy = config.evictionPolicy;
         this.inMemoryFormat = config.inMemoryFormat;
+        this.defensiveCopyObjectMemoryFormat = config.defensiveCopyObjectMemoryFormat;
         this.mapStoreConfig = config.mapStoreConfig != null ? new MapStoreConfig(config.mapStoreConfig) : null;
         this.nearCacheConfig = config.nearCacheConfig != null ? new NearCacheConfig(config.nearCacheConfig) : null;
         this.readBackupData = config.readBackupData;
@@ -220,6 +223,14 @@ public class MapConfig {
     public MapConfig setInMemoryFormat(InMemoryFormat inMemoryFormat) {
         this.inMemoryFormat = isNotNull(inMemoryFormat, "inMemoryFormat");
         return this;
+    }
+
+    public boolean isDefensiveCopyObjectMemoryFormat() {
+        return defensiveCopyObjectMemoryFormat;
+    }
+
+    public void setDefensiveCopyObjectMemoryFormat(boolean defensiveCopyObjectMemoryFormat) {
+        this.defensiveCopyObjectMemoryFormat = defensiveCopyObjectMemoryFormat;
     }
 
     /**
@@ -731,6 +742,7 @@ public class MapConfig {
                         && (this.mergePolicy != null ? this.mergePolicy.equals(other.mergePolicy) : other.mergePolicy == null)
                         && (this.inMemoryFormat != null ? this.inMemoryFormat.equals(other.inMemoryFormat)
                         : other.inMemoryFormat == null)
+                        && this.defensiveCopyObjectMemoryFormat == other.defensiveCopyObjectMemoryFormat
                         && (this.evictionPolicy != null ? this.evictionPolicy.equals(other.evictionPolicy)
                         : other.evictionPolicy == null)
                         && (this.mapStoreConfig != null ? this.mapStoreConfig.equals(other.mapStoreConfig)
@@ -745,6 +757,7 @@ public class MapConfig {
         sb.append("MapConfig");
         sb.append("{name='").append(name).append('\'');
         sb.append(", inMemoryFormat=").append(inMemoryFormat).append('\'');
+        sb.append(", defensiveCopyObjectMemoryFormat=").append(defensiveCopyObjectMemoryFormat).append('\'');
         sb.append(", backupCount=").append(backupCount);
         sb.append(", asyncBackupCount=").append(asyncBackupCount);
         sb.append(", timeToLiveSeconds=").append(timeToLiveSeconds);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/DefaultRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/DefaultRecordStore.java
@@ -647,7 +647,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore implements 
     }
 
     @Override
-    public Data readBackupData(Data key) {
+    public Object readBackup(Data key) {
         final long now = getNow();
 
         final Record record = getRecord(key);
@@ -666,7 +666,16 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore implements 
         final Object value = record.getValue();
         mapServiceContext.interceptAfterGet(name, value);
         // this serialization step is needed not to expose the object, see issue 1292
-        return mapServiceContext.toData(value);
+        return value;
+    }
+
+    @Override
+    public Data readBackupData(Data key) {
+        Object data = readBackup(key);
+        if (data == null) {
+            return null;
+        }
+        return mapServiceContext.toData(data);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/RecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/RecordStore.java
@@ -93,6 +93,8 @@ public interface RecordStore {
      */
     Data readBackupData(Data key);
 
+    Object readBackup(Data key);
+
     MapEntrySet getAll(Set<Data> keySet);
 
     boolean containsKey(Data dataKey);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
@@ -289,15 +289,15 @@ abstract class MapProxySupport extends AbstractDistributedObject<MapService> imp
         return value;
     }
 
-	private Object readBackup(Data key) {
-		final Object toReturn;
-		if (defensiveCopyObjectMemoryFormat) {
-			toReturn = readBackupDataOrNull(key);
-		} else {
-			toReturn = readBackupOrNull(key);
-		}
-		return toReturn;
-	}
+    private Object readBackup(Data key) {
+        final Object toReturn;
+        if (defensiveCopyObjectMemoryFormat) {
+            toReturn = readBackupDataOrNull(key);
+        } else {
+            toReturn = readBackupOrNull(key);
+        }
+        return toReturn;
+    }
 
     private boolean notOwnerPartitionForKey(Data key) {
         final MapService mapService = getService();

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
@@ -164,9 +164,11 @@ abstract class MapProxySupport extends AbstractDistributedObject<MapService> imp
         localMapStats = mapServiceContext.getLocalMapStatsProvider().getLocalMapStatsImpl(name);
         this.partitionService = getNodeEngine().getPartitionService();
         lockSupport = new LockProxySupport(new DefaultObjectNamespace(MapService.SERVICE_NAME, name));
-        defensiveCopyObjectMemoryFormat = 
-			getMapConfig().isDefensiveCopyObjectMemoryFormat() || 
-			!InMemoryFormat.OBJECT.equals(getMapConfig().getInMemoryFormat());
+        boolean defensiveCopy = getMapConfig().isDefensiveCopyObjectMemoryFormat();
+        if (!InMemoryFormat.OBJECT.equals(getMapConfig().getInMemoryFormat())) {
+            defensiveCopy = true;
+        }
+        defensiveCopyObjectMemoryFormat = defensiveCopy;
     }
 
     @Override
@@ -286,7 +288,7 @@ abstract class MapProxySupport extends AbstractDistributedObject<MapService> imp
         }
         return value;
     }
-	
+
 	private Object readBackup(Data key) {
 		final Object toReturn;
 		if (defensiveCopyObjectMemoryFormat) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
@@ -164,7 +164,9 @@ abstract class MapProxySupport extends AbstractDistributedObject<MapService> imp
         localMapStats = mapServiceContext.getLocalMapStatsProvider().getLocalMapStatsImpl(name);
         this.partitionService = getNodeEngine().getPartitionService();
         lockSupport = new LockProxySupport(new DefaultObjectNamespace(MapService.SERVICE_NAME, name));
-        defensiveCopyObjectMemoryFormat = getMapConfig().isDefensiveCopyObjectMemoryFormat() || !InMemoryFormat.OBJECT.equals(getMapConfig().getInMemoryFormat());
+        defensiveCopyObjectMemoryFormat = 
+			getMapConfig().isDefensiveCopyObjectMemoryFormat() || 
+			!InMemoryFormat.OBJECT.equals(getMapConfig().getInMemoryFormat());
     }
 
     @Override
@@ -268,12 +270,7 @@ abstract class MapProxySupport extends AbstractDistributedObject<MapService> imp
         }
         // todo action for read-backup true is not well tested.
         if (mapConfig.isReadBackupData()) {
-            final Object fromBackup;
-            if (defensiveCopyObjectMemoryFormat) {
-                fromBackup = readBackupDataOrNull(key);
-            } else {
-                fromBackup = readBackupOrNull(key);
-            }
+            final Object fromBackup = readBackup(key);
             if (fromBackup != null) {
                 return fromBackup;
             }
@@ -289,6 +286,16 @@ abstract class MapProxySupport extends AbstractDistributedObject<MapService> imp
         }
         return value;
     }
+	
+	private Object readBackup(Data key) {
+		final Object toReturn;
+		if (defensiveCopyObjectMemoryFormat) {
+			toReturn = readBackupDataOrNull(key);
+		} else {
+			toReturn = readBackupOrNull(key);
+		}
+		return toReturn;
+	}
 
     private boolean notOwnerPartitionForKey(Data key) {
         final MapService mapService = getService();
@@ -353,7 +360,7 @@ abstract class MapProxySupport extends AbstractDistributedObject<MapService> imp
         return NearCache.NULL_OBJECT.equals(cached);
     }
 
-    private RecordStore getRecordStore(Data key){
+    private RecordStore getRecordStore(Data key) {
         final MapService mapService = getService();
         final MapServiceContext mapServiceContext = mapService.getMapServiceContext();
         final NodeEngine nodeEngine = mapServiceContext.getNodeEngine();


### PR DESCRIPTION
This enhacement is really cool with paths where the speed is critical over data integrity.
This modification is only for map.
It add's a new option on mapConfig: 
The option let choose if a map can retrieve the object without serialize and deserialize (a defensive copy).
The RecordStore has been enhaced and the readBackupData has been refactored: now exists a new method readBackup that contais all the code in the old readBackupData except the "toData method call". The readBackupData now calls to readBackup and then call to the toData method on mapServiceContext.
Then the MapProxySupport does this:
if true, hazelcast will work as ever.
If false, and in memory type is not Object, hazelcast will work as ever.
If false and in memory type is Object and isReadBackupData is active: it will use the readBackup and retrieve the object as is. With 35KB serialized value, and a bit of bussiness logic, the response time was around 200ms. Now without this defensive copy, the response time is around 30ms