### PR TITLE
Send correct exceptions to client

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractMessageTask.java
@@ -33,6 +33,7 @@ import com.hazelcast.nio.Connection;
 import com.hazelcast.security.Credentials;
 import com.hazelcast.security.SecurityContext;
 import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.util.ExceptionUtil;
 
 import java.security.Permission;
 import java.util.logging.Level;
@@ -234,7 +235,7 @@ public abstract class AbstractMessageTask<P>
     }
 
     protected void sendClientMessage(Throwable throwable) {
-        ClientMessage exception = createExceptionMessage(throwable);
+        ClientMessage exception = createExceptionMessage(ExceptionUtil.peel(throwable));
         sendClientMessage(exception);
     }
 


### PR DESCRIPTION
Before exceptions send to client, they will get through a similar
method like ExceptionUtil.rethrow so that clients can get real
exception.

related to https://github.com/hazelcast/hazelcast/issues/6970