### PR TITLE
NearCacheBatchInvalidator fixes

### DIFF
--- a/hazelcast-client-legacy/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientNearCacheBatchInvalidationTest.java
+++ b/hazelcast-client-legacy/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientNearCacheBatchInvalidationTest.java
@@ -57,7 +57,7 @@ public class ClientNearCacheBatchInvalidationTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void testBatchInvalidationWorks() throws Exception {
+    public void testBatchInvalidationRemovesEntries() throws Exception {
         Config config = getConfig();
         configureBatching(config, true, 10, 1);
         HazelcastInstance server = factory.newHazelcastInstance(config);

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientNearCacheBatchInvalidationTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientNearCacheBatchInvalidationTest.java
@@ -57,7 +57,7 @@ public class ClientNearCacheBatchInvalidationTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void testBatchInvalidationWorks() throws Exception {
+    public void testBatchInvalidationRemovesEntries() throws Exception {
         Config config = getConfig();
         configureBatching(config, true, 10, 1);
         HazelcastInstance server = factory.newHazelcastInstance(config);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContext.java
@@ -59,6 +59,8 @@ public interface MapServiceContext extends MapServiceContextInterceptorSupport, 
 
     MapContainer getMapContainer(String mapName);
 
+    MapContainer getOrNullMapContainer(String mapName);
+
     Map<String, MapContainer> getMapContainers();
 
     PartitionContainer getPartitionContainer(int partitionId);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
@@ -51,6 +51,7 @@ import com.hazelcast.spi.impl.operationservice.InternalOperationService;
 import com.hazelcast.util.ConcurrencyUtil;
 import com.hazelcast.util.ConstructorFunction;
 import com.hazelcast.util.ExceptionUtil;
+
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashSet;
@@ -146,6 +147,11 @@ class MapServiceContextImpl implements MapServiceContext {
     @Override
     public MapContainer getMapContainer(String mapName) {
         return ConcurrencyUtil.getOrPutSynchronized(mapContainers, mapName, mapContainers, mapConstructor);
+    }
+
+    @Override
+    public MapContainer getOrNullMapContainer(String mapName) {
+        return mapContainers.get(mapName);
     }
 
     @Override
@@ -482,11 +488,9 @@ class MapServiceContextImpl implements MapServiceContext {
         }
     }
 
-
     @Override
     public boolean removeEventListener(String mapName, String registrationId) {
         return eventService.deregisterListener(SERVICE_NAME, mapName, registrationId);
-
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/CleaningNearCacheInvalidation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/CleaningNearCacheInvalidation.java
@@ -18,7 +18,7 @@ package com.hazelcast.map.impl.nearcache;
 
 /**
  * Used when invalidating client near-caches.
- * When a client near-cache invalidation listener receives this data, the near-cache is cleared.
+ * When a client near-cache invalidation listener receives this data, it clears its near-cache.
  */
 public class CleaningNearCacheInvalidation extends Invalidation {
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/NearCacheInvalidator.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/NearCacheInvalidator.java
@@ -59,10 +59,10 @@ public interface NearCacheInvalidator {
      * Local near-caches are node local, remote near-caches can be exist on remote nodes or clients.
      *
      * @param mapName    name of the map.
-     * @param owner      <code>true</code> if this method is called from owner, otherwise <code>false</code>.
+     * @param owner      <code>true</code> if this method is called from partition owner, otherwise <code>false</code>.
      * @param sourceUuid caller uuid
      */
-    void clearNearCache(String mapName, boolean owner, String sourceUuid);
+    void clearNearCaches(String mapName, boolean owner, String sourceUuid);
 
     /**
      * Invalidates local and remote near-caches.
@@ -72,7 +72,7 @@ public interface NearCacheInvalidator {
      * @param key        key of the entry to be removed.
      * @param sourceUuid caller uuid
      */
-    void invalidateNearCache(String mapName, Data key, String sourceUuid);
+    void invalidateNearCaches(String mapName, Data key, String sourceUuid);
 
     /**
      * Invalidates local and remote near-caches.
@@ -82,7 +82,7 @@ public interface NearCacheInvalidator {
      * @param keys       keys of the entries to be removed.
      * @param sourceUuid caller uuid
      */
-    void invalidateNearCache(String mapName, List<Data> keys, String sourceUuid);
+    void invalidateNearCaches(String mapName, List<Data> keys, String sourceUuid);
 
     /**
      * Removes supplied maps invalidation queue and flushes its content.
@@ -90,5 +90,6 @@ public interface NearCacheInvalidator {
      *
      * @param mapName name of the map.
      */
-    void remove(String mapName);
+    void flushAndRemoveInvalidationQueue(String mapName);
+
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/NearCacheProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/NearCacheProvider.java
@@ -78,7 +78,7 @@ public class NearCacheProvider {
         if (nearCache != null) {
             nearCache.clear();
         }
-        nearCacheInvalidator.remove(mapName);
+        nearCacheInvalidator.flushAndRemoveInvalidationQueue(mapName);
     }
 
     public Object getFromNearCache(String mapName, Data key) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperation.java
@@ -80,16 +80,16 @@ public abstract class MapOperation extends AbstractNamedOperation {
 
     protected final void invalidateNearCache(List<Data> keys) {
         NearCacheProvider nearCacheProvider = mapServiceContext.getNearCacheProvider();
-        nearCacheProvider.getNearCacheInvalidator().invalidateNearCache(name, keys, getCallerUuid());
+        nearCacheProvider.getNearCacheInvalidator().invalidateNearCaches(name, keys, getCallerUuid());
     }
 
     protected final void invalidateNearCache(Data key) {
         NearCacheProvider nearCacheProvider = mapServiceContext.getNearCacheProvider();
-        nearCacheProvider.getNearCacheInvalidator().invalidateNearCache(name, key, getCallerUuid());
+        nearCacheProvider.getNearCacheInvalidator().invalidateNearCaches(name, key, getCallerUuid());
     }
 
     protected final void clearNearCache(boolean owner) {
         NearCacheProvider nearCacheProvider = mapServiceContext.getNearCacheProvider();
-        nearCacheProvider.getNearCacheInvalidator().clearNearCache(name, owner, getCallerUuid());
+        nearCacheProvider.getNearCacheInvalidator().clearNearCaches(name, owner, getCallerUuid());
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/NearCacheBatchInvalidationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/NearCacheBatchInvalidationTest.java
@@ -52,7 +52,7 @@ import static org.junit.Assert.assertEquals;
 public class NearCacheBatchInvalidationTest extends HazelcastTestSupport {
 
     @Test
-    public void testBatchInvalidationWorks() throws Exception {
+    public void testBatchInvalidationRemovesEntries() throws Exception {
         String mapName = randomMapName();
         Config config = newConfig(mapName);
         config.setProperty(GroupProperty.PARTITION_COUNT, "1");


### PR DESCRIPTION
- Fixed mapConfig retrieval complexity by getting it from mapContainer
- Fixed unnecessary object creation in `NearCacheInvalidatorImpl`