### PR TITLE
Added serialization constants for Hibernate 5.

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/SerializationConstants.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/SerializationConstants.java
@@ -83,8 +83,6 @@ public final class SerializationConstants {
     // NUMBER OF CONSTANT SERIALIZERS...
     public static final int CONSTANT_SERIALIZERS_LENGTH = 28;
 
-
-
     // ------------------------------------------------------------
     // JAVA SERIALIZATION
 
@@ -99,6 +97,10 @@ public final class SerializationConstants {
 
     public static final int HIBERNATE4_TYPE_HIBERNATE_CACHE_KEY = -202;
     public static final int HIBERNATE4_TYPE_HIBERNATE_CACHE_ENTRY = -203;
+
+    public static final int HIBERNATE5_TYPE_HIBERNATE_CACHE_KEY = -204;
+    public static final int HIBERNATE5_TYPE_HIBERNATE_CACHE_ENTRY = -205;
+    public static final int HIBERNATE5_TYPE_HIBERNATE_NATURAL_ID_KEY = -206;
 
     private SerializationConstants() {
     }


### PR DESCRIPTION
- Essentially duplicates hazelcast-hibernate4, with API/SPI updates for Hibernate 5
- Unlike Hibernate 4, on Hibernate 5 there are different cache key types for collection/entity and natural ID, so two serializers are required
    - The CacheKey class has been renamed to OldCacheKeyImplementation, and is now package-private, so serialization must be done entirely via Reflection
    - The StreamSerializer implementations for both of the key types are StreamSerializer<Object> because the types they're bound to are package-private