### PR TITLE
Increased code coverage of OutOfMemoryHandler and OutOfMemoryHandlerHelper

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/core/OutOfMemoryHandlerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/core/OutOfMemoryHandlerTest.java
@@ -1,0 +1,90 @@
+package com.hazelcast.core;
+
+import com.hazelcast.instance.AbstractOutOfMemoryHandlerTest;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class OutOfMemoryHandlerTest extends AbstractOutOfMemoryHandlerTest {
+
+    TestOutOfMemoryHandler outOfMemoryHandler;
+
+    @Before
+    public void setUp() throws Exception {
+        initHazelcastInstances();
+
+        outOfMemoryHandler = new TestOutOfMemoryHandler();
+    }
+
+    @Test
+    public void testShouldHandle() throws Exception {
+        assertTrue(outOfMemoryHandler.shouldHandle(new OutOfMemoryError()));
+    }
+
+    @Test
+    public void testTryCloseConnections() {
+        outOfMemoryHandler.closeConnections(hazelcastInstance);
+    }
+
+    @Test
+    public void testTryCloseConnections_shouldDoNothingWithNullInstance() {
+        outOfMemoryHandler.closeConnections(null);
+    }
+
+    @Test
+    public void testTryCloseConnections_shouldDoNothingWhenThrowableIsThrown() {
+        outOfMemoryHandler.closeConnections(hazelcastInstanceThrowsException);
+    }
+
+    @Test
+    public void testTryShutdown() {
+        outOfMemoryHandler.shutdown(hazelcastInstance);
+    }
+
+    @Test
+    public void testTryShutdown_shouldDoNothingWithNullInstance() {
+        outOfMemoryHandler.shutdown(null);
+    }
+
+    @Test
+    public void testTryShutdown_shouldDoNothingWhenThrowableIsThrown() {
+        outOfMemoryHandler.shutdown(hazelcastInstanceThrowsException);
+    }
+
+    @Test
+    public void testTryStopThreads() {
+        outOfMemoryHandler.stopThreads(hazelcastInstance);
+    }
+
+    @Test
+    public void testTryStopThreads_shouldDoNothingWithNullInstance() {
+        outOfMemoryHandler.stopThreads(null);
+    }
+
+    static class TestOutOfMemoryHandler extends OutOfMemoryHandler {
+
+        void closeConnections(HazelcastInstance hazelcastInstance) {
+            tryCloseConnections(hazelcastInstance);
+        }
+
+        void shutdown(HazelcastInstance hazelcastInstance) {
+            tryShutdown(hazelcastInstance);
+        }
+
+        void stopThreads(HazelcastInstance hazelcastInstance) {
+            tryStopThreads(hazelcastInstance);
+        }
+
+        @Override
+        public void onOutOfMemory(OutOfMemoryError oome, HazelcastInstance[] hazelcastInstances) {
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/instance/AbstractOutOfMemoryHandlerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/AbstractOutOfMemoryHandlerTest.java
@@ -1,0 +1,28 @@
+package com.hazelcast.instance;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.nio.ConnectionManager;
+import com.hazelcast.test.HazelcastTestSupport;
+
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+
+public abstract class AbstractOutOfMemoryHandlerTest extends HazelcastTestSupport {
+
+    protected HazelcastInstanceImpl hazelcastInstance;
+    protected HazelcastInstanceImpl hazelcastInstanceThrowsException;
+
+    public void initHazelcastInstances() throws Exception {
+        Config config = new Config();
+
+        ConnectionManager connectionManager = mock(ConnectionManager.class);
+        doThrow(new OutOfMemoryError()).when(connectionManager).shutdown();
+
+        NodeContext nodeContext = new TestNodeContext();
+        NodeContext nodeContextWithThrowable = new TestNodeContext(connectionManager);
+
+        hazelcastInstance = new HazelcastInstanceImpl("OutOfMemoryHandlerHelper", config, nodeContext);
+        hazelcastInstanceThrowsException = new HazelcastInstanceImpl("OutOfMemoryHandlerHelperThrowsException", config,
+                nodeContextWithThrowable);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/instance/NodeExtensionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/NodeExtensionTest.java
@@ -16,33 +16,21 @@
 
 package com.hazelcast.instance;
 
-import com.hazelcast.cache.impl.ICacheService;
-import com.hazelcast.cluster.Joiner;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.JoinConfig;
 import com.hazelcast.config.NetworkConfig;
-import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
-import com.hazelcast.map.impl.MapService;
-import com.hazelcast.nio.Address;
-import com.hazelcast.nio.ConnectionManager;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
-import com.hazelcast.wan.WanReplicationService;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.mockito.InOrder;
 
-import java.net.UnknownHostException;
-import java.nio.channels.ServerSocketChannel;
-
 import static org.mockito.Mockito.inOrder;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.when;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
@@ -59,7 +47,7 @@ public class NodeExtensionTest extends HazelcastTestSupport {
 
     @Test
     public void verifyMethods() throws Exception {
-        DummyNodeContext nodeContext = new DummyNodeContext(new Address("127.0.0.1", 5000));
+        TestNodeContext nodeContext = new TestNodeContext();
         NodeExtension nodeExtension = nodeContext.getNodeExtension();
 
         hazelcastInstance = new HazelcastInstanceImpl(randomName(), getConfig(), nodeContext);
@@ -84,74 +72,5 @@ public class NodeExtensionTest extends HazelcastTestSupport {
         JoinConfig join = networkConfig.getJoin();
         join.getMulticastConfig().setEnabled(false);
         return config;
-    }
-
-    public static class DummyAddressPicker implements AddressPicker {
-        final Address address;
-
-        private DummyAddressPicker(Address address) {
-            this.address = address;
-        }
-
-        @Override
-        public void pickAddress() throws Exception {
-        }
-
-        @Override
-        public Address getBindAddress() {
-            return address;
-        }
-
-        @Override
-        public Address getPublicAddress() {
-            return address;
-        }
-
-        @Override
-        public ServerSocketChannel getServerSocketChannel() {
-            return null;
-        }
-    }
-
-    public static class DummyNodeContext implements NodeContext {
-
-        private final Address address;
-        private final NodeExtension nodeExtension = mock(NodeExtension.class);
-
-        public DummyNodeContext() throws UnknownHostException {
-            this(new Address("127.0.0.1", 5000));
-        }
-
-        public DummyNodeContext(Address address) {
-            this.address = address;
-        }
-
-        public NodeExtension getNodeExtension() {
-            return nodeExtension;
-        }
-
-        @Override
-        public NodeExtension createNodeExtension(Node node) {
-            when(nodeExtension.createService(MapService.class)).thenReturn(mock(MapService.class));
-            when(nodeExtension.createService(ICacheService.class)).thenReturn(mock(ICacheService.class));
-            when(nodeExtension.createService(WanReplicationService.class)).thenReturn(mock(WanReplicationService.class));
-            when(nodeExtension.createSerializationService()).thenReturn(new DefaultSerializationServiceBuilder().build());
-            return nodeExtension;
-        }
-
-        @Override
-        public AddressPicker createAddressPicker(Node node) {
-            return new DummyAddressPicker(address);
-        }
-
-        @Override
-        public Joiner createJoiner(Node node) {
-            return null;
-        }
-
-        @Override
-        public ConnectionManager createConnectionManager(Node node, ServerSocketChannel serverSocketChannel) {
-            return mock(ConnectionManager.class);
-        }
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/instance/OutOfMemoryHandlerHelperTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/OutOfMemoryHandlerHelperTest.java
@@ -1,35 +1,24 @@
 package com.hazelcast.instance;
 
-import com.hazelcast.config.Config;
-import com.hazelcast.nio.ConnectionManager;
-import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import static com.hazelcast.instance.OutOfMemoryHandlerHelper.tryCloseConnections;
 import static com.hazelcast.instance.OutOfMemoryHandlerHelper.tryShutdown;
 import static com.hazelcast.instance.OutOfMemoryHandlerHelper.tryStopThreads;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
 
-public class OutOfMemoryHandlerHelperTest extends HazelcastTestSupport {
-
-    private HazelcastInstanceImpl hazelcastInstance;
-    private HazelcastInstanceImpl hazelcastInstanceThrowsException;
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class OutOfMemoryHandlerHelperTest extends AbstractOutOfMemoryHandlerTest {
 
     @Before
     public void setUp() throws Exception {
-        Config config = new Config();
-
-        ConnectionManager connectionManager = mock(ConnectionManager.class);
-        doThrow(new OutOfMemoryError()).when(connectionManager).shutdown();
-
-        NodeContext nodeContext = new TestNodeContext();
-        NodeContext nodeContextWithThrowable = new TestNodeContext(connectionManager);
-
-        hazelcastInstance = new HazelcastInstanceImpl("OutOfMemoryHandlerHelper", config, nodeContext);
-        hazelcastInstanceThrowsException = new HazelcastInstanceImpl("OutOfMemoryHandlerHelperThrowsException", config,
-                nodeContextWithThrowable);
+        initHazelcastInstances();
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/instance/OutOfMemoryHandlerHelperTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/OutOfMemoryHandlerHelperTest.java
@@ -1,0 +1,79 @@
+package com.hazelcast.instance;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.nio.ConnectionManager;
+import com.hazelcast.test.HazelcastTestSupport;
+import org.junit.Before;
+import org.junit.Test;
+
+import static com.hazelcast.instance.OutOfMemoryHandlerHelper.tryCloseConnections;
+import static com.hazelcast.instance.OutOfMemoryHandlerHelper.tryShutdown;
+import static com.hazelcast.instance.OutOfMemoryHandlerHelper.tryStopThreads;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+
+public class OutOfMemoryHandlerHelperTest extends HazelcastTestSupport {
+
+    private HazelcastInstanceImpl hazelcastInstance;
+    private HazelcastInstanceImpl hazelcastInstanceThrowsException;
+
+    @Before
+    public void setUp() throws Exception {
+        Config config = new Config();
+
+        ConnectionManager connectionManager = mock(ConnectionManager.class);
+        doThrow(new OutOfMemoryError()).when(connectionManager).shutdown();
+
+        NodeContext nodeContext = new TestNodeContext();
+        NodeContext nodeContextWithThrowable = new TestNodeContext(connectionManager);
+
+        hazelcastInstance = new HazelcastInstanceImpl("OutOfMemoryHandlerHelper", config, nodeContext);
+        hazelcastInstanceThrowsException = new HazelcastInstanceImpl("OutOfMemoryHandlerHelperThrowsException", config,
+                nodeContextWithThrowable);
+    }
+
+    @Test
+    public void testConstructor() throws Exception {
+        assertUtilityConstructor(OutOfMemoryHandlerHelper.class);
+    }
+
+    @Test
+    public void testTryCloseConnections() {
+        tryCloseConnections(hazelcastInstance);
+    }
+
+    @Test
+    public void testTryCloseConnections_shouldDoNothingWithNullInstance() {
+        tryCloseConnections(null);
+    }
+
+    @Test
+    public void testTryCloseConnections_shouldDoNothingWhenThrowableIsThrown() {
+        tryCloseConnections(hazelcastInstanceThrowsException);
+    }
+
+    @Test
+    public void testTryShutdown() {
+        tryShutdown(hazelcastInstance);
+    }
+
+    @Test
+    public void testTryShutdown_shouldDoNothingWithNullInstance() {
+        tryShutdown(null);
+    }
+
+    @Test
+    public void testTryShutdown_shouldDoNothingWhenThrowableIsThrown() {
+        tryShutdown(hazelcastInstanceThrowsException);
+    }
+
+    @Test
+    public void testTryStopThreads() {
+        tryStopThreads(hazelcastInstance);
+    }
+
+    @Test
+    public void testTryStopThreads_shouldDoNothingWithNullInstance() {
+        tryStopThreads(null);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/instance/TestNodeContext.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/TestNodeContext.java
@@ -1,0 +1,91 @@
+package com.hazelcast.instance;
+
+import com.hazelcast.cache.impl.ICacheService;
+import com.hazelcast.cluster.Joiner;
+import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
+import com.hazelcast.map.impl.MapService;
+import com.hazelcast.nio.Address;
+import com.hazelcast.nio.ConnectionManager;
+import com.hazelcast.wan.WanReplicationService;
+
+import java.net.UnknownHostException;
+import java.nio.channels.ServerSocketChannel;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class TestNodeContext implements NodeContext {
+
+    private final Address address;
+    private final NodeExtension nodeExtension = mock(NodeExtension.class);
+    private final ConnectionManager connectionManager;
+
+    public TestNodeContext() throws UnknownHostException {
+        this(mock(ConnectionManager.class));
+    }
+
+    public TestNodeContext(ConnectionManager connectionManager) throws UnknownHostException {
+        this(new Address("127.0.0.1", 5000), connectionManager);
+    }
+
+    public TestNodeContext(Address address, ConnectionManager connectionManager) {
+        this.address = address;
+        this.connectionManager = connectionManager;
+    }
+
+    public NodeExtension getNodeExtension() {
+        return nodeExtension;
+    }
+
+    @Override
+    public NodeExtension createNodeExtension(Node node) {
+        when(nodeExtension.createService(MapService.class)).thenReturn(mock(MapService.class));
+        when(nodeExtension.createService(ICacheService.class)).thenReturn(mock(ICacheService.class));
+        when(nodeExtension.createService(WanReplicationService.class)).thenReturn(mock(WanReplicationService.class));
+        when(nodeExtension.createSerializationService()).thenReturn(new DefaultSerializationServiceBuilder().build());
+        return nodeExtension;
+    }
+
+    @Override
+    public AddressPicker createAddressPicker(Node node) {
+        return new TestAddressPicker(address);
+    }
+
+    @Override
+    public Joiner createJoiner(Node node) {
+        return null;
+    }
+
+    @Override
+    public ConnectionManager createConnectionManager(Node node, ServerSocketChannel serverSocketChannel) {
+        return connectionManager;
+    }
+
+    static class TestAddressPicker implements AddressPicker {
+
+        final Address address;
+
+        TestAddressPicker(Address address) {
+            this.address = address;
+        }
+
+        @Override
+        public void pickAddress() throws Exception {
+        }
+
+        @Override
+        public Address getBindAddress() {
+            return address;
+        }
+
+        @Override
+        public Address getPublicAddress() {
+            return address;
+        }
+
+        @Override
+        public ServerSocketChannel getServerSocketChannel() {
+            return null;
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/util/HazelcastInstanceFactoryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/HazelcastInstanceFactoryTest.java
@@ -22,7 +22,7 @@ import com.hazelcast.instance.HazelcastInstanceFactory;
 import com.hazelcast.instance.Node;
 import com.hazelcast.instance.NodeContext;
 import com.hazelcast.instance.NodeExtension;
-import com.hazelcast.instance.NodeExtensionTest;
+import com.hazelcast.instance.TestNodeContext;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.ExpectedRuntimeException;
 import com.hazelcast.test.HazelcastParallelClassRunner;
@@ -103,7 +103,7 @@ public class HazelcastInstanceFactoryTest extends HazelcastTestSupport {
 
     @Test(expected = ExpectedRuntimeException.class)
     public void test_NewInstance_failed_beforeNodeStart() throws Exception {
-        NodeContext context = new NodeExtensionTest.DummyNodeContext() {
+        NodeContext context = new TestNodeContext() {
             @Override
             public NodeExtension createNodeExtension(Node node) {
                 NodeExtension nodeExtension = super.createNodeExtension(node);
@@ -120,7 +120,7 @@ public class HazelcastInstanceFactoryTest extends HazelcastTestSupport {
 
     @Test(expected = ExpectedRuntimeException.class)
     public void test_NewInstance_failed_beforeJoin() throws Exception {
-        NodeContext context = new NodeExtensionTest.DummyNodeContext() {
+        NodeContext context = new TestNodeContext() {
             @Override
             public NodeExtension createNodeExtension(Node node) {
                 NodeExtension nodeExtension = super.createNodeExtension(node);
@@ -137,7 +137,7 @@ public class HazelcastInstanceFactoryTest extends HazelcastTestSupport {
 
     @Test(expected = ExpectedRuntimeException.class)
     public void test_NewInstance_failed_afterNodeStart() throws Exception {
-        NodeContext context = new NodeExtensionTest.DummyNodeContext() {
+        NodeContext context = new TestNodeContext() {
             @Override
             public NodeExtension createNodeExtension(Node node) {
                 NodeExtension nodeExtension = super.createNodeExtension(node);
@@ -154,7 +154,7 @@ public class HazelcastInstanceFactoryTest extends HazelcastTestSupport {
 
     @Test(expected = ExpectedRuntimeException.class)
     public void test_NewInstance_failed_beforeNodeShutdown() throws Exception {
-        NodeContext context = new NodeExtensionTest.DummyNodeContext() {
+        NodeContext context = new TestNodeContext() {
             @Override
             public NodeExtension createNodeExtension(Node node) {
                 NodeExtension nodeExtension = super.createNodeExtension(node);
@@ -186,7 +186,7 @@ public class HazelcastInstanceFactoryTest extends HazelcastTestSupport {
 
     @Test(expected = ExpectedRuntimeException.class)
     public void test_NewInstance_failedAfterStartAndBeforeShutdown() throws Exception {
-        NodeContext context = new NodeExtensionTest.DummyNodeContext() {
+        NodeContext context = new TestNodeContext() {
             @Override
             public NodeExtension createNodeExtension(Node node) {
                 NodeExtension nodeExtension = super.createNodeExtension(node);
@@ -204,7 +204,7 @@ public class HazelcastInstanceFactoryTest extends HazelcastTestSupport {
 
     @Test(expected = IllegalStateException.class)
     public void test_NewInstance_terminateInstance_afterNodeStart() throws Exception {
-        NodeContext context = new NodeExtensionTest.DummyNodeContext() {
+        NodeContext context = new TestNodeContext() {
             @Override
             public NodeExtension createNodeExtension(final Node node) {
                 NodeExtension nodeExtension = super.createNodeExtension(node);


### PR DESCRIPTION
* Increased code coverage of `OutOfMemoryHandler` and `OutOfMemoryHandlerHelper`
* Pulled out inner classes `DummyNodeContext` and `DummyAddressPicker` from `NodeExtensionTest` to re-use them in other tests

Both files were modified by the Hot Restart feature and has no code coverage at all, so they're on my radar.