### PR TITLE
Relax assertion on closed key iterator in map loader

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/map/mapstore/MapStoreEvictionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/mapstore/MapStoreEvictionTest.java
@@ -9,6 +9,7 @@ import com.hazelcast.config.MapStoreConfig;
 import com.hazelcast.config.MaxSizeConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
+import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
@@ -58,7 +59,7 @@ public class MapStoreEvictionTest extends HazelcastTestSupport {
 
         assertSizeEventually(MAP_STORE_ENTRY_COUNT, map);
         assertEquals(MAP_STORE_ENTRY_COUNT, loader.getLoadedValueCount());
-        assertTrue(loader.isLoadAllKeysClosed());
+        assertLoaderIsClosedEventually();
     }
 
     private IMap<Object, Object> getMap(final String mapName, Config cfg) {
@@ -123,7 +124,16 @@ public class MapStoreEvictionTest extends HazelcastTestSupport {
         assertFalse("Map is not empty", map.isEmpty());
         assertTrue(MAX_SIZE_PER_CLUSTER >= map.size());
         assertTrue(MAX_SIZE_PER_CLUSTER >= loader.getLoadedValueCount());
-        assertTrue(loader.isLoadAllKeysClosed());
+        assertLoaderIsClosedEventually();
+    }
+
+    private void assertLoaderIsClosedEventually() {
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertTrue(loader.isLoadAllKeysClosed());
+            }
+        });
     }
 
     private Config newConfig(String mapName, boolean sizeLimited, MapStoreConfig.InitialLoadMode loadMode) {


### PR DESCRIPTION
Fixes #6772
The test was failing because a key iterator was not closed. However the test assertion was racy.
as the iterator is closed *after * notifications about key loading completion are send and
user thread is unblocked.

Supporting Evidence:
I could reproduce the test failure by inserting some sleeping just in front of the iterator closing in MapKeyLoader.