### PR TITLE
Add fsync flag to map & cache hot restart configurations

### DIFF
--- a/hazelcast-spring/src/main/resources/hazelcast-spring-3.6.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-3.6.xsd
@@ -253,6 +253,7 @@
                                             </xs:sequence>
                                         </xs:complexType>
                                     </xs:element>
+                                    <xs:element name="hot-restart" type="hot-restart" minOccurs="0" maxOccurs="1" />
                                 </xs:sequence>
                                 <xs:attribute name="name" use="required" type="xs:string"/>
                                 <xs:attribute name="in-memory-format" use="optional" type="xs:string" default="BINARY">
@@ -437,16 +438,6 @@
                                         </xs:documentation>
                                     </xs:annotation>
                                 </xs:attribute>
-                                <xs:attribute name="hot-restart-enabled" use="optional" type="parameterized-boolean">
-                                    <xs:annotation>
-                                        <xs:documentation>
-                                            This boolean parameter enables hot-restart feature when set as
-                                            `true`.
-                                            Only available on Hazelcast Enterprise.
-                                        </xs:documentation>
-                                    </xs:annotation>
-                                </xs:attribute>
-
                             </xs:complexType>
                         </xs:element>
                         <xs:element name="cache" minOccurs="0" maxOccurs="unbounded">
@@ -562,6 +553,7 @@
                                             </xs:documentation>
                                         </xs:annotation>
                                     </xs:element>
+                                    <xs:element name="hot-restart" type="hot-restart" minOccurs="0" maxOccurs="1" />
                                 </xs:sequence>
                                 <xs:attribute name="name" type="xs:string" use="required">
                                     <xs:annotation>
@@ -1008,7 +1000,7 @@
                                 </xs:attribute>
                             </xs:complexType>
                         </xs:element>
-                        <xs:element name="hot-restart" type="hot-restart" minOccurs="0" maxOccurs="1" />
+                        <xs:element name="hot-restart-persistence" type="hot-restart-persistence" minOccurs="0" maxOccurs="1" />
                     </xs:sequence>
                 </xs:extension>
             </xs:complexContent>
@@ -2461,7 +2453,7 @@
         <xs:union memberTypes="wan-ack-type-format-enum non-space-string"/>
     </xs:simpleType>
 
-    <xs:complexType name="hot-restart">
+    <xs:complexType name="hot-restart-persistence">
         <xs:sequence>
             <xs:element name="base-dir" type="xs:string" minOccurs="0" maxOccurs="1" default="hot-restart">
                 <xs:annotation>
@@ -2492,6 +2484,24 @@
                     Data load timeout for hot-restart process,
                     all members in the cluster should complete restoring their local data
                     before this timeout.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+    <xs:complexType name="hot-restart">
+        <xs:attribute name="fsync" type="xs:boolean" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    True if disk write should be followed by an fsync() system call,
+                    false otherwise.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="enabled" type="xs:boolean" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    True if hot-restart is enabled, false otherwise
+                    Only available on Hazelcast Enterprise.
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
@@ -25,7 +25,7 @@ import com.hazelcast.config.EvictionPolicy;
 import com.hazelcast.config.ExecutorConfig;
 import com.hazelcast.config.GlobalSerializerConfig;
 import com.hazelcast.config.GroupConfig;
-import com.hazelcast.config.HotRestartConfig;
+import com.hazelcast.config.HotRestartPersistenceConfig;
 import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.config.ItemListenerConfig;
 import com.hazelcast.config.ListenerConfig;
@@ -216,7 +216,8 @@ public class TestFullApplicationContext {
         assertEquals(1, config.getCacheConfigs().size());
         CacheSimpleConfig cacheConfig = config.getCacheConfig("testCache");
         assertEquals("testCache", cacheConfig.getName());
-        assertTrue(cacheConfig.isHotRestartEnabled());
+        assertTrue(cacheConfig.getHotRestartConfig().isEnabled());
+        assertTrue(cacheConfig.getHotRestartConfig().isFsync());
 
         WanReplicationRef wanRef = cacheConfig.getWanReplicationRef();
         assertEquals("testWan", wanRef.getName());
@@ -239,7 +240,8 @@ public class TestFullApplicationContext {
         assertEquals(Integer.MAX_VALUE, testMapConfig.getMaxSizeConfig().getSize());
         assertEquals(30, testMapConfig.getEvictionPercentage());
         assertEquals(0, testMapConfig.getTimeToLiveSeconds());
-        assertTrue(testMapConfig.isHotRestartEnabled());
+        assertTrue(testMapConfig.getHotRestartConfig().isEnabled());
+        assertTrue(testMapConfig.getHotRestartConfig().isFsync());
         assertEquals(1000, testMapConfig.getMinEvictionCheckMillis());
         assertEquals("PUT_IF_ABSENT", testMapConfig.getMergePolicy());
         assertTrue(testMapConfig.isReadBackupData());
@@ -766,11 +768,11 @@ public class TestFullApplicationContext {
     @Test
     public void testHotRestart() {
         File dir = new File("/mnt/hot-restart/");
-        HotRestartConfig hotRestartConfig = config.getHotRestartConfig();
-        assertTrue(hotRestartConfig.isEnabled());
-        assertEquals(dir.getAbsolutePath(), hotRestartConfig.getBaseDir().getAbsolutePath());
-        assertEquals(1111, hotRestartConfig.getValidationTimeoutSeconds());
-        assertEquals(2222, hotRestartConfig.getDataLoadTimeoutSeconds());
+        HotRestartPersistenceConfig hotRestartPersistenceConfig = config.getHotRestartPersistenceConfig();
+        assertTrue(hotRestartPersistenceConfig.isEnabled());
+        assertEquals(dir.getAbsolutePath(), hotRestartPersistenceConfig.getBaseDir().getAbsolutePath());
+        assertEquals(1111, hotRestartPersistenceConfig.getValidationTimeoutSeconds());
+        assertEquals(2222, hotRestartPersistenceConfig.getDataLoadTimeoutSeconds());
     }
 
 }

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullcacheconfig-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullcacheconfig-applicationContext-hazelcast.xml
@@ -137,7 +137,6 @@
                     eviction-percentage="30"
                     min-eviction-check-millis="1000"
                     read-backup-data="true"
-                    hot-restart-enabled="true"
                     eviction-policy="NONE"
                     merge-policy="PUT_IF_ABSENT"
                     in-memory-format="BINARY">
@@ -155,6 +154,7 @@
                     <hz:attribute name="weight" extractor="com.car.WeightExtractor" />
                 </hz:attributes>
                 <hz:quorum-ref>my-quorum</hz:quorum-ref>
+                <hz:hot-restart enabled="true" fsync="true" />
             </hz:map>
             <hz:map name="testMap2"
                     backup-count="2"
@@ -243,12 +243,13 @@
                 </hz:partition-lost-listeners>
             </hz:map>
 
-            <hz:cache name="testCache" hot-restart-enabled="true">
+            <hz:cache name="testCache">
                 <hz:wan-replication-ref name="testWan" merge-policy="PUT_IF_ABSENT" republishing-enabled="false">
                     <hz:filters>
                         <hz:filter-impl>com.example.SampleFilter</hz:filter-impl>
                     </hz:filters>
                 </hz:wan-replication-ref>
+                <hz:hot-restart enabled="true" fsync="true" />
             </hz:cache>
 
             <hz:multimap name="testMultimap"
@@ -353,9 +354,9 @@
                 </hz:quorum-listeners>
             </hz:quorum>
 
-            <hz:hot-restart enabled="true" validation-timeout-seconds="1111" data-load-timeout-seconds="2222">
+            <hz:hot-restart-persistence enabled="true" validation-timeout-seconds="1111" data-load-timeout-seconds="2222">
                 <hz:base-dir>/mnt/hot-restart/</hz:base-dir>
-            </hz:hot-restart>
+            </hz:hot-restart-persistence>
         </hz:config>
     </hz:hazelcast>
 

--- a/hazelcast/src/main/java/com/hazelcast/config/AbstractCacheConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/AbstractCacheConfig.java
@@ -94,10 +94,7 @@ abstract class AbstractCacheConfig<K, V> implements CacheConfiguration<K, V>, Da
      */
     protected boolean isManagementEnabled;
 
-    /**
-     * Whether Hot Restart is enabled
-     */
-    protected boolean hotRestartEnabled;
+    protected HotRestartConfig hotRestartConfig = new HotRestartConfig();
 
     public AbstractCacheConfig() {
         this.keyType = (Class<K>) Object.class;
@@ -232,21 +229,21 @@ abstract class AbstractCacheConfig<K, V> implements CacheConfiguration<K, V>, Da
     }
 
     /**
-     * Sets whether hot restart is enabled on this cache.
-     * @return this
+     * Gets the {@code HotRestartConfig} for this {@code CacheConfiguration}
+     * @return hot restart config
      */
-    public CacheConfiguration<K, V> setHotRestartEnabled(boolean hotRestart) {
-        this.hotRestartEnabled = hotRestart;
-        return this;
+    public HotRestartConfig getHotRestartConfig() {
+        return hotRestartConfig;
     }
 
     /**
-     * Returns whether hot restart enabled on this cache.
-     *
-     * @return true if hot restart enabled, false otherwise
+     * Sets the {@code HotRestartConfig} for this {@code CacheConfiguration}
+     * @param hotRestartConfig hot restart config
+     * @return this {@code CacheConfiguration} instance
      */
-    public boolean isHotRestartEnabled() {
-        return hotRestartEnabled;
+    public CacheConfiguration<K, V> setHotRestartConfig(HotRestartConfig hotRestartConfig) {
+        this.hotRestartConfig = hotRestartConfig;
+        return this;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/config/CacheConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CacheConfig.java
@@ -90,7 +90,7 @@ public class CacheConfig<K, V>
             this.asyncBackupCount = config.asyncBackupCount;
             this.backupCount = config.backupCount;
             this.inMemoryFormat = config.inMemoryFormat;
-            this.hotRestartEnabled = config.hotRestartEnabled;
+            this.hotRestartConfig = new HotRestartConfig(config.hotRestartConfig);
             // Eviction config cannot be null
             if (config.evictionConfig != null) {
                 this.evictionConfig = new CacheEvictionConfig(config.evictionConfig);
@@ -157,7 +157,7 @@ public class CacheConfig<K, V>
         }
         this.quorumName = simpleConfig.getQuorumName();
         this.mergePolicy = simpleConfig.getMergePolicy();
-        this.hotRestartEnabled = simpleConfig.isHotRestartEnabled();
+        this.hotRestartConfig = new HotRestartConfig(simpleConfig.getHotRestartConfig());
     }
 
     private void initExpiryPolicyFactoryConfig(CacheSimpleConfig simpleConfig) throws Exception {
@@ -506,7 +506,8 @@ public class CacheConfig<K, V>
         out.writeBoolean(isStoreByValue);
         out.writeBoolean(isManagementEnabled);
         out.writeBoolean(isStatisticsEnabled);
-        out.writeBoolean(hotRestartEnabled);
+        out.writeBoolean(hotRestartConfig.isEnabled());
+        out.writeBoolean(hotRestartConfig.isFsync());
 
         out.writeUTF(quorumName);
 
@@ -549,7 +550,8 @@ public class CacheConfig<K, V>
         isStoreByValue = in.readBoolean();
         isManagementEnabled = in.readBoolean();
         isStatisticsEnabled = in.readBoolean();
-        hotRestartEnabled = in.readBoolean();
+        hotRestartConfig.setEnabled(in.readBoolean());
+        hotRestartConfig.setFsync(in.readBoolean());
 
         quorumName = in.readUTF();
 
@@ -606,8 +608,7 @@ public class CacheConfig<K, V>
                 + ", managerPrefix='" + managerPrefix + '\''
                 + ", inMemoryFormat=" + inMemoryFormat
                 + ", backupCount=" + backupCount
-                + ", hotRestart=" + isHotRestartEnabled()
+                + ", hotRestart=" + hotRestartConfig
                 + '}';
     }
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/CacheConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CacheConfigReadOnly.java
@@ -146,7 +146,7 @@ public class CacheConfigReadOnly<K, V> extends CacheConfig<K, V> {
     }
 
     @Override
-    public CacheConfiguration<K, V> setHotRestartEnabled(boolean hotRestart) {
+    public CacheConfiguration<K, V> setHotRestartConfig(HotRestartConfig hotRestartConfig) {
         throw new UnsupportedOperationException("This config is read-only cache: " + getName());
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/config/CacheSimpleConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CacheSimpleConfig.java
@@ -99,7 +99,7 @@ public class CacheSimpleConfig {
 
     private String mergePolicy = BuiltInCacheMergePolicies.getDefault().getImplementationClassName();
 
-    private boolean hotRestartEnabled;
+    private HotRestartConfig hotRestartConfig = new HotRestartConfig();
 
     @SuppressWarnings("checkstyle:executablestatementcount")
     public CacheSimpleConfig(CacheSimpleConfig cacheSimpleConfig) {
@@ -126,7 +126,7 @@ public class CacheSimpleConfig {
                 new ArrayList<CachePartitionLostListenerConfig>(cacheSimpleConfig.getPartitionLostListenerConfigs());
         this.quorumName = cacheSimpleConfig.quorumName;
         this.mergePolicy = cacheSimpleConfig.mergePolicy;
-        this.hotRestartEnabled = cacheSimpleConfig.hotRestartEnabled;
+        this.hotRestartConfig = new HotRestartConfig(cacheSimpleConfig.hotRestartConfig);
     }
 
     public CacheSimpleConfig() {
@@ -555,24 +555,6 @@ public class CacheSimpleConfig {
     }
 
     /**
-     * Sets whether hot restart is enabled on this cache.
-     * @return this
-     */
-    public CacheSimpleConfig setHotRestartEnabled(boolean hotRestart) {
-        this.hotRestartEnabled = hotRestart;
-        return this;
-    }
-
-    /**
-     * Returns whether hot restart enabled on this cache.
-     *
-     * @return true if hot restart enabled, false otherwise
-     */
-    public boolean isHotRestartEnabled() {
-        return hotRestartEnabled;
-    }
-
-    /**
      * Gets the class name of {@link com.hazelcast.cache.CacheMergePolicy}
      * implementation of this cache config.
      *
@@ -592,6 +574,24 @@ public class CacheSimpleConfig {
      */
     public void setMergePolicy(String mergePolicy) {
         this.mergePolicy = mergePolicy;
+    }
+
+    /**
+     * Gets the {@code HotRestartConfig} for this {@code CacheSimpleConfig}
+     * @return hot restart config
+     */
+    public HotRestartConfig getHotRestartConfig() {
+        return hotRestartConfig;
+    }
+
+    /**
+     * Sets the {@code HotRestartConfig} for this {@code CacheSimpleConfig}
+     * @param hotRestartConfig hot restart config
+     * @return this {@code CacheSimpleConfig} instance
+     */
+    public CacheSimpleConfig setHotRestartConfig(HotRestartConfig hotRestartConfig) {
+        this.hotRestartConfig = hotRestartConfig;
+        return this;
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/config/Config.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/Config.java
@@ -118,7 +118,7 @@ public class Config {
 
     private NativeMemoryConfig nativeMemoryConfig = new NativeMemoryConfig();
 
-    private HotRestartConfig hotRestartConfig = new HotRestartConfig();
+    private HotRestartPersistenceConfig hotRestartPersistenceConfig = new HotRestartPersistenceConfig();
 
     private String licenseKey;
 
@@ -1002,8 +1002,8 @@ public class Config {
      *
      * @return hot restart configuration
      */
-    public HotRestartConfig getHotRestartConfig() {
-        return hotRestartConfig;
+    public HotRestartPersistenceConfig getHotRestartPersistenceConfig() {
+        return hotRestartPersistenceConfig;
     }
 
     /**
@@ -1012,9 +1012,9 @@ public class Config {
      * @param hrConfig hot restart configuration
      * @return Config
      */
-    public Config setHotRestartConfig(HotRestartConfig hrConfig) {
+    public Config setHotRestartPersistenceConfig(HotRestartPersistenceConfig hrConfig) {
         checkNotNull(hrConfig, "Hot restart config cannot be null!");
-        this.hotRestartConfig = hrConfig;
+        this.hotRestartPersistenceConfig = hrConfig;
         return this;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
@@ -389,8 +389,7 @@ public class ConfigXmlGenerator {
                     .append("</merge-policy>");
             xml.append("<read-backup-data>").append(m.isReadBackupData())
                     .append("</read-backup-data>");
-            xml.append("<hot-restart-enabled>").append(m.isHotRestartEnabled())
-                    .append("</hot-restart-enabled>");
+            appendHotRestartConfig(xml, m.getHotRestartConfig());
             xml.append("<statistics-enabled>").append(m.isStatisticsEnabled())
                     .append("</statistics-enabled>");
 
@@ -410,6 +409,13 @@ public class ConfigXmlGenerator {
         }
     }
 
+    private void appendHotRestartConfig(StringBuilder xml, HotRestartConfig m) {
+        xml.append("<hot-restart enabled=\"")
+                .append(m != null && m.isEnabled()).append("\">")
+                .append("<fsync>").append(m != null && m.isFsync()).append("</fsync>")
+                .append("</hot-restart>");
+    }
+
     private void cacheConfigXmlGenerator(StringBuilder xml, Config config) {
         for (CacheSimpleConfig c : config.getCacheConfigs().values()) {
             xml.append("<cache name=\"").append(c.getName()).append("\">");
@@ -420,7 +426,7 @@ public class ConfigXmlGenerator {
             xml.append("<management-enabled>").append(c.isManagementEnabled()).append("</management-enabled>");
             xml.append("<backup-count>").append(c.getBackupCount()).append("</backup-count>");
             xml.append("<async-backup-count>").append(c.getAsyncBackupCount()).append("</async-backup-count>");
-            xml.append("<hot-restart-enabled>").append(c.isHotRestartEnabled()) .append("</hot-restart-enabled>");
+            appendHotRestartConfig(xml, c.getHotRestartConfig());
             xml.append("<read-through>").append(c.isReadThrough()).append("</read-through>");
             xml.append("<write-through>").append(c.isWriteThrough()).append("</write-through>");
             xml.append("<cache-loader-factory class-name=\"").append(c.getCacheLoaderFactory()).append("\"/>");
@@ -709,20 +715,20 @@ public class ConfigXmlGenerator {
     }
 
     private void hotRestartXmlGenerator(StringBuilder xml, Config config) {
-        HotRestartConfig hotRestartConfig = config.getHotRestartConfig();
-        if (hotRestartConfig == null) {
-            xml.append("<hot-restart enabled=\"false\" />");
+        HotRestartPersistenceConfig hotRestartPersistenceConfig = config.getHotRestartPersistenceConfig();
+        if (hotRestartPersistenceConfig == null) {
+            xml.append("<hot-restart-persistence enabled=\"false\" />");
             return;
         }
-        xml.append("<hot-restart enabled=\"").append(hotRestartConfig.isEnabled()).append("\">");
-        xml.append("<base-dir>").append(hotRestartConfig.getBaseDir().getAbsolutePath()).append("</base-dir>");
+        xml.append("<hot-restart-persistence enabled=\"").append(hotRestartPersistenceConfig.isEnabled()).append("\">");
+        xml.append("<base-dir>").append(hotRestartPersistenceConfig.getBaseDir().getAbsolutePath()).append("</base-dir>");
         xml.append("<validation-timeout-seconds>")
-                .append(hotRestartConfig.getValidationTimeoutSeconds())
+                .append(hotRestartPersistenceConfig.getValidationTimeoutSeconds())
                 .append("</validation-timeout-seconds>");
         xml.append("<data-load-timeout-seconds>")
-                .append(hotRestartConfig.getDataLoadTimeoutSeconds())
+                .append(hotRestartPersistenceConfig.getDataLoadTimeoutSeconds())
                 .append("</data-load-timeout-seconds>");
-        xml.append("</hot-restart>");
+        xml.append("</hot-restart-persistence>");
     }
 
     private void liteMemberXmlGenerator(StringBuilder xml, Config config) {

--- a/hazelcast/src/main/java/com/hazelcast/config/HotRestartConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/HotRestartConfig.java
@@ -16,43 +16,24 @@
 
 package com.hazelcast.config;
 
-import java.io.File;
-
-import static com.hazelcast.util.Preconditions.checkNotNull;
-import static com.hazelcast.util.Preconditions.checkPositive;
-
 /**
- * Configures the Hot Restart stores.
- * <p/>
- * Hot restart stores are used to hold copy of in-memory data in
- * disk to be able to restart very fast without needing to load
- * data from a central storage.
- * <p/>
- * HotRestartConfig configures whether hot restart is enabled,
- * where disk data will be stored, should data be persisted
- * sync or async etc.
+ * Configures the Hot Restart Persistence per Hazelcast data structure.
  */
 public class HotRestartConfig {
-    /** Default directory name for the Hot Restart store's home */
-    public static final String HOT_RESTART_BASE_DIR_DEFAULT = "hot-restart";
-
-    /**
-     * Default validation timeout
-     */
-    public static final int DEFAULT_VALIDATION_TIMEOUT = 2 * 60;
-
-    /**
-     * Default load timeout
-     */
-    public static final int DEFAULT_DATA_LOAD_TIMEOUT = 15 * 60;
 
     private boolean enabled;
-    private File baseDir = new File(HOT_RESTART_BASE_DIR_DEFAULT);
-    private int validationTimeoutSeconds = DEFAULT_VALIDATION_TIMEOUT;
-    private int dataLoadTimeoutSeconds = DEFAULT_DATA_LOAD_TIMEOUT;
+    private boolean fsync;
+
+    public HotRestartConfig() {
+    }
+
+    public HotRestartConfig(HotRestartConfig hotRestartConfig) {
+        enabled = hotRestartConfig.enabled;
+        fsync = hotRestartConfig.fsync;
+    }
 
     /**
-     * Returns whether hot restart enabled on this member.
+     * Returns whether hot restart enabled on related data structure.
      *
      * @return true if hot restart enabled, false otherwise
      */
@@ -61,7 +42,7 @@ public class HotRestartConfig {
     }
 
     /**
-     * Sets whether hot restart is enabled on this member.
+     * Sets whether hot restart is enabled on related data structure.
      *
      * @return HotRestartConfig
      */
@@ -71,66 +52,31 @@ public class HotRestartConfig {
     }
 
     /**
-     * Base directory for all Hot Restart stores.
+     * Returns whether disk write should be followed by an {@code fsync()} system call.
+     *
+     * @return true if fsync is be called after disk write, false otherwise
      */
-    public File getBaseDir() {
-        return baseDir;
+    public boolean isFsync() {
+        return fsync;
     }
 
     /**
-     * Sets base directory for all Hot Restart stores.
+     * Sets whether disk write should be followed by an {@code fsync()} system call.
      *
-     * @param baseDir home directory
-     * @return HotRestartConfig
+     * @param fsync fsync
+     * @return this HotRestartConfig
      */
-    public HotRestartConfig setBaseDir(File baseDir) {
-        checkNotNull(baseDir, "Base directory cannot be null!");
-        this.baseDir = baseDir;
+    public HotRestartConfig setFsync(boolean fsync) {
+        this.fsync = fsync;
         return this;
     }
 
-    /**
-     * Returns configured validation timeout for hot-restart process.
-     *
-     * @return validation timeout in seconds
-     */
-    public int getValidationTimeoutSeconds() {
-        return validationTimeoutSeconds;
-    }
-
-    /**
-     * Sets validation timeout for hot-restart process, includes validating
-     * cluster members expected to join and partition table on all cluster.
-     *
-     * @param validationTimeoutSeconds validation timeout in seconds
-     * @return HotRestartConfig
-     */
-    public HotRestartConfig setValidationTimeoutSeconds(int validationTimeoutSeconds) {
-        checkPositive(validationTimeoutSeconds, "Validation timeout should be positive!");
-        this.validationTimeoutSeconds = validationTimeoutSeconds;
-        return this;
-    }
-
-    /**
-     * Returns configured data load timeout for hot-restart process.
-     *
-     * @return data load timeout in seconds
-     */
-    public int getDataLoadTimeoutSeconds() {
-        return dataLoadTimeoutSeconds;
-    }
-
-    /**
-     * Sets data load timeout for hot-restart process,
-     * all members in the cluster should complete restoring their local data
-     * before this timeout.
-     *
-     * @param dataLoadTimeoutSeconds data load timeout in seconds
-     * @return HotRestartConfig
-     */
-    public HotRestartConfig setDataLoadTimeoutSeconds(int dataLoadTimeoutSeconds) {
-        checkPositive(dataLoadTimeoutSeconds, "Load timeout should be positive!");
-        this.dataLoadTimeoutSeconds = dataLoadTimeoutSeconds;
-        return this;
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder("HotRestartConfig{");
+        sb.append("enabled=").append(enabled);
+        sb.append(", fsync=").append(fsync);
+        sb.append('}');
+        return sb.toString();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/HotRestartPersistenceConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/HotRestartPersistenceConfig.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+import java.io.File;
+
+import static com.hazelcast.util.Preconditions.checkNotNull;
+import static com.hazelcast.util.Preconditions.checkPositive;
+
+/**
+ * Configures the Hot Restart stores.
+ * <p/>
+ * Hot restart stores are used to hold copy of in-memory data in
+ * disk to be able to restart very fast without needing to load
+ * data from a central storage.
+ * <p/>
+ * HotRestartConfig configures whether hot restart is enabled,
+ * where disk data will be stored, should data be persisted
+ * sync or async etc.
+ */
+public class HotRestartPersistenceConfig {
+    /** Default directory name for the Hot Restart store's home */
+    public static final String HOT_RESTART_BASE_DIR_DEFAULT = "hot-restart";
+
+    /**
+     * Default validation timeout
+     */
+    public static final int DEFAULT_VALIDATION_TIMEOUT = 2 * 60;
+
+    /**
+     * Default load timeout
+     */
+    public static final int DEFAULT_DATA_LOAD_TIMEOUT = 15 * 60;
+
+    private boolean enabled;
+    private File baseDir = new File(HOT_RESTART_BASE_DIR_DEFAULT);
+    private int validationTimeoutSeconds = DEFAULT_VALIDATION_TIMEOUT;
+    private int dataLoadTimeoutSeconds = DEFAULT_DATA_LOAD_TIMEOUT;
+
+    /**
+     * Returns whether hot restart enabled on this member.
+     *
+     * @return true if hot restart enabled, false otherwise
+     */
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    /**
+     * Sets whether hot restart is enabled on this member.
+     *
+     * @return HotRestartConfig
+     */
+    public HotRestartPersistenceConfig setEnabled(boolean enabled) {
+        this.enabled = enabled;
+        return this;
+    }
+
+    /**
+     * Base directory for all Hot Restart stores.
+     */
+    public File getBaseDir() {
+        return baseDir;
+    }
+
+    /**
+     * Sets base directory for all Hot Restart stores.
+     *
+     * @param baseDir home directory
+     * @return HotRestartConfig
+     */
+    public HotRestartPersistenceConfig setBaseDir(File baseDir) {
+        checkNotNull(baseDir, "Base directory cannot be null!");
+        this.baseDir = baseDir;
+        return this;
+    }
+
+    /**
+     * Returns configured validation timeout for hot-restart process.
+     *
+     * @return validation timeout in seconds
+     */
+    public int getValidationTimeoutSeconds() {
+        return validationTimeoutSeconds;
+    }
+
+    /**
+     * Sets validation timeout for hot-restart process, includes validating
+     * cluster members expected to join and partition table on all cluster.
+     *
+     * @param validationTimeoutSeconds validation timeout in seconds
+     * @return HotRestartConfig
+     */
+    public HotRestartPersistenceConfig setValidationTimeoutSeconds(int validationTimeoutSeconds) {
+        checkPositive(validationTimeoutSeconds, "Validation timeout should be positive!");
+        this.validationTimeoutSeconds = validationTimeoutSeconds;
+        return this;
+    }
+
+    /**
+     * Returns configured data load timeout for hot-restart process.
+     *
+     * @return data load timeout in seconds
+     */
+    public int getDataLoadTimeoutSeconds() {
+        return dataLoadTimeoutSeconds;
+    }
+
+    /**
+     * Sets data load timeout for hot-restart process,
+     * all members in the cluster should complete restoring their local data
+     * before this timeout.
+     *
+     * @param dataLoadTimeoutSeconds data load timeout in seconds
+     * @return HotRestartConfig
+     */
+    public HotRestartPersistenceConfig setDataLoadTimeoutSeconds(int dataLoadTimeoutSeconds) {
+        checkPositive(dataLoadTimeoutSeconds, "Load timeout should be positive!");
+        this.dataLoadTimeoutSeconds = dataLoadTimeoutSeconds;
+        return this;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/config/MapConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MapConfig.java
@@ -140,7 +140,7 @@ public class MapConfig {
 
     private String quorumName;
 
-    private boolean hotRestartEnabled;
+    private HotRestartConfig hotRestartConfig = new HotRestartConfig();
 
     private MapConfigReadOnly readOnly;
 
@@ -184,7 +184,7 @@ public class MapConfig {
         this.partitioningStrategyConfig = config.partitioningStrategyConfig != null
                 ? new PartitioningStrategyConfig(config.getPartitioningStrategyConfig()) : null;
         this.quorumName = config.quorumName;
-        this.hotRestartEnabled = config.hotRestartEnabled;
+        this.hotRestartConfig = new HotRestartConfig(config.hotRestartConfig);
     }
     //CHECKSTYLE:ON
 
@@ -193,15 +193,6 @@ public class MapConfig {
             readOnly = new MapConfigReadOnly(this);
         }
         return readOnly;
-    }
-
-    public boolean isHotRestartEnabled() {
-        return hotRestartEnabled;
-    }
-
-    public MapConfig setHotRestartEnabled(boolean hotRestartEnabled) {
-        this.hotRestartEnabled = hotRestartEnabled;
-        return this;
     }
 
     /**
@@ -765,6 +756,24 @@ public class MapConfig {
     }
 
     /**
+     * Gets the {@code HotRestartConfig} for this {@code MapConfig}
+     * @return hot restart config
+     */
+    public HotRestartConfig getHotRestartConfig() {
+        return hotRestartConfig;
+    }
+
+    /**
+     * Sets the {@code HotRestartConfig} for this {@code MapConfig}
+     * @param hotRestartConfig hot restart config
+     * @return this {@code MapConfig} instance
+     */
+    public MapConfig setHotRestartConfig(HotRestartConfig hotRestartConfig) {
+        this.hotRestartConfig = hotRestartConfig;
+        return this;
+    }
+
+    /**
      * Get current value cache settings
      *
      * @return current value cache settings
@@ -789,7 +798,7 @@ public class MapConfig {
                 || (Math.min(maxSizeConfig.getSize(), other.maxSizeConfig.getSize()) == 0
                 && Math.max(maxSizeConfig.getSize(), other.maxSizeConfig.getSize()) == Integer.MAX_VALUE))
                 && this.timeToLiveSeconds == other.timeToLiveSeconds
-                && this.hotRestartEnabled == other.hotRestartEnabled
+                && this.hotRestartConfig.isEnabled() == other.hotRestartConfig.isEnabled()
                 && this.readBackupData == other.readBackupData;
     }
 
@@ -879,7 +888,7 @@ public class MapConfig {
                 + ", minEvictionCheckMillis=" + minEvictionCheckMillis
                 + ", maxSizeConfig=" + maxSizeConfig
                 + ", readBackupData=" + readBackupData
-                + ", hotRestartEnabled=" + hotRestartEnabled
+                + ", hotRestart=" + hotRestartConfig
                 + ", nearCacheConfig=" + nearCacheConfig
                 + ", mapStoreConfig=" + mapStoreConfig
                 + ", mergePolicyConfig='" + mergePolicy + '\''

--- a/hazelcast/src/main/java/com/hazelcast/config/MapConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MapConfigReadOnly.java
@@ -107,7 +107,8 @@ public class MapConfigReadOnly extends MapConfig {
         return Collections.unmodifiableList(readOnlyOnes);
     }
 
-    public MapConfig setHotRestartEnabled(boolean hotRestartEnabled) {
+    @Override
+    public MapConfig setHotRestartConfig(HotRestartConfig hotRestartConfig) {
         throw new UnsupportedOperationException("This config is read-only map: " + getName());
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/config/XmlElements.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/XmlElements.java
@@ -48,7 +48,7 @@ enum XmlElements {
     NATIVE_MEMORY("native-memory", false),
     QUORUM("quorum", true),
     LITE_MEMBER("lite-member", false),
-    HOT_RESTART("hot-restart", false),
+    HOT_RESTART_PERSISTENCE("hot-restart-persistence", false),
     ;
 
     final String name;

--- a/hazelcast/src/main/java/com/hazelcast/spi/exception/CallerNotMemberException.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/exception/CallerNotMemberException.java
@@ -24,8 +24,9 @@ import com.hazelcast.nio.Address;
  */
 public class CallerNotMemberException extends RetryableHazelcastException {
 
-    public CallerNotMemberException(Address target, int partitionId, String operationName, String serviceName) {
-        super("Not Member! caller:" + target + ", partitionId: " + partitionId
+    public CallerNotMemberException(Address thisAddress, Address caller, int partitionId,
+            String operationName, String serviceName) {
+        super("Not Member! This: " + thisAddress + ", caller: " + caller + ", partitionId: " + partitionId
                 + ", operation: " + operationName + ", service: " + serviceName);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImpl.java
@@ -423,7 +423,7 @@ class OperationRunnerImpl extends OperationRunner {
             return true;
         }
 
-        Exception error = new CallerNotMemberException(
+        Exception error = new CallerNotMemberException(node.getThisAddress(),
                 op.getCallerAddress(), op.getPartitionId(),
                 op.getClass().getName(), op.getServiceName());
         handleOperationError(op, error);

--- a/hazelcast/src/main/resources/hazelcast-config-3.6.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-3.6.xsd
@@ -60,7 +60,7 @@
                 <xs:element ref="member-attributes" minOccurs="0" maxOccurs="1"/>
                 <xs:element name="quorum" type="quorum" minOccurs="0" maxOccurs="1"/>
                 <xs:element name="lite-member" type="lite-member" minOccurs="0" maxOccurs="1"/>
-                <xs:element name="hot-restart" type="hot-restart" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="hot-restart-persistence" type="hot-restart-persistence" minOccurs="0" maxOccurs="1"/>
             </xs:choice>
             <xs:attribute name="id" type="xs:string" use="optional" default="default"/>
         </xs:complexType>
@@ -267,14 +267,7 @@
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:element name="hot-restart-enabled" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false">
-                <xs:annotation>
-                    <xs:documentation>
-                        True if hot-restart is enabled, false otherwise
-                        Only available on Hazelcast Enterprise.
-                    </xs:documentation>
-                </xs:annotation>
-            </xs:element>
+            <xs:element name="hot-restart" type="hot-restart" minOccurs="0" maxOccurs="1" />
             <xs:element name="map-store" type="map-store" minOccurs="0" maxOccurs="1"/>
             <xs:element name="near-cache" type="near-cache" minOccurs="0" maxOccurs="1"/>
             <xs:element name="wan-replication-ref" type="wan-replication-ref" minOccurs="0" maxOccurs="1"/>
@@ -533,14 +526,7 @@
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:element name="hot-restart-enabled" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false">
-                <xs:annotation>
-                    <xs:documentation>
-                        True if hot-restart is enabled, false otherwise
-                        Only available on Hazelcast Enterprise.
-                    </xs:documentation>
-                </xs:annotation>
-            </xs:element>
+            <xs:element name="hot-restart" type="hot-restart" minOccurs="0" maxOccurs="1" />
         </xs:all>
 
         <xs:attribute name="name" use="required">
@@ -2748,7 +2734,7 @@
         </xs:attribute>
     </xs:complexType>
 
-    <xs:complexType name="hot-restart">
+    <xs:complexType name="hot-restart-persistence">
         <xs:all>
             <xs:element name="base-dir" type="xs:string" minOccurs="0" maxOccurs="1" default="hot-restart">
                 <xs:annotation>
@@ -2779,6 +2765,28 @@
             <xs:annotation>
                 <xs:documentation>
                     True to enable hot-restart, false otherwise.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="hot-restart">
+        <xs:all>
+            <xs:element name="fsync" type="xs:boolean" default="false">
+                <xs:annotation>
+                    <xs:documentation>
+                        True if disk write should be followed by an fsync() system call,
+                        false otherwise.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:all>
+
+        <xs:attribute name="enabled" type="xs:boolean" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    True if hot-restart is enabled, false otherwise
+                    Only available on Hazelcast Enterprise.
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>

--- a/hazelcast/src/main/resources/hazelcast-default.xml
+++ b/hazelcast/src/main/resources/hazelcast-default.xml
@@ -257,6 +257,4 @@
 
     <lite-member enabled="false"/>
 
-    <hot-restart enabled="false" />
-
 </hazelcast>

--- a/hazelcast/src/test/java/com/hazelcast/cache/config/CacheConfigReadOnlyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/config/CacheConfigReadOnlyTest.java
@@ -20,6 +20,7 @@ import com.hazelcast.config.CacheConfig;
 import com.hazelcast.config.CacheConfigReadOnly;
 import com.hazelcast.config.CacheSimpleConfig;
 import com.hazelcast.config.CacheSimpleConfigReadOnly;
+import com.hazelcast.config.HotRestartConfig;
 import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
@@ -47,7 +48,7 @@ public class CacheConfigReadOnlyTest {
 
     @Test(expected = UnsupportedOperationException.class)
     public void settingHotRestartEnabledOfReadOnlyCacheConfigShouldFail() {
-        getCacheConfigReadOnly().setHotRestartEnabled(false);
+        getCacheConfigReadOnly().setHotRestartConfig(new HotRestartConfig());
     }
 
     @Test(expected = UnsupportedOperationException.class)

--- a/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
@@ -1156,19 +1156,19 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         int validationTimeout = 13131;
         int dataLoadTimeout = 45454;
         String xml = "<hazelcast xmlns=\"http://www.hazelcast.com/schema/config\">\n" +
-                "<hot-restart enabled=\"true\">"
+                "<hot-restart-persistence enabled=\"true\">"
                 + "<base-dir>" + dir + "</base-dir>"
                 + "<validation-timeout-seconds>" + validationTimeout + "</validation-timeout-seconds>"
                 + "<data-load-timeout-seconds>" + dataLoadTimeout + "</data-load-timeout-seconds>"
-                + "</hot-restart>\n" +
+                + "</hot-restart-persistence>\n" +
                 "</hazelcast>";
 
         Config config = new InMemoryXmlConfig(xml);
-        HotRestartConfig hotRestartConfig = config.getHotRestartConfig();
-        assertTrue(hotRestartConfig.isEnabled());
-        assertEquals(new File(dir).getAbsolutePath(), hotRestartConfig.getBaseDir().getAbsolutePath());
-        assertEquals(validationTimeout, hotRestartConfig.getValidationTimeoutSeconds());
-        assertEquals(dataLoadTimeout, hotRestartConfig.getDataLoadTimeoutSeconds());
+        HotRestartPersistenceConfig hotRestartPersistenceConfig = config.getHotRestartPersistenceConfig();
+        assertTrue(hotRestartPersistenceConfig.isEnabled());
+        assertEquals(new File(dir).getAbsolutePath(), hotRestartPersistenceConfig.getBaseDir().getAbsolutePath());
+        assertEquals(validationTimeout, hotRestartPersistenceConfig.getValidationTimeoutSeconds());
+        assertEquals(dataLoadTimeout, hotRestartPersistenceConfig.getDataLoadTimeoutSeconds());
     }
 
     @Test(expected = InvalidConfigurationException.class)


### PR DESCRIPTION
- Renamed HotRestartConfig to HotRestartPersistenceConfig
- Created HotRestartConfig for map & cache which included fsync flag
which defaults to false.

Also includes a non-related trivial change where more diagnostic data is added to `CallerNotMemberException`.