### PR TITLE
Value/response made volatile, added null check to callback too, removed redundant null check getService

### DIFF
--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/util/ClientDelegatingFuture.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/util/ClientDelegatingFuture.java
@@ -45,7 +45,7 @@ public class ClientDelegatingFuture<V> implements ICompletableFuture<V> {
     private final Object mutex = new Object();
     private Throwable error;
     private V deserializedValue;
-    private Object response;
+    private volatile Object response;
     private volatile boolean done;
 
     public ClientDelegatingFuture(ClientInvocationFuture clientInvocationFuture,
@@ -194,9 +194,9 @@ public class ClientDelegatingFuture<V> implements ICompletableFuture<V> {
 
         @Override
         public void onResponse(ClientMessage message) {
-            if (!done) {
+            if (!done || response == null) {
                 synchronized (mutex) {
-                    if (!done) {
+                    if (!done || response == null) {
                         response = resolveMessageToValue(message);
                         if (shouldDeserializeData && deserializedValue == null) {
                             deserializedValue = serializationService.toObject(response);

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/EventPacketProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/EventPacketProcessor.java
@@ -41,7 +41,7 @@ public class EventPacketProcessor implements StripedRunnable {
         Object eventObject = getEventObject(eventPacket);
         String serviceName = eventPacket.getServiceName();
 
-        EventPublishingService<Object, Object> service = getPublishingService(serviceName);
+        EventPublishingService<Object, Object> service = eventService.nodeEngine.getService(serviceName);
 
         Registration registration = getRegistration(eventPacket, serviceName);
         if (registration == null) {
@@ -50,16 +50,6 @@ public class EventPacketProcessor implements StripedRunnable {
         service.dispatchEvent(eventObject, registration.getListener());
     }
 
-    private EventPublishingService<Object, Object> getPublishingService(String serviceName) {
-        EventPublishingService<Object, Object> service = eventService.nodeEngine.getService(serviceName);
-        if (service == null) {
-            if (eventService.nodeEngine.isActive()) {
-                eventService.logger.warning("There is no service named: " + serviceName);
-            }
-            return null;
-        }
-        return service;
-    }
 
     private Registration getRegistration(EventPacket eventPacket, String serviceName) {
         EventServiceSegment segment = eventService.getSegment(serviceName, false);

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/ProxyRegistry.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/ProxyRegistry.java
@@ -27,6 +27,7 @@ import com.hazelcast.spi.impl.DistributedObjectEventPacket;
 import com.hazelcast.spi.impl.eventservice.InternalEventService;
 import com.hazelcast.util.EmptyStatement;
 import com.hazelcast.util.ExceptionUtil;
+
 import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -49,20 +50,7 @@ public final class ProxyRegistry {
     ProxyRegistry(ProxyServiceImpl proxyService, String serviceName) {
         this.proxyService = proxyService;
         this.serviceName = serviceName;
-        this.service = getService(proxyService, serviceName);
-    }
-
-    private RemoteService getService(ProxyServiceImpl proxyService, String serviceName) {
-        RemoteService service = proxyService.nodeEngine.getService(serviceName);
-        if (service != null) {
-            return service;
-        }
-
-        if (proxyService.nodeEngine.isActive()) {
-            throw new IllegalArgumentException("Unknown service: " + serviceName);
-        } else {
-            throw new HazelcastInstanceNotActiveException();
-        }
+        this.service = proxyService.nodeEngine.getService(serviceName);
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/util/executor/DelegatingFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/executor/DelegatingFuture.java
@@ -35,8 +35,8 @@ public class DelegatingFuture<V> implements ICompletableFuture<V> {
     private final V defaultValue;
     private final boolean hasDefaultValue;
     private final Object mutex = new Object();
-    private V value;
     private Throwable error;
+    private volatile V value;
     private volatile boolean done;
 
     public DelegatingFuture(ICompletableFuture future, SerializationService serializationService) {
@@ -158,9 +158,9 @@ public class DelegatingFuture<V> implements ICompletableFuture<V> {
 
         @Override
         public void onResponse(Object response) {
-            if (!done) {
+            if (!done || value == null) {
                 synchronized (mutex) {
-                    if (!done) {
+                    if (!done || value == null) {
                         value = getResult(response);
                         done = true;
                     }


### PR DESCRIPTION
backport of https://github.com/hazelcast/hazelcast/pull/6995
added another findbugs fix: removed redundant null check. `NodeEngine.getService()` never returns null, throws exception in case of the service not found