### PR TITLE
TransactionalQueue.poll not rolled back correctly on backup

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueContainer.java
@@ -149,7 +149,7 @@ public class QueueContainer implements IdentifiedDataSerializable {
     public void txnPollBackupReserve(long itemId, String transactionId) {
         QueueItem item = getBackupMap().remove(itemId);
         if (item == null) {
-            logger.warning("Backup reserve failed, itemId: " + itemId);
+            logger.warning("Backup reserve failed, itemId: " + itemId + " is not found");
             return;
         }
         txMap.put(itemId, new TxQueueItem(item).setPollOperation(true).setTransactionId(transactionId));
@@ -182,7 +182,10 @@ public class QueueContainer implements IdentifiedDataSerializable {
         if (item == null) {
             return false;
         }
-        if (!backup) {
+
+        if (backup) {
+            getBackupMap().put(itemId, item);
+        } else {
             addTxItemOrdered(item);
         }
         cancelEvictionIfExists();

--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/txnqueue/TransactionQueueTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/txnqueue/TransactionQueueTest.java
@@ -31,7 +31,8 @@ import com.hazelcast.transaction.TransactionContext;
 import com.hazelcast.transaction.TransactionException;
 import com.hazelcast.transaction.TransactionNotActiveException;
 import com.hazelcast.transaction.TransactionOptions;
-import org.junit.Ignore;
+import com.hazelcast.transaction.TransactionalTask;
+import com.hazelcast.transaction.TransactionalTaskContext;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -310,6 +311,44 @@ public class TransactionQueueTest extends HazelcastTestSupport {
             moveMessage1.interrupt();
             moveMessage2.interrupt();
         }
+    }
+
+    // https://github.com/hazelcast/hazelcast/issues/6259
+    @Test
+    public void issue_6259_backupNotRollingBackCorrectly() {
+        HazelcastInstance[] cluster = createHazelcastInstanceFactory(2).newInstances();
+        HazelcastInstance local = cluster[0];
+        HazelcastInstance remote = cluster[1];
+        final String queueName = generateKeyOwnedBy(remote);
+
+        // first we add an item
+        local.executeTransaction(new TransactionalTask<Object>() {
+            @Override
+            public Object execute(TransactionalTaskContext context) throws TransactionException {
+                TransactionalQueue<String> queue = context.getQueue(queueName);
+                queue.offer("item");
+                return null;
+            }
+        });
+
+        // we remove the item and then do a rollback. This causes the local (backup) to become out
+        // of sync with the remote (primary)
+        TransactionContext firstCtxt = local.newTransactionContext();
+        firstCtxt.beginTransaction();
+        TransactionalQueue<String> queue = firstCtxt.getQueue(queueName);
+        queue.poll();
+        firstCtxt.rollbackTransaction();
+
+        // we kill the remote. Now the local (which was the backup) is going to become primary
+        remote.shutdown();
+
+        // if we take the item, we should get an error
+        TransactionContext secondCtxt = local.newTransactionContext();
+        secondCtxt.beginTransaction();
+        queue = secondCtxt.getQueue(queueName);
+
+        String found = queue.poll();
+        assertEquals("item", found);
     }
 
     @Test


### PR DESCRIPTION
Fixes #6259

The problem was that on the backup the poll was not rolled back correctly. So the backup becomes
out of sync with the primary. This can not only lead to logging noise, but in case of a failover,
data is lost.