### PR TITLE
Value/response made volatile, added null check to callback too

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/util/ClientDelegatingFuture.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/util/ClientDelegatingFuture.java
@@ -45,7 +45,7 @@ public class ClientDelegatingFuture<V> implements ICompletableFuture<V> {
     private final Object mutex = new Object();
     private Throwable error;
     private V deserializedValue;
-    private Object response;
+    private volatile Object response;
     private volatile boolean done;
 
     public ClientDelegatingFuture(ClientInvocationFuture clientInvocationFuture,
@@ -194,9 +194,9 @@ public class ClientDelegatingFuture<V> implements ICompletableFuture<V> {
 
         @Override
         public void onResponse(ClientMessage message) {
-            if (!done) {
+            if (!done || response == null) {
                 synchronized (mutex) {
-                    if (!done) {
+                    if (!done || response == null) {
                         response = resolveMessageToValue(message);
                         if (shouldDeserializeData && deserializedValue == null) {
                             deserializedValue = serializationService.toObject(response);

--- a/hazelcast/src/main/java/com/hazelcast/util/executor/DelegatingFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/executor/DelegatingFuture.java
@@ -36,8 +36,8 @@ public class DelegatingFuture<V> implements ICompletableFuture<V> {
     private final V defaultValue;
     private final boolean hasDefaultValue;
     private final Object mutex = new Object();
-    private V value;
     private Throwable error;
+    private volatile V value;
     private volatile boolean done;
 
     public DelegatingFuture(ICompletableFuture future, SerializationService serializationService) {
@@ -159,9 +159,9 @@ public class DelegatingFuture<V> implements ICompletableFuture<V> {
 
         @Override
         public void onResponse(Object response) {
-            if (!done) {
+            if (!done || value == null) {
                 synchronized (mutex) {
-                    if (!done) {
+                    if (!done || value == null) {
                         value = getResult(response);
                         done = true;
                     }


### PR DESCRIPTION
double-checking without marking field as volatile does not work, thank you findbugs for reminding.
It also reminded me to add the null check of the value/response to callback too, since it may suffer from the race in cancel