### PR TITLE
Fix mock network issues

### DIFF
--- a/hazelcast-client-legacy/src/test/java/com/hazelcast/client/test/TestClientRegistry.java
+++ b/hazelcast-client-legacy/src/test/java/com/hazelcast/client/test/TestClientRegistry.java
@@ -271,6 +271,12 @@ public class TestClientRegistry {
             super(localEndpoint, remoteEndpoint, nodeEngine);
             this.responseConnection = responseConnection;
             this.connectionId = connectionId;
+            register();
+        }
+
+        private void register() {
+            Node node = nodeEngine.getNode();
+            node.getConnectionManager().registerConnection(getEndPoint(), this);
         }
 
         @Override

--- a/hazelcast-client/src/test/java/com/hazelcast/client/test/TestClientRegistry.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/test/TestClientRegistry.java
@@ -250,6 +250,12 @@ public class TestClientRegistry {
             super(localEndpoint, remoteEndpoint, nodeEngine);
             this.responseConnection = responseConnection;
             this.connectionId = connectionId;
+            register();
+        }
+
+        private void register() {
+            Node node = nodeEngine.getNode();
+            node.getConnectionManager().registerConnection(getEndPoint(), this);
         }
 
         @Override

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImplTest.java
@@ -191,7 +191,7 @@ public class OperationRunnerImplTest extends HazelcastTestSupport {
         Operation op = new DummyOperation();
         setCallId(op, 1000 * 1000);
 
-        Packet packet = toPacket(remote, op);
+        Packet packet = toPacket(local, remote, op);
         operationRunner.run(packet);
     }
 
@@ -200,7 +200,7 @@ public class OperationRunnerImplTest extends HazelcastTestSupport {
         Operation op = new DummyOperation();
         setCallId(op, 1000 * 1000);
 
-        Packet packet = toPacket(remote, op);
+        Packet packet = toPacket(local, remote, op);
         byte[] bytes = packet.toByteArray();
         for (int k = 0; k < bytes.length; k++) {
             bytes[k]++;

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
@@ -165,13 +165,13 @@ public abstract class HazelcastTestSupport {
         return node.clusterService.getThisAddress();
     }
 
-    public static Packet toPacket(HazelcastInstance hz, Operation operation) {
-        SerializationService serializationService = getSerializationService(hz);
-        ConnectionManager connectionManager = getConnectionManager(hz);
+    public static Packet toPacket(HazelcastInstance local, HazelcastInstance remote, Operation operation) {
+        SerializationService serializationService = getSerializationService(local);
+        ConnectionManager connectionManager = getConnectionManager(local);
 
         Packet packet = new Packet(serializationService.toBytes(operation), operation.getPartitionId());
         packet.setHeader(Packet.HEADER_OP);
-        packet.setConn(connectionManager.getConnection(getAddress(hz)));
+        packet.setConn(connectionManager.getConnection(getAddress(remote)));
         return packet;
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockConnection.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockConnection.java
@@ -138,7 +138,7 @@ public class MockConnection implements Connection {
 
     @Override
     public boolean isAlive() {
-        return live;
+        return live && nodeEngine.isRunning();
     }
 
     @Override


### PR DESCRIPTION
- getConnection() should follow the ConnectionManager contract and just return available connection
- getOrConnect() should create a new connection if a connection is not found or connection is not alive
and remote NodeEngine is running/alive.
- MockConnection.isAlive() check should include running status of NodeEngine, a connection to a terminated
node should not be considered as alive.
- MockConnectionManager should close all connections on shutdown.
- ClientMockConnectionManager should register its server-side connection to server ConnectionManager.

Closely related to failures:
fixes #6974
fixes #7004 
fixes #6383