### PR TITLE
Code coverage and fix for client specific MemberImpl

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/MemberImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/MemberImpl.java
@@ -27,12 +27,10 @@ import java.util.Map;
 /**
  * Client side specific Member implementation.
  *
- * <p>Caution: This class is required by protocol encoder/decoder which are on hazelcast module
- * so this impl also stays in the same module, although it is totally client side specific</p>
+ * <p>Caution: This class is required by protocol encoder/decoder which are on the Hazelcast module.
+ * So this implementation also stays in the same module, although it is totally client side specific.</p>
  */
-public final class MemberImpl
-        extends AbstractMember
-        implements Member {
+public final class MemberImpl extends AbstractMember implements Member {
 
     public MemberImpl() {
     }
@@ -70,94 +68,93 @@ public final class MemberImpl
 
     @Override
     public void setStringAttribute(String key, String value) {
-        notSupportedOnClient();
+        throw notSupportedOnClient();
     }
 
     @SuppressFBWarnings(value = "NP_BOOLEAN_RETURN_NULL", justification = "null means 'missing'")
     @Override
     public Boolean getBooleanAttribute(String key) {
-        final Object attribute = getAttribute(key);
+        Object attribute = getAttribute(key);
         return attribute != null ? Boolean.valueOf(attribute.toString()) : null;
     }
 
     @Override
     public void setBooleanAttribute(String key, boolean value) {
-        notSupportedOnClient();
+        throw notSupportedOnClient();
     }
 
     @Override
     public Byte getByteAttribute(String key) {
-        final Object attribute = getAttribute(key);
+        Object attribute = getAttribute(key);
         return attribute != null ? Byte.valueOf(attribute.toString()) : null;
     }
 
     @Override
     public void setByteAttribute(String key, byte value) {
-        notSupportedOnClient();
+        throw notSupportedOnClient();
     }
 
     @Override
     public Short getShortAttribute(String key) {
-        final Object attribute = getAttribute(key);
+        Object attribute = getAttribute(key);
         return attribute != null ? Short.valueOf(attribute.toString()) : null;
     }
 
     @Override
     public void setShortAttribute(String key, short value) {
-        notSupportedOnClient();
+        throw notSupportedOnClient();
     }
 
     @Override
     public Integer getIntAttribute(String key) {
-        final Object attribute = getAttribute(key);
+        Object attribute = getAttribute(key);
         return attribute != null ? Integer.valueOf(attribute.toString()) : null;
     }
 
     @Override
     public void setIntAttribute(String key, int value) {
-        notSupportedOnClient();
+        throw notSupportedOnClient();
     }
 
     @Override
     public Long getLongAttribute(String key) {
-        final Object attribute = getAttribute(key);
-        return attribute != null ? Long.getLong(attribute.toString()) : null;
+        Object attribute = getAttribute(key);
+        return attribute != null ? Long.valueOf(attribute.toString()) : null;
     }
 
     @Override
     public void setLongAttribute(String key, long value) {
-        notSupportedOnClient();
+        throw notSupportedOnClient();
     }
 
     @Override
     public Float getFloatAttribute(String key) {
-        final Object attribute = getAttribute(key);
+        Object attribute = getAttribute(key);
         return attribute != null ? Float.valueOf(attribute.toString()) : null;
     }
 
     @Override
     public void setFloatAttribute(String key, float value) {
-        notSupportedOnClient();
+        throw notSupportedOnClient();
     }
 
     @Override
     public Double getDoubleAttribute(String key) {
-        final Object attribute = getAttribute(key);
+        Object attribute = getAttribute(key);
         return attribute != null ? Double.valueOf(attribute.toString()) : null;
     }
 
     @Override
     public void setDoubleAttribute(String key, double value) {
-        notSupportedOnClient();
+        throw notSupportedOnClient();
     }
 
     @Override
     public void removeAttribute(String key) {
-        notSupportedOnClient();
+        throw notSupportedOnClient();
     }
 
-    private void notSupportedOnClient() {
-        throw new UnsupportedOperationException("Attributes on remote members must not be changed");
+    private UnsupportedOperationException notSupportedOnClient() {
+        return new UnsupportedOperationException("Attributes on remote members must not be changed");
     }
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/MemberImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/MemberImplTest.java
@@ -1,0 +1,182 @@
+package com.hazelcast.client.impl;
+
+import com.hazelcast.nio.Address;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class MemberImplTest extends HazelcastTestSupport {
+
+    private static Address address;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        address = new Address("127.0.0.1", 5701);
+    }
+
+    @Test
+    public void testConstructor() {
+        MemberImpl member = new MemberImpl();
+
+        assertNull(member.getAddress());
+        assertFalse(member.localMember());
+        assertFalse(member.isLiteMember());
+    }
+
+    @Test
+    public void testConstructor_withAddress() {
+        MemberImpl member = new MemberImpl(address);
+
+        assertBasicMemberImplFields(member);
+        assertFalse(member.isLiteMember());
+    }
+
+    @Test
+    public void testConstructor_withAddressAndUUid() {
+        MemberImpl member = new MemberImpl(address, "uuid2342");
+
+        assertBasicMemberImplFields(member);
+        assertEquals("uuid2342", member.getUuid());
+        assertFalse(member.isLiteMember());
+    }
+
+    @Test
+    public void testConstructor_withAttributes() throws Exception {
+        Map<String, Object> attributes = new HashMap<String, Object>();
+        attributes.put("stringKey", "value");
+        attributes.put("booleanKeyTrue", true);
+        attributes.put("booleanKeyFalse", false);
+        attributes.put("byteKey", Byte.MAX_VALUE);
+        attributes.put("shortKey", Short.MAX_VALUE);
+        attributes.put("intKey", Integer.MAX_VALUE);
+        attributes.put("longKey", Long.MAX_VALUE);
+        attributes.put("floatKey", Float.MAX_VALUE);
+        attributes.put("doubleKey", Double.MAX_VALUE);
+
+        MemberImpl member = new MemberImpl(address, "uuid2342", attributes, true);
+
+        assertBasicMemberImplFields(member);
+        assertEquals("uuid2342", member.getUuid());
+        assertTrue(member.isLiteMember());
+
+        assertEquals("value", member.getStringAttribute("stringKey"));
+        assertNull(member.getBooleanAttribute("booleanKey"));
+
+        Boolean booleanValueTrue = member.getBooleanAttribute("booleanKeyTrue");
+        assertNotNull(booleanValueTrue);
+        assertTrue(booleanValueTrue);
+
+        Boolean booleanValueFalse = member.getBooleanAttribute("booleanKeyFalse");
+        assertNotNull(booleanValueFalse);
+        assertFalse(booleanValueFalse);
+
+        Byte byteValue = member.getByteAttribute("byteKey");
+        assertNotNull(byteValue);
+        assertEquals(Byte.MAX_VALUE, byteValue.byteValue());
+
+        Short shortValue = member.getShortAttribute("shortKey");
+        assertNotNull(shortValue);
+        assertEquals(Short.MAX_VALUE, shortValue.shortValue());
+
+        Integer intValue = member.getIntAttribute("intKey");
+        assertNotNull(intValue);
+        assertEquals(Integer.MAX_VALUE, intValue.intValue());
+
+        Long longValue = member.getLongAttribute("longKey");
+        assertNotNull(longValue);
+        assertEquals(Long.MAX_VALUE, longValue.longValue());
+
+        Float floatValue = member.getFloatAttribute("floatKey");
+        assertNotNull(floatValue);
+        assertEquals(Float.MAX_VALUE, floatValue, 0.000001);
+
+        Double doubleValue = member.getDoubleAttribute("doubleKey");
+        assertNotNull(doubleValue);
+        assertEquals(Double.MAX_VALUE, doubleValue, 0.000001);
+    }
+
+    @Test
+    public void testConstructor_withMemberImpl() {
+        MemberImpl member = new MemberImpl(new MemberImpl(address));
+
+        assertBasicMemberImplFields(member);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testSetStringAttribute() {
+        MemberImpl member = new MemberImpl(address);
+        member.setStringAttribute("stringKey", "stringValue");
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testSetBooleanAttribute() {
+        MemberImpl member = new MemberImpl(address);
+        member.setBooleanAttribute("booleanKeyTrue", true);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testSetByteAttribute() {
+        MemberImpl member = new MemberImpl(address);
+        member.setByteAttribute("byteKey", Byte.MAX_VALUE);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testSetShortAttribute() {
+        MemberImpl member = new MemberImpl(address);
+        member.setShortAttribute("shortKey", Short.MAX_VALUE);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testSetIntAttribute() {
+        MemberImpl member = new MemberImpl(address);
+        member.setIntAttribute("intKey", Integer.MAX_VALUE);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testSetLongAttribute() {
+        MemberImpl member = new MemberImpl(address);
+        member.setLongAttribute("longKey", Long.MAX_VALUE);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testSetFloatAttribute() {
+        MemberImpl member = new MemberImpl(address);
+        member.setFloatAttribute("floatKey", Float.MAX_VALUE);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testSetDoubleAttribute() {
+        MemberImpl member = new MemberImpl(address);
+        member.setDoubleAttribute("doubleKey", Double.MAX_VALUE);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testRemoveAttribute() {
+        MemberImpl member = new MemberImpl(address);
+        member.removeAttribute("removeKey");
+    }
+
+    private static void assertBasicMemberImplFields(MemberImpl member) {
+        assertEquals(address, member.getAddress());
+        assertEquals(5701, member.getPort());
+        assertEquals("127.0.0.1", member.getInetAddress().getHostAddress());
+        assertNull(member.getLogger());
+        assertFalse(member.localMember());
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/instance/MemberImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/MemberImplTest.java
@@ -28,8 +28,6 @@ public class MemberImplTest extends HazelcastTestSupport {
     private static HazelcastInstanceImpl hazelcastInstance;
     private static Address address;
 
-    private MemberImpl member;
-
     @BeforeClass
     public static void setUp() throws Exception {
         hazelcastInstance = new HazelcastInstanceImpl("test", new Config(), new DefaultNodeContext());
@@ -43,43 +41,43 @@ public class MemberImplTest extends HazelcastTestSupport {
 
     @Test
     public void testConstructor_withLocalMember_isTrue() {
-        member = new MemberImpl(address, true);
+        MemberImpl member = new MemberImpl(address, true);
 
-        assertMemberImpl();
+        assertBasicMemberImplFields(member);
         assertTrue(member.localMember());
     }
 
     @Test
     public void testConstructor_withLocalMember_isFalse() {
-        member = new MemberImpl(address, false);
+        MemberImpl member = new MemberImpl(address, false);
 
-        assertMemberImpl();
+        assertBasicMemberImplFields(member);
         assertFalse(member.localMember());
     }
 
     @Test
     public void testConstructor_withLiteMember_isTrue() {
-        member = new MemberImpl(address, true, true);
+        MemberImpl member = new MemberImpl(address, true, true);
 
-        assertMemberImpl();
+        assertBasicMemberImplFields(member);
         assertTrue(member.localMember());
         assertTrue(member.isLiteMember());
     }
 
     @Test
     public void testConstructor_withLiteMember_isFalse() {
-        member = new MemberImpl(address, true, false);
+        MemberImpl member = new MemberImpl(address, true, false);
 
-        assertMemberImpl();
+        assertBasicMemberImplFields(member);
         assertTrue(member.localMember());
         assertFalse(member.isLiteMember());
     }
 
     @Test
     public void testConstructor_withHazelcastInstance() throws Exception {
-        member = new MemberImpl(address, true, "uuid2342", hazelcastInstance);
+        MemberImpl member = new MemberImpl(address, true, "uuid2342", hazelcastInstance);
 
-        assertMemberImpl();
+        assertBasicMemberImplFields(member);
         assertTrue(member.localMember());
         assertEquals("uuid2342", member.getUuid());
     }
@@ -90,9 +88,9 @@ public class MemberImplTest extends HazelcastTestSupport {
         attributes.put("key1", "value");
         attributes.put("key2", 12345);
 
-        member = new MemberImpl(address, true, "uuid2342", hazelcastInstance, attributes, false);
+        MemberImpl member = new MemberImpl(address, true, "uuid2342", hazelcastInstance, attributes, false);
 
-        assertMemberImpl();
+        assertBasicMemberImplFields(member);
         assertTrue(member.localMember());
         assertEquals("uuid2342", member.getUuid());
         assertEquals("value", member.getAttribute("key1"));
@@ -102,15 +100,15 @@ public class MemberImplTest extends HazelcastTestSupport {
 
     @Test
     public void testConstructor_withMemberImpl() {
-        member = new MemberImpl(new MemberImpl(address, true));
+        MemberImpl member = new MemberImpl(new MemberImpl(address, true));
 
-        assertMemberImpl();
+        assertBasicMemberImplFields(member);
         assertTrue(member.localMember());
     }
 
     @Test
     public void testSetHazelcastInstance() throws Exception {
-        member = new MemberImpl(address, true);
+        MemberImpl member = new MemberImpl(address, true);
         assertNull(member.getLogger());
 
         member.setHazelcastInstance(hazelcastInstance);
@@ -120,7 +118,7 @@ public class MemberImplTest extends HazelcastTestSupport {
 
     @Test
     public void testStringAttribute() {
-        member = new MemberImpl(address, true);
+        MemberImpl member = new MemberImpl(address, true);
         assertNull(member.getStringAttribute("stringKey"));
 
         member.setStringAttribute("stringKey", "stringValue");
@@ -129,7 +127,7 @@ public class MemberImplTest extends HazelcastTestSupport {
 
     @Test
     public void testBooleanAttribute() {
-        member = new MemberImpl(address, true);
+        MemberImpl member = new MemberImpl(address, true);
         assertNull(member.getBooleanAttribute("booleanKeyTrue"));
         assertNull(member.getBooleanAttribute("booleanKeyFalse"));
 
@@ -142,7 +140,7 @@ public class MemberImplTest extends HazelcastTestSupport {
 
     @Test
     public void testByteAttribute() {
-        member = new MemberImpl(address, true);
+        MemberImpl member = new MemberImpl(address, true);
         assertNull(member.getByteAttribute("byteKey"));
 
         Byte value = Byte.MAX_VALUE;
@@ -152,7 +150,7 @@ public class MemberImplTest extends HazelcastTestSupport {
 
     @Test
     public void testShortAttribute() {
-        member = new MemberImpl(address, true);
+        MemberImpl member = new MemberImpl(address, true);
         assertNull(member.getShortAttribute("shortKey"));
 
         Short value = Short.MAX_VALUE;
@@ -162,7 +160,7 @@ public class MemberImplTest extends HazelcastTestSupport {
 
     @Test
     public void testIntAttribute() {
-        member = new MemberImpl(address, true);
+        MemberImpl member = new MemberImpl(address, true);
         assertNull(member.getIntAttribute("intKey"));
 
         Integer value = Integer.MAX_VALUE;
@@ -172,7 +170,7 @@ public class MemberImplTest extends HazelcastTestSupport {
 
     @Test
     public void testLongAttribute() {
-        member = new MemberImpl(address, true);
+        MemberImpl member = new MemberImpl(address, true);
         assertNull(member.getLongAttribute("longKey"));
 
         Long value = Long.MAX_VALUE;
@@ -182,7 +180,7 @@ public class MemberImplTest extends HazelcastTestSupport {
 
     @Test
     public void testFloatAttribute() {
-        member = new MemberImpl(address, true);
+        MemberImpl member = new MemberImpl(address, true);
         assertNull(member.getFloatAttribute("floatKey"));
 
         Float value = Float.MAX_VALUE;
@@ -192,7 +190,7 @@ public class MemberImplTest extends HazelcastTestSupport {
 
     @Test
     public void testDoubleAttribute() {
-        member = new MemberImpl(address, true);
+        MemberImpl member = new MemberImpl(address, true);
         assertNull(member.getDoubleAttribute("doubleKey"));
 
         Double value = Double.MAX_VALUE;
@@ -202,7 +200,7 @@ public class MemberImplTest extends HazelcastTestSupport {
 
     @Test
     public void testRemoveAttribute() {
-        member = new MemberImpl(address, true);
+        MemberImpl member = new MemberImpl(address, true);
         assertNull(member.getStringAttribute("removeKey"));
 
         member.setStringAttribute("removeKey", "removeValue");
@@ -214,7 +212,7 @@ public class MemberImplTest extends HazelcastTestSupport {
 
     @Test
     public void testRemoveAttribute_withHazelcastInstance() {
-        member = new MemberImpl(address, true, "uuid", hazelcastInstance);
+        MemberImpl member = new MemberImpl(address, true, "uuid", hazelcastInstance);
 
         member.removeAttribute("removeKeyWithInstance");
         assertNull(member.getStringAttribute("removeKeyWithInstance"));
@@ -222,7 +220,7 @@ public class MemberImplTest extends HazelcastTestSupport {
 
     @Test
     public void testSetAttribute_withHazelcastInstance() {
-        member = new MemberImpl(address, true, "uuid", hazelcastInstance);
+        MemberImpl member = new MemberImpl(address, true, "uuid", hazelcastInstance);
 
         member.setStringAttribute("setKeyWithInstance", "setValueWithInstance");
         assertEquals("setValueWithInstance", member.getStringAttribute("setKeyWithInstance"));
@@ -230,17 +228,17 @@ public class MemberImplTest extends HazelcastTestSupport {
 
     @Test(expected = UnsupportedOperationException.class)
     public void testRemoveAttribute_onRemoteMember() {
-        member = new MemberImpl(address, false);
+        MemberImpl member = new MemberImpl(address, false);
         member.removeAttribute("remoteMemberRemove");
     }
 
     @Test(expected = UnsupportedOperationException.class)
     public void testSetAttribute_onRemoteMember() {
-        member = new MemberImpl(address, false);
+        MemberImpl member = new MemberImpl(address, false);
         member.setStringAttribute("remoteMemberSet", "wontWork");
     }
 
-    private void assertMemberImpl() {
+    private static void assertBasicMemberImplFields(MemberImpl member) {
         assertEquals(address, member.getAddress());
         assertEquals(5701, member.getPort());
         assertEquals("127.0.0.1", member.getInetAddress().getHostAddress());


### PR DESCRIPTION
* Increased code coverage of client specific `MemberImpl`
* Fixed bug in `getLongAttribute()`

The client class was accidentically covered by the QA whitelisting. Actually the `MemberImpl.getLongAttribute()` was using a wrong method to retrieve the Long value, which was not detected due to missing code coverage.