### PR TITLE
Mark IsStillExecuting operations as readonly

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/operations/IsStillExecutingOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/operations/IsStillExecutingOperation.java
@@ -19,6 +19,7 @@ package com.hazelcast.spi.impl.operationservice.impl.operations;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.spi.AbstractOperation;
+import com.hazelcast.spi.ReadonlyOperation;
 import com.hazelcast.spi.UrgentSystemOperation;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.impl.operationservice.impl.IsStillRunningService;
@@ -29,7 +30,8 @@ import java.io.IOException;
 /**
  * An operation that checks if another operation is still running.
  */
-public class IsStillExecutingOperation extends AbstractOperation implements UrgentSystemOperation {
+public class IsStillExecutingOperation extends AbstractOperation
+        implements UrgentSystemOperation, ReadonlyOperation {
 
     private long operationCallId;
     private int operationPartitionId;

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/operations/TraceableIsStillExecutingOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/operations/TraceableIsStillExecutingOperation.java
@@ -19,6 +19,7 @@ package com.hazelcast.spi.impl.operationservice.impl.operations;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.spi.AbstractOperation;
+import com.hazelcast.spi.ReadonlyOperation;
 import com.hazelcast.spi.UrgentSystemOperation;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.impl.operationservice.impl.IsStillRunningService;
@@ -26,7 +27,8 @@ import com.hazelcast.spi.impl.operationservice.impl.OperationServiceImpl;
 
 import java.io.IOException;
 
-public class TraceableIsStillExecutingOperation extends AbstractOperation implements UrgentSystemOperation {
+public class TraceableIsStillExecutingOperation extends AbstractOperation
+        implements UrgentSystemOperation, ReadonlyOperation {
 
     private String serviceName;
     private Object identifier;


### PR DESCRIPTION
Marked IsStillExecuting operations as readonly, because they can be invoked
when cluster is PASSIVE.