### PR TITLE
[DONT MERGE] Put data immediately to near cache when LocalInvalidation is CACHE

### DIFF
--- a/hazelcast-client-legacy/src/main/java/com/hazelcast/client/cache/impl/AbstractClientInternalCacheProxy.java
+++ b/hazelcast-client-legacy/src/main/java/com/hazelcast/client/cache/impl/AbstractClientInternalCacheProxy.java
@@ -386,15 +386,14 @@ abstract class AbstractClientInternalCacheProxy<K, V>
         } catch (Exception e) {
             throw ExceptionUtil.rethrow(e);
         }
+        if (cacheOnUpdate) {
+            storeInNearCache(keyData, valueData, value);
+        }
         if (!async) {
             try {
                 Object response = future.get();
-                if (nearCache != null) {
-                    if (cacheOnUpdate) {
-                        storeInNearCache(keyData, valueData, value);
-                    } else {
-                        invalidateNearCache(keyData);
-                    }
+                if (nearCache != null && !cacheOnUpdate) {
+                    invalidateNearCache(keyData);
                 }
                 if (statisticsEnabled) {
                     handleStatisticsOnPut(isGet, start, response);
@@ -408,12 +407,8 @@ abstract class AbstractClientInternalCacheProxy<K, V>
                 future.andThen(new ExecutionCallback<Object>() {
                     @Override
                     public void onResponse(Object responseData) {
-                        if (nearCache != null) {
-                            if (cacheOnUpdate) {
-                                storeInNearCache(keyData, valueData, value);
-                            } else {
-                                invalidateNearCache(keyData);
-                            }
+                        if (nearCache != null && !cacheOnUpdate) {
+                            invalidateNearCache(keyData);
                         }
                         if (statisticsEnabled) {
                             handleStatisticsOnPut(isGet, start, responseData);
@@ -462,15 +457,14 @@ abstract class AbstractClientInternalCacheProxy<K, V>
         }
         DelegatingFuture delegatingFuture =
                 new DelegatingFuture<Boolean>(future, clientContext.getSerializationService());
+        if (cacheOnUpdate) {
+            storeInNearCache(keyData, valueData, value);
+        }
         if (!async) {
             try {
                 Object response = delegatingFuture.get();
-                if (nearCache != null) {
-                    if (cacheOnUpdate) {
-                        storeInNearCache(keyData, valueData, value);
-                    } else {
-                        invalidateNearCache(keyData);
-                    }
+                if (nearCache != null && !cacheOnUpdate) {
+                    invalidateNearCache(keyData);
                 }
                 if (statisticsEnabled) {
                     handleStatisticsOnPutIfAbsent(start, (Boolean) response);
@@ -484,12 +478,8 @@ abstract class AbstractClientInternalCacheProxy<K, V>
                 delegatingFuture.andThen(new ExecutionCallback<Object>() {
                     @Override
                     public void onResponse(Object responseData) {
-                        if (nearCache != null) {
-                            if (cacheOnUpdate) {
-                                storeInNearCache(keyData, valueData, value);
-                            } else {
-                                invalidateNearCache(keyData);
-                            }
+                        if (nearCache != null && !cacheOnUpdate) {
+                            invalidateNearCache(keyData);
                         }
                         if (statisticsEnabled) {
                             Object response = clientContext.getSerializationService().toObject(responseData);

--- a/hazelcast-client-legacy/src/test/java/com/hazelcast/client/cache/nearcache/ClientNearCacheTest.java
+++ b/hazelcast-client-legacy/src/test/java/com/hazelcast/client/cache/nearcache/ClientNearCacheTest.java
@@ -58,6 +58,26 @@ public class ClientNearCacheTest extends ClientNearCacheTestSupport {
     }
 
     @Test
+    public void putAsyncToCacheAndThenGetFromClientNearCacheWithBinaryInMemoryFormat() {
+        putAsyncToCacheAndThenGetFromClientNearCache(InMemoryFormat.BINARY);
+    }
+
+    @Test
+    public void putAsyncToCacheAndThenGetFromClientNearCacheWithObjectInMemoryFormat() {
+        putAsyncToCacheAndThenGetFromClientNearCache(InMemoryFormat.OBJECT);
+    }
+
+    @Test
+    public void putIfAbsentAsyncToCacheAndThenGetFromClientNearCacheWithBinaryInMemoryFormat() {
+        putIfAbsentAsyncToCacheAndThenGetFromClientNearCache(InMemoryFormat.BINARY);
+    }
+
+    @Test
+    public void putIfAbsentAsyncToCacheAndThenGetFromClientNearCacheWithObjectInMemoryFormat() {
+        putIfAbsentAsyncToCacheAndThenGetFromClientNearCache(InMemoryFormat.OBJECT);
+    }
+
+    @Test
     public void putToCacheAndUpdateFromOtherNodeThenGetUpdatedFromClientNearCacheWithBinaryInMemoryFormat() {
         putToCacheAndUpdateFromOtherNodeThenGetUpdatedFromClientNearCache(InMemoryFormat.BINARY);
     }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/AbstractClientInternalCacheProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/AbstractClientInternalCacheProxy.java
@@ -493,15 +493,15 @@ abstract class AbstractClientInternalCacheProxy<K, V>
 
         ClientDelegatingFuture delegatingFuture =
                 new ClientDelegatingFuture(future, clientContext.getSerializationService(), putResponseDecoder);
+
+        if (cacheOnUpdate) {
+            storeInNearCache(keyData, valueData, value);
+        }
         if (!async) {
             try {
                 Object response = delegatingFuture.get();
-                if (nearCache != null) {
-                    if (cacheOnUpdate) {
-                        storeInNearCache(keyData, valueData, value);
-                    } else {
-                        invalidateNearCache(keyData);
-                    }
+                if (nearCache != null && !cacheOnUpdate) {
+                    invalidateNearCache(keyData);
                 }
                 if (statisticsEnabled) {
                     handleStatisticsOnPut(isGet, start, response);
@@ -515,12 +515,8 @@ abstract class AbstractClientInternalCacheProxy<K, V>
                 delegatingFuture.andThen(new ExecutionCallback<Object>() {
                     @Override
                     public void onResponse(Object responseData) {
-                        if (nearCache != null) {
-                            if (cacheOnUpdate) {
-                                storeInNearCache(keyData, valueData, value);
-                            } else {
-                                invalidateNearCache(keyData);
-                            }
+                        if (nearCache != null && !cacheOnUpdate) {
+                            invalidateNearCache(keyData);
                         }
                         if (statisticsEnabled) {
                             handleStatisticsOnPut(isGet, start, responseData);
@@ -572,15 +568,15 @@ abstract class AbstractClientInternalCacheProxy<K, V>
         ClientDelegatingFuture delegatingFuture =
                 new ClientDelegatingFuture<Boolean>(future, clientContext.getSerializationService(),
                         putIfAbsentResponseDecoder);
+
+        if (cacheOnUpdate) {
+            storeInNearCache(keyData, valueData, value);
+        }
         if (!async) {
             try {
                 Object response = delegatingFuture.get();
-                if (nearCache != null) {
-                    if (cacheOnUpdate) {
-                        storeInNearCache(keyData, valueData, value);
-                    } else {
-                        invalidateNearCache(keyData);
-                    }
+                if (nearCache != null && !cacheOnUpdate) {
+                    invalidateNearCache(keyData);
                 }
                 if (statisticsEnabled) {
                     handleStatisticsOnPutIfAbsent(start, (Boolean) response);
@@ -594,12 +590,8 @@ abstract class AbstractClientInternalCacheProxy<K, V>
                 delegatingFuture.andThen(new ExecutionCallback<Object>() {
                     @Override
                     public void onResponse(Object responseData) {
-                        if (nearCache != null) {
-                            if (cacheOnUpdate) {
-                                storeInNearCache(keyData, valueData, value);
-                            } else {
-                                invalidateNearCache(keyData);
-                            }
+                        if (nearCache != null && !cacheOnUpdate) {
+                            invalidateNearCache(keyData);
                         }
                         if (statisticsEnabled) {
                             Object response = clientContext.getSerializationService().toObject(responseData);

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientNearCacheTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientNearCacheTest.java
@@ -58,6 +58,26 @@ public class ClientNearCacheTest extends ClientNearCacheTestSupport {
     }
 
     @Test
+    public void putAsyncToCacheAndThenGetFromClientNearCacheWithBinaryInMemoryFormat() {
+        putAsyncToCacheAndThenGetFromClientNearCache(InMemoryFormat.BINARY);
+    }
+
+    @Test
+    public void putAsyncToCacheAndThenGetFromClientNearCacheWithObjectInMemoryFormat() {
+        putAsyncToCacheAndThenGetFromClientNearCache(InMemoryFormat.OBJECT);
+    }
+
+    @Test
+    public void putIfAbsentAsyncToCacheAndThenGetFromClientNearCacheWithBinaryInMemoryFormat() {
+        putIfAbsentAsyncToCacheAndThenGetFromClientNearCache(InMemoryFormat.BINARY);
+    }
+
+    @Test
+    public void putIfAbsentAsyncToCacheAndThenGetFromClientNearCacheWithObjectInMemoryFormat() {
+        putIfAbsentAsyncToCacheAndThenGetFromClientNearCache(InMemoryFormat.OBJECT);
+    }
+
+    @Test
     public void putToCacheAndUpdateFromOtherNodeThenGetUpdatedFromClientNearCacheWithBinaryInMemoryFormat() {
         putToCacheAndUpdateFromOtherNodeThenGetUpdatedFromClientNearCache(InMemoryFormat.BINARY);
     }

--- a/hazelcast/src/test/java/com/hazelcast/cache/stats/CacheStatsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/stats/CacheStatsTest.java
@@ -461,4 +461,40 @@ public class CacheStatsTest extends CacheTestSupport {
         stats.getNearCacheStatistics();
     }
 
+    @Test
+    public void testLocalUpdate() {
+        ICache<Integer, String> cache = createCache();
+        CacheStatistics stats = cache.getLocalCacheStatistics();
+
+        final int ENTRY_COUNT = 100;
+        long start, end;
+
+        start = System.currentTimeMillis();
+        for (int i = 0; i < ENTRY_COUNT; i++) {
+            cache.put(i, "Value-" + i);
+        }
+        end = System.currentTimeMillis();
+
+        assertTrue(stats.getLastUpdateTime() >= start);
+        assertTrue(stats.getLastUpdateTime() <= end);
+
+        start = System.currentTimeMillis();
+        for (int i = 0; i < ENTRY_COUNT; i++) {
+            cache.remove(i);
+        }
+        end = System.currentTimeMillis();
+
+        assertTrue(stats.getLastUpdateTime() >= start);
+        assertTrue(stats.getLastUpdateTime() <= end);
+
+        long currentLastUpdateTime = stats.getLastUpdateTime();
+        sleepAtLeastMillis(1);
+        for (int i = 0; i < ENTRY_COUNT; i++) {
+            cache.remove(i);
+        }
+
+        // Latest removes has no effect since keys are already removed at previous loop
+        assertEquals(currentLastUpdateTime, stats.getLastUpdateTime());
+    }
+
 }


### PR DESCRIPTION
Behaviour was different between sync and async API.
This pr makes sures that data is put the nearcache before remote
operation to cluster when LocalInvalidation is CACHE for both sync
and async put/putIfAbsent operations.