### PR TITLE
Test Failure Fix: Clears internal resources upon terminate

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapRemoteService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapRemoteService.java
@@ -59,7 +59,7 @@ class MapRemoteService implements RemoteService {
         Map<String, MapContainer> mapContainers = mapServiceContext.getMapContainers();
         MapContainer mapContainer = mapContainers.remove(name);
         if (mapContainer != null) {
-            mapServiceContext.getNearCacheProvider().remove(name);
+            mapServiceContext.getNearCacheProvider().destroyNearCache(name);
             mapContainer.getMapStoreContext().stop();
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
@@ -246,7 +246,7 @@ class MapServiceContextImpl implements MapServiceContext {
     @Override
     public void reset() {
         clearPartitions();
-        getNearCacheProvider().clear();
+        getNearCacheProvider().reset();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/NearCacheInvalidator.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/NearCacheInvalidator.java
@@ -17,6 +17,7 @@
 package com.hazelcast.map.impl.nearcache;
 
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.spi.ManagedService;
 
 import java.util.Collection;
 import java.util.List;
@@ -86,10 +87,27 @@ public interface NearCacheInvalidator {
 
     /**
      * Removes supplied maps invalidation queue and flushes its content.
-     * This method is called when removing a near-cache.
+     * This method is called when removing a near-cache with
+     * {@link com.hazelcast.map.impl.MapRemoteService#destroyDistributedObject(String)}
      *
      * @param mapName name of the map.
+     * @see com.hazelcast.map.impl.MapRemoteService#destroyDistributedObject(String)
      */
     void flushAndRemoveInvalidationQueue(String mapName);
 
+    /**
+     * Resets this invalidator back to its initial state.
+     * Aimed to call with {@link ManagedService#reset()}
+     *
+     * @see {@link ManagedService#reset()}
+     */
+    void reset();
+
+    /**
+     * Shuts down this invalidator and releases used resources.
+     * Aimed to call with {@link com.hazelcast.spi.ManagedService#shutdown(boolean)}
+     *
+     * @see {@link com.hazelcast.spi.ManagedService#shutdown(boolean)}
+     */
+    void shutdown();
 }


### PR DESCRIPTION
- Added missing  shutdown logic to `NearCacheInvalidator`.
- `MapManagedService` `terminate` will clear internal resources.

closes https://github.com/hazelcast/hazelcast-enterprise/issues/455
