### PR TITLE
Introducing max allowed invocation for clients

### DIFF
--- a/hazelcast-client-legacy/src/main/java/com/hazelcast/client/config/ClientProperty.java
+++ b/hazelcast-client-legacy/src/main/java/com/hazelcast/client/config/ClientProperty.java
@@ -65,7 +65,18 @@ public enum ClientProperty implements HazelcastProperty {
     /**
      * Time to give up on invocation when a member in the member list is not reachable.
      */
-    INVOCATION_TIMEOUT_SECONDS("hazelcast.client.invocation.timeout.seconds", 120, SECONDS);
+    INVOCATION_TIMEOUT_SECONDS("hazelcast.client.invocation.timeout.seconds", 120, SECONDS),
+
+    /**
+     * The maximum number of concurrent invocations allowed.
+     * <p/>
+     * To prevent the system from overloading, user can apply a constraint on the number of concurrent invocations.
+     * If the maximum number of concurrent invocations has been exceeded and a new invocation comes in,
+     * then hazelcast will throw HazelcastOverloadException
+     * <p/>
+     * By default it is configured as Integer.MaxValue.
+     */
+    MAX_CONCURRENT_INVOCATIONS("hazelcast.client.max.concurrent.invocations", Integer.MAX_VALUE);
 
     private final String name;
     private final String defaultValue;

--- a/hazelcast-client-legacy/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
+++ b/hazelcast-client-legacy/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
@@ -360,7 +360,7 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
                 }
                 if (now - connection.lastReadTimeMillis() > heartBeatInterval) {
                     final ClientPingRequest request = new ClientPingRequest();
-                    new ClientInvocation(client, request, connection).invoke();
+                    new ClientInvocation(client, request, connection).invokeUrgent();
                 } else {
                     if (!connection.isHeartBeating()) {
                         connection.heartBeatingSucceed();

--- a/hazelcast-client-legacy/src/main/java/com/hazelcast/client/impl/ClusterAuthenticator.java
+++ b/hazelcast-client-legacy/src/main/java/com/hazelcast/client/impl/ClusterAuthenticator.java
@@ -60,7 +60,7 @@ public class ClusterAuthenticator implements Authenticator {
         //contains remoteAddress and principal
         SerializableList collectionWrapper;
         final ClientInvocation clientInvocation = new ClientInvocation(client, auth, connection);
-        final Future<SerializableList> future = clientInvocation.invoke();
+        final Future<SerializableList> future = clientInvocation.invokeUrgent();
         try {
             collectionWrapper = ss.toObject(future.get());
         } catch (Exception e) {

--- a/hazelcast-client-legacy/src/main/java/com/hazelcast/client/spi/impl/CallIdSequence.java
+++ b/hazelcast-client-legacy/src/main/java/com/hazelcast/client/spi/impl/CallIdSequence.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.spi.impl;
+
+
+import com.hazelcast.core.HazelcastOverloadException;
+
+import java.util.concurrent.atomic.AtomicLongArray;
+
+import static com.hazelcast.nio.Bits.CACHE_LINE_LENGTH;
+import static com.hazelcast.nio.Bits.LONG_SIZE_IN_BYTES;
+
+
+public abstract class CallIdSequence {
+
+    /**
+     * Creates the next call-id.
+     * <p/>
+     *
+     * @return the generated callId.
+     */
+    public abstract long next();
+
+    /**
+     * Creates the call id without applying any backpressure
+     *
+     * @return the generated call id.
+     */
+    public abstract long renew();
+
+    public abstract void complete();
+
+    /**
+     * A {@link com.hazelcast.spi.impl.operationservice.impl.CallIdSequence} that provided backpressure by taking
+     * the number in flight operations into account when a call-id needs to be determined.
+     * <p/>
+     * It is possible to temporary exceed the capacity:
+     * - due to system operations
+     * - due to racy nature of checking if space is available and getting the next sequence.
+     * <p/>
+     */
+    public static final class CallIdSequenceWithBackpressureViaException extends CallIdSequence {
+        private static final int INDEX_HEAD = 7;
+        private static final int INDEX_TAIL = INDEX_HEAD + CACHE_LINE_LENGTH / LONG_SIZE_IN_BYTES;
+
+        // instead of using 2 AtomicLongs, we use an array if width of 3 cache lines to prevent any false sharing.
+        private final AtomicLongArray longs = new AtomicLongArray(3 * CACHE_LINE_LENGTH / LONG_SIZE_IN_BYTES);
+
+        private final int maxConcurrentInvocations;
+
+        public CallIdSequenceWithBackpressureViaException(int maxConcurrentInvocations) {
+            this.maxConcurrentInvocations = maxConcurrentInvocations;
+        }
+
+        @Override
+        public long next() {
+            if (!hasSpace()) {
+                throw new HazelcastOverloadException("Failed to get a callId for invocation: ");
+            }
+
+            return longs.incrementAndGet(INDEX_HEAD);
+        }
+
+        @Override
+        public long renew() {
+            return longs.incrementAndGet(INDEX_HEAD);
+        }
+
+        private boolean hasSpace() {
+            return longs.get(INDEX_HEAD) - longs.get(INDEX_TAIL) < maxConcurrentInvocations;
+        }
+
+        @Override
+        public void complete() {
+            longs.incrementAndGet(INDEX_TAIL);
+        }
+    }
+}

--- a/hazelcast-client-legacy/src/main/java/com/hazelcast/client/spi/impl/ClientMembershipListener.java
+++ b/hazelcast-client-legacy/src/main/java/com/hazelcast/client/spi/impl/ClientMembershipListener.java
@@ -99,7 +99,7 @@ class ClientMembershipListener implements EventHandler<ClientInitialMembershipEv
                         + "Address " + ownerConnectionAddress);
             }
             ClientInvocation invocation = new ClientInvocation(client, this, request, connection);
-            invocation.invoke().get();
+            invocation.invokeUrgent().get();
             waitInitialMemberListFetched();
 
         } catch (Exception e) {

--- a/hazelcast-client-legacy/src/main/java/com/hazelcast/client/spi/impl/ClientPartitionServiceImpl.java
+++ b/hazelcast-client-legacy/src/main/java/com/hazelcast/client/spi/impl/ClientPartitionServiceImpl.java
@@ -119,11 +119,11 @@ public final class ClientPartitionServiceImpl implements ClientPartitionService 
         }
         try {
             final GetPartitionsRequest request = new GetPartitionsRequest();
-            Future<PartitionsResponse> future = new ClientInvocation(client, request, connection).invoke();
+            Future<PartitionsResponse> future = new ClientInvocation(client, request, connection).invokeUrgent();
             return client.getSerializationService().toObject(future.get());
         } catch (Exception e) {
             if (client.getLifecycleService().isRunning()) {
-                LOGGER.severe("Error while fetching cluster partition table!", e);
+                LOGGER.warning("Error while fetching cluster partition table!", e);
             }
         }
         return null;

--- a/hazelcast-client-legacy/src/main/java/com/hazelcast/client/spi/impl/ClusterListenerSupport.java
+++ b/hazelcast-client-legacy/src/main/java/com/hazelcast/client/spi/impl/ClusterListenerSupport.java
@@ -117,7 +117,7 @@ public abstract class ClusterListenerSupport implements ConnectionListener, Conn
             //contains remoteAddress and principal
             SerializableList collectionWrapper;
             final ClientInvocation clientInvocation = new ClientInvocation(client, auth, connection);
-            final Future<SerializableList> future = clientInvocation.invoke();
+            final Future<SerializableList> future = clientInvocation.invokeUrgent();
             try {
                 collectionWrapper = ss.toObject(future.get());
             } catch (Exception e) {

--- a/hazelcast-client-legacy/src/main/java/com/hazelcast/client/spi/impl/listener/ClientEventRegistration.java
+++ b/hazelcast-client-legacy/src/main/java/com/hazelcast/client/spi/impl/listener/ClientEventRegistration.java
@@ -28,11 +28,11 @@ public class ClientEventRegistration {
 
     private Address subscriber;
     private final String serverRegistrationId;
-    private final int callId;
+    private final long callId;
     private BaseClientRemoveListenerRequest removeRequest;
 
     public ClientEventRegistration(String serverRegistrationId,
-                                   int callId, Address subscriber, BaseClientRemoveListenerRequest removeRequest) {
+                                   long callId, Address subscriber, BaseClientRemoveListenerRequest removeRequest) {
         this.removeRequest = removeRequest;
         isNotNull(serverRegistrationId, "serverRegistrationId");
         this.serverRegistrationId = serverRegistrationId;
@@ -77,7 +77,7 @@ public class ClientEventRegistration {
      *
      * @return call id
      */
-    public int getCallId() {
+    public long getCallId() {
         return callId;
     }
 

--- a/hazelcast-client-legacy/src/main/java/com/hazelcast/client/spi/impl/listener/ClientListenerServiceImpl.java
+++ b/hazelcast-client-legacy/src/main/java/com/hazelcast/client/spi/impl/listener/ClientListenerServiceImpl.java
@@ -44,8 +44,8 @@ public abstract class ClientListenerServiceImpl implements ClientListenerService
     protected final SerializationService serializationService;
     protected final ClientInvocationService invocationService;
     protected final ILogger logger = Logger.getLogger(ClientListenerService.class);
-    private final ConcurrentMap<Integer, EventHandler> eventHandlerMap
-            = new ConcurrentHashMap<Integer, EventHandler>();
+    private final ConcurrentMap<Long, EventHandler> eventHandlerMap
+            = new ConcurrentHashMap<Long, EventHandler>();
 
     private final StripedExecutor eventExecutor;
 
@@ -59,15 +59,15 @@ public abstract class ClientListenerServiceImpl implements ClientListenerService
     }
 
 
-    public void addEventHandler(int callId, EventHandler handler) {
+    public void addEventHandler(long callId, EventHandler handler) {
         eventHandlerMap.put(callId, handler);
     }
 
-    protected void removeEventHandler(int callId) {
+    protected void removeEventHandler(long callId) {
         eventHandlerMap.remove(callId);
     }
 
-    protected EventHandler getEventHandler(int callId) {
+    protected EventHandler getEventHandler(long callId) {
         return eventHandlerMap.get(callId);
     }
 
@@ -102,7 +102,7 @@ public abstract class ClientListenerServiceImpl implements ClientListenerService
             ClientConnection conn = (ClientConnection) packet.getConn();
             try {
                 ClientResponse clientResponse = serializationService.toObject(packet);
-                int callId = clientResponse.getCallId();
+                long callId = clientResponse.getCallId();
                 Data response = clientResponse.getResponse();
                 handleEvent(response, callId, conn);
             } finally {
@@ -110,7 +110,7 @@ public abstract class ClientListenerServiceImpl implements ClientListenerService
             }
         }
 
-        private void handleEvent(Data event, int callId, ClientConnection conn) {
+        private void handleEvent(Data event, long callId, ClientConnection conn) {
             Object eventObject = serializationService.toObject(event);
             EventHandler eventHandler = eventHandlerMap.get(callId);
             if (eventHandler == null) {

--- a/hazelcast-client-legacy/src/main/java/com/hazelcast/client/spi/impl/listener/ClientSmartListenerService.java
+++ b/hazelcast-client-legacy/src/main/java/com/hazelcast/client/spi/impl/listener/ClientSmartListenerService.java
@@ -88,7 +88,7 @@ public class ClientSmartListenerService extends ClientListenerServiceImpl implem
         String serverRegistrationId = serializationService.toObject(future.get());
 
         handler.onListenerRegister();
-        int callId = invocation.getRequest().getCallId();
+        long callId = invocation.getRequest().getCallId();
         ClientEventRegistration registration
                 = new ClientEventRegistration(serverRegistrationId, callId, address, removeRequest);
 

--- a/hazelcast-client-legacy/src/test/java/com/hazelcast/client/ClientMaxAllowedInvocationTest.java
+++ b/hazelcast-client-legacy/src/test/java/com/hazelcast/client/ClientMaxAllowedInvocationTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client;
+
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.config.ClientProperty;
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.HazelcastOverloadException;
+import com.hazelcast.core.IExecutorService;
+import com.hazelcast.core.IMap;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.io.Serializable;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ClientMaxAllowedInvocationTest extends HazelcastTestSupport {
+
+    private final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
+
+    @After
+    public void cleanup() {
+        hazelcastFactory.terminateAll();
+    }
+
+
+    @Test(expected = HazelcastOverloadException.class)
+    public void testMaxAllowed_withSyncOperation() {
+        int MAX_ALLOWED = 10;
+        hazelcastFactory.newHazelcastInstance();
+        ClientConfig clientConfig = new ClientConfig();
+        clientConfig.setProperty(ClientProperty.MAX_CONCURRENT_INVOCATIONS.getName(), String.valueOf(MAX_ALLOWED));
+        HazelcastInstance client = hazelcastFactory.newHazelcastClient(clientConfig);
+        IMap map = client.getMap(randomString());
+
+        IExecutorService executorService = client.getExecutorService(randomString());
+
+        for (int i = 0; i < MAX_ALLOWED; i++) {
+            executorService.submit(new SleepyProcessor(Integer.MAX_VALUE));
+        }
+
+        map.get(2);
+    }
+
+    @Test(expected = HazelcastOverloadException.class)
+    public void testMaxAllowed_withAsyncOperation() {
+        int MAX_ALLOWED = 10;
+        hazelcastFactory.newHazelcastInstance();
+        ClientConfig clientConfig = new ClientConfig();
+        clientConfig.setProperty(ClientProperty.MAX_CONCURRENT_INVOCATIONS.getName(), String.valueOf(MAX_ALLOWED));
+        HazelcastInstance client = hazelcastFactory.newHazelcastClient(clientConfig);
+        IMap map = client.getMap(randomString());
+
+        IExecutorService executorService = client.getExecutorService(randomString());
+
+        for (int i = 0; i < MAX_ALLOWED; i++) {
+            executorService.submit(new SleepyProcessor(Integer.MAX_VALUE));
+        }
+
+        map.getAsync(1);
+    }
+
+    static class SleepyProcessor implements Runnable, Serializable {
+
+        private long millis;
+
+        SleepyProcessor(long millis) {
+            this.millis = millis;
+        }
+
+        @Override
+        public void run() {
+            try {
+
+                Thread.sleep(millis);
+            } catch (InterruptedException e) {
+                //ignored
+            }
+        }
+    }
+}

--- a/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientProperty.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientProperty.java
@@ -65,7 +65,18 @@ public enum ClientProperty implements HazelcastProperty {
     /**
      * Time to give up on invocation when a member in the member list is not reachable.
      */
-    INVOCATION_TIMEOUT_SECONDS("hazelcast.client.invocation.timeout.seconds", 120, SECONDS);
+    INVOCATION_TIMEOUT_SECONDS("hazelcast.client.invocation.timeout.seconds", 120, SECONDS),
+
+    /**
+     * The maximum number of concurrent invocations allowed.
+     * <p/>
+     * To prevent the system from overloading, user can apply a constraint on the number of concurrent invocations.
+     * If the maximum number of concurrent invocations has been exceeded and a new invocation comes in,
+     * then hazelcast will throw HazelcastOverloadException
+     * <p/>
+     * By default it is configured as Integer.MaxValue.
+     */
+    MAX_CONCURRENT_INVOCATIONS("hazelcast.client.max.concurrent.invocations", Integer.MAX_VALUE);
 
     private final String name;
     private final String defaultValue;

--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
@@ -365,7 +365,7 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
                     ClientMessage request = ClientPingCodec.encodeRequest();
                     ClientInvocation clientInvocation = new ClientInvocation(client, request, connection);
                     clientInvocation.setBypassHeartbeatCheck(true);
-                    clientInvocation.invoke();
+                    clientInvocation.invokeUrgent();
                 } else {
                     if (!connection.isHeartBeating()) {
                         LOGGER.warning("Heartbeat is back to healthy for connection : " + connection);

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/ClusterAuthenticator.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/ClusterAuthenticator.java
@@ -73,7 +73,7 @@ public class ClusterAuthenticator implements Authenticator {
 
         ClientMessage response;
         final ClientInvocation clientInvocation = new ClientInvocation(client, clientMessage, connection);
-        final Future<ClientMessage> future = clientInvocation.invoke();
+        final Future<ClientMessage> future = clientInvocation.invokeUrgent();
         try {
             response = future.get();
         } catch (Exception e) {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/CallIdSequence.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/CallIdSequence.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.spi.impl;
+
+import com.hazelcast.core.HazelcastOverloadException;
+
+import java.util.concurrent.atomic.AtomicLongArray;
+
+import static com.hazelcast.nio.Bits.CACHE_LINE_LENGTH;
+import static com.hazelcast.nio.Bits.LONG_SIZE_IN_BYTES;
+
+
+public abstract class CallIdSequence {
+
+    /**
+     * Creates the next call-id.
+     * <p/>
+     *
+     * @return the generated callId.
+     */
+    public abstract long next();
+
+    /**
+     * Creates the call id without applying any backpressure
+     *
+     * @return the generated call id.
+     */
+    public abstract long renew();
+
+    public abstract void complete();
+
+    /**
+     * A {@link com.hazelcast.spi.impl.operationservice.impl.CallIdSequence} that provided backpressure by taking
+     * the number in flight operations into account when a call-id needs to be determined.
+     * <p/>
+     * It is possible to temporary exceed the capacity:
+     * - due to system operations
+     * - due to racy nature of checking if space is available and getting the next sequence.
+     * <p/>
+     */
+    public static final class CallIdSequenceWithBackpressureViaException extends CallIdSequence {
+        private static final int INDEX_HEAD = 7;
+        private static final int INDEX_TAIL = INDEX_HEAD + CACHE_LINE_LENGTH / LONG_SIZE_IN_BYTES;
+
+        // instead of using 2 AtomicLongs, we use an array if width of 3 cache lines to prevent any false sharing.
+        private final AtomicLongArray longs = new AtomicLongArray(3 * CACHE_LINE_LENGTH / LONG_SIZE_IN_BYTES);
+
+        private final int maxConcurrentInvocations;
+
+        public CallIdSequenceWithBackpressureViaException(int maxConcurrentInvocations) {
+            this.maxConcurrentInvocations = maxConcurrentInvocations;
+        }
+
+        @Override
+        public long next() {
+            if (!hasSpace()) {
+                throw new HazelcastOverloadException("Failed to get a callId for invocation: ");
+            }
+
+            return longs.incrementAndGet(INDEX_HEAD);
+        }
+
+        @Override
+        public long renew() {
+            return longs.incrementAndGet(INDEX_HEAD);
+        }
+
+        private boolean hasSpace() {
+            return longs.get(INDEX_HEAD) - longs.get(INDEX_TAIL) < maxConcurrentInvocations;
+        }
+
+        @Override
+        public void complete() {
+            longs.incrementAndGet(INDEX_TAIL);
+        }
+    }
+}

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocation.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocation.java
@@ -27,6 +27,7 @@ import com.hazelcast.client.spi.ClientInvocationService;
 import com.hazelcast.client.spi.EventHandler;
 import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.core.HazelcastInstanceNotActiveException;
+import com.hazelcast.core.HazelcastOverloadException;
 import com.hazelcast.core.ICompletableFuture;
 import com.hazelcast.core.LifecycleService;
 import com.hazelcast.logging.ILogger;
@@ -67,6 +68,7 @@ public class ClientInvocation implements Runnable {
     private final Connection connection;
     private volatile ClientConnection sendConnection;
     private boolean bypassHeartbeatCheck;
+    private boolean urgent;
     private long retryTimeoutPointInMillis;
     private EventHandler handler;
 
@@ -130,10 +132,18 @@ public class ClientInvocation implements Runnable {
         try {
             invokeOnSelection();
         } catch (Exception e) {
+            if (e instanceof HazelcastOverloadException) {
+                throw (HazelcastOverloadException) e;
+            }
             notifyException(e);
         }
         return clientInvocationFuture;
 
+    }
+
+    public ClientInvocationFuture invokeUrgent() {
+        urgent = true;
+        return invoke();
     }
 
     private void invokeOnSelection() throws IOException {
@@ -270,6 +280,10 @@ public class ClientInvocation implements Runnable {
 
     public boolean shouldBypassHeartbeatCheck() {
         return bypassHeartbeatCheck;
+    }
+
+    public boolean isUrgent() {
+        return urgent;
     }
 
     public void setBypassHeartbeatCheck(boolean bypassHeartbeatCheck) {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientMembershipListener.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientMembershipListener.java
@@ -138,7 +138,7 @@ class ClientMembershipListener extends ClientAddMembershipListenerCodec.Abstract
             }
             ClientInvocation invocation = new ClientInvocation(client, clientMessage, connection);
             invocation.setEventHandler(this);
-            invocation.invoke().get();
+            invocation.invokeUrgent().get();
             waitInitialMemberListFetched();
 
         } catch (Exception e) {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientPartitionServiceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientPartitionServiceImpl.java
@@ -120,12 +120,12 @@ public final class ClientPartitionServiceImpl
         }
         try {
             ClientMessage requestMessage = ClientGetPartitionsCodec.encodeRequest();
-            Future<ClientMessage> future = new ClientInvocation(client, requestMessage, connection).invoke();
+            Future<ClientMessage> future = new ClientInvocation(client, requestMessage, connection).invokeUrgent();
             ClientMessage responseMessage = future.get();
             return ClientGetPartitionsCodec.decodeResponse(responseMessage);
         } catch (Exception e) {
             if (client.getLifecycleService().isRunning()) {
-                LOGGER.severe("Error while fetching cluster partition table!", e);
+                LOGGER.warning("Error while fetching cluster partition table!", e);
             }
         }
         return null;

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClusterListenerSupport.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClusterListenerSupport.java
@@ -136,7 +136,7 @@ public abstract class ClusterListenerSupport implements ConnectionListener, Conn
 
             ClientMessage response;
             final ClientInvocation clientInvocation = new ClientInvocation(client, clientMessage, connection);
-            final Future<ClientMessage> future = clientInvocation.invoke();
+            final Future<ClientMessage> future = clientInvocation.invokeUrgent();
             try {
                 response = future.get();
             } catch (Exception e) {

--- a/hazelcast-client/src/test/java/com/hazelcast/client/ClientMaxAllowedInvocationTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ClientMaxAllowedInvocationTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client;
+
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.config.ClientProperty;
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.HazelcastOverloadException;
+import com.hazelcast.core.IExecutorService;
+import com.hazelcast.core.IMap;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.io.Serializable;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ClientMaxAllowedInvocationTest extends HazelcastTestSupport {
+
+    private final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
+
+    @After
+    public void cleanup() {
+        hazelcastFactory.terminateAll();
+    }
+
+
+    @Test(expected = HazelcastOverloadException.class)
+    public void testMaxAllowed_withSyncOperation() {
+        int MAX_ALLOWED = 10;
+        hazelcastFactory.newHazelcastInstance();
+        ClientConfig clientConfig = new ClientConfig();
+        clientConfig.setProperty(ClientProperty.MAX_CONCURRENT_INVOCATIONS.getName(), String.valueOf(MAX_ALLOWED));
+        HazelcastInstance client = hazelcastFactory.newHazelcastClient(clientConfig);
+        IMap map = client.getMap(randomString());
+
+        IExecutorService executorService = client.getExecutorService(randomString());
+
+        for (int i = 0; i < MAX_ALLOWED; i++) {
+            executorService.submit(new SleepyProcessor(Integer.MAX_VALUE));
+        }
+
+        map.get(2);
+    }
+
+    @Test(expected = HazelcastOverloadException.class)
+    public void testMaxAllowed_withAsyncOperation() {
+        int MAX_ALLOWED = 10;
+        hazelcastFactory.newHazelcastInstance();
+        ClientConfig clientConfig = new ClientConfig();
+        clientConfig.setProperty(ClientProperty.MAX_CONCURRENT_INVOCATIONS.getName(), String.valueOf(MAX_ALLOWED));
+        HazelcastInstance client = hazelcastFactory.newHazelcastClient(clientConfig);
+        IMap map = client.getMap(randomString());
+
+        IExecutorService executorService = client.getExecutorService(randomString());
+
+        for (int i = 0; i < MAX_ALLOWED; i++) {
+            executorService.submit(new SleepyProcessor(Integer.MAX_VALUE));
+        }
+
+        map.getAsync(1);
+    }
+
+    static class SleepyProcessor implements Runnable, Serializable {
+
+        private long millis;
+
+        SleepyProcessor(long millis) {
+            this.millis = millis;
+        }
+
+        @Override
+        public void run() {
+            try {
+
+                Thread.sleep(millis);
+            } catch (InterruptedException e) {
+                //ignored
+            }
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/client/CacheAddEntryListenerRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/client/CacheAddEntryListenerRequest.java
@@ -83,10 +83,10 @@ public class CacheAddEntryListenerRequest extends BaseClientAddListenerRequest {
             ListenerWrapperEventFilter,
             Serializable {
 
-        private final int callId;
+        private final long callId;
         private final transient ClientEndpoint endpoint;
 
-        private CacheEntryListener(int callId, ClientEndpoint endpoint) {
+        private CacheEntryListener(long callId, ClientEndpoint endpoint) {
             this.callId = callId;
             this.endpoint = endpoint;
         }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/client/CacheInvalidationListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/client/CacheInvalidationListener.java
@@ -30,10 +30,10 @@ public final class CacheInvalidationListener
         implements CacheEventListener, NotifiableEventListener<ICacheService> {
 
     private final ClientEndpoint endpoint;
-    private final int callId;
+    private final long callId;
     private final CacheContext cacheContext;
 
-    public CacheInvalidationListener(ClientEndpoint endpoint, int callId, CacheContext cacheContext) {
+    public CacheInvalidationListener(ClientEndpoint endpoint, long callId, CacheContext cacheContext) {
         this.endpoint = endpoint;
         this.callId = callId;
         this.cacheContext = cacheContext;

--- a/hazelcast/src/main/java/com/hazelcast/client/ClientEndpoint.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/ClientEndpoint.java
@@ -38,10 +38,10 @@ public interface ClientEndpoint {
     boolean isAlive();
 
     //TODO remove after requests removed
-    void sendResponse(Object response, int callId);
+    void sendResponse(Object response, long callId);
 
     //TODO remove after requests removed
-    void sendEvent(Object key, Object event, int callId);
+    void sendEvent(Object key, Object event, long callId);
 
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEndpointImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEndpointImpl.java
@@ -241,7 +241,7 @@ public final class ClientEndpointImpl implements Client, ClientEndpoint {
     }
 
     @Override
-    public void sendResponse(Object response, int callId) {
+    public void sendResponse(Object response, long callId) {
         boolean isError = false;
         Object clientResponseObject;
         if (response instanceof Throwable) {
@@ -261,7 +261,7 @@ public final class ClientEndpointImpl implements Client, ClientEndpoint {
     }
 
     @Override
-    public void sendEvent(Object key, Object event, int callId) {
+    public void sendEvent(Object key, Object event, long callId) {
         clientEngine.sendResponse(this, key, event, callId, false, true);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngineImpl.java
@@ -214,7 +214,8 @@ public class ClientEngineImpl implements ClientEngine, CoreService, PostJoinAwar
         return nodeEngine.getProxyService();
     }
 
-    public void sendResponse(ClientEndpoint endpoint, Object key, Object response, int callId, boolean isError, boolean isEvent) {
+    public void sendResponse(ClientEndpoint endpoint, Object key, Object response, long callId,
+                             boolean isError, boolean isEvent) {
         Data data = serializationService.toData(response);
         ClientResponse clientResponse = new ClientResponse(data, callId, isError);
         int partitionId = key == null ? -1 : getPartitionService().getPartitionId(key);
@@ -445,7 +446,7 @@ public class ClientEngineImpl implements ClientEngine, CoreService, PostJoinAwar
             if (request != null && endpoint != null) {
                 endpoint.sendResponse(e, request.getCallId());
             } else if (data != null && endpoint != null) {
-                int callId = extractCallId(data);
+                long callId = extractCallId(data);
                 if (callId != -1) {
                     endpoint.sendResponse(e, callId);
                 }
@@ -453,10 +454,10 @@ public class ClientEngineImpl implements ClientEngine, CoreService, PostJoinAwar
             }
         }
 
-        private int extractCallId(Data data) {
+        private long extractCallId(Data data) {
             try {
                 PortableReader portableReader = serializationService.createPortableReader(data);
-                return portableReader.readInt("cId");
+                return portableReader.readLong("cId");
 
             } catch (Throwable e) {
                 Level level = nodeEngine.isRunning() ? Level.SEVERE : Level.FINEST;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/client/ClientRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/client/ClientRequest.java
@@ -29,7 +29,7 @@ import java.io.IOException;
 
 public abstract class ClientRequest implements SecureRequest, VersionedPortable {
 
-    protected volatile int callId = -1;
+    protected volatile long callId = -1;
     protected transient ClientEngineImpl clientEngine;
     protected transient OperationService operationService;
     protected transient SerializationService serializationService;
@@ -72,17 +72,17 @@ public abstract class ClientRequest implements SecureRequest, VersionedPortable 
 
     public abstract String getServiceName();
 
-    public int getCallId() {
+    public long getCallId() {
         return callId;
     }
 
-    public void setCallId(int callId) {
+    public void setCallId(long callId) {
         this.callId = callId;
     }
 
     @Override
     public final void writePortable(PortableWriter writer) throws IOException {
-        writer.writeInt("cId", callId);
+        writer.writeLong("cId", callId);
         write(writer);
     }
 
@@ -91,7 +91,7 @@ public abstract class ClientRequest implements SecureRequest, VersionedPortable 
 
     @Override
     public final void readPortable(PortableReader reader) throws IOException {
-        callId = reader.readInt("cId");
+        callId = reader.readLong("cId");
         read(reader);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/client/ClientResponse.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/client/ClientResponse.java
@@ -27,13 +27,13 @@ import java.io.IOException;
 public class ClientResponse implements IdentifiedDataSerializable {
 
     private Data response;
-    private int callId;
+    private long callId;
     private boolean isError;
 
     public ClientResponse() {
     }
 
-    public ClientResponse(Data response, int callId, boolean isError) {
+    public ClientResponse(Data response, long callId, boolean isError) {
         this.response = response;
         this.callId = callId;
         this.isError = isError;
@@ -43,7 +43,7 @@ public class ClientResponse implements IdentifiedDataSerializable {
         return response;
     }
 
-    public int getCallId() {
+    public long getCallId() {
         return callId;
     }
 
@@ -63,14 +63,14 @@ public class ClientResponse implements IdentifiedDataSerializable {
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeInt(callId);
+        out.writeLong(callId);
         out.writeBoolean(isError);
         out.writeData(response);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        callId = in.readInt();
+        callId = in.readLong();
         isError = in.readBoolean();
         response = in.readData();
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/client/ClientMapListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/client/ClientMapListener.java
@@ -27,10 +27,10 @@ import com.hazelcast.spi.impl.PortableEntryEvent;
 
 public class ClientMapListener extends MapListenerAdapter<Object, Object> {
 
-    private final int callId;
+    private final long callId;
     private final ClientEndpoint endpoint;
 
-    public ClientMapListener(ClientEndpoint endpoint, int callId) {
+    public ClientMapListener(ClientEndpoint endpoint, long callId) {
         this.endpoint = endpoint;
         this.callId = callId;
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/client/MapAddNearCacheEntryListenerRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/client/MapAddNearCacheEntryListenerRequest.java
@@ -49,11 +49,11 @@ public class MapAddNearCacheEntryListenerRequest extends MapAddEntryListenerRequ
 
     private static class ClientNearCacheInvalidationListenerImpl implements InvalidationListener {
 
-        private final int callId;
+        private final long callId;
         private final String mapName;
         private final ClientEndpoint endpoint;
 
-        ClientNearCacheInvalidationListenerImpl(String mapName, ClientEndpoint endpoint, int callId) {
+        ClientNearCacheInvalidationListenerImpl(String mapName, ClientEndpoint endpoint, long callId) {
             this.mapName = mapName;
             this.endpoint = endpoint;
             this.callId = callId;

--- a/hazelcast/src/main/java/com/hazelcast/topic/impl/client/AddMessageListenerRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/impl/client/AddMessageListenerRequest.java
@@ -88,10 +88,10 @@ public class AddMessageListenerRequest extends BaseClientAddListenerRequest {
 
     private static class MessageListenerImpl implements MessageListener {
         private final ClientEndpoint endpoint;
-        private final int callId;
+        private final long callId;
         private final Data partitionKey;
 
-        public MessageListenerImpl(ClientEndpoint endpoint, Data partitionKey, int callId) {
+        public MessageListenerImpl(ClientEndpoint endpoint, Data partitionKey, long callId) {
             this.endpoint = endpoint;
             this.partitionKey = partitionKey;
             this.callId = callId;


### PR DESCRIPTION
Its default value is int max. If total number of invocations that
did not return response yet passes the configured threshold, user
gets HazelcastOverloadException.