### PR TITLE
Fixes memory leak in TestNodeRegistry by removing node upon instance …

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/test/TestHazelcastInstanceFactory.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/TestHazelcastInstanceFactory.java
@@ -34,6 +34,8 @@ import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static com.hazelcast.instance.TestUtil.getNode;
+import static com.hazelcast.instance.TestUtil.terminateInstance;
 import static com.hazelcast.util.Preconditions.checkNotNull;
 
 public class TestHazelcastInstanceFactory {
@@ -112,6 +114,7 @@ public class TestHazelcastInstanceFactory {
 
     /**
      * Creates a new test Hazelcast instance.
+     *
      * @param address the address to use as Member's address instead of picking the next address
      */
     public HazelcastInstance newHazelcastInstance(Address address) {
@@ -120,11 +123,12 @@ public class TestHazelcastInstanceFactory {
 
     /**
      * Creates a new test Hazelcast instance.
+     *
      * @param address the address to use as Member's address instead of picking the next address
-     * @param config the config to use; use <code>null</code> to get the default config.
+     * @param config  the config to use; use <code>null</code> to get the default config.
      */
     public HazelcastInstance newHazelcastInstance(Address address, Config config) {
-        final String instanceName = config != null? config.getInstanceName() : null;
+        final String instanceName = config != null ? config.getInstanceName() : null;
         if (mockNetwork) {
             init(config);
             NodeContext nodeContext = registry.createNodeContext(address);
@@ -164,6 +168,17 @@ public class TestHazelcastInstanceFactory {
             return registry.getAllHazelcastInstances();
         }
         return Hazelcast.getAllHazelcastInstances();
+    }
+
+    /**
+     * Terminates supplied instance by releasing internal resources.
+     *
+     * @param instance the instance.
+     */
+    public void terminate(HazelcastInstance instance) {
+        Address address = getNode(instance).address;
+        terminateInstance(instance);
+        registry.removeInstance(address);
     }
 
     public void shutdownAll() {
@@ -236,5 +251,9 @@ public class TestHazelcastInstanceFactory {
     @Override
     public String toString() {
         return "TestHazelcastInstanceFactory{addresses=" + addresses + '}';
+    }
+
+    public TestNodeRegistry getRegistry() {
+        return registry;
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/TestNodeRegistry.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/TestNodeRegistry.java
@@ -55,6 +55,10 @@ public final class TestNodeRegistry {
         return nodeEngine != null && nodeEngine.isRunning() ? nodeEngine.getHazelcastInstance() : null;
     }
 
+    public boolean removeInstance(Address address) {
+        return nodes.remove(address) != null;
+    }
+
     public Collection<HazelcastInstance> getAllHazelcastInstances() {
         Collection<HazelcastInstance> all = new LinkedList<HazelcastInstance>();
         for (NodeEngineImpl nodeEngine : nodes.values()) {
@@ -80,6 +84,10 @@ public final class TestNodeRegistry {
             HazelcastInstance hz = value.getHazelcastInstance();
             hz.getLifecycleService().terminate();
         }
+    }
+
+    ConcurrentMap<Address, NodeEngineImpl> getNodes() {
+        return nodes;
     }
 
 }

--- a/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/TestNodeRegistryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/TestNodeRegistryTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test.mocknetwork;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class TestNodeRegistryTest extends HazelcastTestSupport {
+
+    @Test
+    public void testTerminate_clearsNodeReferences() throws Exception {
+        TestHazelcastInstanceFactory factory = new TestHazelcastInstanceFactory();
+        HazelcastInstance hazelcastInstance = factory.newHazelcastInstance();
+
+        factory.terminate(hazelcastInstance);
+
+        assertEquals(0, factory.getRegistry().getNodes().size());
+    }
+}


### PR DESCRIPTION
…termination

This can be seen in continuous `HazelcastInstance create-terminate cycles`, as in some stress tests.