### PR TITLE
Changes required for integration with Hazelcast Jet

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/HazelcastClientFactory.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/HazelcastClientFactory.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client;
+
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.impl.HazelcastClientProxy;
+import com.hazelcast.client.impl.HazelcastClientInstanceImpl;
+import com.hazelcast.client.impl.ClientConnectionManagerFactory;
+
+/***
+ * This is interface which provides capability for Hazelcast client factories customization;
+ * It's implementation can be changed and passed to the HazelcastClientManager's constructors;
+ */
+public interface HazelcastClientFactory<T extends HazelcastClientInstanceImpl,
+        V extends HazelcastClientProxy,
+        C extends ClientConfig> {
+    T createHazelcastInstanceClient(C config,
+                                    ClientConnectionManagerFactory hazelcastClientFactory);
+
+    V createProxy(T client);
+}

--- a/hazelcast-client/src/main/java/com/hazelcast/client/HazelcastClientManager.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/HazelcastClientManager.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client;
+
+import java.util.HashSet;
+import java.util.Collection;
+import java.util.Collections;
+
+import com.hazelcast.util.EmptyStatement;
+
+import java.util.concurrent.ConcurrentMap;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.OutOfMemoryHandler;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.impl.HazelcastClientProxy;
+import com.hazelcast.instance.OutOfMemoryErrorDispatcher;
+import com.hazelcast.core.DuplicateInstanceNameException;
+import com.hazelcast.client.config.XmlClientConfigBuilder;
+import com.hazelcast.client.impl.HazelcastClientInstanceImpl;
+import com.hazelcast.client.impl.ClientConnectionManagerFactory;
+import com.hazelcast.client.impl.DefaultClientConnectionManagerFactory;
+
+/***
+ * This is central manager for all Hazelcast clients in JVM;
+ * All creation functionality will be stored here and particular;
+ * instance of Client will delegate here;
+ */
+public final class HazelcastClientManager {
+    /***
+     * Instance for clientManagers
+     */
+    public static final HazelcastClientManager INSTANCE = new HazelcastClientManager();
+
+    static {
+        OutOfMemoryErrorDispatcher.setClientHandler(new ClientOutOfMemoryHandler());
+    }
+
+    private final ConcurrentMap<String, HazelcastClientProxy> clients
+            = new ConcurrentHashMap<String, HazelcastClientProxy>(5);
+
+    private HazelcastClientManager() {
+    }
+
+    public static HazelcastInstance newHazelcastClient(HazelcastClientFactory hazelcastClientFactory) {
+        return newHazelcastClient(new XmlClientConfigBuilder().build(), hazelcastClientFactory);
+    }
+
+    @SuppressWarnings("unchecked")
+    public static HazelcastInstance newHazelcastClient(ClientConfig config, HazelcastClientFactory hazelcastClientFactory) {
+        if (config == null) {
+            config = new XmlClientConfigBuilder().build();
+        }
+
+        final ClassLoader tccl = Thread.currentThread().getContextClassLoader();
+        HazelcastClientProxy proxy;
+        try {
+            Thread.currentThread().setContextClassLoader(HazelcastClient.class.getClassLoader());
+            ClientConnectionManagerFactory clientConnectionManagerFactory = new DefaultClientConnectionManagerFactory();
+            final HazelcastClientInstanceImpl client = hazelcastClientFactory.createHazelcastInstanceClient(
+                    config,
+                    clientConnectionManagerFactory
+            );
+            client.start();
+            OutOfMemoryErrorDispatcher.registerClient(client);
+            proxy = hazelcastClientFactory.createProxy(client);
+
+            if (INSTANCE.clients.putIfAbsent(client.getName(), proxy) != null) {
+                throw new DuplicateInstanceNameException("HazelcastClientInstance with name '" + client.getName()
+                        + "' already exists!");
+            }
+        } finally {
+            Thread.currentThread().setContextClassLoader(tccl);
+        }
+        return proxy;
+    }
+
+    public static HazelcastInstance getHazelcastClientByName(String instanceName) {
+        return INSTANCE.clients.get(instanceName);
+    }
+
+    public static Collection<HazelcastInstance> getAllHazelcastClients() {
+        Collection<HazelcastClientProxy> values = INSTANCE.clients.values();
+        return Collections.unmodifiableCollection(new HashSet<HazelcastInstance>(values));
+    }
+
+    public static void shutdownAll() {
+        for (HazelcastClientProxy proxy : INSTANCE.clients.values()) {
+            HazelcastClientInstanceImpl client = proxy.client;
+            if (client == null) {
+                continue;
+            }
+            proxy.client = null;
+            try {
+                client.shutdown();
+            } catch (Throwable ignored) {
+                EmptyStatement.ignore(ignored);
+            }
+        }
+        OutOfMemoryErrorDispatcher.clearClients();
+        INSTANCE.clients.clear();
+    }
+
+
+    public static void shutdown(HazelcastInstance instance) {
+        if (instance instanceof HazelcastClientProxy) {
+            final HazelcastClientProxy proxy = (HazelcastClientProxy) instance;
+            HazelcastClientInstanceImpl client = proxy.client;
+            if (client == null) {
+                return;
+            }
+            proxy.client = null;
+            INSTANCE.clients.remove(client.getName());
+
+            try {
+                client.shutdown();
+            } catch (Throwable ignored) {
+                EmptyStatement.ignore(ignored);
+            } finally {
+                OutOfMemoryErrorDispatcher.deregisterClient(client);
+            }
+        }
+    }
+
+    public static void shutdown(String instanceName) {
+        HazelcastClientProxy proxy = INSTANCE.clients.remove(instanceName);
+        if (proxy == null) {
+            return;
+        }
+        HazelcastClientInstanceImpl client = proxy.client;
+        if (client == null) {
+            return;
+        }
+        proxy.client = null;
+        try {
+            client.shutdown();
+        } catch (Throwable ignored) {
+            EmptyStatement.ignore(ignored);
+        } finally {
+            OutOfMemoryErrorDispatcher.deregisterClient(client);
+        }
+    }
+
+    public static void setOutOfMemoryHandler(OutOfMemoryHandler outOfMemoryHandler) {
+        OutOfMemoryErrorDispatcher.setClientHandler(outOfMemoryHandler);
+    }
+}

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientProxy.java
@@ -58,9 +58,8 @@ import java.util.concurrent.ConcurrentMap;
 
 /**
  * A client-side proxy {@link com.hazelcast.core.HazelcastInstance} instance.
- *
  */
-public final class HazelcastClientProxy implements HazelcastInstance, SerializationServiceSupport {
+public class HazelcastClientProxy implements HazelcastInstance, SerializationServiceSupport {
 
     public volatile HazelcastClientInstanceImpl client;
 
@@ -264,7 +263,7 @@ public final class HazelcastClientProxy implements HazelcastInstance, Serializat
         return getClient().getSerializationService();
     }
 
-    private HazelcastClientInstanceImpl getClient() {
+    protected HazelcastClientInstanceImpl getClient() {
         final HazelcastClientInstanceImpl c = client;
         if (c == null || !c.getLifecycleService().isRunning()) {
             throw new HazelcastInstanceNotActiveException();

--- a/hazelcast-code-generator/src/main/java/com/hazelcast/client/protocol/generator/CodeGeneratorMessageTaskFactory.java
+++ b/hazelcast-code-generator/src/main/java/com/hazelcast/client/protocol/generator/CodeGeneratorMessageTaskFactory.java
@@ -87,13 +87,19 @@ public class CodeGeneratorMessageTaskFactory
             return false;
         }
         boolean isEnterprise = false;
+        boolean isJet=false;
         for (Element element : elementsAnnotatedWith) {
             isEnterprise = element.toString().contains("enterprise");
+            if (element.toString().contains("jet")) {
+                isJet = true;
+            }
             map.put(element.toString(), addAllFromPackage((PackageElement) element));
         }
         String className;
         if (isEnterprise) {
             className = "EnterpriseMessageTaskFactoryImpl";
+        } else if (isJet) {
+            className = "JetMessageTaskFactoryImpl";
         } else {
             className = "MessageTaskFactoryImpl";
         }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/TemplateConstants.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/TemplateConstants.java
@@ -44,6 +44,7 @@ public final class TemplateConstants {
     public static final int TRANSACTION_TEMPLATE_ID = 23;
     public static final int ENTERPRISE_MAP_TEMPLATE_ID = 24;
     public static final int RINGBUFFER_TEMPLATE_ID = 25;
+    public static final int JET_TEMPLATE_ID = 26;
 
     private TemplateConstants() {
     }

--- a/hazelcast/src/main/java/com/hazelcast/core/PartitioningStrategy.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/PartitioningStrategy.java
@@ -16,13 +16,15 @@
 
 package com.hazelcast.core;
 
+import java.io.Serializable;
+
 /**
  * PartitioningStrategy allows keys to be located on the same member.
  * This causes related data to be stored in the same location. (See data-affinity.)
  *
  * @param <K> key type
  */
-public interface PartitioningStrategy<K> {
+public interface PartitioningStrategy<K> extends Serializable {
 
     /**
      * Returns the key object that will be used by Hazelcast to specify the partition.

--- a/hazelcast/src/main/java/com/hazelcast/instance/DefaultHazelcastInstanceFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/DefaultHazelcastInstanceFactory.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.instance;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.config.XmlConfigBuilder;
+
+/***
+ * Default implementation for Hazelcast instance factoriy;
+ */
+public class DefaultHazelcastInstanceFactory implements HazelcastInstanceFactory {
+    protected Config wrapConfig(Config config) {
+        if (config == null) {
+            config = new XmlConfigBuilder().build();
+        }
+
+        return config;
+    }
+
+    public HazelcastInstance newHazelcastInstance(Config config, String instanceName,
+                                                  NodeContext nodeContext) throws Exception {
+        return new HazelcastInstanceImpl(instanceName, wrapConfig(config), nodeContext);
+    }
+
+    public HazelcastInstance newHazelcastInstance(Config config) throws Exception {
+        Config wrappedConfig = wrapConfig(config);
+        return newHazelcastInstance(wrappedConfig, wrappedConfig.getInstanceName(), new DefaultNodeContext());
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/instance/HazelcastInstanceFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/HazelcastInstanceFactory.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.instance;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.core.HazelcastInstance;
+
+/***
+ * This is interface which provides capability for Hazelcast factories customization;
+ * DefaultHazelcastInstanceFactory is used by default, but external service can have;
+ * custom implementation which should be specified in META-INF services;
+ */
+public interface HazelcastInstanceFactory {
+    HazelcastInstance newHazelcastInstance(Config config, String instanceName,
+                                           NodeContext nodeContext) throws Exception;
+
+    HazelcastInstance newHazelcastInstance(Config config) throws Exception;
+}

--- a/hazelcast/src/main/java/com/hazelcast/instance/HazelcastInstanceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/HazelcastInstanceImpl.java
@@ -109,12 +109,11 @@ public class HazelcastInstanceImpl implements HazelcastInstance {
 
     final HealthMonitor healthMonitor;
 
-    HazelcastInstanceImpl(String name, Config config, NodeContext nodeContext)
+    protected HazelcastInstanceImpl(String name, Config config, NodeContext nodeContext)
             throws Exception {
         this.name = name;
+        this.lifecycleService = new LifecycleServiceImpl(this);
 
-
-        lifecycleService = new LifecycleServiceImpl(this);
         ManagedContext configuredManagedContext = config.getManagedContext();
         managedContext = new HazelcastManagedContext(this, configuredManagedContext);
 
@@ -122,7 +121,7 @@ public class HazelcastInstanceImpl implements HazelcastInstance {
         //user-context map instance instead of having a shared map instance. So changes made to the user-context map
         //in one HazelcastInstance will not reflect on other the user-context of other HazelcastInstances.
         userContext.putAll(config.getUserContext());
-        node = new Node(this, config, nodeContext);
+        node = createNode(config, nodeContext);
 
         try {
             logger = node.getLogger(getClass().getName());
@@ -148,6 +147,10 @@ public class HazelcastInstanceImpl implements HazelcastInstance {
             }
             throw ExceptionUtil.rethrow(e);
         }
+    }
+
+    protected Node createNode(Config config, NodeContext nodeContext) {
+        return new Node(this, config, nodeContext);
     }
 
     private void initManagedContext(ManagedContext configuredManagedContext) {

--- a/hazelcast/src/main/java/com/hazelcast/instance/HazelcastInstanceManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/HazelcastInstanceManager.java
@@ -26,14 +26,17 @@ import com.hazelcast.spi.annotation.PrivateApi;
 import com.hazelcast.util.EmptyStatement;
 import com.hazelcast.util.ExceptionUtil;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Comparator;
+import java.util.Set;
+import java.util.Map;
+import java.util.List;
 import java.util.HashSet;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedList;
-import java.util.List;
-import java.util.Set;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.Collections;
+import java.util.ServiceLoader;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -47,13 +50,26 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 @SuppressWarnings("SynchronizationOnStaticField")
 @PrivateApi
 public final class HazelcastInstanceManager {
-
-    private static final int ADDITIONAL_SLEEP_SECONDS_FOR_NON_FIRST_MEMBERS = 4;
-
-    private static final ConcurrentMap<String, InstanceFuture> INSTANCE_MAP = new ConcurrentHashMap<String, InstanceFuture>(5);
+    /***
+     * Instance for clientManagers
+     */
+    private static final HazelcastInstanceFactory INSTANCE_FACTORY;
     private static final AtomicInteger FACTORY_ID_GEN = new AtomicInteger();
+    private static final int ADDITIONAL_SLEEP_SECONDS_FOR_NON_FIRST_MEMBERS = 4;
+    private static final ConcurrentMap<String, InstanceFuture> INSTANCE_MAP = new ConcurrentHashMap<String, InstanceFuture>(5);
+
+    static {
+        ServiceLoader serviceLoader = ServiceLoader.load(HazelcastInstanceFactory.class);
+        Iterator iterator = serviceLoader.iterator();
+        if (iterator.hasNext()) {
+            INSTANCE_FACTORY = ServiceLoader.load(HazelcastInstanceFactory.class).iterator().next();
+        } else {
+            INSTANCE_FACTORY = new DefaultHazelcastInstanceFactory();
+        }
+    }
 
     private HazelcastInstanceManager() {
+
     }
 
     public static Set<HazelcastInstance> getAllHazelcastInstances() {
@@ -103,16 +119,43 @@ public final class HazelcastInstanceManager {
         }
     }
 
+    /**
+     * Creates a new Hazelcast instance.
+     *
+     * @param config       the configuration to use; if <code>null</code>, the set of defaults
+     *                     as specified in the XSD for the configuration XML will be used.
+     * @return the configured {@link HazelcastInstance}
+     */
     public static HazelcastInstance newHazelcastInstance(Config config) {
         if (config == null) {
             config = new XmlConfigBuilder().build();
         }
 
-        return newHazelcastInstance(config, config.getInstanceName(), new DefaultNodeContext());
+        return newHazelcastInstance(
+                config,
+                config.getInstanceName(),
+                new DefaultNodeContext()
+        );
     }
 
     private static String createInstanceName(Config config) {
         return "_hzInstance_" + FACTORY_ID_GEN.incrementAndGet() + "_" + config.getGroupConfig().getName();
+    }
+
+    /**
+     * Return real name for the hazelcast instance's instance
+     * @param instanceName -  template of the name
+     * @param config    -   config
+     * @return  -   real hazelcast instance's name
+     */
+    public static String getInstanceName(String instanceName, Config config) {
+        String name = instanceName;
+
+        if (name == null || name.trim().length() == 0) {
+            name = createInstanceName(config);
+        }
+
+        return name;
     }
 
     /**
@@ -129,10 +172,7 @@ public final class HazelcastInstanceManager {
             config = new XmlConfigBuilder().build();
         }
 
-        String name = instanceName;
-        if (name == null || name.trim().length() == 0) {
-            name = createInstanceName(config);
-        }
+        String name = getInstanceName(instanceName, config);
 
         InstanceFuture future = new InstanceFuture();
         if (INSTANCE_MAP.putIfAbsent(name, future) != null) {
@@ -148,6 +188,31 @@ public final class HazelcastInstanceManager {
         }
     }
 
+    public static Set<HazelcastInstanceImpl> getInstanceImpls(Collection<Member> members) {
+        Set<HazelcastInstanceImpl> set = new HashSet<HazelcastInstanceImpl>();
+        for (InstanceFuture future : INSTANCE_MAP.values()) {
+            try {
+                if (future.isSet()) {
+                    HazelcastInstanceProxy instanceProxy = future.get();
+                    HazelcastInstanceImpl impl = instanceProxy.original;
+                    if (impl != null) {
+                        final MemberImpl localMember = impl.node.getLocalMember();
+                        if (members.contains(localMember)) {
+                            set.add(impl);
+                        }
+                    }
+                }
+            } catch (RuntimeException ignored) {
+                EmptyStatement.ignore(ignored);
+            }
+        }
+        return set;
+    }
+
+    protected static HazelcastInstanceProxy newHazelcastProxy(HazelcastInstanceImpl hazelcastInstance) {
+        return new HazelcastInstanceProxy(hazelcastInstance);
+    }
+
     private static HazelcastInstanceProxy constructHazelcastInstance(Config config, String instanceName, NodeContext nodeContext,
                                                                      InstanceFuture future) {
         ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
@@ -155,11 +220,12 @@ public final class HazelcastInstanceManager {
         HazelcastInstanceProxy proxy;
         try {
             if (classLoader == null) {
-                Thread.currentThread().setContextClassLoader(HazelcastInstanceManager.class.getClassLoader());
+                Thread.currentThread().setContextClassLoader(HazelcastInstanceFactory.class.getClassLoader());
             }
-            HazelcastInstanceImpl hazelcastInstance = new HazelcastInstanceImpl(instanceName, config, nodeContext);
+            HazelcastInstanceImpl hazelcastInstance =
+                    (HazelcastInstanceImpl) INSTANCE_FACTORY.newHazelcastInstance(config, instanceName, nodeContext);
             OutOfMemoryErrorDispatcher.registerServer(hazelcastInstance);
-            proxy = new HazelcastInstanceProxy(hazelcastInstance);
+            proxy = newHazelcastProxy(hazelcastInstance);
             Node node = hazelcastInstance.node;
             boolean firstMember = isFirstMember(node);
             long initialWaitSeconds = node.groupProperties.getSeconds(GroupProperty.INITIAL_WAIT_SECONDS);
@@ -254,28 +320,23 @@ public final class HazelcastInstanceManager {
         }
     }
 
-    static Set<HazelcastInstanceImpl> getInstanceImpls(Collection<Member> members) {
-        Set<HazelcastInstanceImpl> set = new HashSet<HazelcastInstanceImpl>();
+    public static Map<MemberImpl, HazelcastInstanceImpl> getInstanceImplMap() {
+        Map<MemberImpl, HazelcastInstanceImpl> map = new HashMap<MemberImpl, HazelcastInstanceImpl>();
         for (InstanceFuture future : INSTANCE_MAP.values()) {
             try {
-                if (future.isSet()) {
-                    HazelcastInstanceProxy instanceProxy = future.get();
-                    HazelcastInstanceImpl impl = instanceProxy.original;
-                    if (impl != null) {
-                        final MemberImpl localMember = impl.node.getLocalMember();
-                        if (members.contains(localMember)) {
-                            set.add(impl);
-                        }
-                    }
+                HazelcastInstanceProxy instanceProxy = future.get();
+                HazelcastInstanceImpl impl = instanceProxy.original;
+                if (impl != null) {
+                    map.put(impl.node.getLocalMember(), impl);
                 }
             } catch (RuntimeException ignored) {
                 EmptyStatement.ignore(ignored);
             }
         }
-        return set;
+        return map;
     }
 
-    static void remove(HazelcastInstanceImpl instance) {
+    public static void remove(HazelcastInstanceImpl instance) {
         OutOfMemoryErrorDispatcher.deregisterServer(instance);
         InstanceFuture future = INSTANCE_MAP.remove(instance.getName());
         if (future != null && future.isSet()) {
@@ -287,7 +348,6 @@ public final class HazelcastInstanceManager {
     }
 
     private static class InstanceFuture {
-
         private volatile HazelcastInstanceProxy hz;
         private volatile Throwable throwable;
 

--- a/hazelcast/src/main/java/com/hazelcast/instance/HazelcastInstanceProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/HazelcastInstanceProxy.java
@@ -69,11 +69,10 @@ import java.util.concurrent.ConcurrentMap;
  * </ol>
  */
 public final class HazelcastInstanceProxy implements HazelcastInstance, SerializationServiceSupport {
-
-    volatile HazelcastInstanceImpl original;
+    protected volatile HazelcastInstanceImpl original;
     private final String name;
 
-    HazelcastInstanceProxy(HazelcastInstanceImpl original) {
+    protected HazelcastInstanceProxy(HazelcastInstanceImpl original) {
         this.original = original;
         name = original.getName();
     }
@@ -268,7 +267,7 @@ public final class HazelcastInstanceProxy implements HazelcastInstance, Serializ
         return getOriginal().getSerializationService();
     }
 
-    private HazelcastInstanceImpl getOriginal() {
+    protected HazelcastInstanceImpl getOriginal() {
         final HazelcastInstanceImpl hazelcastInstance = original;
         if (hazelcastInstance == null) {
             throw new HazelcastInstanceNotActiveException();

--- a/hazelcast/src/main/java/com/hazelcast/instance/Node.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/Node.java
@@ -140,7 +140,12 @@ public class Node {
 
     private final HazelcastThreadGroup hazelcastThreadGroup;
 
+
     private final boolean liteMember;
+
+    protected NodeExtension createNodeExtension(NodeContext nodeContext) {
+        return nodeContext.createNodeExtension(this);
+    }
 
     public Node(HazelcastInstanceImpl hazelcastInstance, Config config, NodeContext nodeContext) {
         this.hazelcastInstance = hazelcastInstance;
@@ -167,7 +172,8 @@ public class Node {
             loggingService.setThisMember(localMember);
             logger = loggingService.getLogger(Node.class.getName());
             hazelcastThreadGroup = new HazelcastThreadGroup(hazelcastInstance.getName(), logger, configClassLoader);
-            this.nodeExtension = nodeContext.createNodeExtension(this);
+
+            this.nodeExtension = createNodeExtension(nodeContext);
             nodeExtension.beforeStart();
 
             serializationService = nodeExtension.createSerializationService();

--- a/hazelcast/src/test/java/com/hazelcast/map/EntryProcessorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/EntryProcessorTest.java
@@ -465,6 +465,11 @@ public class EntryProcessorTest extends HazelcastTestSupport {
         HazelcastInstance instance1 = nodeFactory.newHazelcastInstance(cfg);
         HazelcastInstance instance2 = nodeFactory.newHazelcastInstance(cfg);
         HazelcastInstance instance3 = nodeFactory.newHazelcastInstance(cfg);
+
+        assertTrue(instance1.getCluster().getMembers().size()==3);
+        assertTrue(instance2.getCluster().getMembers().size()==3);
+        assertTrue(instance3.getCluster().getMembers().size()==3);
+
         IMap<Integer, Integer> map = instance1.getMap("testBackupMapEntryProcessorAllKeys");
         int size = 100;
         for (int i = 0; i < size; i++) {
@@ -477,6 +482,10 @@ public class EntryProcessorTest extends HazelcastTestSupport {
         }
         instance1.shutdown();
         Thread.sleep(1000);
+
+        assertTrue(instance2.getCluster().getMembers().size() == 2);
+        assertTrue(instance3.getCluster().getMembers().size() == 2);
+
         IMap<Integer, Integer> map2 = instance2.getMap("testBackupMapEntryProcessorAllKeys");
         for (int i = 0; i < size; i++) {
             assertEquals(map2.get(i), (Object) (i + 1));

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapStatsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapStatsTest.java
@@ -246,6 +246,7 @@ public class ReplicatedMapStatsTest extends HazelcastTestSupport {
 
     private <K, V> ReplicatedMap<K, V> getReplicatedMap() {
         HazelcastInstance instance = createHazelcastInstance();
+        warmUpPartitions(instance);
         return instance.getReplicatedMap(randomMapName());
     }
 }


### PR DESCRIPTION
Changes
Hazelcast Server

1) Introduced interface CustomServiceConfig.
   It let us to add custom configs for each external service.
2) HazelcastInstanceFactory has been customized. It let  us to create custom instances of HazelcastInstanceFactory adding them to META-INF/services
By default DefaultHazelcastInstanceFactory will be used.

3) HazelcastInstanceImpl and have been extended.
Now it is possible to inherit from these classes.


Hazelcast Client

1) Introduced interface HazelcastClientFactory to create custom instances of HazelcastClientInstanceImpl

2) CodeGeneratorMessageTaskFactory has been customized
Added opportunity to generate Tasks from Jet component: JetMessageTaskFactoryImpl.

3) TemplateConstants - added JET_TEMPLATE_ID = 26.

4) Opportunity to work with many MessageTaskFactory instances
Introduced method createMessageTaskFactories in NodeExtension.





