### PR TITLE
Cache putAllBackup should skip tombstone records

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CachePutAllBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CachePutAllBackupOperation.java
@@ -60,11 +60,14 @@ public class CachePutAllBackupOperation
     }
 
     @Override
-    public void run()
-            throws Exception {
+    public void run() throws Exception {
         if (cacheRecords != null) {
             for (Map.Entry<Data, CacheRecord> entry : cacheRecords.entrySet()) {
-                cache.putRecord(entry.getKey(), entry.getValue());
+                final CacheRecord record = entry.getValue();
+                if (record.isTombstone()) {
+                    continue;
+                }
+                cache.putRecord(entry.getKey(), record);
             }
         }
     }


### PR DESCRIPTION
Tombstone records are created when an entry is removed
or during eviction/expiration when hot-restart is enabled for the cache.

Fixes hazelcast/hazelcast-enterprise#560