### PR TITLE
Atomicity supported between cache record store and `CacheWriter` while updating existing entry

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheCreateConfigOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheCreateConfigOperation.java
@@ -114,6 +114,13 @@ public class CacheCreateConfigOperation
         returnsResponse = false;
     }
 
+    @Override
+    public void onExecutionFailure(Throwable e) {
+        // Execution failed so we should enable `returnsResponse` flag to prevent waiting anymore
+        returnsResponse = true;
+        super.onExecutionFailure(e);
+    }
+
     private static class CacheConfigCreateCallback extends SimpleExecutionCallback<Object> {
 
         final AtomicInteger counter;
@@ -141,6 +148,7 @@ public class CacheCreateConfigOperation
     public boolean returnsResponse() {
         return returnsResponse;
     }
+
 
     @Override
     protected void writeInternal(ObjectDataOutput out)


### PR DESCRIPTION
Currently, writing to `CacheWriter` is done before record is updated in cache record store. But in case of failure while updating in record store (such as native OOME at EE while doing native memory allocation for new value), record is written to `CacheWriter` more than once while trying to putting to record store.

With this PR, writing to `CacheWriter` is done after new value is allocated but not just set inside existing record as new value. So if writing to `CacheWriter` fails, since we have not updated record value yet with its new value, no need to any action to revert it.

Fixes https://github.com/hazelcast/hazelcast-enterprise/issues/537
with #6935

**P.S 1:** No need to additional tests for Client and EE modules because client (`Client CacheReadWriteThroughTest `) and EE (`HiDensityCacheReadWriteThroughTest `) counterparts already extend from this test `CacheReadWriteThroughTest` so added tests to `CacheReadWriteThroughTest` are applied to them also by inheritance.

**P.S 2:** `HiDensityNativeMemoryCacheRecordStore::onCreateRecordWithExpiryError` should be updated as `HiDensityNativeMemoryCacheRecordStore::onCreateRecordError` after this PR merged because `HiDensityNativeMemoryCacheRecordStore` overrides this method from `AbstractCacheRecordStore` and this method name is updated to `onCreateRecordError` from `onCreateRecordWithExpiryError` with this PR.