### PR TITLE
Cache: Remove tombstone records

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheRecordStore.java
@@ -902,7 +902,7 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
         final boolean isExpired = processExpiredEntry(key, record, now);
 
         try {
-            if (recordNotExistOrExpiredOrTombstone(record, isExpired)) {
+            if (recordNotExistOrExpired(record, isExpired)) {
                 if (isStatisticsEnabled()) {
                     statistics.increaseCacheMisses(1);
                 }
@@ -937,7 +937,7 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
         long now = Clock.currentTimeMillis();
         R record = records.get(key);
         boolean isExpired = processExpiredEntry(key, record, now);
-        return record != null && !record.isTombstone() && !isExpired;
+        return record != null && !isExpired;
     }
 
     protected void onPut(Data key, Object value, ExpiryPolicy expiryPolicy, String source,
@@ -1029,9 +1029,6 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
             if (record == null || isExpired) {
                 saved = createRecordWithExpiry(key, value, expiryPolicy, now,
                                                disableWriteThrough, completionId) != null;
-            } else if (record.isTombstone()) {
-                saved = updateRecordWithExpiry(key, value, record, expiryPolicy, now,
-                                               disableWriteThrough, completionId);
             } else {
                 if (isEventsEnabled()) {
                     publishEvent(createCacheCompleteEvent(toEventData(key), completionId));
@@ -1074,7 +1071,7 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
         final boolean isExpired = record != null && record.isExpiredAt(now);
 
         try {
-            if (recordNotExistOrExpiredOrTombstone(record, isExpired)) {
+            if (recordNotExistOrExpired(record, isExpired)) {
                 if (isEventsEnabled()) {
                     publishEvent(createCacheCompleteEvent(toEventData(key), completionId));
                 }
@@ -1147,7 +1144,7 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
 
         try {
             Object obj = toValue(record);
-            if (recordNotExistOrExpiredOrTombstone(record, isExpired)) {
+            if (recordNotExistOrExpired(record, isExpired)) {
                 obj = null;
                 if (isEventsEnabled()) {
                     publishEvent(createCacheCompleteEvent(toEventData(key), completionId));
@@ -1196,7 +1193,7 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
         boolean removed = false;
 
         try {
-            if (recordNotExistOrExpiredOrTombstone(record, now)) {
+            if (recordNotExistOrExpired(record, now)) {
                 if (isEventsEnabled()) {
                     publishEvent(createCacheCompleteEvent(toEventData(key), CacheRecord.EXPIRATION_TIME_NOT_AVAILABLE,
                                                           origin, completionId));
@@ -1229,7 +1226,7 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
         boolean removed = false;
 
         try {
-            if (recordNotExistOrExpiredOrTombstone(record, now)) {
+            if (recordNotExistOrExpired(record, now)) {
                 if (isStatisticsEnabled()) {
                     statistics.increaseCacheMisses(1);
                 }
@@ -1286,7 +1283,7 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
         boolean removed = false;
 
         try {
-            if (recordNotExistOrExpiredOrTombstone(record, now)) {
+            if (recordNotExistOrExpired(record, now)) {
                 obj = null;
                 if (isEventsEnabled()) {
                     publishEvent(createCacheCompleteEvent(toEventData(key), CacheRecord.EXPIRATION_TIME_NOT_AVAILABLE,
@@ -1406,7 +1403,7 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
             record = null;
         }
         if (isStatisticsEnabled()) {
-            if (recordNotExistOrExpiredOrTombstone(record, isExpired)) {
+            if (recordNotExistOrExpired(record, isExpired)) {
                 statistics.increaseCacheMisses(1);
             } else {
                 statistics.increaseCacheHits(1);
@@ -1419,12 +1416,12 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
         return result;
     }
 
-    private boolean recordNotExistOrExpiredOrTombstone(R record, boolean isExpired) {
-        return record == null || isExpired || record.isTombstone();
+    private boolean recordNotExistOrExpired(R record, boolean isExpired) {
+        return record == null || isExpired;
     }
 
-    private boolean recordNotExistOrExpiredOrTombstone(R record, long now) {
-        return record == null || record.isExpiredAt(now) || record.isTombstone();
+    private boolean recordNotExistOrExpired(R record, long now) {
+        return record == null || record.isExpiredAt(now);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CachePutAllBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CachePutAllBackupOperation.java
@@ -63,10 +63,7 @@ public class CachePutAllBackupOperation
     public void run() throws Exception {
         if (cacheRecords != null) {
             for (Map.Entry<Data, CacheRecord> entry : cacheRecords.entrySet()) {
-                final CacheRecord record = entry.getValue();
-                if (record.isTombstone()) {
-                    continue;
-                }
+                CacheRecord record = entry.getValue();
                 cache.putRecord(entry.getKey(), record);
             }
         }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheReplicationOperation.java
@@ -129,7 +129,7 @@ public class CacheReplicationOperation extends AbstractOperation {
                 final Data key = e.getKey();
                 final CacheRecord record = e.getValue();
 
-                if (record.isExpiredAt(now) || record.isTombstone()) {
+                if (record.isExpiredAt(now)) {
                     continue;
                 }
                 out.writeData(key);

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/record/AbstractCacheRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/record/AbstractCacheRecord.java
@@ -36,7 +36,6 @@ public abstract class AbstractCacheRecord<V> implements CacheRecord<V>, DataSeri
     protected volatile long expirationTime = -1;
     protected volatile long accessTime = -1;
     protected volatile int accessHit;
-    protected long tombstoneSequence;
 
     protected AbstractCacheRecord() {
     }
@@ -100,21 +99,6 @@ public abstract class AbstractCacheRecord<V> implements CacheRecord<V>, DataSeri
     @Override
     public boolean isExpiredAt(long now) {
         return expirationTime > -1 && expirationTime <= now;
-    }
-
-    @Override
-    public boolean isTombstone() {
-        return getValue() == null;
-    }
-
-    @Override
-    public long getTombstoneSequence() {
-        return tombstoneSequence;
-    }
-
-    @Override
-    public void setTombstoneSequence(long seq) {
-        this.tombstoneSequence = seq;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/record/CacheRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/record/CacheRecord.java
@@ -78,25 +78,4 @@ public interface CacheRecord<V> extends Expirable, Evictable {
      */
     void resetAccessHit();
 
-    /**
-     * Tells whether this record is a tombstone or not.
-     *
-     * @return true if this record is tombstone, false otherwise
-     */
-    boolean isTombstone();
-
-    /**
-     * Returns tombstone sequence associated with this record.
-     * Return value is undefined if this is record is not a tombstone.
-     *
-     * @return tombstone sequence
-     */
-    long getTombstoneSequence();
-
-    /**
-     * Sets tombstone sequence associated with this record.
-     *
-     * @param seq tombstone sequence
-     */
-    void setTombstoneSequence(long seq);
 }


### PR DESCRIPTION
Tombstone records were required for hot-restart before.
But due to hot-restart design change, tombstones are not required
anymore. See PR hazelcast/hazelcast-enterprise#562