### PR TITLE
Serialization performance regression fix

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/JavaDefaultSerializers.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/JavaDefaultSerializers.java
@@ -23,6 +23,7 @@ import com.hazelcast.nio.serialization.HazelcastSerializationException;
 import com.hazelcast.nio.serialization.StreamSerializer;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
+import java.io.Externalizable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.ObjectInputStream;
@@ -31,6 +32,8 @@ import java.io.OutputStream;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Date;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 
@@ -39,11 +42,67 @@ import static com.hazelcast.internal.serialization.impl.SerializationConstants.J
 import static com.hazelcast.internal.serialization.impl.SerializationConstants.JAVA_DEFAULT_TYPE_CLASS;
 import static com.hazelcast.internal.serialization.impl.SerializationConstants.JAVA_DEFAULT_TYPE_DATE;
 import static com.hazelcast.internal.serialization.impl.SerializationConstants.JAVA_DEFAULT_TYPE_ENUM;
+import static com.hazelcast.internal.serialization.impl.SerializationConstants.JAVA_DEFAULT_TYPE_EXTERNALIZABLE;
 import static com.hazelcast.internal.serialization.impl.SerializationConstants.JAVA_DEFAULT_TYPE_SERIALIZABLE;
 import static com.hazelcast.nio.IOUtil.newObjectInputStream;
 
 
 public final class JavaDefaultSerializers {
+
+    public static final class ExternalizableSerializer extends SingletonSerializer<Externalizable> {
+
+        private ConcurrentMap<String, Class> clazzCache = new ConcurrentHashMap<String, Class>();
+        private final boolean gzipEnabled;
+
+        public ExternalizableSerializer(boolean gzipEnabled) {
+            this.gzipEnabled = gzipEnabled;
+        }
+
+        @Override
+        public int getTypeId() {
+            return JAVA_DEFAULT_TYPE_EXTERNALIZABLE;
+        }
+
+        @Override
+        public Externalizable read(final ObjectDataInput in) throws IOException {
+            final String className = in.readUTF();
+            try {
+                final Externalizable ds = ClassLoaderUtil.newInstance(in.getClassLoader(), className);
+                final ObjectInputStream objectInputStream;
+                final InputStream inputStream = (InputStream) in;
+                if (gzipEnabled) {
+                    objectInputStream = newObjectInputStream(in.getClassLoader(), new GZIPInputStream(inputStream));
+                } else {
+                    objectInputStream = newObjectInputStream(in.getClassLoader(), inputStream);
+                }
+                ds.readExternal(objectInputStream);
+                return ds;
+            } catch (final Exception e) {
+                throw new HazelcastSerializationException("Problem while reading Externalizable class : "
+                        + className + ", exception: " + e);
+            }
+        }
+
+        @Override
+        public void write(final ObjectDataOutput out, final Externalizable obj) throws IOException {
+            out.writeUTF(obj.getClass().getName());
+            final ObjectOutputStream objectOutputStream;
+            final OutputStream outputStream = (OutputStream) out;
+            GZIPOutputStream gzip = null;
+            if (gzipEnabled) {
+                gzip = new GZIPOutputStream(outputStream);
+                objectOutputStream = new ObjectOutputStream(gzip);
+            } else {
+                objectOutputStream = new ObjectOutputStream(outputStream);
+            }
+            obj.writeExternal(objectOutputStream);
+            // Force flush if not yet written due to internal behavior if pos < 1024
+            objectOutputStream.flush();
+            if (gzipEnabled) {
+                gzip.finish();
+            }
+        }
+    }
 
     public static final class BigIntegerSerializer extends SingletonSerializer<BigInteger> {
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/SerializationConstants.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/SerializationConstants.java
@@ -83,10 +83,13 @@ public final class SerializationConstants {
     // NUMBER OF CONSTANT SERIALIZERS...
     public static final int CONSTANT_SERIALIZERS_LENGTH = 28;
 
+
+
     // ------------------------------------------------------------
     // JAVA SERIALIZATION
 
     public static final int JAVA_DEFAULT_TYPE_SERIALIZABLE = -100;
+    public static final int JAVA_DEFAULT_TYPE_EXTERNALIZABLE = -101;
 
     // ------------------------------------------------------------
     // HIBERNATE SERIALIZERS

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/SerializationServiceV1.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/SerializationServiceV1.java
@@ -36,6 +36,7 @@ import com.hazelcast.nio.serialization.Portable;
 import com.hazelcast.nio.serialization.PortableFactory;
 import com.hazelcast.nio.serialization.PortableReader;
 
+import java.io.Externalizable;
 import java.io.IOException;
 import java.io.Serializable;
 import java.math.BigDecimal;
@@ -95,6 +96,8 @@ public class SerializationServiceV1 extends AbstractSerializationService {
         portableSerializerAdapter = createSerializerAdapter(portableSerializer, this);
 
         javaSerializerAdapter = createSerializerAdapter(new JavaSerializer(enableSharedObject, enableCompression), this);
+        javaExternalizableAdapter = createSerializerAdapter(
+                new JavaDefaultSerializers.ExternalizableSerializer(enableCompression), this);
         registerConstantSerializers();
         registerJavaTypeSerializers();
     }
@@ -148,6 +151,7 @@ public class SerializationServiceV1 extends AbstractSerializationService {
         registerConstant(LinkedList.class, new LinkedListStreamSerializer());
 
         safeRegister(Serializable.class, javaSerializerAdapter);
+        safeRegister(Externalizable.class, javaExternalizableAdapter);
     }
 
     public void registerClassDefinitions(Collection<ClassDefinition> classDefinitions, boolean checkClassDefErrors) {

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/AbstractSerializationServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/AbstractSerializationServiceTest.java
@@ -22,7 +22,14 @@ import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 
+import java.io.Externalizable;
 import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.io.Serializable;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
@@ -38,6 +45,57 @@ public class AbstractSerializationServiceTest {
         DefaultSerializationServiceBuilder defaultSerializationServiceBuilder = new DefaultSerializationServiceBuilder();
         abstractSerializationService = (AbstractSerializationService) defaultSerializationServiceBuilder
                 .setVersion(SerializationService.VERSION_1).build();
+    }
+
+    @Test
+    public void testExternalizable() {
+        ExternalizableValue original = new ExternalizableValue(100);
+
+        Data data = abstractSerializationService.toData(original);
+        ExternalizableValue found = abstractSerializationService.toObject(data);
+
+        assertNotNull(found);
+        assertEquals(original.value, found.value);
+    }
+
+    static class ExternalizableValue implements Externalizable {
+        int value;
+
+        ExternalizableValue() {
+        }
+
+        ExternalizableValue(int value) {
+            this.value = value;
+        }
+
+        @Override
+        public void writeExternal(ObjectOutput out) throws IOException {
+            out.writeInt(value);
+        }
+
+        @Override
+        public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
+            value = in.readInt();
+        }
+    }
+
+    @Test
+    public void testSerializable() {
+        SerializableleValue original = new SerializableleValue(100);
+
+        Data data = abstractSerializationService.toData(original);
+        SerializableleValue found = abstractSerializationService.toObject(data);
+
+        assertNotNull(found);
+        assertEquals(original.value, found.value);
+    }
+
+    static class SerializableleValue implements Serializable {
+        int value;
+
+        SerializableleValue(int value) {
+            this.value = value;
+        }
     }
 
     @Test(expected = HazelcastSerializationException.class)

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/SerializationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/SerializationTest.java
@@ -14,7 +14,6 @@ import static org.junit.Assert.assertEquals;
 @Category({QuickTest.class, ParallelTest.class})
 public class SerializationTest extends HazelcastTestSupport{
 
-
     @Test
     public void testPrivateConstructors() throws Exception {
         assertUtilityConstructor(FactoryIdHelper.class);
@@ -23,8 +22,4 @@ public class SerializationTest extends HazelcastTestSupport{
         assertUtilityConstructor(ConstantSerializers.class);
         assertUtilityConstructor(SerializationConstants.class);
     }
-
-
-
-
 }


### PR DESCRIPTION
Resolves performance regression with Externalizable. The cause was that the ExternalizableSerializer was removed in PR:
    
 https://github.com/hazelcast/hazelcast/pull/6735
    
 This PR restores the ExternalizableSerializer. Benchmarks have confirmed that the performance is restored.
