### PR TITLE
Client protocol's correlation id is extended

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/listener/ClientEventRegistration.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/listener/ClientEventRegistration.java
@@ -28,11 +28,11 @@ public class ClientEventRegistration {
 
     private Address subscriber;
     private final String serverRegistrationId;
-    private final int callId;
+    private final long callId;
     private final ListenerMessageCodec codec;
 
     public ClientEventRegistration(String serverRegistrationId,
-                                   int callId, Address subscriber, ListenerMessageCodec codec) {
+                                   long callId, Address subscriber, ListenerMessageCodec codec) {
         isNotNull(serverRegistrationId, "serverRegistrationId");
         this.serverRegistrationId = serverRegistrationId;
         this.callId = callId;
@@ -68,7 +68,7 @@ public class ClientEventRegistration {
      *
      * @return call id
      */
-    public int getCallId() {
+    public long getCallId() {
         return callId;
     }
 

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/listener/ClientListenerServiceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/listener/ClientListenerServiceImpl.java
@@ -43,8 +43,8 @@ public abstract class ClientListenerServiceImpl implements ClientListenerService
     protected final SerializationService serializationService;
     protected final ClientInvocationService invocationService;
     protected final ILogger logger = Logger.getLogger(ClientListenerService.class);
-    private final ConcurrentMap<Integer, EventHandler> eventHandlerMap
-            = new ConcurrentHashMap<Integer, EventHandler>();
+    private final ConcurrentMap<Long, EventHandler> eventHandlerMap
+            = new ConcurrentHashMap<Long, EventHandler>();
 
     private final StripedExecutor eventExecutor;
 
@@ -57,15 +57,15 @@ public abstract class ClientListenerServiceImpl implements ClientListenerService
                 client.getThreadGroup(), eventThreadCount, eventQueueCapacity);
     }
 
-    public void addEventHandler(int callId, EventHandler handler) {
+    public void addEventHandler(long callId, EventHandler handler) {
         eventHandlerMap.put(callId, handler);
     }
 
-    protected void removeEventHandler(int callId) {
+    protected void removeEventHandler(long callId) {
         eventHandlerMap.remove(callId);
     }
 
-    protected EventHandler getEventHandler(int callId) {
+    protected EventHandler getEventHandler(long callId) {
         return eventHandlerMap.get(callId);
     }
 
@@ -101,7 +101,7 @@ public abstract class ClientListenerServiceImpl implements ClientListenerService
         @Override
         public void run() {
             try {
-                int correlationId = clientMessage.getCorrelationId();
+                long correlationId = clientMessage.getCorrelationId();
                 final EventHandler eventHandler = eventHandlerMap.get(correlationId);
                 if (eventHandler == null) {
                     logger.warning("No eventHandler for callId: " + correlationId + ", event: " + clientMessage

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/listener/ClientSmartListenerService.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/listener/ClientSmartListenerService.java
@@ -82,7 +82,7 @@ public class ClientSmartListenerService extends ClientListenerServiceImpl implem
         String serverRegistrationId = codec.decodeAddResponse(invocation.invoke().get());
 
         handler.onListenerRegister();
-        int correlationId = request.getCorrelationId();
+        long correlationId = request.getCorrelationId();
         ClientEventRegistration registration
                 = new ClientEventRegistration(serverRegistrationId, correlationId, address, codec);
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/ClientMessage.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/ClientMessage.java
@@ -44,7 +44,9 @@ import java.util.Arrays;
  * +-------------+---------------+---------------------------------+
  * |  Version    |B|E|  Flags    |               Type              |
  * +-------------+---------------+---------------------------------+
- * |                       CorrelationId                           |
+ * |                                                               |
+ * +                       CorrelationId                           +
+ * |                                                               |
  * +---------------------------------------------------------------+
  * |                        PartitionId                            |
  * +-----------------------------+---------------------------------+
@@ -100,7 +102,7 @@ public class ClientMessage
     private static final int FLAGS_FIELD_OFFSET = VERSION_FIELD_OFFSET + Bits.BYTE_SIZE_IN_BYTES;
     private static final int TYPE_FIELD_OFFSET = FLAGS_FIELD_OFFSET + Bits.BYTE_SIZE_IN_BYTES;
     private static final int CORRELATION_ID_FIELD_OFFSET = TYPE_FIELD_OFFSET + Bits.SHORT_SIZE_IN_BYTES;
-    private static final int PARTITION_ID_FIELD_OFFSET = CORRELATION_ID_FIELD_OFFSET + Bits.INT_SIZE_IN_BYTES;
+    private static final int PARTITION_ID_FIELD_OFFSET = CORRELATION_ID_FIELD_OFFSET + Bits.LONG_SIZE_IN_BYTES;
     private static final int DATA_OFFSET_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + Bits.INT_SIZE_IN_BYTES;
 
 
@@ -265,8 +267,8 @@ public class ClientMessage
      *
      * @return The correlation id field.
      */
-    public int getCorrelationId() {
-        return int32Get(CORRELATION_ID_FIELD_OFFSET);
+    public long getCorrelationId() {
+        return int64Get(CORRELATION_ID_FIELD_OFFSET);
     }
 
     /**
@@ -275,8 +277,8 @@ public class ClientMessage
      * @param correlationId The value to set in the correlation id field.
      * @return The ClientMessage with the new correlation id field value.
      */
-    public ClientMessage setCorrelationId(final int correlationId) {
-        int32Set(CORRELATION_ID_FIELD_OFFSET, correlationId);
+    public ClientMessage setCorrelationId(final long correlationId) {
+        int64Set(CORRELATION_ID_FIELD_OFFSET, correlationId);
         return this;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/util/ClientMessageBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/util/ClientMessageBuilder.java
@@ -16,8 +16,8 @@
 
 package com.hazelcast.client.impl.protocol.util;
 
-import com.hazelcast.util.collection.Int2ObjectHashMap;
 import com.hazelcast.client.impl.protocol.ClientMessage;
+import com.hazelcast.util.collection.Long2ObjectHashMap;
 
 import java.nio.ByteBuffer;
 
@@ -30,7 +30,7 @@ import static com.hazelcast.client.impl.protocol.ClientMessage.END_FLAG;
  */
 public class ClientMessageBuilder {
 
-    private final Int2ObjectHashMap<BufferBuilder> builderBySessionIdMap = new Int2ObjectHashMap<BufferBuilder>();
+    private final Long2ObjectHashMap<BufferBuilder> builderBySessionIdMap = new Long2ObjectHashMap<BufferBuilder>();
 
     private final MessageHandler delegate;
     private ClientMessage message = ClientMessage.create();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/util/MessageFlyweight.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/util/MessageFlyweight.java
@@ -210,8 +210,16 @@ public class MessageFlyweight {
         return buffer.getInt(index + offset);
     }
 
-    protected void int32Set(int index, int length) {
-        buffer.putInt(index + offset, length);
+    protected void int32Set(int index, int value) {
+        buffer.putInt(index + offset, value);
+    }
+
+    protected long int64Get(int index) {
+        return buffer.getLong(index + offset);
+    }
+
+    protected void int64Set(int index, long value) {
+        buffer.putLong(index + offset, value);
     }
 
     protected short uint8Get(int index) {

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/ClientMessageAccumulatorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/ClientMessageAccumulatorTest.java
@@ -25,7 +25,7 @@ import static org.junit.Assert.assertTrue;
 public class ClientMessageAccumulatorTest {
 
 
-    private static final byte[] BYTE_DATA = new byte[] { 20, 0, 0, 0 ,0, 0, 0 ,0, 0, 0 ,0, 0, 0 ,0, 0, 0 ,0, 0, 0 ,0, 0, 0 };
+    private static final byte[] BYTE_DATA = new byte[] { 24, 0, 0, 0 ,0, 0, 0 ,0, 0, 0 ,0, 0, 0 ,0, 0, 0 ,0, 0, 0 ,0, 0, 0, 0, 0, 0, 0 };
 
     @Before
     public void setUp() {

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/ClientMessageTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/ClientMessageTest.java
@@ -51,7 +51,8 @@ public class ClientMessageTest {
 
         ClientMessage cmEncode = TestClientMessage.createForEncode(safeBuffer, 0);
 
-        cmEncode.setMessageType(0x1122).setVersion((short) 0xEF).addFlag(ClientMessage.BEGIN_AND_END_FLAGS).setCorrelationId(0x12345678)
+        cmEncode.setMessageType(0x1122).setVersion((short) 0xEF).addFlag(ClientMessage.BEGIN_AND_END_FLAGS)
+                .setCorrelationId(0x1234567812345678l)
                 .setPartitionId(0x11223344);
 
         // little endian
@@ -76,16 +77,20 @@ public class ClientMessageTest {
         assertThat(byteBuffer.get(9), is((byte) 0x56));
         assertThat(byteBuffer.get(10), is((byte) 0x34));
         assertThat(byteBuffer.get(11), is((byte) 0x12));
+        assertThat(byteBuffer.get(12), is((byte) 0x78));
+        assertThat(byteBuffer.get(13), is((byte) 0x56));
+        assertThat(byteBuffer.get(14), is((byte) 0x34));
+        assertThat(byteBuffer.get(15), is((byte) 0x12));
 
         //setPartitionId
-        assertThat(byteBuffer.get(12), is((byte) 0x44));
-        assertThat(byteBuffer.get(13), is((byte) 0x33));
-        assertThat(byteBuffer.get(14), is((byte) 0x22));
-        assertThat(byteBuffer.get(15), is((byte) 0x11));
+        assertThat(byteBuffer.get(16), is((byte) 0x44));
+        assertThat(byteBuffer.get(17), is((byte) 0x33));
+        assertThat(byteBuffer.get(18), is((byte) 0x22));
+        assertThat(byteBuffer.get(19), is((byte) 0x11));
 
         //data offset
-        assertThat(byteBuffer.get(16), is((byte) ClientMessage.HEADER_SIZE));
-        assertThat(byteBuffer.get(17), is((byte) 0x00));
+        assertThat(byteBuffer.get(20), is((byte) ClientMessage.HEADER_SIZE));
+        assertThat(byteBuffer.get(21), is((byte) 0x00));
 
     }
 
@@ -371,14 +376,14 @@ public class ClientMessageTest {
 
     @Test
     public void testUnsignedFields() throws IOException {
-        ClientProtocolBuffer buffer = new SafeBuffer(new byte[18]);
+        ClientProtocolBuffer buffer = new SafeBuffer(new byte[22]);
 
         ClientMessage cmEncode = ClientMessage.createForEncode(buffer, 0);
 
         cmEncode.setVersion((short) (Byte.MAX_VALUE + 10));
         cmEncode.setMessageType(Short.MAX_VALUE + 10);
         cmEncode.setDataOffset((int) Short.MAX_VALUE + 10);
-        cmEncode.setCorrelationId(Short.MAX_VALUE + 10);
+        cmEncode.setCorrelationId(Integer.MAX_VALUE + 10);
 
         ClientMessage cmDecode = ClientMessage.createForDecode(buffer, 0);
 

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/MapMessageEncodeDecodeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/MapMessageEncodeDecodeTest.java
@@ -41,7 +41,8 @@ public class MapMessageEncodeDecodeTest {
     public void shouldEncodeDecodeCorrectly_PUT() {
         final int calculatedSize = MapPutCodec.RequestParameters.calculateDataSize(NAME, DATA, DATA, THE_LONG, THE_LONG);
         ClientMessage cmEncode = MapPutCodec.encodeRequest(NAME, DATA, DATA, THE_LONG, THE_LONG);
-        cmEncode.setVersion((short) 3).addFlag(ClientMessage.BEGIN_AND_END_FLAGS).setCorrelationId(66).setPartitionId(77);
+        cmEncode.setVersion((short) 3).addFlag(ClientMessage.BEGIN_AND_END_FLAGS)
+                .setCorrelationId(Long.MAX_VALUE).setPartitionId(77);
 
         assertTrue(calculatedSize > cmEncode.getFrameLength());
         byteBuffer = cmEncode.buffer();
@@ -52,7 +53,7 @@ public class MapMessageEncodeDecodeTest {
         assertEquals(MapPutCodec.REQUEST_TYPE.id(), cmDecode.getMessageType());
         assertEquals(3, cmDecode.getVersion());
         assertEquals(ClientMessage.BEGIN_AND_END_FLAGS, cmDecode.getFlags());
-        assertEquals(66, cmDecode.getCorrelationId());
+        assertEquals(Long.MAX_VALUE, cmDecode.getCorrelationId());
         assertEquals(77, cmDecode.getPartitionId());
 
         assertEquals(NAME, decodeParams.name);


### PR DESCRIPTION
Client protocol's correlation id is extended to eliminate int overflows