### PR TITLE
Added serialisation step to MapProxy.loadAll

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
@@ -544,7 +544,8 @@ public class MapProxyImpl<K, V> extends MapProxySupport implements IMap<K, V>, I
         checkNotNull(getMapStore(), "First you should configure a map store");
         checkNotNull(keys, "Parameter keys should not be null.");
 
-        loadInternal(keys, replaceExistingValues);
+        Iterable<Data> dataKeys = convertToData(keys);
+        loadInternal(dataKeys, replaceExistingValues);
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
@@ -415,11 +415,10 @@ abstract class MapProxySupport extends AbstractDistributedObject<MapService> imp
     /**
      * Maps keys to corresponding partitions and sends operations to them.
      *
-     * @param keys
+     * @param dataKeys
      * @param replaceExistingValues
      */
-    protected void loadInternal(Iterable keys, boolean replaceExistingValues) {
-        Iterable<Data> dataKeys = convertToData(keys);
+    protected void loadInternal(Iterable<Data> dataKeys, boolean replaceExistingValues) {
         Map<Integer, List<Data>> partitionIdToKeys = getPartitionIdToKeysMap(dataKeys);
         Iterable<Entry<Integer, List<Data>>> entries = partitionIdToKeys.entrySet();
 
@@ -433,7 +432,7 @@ abstract class MapProxySupport extends AbstractDistributedObject<MapService> imp
         waitUntilLoaded();
     }
 
-    private <K> Iterable<Data> convertToData(Iterable<K> keys) {
+    protected <K> Iterable<Data> convertToData(Iterable<K> keys) {
         return IterableUtil.map(nullToEmpty(keys), new IFunction<K, Data>() {
             public Data apply(K key) {
                 return toData(key);


### PR DESCRIPTION
fixes #7090

I made changes on MapProxyImpl (and Support) that are super class of NearCachedClientMapProxy to prevent double serialisation.
