### PR TITLE
ClientMessage size calculation problem causes NegativeArraySizeException exception

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/ClientExceptionFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/ClientExceptionFactory.java
@@ -19,6 +19,7 @@ package com.hazelcast.client.impl.protocol;
 import com.hazelcast.cache.CacheNotExistsException;
 import com.hazelcast.client.AuthenticationException;
 import com.hazelcast.client.UndefinedErrorCodeException;
+import com.hazelcast.client.impl.protocol.exception.MaxMessageSizeExceeded;
 import com.hazelcast.cluster.impl.ConfigMismatchException;
 import com.hazelcast.config.ConfigurationException;
 import com.hazelcast.config.InvalidConfigurationException;
@@ -523,6 +524,12 @@ public class ClientExceptionFactory {
             @Override
             public Throwable createException(String message, Throwable cause) {
                 return new ReplicatedMapCantBeCreatedOnLiteMemberException(message);
+            }
+        });
+        register(ClientProtocolErrorCodes.MAX_MESSAGE_SIZE_EXCEEDED, MaxMessageSizeExceeded.class, new ExceptionFactory() {
+            @Override
+            public Throwable createException(String message, Throwable cause) {
+                return new MaxMessageSizeExceeded();
             }
         });
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/ClientProtocolErrorCodes.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/ClientProtocolErrorCodes.java
@@ -95,6 +95,7 @@ public final class ClientProtocolErrorCodes {
     public static final int UNSUPPORTED_CALLBACK = 70;
     public static final int NO_DATA_MEMBER = 71;
     public static final int REPLICATED_MAP_CANT_BE_CREATED = 72;
+    public static final int MAX_MESSAGE_SIZE_EXCEEDED = 73;
 
     private ClientProtocolErrorCodes() {
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/exception/MaxMessageSizeExceeded.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/exception/MaxMessageSizeExceeded.java
@@ -1,0 +1,13 @@
+package com.hazelcast.client.impl.protocol.exception;
+
+import com.hazelcast.core.HazelcastException;
+
+/**
+ * Created by ihsan on 15/12/15.
+ */
+public class MaxMessageSizeExceeded
+        extends HazelcastException {
+    public MaxMessageSizeExceeded() {
+        super("The size of the message exceeds the maximum value of " + Integer.MAX_VALUE + " bytes.");
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/ClientMessageTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/ClientMessageTest.java
@@ -1,6 +1,7 @@
 package com.hazelcast.client.protocol;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
+import com.hazelcast.client.impl.protocol.exception.MaxMessageSizeExceeded;
 import com.hazelcast.client.impl.protocol.util.ClientProtocolBuffer;
 import com.hazelcast.client.impl.protocol.util.ParameterUtil;
 import com.hazelcast.client.impl.protocol.util.SafeBuffer;
@@ -393,4 +394,21 @@ public class ClientMessageTest {
 
     }
 
+    @Test(expected = MaxMessageSizeExceeded.class)
+    public void testMessageSizeOverflow()
+            throws Exception {
+        ClientMessage.findSuitableMessageSize(Integer.MAX_VALUE << 1);
+    }
+
+    @Test
+    public void testMaxMessageSize()
+            throws Exception {
+        assertEquals(Integer.MAX_VALUE, ClientMessage.findSuitableMessageSize(Integer.MAX_VALUE));
+    }
+
+    @Test
+    public void testLargeMessageSize()
+            throws Exception {
+        assertEquals(Integer.MAX_VALUE, ClientMessage.findSuitableMessageSize(Integer.MAX_VALUE / 2 + 1000));
+    }
 }


### PR DESCRIPTION
Some tests returns large message (e.g. a query returning 250000 entries which requires a message size of 1090944467 bytes). The QuickMath.nextPowerOfTwo(initialCapacity); overflows the integer max value.

Solution: if such a large value is required, just set the buffer size to be equal to the max int value.