### PR TITLE
Update `primary` field of `AbstractCacheRecordStore` after migration through `ICacheRecordStore::init()`

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/HazelcastCacheManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/HazelcastCacheManager.java
@@ -29,6 +29,14 @@ public interface HazelcastCacheManager
         extends CacheManager {
 
     /**
+     * Gets cache name by adding manager prefix.
+     *
+     * @param name pure cache name with prefix
+     * @return the cache name with manager prefix
+     */
+    String getCacheNameWithPrefix(String name);
+
+    /**
      * Gets the underlying {@link HazelcastInstance} implementation.
      *
      * @return the underlying {@link HazelcastInstance} implementation

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheService.java
@@ -121,6 +121,7 @@ public abstract class AbstractCacheService
         for (CachePartitionSegment partitionSegment : partitionSegments) {
             if (partitionSegment != null) {
                 partitionSegment.clear();
+                partitionSegment.init();
             }
         }
     }
@@ -151,6 +152,7 @@ public abstract class AbstractCacheService
         if (event.getMigrationEndpoint() == MigrationEndpoint.SOURCE) {
             clearPartitionReplica(event.getPartitionId());
         }
+        initPartitionReplica(event.getPartitionId());
     }
 
     @Override
@@ -158,6 +160,11 @@ public abstract class AbstractCacheService
         if (event.getMigrationEndpoint() == MigrationEndpoint.DESTINATION) {
             clearPartitionReplica(event.getPartitionId());
         }
+        initPartitionReplica(event.getPartitionId());
+    }
+
+    private void initPartitionReplica(int partitionId) {
+        segments[partitionId].init();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractHazelcastCacheManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractHazelcastCacheManager.java
@@ -380,6 +380,7 @@ public abstract class AbstractHazelcastCacheManager
         return sb.toString();
     }
 
+    @Override
     public String getCacheNameWithPrefix(String name) {
         return cacheNamePrefix + name;
     }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CachePartitionSegment.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CachePartitionSegment.java
@@ -92,6 +92,14 @@ public class CachePartitionSegment implements ConstructorFunction<String, ICache
         return recordStores.containsKey(name);
     }
 
+    public void init() {
+        synchronized (mutex) {
+            for (ICacheRecordStore store : recordStores.values()) {
+                store.init();
+            }
+        }
+    }
+
     public void clear() {
         synchronized (mutex) {
             for (ICacheRecordStore store : recordStores.values()) {

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/ICacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/ICacheRecordStore.java
@@ -307,6 +307,11 @@ public interface ICacheRecordStore {
     void removeAll(Set<Data> keys, int completionId);
 
     /**
+     * Initializes record store.
+     */
+    void init();
+
+    /**
      * Close is equivalent to below operations in the given order:
      * <ul>
      *     <li>close resources.</li>

--- a/hazelcast/src/test/java/com/hazelcast/cache/impl/InternalCacheRecordStoreTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/impl/InternalCacheRecordStoreTest.java
@@ -6,6 +6,11 @@ import com.hazelcast.cache.HazelcastCacheManager;
 import com.hazelcast.config.CacheConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.instance.Node;
+import com.hazelcast.instance.TestUtil;
+import com.hazelcast.partition.InternalPartitionService;
+import com.hazelcast.spi.impl.AbstractNamedOperation;
+import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.spi.impl.operationservice.InternalOperationService;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelTest;
@@ -18,20 +23,39 @@ import javax.cache.Cache;
 import javax.cache.configuration.FactoryBuilder;
 import javax.cache.configuration.MutableCacheEntryListenerConfiguration;
 
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class InternalCacheRecordStoreTest extends CacheTestSupport {
 
-    private TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+    private TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(2);
+
+    @Override
+    protected void onSetup() {
+    }
+
+    @Override
+    protected void onTearDown() {
+        factory.shutdownAll();
+    }
+
+    @Override
+    protected HazelcastInstance getHazelcastInstance() {
+        return factory.newHazelcastInstance(createConfig());
+    }
 
     /**
      * Test for issue: https://github.com/hazelcast/hazelcast/issues/6618
      */
     @Test
-    public void testBatchEventMapShouldBeCleanedAfterRemoveAll() {
+    public void batchEventMapShouldBeCleanedAfterRemoveAll() {
         String cacheName = randomString();
 
         CacheConfig<Integer, String> config = createCacheConfig();
@@ -64,17 +88,99 @@ public class InternalCacheRecordStoreTest extends CacheTestSupport {
         assertEquals(0, recordStore.batchEvent.size());
     }
 
-    @Override
-    protected void onSetup() {
+    /**
+     * Test for issue: https://github.com/hazelcast/hazelcast/issues/6983
+     */
+    @Test
+    public void ownerStateShouldBeUpdatedAfterMigration() throws ExecutionException, InterruptedException {
+        HazelcastCacheManager hzCacheManager = (HazelcastCacheManager) cacheManager;
+
+        HazelcastInstance instance1 = hzCacheManager.getHazelcastInstance();
+        Node node1 = TestUtil.getNode(instance1);
+        NodeEngineImpl nodeEngine1 = node1.getNodeEngine();
+        InternalPartitionService partitionService1 = nodeEngine1.getPartitionService();
+        int partitionCount = partitionService1.getPartitionCount();
+
+        String cacheName = randomName();
+        CacheConfig cacheConfig = new CacheConfig().setName(cacheName);
+        Cache cache = cacheManager.createCache(cacheName, cacheConfig);
+        String fullCacheName = hzCacheManager.getCacheNameWithPrefix(cacheName);
+
+        for (int i = 0; i < partitionCount; i++) {
+            String key = generateKeyForPartition(instance1, i);
+            cache.put(key, "Value");
+        }
+
+        for (int i = 0; i < partitionCount; i++) {
+            verifyPrimaryState(node1, fullCacheName, i, true);
+        }
+
+        HazelcastInstance instance2 = getHazelcastInstance();
+        Node node2 = TestUtil.getNode(instance2);
+
+        warmUpPartitions(instance1, instance2);
+        waitAllForSafeState(instance1, instance2);
+
+        for (int i = 0; i < partitionCount; i++) {
+            boolean ownedByNode1 = partitionService1.isPartitionOwner(i);
+            if (ownedByNode1) {
+                verifyPrimaryState(node1, fullCacheName, i, true);
+                verifyPrimaryState(node2, fullCacheName, i, false);
+            } else {
+                verifyPrimaryState(node1, fullCacheName, i, false);
+                verifyPrimaryState(node2, fullCacheName, i, true);
+            }
+        }
     }
 
-    @Override
-    protected void onTearDown() {
-        factory.terminateAll();
+    private void verifyPrimaryState(Node node, String fullCacheName, int partitionId, boolean expectedState)
+            throws ExecutionException, InterruptedException {
+        NodeEngineImpl nodeEngine = node.getNodeEngine();
+        InternalOperationService operationService = nodeEngine.getOperationService();
+        Future<Boolean> isPrimaryOnNode =
+                operationService.invokeOnTarget(ICacheService.SERVICE_NAME,
+                                                createCacheOwnerStateGetterOperation(fullCacheName, partitionId),
+                                                node.getThisAddress());
+        assertEquals(expectedState, isPrimaryOnNode.get());
     }
 
-    @Override
-    protected HazelcastInstance getHazelcastInstance() {
-        return factory.newHazelcastInstance(createConfig());
+    private CachePrimaryStateGetterOperation createCacheOwnerStateGetterOperation(String fullCacheName, int partitionId) {
+        CachePrimaryStateGetterOperation operation = new CachePrimaryStateGetterOperation(fullCacheName);
+        operation.setPartitionId(partitionId);
+        operation.setValidateTarget(false);
+        return operation;
     }
+
+    private static class CachePrimaryStateGetterOperation
+            extends AbstractNamedOperation {
+
+        private boolean isPrimary;
+
+        private CachePrimaryStateGetterOperation() {
+        }
+
+        private CachePrimaryStateGetterOperation(String cacheName) {
+            super(cacheName);
+        }
+
+        @Override
+        public void run() throws Exception {
+            ICacheService cacheService = getService();
+            AbstractCacheRecordStore cacheRecordStore =
+                    (AbstractCacheRecordStore) cacheService.getRecordStore(name, getPartitionId());
+            isPrimary = cacheRecordStore.primary;
+        }
+
+        @Override
+        public Object getResponse() {
+            return isPrimary;
+        }
+
+        @Override
+        public String getServiceName() {
+            return ICacheService.SERVICE_NAME;
+        }
+
+    }
+
 }


### PR DESCRIPTION
Fixes #6983 