### PR TITLE
Move IdleStrategy classes from Hot Restart

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/util/concurrent/BackoffIdleStrategy.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/concurrent/BackoffIdleStrategy.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.util.concurrent;
+
+
+import java.util.concurrent.locks.LockSupport;
+
+import static com.hazelcast.util.Preconditions.checkNotNegative;
+import static java.lang.Long.numberOfLeadingZeros;
+import static java.lang.Math.min;
+
+/**
+ * Idling strategy for threads when they have no work to do.
+ * <p/>
+ * Spin for maxSpins, then
+ * {@link Thread#yield()} for maxYields, then
+ * {@link LockSupport#parkNanos(long)} on an exponential backoff to maxParkPeriodNs
+ */
+public class BackoffIdleStrategy implements IdleStrategy {
+    private final long yieldThreshold;
+    private final long parkThreshold;
+    private final long minParkPeriodNs;
+    private final long maxParkPeriodNs;
+    private final int maxShift;
+
+    /**
+     * Create a set of state tracking idle behavior
+     *
+     * @param maxSpins        to perform before moving to {@link Thread#yield()}
+     * @param maxYields       to perform before moving to {@link LockSupport#parkNanos(long)}
+     * @param minParkPeriodNs to use when initiating parking
+     * @param maxParkPeriodNs to use when parking
+     */
+    public BackoffIdleStrategy(long maxSpins, long maxYields, long minParkPeriodNs, long maxParkPeriodNs) {
+        checkNotNegative(maxSpins, "maxSpins must be positive or zero");
+        checkNotNegative(maxYields, "maxYields must be positive or zero");
+        checkNotNegative(minParkPeriodNs, "minParkPeriodNs must be positive or zero");
+        checkNotNegative(maxParkPeriodNs - minParkPeriodNs,
+                "maxParkPeriodNs must be greater than or equal to minParkPeriodNs");
+        this.yieldThreshold = maxSpins;
+        this.parkThreshold = maxSpins + maxYields;
+        this.minParkPeriodNs = minParkPeriodNs;
+        this.maxParkPeriodNs = maxParkPeriodNs;
+        this.maxShift = numberOfLeadingZeros(minParkPeriodNs) - numberOfLeadingZeros(maxParkPeriodNs);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override public boolean idle(long n) {
+        if (n < yieldThreshold) {
+            return false;
+        }
+        if (n < parkThreshold) {
+            Thread.yield();
+            return false;
+        }
+        final long parkTime = parkTime(n);
+        LockSupport.parkNanos(parkTime);
+        return parkTime == maxParkPeriodNs;
+    }
+
+    long parkTime(long n) {
+        final long proposedShift = n - parkThreshold;
+        final long allowedShift = min(maxShift, proposedShift);
+        return proposedShift > maxShift ? maxParkPeriodNs
+             : proposedShift < maxShift ? minParkPeriodNs << allowedShift
+             : min(minParkPeriodNs << allowedShift, maxParkPeriodNs);
+    }
+}
+

--- a/hazelcast/src/main/java/com/hazelcast/util/concurrent/BusySpinIdleStrategy.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/concurrent/BusySpinIdleStrategy.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.util.concurrent;
+
+/**
+ * Busy spin strategy targeted at lowest possible latency. This strategy will monopolise a thread to achieve the lowest
+ * possible latency. Useful for creating bubbles in the execution pipeline of tight busy spin loops with no other
+ * logic than status checks on progress.
+ */
+public class BusySpinIdleStrategy implements IdleStrategy {
+    private int dummyCounter;
+
+    public boolean idle(final long n) {
+        final int dummyValue = 64;
+        // Trick speculative execution into not progressing
+        if (dummyCounter > 0) {
+            if (Math.random() > 0) {
+                --dummyCounter;
+            }
+        } else {
+            dummyCounter = dummyValue;
+        }
+        return true;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/util/concurrent/IdleStrategy.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/concurrent/IdleStrategy.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.util.concurrent;
+
+/**
+ * Idle strategy for use by threads when then they don't have work to do.
+ */
+public interface IdleStrategy {
+    /**
+     * Perform current idle strategy's step <i>n</i>.
+     *
+     * @param n number of times this method has been previously called with no intervening work done.
+     * @return whether the strategy has reached the longest pause time.
+     */
+    boolean idle(long n);
+}

--- a/hazelcast/src/main/java/com/hazelcast/util/concurrent/NoOpIdleStrategy.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/concurrent/NoOpIdleStrategy.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.util.concurrent;
+
+/**
+ * Low-latency idle strategy to be employed in loops that do significant work
+ * on each iteration such that any work in the idle strategy would be wasteful.
+ */
+public class NoOpIdleStrategy implements IdleStrategy {
+    public boolean idle(final long n) {
+        return true;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/util/concurrent/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/concurrent/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Abstractions that deal with common needs in concurrent programming.
+ */
+package com.hazelcast.util.concurrent;

--- a/hazelcast/src/test/java/com/hazelcast/util/concurrent/BackoffIdleStrategyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/concurrent/BackoffIdleStrategyTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.util.concurrent;
+
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class BackoffIdleStrategyTest {
+
+    @Test public void when_proposedShiftLessThanAllowed_then_shiftProposed() {
+        final BackoffIdleStrategy strat = new BackoffIdleStrategy(0, 0, 1, 4);
+
+        assertEquals(1, strat.parkTime(0));
+        assertEquals(2, strat.parkTime(1));
+    }
+
+    @Test public void when_maxShiftedGreaterThanMaxParkTime_thenParkMax() {
+        final BackoffIdleStrategy strat = new BackoffIdleStrategy(0, 0, 3, 4);
+
+        assertEquals(3, strat.parkTime(0));
+        assertEquals(4, strat.parkTime(1));
+        assertEquals(4, strat.parkTime(2));
+    }
+
+    @Test public void when_maxShiftedLessThanMaxParkTime_thenParkMaxShifted() {
+        final BackoffIdleStrategy strat = new BackoffIdleStrategy(0, 0, 2, 3);
+
+        assertEquals(2, strat.parkTime(0));
+        assertEquals(3, strat.parkTime(1));
+        assertEquals(3, strat.parkTime(2));
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/util/concurrent/IdleStrategyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/concurrent/IdleStrategyTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.util.concurrent;
+
+import com.hazelcast.test.HazelcastTestRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.test.annotation.RunParallel;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.util.Collection;
+
+import static com.hazelcast.util.concurrent.IdleStrategyTest.StrategyToTest.BACK_OFF;
+import static com.hazelcast.util.concurrent.IdleStrategyTest.StrategyToTest.BUSY_SPIN;
+import static com.hazelcast.util.concurrent.IdleStrategyTest.StrategyToTest.NO_OP;
+import static java.util.Arrays.asList;
+import static org.junit.Assert.fail;
+
+@RunParallel
+@RunWith(HazelcastTestRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class IdleStrategyTest {
+    private static final int MAX_CALLS = 10;
+
+    @Parameters(name = "manyToOne == {0}")
+    public static Collection<Object[]> params() {
+        return asList(new Object[][] { {NO_OP}, {BUSY_SPIN}, {BACK_OFF} });
+    }
+
+    @Parameter public StrategyToTest strategyToTest;
+
+    private IdleStrategy idler;
+
+    @Before public void setup() {
+        this.idler = strategyToTest.create();
+    }
+
+    enum StrategyToTest {
+        NO_OP     { IdleStrategy create() { return new NoOpIdleStrategy(); } },
+        BUSY_SPIN { IdleStrategy create() { return new BusySpinIdleStrategy(); } },
+        BACK_OFF  { IdleStrategy create() { return new BackoffIdleStrategy(1, 1, 1, 2); } }
+        ;
+        abstract IdleStrategy create();
+    }
+
+    @Test public void when_idle_thenReturnTrueEventually() {
+        for (int i = 0; i < MAX_CALLS; i++) {
+            if (idler.idle(i)) {
+                return;
+            }
+        }
+        fail();
+    }
+}


### PR DESCRIPTION
`IdleStrategy` is an abstraction that encapsulates the backoff strategy in busy-spin loops. It started its life in the Hot Restart module, but there are plans to use it elsewhere as well.

This is a minor PR (pure code move) therefore only one review is enough.