### PR TITLE
Server should respond to authentication message when node is not active

### DIFF
--- a/hazelcast-client-new/src/test/java/com/hazelcast/client/ClientRegressionWithRealNetworkTest.java
+++ b/hazelcast-client-new/src/test/java/com/hazelcast/client/ClientRegressionWithRealNetworkTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client;
+
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.config.Config;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class ClientRegressionWithRealNetworkTest extends HazelcastTestSupport {
+
+    @After
+    public void cleanUp() {
+        HazelcastClient.shutdownAll();
+        Hazelcast.shutdownAll();
+    }
+
+    @Test
+    public void testClientPortConnection() {
+        final Config config1 = new Config();
+        config1.getGroupConfig().setName("foo");
+        config1.getNetworkConfig().setPort(5701);
+        final HazelcastInstance instance1 = Hazelcast.newHazelcastInstance(config1);
+        instance1.getMap("map").put("key", "value");
+
+        final Config config2 = new Config();
+        config2.getGroupConfig().setName("bar");
+        config2.getNetworkConfig().setPort(5702);
+        Hazelcast.newHazelcastInstance(config2);
+
+        final ClientConfig clientConfig = new ClientConfig();
+        clientConfig.getGroupConfig().setName("bar");
+        final HazelcastInstance client = HazelcastClient.newHazelcastClient(clientConfig);
+
+        final IMap<Object, Object> map = client.getMap("map");
+        assertNull(map.put("key", "value"));
+        assertEquals(1, map.size());
+    }
+
+    @Test
+    public void testClientConnectionBeforeServerReady() throws InterruptedException {
+        ExecutorService executorService = Executors.newFixedThreadPool(2);
+        executorService.submit(new Runnable() {
+            @Override
+            public void run() {
+                Hazelcast.newHazelcastInstance();
+            }
+        });
+
+        final CountDownLatch clientLatch = new CountDownLatch(1);
+        executorService.submit(new Runnable() {
+            @Override
+            public void run() {
+                ClientConfig config = new ClientConfig();
+                config.getNetworkConfig().setConnectionAttemptLimit(10);
+                HazelcastClient.newHazelcastClient(config);
+                clientLatch.countDown();
+            }
+        });
+
+        assertOpenEventually(clientLatch);
+    }
+}
+
+

--- a/hazelcast-client/src/test/java/com/hazelcast/client/ClientRegressionWithRealNetworkTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ClientRegressionWithRealNetworkTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client;
+
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.config.Config;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class ClientRegressionWithRealNetworkTest extends HazelcastTestSupport {
+
+    @After
+    public void cleanUp() {
+        HazelcastClient.shutdownAll();
+        Hazelcast.shutdownAll();
+    }
+
+    @Test
+    public void testClientPortConnection() {
+        final Config config1 = new Config();
+        config1.getGroupConfig().setName("foo");
+        config1.getNetworkConfig().setPort(5701);
+        final HazelcastInstance instance1 = Hazelcast.newHazelcastInstance(config1);
+        instance1.getMap("map").put("key", "value");
+
+        final Config config2 = new Config();
+        config2.getGroupConfig().setName("bar");
+        config2.getNetworkConfig().setPort(5702);
+        HazelcastInstance instance2 = Hazelcast.newHazelcastInstance(config2);
+
+        final ClientConfig clientConfig = new ClientConfig();
+        clientConfig.getGroupConfig().setName("bar");
+        final HazelcastInstance client = HazelcastClient.newHazelcastClient(clientConfig);
+
+        final IMap<Object, Object> map = client.getMap("map");
+        assertNull(map.put("key", "value"));
+        assertEquals(1, map.size());
+    }
+
+    @Test
+    public void testClientConnectionBeforeServerReady() throws InterruptedException {
+        ExecutorService executorService = Executors.newFixedThreadPool(2);
+        executorService.submit(new Runnable() {
+            @Override
+            public void run() {
+                Hazelcast.newHazelcastInstance();
+            }
+        });
+
+        final CountDownLatch clientLatch = new CountDownLatch(1);
+        executorService.submit(new Runnable() {
+            @Override
+            public void run() {
+                ClientConfig config = new ClientConfig();
+                config.getNetworkConfig().setConnectionAttemptLimit(10);
+                HazelcastClient.newHazelcastClient(config);
+                clientLatch.countDown();
+            }
+        });
+
+        assertOpenEventually(clientLatch);
+    }
+}
+
+

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractMessageTask.java
@@ -156,7 +156,7 @@ public abstract class AbstractMessageTask<P>
     }
 
     private void handleProcessingFailure(Throwable throwable) {
-        if (parameters != null && endpoint != null) {
+        if (endpoint != null) {
             sendClientMessage(throwable);
         }
     }


### PR DESCRIPTION
This seems to be a regression after the message decoding was moved
 to partition thread. When the node is not active, the error message
is not sent back to the client

Backport of : https://github.com/hazelcast/hazelcast/pull/6926